### PR TITLE
chore(product tours): add preview button from main app for announcements

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -9,7 +9,7 @@ import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconOpenInApp } from 'lib/lemon-ui/icons'
 
-import { ExperimentIdType } from '~/types'
+import { ExperimentIdType, ToolbarUserIntent } from '~/types'
 
 import { AuthorizedUrlForm } from './AuthorizedUrlForm'
 import { EmptyState } from './EmptyState'
@@ -20,6 +20,7 @@ export interface AuthorizedUrlListProps {
     actionId?: number
     experimentId?: ExperimentIdType
     productTourId?: string | null
+    userIntent?: ToolbarUserIntent
     query?: string | null
     allowWildCards?: boolean
     displaySuggestions?: boolean
@@ -32,6 +33,7 @@ export function AuthorizedUrlList({
     actionId,
     experimentId,
     productTourId,
+    userIntent,
     query,
     type,
     addText = 'Add new authorized URL',
@@ -45,6 +47,7 @@ export function AuthorizedUrlList({
         experimentId: experimentId ?? null,
         productTourId: productTourId ?? null,
         actionId: actionId ?? null,
+        userIntent,
         type,
         query,
         allowWildCards,

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -232,6 +232,7 @@ export interface AuthorizedUrlListLogicProps {
     actionId: number | null
     experimentId: ExperimentIdType | null
     productTourId: string | null
+    userIntent?: ToolbarUserIntent
     type: AuthorizedUrlListType
     allowWildCards?: boolean
 }
@@ -240,6 +241,7 @@ export const defaultAuthorizedUrlProperties = {
     actionId: null,
     experimentId: null,
     productTourId: null,
+    userIntent: undefined,
 }
 
 export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
@@ -479,8 +481,8 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
             },
         ],
         launchUrl: [
-            (_, p) => [p.actionId, p.experimentId, p.productTourId],
-            (actionId, experimentId, productTourId) => (url: string) => {
+            (_, p) => [p.actionId, p.experimentId, p.productTourId, p.userIntent ?? (() => undefined)],
+            (actionId, experimentId, productTourId, userIntent) => (url: string) => {
                 if (experimentId) {
                     return appEditorUrl(url, {
                         experimentId,
@@ -488,7 +490,7 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
                 }
 
                 if (productTourId) {
-                    return appEditorUrl(url, { productTourId })
+                    return appEditorUrl(url, { productTourId, userIntent })
                 }
 
                 return appEditorUrl(url, {

--- a/frontend/src/lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic.ts
+++ b/frontend/src/lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic.ts
@@ -42,6 +42,7 @@ export const UserIntentVerb: {
     'edit-experiment': 'edit the experiment',
     'add-product-tour': 'add product tour',
     'edit-product-tour': 'edit the product tour',
+    'preview-product-tour': 'preview the product tour',
 }
 
 export const iframedToolbarBrowserLogic = kea<iframedToolbarBrowserLogicType>([

--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -20,8 +20,8 @@ import { AnnouncementContentEditor } from './AnnouncementContentEditor'
 import { BannerContentEditor } from './BannerContentEditor'
 import { AutoShowSection } from './components/AutoShowSection'
 import { BannerCustomization } from './components/BannerCustomization'
-import { EditInToolbarButton } from './components/EditInToolbarButton'
 import { ProductTourCustomization } from './components/ProductTourCustomization'
+import { ProductToursToolbarButton } from './components/ProductToursToolbarButton'
 import { ProductTourStepsEditor } from './editor'
 import { ProductTourEditTab, productTourLogic } from './productTourLogic'
 import { isAnnouncement, isBannerAnnouncement } from './productToursLogic'
@@ -60,7 +60,10 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                     isLoading={productTourLoading}
                     actions={
                         <>
-                            {!isAnnouncement(productTour) && <EditInToolbarButton tourId={id} />}
+                            <ProductToursToolbarButton
+                                tourId={id}
+                                mode={isAnnouncement(productTour) ? 'preview' : 'edit'}
+                            />
                             <LemonButton type="secondary" size="small" onClick={() => editingProductTour(false)}>
                                 Cancel
                             </LemonButton>

--- a/frontend/src/scenes/product-tours/ProductTourView.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourView.tsx
@@ -37,8 +37,8 @@ import {
     SurveyMatchType,
 } from '~/types'
 
-import { EditInToolbarButton } from './components/EditInToolbarButton'
 import { ProductTourStatsSummary } from './components/ProductTourStatsSummary'
+import { ProductToursToolbarButton } from './components/ProductToursToolbarButton'
 import { productTourLogic } from './productTourLogic'
 import { getProductTourStatus, isAnnouncement, isProductTourRunning, productToursLogic } from './productToursLogic'
 
@@ -106,7 +106,10 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
                 isLoading={productTourLoading}
                 actions={
                     <>
-                        {!isAnnouncement(productTour) && <EditInToolbarButton tourId={id} />}
+                        <ProductToursToolbarButton
+                            tourId={id}
+                            mode={isAnnouncement(productTour) ? 'preview' : 'edit'}
+                        />
                         <LemonButton type="secondary" size="small" onClick={() => editingProductTour(true)}>
                             Edit
                         </LemonButton>

--- a/frontend/src/scenes/product-tours/components/ProductToursToolbarButton.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductToursToolbarButton.tsx
@@ -5,27 +5,52 @@ import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
 import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
 
-interface EditInToolbarButtonProps {
+import { ToolbarUserIntent } from '~/types'
+
+type ToolbarButtonMode = 'edit' | 'preview'
+
+interface ToolbarButtonProps {
     tourId: string
+    mode?: ToolbarButtonMode
     type?: 'primary' | 'secondary' | 'tertiary'
     size?: 'xsmall' | 'small' | 'medium' | 'large'
 }
 
-export function EditInToolbarButton({
+const MODE_CONFIG: Record<
+    ToolbarButtonMode,
+    { label: string; title: string; description: string; intent: ToolbarUserIntent }
+> = {
+    edit: {
+        label: 'Edit in toolbar',
+        title: 'Edit product tour in toolbar',
+        description: 'Select a URL to launch the toolbar and edit your product tour',
+        intent: 'edit-product-tour',
+    },
+    preview: {
+        label: 'Preview in toolbar',
+        title: 'Preview product tour',
+        description: 'Select a URL to launch the toolbar and preview your product tour on your site',
+        intent: 'preview-product-tour',
+    },
+}
+
+export function ProductToursToolbarButton({
     tourId,
+    mode = 'edit',
     type = 'secondary',
     size = 'small',
-}: EditInToolbarButtonProps): JSX.Element {
+}: ToolbarButtonProps): JSX.Element {
     const [isModalOpen, setIsModalOpen] = useState(false)
+    const config = MODE_CONFIG[mode]
 
     return (
         <>
             <LemonButton size={size} type={type} onClick={() => setIsModalOpen(true)}>
-                Edit in toolbar
+                {config.label}
             </LemonButton>
             <LemonModal
-                title="Edit product tour in toolbar"
-                description="Select a URL to launch the toolbar and edit your product tour"
+                title={config.title}
+                description={config.description}
                 isOpen={isModalOpen}
                 onClose={() => setIsModalOpen(false)}
                 width={600}
@@ -35,6 +60,7 @@ export function EditInToolbarButton({
                         type={AuthorizedUrlListType.TOOLBAR_URLS}
                         addText="Add authorized URL"
                         productTourId={tourId}
+                        userIntent={config.intent}
                     />
                 </div>
             </LemonModal>

--- a/frontend/src/toolbar/product-tours/ProductToursToolbarMenu.tsx
+++ b/frontend/src/toolbar/product-tours/ProductToursToolbarMenu.tsx
@@ -31,7 +31,7 @@ export function ProductToursToolbarMenu(): JSX.Element {
                         <div className="space-y-1">
                             <div className="text-xs font-medium text-muted uppercase">Existing tours</div>
                             {tours
-                                .filter((tour) => !tour.archived)
+                                .filter((tour) => !tour.archived && tour.content?.type !== 'announcement')
                                 .map((tour) => (
                                     <LemonButton
                                         key={tour.id}

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -219,6 +219,7 @@ export const productToursLogic = kea<productToursLogicType>([
             promise,
         }),
         clearPendingScreenshotPromise: true,
+        setLaunchedForPreview: (value: boolean) => ({ value }),
     }),
 
     loaders(() => ({
@@ -352,6 +353,13 @@ export const productToursLogic = kea<productToursLogicType>([
                 clearPendingScreenshotPromise: () => null,
                 cancelEditing: () => null,
                 selectTour: () => null,
+            },
+        ],
+        launchedForPreview: [
+            false,
+            {
+                setLaunchedForPreview: (_, { value }) => value,
+                selectTour: () => false,
             },
         ],
     }),
@@ -702,6 +710,17 @@ export const productToursLogic = kea<productToursLogicType>([
             productTours.previewTour(tour)
         },
         stopPreview: () => {
+            const { selectedTourId, tours, launchedForPreview } = values
+            const selectedTour = tours.find((t: ProductTour) => t.id === selectedTourId)
+            const isAnnouncement = selectedTour?.content?.type === 'announcement'
+
+            if (isAnnouncement) {
+                if (launchedForPreview) {
+                    window.close() // go back to posthog app
+                    return
+                }
+                actions.selectTour(null)
+            }
             toolbarLogic.actions.toggleMinimized(false)
         },
         updateRects: () => {
@@ -853,6 +872,11 @@ export const productToursLogic = kea<productToursLogicType>([
                 toolbarConfigLogic.actions.clearUserIntent()
             } else if (userIntent === 'add-product-tour') {
                 actions.startCreation()
+                toolbarConfigLogic.actions.clearUserIntent()
+            } else if (userIntent === 'preview-product-tour' && productTourId) {
+                actions.setLaunchedForPreview(true)
+                actions.selectTour(productTourId)
+                actions.previewTour()
                 toolbarConfigLogic.actions.clearUserIntent()
             }
         },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -768,6 +768,7 @@ export type ToolbarUserIntent =
     | 'edit-experiment'
     | 'add-product-tour'
     | 'edit-product-tour'
+    | 'preview-product-tour'
 export type ToolbarSource = 'url' | 'localstorage'
 export type ToolbarVersion = 'toolbar'
 


### PR DESCRIPTION
## Problem

there's no way to preview an announcement or banner easily

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds "preview in toolbar" button for announcements, and functionality to close the window and send you back to posthog when you dismiss the preview

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->