### PR TITLE
feat: add team ranges to reconciliation script

### DIFF
--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -956,7 +956,15 @@ def query_team_ids_from_clickhouse(
 
     Returns:
         List of team_ids sorted ascending
+
+    Raises:
+        ValueError: If min_team_id > max_team_id
     """
+    if min_team_id is not None and max_team_id is not None and min_team_id > max_team_id:
+        raise ValueError(
+            f"Invalid team_id range: min_team_id ({min_team_id}) cannot be greater than max_team_id ({max_team_id})"
+        )
+
     team_id_filters = []
     params: dict[str, Any] = {
         "bug_window_start": bug_window_start,
@@ -973,7 +981,7 @@ def query_team_ids_from_clickhouse(
 
     if exclude_team_ids:
         team_id_filters.append("team_id NOT IN %(exclude_team_ids)s")
-        params["exclude_team_ids"] = exclude_team_ids
+        params["exclude_team_ids"] = tuple(exclude_team_ids)
 
     team_id_filter_clause = (" AND " + " AND ".join(team_id_filters)) if team_id_filters else ""
 

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -5213,8 +5213,8 @@ class TestQueryTeamIdsFromClickHouse:
 
         assert result == [91002, 91003, 91004]
 
-    def test_no_filters_returns_all_teams(self, cluster: ClickhouseCluster):
-        """Test that omitting filters returns all teams with property events."""
+    def test_team_range_returns_all_matching_teams(self, cluster: ClickhouseCluster):
+        """Test that team range filter returns all teams with property events within range."""
         now = datetime.now().replace(microsecond=0)
         bug_window_start = now - timedelta(days=10)
         bug_window_end = now + timedelta(days=1)

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -5308,3 +5308,15 @@ class TestQueryTeamIdsFromClickHouse:
         )
 
         assert result == [93001, 93003]
+
+    def test_invalid_range_raises_error(self):
+        """Test that min_team_id > max_team_id raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            query_team_ids_from_clickhouse(
+                bug_window_start="2024-01-01 00:00:00",
+                bug_window_end="2024-01-02 00:00:00",
+                min_team_id=100,
+                max_team_id=50,
+            )
+
+        assert "min_team_id (100) cannot be greater than max_team_id (50)" in str(exc_info.value)


### PR DESCRIPTION
## Problem

We can't run a big batch of teams, but not all at once.

## Changes

Adds min and max team id filter.

## How did you test this code?

Added tests