### PR TITLE
chore(product tours): add validation for announcement step length

### DIFF
--- a/products/product_tours/backend/api/product_tour.py
+++ b/products/product_tours/backend/api/product_tour.py
@@ -163,6 +163,12 @@ class ProductTourSerializerCreateUpdateOnly(serializers.ModelSerializer):
             return {}
         if not isinstance(value, dict):
             raise serializers.ValidationError("Content must be an object")
+
+        if value.get("type") == "announcement":
+            steps = value.get("steps") or []
+            if len(steps) != 1:
+                raise serializers.ValidationError("Announcements must have exactly 1 step.")
+
         return value
 
     @transaction.atomic


### PR DESCRIPTION
## Problem

announcements are modeled as tours with exactly 1 step - validation is handled on the frontend, but we also need backend validation

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds backend validation + tests for announcement tour step length

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual / unit tests

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->