### PR TITLE
feat(product tours): add banner editor

### DIFF
--- a/frontend/src/scenes/product-tours/BannerContentEditor.tsx
+++ b/frontend/src/scenes/product-tours/BannerContentEditor.tsx
@@ -1,0 +1,135 @@
+import { JSONContent } from '@tiptap/core'
+
+import { LemonInput, LemonSegmentedButton, LemonSelect } from '@posthog/lemon-ui'
+
+import { ProductTourAppearance, ProductTourBannerConfig, ProductTourStep } from '~/types'
+
+import { BannerPreviewWrapper } from './components/ProductTourPreview'
+import { TourSelector } from './components/TourSelector'
+import { StepContentEditor } from './editor/StepContentEditor'
+
+export interface BannerContentEditorProps {
+    step: ProductTourStep | undefined
+    appearance: ProductTourAppearance | undefined
+    onChange: (step: ProductTourStep) => void
+}
+
+export function BannerContentEditor({ step, appearance, onChange }: BannerContentEditorProps): JSX.Element {
+    const updateStep = (updates: Partial<ProductTourStep>): void => {
+        if (step) {
+            onChange({ ...step, ...updates })
+        }
+    }
+
+    if (!step) {
+        return <div>No content</div>
+    }
+
+    const behavior = step.bannerConfig?.behavior ?? 'sticky'
+    const actionType = step.bannerConfig?.action?.type ?? 'none'
+
+    const updateBannerConfig = (updates: Partial<ProductTourBannerConfig>): void => {
+        updateStep({
+            bannerConfig: {
+                ...step.bannerConfig,
+                behavior,
+                ...updates,
+            },
+        })
+    }
+
+    const updateAction = (updates: Partial<NonNullable<ProductTourBannerConfig['action']>>): void => {
+        updateBannerConfig({
+            action: {
+                ...step.bannerConfig?.action,
+                type: actionType,
+                ...updates,
+            },
+        })
+    }
+
+    return (
+        <div className="space-y-6">
+            {/* Full-width preview */}
+            <BannerPreviewWrapper step={step} appearance={appearance} />
+
+            {/* Editor and settings */}
+            <div className="flex gap-8">
+                <div className="flex-1 min-w-0">
+                    <label className="text-sm font-medium block mb-2">Banner message</label>
+                    <StepContentEditor
+                        content={step.content as JSONContent | null}
+                        onChange={(content) => updateStep({ content })}
+                        placeholder="Your banner message here..."
+                        inlineOnly
+                    />
+                </div>
+
+                <div className="flex-1 min-w-0 space-y-4">
+                    <div>
+                        <label className="text-sm font-medium block mb-3">Settings</label>
+                        <div className="flex items-center justify-between">
+                            <div>
+                                <div className="font-medium text-sm">Behavior</div>
+                                <div className="text-muted text-xs">Stays visible while scrolling</div>
+                            </div>
+                            <LemonSegmentedButton
+                                size="small"
+                                value={behavior}
+                                onChange={(value) =>
+                                    updateBannerConfig({
+                                        behavior: value as ProductTourBannerConfig['behavior'],
+                                    })
+                                }
+                                options={[
+                                    { value: 'sticky', label: 'Sticky' },
+                                    { value: 'static', label: 'Static' },
+                                ]}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="pt-4 border-t">
+                        <label className="text-sm font-medium block mb-3">Click action</label>
+                        <div className="space-y-3">
+                            <LemonSelect
+                                value={actionType}
+                                onChange={(value) =>
+                                    updateAction({
+                                        type: value as NonNullable<ProductTourBannerConfig['action']>['type'],
+                                        link: value === 'link' ? step.bannerConfig?.action?.link : undefined,
+                                        tourId:
+                                            value === 'trigger_tour' ? step.bannerConfig?.action?.tourId : undefined,
+                                    })
+                                }
+                                options={[
+                                    { value: 'none', label: 'None' },
+                                    { value: 'link', label: 'Open link' },
+                                    { value: 'trigger_tour', label: 'Start tour' },
+                                ]}
+                                size="small"
+                                fullWidth
+                            />
+                            {actionType === 'link' && (
+                                <LemonInput
+                                    value={step.bannerConfig?.action?.link ?? ''}
+                                    onChange={(link) => updateAction({ link })}
+                                    placeholder="https://example.com"
+                                    size="small"
+                                    fullWidth
+                                />
+                            )}
+                            {actionType === 'trigger_tour' && (
+                                <TourSelector
+                                    value={step.bannerConfig?.action?.tourId}
+                                    onChange={(tourId) => updateAction({ tourId })}
+                                    fullWidth
+                                />
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -17,12 +17,14 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductTourStep } from '~/types'
 
 import { AnnouncementContentEditor } from './AnnouncementContentEditor'
+import { BannerContentEditor } from './BannerContentEditor'
 import { AutoShowSection } from './components/AutoShowSection'
+import { BannerCustomization } from './components/BannerCustomization'
 import { EditInToolbarButton } from './components/EditInToolbarButton'
 import { ProductTourCustomization } from './components/ProductTourCustomization'
 import { ProductTourStepsEditor } from './editor'
 import { ProductTourEditTab, productTourLogic } from './productTourLogic'
-import { isAnnouncement } from './productToursLogic'
+import { isAnnouncement, isBannerAnnouncement } from './productToursLogic'
 
 export function ProductTourEdit({ id }: { id: string }): JSX.Element {
     const {
@@ -216,16 +218,29 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                                     <span />
                                 </LemonField>
                             )}
-                            <AnnouncementContentEditor
-                                step={productTourForm.content?.steps?.[0]}
-                                appearance={productTourForm.content?.appearance}
-                                onChange={(step: ProductTourStep) => {
-                                    setProductTourFormValue('content', {
-                                        ...productTourForm.content,
-                                        steps: [step],
-                                    })
-                                }}
-                            />
+                            {isBannerAnnouncement(productTour) ? (
+                                <BannerContentEditor
+                                    step={productTourForm.content?.steps?.[0]}
+                                    appearance={productTourForm.content?.appearance}
+                                    onChange={(step: ProductTourStep) => {
+                                        setProductTourFormValue('content', {
+                                            ...productTourForm.content,
+                                            steps: [step],
+                                        })
+                                    }}
+                                />
+                            ) : (
+                                <AnnouncementContentEditor
+                                    step={productTourForm.content?.steps?.[0]}
+                                    appearance={productTourForm.content?.appearance}
+                                    onChange={(step: ProductTourStep) => {
+                                        setProductTourFormValue('content', {
+                                            ...productTourForm.content,
+                                            steps: [step],
+                                        })
+                                    }}
+                                />
+                            )}
                         </>
                     ) : (
                         <ProductTourStepsEditor
@@ -240,18 +255,30 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                         />
                     ))}
 
-                {editTab === ProductTourEditTab.Customization && (
-                    <ProductTourCustomization
-                        appearance={productTourForm.content?.appearance}
-                        steps={productTourForm.content?.steps ?? []}
-                        onChange={(appearance) => {
-                            setProductTourFormValue('content', {
-                                ...productTourForm.content,
-                                appearance,
-                            })
-                        }}
-                    />
-                )}
+                {editTab === ProductTourEditTab.Customization &&
+                    (isBannerAnnouncement(productTour) ? (
+                        <BannerCustomization
+                            appearance={productTourForm.content?.appearance}
+                            step={productTourForm.content?.steps?.[0]}
+                            onChange={(appearance) => {
+                                setProductTourFormValue('content', {
+                                    ...productTourForm.content,
+                                    appearance,
+                                })
+                            }}
+                        />
+                    ) : (
+                        <ProductTourCustomization
+                            appearance={productTourForm.content?.appearance}
+                            steps={productTourForm.content?.steps ?? []}
+                            onChange={(appearance) => {
+                                setProductTourFormValue('content', {
+                                    ...productTourForm.content,
+                                    appearance,
+                                })
+                            }}
+                        />
+                    ))}
             </SceneContent>
         </Form>
     )

--- a/frontend/src/scenes/product-tours/ProductTourView.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourView.tsx
@@ -106,7 +106,7 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
                 isLoading={productTourLoading}
                 actions={
                     <>
-                        <EditInToolbarButton tourId={id} />
+                        {!isAnnouncement(productTour) && <EditInToolbarButton tourId={id} />}
                         <LemonButton type="secondary" size="small" onClick={() => editingProductTour(true)}>
                             Edit
                         </LemonButton>

--- a/frontend/src/scenes/product-tours/ProductTours.tsx
+++ b/frontend/src/scenes/product-tours/ProductTours.tsx
@@ -23,7 +23,7 @@ export const scene: SceneExport = {
 }
 
 function NewTourButton(): JSX.Element {
-    const { createAnnouncement } = useActions(productToursLogic)
+    const { createAnnouncement, createBanner } = useActions(productToursLogic)
     const [isModalOpen, setIsModalOpen] = useState(false)
 
     return (
@@ -35,6 +35,7 @@ function NewTourButton(): JSX.Element {
                 isOpen={isModalOpen}
                 onClose={() => setIsModalOpen(false)}
                 onCreateAnnouncement={createAnnouncement}
+                onCreateBanner={createBanner}
             />
         </>
     )

--- a/frontend/src/scenes/product-tours/components/BannerCustomization.tsx
+++ b/frontend/src/scenes/product-tours/components/BannerCustomization.tsx
@@ -1,0 +1,70 @@
+import { ProductTourAppearance, ProductTourStep } from '~/types'
+
+import { BoxShadowSelector, ColorPickerField, FontSelector } from './CustomizationFields'
+import { BannerPreviewWrapper } from './ProductTourPreview'
+
+const DEFAULT_BANNER_APPEARANCE: ProductTourAppearance = {
+    backgroundColor: '#ffffff',
+    textColor: '#1d1f27',
+    borderColor: '#e5e7eb',
+    fontFamily: 'system-ui',
+    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
+}
+
+interface BannerCustomizationProps {
+    appearance: ProductTourAppearance | undefined
+    step: ProductTourStep | undefined
+    onChange: (appearance: ProductTourAppearance) => void
+}
+
+export function BannerCustomization({ appearance, step, onChange }: BannerCustomizationProps): JSX.Element {
+    const currentAppearance = { ...DEFAULT_BANNER_APPEARANCE, ...appearance }
+
+    const updateAppearance = (updates: Partial<ProductTourAppearance>): void => {
+        onChange({ ...currentAppearance, ...updates })
+    }
+
+    return (
+        <div className="space-y-6">
+            {step && <BannerPreviewWrapper step={step} appearance={currentAppearance} />}
+
+            <div className="flex gap-8">
+                <div className="flex-1 space-y-4">
+                    <h3 className="font-semibold">Colors</h3>
+                    <div className="grid grid-cols-3 gap-4">
+                        <ColorPickerField
+                            label="Background"
+                            value={currentAppearance.backgroundColor}
+                            onChange={(backgroundColor) => updateAppearance({ backgroundColor })}
+                        />
+                        <ColorPickerField
+                            label="Text"
+                            value={currentAppearance.textColor}
+                            onChange={(textColor) => updateAppearance({ textColor })}
+                        />
+                        <ColorPickerField
+                            label="Border"
+                            value={currentAppearance.borderColor}
+                            onChange={(borderColor) => updateAppearance({ borderColor })}
+                            showNone
+                        />
+                    </div>
+                </div>
+
+                <div className="flex-1 space-y-4">
+                    <h3 className="font-semibold">Style</h3>
+                    <div className="grid grid-cols-2 gap-4">
+                        <FontSelector
+                            value={currentAppearance.fontFamily}
+                            onChange={(fontFamily) => updateAppearance({ fontFamily })}
+                        />
+                        <BoxShadowSelector
+                            value={currentAppearance.boxShadow}
+                            onChange={(boxShadow) => updateAppearance({ boxShadow })}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/product-tours/components/CustomizationFields.tsx
+++ b/frontend/src/scenes/product-tours/components/CustomizationFields.tsx
@@ -1,0 +1,107 @@
+import { IconX } from '@posthog/icons'
+import { LemonButton, LemonSelect } from '@posthog/lemon-ui'
+
+import { LemonColorPicker } from 'lib/lemon-ui/LemonColor/LemonColorPicker'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { WEB_SAFE_FONTS } from 'scenes/surveys/constants'
+
+export const COLOR_PRESETS = [
+    '#ffffff',
+    '#1d1f27',
+    '#1d4aff',
+    '#f3f4f6',
+    '#e5e7eb',
+    '#ef4444',
+    '#22c55e',
+    '#f59e0b',
+    '#8b5cf6',
+    '#ec4899',
+]
+
+export const BOX_SHADOW_PRESETS = [
+    { value: 'none', label: 'None' },
+    { value: '0 2px 8px rgba(0, 0, 0, 0.1)', label: 'Subtle' },
+    { value: '0 4px 12px rgba(0, 0, 0, 0.15)', label: 'Medium' },
+    { value: '0 8px 24px rgba(0, 0, 0, 0.2)', label: 'Large' },
+    { value: '0 12px 32px rgba(0, 0, 0, 0.25)', label: 'Extra large' },
+]
+
+export function ColorPickerField({
+    label,
+    value,
+    onChange,
+    showNone = false,
+}: {
+    label: string
+    value: string | undefined
+    onChange: (color: string) => void
+    showNone?: boolean
+}): JSX.Element {
+    const isNone = value === 'transparent'
+    const displayValue = isNone ? 'None' : value
+
+    return (
+        <LemonField.Pure label={label} className="flex-1">
+            <div className="flex items-center gap-2">
+                <LemonColorPicker
+                    colors={COLOR_PRESETS}
+                    selectedColor={isNone ? null : value}
+                    onSelectColor={onChange}
+                    showCustomColor
+                />
+                <span className="text-xs text-secondary font-mono">{displayValue}</span>
+                {showNone && (
+                    <LemonButton
+                        type="tertiary"
+                        size="xsmall"
+                        icon={<IconX />}
+                        onClick={() => onChange('transparent')}
+                    />
+                )}
+            </div>
+        </LemonField.Pure>
+    )
+}
+
+export function FontSelector({
+    value,
+    onChange,
+}: {
+    value: string | undefined
+    onChange: (font: string) => void
+}): JSX.Element {
+    return (
+        <LemonField.Pure label="Font">
+            <LemonSelect
+                value={value}
+                onChange={(font) => onChange(font || 'system-ui')}
+                options={WEB_SAFE_FONTS.map((font) => ({
+                    label: (
+                        <span style={{ fontFamily: font.value === 'inherit' ? undefined : font.value }}>
+                            {font.label}
+                        </span>
+                    ),
+                    value: font.value,
+                }))}
+            />
+        </LemonField.Pure>
+    )
+}
+
+export function BoxShadowSelector({
+    value,
+    onChange,
+}: {
+    value: string | undefined
+    onChange: (shadow: string) => void
+}): JSX.Element {
+    return (
+        <LemonField.Pure label="Drop shadow">
+            <LemonSelect
+                value={value}
+                onChange={(shadow) => onChange(shadow || '0 4px 12px rgba(0, 0, 0, 0.15)')}
+                options={BOX_SHADOW_PRESETS}
+            />
+        </LemonField.Pure>
+    )
+}

--- a/frontend/src/scenes/product-tours/components/ProductTourCustomization.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductTourCustomization.tsx
@@ -2,13 +2,12 @@ import { useState } from 'react'
 
 import { LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
-import { LemonColorPicker } from 'lib/lemon-ui/LemonColor/LemonColorPicker'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider/LemonSlider'
-import { WEB_SAFE_FONTS } from 'scenes/surveys/constants'
 
 import { ProductTourAppearance, ProductTourStep } from '~/types'
 
+import { BoxShadowSelector, ColorPickerField, FontSelector } from './CustomizationFields'
 import { ProductTourPreview } from './ProductTourPreview'
 
 const DEFAULT_APPEARANCE: ProductTourAppearance = {
@@ -24,55 +23,10 @@ const DEFAULT_APPEARANCE: ProductTourAppearance = {
     whiteLabel: false,
 }
 
-const COLOR_PRESETS = [
-    '#ffffff',
-    '#1d1f27',
-    '#1d4aff',
-    '#f3f4f6',
-    '#e5e7eb',
-    '#ef4444',
-    '#22c55e',
-    '#f59e0b',
-    '#8b5cf6',
-    '#ec4899',
-]
-
-const BOX_SHADOW_PRESETS = [
-    { value: 'none', label: 'None' },
-    { value: '0 2px 8px rgba(0, 0, 0, 0.1)', label: 'Subtle' },
-    { value: '0 4px 12px rgba(0, 0, 0, 0.15)', label: 'Medium' },
-    { value: '0 8px 24px rgba(0, 0, 0, 0.2)', label: 'Large' },
-    { value: '0 12px 32px rgba(0, 0, 0, 0.25)', label: 'Extra large' },
-]
-
 interface ProductTourCustomizationProps {
     appearance: ProductTourAppearance | undefined
     steps: ProductTourStep[]
     onChange: (appearance: ProductTourAppearance) => void
-}
-
-function ColorPickerField({
-    label,
-    value,
-    onChange,
-}: {
-    label: string
-    value: string | undefined
-    onChange: (color: string) => void
-}): JSX.Element {
-    return (
-        <LemonField.Pure label={label} className="flex-1">
-            <div className="flex items-center gap-2">
-                <LemonColorPicker
-                    colors={COLOR_PRESETS}
-                    selectedColor={value}
-                    onSelectColor={onChange}
-                    showCustomColor
-                />
-                <span className="text-xs text-secondary font-mono">{value}</span>
-            </div>
-        </LemonField.Pure>
-    )
 }
 
 function TourStepPreview({
@@ -192,30 +146,15 @@ export function ProductTourCustomization({ appearance, steps, onChange }: Produc
                             </div>
                         </LemonField.Pure>
 
-                        <LemonField.Pure label="Font">
-                            <LemonSelect
-                                value={currentAppearance.fontFamily}
-                                onChange={(fontFamily) => updateAppearance({ fontFamily: fontFamily || 'system-ui' })}
-                                options={WEB_SAFE_FONTS.map((font) => ({
-                                    label: (
-                                        <span style={{ fontFamily: font.value === 'inherit' ? undefined : font.value }}>
-                                            {font.label}
-                                        </span>
-                                    ),
-                                    value: font.value,
-                                }))}
-                            />
-                        </LemonField.Pure>
+                        <FontSelector
+                            value={currentAppearance.fontFamily}
+                            onChange={(fontFamily) => updateAppearance({ fontFamily })}
+                        />
 
-                        <LemonField.Pure label="Drop shadow">
-                            <LemonSelect
-                                value={currentAppearance.boxShadow}
-                                onChange={(boxShadow) =>
-                                    updateAppearance({ boxShadow: boxShadow || '0 4px 12px rgba(0, 0, 0, 0.15)' })
-                                }
-                                options={BOX_SHADOW_PRESETS}
-                            />
-                        </LemonField.Pure>
+                        <BoxShadowSelector
+                            value={currentAppearance.boxShadow}
+                            onChange={(boxShadow) => updateAppearance({ boxShadow })}
+                        />
 
                         <div className="flex items-center justify-between">
                             <span className="text-sm font-medium">Show dark overlay</span>

--- a/frontend/src/scenes/product-tours/components/ProductTourPreview.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductTourPreview.tsx
@@ -36,3 +36,20 @@ export function ProductTourPreview({
 
     return <div ref={ref} />
 }
+
+export function BannerPreviewWrapper({
+    step,
+    appearance,
+}: {
+    step: ProductTourStep
+    appearance?: ProductTourAppearance
+}): JSX.Element {
+    return (
+        <div>
+            <div className="text-xs text-muted uppercase tracking-wide mb-3">Preview</div>
+            <div className="bg-[#f0f0f0] overflow-hidden">
+                {step && <ProductTourPreview step={step} appearance={appearance} />}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
@@ -39,13 +39,13 @@ export interface ProductTourStepsEditorProps {
     onChange: (steps: ProductTourStep[]) => void
 }
 
-const STEP_TYPE_ICONS: Record<ProductTourStepType, JSX.Element> = {
+const STEP_TYPE_ICONS: Partial<Record<ProductTourStepType, JSX.Element>> = {
     element: <IconCursorClick />,
     modal: <IconMessage />,
     survey: <IconQuestion />,
 }
 
-const STEP_TYPE_LABELS: Record<ProductTourStepType, string> = {
+const STEP_TYPE_LABELS: Partial<Record<ProductTourStepType, string>> = {
     element: 'Element',
     modal: 'Modal',
     survey: 'Survey',

--- a/frontend/src/scenes/product-tours/editor/StepContentEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/StepContentEditor.tsx
@@ -47,6 +47,8 @@ export interface StepContentEditorProps {
     uploadImage?: (file: File) => Promise<{ url: string; fileName: string }>
     /** Compact mode shows a condensed toolbar with dropdown menus. Useful for narrow containers like the toolbar. */
     compact?: boolean
+    // restrict to only inline styles - no images/videos/etc
+    inlineOnly?: boolean
 }
 
 const DEFAULT_CONTENT: JSONContent = {
@@ -65,6 +67,7 @@ export function StepContentEditor({
     autoFocus = false,
     uploadImage,
     compact = false,
+    inlineOnly = false,
 }: StepContentEditorProps): JSX.Element {
     const dropRef = useRef<HTMLDivElement>(null)
     const [linkUrl, setLinkUrl] = useState('')
@@ -77,33 +80,48 @@ export function StepContentEditor({
     const [customUploading, setCustomUploading] = useState(false)
 
     const editor = useEditor({
-        extensions: [
-            StarterKit.configure({
-                heading: {
-                    levels: [1, 2, 3],
-                },
-                codeBlock: false,
-            }),
-            CodeBlockExtension,
-            Link.configure({
-                openOnClick: false,
-                HTMLAttributes: {
-                    class: 'step-content-link',
-                },
-            }),
-            Image.configure({
-                HTMLAttributes: {
-                    class: 'step-content-image',
-                },
-                allowBase64: true,
-            }),
-            Underline,
-            Placeholder.configure({
-                placeholder,
-            }),
-            EmbedExtension,
-            SlashCommandExtension,
-        ],
+        extensions: inlineOnly
+            ? [
+                  StarterKit.configure({
+                      heading: false,
+                      codeBlock: false,
+                      blockquote: false,
+                      bulletList: false,
+                      orderedList: false,
+                      horizontalRule: false,
+                  }),
+                  Underline,
+                  Placeholder.configure({
+                      placeholder,
+                  }),
+              ]
+            : [
+                  StarterKit.configure({
+                      heading: {
+                          levels: [1, 2, 3],
+                      },
+                      codeBlock: false,
+                  }),
+                  CodeBlockExtension,
+                  Link.configure({
+                      openOnClick: false,
+                      HTMLAttributes: {
+                          class: 'step-content-link',
+                      },
+                  }),
+                  Image.configure({
+                      HTMLAttributes: {
+                          class: 'step-content-image',
+                      },
+                      allowBase64: true,
+                  }),
+                  Underline,
+                  Placeholder.configure({
+                      placeholder,
+                  }),
+                  EmbedExtension,
+                  SlashCommandExtension,
+              ],
         content: content || DEFAULT_CONTENT,
         autofocus: autoFocus,
         onUpdate: ({ editor: e }) => {
@@ -279,47 +297,49 @@ export function StepContentEditor({
                 <LemonButton size="small" icon={<IconTextSize />} sideIcon={null} tooltip="Styles" />
             </LemonMenu>
 
-            <Popover
-                visible={showLinkPopover}
-                onClickOutside={() => setShowLinkPopover(false)}
-                overlay={
-                    <div className="p-2 flex flex-col gap-2 min-w-64">
-                        <LemonInput
-                            size="small"
-                            placeholder="https://..."
-                            value={linkUrl}
-                            onChange={setLinkUrl}
-                            onPressEnter={setLink}
-                            autoFocus
-                            fullWidth
-                        />
-                        <div className="flex gap-2 justify-end">
-                            {hasExistingLink && (
-                                <LemonButton size="small" status="danger" onClick={removeLink}>
-                                    Remove
-                                </LemonButton>
-                            )}
-                            <LemonButton
+            {!inlineOnly && (
+                <Popover
+                    visible={showLinkPopover}
+                    onClickOutside={() => setShowLinkPopover(false)}
+                    overlay={
+                        <div className="p-2 flex flex-col gap-2 min-w-64">
+                            <LemonInput
                                 size="small"
-                                type="primary"
-                                onClick={setLink}
-                                disabledReason={!linkUrl ? 'Enter a URL' : undefined}
-                            >
-                                {hasExistingLink ? 'Update' : 'Set'}
-                            </LemonButton>
+                                placeholder="https://..."
+                                value={linkUrl}
+                                onChange={setLinkUrl}
+                                onPressEnter={setLink}
+                                autoFocus
+                                fullWidth
+                            />
+                            <div className="flex gap-2 justify-end">
+                                {hasExistingLink && (
+                                    <LemonButton size="small" status="danger" onClick={removeLink}>
+                                        Remove
+                                    </LemonButton>
+                                )}
+                                <LemonButton
+                                    size="small"
+                                    type="primary"
+                                    onClick={setLink}
+                                    disabledReason={!linkUrl ? 'Enter a URL' : undefined}
+                                >
+                                    {hasExistingLink ? 'Update' : 'Set'}
+                                </LemonButton>
+                            </div>
                         </div>
-                    </div>
-                }
-            >
-                <LemonButton
-                    ref={linkButtonRef}
-                    size="small"
-                    active={editor.isActive('link')}
-                    onClick={openLinkPopover}
-                    icon={<IconLink />}
-                    tooltip="Link"
-                />
-            </Popover>
+                    }
+                >
+                    <LemonButton
+                        ref={linkButtonRef}
+                        size="small"
+                        active={editor.isActive('link')}
+                        onClick={openLinkPopover}
+                        icon={<IconLink />}
+                        tooltip="Link"
+                    />
+                </Popover>
+            )}
 
             <LemonMenu
                 items={[
@@ -353,32 +373,35 @@ export function StepContentEditor({
 
     const fullToolbar = (
         <div className="StepContentEditor__format-toolbar">
-            <LemonButton
-                size="small"
-                active={editor.isActive('heading', { level: 1 })}
-                onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
-                tooltip="Heading 1"
-            >
-                H1
-            </LemonButton>
-            <LemonButton
-                size="small"
-                active={editor.isActive('heading', { level: 2 })}
-                onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-                tooltip="Heading 2"
-            >
-                H2
-            </LemonButton>
-            <LemonButton
-                size="small"
-                active={editor.isActive('heading', { level: 3 })}
-                onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
-                tooltip="Heading 3"
-            >
-                H3
-            </LemonButton>
-
-            <LemonDivider vertical className="mx-1 self-stretch" />
+            {!inlineOnly && (
+                <>
+                    <LemonButton
+                        size="small"
+                        active={editor.isActive('heading', { level: 1 })}
+                        onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+                        tooltip="Heading 1"
+                    >
+                        H1
+                    </LemonButton>
+                    <LemonButton
+                        size="small"
+                        active={editor.isActive('heading', { level: 2 })}
+                        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+                        tooltip="Heading 2"
+                    >
+                        H2
+                    </LemonButton>
+                    <LemonButton
+                        size="small"
+                        active={editor.isActive('heading', { level: 3 })}
+                        onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+                        tooltip="Heading 3"
+                    >
+                        H3
+                    </LemonButton>
+                    <LemonDivider vertical className="mx-1 self-stretch" />
+                </>
+            )}
 
             <LemonButton
                 size="small"
@@ -408,124 +431,132 @@ export function StepContentEditor({
                 icon={<IconCode />}
                 tooltip="Inline code"
             />
-            <Popover
-                visible={showLinkPopover}
-                onClickOutside={() => setShowLinkPopover(false)}
-                overlay={
-                    <div className="p-2 flex flex-col gap-2 min-w-64">
-                        <LemonInput
-                            size="small"
-                            placeholder="https://..."
-                            value={linkUrl}
-                            onChange={setLinkUrl}
-                            onPressEnter={setLink}
-                            autoFocus
-                            fullWidth
-                        />
-                        <div className="flex gap-2 justify-end">
-                            {hasExistingLink && (
-                                <LemonButton size="small" status="danger" onClick={removeLink}>
-                                    Remove
+            {!inlineOnly && (
+                <Popover
+                    visible={showLinkPopover}
+                    onClickOutside={() => setShowLinkPopover(false)}
+                    overlay={
+                        <div className="p-2 flex flex-col gap-2 min-w-64">
+                            <LemonInput
+                                size="small"
+                                placeholder="https://..."
+                                value={linkUrl}
+                                onChange={setLinkUrl}
+                                onPressEnter={setLink}
+                                autoFocus
+                                fullWidth
+                            />
+                            <div className="flex gap-2 justify-end">
+                                {hasExistingLink && (
+                                    <LemonButton size="small" status="danger" onClick={removeLink}>
+                                        Remove
+                                    </LemonButton>
+                                )}
+                                <LemonButton
+                                    size="small"
+                                    type="primary"
+                                    onClick={setLink}
+                                    disabledReason={!linkUrl ? 'Enter a URL' : undefined}
+                                >
+                                    {hasExistingLink ? 'Update' : 'Set'}
                                 </LemonButton>
-                            )}
+                            </div>
+                        </div>
+                    }
+                >
+                    <LemonButton
+                        ref={linkButtonRef}
+                        size="small"
+                        active={editor.isActive('link')}
+                        onClick={openLinkPopover}
+                        icon={<IconLink />}
+                        tooltip="Link"
+                    />
+                </Popover>
+            )}
+
+            {!inlineOnly && (
+                <>
+                    <LemonDivider vertical className="mx-1 self-stretch" />
+                    <LemonFileInput
+                        accept="image/*"
+                        multiple={false}
+                        alternativeDropTargetRef={dropRef}
+                        onChange={(files) => void handleFileUpload(files)}
+                        loading={uploading}
+                        showUploadedFiles={false}
+                        callToAction={
                             <LemonButton
                                 size="small"
-                                type="primary"
-                                onClick={setLink}
-                                disabledReason={!linkUrl ? 'Enter a URL' : undefined}
-                            >
-                                {hasExistingLink ? 'Update' : 'Set'}
-                            </LemonButton>
-                        </div>
-                    </div>
-                }
-            >
-                <LemonButton
-                    ref={linkButtonRef}
-                    size="small"
-                    active={editor.isActive('link')}
-                    onClick={openLinkPopover}
-                    icon={<IconLink />}
-                    tooltip="Link"
-                />
-            </Popover>
-
-            <LemonDivider vertical className="mx-1 self-stretch" />
-
-            <LemonFileInput
-                accept="image/*"
-                multiple={false}
-                alternativeDropTargetRef={dropRef}
-                onChange={(files) => void handleFileUpload(files)}
-                loading={uploading}
-                showUploadedFiles={false}
-                callToAction={
+                                icon={uploading ? <Spinner className="text-sm" textColored /> : <IconImage />}
+                                tooltip="Upload image (or drag & drop)"
+                            />
+                        }
+                    />
                     <LemonButton
                         size="small"
-                        icon={uploading ? <Spinner className="text-sm" textColored /> : <IconImage />}
-                        tooltip="Upload image (or drag & drop)"
+                        icon={<IconVideoCamera />}
+                        tooltip="Embed video"
+                        onClick={() => setShowVideoModal(true)}
                     />
-                }
-            />
-            <LemonButton
-                size="small"
-                icon={<IconVideoCamera />}
-                tooltip="Embed video"
-                onClick={() => setShowVideoModal(true)}
-            />
-
-            <span className="text-xs text-muted ml-auto">
-                Type <code>/</code> for commands
-            </span>
+                    <span className="text-xs text-muted ml-auto">
+                        Type <code>/</code> for commands
+                    </span>
+                </>
+            )}
         </div>
     )
 
+    const toolbar = compact ? compactToolbar : fullToolbar
+
     return (
-        <div ref={dropRef} className="StepContentEditor">
-            {compact ? compactToolbar : fullToolbar}
+        <div ref={inlineOnly ? undefined : dropRef} className="StepContentEditor">
+            {toolbar}
 
             <EditorContent editor={editor} className="StepContentEditor__content" />
 
-            <LemonModal
-                isOpen={showVideoModal}
-                onClose={() => {
-                    setShowVideoModal(false)
-                    setVideoUrl('')
-                }}
-                title="Embed video"
-                footer={
-                    <>
-                        <LemonButton
-                            type="secondary"
-                            onClick={() => {
-                                setShowVideoModal(false)
-                                setVideoUrl('')
-                            }}
-                        >
-                            Cancel
-                        </LemonButton>
-                        <LemonButton
-                            type="primary"
-                            onClick={insertEmbed}
-                            disabledReason={!videoUrl ? 'Enter a URL' : undefined}
-                        >
-                            Embed
-                        </LemonButton>
-                    </>
-                }
-            >
-                <div className="space-y-2">
-                    <p className="text-muted text-sm">Paste a YouTube, Vimeo, or Loom URL</p>
-                    <LemonInput
-                        placeholder="https://www.youtube.com/watch?v=..."
-                        value={videoUrl}
-                        onChange={setVideoUrl}
-                        onPressEnter={insertEmbed}
-                        autoFocus
-                        fullWidth
-                    />
-                </div>
-            </LemonModal>
+            {!inlineOnly && (
+                <LemonModal
+                    isOpen={showVideoModal}
+                    onClose={() => {
+                        setShowVideoModal(false)
+                        setVideoUrl('')
+                    }}
+                    title="Embed video"
+                    footer={
+                        <>
+                            <LemonButton
+                                type="secondary"
+                                onClick={() => {
+                                    setShowVideoModal(false)
+                                    setVideoUrl('')
+                                }}
+                            >
+                                Cancel
+                            </LemonButton>
+                            <LemonButton
+                                type="primary"
+                                onClick={insertEmbed}
+                                disabledReason={!videoUrl ? 'Enter a URL' : undefined}
+                            >
+                                Embed
+                            </LemonButton>
+                        </>
+                    }
+                >
+                    <div className="space-y-2">
+                        <p className="text-muted text-sm">Paste a YouTube, Vimeo, or Loom URL</p>
+                        <LemonInput
+                            placeholder="https://www.youtube.com/watch?v=..."
+                            value={videoUrl}
+                            onChange={setVideoUrl}
+                            onPressEnter={insertEmbed}
+                            autoFocus
+                            fullWidth
+                        />
+                    </div>
+                </LemonModal>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/product-tours/productTourLogic.ts
+++ b/frontend/src/scenes/product-tours/productTourLogic.ts
@@ -11,7 +11,14 @@ import { sceneConfigurations } from 'scenes/scenes'
 import { urls } from 'scenes/urls'
 
 import { DateRange } from '~/queries/schema/schema-general'
-import { Breadcrumb, FeatureFlagFilters, ProductTour, ProductTourContent, ProductTourStepButton } from '~/types'
+import {
+    Breadcrumb,
+    FeatureFlagFilters,
+    ProductTour,
+    ProductTourBannerConfig,
+    ProductTourContent,
+    ProductTourStepButton,
+} from '~/types'
 
 import { prepareStepsForRender } from './editor/generateStepHtml'
 import type { productTourLogicType } from './productTourLogicType'
@@ -294,10 +301,28 @@ export const productTourLogic = kea<productTourLogicType>([
                     return undefined
                 }
 
+                const validateBannerAction = (
+                    action: ProductTourBannerConfig['action'] | undefined,
+                    errorLabel: string
+                ): string | undefined => {
+                    if (!action?.type) {
+                        return undefined
+                    }
+                    if (action.type === 'link' && !action.link?.trim()) {
+                        return `${errorLabel} requires a URL`
+                    }
+                    if (action.type === 'trigger_tour' && !action.tourId) {
+                        return `${errorLabel} requires a tour selection`
+                    }
+                    return undefined
+                }
+
                 for (const step of content.steps || []) {
                     const error =
-                        validateButton(step.buttons?.primary, 'Primary button') ||
-                        validateButton(step.buttons?.secondary, 'Secondary button')
+                        step.type === 'banner'
+                            ? validateBannerAction(step.bannerConfig?.action, 'Banner click action')
+                            : validateButton(step.buttons?.primary, 'Primary button') ||
+                              validateButton(step.buttons?.secondary, 'Secondary button')
 
                     if (error) {
                         errors._form = error

--- a/frontend/src/scenes/product-tours/productToursLogic.ts
+++ b/frontend/src/scenes/product-tours/productToursLogic.ts
@@ -107,6 +107,43 @@ function createDefaultAnnouncementContent(): ProductTourContent {
     }
 }
 
+function createDefaultBannerContent(): ProductTourContent {
+    return {
+        type: 'announcement',
+        steps: [
+            {
+                id: uuid(),
+                type: 'banner',
+                content: {
+                    type: 'doc',
+                    content: [
+                        {
+                            type: 'paragraph',
+                            content: [
+                                {
+                                    type: 'text',
+                                    text: 'Your banner message here. Keep it short and actionable.',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                bannerConfig: {
+                    behavior: 'sticky',
+                    action: {
+                        type: 'none',
+                    },
+                },
+            },
+        ],
+        appearance: {
+            showOverlay: false,
+            dismissOnClickOutside: false,
+            whiteLabel: true, // banners simply have no branding
+        },
+    }
+}
+
 export enum ProductToursTabs {
     Active = 'active',
     Archived = 'archived',
@@ -129,6 +166,14 @@ export function isAnnouncement(tour: Pick<ProductTour, 'content'>): boolean {
     return tour.content?.type === 'announcement'
 }
 
+export function isBannerAnnouncement(tour: Pick<ProductTour, 'content'>): boolean {
+    return isAnnouncement(tour) && tour.content?.steps?.[0]?.type === 'banner'
+}
+
+export function isModalAnnouncement(tour: Pick<ProductTour, 'content'>): boolean {
+    return isAnnouncement(tour) && tour.content?.steps?.[0]?.type === 'modal'
+}
+
 export interface ProductToursFilters {
     archived: boolean
 }
@@ -141,6 +186,7 @@ export const productToursLogic = kea<productToursLogicType>([
         setFilters: (filters: Partial<ProductToursFilters>) => ({ filters }),
         setTab: (tab: ProductToursTabs) => ({ tab }),
         createAnnouncement: (name: string) => ({ name }),
+        createBanner: (name: string) => ({ name }),
     }),
     loaders(({ values }) => ({
         productTours: {
@@ -199,6 +245,18 @@ export const productToursLogic = kea<productToursLogicType>([
                 router.actions.push(urls.productTour(announcement.id))
             } catch {
                 lemonToast.error('Failed to create announcement')
+            }
+        },
+        createBanner: async ({ name }) => {
+            try {
+                const banner = await api.productTours.create({
+                    name,
+                    content: createDefaultBannerContent(),
+                })
+                actions.loadProductTours()
+                router.actions.push(urls.productTour(banner.id))
+            } catch {
+                lemonToast.error('Failed to create banner')
             }
         },
     })),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3318,7 +3318,16 @@ export interface ProductTourSurveyQuestion {
 
 export type ProductTourProgressionTriggerType = 'button' | 'click'
 
-export type ProductTourStepType = 'element' | 'modal' | 'survey'
+export type ProductTourStepType = 'element' | 'modal' | 'survey' | 'banner'
+
+export interface ProductTourBannerConfig {
+    behavior: 'sticky' | 'static'
+    action?: {
+        type: 'none' | 'link' | 'trigger_tour'
+        link?: string
+        tourId?: string
+    }
+}
 
 export type ProductTourButtonAction = 'dismiss' | 'link' | 'next_step' | 'previous_step' | 'trigger_tour'
 
@@ -3374,6 +3383,8 @@ export interface ProductTourStep {
     inferenceData?: InferredSelector
     /** Button configuration for tour steps (modals / announcements) */
     buttons?: ProductTourStepButtons
+    /** Banner configuration (only for banner steps) */
+    bannerConfig?: ProductTourBannerConfig
 }
 
 /** Tracks a snapshot of steps at a point in time for funnel analysis */


### PR DESCRIPTION
## Problem

sdk can render banners now, but we need a way to edit them!

needs https://github.com/PostHog/posthog-js/pull/2865 to work (playback and preview)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

|  |  |
| --- | --- |
| ![Screenshot 2026-01-09 at 11.31.29 AM.png](https://app.graphite.com/user-attachments/assets/0af35f1f-46c9-4ea9-8b4e-30539c186959.png)<br> | ![Screenshot 2026-01-09 at 10.24.54 AM.png](https://app.graphite.com/user-attachments/assets/fc1d9c4c-d28f-4e9b-ab37-2eb78c07f289.png)<br> |

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->