### PR TITLE
fix: django does not clear sessions that have expired so we have 5 years of expired sessions on disk

### DIFF
--- a/posthog/dags/common/common.py
+++ b/posthog/dags/common/common.py
@@ -20,6 +20,7 @@ class JobOwners(str, Enum):
     TEAM_POSTHOG_AI = "team-posthog-ai"
     TEAM_REVENUE_ANALYTICS = "team-revenue-analytics"
     TEAM_WEB_ANALYTICS = "team-web-analytics"
+    TEAM_DJANGO_INFRA = "team-django-infra"
 
 
 def dagster_tags(

--- a/posthog/dags/locations/analytics_platform.py
+++ b/posthog/dags/locations/analytics_platform.py
@@ -1,10 +1,11 @@
 import dagster
 
-from posthog.dags import sessions
+from posthog.dags import session_cleanup, sessions
 from posthog.dags.exported_asset_expiry_backfill import exported_asset_expiry_backfill_job
 from posthog.dags.sessions import sessions_backfill_job
 
 defs = dagster.Definitions(
     assets=[sessions.sessions_v3_backfill, sessions.sessions_v3_backfill_replay],
-    jobs=[sessions_backfill_job, exported_asset_expiry_backfill_job],
+    jobs=[sessions_backfill_job, exported_asset_expiry_backfill_job, session_cleanup.expired_session_cleanup_job],
+    schedules=[session_cleanup.expired_session_cleanup_schedule],
 )

--- a/posthog/dags/session_cleanup.py
+++ b/posthog/dags/session_cleanup.py
@@ -1,0 +1,52 @@
+import datetime
+
+from django.contrib.sessions.models import Session
+from django.utils import timezone
+
+import dagster
+
+from posthog.dags.common import JobOwners
+
+
+class ExpiredSessionCleanupConfig(dagster.Config):
+    days_expired: int = 7
+
+
+@dagster.op
+def clean_expired_sessions(
+    context: dagster.OpExecutionContext,
+    config: ExpiredSessionCleanupConfig,
+) -> int:
+    cutoff = timezone.now() - datetime.timedelta(days=config.days_expired)
+
+    deleted_count, _ = Session.objects.filter(expire_date__lt=cutoff).delete()
+
+    context.log.info(f"Deleted {deleted_count} expired sessions")
+    context.add_output_metadata(
+        {
+            "deleted_count": dagster.MetadataValue.int(deleted_count),
+            "cutoff_date": dagster.MetadataValue.text(cutoff.isoformat()),
+        }
+    )
+
+    return deleted_count
+
+
+@dagster.job(tags={"owner": JobOwners.TEAM_DJANGO_INFRA.value})
+def expired_session_cleanup_job():
+    clean_expired_sessions()
+
+
+@dagster.schedule(
+    job=expired_session_cleanup_job,
+    cron_schedule="0 4 * * *",
+    execution_timezone="UTC",
+    default_status=dagster.DefaultScheduleStatus.RUNNING,
+)
+def expired_session_cleanup_schedule(context: dagster.ScheduleEvaluationContext):
+    return dagster.RunRequest(
+        run_key=f"expired_session_cleanup_{context.scheduled_execution_time.strftime('%Y%m%d')}",
+        run_config={
+            "ops": {"clean_expired_sessions": {"config": ExpiredSessionCleanupConfig(days_expired=7).model_dump()}}
+        },
+    )

--- a/posthog/dags/tests/test_session_cleanup.py
+++ b/posthog/dags/tests/test_session_cleanup.py
@@ -1,0 +1,124 @@
+from datetime import timedelta
+
+import pytest
+from freezegun import freeze_time
+
+from django.contrib.sessions.models import Session
+from django.utils import timezone
+
+from dagster import build_op_context
+
+from posthog.dags.session_cleanup import (
+    ExpiredSessionCleanupConfig,
+    clean_expired_sessions,
+    expired_session_cleanup_job,
+)
+
+
+def create_session(expire_date: timezone.datetime) -> Session:
+    session = Session(
+        session_key=f"test_session_{expire_date.isoformat()}",
+        session_data="test_data",
+        expire_date=expire_date,
+    )
+    session.save()
+    return session
+
+
+class TestCleanExpiredSessionsOp:
+    @pytest.mark.django_db
+    @freeze_time("2024-01-15 12:00:00")
+    def test_deletes_sessions_expired_more_than_7_days_ago(self):
+        expired_8_days = create_session(timezone.now() - timedelta(days=8))
+        expired_7_days_1_sec = create_session(timezone.now() - timedelta(days=7, seconds=1))
+
+        context = build_op_context()
+        result = clean_expired_sessions(context, ExpiredSessionCleanupConfig(days_expired=7))
+
+        assert result == 2
+        assert not Session.objects.filter(session_key=expired_8_days.session_key).exists()
+        assert not Session.objects.filter(session_key=expired_7_days_1_sec.session_key).exists()
+
+    @pytest.mark.django_db
+    @freeze_time("2024-01-15 12:00:00")
+    def test_keeps_sessions_expired_7_days_or_less(self):
+        expired_exactly_7_days = create_session(timezone.now() - timedelta(days=7))
+        expired_6_days = create_session(timezone.now() - timedelta(days=6))
+        expired_1_day = create_session(timezone.now() - timedelta(days=1))
+
+        context = build_op_context()
+        result = clean_expired_sessions(context, ExpiredSessionCleanupConfig(days_expired=7))
+
+        assert result == 0
+        assert Session.objects.filter(session_key=expired_exactly_7_days.session_key).exists()
+        assert Session.objects.filter(session_key=expired_6_days.session_key).exists()
+        assert Session.objects.filter(session_key=expired_1_day.session_key).exists()
+
+    @pytest.mark.django_db
+    @freeze_time("2024-01-15 12:00:00")
+    def test_keeps_sessions_not_yet_expired(self):
+        not_expired = create_session(timezone.now() + timedelta(days=1))
+        expires_in_7_days = create_session(timezone.now() + timedelta(days=7))
+
+        context = build_op_context()
+        result = clean_expired_sessions(context, ExpiredSessionCleanupConfig(days_expired=7))
+
+        assert result == 0
+        assert Session.objects.filter(session_key=not_expired.session_key).exists()
+        assert Session.objects.filter(session_key=expires_in_7_days.session_key).exists()
+
+    @pytest.mark.django_db
+    @freeze_time("2024-01-15 12:00:00")
+    def test_deletes_multiple_stale_sessions(self):
+        stale_sessions = [
+            create_session(timezone.now() - timedelta(days=10)),
+            create_session(timezone.now() - timedelta(days=14)),
+            create_session(timezone.now() - timedelta(days=30)),
+        ]
+        fresh_session = create_session(timezone.now() - timedelta(days=3))
+
+        context = build_op_context()
+        result = clean_expired_sessions(context, ExpiredSessionCleanupConfig(days_expired=7))
+
+        assert result == 3
+        for session in stale_sessions:
+            assert not Session.objects.filter(session_key=session.session_key).exists()
+        assert Session.objects.filter(session_key=fresh_session.session_key).exists()
+
+    @pytest.mark.django_db
+    def test_handles_empty_table(self):
+        Session.objects.all().delete()
+
+        context = build_op_context()
+        result = clean_expired_sessions(context, ExpiredSessionCleanupConfig(days_expired=7))
+
+        assert result == 0
+        assert Session.objects.count() == 0
+
+    @pytest.mark.django_db
+    @freeze_time("2024-01-15 12:00:00")
+    def test_adds_metadata(self):
+        create_session(timezone.now() - timedelta(days=10))
+        create_session(timezone.now() - timedelta(days=14))
+
+        context = build_op_context()
+        clean_expired_sessions(context, ExpiredSessionCleanupConfig(days_expired=7))
+
+        metadata = context.get_output_metadata("result")
+        assert metadata["deleted_count"].value == 2
+
+
+class TestExpiredSessionCleanupJob:
+    @pytest.mark.django_db
+    @freeze_time("2024-01-15 12:00:00")
+    def test_job_execution_success(self):
+        stale_session = create_session(timezone.now() - timedelta(days=10))
+        fresh_session = create_session(timezone.now() - timedelta(days=3))
+
+        result = expired_session_cleanup_job.execute_in_process(
+            run_config={"ops": {"clean_expired_sessions": {"config": {"days_expired": 7}}}}
+        )
+
+        assert result.success
+        assert not Session.objects.filter(session_key=stale_session.session_key).exists()
+        assert Session.objects.filter(session_key=fresh_session.session_key).exists()

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -74,6 +74,7 @@
     'posthog.tasks.tasks.calculate_decide_usage',
     'posthog.tasks.tasks.check_async_migration_health',
     'posthog.tasks.tasks.check_flags_to_rollback',
+    'posthog.tasks.tasks.clean_stale_expired_sessions',
     'posthog.tasks.tasks.clean_stale_partials',
     'posthog.tasks.tasks.clear_clickhouse_deleted_person',
     'posthog.tasks.tasks.clickhouse_clear_removed_data',

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -74,7 +74,6 @@
     'posthog.tasks.tasks.calculate_decide_usage',
     'posthog.tasks.tasks.check_async_migration_health',
     'posthog.tasks.tasks.check_flags_to_rollback',
-    'posthog.tasks.tasks.clean_stale_expired_sessions',
     'posthog.tasks.tasks.clean_stale_partials',
     'posthog.tasks.tasks.clear_clickhouse_deleted_person',
     'posthog.tasks.tasks.clickhouse_clear_removed_data',


### PR DESCRIPTION
while reading about other things we discovered that Django does not clear expired sessions

looking in metabase we have hundreds of millions of expired rows

looking in pganalyze the index on the table is 95GB in US

let's periodically clean them

NB we should also manually clear them once before we start this since there are _so_ many