### PR TITLE
fix: left join team_id

### DIFF
--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -280,7 +280,9 @@ class HogQLPrinter(Visitor[str]):
         raise ImpossibleASTError(f"Unsupported dialect {self.dialect}")
 
     def visit_join_expr(self, node: ast.JoinExpr) -> JoinExprResponse:
+        # Constraints to add to the SELECT's WHERE clause (for most join types)
         extra_where: ast.Expr | None = None
+        # For LEFT JOINs, team_id goes in ON instead of WHERE to preserve NULL rows
         team_id_for_on_clause: ast.Expr | None = None
 
         join_strings = []

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -267,7 +267,9 @@ class HogQLPrinter(Visitor[str]):
         return []
 
     def _ensure_team_id_where_clause(
-        self, table_type: ast.TableType | ast.LazyTableType, node_type: ast.TableOrSelectType
+        self,
+        table_type: ast.TableType | ast.LazyTableType,
+        node_type: ast.TableOrSelectType,
     ):
         if self.dialect != "hogql":
             raise NotImplementedError("HogQLPrinter._ensure_team_id_where_clause not overridden")
@@ -278,8 +280,8 @@ class HogQLPrinter(Visitor[str]):
         raise ImpossibleASTError(f"Unsupported dialect {self.dialect}")
 
     def visit_join_expr(self, node: ast.JoinExpr) -> JoinExprResponse:
-        # return constraints we must place on the select query
         extra_where: ast.Expr | None = None
+        team_id_for_on_clause: ast.Expr | None = None
 
         join_strings = []
 
@@ -294,8 +296,14 @@ class HogQLPrinter(Visitor[str]):
             if not isinstance(table_type, ast.TableType) and not isinstance(table_type, ast.LazyTableType):
                 raise ImpossibleASTError(f"Invalid table type {type(table_type).__name__} in join_expr")
 
-            # :IMPORTANT: This assures a "team_id" where clause is present on every selected table.
-            extra_where = self._ensure_team_id_where_clause(table_type, node.type)
+            # :IMPORTANT: Ensures team_id filtering on every table. For LEFT JOINs, we add it to the
+            # ON clause (not WHERE) to preserve LEFT JOIN semantics - otherwise NULL rows get filtered out.
+            team_id_expr = self._ensure_team_id_where_clause(table_type, node.type)
+            is_left_join = node.join_type is not None and "LEFT" in node.join_type
+            if is_left_join and team_id_expr is not None and node.constraint is not None:
+                team_id_for_on_clause = team_id_expr
+            else:
+                extra_where = team_id_expr
 
             sql = self._print_table_ref(table_type, node)
 
@@ -363,7 +371,11 @@ class HogQLPrinter(Visitor[str]):
                 join_strings.append(sample_clause)
 
         if node.constraint is not None:
-            join_strings.append(f"{node.constraint.constraint_type} {self.visit(node.constraint)}")
+            if team_id_for_on_clause is not None:
+                combined_constraint = ast.And(exprs=[team_id_for_on_clause, node.constraint.expr])
+                join_strings.append(f"{node.constraint.constraint_type} {self.visit(combined_constraint)}")
+            else:
+                join_strings.append(f"{node.constraint.constraint_type} {self.visit(node.constraint)}")
 
         return JoinExprResponse(printed_sql=" ".join(join_strings), where=extra_where)
 

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -663,7 +663,9 @@ class ClickHousePrinter(HogQLPrinter):
         return escape_clickhouse_string(name, timezone=self._get_timezone())
 
     def _ensure_team_id_where_clause(
-        self, table_type: ast.TableType | ast.LazyTableType, node_type: ast.TableOrSelectType | None
+        self,
+        table_type: ast.TableType | ast.LazyTableType,
+        node_type: ast.TableOrSelectType | None,
     ):
         # :IMPORTANT: This assures a "team_id" where clause is present on every selected table.
         # Skip warehouse tables and tables with an explicit skip.

--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -105,7 +105,9 @@ class PostgresPrinter(HogQLPrinter):
         return table_type.table.to_printed_clickhouse(self.context)
 
     def _ensure_team_id_where_clause(
-        self, table_type: ast.TableType | ast.LazyTableType, node_type: ast.TableOrSelectType
+        self,
+        table_type: ast.TableType | ast.LazyTableType,
+        node_type: ast.TableOrSelectType,
     ):
         # Team ID filtering is not required for Postgres queries
         pass

--- a/posthog/hogql/test/__snapshots__/test_query.ambr
+++ b/posthog/hogql/test/__snapshots__/test_query.ambr
@@ -323,8 +323,8 @@
   SELECT session_replay_events.session_id AS session_id 
   FROM session_replay_events 
   WHERE equals(session_replay_events.team_id, 99999) 
-  GROUP BY session_replay_events.session_id) AS s LEFT JOIN events AS e ON equals(nullIf(nullIf(e.`$session_id`, ''), 'null'), s.session_id) 
-  WHERE and(equals(e.team_id, 99999), isNotNull(nullIf(nullIf(e.`$session_id`, ''), 'null'))) 
+  GROUP BY session_replay_events.session_id) AS s LEFT JOIN events AS e ON and(equals(e.team_id, 99999), ifNull(equals(nullIf(nullIf(e.`$session_id`, ''), 'null'), s.session_id), isNull(nullIf(nullIf(e.`$session_id`, ''), 'null')) and isNull(s.session_id))) 
+  WHERE isNotNull(nullIf(nullIf(e.`$session_id`, ''), 'null')) 
   LIMIT 10 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0
   
@@ -385,8 +385,8 @@
   SELECT session_replay_events.session_id AS session_id 
   FROM session_replay_events 
   WHERE equals(session_replay_events.team_id, 99999) 
-  GROUP BY session_replay_events.session_id) AS s LEFT JOIN events AS e ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), s.session_id) 
-  WHERE and(equals(e.team_id, 99999), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', ''))) 
+  GROUP BY session_replay_events.session_id) AS s LEFT JOIN events AS e ON and(equals(e.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), s.session_id), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '')) and isNull(s.session_id))) 
+  WHERE isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', '')) 
   LIMIT 10 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0
   


### PR DESCRIPTION
## Problem
```
select
e1.event,
e2.event
from events as e1
left join events as e2 on e1.blah = e2.blah
```

prints out with
`WHERE e1.team_id = 2 and e2.team_id = 2`

this means that the left join is never respected because if the e2 doesn't exist we don't return the row

## Changes
Move the team_id check to the ON for left joins

## How did you test this code?
Wrote tests

## Publish to changelog?
No