### PR TITLE
fix(persons): fix Split ID modal not closing on cancel

### DIFF
--- a/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
+++ b/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
@@ -21,13 +21,10 @@ export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>([
     props({} as SplitPersonLogicProps),
     key((props) => props.person.id ?? 'new'),
     path((key) => ['scenes', 'persons', 'mergeSplitPersonLogic', key]),
-    connect(() => ({
-        actions: [
-            personsLogic({ syncWithUrl: true }),
-            ['setListFilters', 'loadPersons', 'setPerson', 'setSplitMergeModalShown'],
-        ],
-        values: [personsLogic({ syncWithUrl: true }), ['persons']],
-    })),
+    connect({
+        actions: [personsLogic, ['setListFilters', 'loadPersons', 'setPerson', 'setSplitMergeModalShown']],
+        values: [personsLogic, ['persons']],
+    }),
     actions({
         setSelectedPersonToAssignSplit: (id: string) => ({ id }),
         cancel: true,


### PR DESCRIPTION
## Problem

The Split ID modal in the Person scene doesn't close when clicking the X button or Cancel button.

Fixes #40420

## Root Cause

`mergeSplitPersonLogic` was connecting to `personsLogic({ syncWithUrl: true })`, which creates a logic instance with key `'scene'`. However, `PersonScene` uses `personsLogic` bound to the scene with props `{ syncWithUrl: true, urlId: ... }`, which creates a logic instance with key `url_${urlId}`.

When `cancel` called `setSplitMergeModalShown(false)`, it was updating the wrong logic instance, so the modal never closed.

## Solution

Remove the explicit props from the `connect` call, allowing kea to use the logic instance that's already bound to the scene context.

## Changes
- `frontend/src/scenes/persons/mergeSplitPersonLogic.ts`: Changed `personsLogic({ syncWithUrl: true })` to `personsLogic` in the connect block

## How did you test this code?

The fix ensures the same logic instance is used by both the modal and the scene, so `setSplitMergeModalShown(false)` now correctly closes the modal.