### PR TITLE
feat(logs): implement caching for team logs check and update logic flow

### DIFF
--- a/products/logs/frontend/components/SetupPrompt/SetupPrompt.tsx
+++ b/products/logs/frontend/components/SetupPrompt/SetupPrompt.tsx
@@ -18,10 +18,10 @@ export const LogsSetupPrompt = ({
     children: React.ReactNode
     className?: string
 }): JSX.Element => {
-    const { teamHasLogs, teamHasLogsLoading, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
+    const { hasLogs, teamHasLogsLoading, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
     const { currentTeam } = useValues(teamLogic)
 
-    if (teamHasLogsLoading || !currentTeam) {
+    if ((teamHasLogsLoading && hasLogs === undefined) || !currentTeam) {
         return (
             <div className="flex justify-center">
                 <Spinner />
@@ -29,11 +29,11 @@ export const LogsSetupPrompt = ({
         )
     }
 
-    if (teamHasLogsCheckFailed || teamHasLogs === undefined) {
+    if (teamHasLogsCheckFailed || hasLogs === undefined) {
         return <>{children}</>
     }
 
-    if (!teamHasLogs) {
+    if (!hasLogs) {
         return <NoLogsPrompt className={className} />
     }
 


### PR DESCRIPTION
## Problem

`hasLogs` check makes an API call on every page load.

## Changes

Persist the result in localStorage. Once true, skip future API calls (logs don't disappear).

## How did you test this code?

Manual testing - verified API call is skipped on subsequent loads when logs exist.

## Publish to changelog

no