### PR TITLE
chore(flags): add feature flags internal docs

### DIFF
--- a/docs/internal/feature-flags/database-interaction-patterns.md
+++ b/docs/internal/feature-flags/database-interaction-patterns.md
@@ -1,0 +1,291 @@
+# Database Interaction Patterns
+
+This document explains how the Rust feature flags service interacts with PostgreSQL, including connection pooling, query routing, error handling, and observability.
+
+## Architecture overview
+
+The service uses a four-pool architecture to separate concerns and optimize for different access patterns:
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│                      PostgresRouter                             │
+├─────────────────────────────────────────────────────────────────┤
+│  ┌─────────────────┐  ┌─────────────────┐                       │
+│  │ persons_reader  │  │ persons_writer  │  ← Persons database   │
+│  └─────────────────┘  └─────────────────┘    (optional)         │
+│  ┌─────────────────┐  ┌─────────────────┐                       │
+│  │ non_persons_    │  │ non_persons_    │  ← Main database      │
+│  │ reader          │  │ writer          │                       │
+│  └─────────────────┘  └─────────────────┘                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+When the persons database is not configured separately, the persons pools alias to the non-persons pools, effectively creating a two-pool architecture.
+
+## Connection pooling
+
+### Pool configuration
+
+The service uses SQLx's `PgPool` with configurable parameters per pool:
+
+```rust
+pub struct PoolConfig {
+    pub min_connections: u32,        // Minimum idle connections to maintain
+    pub max_connections: u32,        // Maximum connections in the pool
+    pub acquire_timeout: Duration,   // Timeout for acquiring a connection
+    pub idle_timeout: Option<Duration>, // Close idle connections after this duration
+    pub test_before_acquire: bool,   // Validate connection health before use
+    pub statement_timeout_ms: Option<u64>, // PostgreSQL statement_timeout per connection
+}
+```
+
+### Default values
+
+| Parameter              | Library default | Service default | Purpose                                    |
+| ---------------------- | --------------- | --------------- | ------------------------------------------ |
+| `min_connections`      | 0               | 0 per pool      | Start with no connections, scale on demand |
+| `max_connections`      | 10              | 10              | Maximum connections per pool               |
+| `acquire_timeout`      | 10s             | 3s (test)       | Wait time for connection from pool         |
+| `idle_timeout`         | 300s (5 min)    | 300s            | Close unused connections                   |
+| `test_before_acquire`  | true            | true            | Validate connection before use             |
+| `statement_timeout_ms` | None            | 5000ms          | Cancel queries exceeding this duration     |
+
+### Per-pool statement timeouts
+
+Different pools can have different statement timeouts to match their workload:
+
+| Pool                 | Config key                                | Typical use                       |
+| -------------------- | ----------------------------------------- | --------------------------------- |
+| `non_persons_reader` | `NON_PERSONS_READER_STATEMENT_TIMEOUT_MS` | Flag definitions, team data       |
+| `persons_reader`     | `PERSONS_READER_STATEMENT_TIMEOUT_MS`     | Person lookups, cohort membership |
+| `persons_writer`     | `WRITER_STATEMENT_TIMEOUT_MS`             | Hash key override writes          |
+| `non_persons_writer` | `WRITER_STATEMENT_TIMEOUT_MS`             | Same as persons_writer            |
+
+Statement timeouts are set via `SET statement_timeout = {ms}` on each new connection using SQLx's `after_connect` hook.
+
+### Total connection count
+
+```text
+With persons DB routing enabled:  4 pools × max_connections
+With persons DB routing disabled: 2 pools × max_connections (pools are aliased)
+```
+
+For production with `max_connections=10`:
+
+- **Routing enabled**: 40 connections max per service instance
+- **Routing disabled**: 20 connections max per service instance
+
+## Query routing
+
+The `PostgresRouter` routes queries to the appropriate pool based on the table being accessed:
+
+```rust
+pub struct PostgresRouter {
+    pub persons_reader: PostgresReader,
+    pub persons_writer: PostgresWriter,
+    pub non_persons_reader: PostgresReader,
+    pub non_persons_writer: PostgresWriter,
+}
+```
+
+### Routing rules
+
+| Tables                                                                              | Pool            |
+| ----------------------------------------------------------------------------------- | --------------- |
+| `posthog_person`, `posthog_persondistinctid`, `posthog_featureflaghashkeyoverride`  | `persons_*`     |
+| `posthog_featureflag`, `posthog_team`, `posthog_grouptypemapping`, `posthog_cohort` | `non_persons_*` |
+
+### Usage pattern
+
+```rust
+// Read person data
+let mut conn = router.get_persons_reader().get_connection().await?;
+let person = sqlx::query("SELECT * FROM posthog_person WHERE id = $1")
+    .bind(person_id)
+    .fetch_optional(&mut *conn)
+    .await?;
+
+// Read flag definitions
+let mut conn = router.get_non_persons_reader().get_connection().await?;
+let flags = sqlx::query("SELECT * FROM posthog_featureflag WHERE team_id = $1")
+    .bind(team_id)
+    .fetch_all(&mut *conn)
+    .await?;
+```
+
+## Error handling
+
+### Transient error detection
+
+The `common_database` crate provides error classification for retry logic:
+
+```rust
+pub fn is_transient_error(error: &SqlxError) -> bool
+```
+
+Transient errors (suitable for retry):
+
+| SQLSTATE class | Meaning                                             |
+| -------------- | --------------------------------------------------- |
+| `08***`        | Connection exception                                |
+| `53***`        | Insufficient resources                              |
+| `57***`        | Operator intervention (includes query cancellation) |
+| `58***`        | System error                                        |
+| `40001`        | Serialization failure                               |
+| `40003`        | Statement completion unknown                        |
+| `40P01`        | Deadlock detected                                   |
+
+Non-transient errors (fail immediately):
+
+| SQLSTATE class | Meaning                          |
+| -------------- | -------------------------------- |
+| `23***`        | Integrity constraint violation   |
+| `42***`        | Syntax error or access violation |
+| `22***`        | Data exception                   |
+
+### Timeout detection
+
+```rust
+pub fn is_timeout_error(error: &SqlxError) -> bool
+pub fn extract_timeout_type(error: &SqlxError) -> Option<&'static str>
+```
+
+Timeout types detected:
+
+| Type                          | Source                             |
+| ----------------------------- | ---------------------------------- |
+| `pool_timeout`                | Pool acquisition timed out         |
+| `io_timeout`                  | Network/socket timeout             |
+| `protocol_timeout`            | Protocol-level timeout             |
+| `query_canceled`              | SQLSTATE 57014 (statement_timeout) |
+| `lock_not_available`          | SQLSTATE 55P03 (lock_timeout)      |
+| `idle_in_transaction_timeout` | SQLSTATE 25P03                     |
+
+### Foreign key constraint detection
+
+```rust
+pub fn is_foreign_key_constraint_error(error: &SqlxError) -> bool
+```
+
+Used for retrying hash key override writes when a person is deleted during the operation (race condition).
+
+## Retry strategies
+
+The service uses the `tokio-retry` crate with exponential backoff:
+
+### Read operations
+
+```rust
+let retry_strategy = ExponentialBackoff::from_millis(50)
+    .max_delay(Duration::from_millis(300))
+    .take(3)  // 3 attempts total
+    .map(jitter);
+```
+
+- **Initial delay**: 50ms
+- **Max delay**: 300ms
+- **Max attempts**: 3
+- **Retry on**: Transient errors only
+
+### Write operations
+
+```rust
+let retry_strategy = ExponentialBackoff::from_millis(100)
+    .max_delay(Duration::from_millis(300))
+    .take(2)  // 2 attempts for writes
+    .map(jitter);
+```
+
+- **Initial delay**: 100ms (slower to avoid overwhelming)
+- **Max delay**: 300ms
+- **Max attempts**: 2 (more conservative)
+- **Retry on**: Foreign key constraint errors (person deletion race)
+
+## Observability
+
+### Prometheus metrics
+
+| Metric                              | Labels                 | Purpose                        |
+| ----------------------------------- | ---------------------- | ------------------------------ |
+| `flags_db_connection_time`          | `pool`, `operation`    | Connection acquisition latency |
+| `flags_person_query_time`           | -                      | Person lookup query duration   |
+| `flags_definition_query_time`       | -                      | Flag definition query duration |
+| `flags_pool_utilization_ratio`      | `pool`                 | Pool utilization (0.0-1.0)     |
+| `flags_connection_hold_time_ms`     | `pool`, `operation`    | How long connections are held  |
+| `flags_hash_key_retries_total`      | `team_id`, `operation` | Retry counter                  |
+| `flags_flag_evaluation_error_total` | `error_type`           | Error counter                  |
+
+### Pool stats
+
+Each pool exposes stats via `get_pool_stats()`:
+
+```rust
+pub struct PoolStats {
+    pub size: u32,      // Current number of connections
+    pub num_idle: usize, // Connections not currently in use
+}
+```
+
+Utilization is calculated as: `(size - num_idle) / size`
+
+### Slow query warnings
+
+Queries exceeding 500ms are logged at WARN level with timing information.
+
+## Configuration reference
+
+### Environment variables
+
+| Variable                                  | Default      | Purpose                                         |
+| ----------------------------------------- | ------------ | ----------------------------------------------- |
+| `READ_DATABASE_URL`                       | required     | Main database read replica URL                  |
+| `WRITE_DATABASE_URL`                      | required     | Main database primary URL                       |
+| `PERSONS_READ_DATABASE_URL`               | empty        | Persons database read replica (enables routing) |
+| `PERSONS_WRITE_DATABASE_URL`              | empty        | Persons database primary (enables routing)      |
+| `MAX_PG_CONNECTIONS`                      | 10           | Max connections per pool                        |
+| `MIN_NON_PERSONS_READER_CONNECTIONS`      | 0            | Min idle connections for non-persons reader     |
+| `MIN_NON_PERSONS_WRITER_CONNECTIONS`      | 0            | Min idle connections for non-persons writer     |
+| `MIN_PERSONS_READER_CONNECTIONS`          | 0            | Min idle connections for persons reader         |
+| `MIN_PERSONS_WRITER_CONNECTIONS`          | 0            | Min idle connections for persons writer         |
+| `ACQUIRE_TIMEOUT_SECS`                    | 10           | Connection acquisition timeout                  |
+| `IDLE_TIMEOUT_SECS`                       | 300          | Idle connection timeout                         |
+| `TEST_BEFORE_ACQUIRE`                     | true         | Validate connections before use                 |
+| `NON_PERSONS_READER_STATEMENT_TIMEOUT_MS` | 0 (disabled) | Statement timeout for non-persons reads         |
+| `PERSONS_READER_STATEMENT_TIMEOUT_MS`     | 0 (disabled) | Statement timeout for persons reads             |
+| `WRITER_STATEMENT_TIMEOUT_MS`             | 0 (disabled) | Statement timeout for writes                    |
+
+### Tuning guidance
+
+**High traffic deployment**:
+
+```bash
+MAX_PG_CONNECTIONS=25  # Increase pool size
+MIN_NON_PERSONS_READER_CONNECTIONS=5  # Keep connections warm
+MIN_PERSONS_READER_CONNECTIONS=5
+```
+
+**Bursty traffic**:
+
+```bash
+IDLE_TIMEOUT_SECS=600  # Keep connections warm longer
+MIN_NON_PERSONS_READER_CONNECTIONS=3  # Pre-warm some connections
+```
+
+**Strict timeout enforcement**:
+
+```bash
+NON_PERSONS_READER_STATEMENT_TIMEOUT_MS=5000  # 5s for reads
+PERSONS_READER_STATEMENT_TIMEOUT_MS=5000
+WRITER_STATEMENT_TIMEOUT_MS=2000  # 2s for writes (should be fast)
+```
+
+## Related files
+
+| File                                                  | Purpose                                  |
+| ----------------------------------------------------- | ---------------------------------------- |
+| `rust/common/database/src/lib.rs`                     | Pool configuration, error classification |
+| `rust/feature-flags/src/database_pools.rs`            | Four-pool architecture                   |
+| `rust/feature-flags/src/database/postgres_router.rs`  | Query routing                            |
+| `rust/feature-flags/src/config.rs`                    | Environment configuration                |
+| `rust/feature-flags/src/flags/flag_matching_utils.rs` | Query patterns, retry logic              |
+| `rust/feature-flags/src/metrics/consts.rs`            | Metric constants                         |

--- a/docs/internal/feature-flags/experience-continuity.md
+++ b/docs/internal/feature-flags/experience-continuity.md
@@ -366,3 +366,9 @@ Ensure `$anon_distinct_id` is a **top-level field**, not nested in `person_prope
 - `/flags` endpoint logs for `anon_distinct_id` processing
 - Canonical log field: `hash_key_override_skipped` (optimization active)
 - Metric: `flags_experience_continuity_optimized_total`
+
+## See also
+
+- [Creating feature flags](https://posthog.com/docs/feature-flags/creating-feature-flags) - How to enable "persist flag across authentication steps"
+- [Client-side bootstrapping](https://posthog.com/docs/feature-flags/bootstrapping) - Alternative approach (incompatible with experience continuity)
+- [Feature flags troubleshooting](https://posthog.com/docs/feature-flags/common-questions) - Common issues and solutions

--- a/docs/internal/feature-flags/experience-continuity.md
+++ b/docs/internal/feature-flags/experience-continuity.md
@@ -1,0 +1,368 @@
+# Feature Flags Experience Continuity
+
+Experience continuity ensures users see consistent feature flag variants when transitioning from anonymous to identified state. Without it, a user might see variant A while anonymous, then suddenly switch to variant B after logging in.
+
+## Why the switch happens
+
+When evaluating a feature flag with multiple variants, PostHog determines which variant a user gets by hashing the `distinct_id`:
+
+1. Takes the user's `distinct_id` (e.g., `"anon_abc123"` or `"user@example.com"`)
+2. Combines it with the feature flag key
+3. Hashes the result to get a number between 0-100
+4. Uses that number to assign a variant based on the configured percentages
+
+For example, with a 50/50 A/B test:
+
+- Hash values 0-50 → Variant A
+- Hash values 51-100 → Variant B
+
+When a user logs in, their `distinct_id` changes, which produces a different hash value that can land in a different variant bucket:
+
+```text
+Anonymous:   hash("anon_abc123" + "my-flag") → 23 → Variant A
+Logged in:   hash("user@example.com" + "my-flag") → 67 → Variant B
+```
+
+This is the problem experience continuity solves.
+
+## How It Works
+
+When a user identifies, PostHog stores a "hash key override" that preserves the original anonymous `distinct_id` for future flag evaluations. This ensures the same hash bucket is used before and after identification.
+
+```text
+Anonymous visit: distinct_id = "anon_abc123" → hash bucket 42 → variant "control"
+User identifies:  distinct_id = "user_456"   → stored override: use "anon_abc123" for hashing
+Future requests:  distinct_id = "user_456"   → hash bucket 42 → variant "control" (consistent!)
+```
+
+## Key Concepts
+
+### When Overrides Are Written
+
+Hash key overrides are written during `/flags` requests that include `$anon_distinct_id`. They are **not** written during `identify()` calls.
+
+| SDK Type        | Behavior                                                                                              |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| **Web SDK**     | Automatic. When `identify()` is called, the SDK automatically reloads flags with `$anon_distinct_id`. |
+| **Server SDKs** | Manual. You must include `$anon_distinct_id` as a top-level field in `/flags` requests.               |
+
+### Flag Configuration
+
+A flag must have `ensure_experience_continuity = true` to participate in the override system. This setting is only meaningful for:
+
+- Person-based flags (not group-based)
+- Flags using `distinct_id` bucketing (not `device_id`)
+
+### Database Schema
+
+Overrides are stored in `posthog_featureflaghashkeyoverride`:
+
+```sql
+-- Schema (simplified)
+CREATE TABLE posthog_featureflaghashkeyoverride (
+    team_id          INTEGER,
+    person_id        INTEGER,      -- FK to Person (required!)
+    feature_flag_key VARCHAR(400),
+    hash_key         VARCHAR(400)  -- The original anonymous distinct_id
+);
+```
+
+## Request Flow
+
+### Web SDK (Automatic)
+
+```text
+1. User calls posthog.identify("user_456")
+2. SDK stores previous distinct_id internally
+3. SDK automatically calls /flags with:
+   {
+     "distinct_id": "user_456",
+     "$anon_distinct_id": "anon_abc123",  // Top-level field!
+     ...
+   }
+4. Server writes hash key overrides for continuity-enabled flags
+5. Server returns flag values using stored overrides
+```
+
+### Server SDK (Manual)
+
+```python
+# You must manually include $anon_distinct_id
+requests.post('https://app.posthog.com/flags/', json={
+    'token': 'phc_abc123',
+    'distinct_id': 'user_456',
+    '$anon_distinct_id': 'anon_abc123',  # Top-level, NOT in person_properties
+    'person_properties': {}
+})
+```
+
+## Implementation Details
+
+### Code Locations (Rust - Primary)
+
+| Component             | Location                                              |
+| --------------------- | ----------------------------------------------------- |
+| Flag evaluation entry | `rust/feature-flags/src/flags/flag_matching.rs`       |
+| Override processing   | `rust/feature-flags/src/flags/flag_matching_utils.rs` |
+| Request parsing       | `rust/feature-flags/src/handler/properties.rs`        |
+| Helper methods        | `rust/feature-flags/src/flags/flag_operations.rs`     |
+
+### Processing Logic
+
+1. **Check eligibility**: Does any flag have `ensure_experience_continuity = true`?
+2. **Determine if lookup needed**: See optimization section below
+3. **Write overrides**: For flags with continuity enabled, store the hash key
+4. **Read overrides**: Load stored overrides for flag evaluation
+5. **Apply overrides**: Use stored `hash_key` instead of current `distinct_id` for hashing
+
+### Read-After-Write Consistency
+
+When writing hash key overrides, the system reads from the **writer** database (not the replica) to avoid replication lag issues:
+
+```rust
+// flag_matching.rs:152-160
+let database_for_reading = if writing_hash_key_override {
+    self.router.get_persons_writer().clone()
+} else {
+    self.router.get_persons_reader().clone()
+};
+```
+
+## Optimization: Skipping Unnecessary Lookups
+
+**Added in PR #44293**
+
+Flags at 100% rollout with no multivariate variants return the same value for everyone, making the hash bucket irrelevant. The system can skip database lookups for these flags.
+
+### Config
+
+```bash
+OPTIMIZE_EXPERIENCE_CONTINUITY_LOOKUPS=true  # Default: true
+```
+
+### Helper Methods
+
+```rust
+// Does flag have continuity enabled AND is eligible (person-based, distinct_id bucketing)?
+flag.has_experience_continuity()
+
+// Does the flag have variants where hashing affects assignment?
+flag.has_hash_dependent_variants()
+
+// Does any condition group have < 100% rollout?
+flag.has_partial_rollout()
+
+// Final decision: should we do the database lookup?
+flag.needs_hash_key_override()
+```
+
+### When Lookups Are Skipped
+
+A flag **doesn't need** a hash key override lookup when:
+
+- It's at 100% rollout, AND
+- It has no multivariate variants (or a single variant at 100%)
+
+Example: A flag rolled out to everyone (`rollout_percentage: 100`) returns `true` for all users regardless of their hash bucket.
+
+### Metrics
+
+```text
+flags_experience_continuity_optimized_total{status="skipped"}   # Lookup was skipped
+flags_experience_continuity_optimized_total{status="eligible"}  # Could have been skipped (optimization disabled)
+```
+
+### Impact
+
+Query to identify teams that can benefit:
+
+```sql
+WITH continuity_flags AS (
+    SELECT
+        team_id,
+        CASE
+            WHEN jsonb_array_length(COALESCE(filters->'multivariate'->'variants', '[]'::jsonb)) > 0
+            THEN true ELSE false
+        END as has_variants,
+        CASE
+            WHEN EXISTS (
+                SELECT 1 FROM jsonb_array_elements(COALESCE(filters->'groups', '[]'::jsonb)) as g
+                WHERE (g->>'rollout_percentage')::numeric < 100
+            )
+            THEN true ELSE false
+        END as has_partial_rollout
+    FROM posthog_featureflag
+    WHERE ensure_experience_continuity = true
+        AND active = true
+        AND deleted = false
+),
+team_summary AS (
+    SELECT
+        team_id,
+        bool_and(NOT (has_variants OR has_partial_rollout)) as can_skip_lookup
+    FROM continuity_flags
+    GROUP BY team_id
+)
+SELECT
+    COUNT(*) as teams_with_continuity,
+    SUM(CASE WHEN can_skip_lookup THEN 1 ELSE 0 END) as teams_that_can_skip,
+    ROUND(100.0 * SUM(CASE WHEN can_skip_lookup THEN 1 ELSE 0 END) / COUNT(*), 1) as pct_optimizable
+FROM team_summary;
+```
+
+Common pattern: Teams enable continuity for A/B tests, roll out to 100%, but leave the setting enabled. This optimization handles that automatically.
+
+## Known Limitation: `person_profiles: 'identified_only'`
+
+Experience continuity **does not work** with `person_profiles: 'identified_only'` due to a race condition.
+
+### The Problem
+
+With `identified_only`, no person record exists until the `$identify` event is processed. But:
+
+1. SDK calls `identify()` which sends `$identify` event (async processing)
+2. SDK immediately sends `/flags` request with `$anon_distinct_id` (sync)
+3. `/flags` request arrives **before** the person is created
+4. Hash key override write fails silently (no person_id to reference)
+5. Client receives HTTP 200, clears `$anon_distinct_id`
+6. Person eventually created, but no retry happens
+
+### Why It Works with `person_profiles: 'always'`
+
+With `always`, a person record already exists from the anonymous visit. The `identify()` call adds the new `distinct_id` to the **existing** person, so the hash key override write succeeds.
+
+### Workaround Options
+
+1. **Use `person_profiles: 'always'`** - Creates person records for anonymous users
+2. **Use `$device_id` bucketing** - Stable across identity changes, no person needed
+3. **Future: Server signals success** - Client only clears `$anon_distinct_id` when confirmed
+
+## Alternative: Device ID Bucketing
+
+Because of the issues with experience continuity (such as not working for anonymous users), we've added a new bucketing identifier: `device_id` to address these issues. This feature is still under construction.
+
+Instead of using experience continuity (which requires database writes and person records), you can configure a flag to use `device_id` as the bucketing identifier. This is a simpler approach that works without person profiles.
+
+### Mechanism
+
+When a flag is configured for `device_id` bucketing:
+
+1. The hash is computed using the `$device_id` instead of `distinct_id`
+2. Since `$device_id` is stable across authentication state changes, users always get the same variant
+3. No hash key overrides are written or read from the database
+4. Works with `person_profiles: 'identified_only'` (no person record needed)
+
+```text
+Anonymous:   hash("device_xyz" + "my-flag") → 42 → Variant A
+Logged in:   hash("device_xyz" + "my-flag") → 42 → Variant A (same!)
+```
+
+### When to Use Device ID Bucketing
+
+| Scenario                                   | Recommendation                  |
+| ------------------------------------------ | ------------------------------- |
+| Anonymous user experiments (signup flows)  | ✅ device_id bucketing          |
+| Using `person_profiles: 'identified_only'` | ✅ device_id bucketing          |
+| Experiment must persist across devices     | ❌ Use distinct_id + continuity |
+| Already have person records (always mode)  | Either works                    |
+
+### Configuration
+
+Set `bucketing_identifier` on the feature flag:
+
+- `distinct_id` (default) - Uses `distinct_id`, supports experience continuity
+- `device_id` - Uses `$device_id`, no experience continuity needed
+
+### Code References
+
+The Rust service determines the hashed identifier in `flag_matching.rs:1234-1270`:
+
+```rust
+// Check if flag is configured for device_id bucketing
+if feature_flag.get_bucketing_identifier() == BucketingIdentifier::DeviceId {
+    if let Some(device_id) = &self.device_id {
+        if !device_id.is_empty() {
+            return Ok(device_id.clone());
+        }
+    }
+    // Falls back to distinct_id if device_id not provided
+}
+```
+
+### Current Status
+
+| Component               | Status     | PR/Notes                                          |
+| ----------------------- | ---------- | ------------------------------------------------- |
+| Rust flag evaluation    | ✅ Shipped | #41281                                            |
+| Database field          | ✅ Shipped | #42463                                            |
+| UI (behind flag)        | ✅ Shipped | #43576                                            |
+| AA test validation      | ✅ Running | #44532 (signup form AA test)                      |
+| SDK support             | 🔄 Pending | SDKs need to send `$device_id` in `/flags`        |
+| Local evaluation (SDKs) | 🔄 Pending | SDK local eval needs bucketing_identifier support |
+| Documentation           | 🔄 Pending | Public docs explaining when to use each approach  |
+
+### Request Payload
+
+The SDK must include `$device_id` as a top-level field in `/flags` requests:
+
+```json
+{
+  "token": "phc_abc123",
+  "distinct_id": "user_456",
+  "$device_id": "device_xyz789",
+  "person_properties": {}
+}
+```
+
+### Fallback Behavior
+
+If a flag is configured for `device_id` bucketing but no `$device_id` is provided in the request, the system falls back to using `distinct_id`. This maintains backward compatibility but may result in variant changes during identity transitions.
+
+## Debugging Guide
+
+### Check If Overrides Were Written
+
+```sql
+SELECT * FROM posthog_featureflaghashkeyoverride
+WHERE team_id = ?
+  AND person_id = ?
+  AND feature_flag_key = ?;
+```
+
+### Check Which Flags Have Continuity Enabled
+
+```sql
+SELECT key, ensure_experience_continuity, active, deleted
+FROM posthog_featureflag
+WHERE team_id = ?
+  AND ensure_experience_continuity = TRUE
+  AND active = TRUE
+  AND deleted = FALSE;
+```
+
+### Verify Request Structure
+
+Ensure `$anon_distinct_id` is a **top-level field**, not nested in `person_properties`:
+
+```json
+{
+  "distinct_id": "user_456",
+  "$anon_distinct_id": "anon_abc123",
+  "person_properties": {}
+}
+```
+
+### Common Issues
+
+| Symptom                              | Likely Cause               | Solution                                                    |
+| ------------------------------------ | -------------------------- | ----------------------------------------------------------- |
+| Variant changes after identify       | Override not written       | Check request includes `$anon_distinct_id` at top level     |
+| Only some flags maintain continuity  | Not all flags have setting | Enable `ensure_experience_continuity` on all relevant flags |
+| Overrides never written (server SDK) | Manual step missing        | Include `$anon_distinct_id` in `/flags` requests            |
+| Race condition failures              | `identified_only` mode     | Switch to `always` or use `device_id` bucketing             |
+
+### Logs to Check
+
+- `/flags` endpoint logs for `anon_distinct_id` processing
+- Canonical log field: `hash_key_override_skipped` (optimization active)
+- Metric: `flags_experience_continuity_optimized_total`

--- a/docs/internal/feature-flags/hypercache-system.md
+++ b/docs/internal/feature-flags/hypercache-system.md
@@ -76,7 +76,7 @@ The `token_based` parameter determines the cache key structure:
 | `get_if_none_match(key, etag)`    | ETag support for HTTP 304 responses                             |
 | `update_cache(key)`               | Force refresh from database                                     |
 | `set_cache_value(key, data)`      | Write to both Redis and S3                                      |
-| `clear_cache(key)`                | Delete from Redis and S3 (tests only)                           |
+| `clear_cache(key)`                | Delete from Redis and S3                                        |
 
 ### ETag support
 

--- a/docs/internal/feature-flags/hypercache-system.md
+++ b/docs/internal/feature-flags/hypercache-system.md
@@ -1,0 +1,296 @@
+# HyperCache System
+
+PostHog's HyperCache provides multi-tier caching with Redis → S3 → Database fallback. It's designed for high-traffic, read-heavy endpoints where pre-caching every possible value is worth the storage cost.
+
+## Architecture overview
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│                         Client Request                          │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                        Redis (Layer 1)                          │
+│                        TTL: 30 days                             │
+│                        Latency: ~1-2ms                          │
+└─────────────────────────────────────────────────────────────────┘
+                                │ miss
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                         S3 (Layer 2)                            │
+│                        Latency: ~50-100ms                       │
+│                        Warms Redis on hit                       │
+└─────────────────────────────────────────────────────────────────┘
+                                │ miss
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      Database (Layer 3)                         │
+│                        Latency: ~200-500ms                      │
+│                        Warms Redis + S3                         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Core components
+
+| Component        | File                                              | Purpose                          |
+| ---------------- | ------------------------------------------------- | -------------------------------- |
+| HyperCache class | `posthog/storage/hypercache.py`                   | Multi-tier cache with fallback   |
+| Local evaluation | `posthog/models/feature_flag/local_evaluation.py` | Feature flag caching for SDKs    |
+| Remote config    | `posthog/models/remote_config.py`                 | Client configuration caching     |
+| Team caching     | `posthog/models/team/team_caching.py`             | Authentication team lookup cache |
+
+## HyperCache class
+
+The `HyperCache` class in `posthog/storage/hypercache.py` provides the core caching logic.
+
+### Creating an instance
+
+```python
+from posthog.storage.hypercache import HyperCache
+
+cache = HyperCache(
+    namespace="feature_flags",           # Category name for metrics
+    value="flags_with_cohorts.json",     # Value identifier for metrics
+    load_fn=lambda key: load_data(key),  # Fallback loader when cache misses
+    token_based=False,                   # Use team ID (False) or API token (True)
+    cache_ttl=60 * 60 * 24 * 30,        # 30 days for cache hits
+    cache_miss_ttl=60 * 60 * 24,        # 1 day for cache misses
+    enable_etag=True,                    # Enable HTTP 304 support
+)
+```
+
+### Cache key formats
+
+The `token_based` parameter determines the cache key structure:
+
+- **Team ID-based** (`token_based=False`): `cache/teams/{team_id}/{namespace}/{value}`
+- **Token-based** (`token_based=True`): `cache/team_tokens/{api_token}/{namespace}/{value}`
+
+### Key methods
+
+| Method                            | Purpose                                                         |
+| --------------------------------- | --------------------------------------------------------------- |
+| `get_from_cache(key)`             | Get cached data, returns `None` on miss                         |
+| `get_from_cache_with_source(key)` | Returns `(data, source)` where source is `redis`, `s3`, or `db` |
+| `get_if_none_match(key, etag)`    | ETag support for HTTP 304 responses                             |
+| `update_cache(key)`               | Force refresh from database                                     |
+| `set_cache_value(key, data)`      | Write to both Redis and S3                                      |
+| `clear_cache(key)`                | Delete from Redis and S3 (tests only)                           |
+
+### ETag support
+
+HyperCache supports HTTP 304 "Not Modified" responses to reduce bandwidth:
+
+```python
+data, etag, modified = cache.get_if_none_match(team, client_etag)
+
+if not modified:
+    return HttpResponse(status=304, headers={"ETag": etag})
+else:
+    return JsonResponse(data, headers={"ETag": etag})
+```
+
+ETags are computed as SHA256 hashes of the JSON content.
+
+## Local evaluation caching
+
+Feature flag local evaluation uses two separate HyperCache instances in `posthog/models/feature_flag/local_evaluation.py`:
+
+```python
+# Full flags with cohort definitions (for smart clients)
+flags_hypercache = HyperCache(
+    namespace="feature_flags",
+    value="flags_with_cohorts.json",
+    load_fn=lambda key: _get_flags_response_for_local_evaluation(team, include_cohorts=True),
+    enable_etag=True,
+)
+
+# Simplified flags without cohorts (legacy)
+flags_without_cohorts_hypercache = HyperCache(
+    namespace="feature_flags",
+    value="flags_without_cohorts.json",
+    load_fn=lambda key: _get_flags_response_for_local_evaluation(team, include_cohorts=False),
+    enable_etag=True,
+)
+```
+
+All current SDKs support cohort evaluation locally, so the dual-cache strategy is legacy. The `flags_without_cohorts` cache exists for older SDK versions that couldn't handle cohort definitions. Once requests for flags without cohorts decline sufficiently, this cache can be removed.
+
+### Cache invalidation
+
+Django signals trigger cache updates when models change:
+
+```python
+@receiver([post_save, post_delete], sender=FeatureFlag)
+def feature_flag_changed(sender, instance, **kwargs):
+    transaction.on_commit(lambda: update_team_flags_cache.delay(instance.team_id))
+```
+
+Models that invalidate the flags cache:
+
+- `FeatureFlag` - Flag created, updated, or deleted
+- `Cohort` - Cohort properties changed
+- `FeatureFlagEvaluationTag` - Evaluation tags changed
+- `Tag` - Tag renamed
+
+## Remote config caching
+
+Remote config uses a different caching strategy than local evaluation. It prioritizes zero-overhead cache hits by using Redis-only caching for serving, with HyperCache used only for background sync operations.
+
+### Cache lookup flow
+
+```python
+def _get_config_via_cache(cls, token: str) -> dict:
+    key = f"remote_config/{token}/config"
+
+    data = cache.get(key)  # Direct Redis lookup
+    if data:
+        return data  # Cache hit - zero database calls
+
+    # Cache miss - query database and warm cache
+    remote_config = RemoteConfig.objects.select_related("team").get(team__api_token=token)
+    data = remote_config.build_config()
+    cache.set(key, data, timeout=CACHE_TIMEOUT)  # 1 day
+
+    return data
+```
+
+### No authentication
+
+Remote config endpoints have no authentication (`authentication_classes = []`). The token in the URL is treated as a public identifier, not a credential. This eliminates all authentication overhead for cache hits.
+
+### CDN integration
+
+When remote config changes, the system:
+
+1. Updates the database record
+2. Warms the HyperCache (Redis + S3)
+3. Updates the Redis serving cache
+4. Purges Cloudflare CDN cache
+
+## Team authentication caching
+
+Team objects are cached by API token in `posthog/models/team/team_caching.py` to avoid database lookups during authentication.
+
+### Cache format
+
+```python
+# Cache key
+f"team_token:{api_token}"
+
+# TTL: 5 days
+FIVE_DAYS = 60 * 60 * 24 * 5
+```
+
+### Usage
+
+```python
+from posthog.models.team.team_caching import get_team_in_cache, set_team_in_cache
+
+# Check cache first
+team = get_team_in_cache(api_token)
+if team is None:
+    team = Team.objects.get(api_token=api_token)
+    set_team_in_cache(api_token, team)
+```
+
+The cached team is serialized using `CachingTeamSerializer` and reconstructed as a `Team` instance on retrieval.
+
+## Cache TTL settings
+
+| Cache                 | Hit TTL | Miss TTL              |
+| --------------------- | ------- | --------------------- |
+| HyperCache (default)  | 30 days | 1 day                 |
+| Remote config serving | 1 day   | 1 day                 |
+| Team authentication   | 5 days  | N/A (deleted on miss) |
+
+## Performance characteristics
+
+| Scenario                     | Latency    | Database calls        |
+| ---------------------------- | ---------- | --------------------- |
+| Local evaluation (Redis hit) | ~1-2ms     | 0 (but auth overhead) |
+| Remote config (Redis hit)    | ~1ms       | 0                     |
+| S3 fallback                  | ~50-100ms  | 0                     |
+| Database fallback            | ~200-500ms | 1+                    |
+
+## Prometheus metrics
+
+| Metric                                     | Labels                         | Purpose                         |
+| ------------------------------------------ | ------------------------------ | ------------------------------- |
+| `posthog_hypercache_get_from_cache`        | `result`, `namespace`, `value` | Cache hit/miss tracking         |
+| `posthog_hypercache_sync`                  | `result`, `namespace`, `value` | Cache sync task outcomes        |
+| `posthog_hypercache_sync_duration_seconds` | `result`, `namespace`, `value` | Cache sync timing               |
+| `posthog_remote_config_via_cache`          | `result`                       | Remote config cache performance |
+
+Result labels: `hit_redis`, `hit_s3`, `hit_db`, `missing`, `batch_miss`
+
+## Debugging
+
+### Check Redis cache
+
+```bash
+# Local evaluation flags
+redis-cli get "cache/teams/{team_id}/feature_flags/flags_with_cohorts.json"
+
+# Remote config
+redis-cli get "remote_config/{api_token}/config"
+
+# Team authentication
+redis-cli get "team_token:{api_token}"
+```
+
+### Check cache source in responses
+
+Local evaluation responses include cache source information via Prometheus metrics. Check the `posthog_hypercache_get_from_cache` metric with the appropriate labels.
+
+### Force cache refresh
+
+```python
+from posthog.models.feature_flag.local_evaluation import update_flag_caches
+from posthog.models.team import Team
+
+team = Team.objects.get(id=123)
+update_flag_caches(team)
+```
+
+## Common issues
+
+| Symptom                      | Likely cause                         | Solution                              |
+| ---------------------------- | ------------------------------------ | ------------------------------------- |
+| Stale data after flag change | Signal not firing                    | Check transaction.on_commit is used   |
+| Cache misses in production   | Redis connection issues              | Check Redis connectivity and metrics  |
+| S3 fallback errors           | Object storage misconfigured         | Verify OBJECT_STORAGE_ENABLED setting |
+| ETag mismatches              | Non-deterministic JSON serialization | HyperCache uses `sort_keys=True`      |
+
+## Configuration
+
+```bash
+# Required
+REDIS_URL=redis://localhost:6379
+
+# For S3 fallback
+OBJECT_STORAGE_ENABLED=true
+AWS_S3_BUCKET_NAME=posthog-cache
+
+# Remote config CDN purge (optional)
+REMOTE_CONFIG_CDN_PURGE_ENDPOINT=https://api.cloudflare.com/...
+REMOTE_CONFIG_CDN_PURGE_TOKEN=...
+REMOTE_CONFIG_CDN_PURGE_DOMAINS=["cdn.example.com"]
+```
+
+## Related files
+
+- `posthog/storage/hypercache.py` - Core HyperCache implementation
+- `posthog/models/feature_flag/local_evaluation.py` - Local evaluation caching
+- `posthog/models/remote_config.py` - Remote config caching
+- `posthog/models/team/team_caching.py` - Team authentication caching
+- `posthog/tasks/feature_flags.py` - Cache update Celery tasks
+- `posthog/tasks/remote_config.py` - Remote config sync tasks
+
+## See also
+
+- [Server-side local evaluation](https://posthog.com/docs/feature-flags/local-evaluation) - Public docs on local evaluation
+- [Local evaluation in distributed environments](https://posthog.com/docs/feature-flags/local-evaluation/distributed-environments) - Using external cache providers
+- [Remote config](https://posthog.com/docs/feature-flags/remote-config) - Client-side configuration delivery
+- [Cutting feature flag costs](https://posthog.com/docs/feature-flags/cutting-costs) - Cost optimization strategies


### PR DESCRIPTION
## Problem

Getting acquainted with all the complexity of the feature-flags system can be daunting. To help new employees (and contributors), we need some internal documentation that highlights how the system is designed.

## Changes

Adds some internal markdown docs.

- database-interaction-patterns.md
- experience-continuity.md
- hypercache-system.md

## How did you test this code?

No code changes.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No.