### PR TITLE
fix(logs): Update fetch_log_by_uuid to include workload for LogExplainQuery

### DIFF
--- a/products/logs/backend/explain.py
+++ b/products/logs/backend/explain.py
@@ -28,6 +28,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.clickhouse.client.connection import Workload
 from posthog.models import Team
 from posthog.rate_limit import (
     LLMAnalyticsSummarizationBurstThrottle,
@@ -188,8 +189,10 @@ def fetch_log_by_uuid(team: Team, uuid: str, timestamp: str) -> dict | None:
         },
     )
     response = execute_hogql_query(
+        query_type="LogExplainQuery",
         query=query,
         team=team,
+        workload=Workload.LOGS,
     )
     if not response.results:
         return None


### PR DESCRIPTION
## Problem

Workload was missing from the fetch_log_by_uuid query meaning it wasn't being routed to the logs CHI

## Changes

- Adds Workload.LOGS to the execute_hogql_query call in fetch_log_by_uuid
- Adds query_type="LogExplainQuery" for better query identification

## How did you test this code?

Local dev

## Publish to changelog?

No