### PR TITLE
chore: Retrigger image builds after migration_utils revert

### DIFF
--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -20,7 +20,7 @@ from ee.tasks.subscriptions import deliver_subscription_report_async
 
 LOGGER = get_logger(__name__)
 
-# Changed 28-Nov-2025
+# Changed 20260109-01
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Problem

Previous images were built between the migration_utils feature PR and its revert, leaving broken images in dev that fail with `ModuleNotFoundError: No module named 'migration_utils'`.

## Changes

Empty commit to trigger fresh image builds for all PostHog services.

The migration_utils feature was introduced and then reverted in quick succession:
1. `dd579b8cc3` - Added stranded migration detection (#43946)
2. `03106096e3` - Docker fix for missing migration_utils
3. `ebe0afd509` - Reverted original feature
4. `a8e87955df` - Reverted Docker fix

Some images were built from commits between steps 1-2, before the feature was fully reverted, causing the module not found error.

## How did you test this code?

This is a no-op change to trigger CI. Will verify:
- CI builds complete successfully
- Dev deployments use new images without migration_utils errors

## Publish to changelog?

no
