### PR TITLE
feat(logs): Add log selection tracking and clear selection functionality

### DIFF
--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -377,6 +377,16 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
                 posthog.capture('logs log pinned')
             }
         },
+        toggleSelectLog: ({ logId }) => {
+            if (values.selectedLogIds[logId]) {
+                posthog.capture('logs log selected')
+            } else {
+                posthog.capture('logs log unselected')
+            }
+        },
+        clearSelection: () => {
+            posthog.capture('logs clear selection', { count: values.selectedCount })
+        },
         closeLogDetails: () => {
             // Restore focus to logs viewer when modal closes
             actions.setFocused(true)
@@ -465,6 +475,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
             void copyToClipboard(text, `${selectedLogs.length} log message${selectedLogs.length === 1 ? '' : 's'}`)
         },
         selectLogRange: ({ fromIndex, toIndex }) => {
+            posthog.capture('logs range selected', { count: Math.abs(toIndex - fromIndex) + 1 })
             const minIndex = Math.min(fromIndex, toIndex)
             const maxIndex = Math.max(fromIndex, toIndex)
             const newSelection: Record<string, boolean> = { ...values.selectedLogIds }
@@ -478,6 +489,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         },
         selectAll: ({ logsToSelect }) => {
             const logs = logsToSelect ?? values.logs
+            posthog.capture('logs select all', { count: logs.length })
             const newSelection: Record<string, boolean> = {}
             for (const log of logs) {
                 newSelection[log.uuid] = true


### PR DESCRIPTION
## Problem

We need to track user interactions with log selection features to better understand how users are interacting with the logs viewer.

## Changes

Added PostHog event tracking for the following log selection actions:
- Added tracking when users select or unselect individual logs
- Added tracking when users clear their log selection, including the count of logs that were selected
- Added tracking when users select a range of logs, including the count of logs selected
- Added tracking when users select all logs, including the count of logs selected

## How did you test this code?

Manually tested each selection action in the logs viewer and verified that the appropriate PostHog events were captured with the correct properties.

## Publish to changelog?

No