### PR TITLE
feat(dagster): add sensor for persons reconciliation job to automate chunked runs on ranges

### DIFF
--- a/posthog/dags/locations/ingestion.py
+++ b/posthog/dags/locations/ingestion.py
@@ -22,5 +22,8 @@ defs = dagster.Definitions(
         persons_new_backfill.persons_new_backfill_job,
         persons_without_distinct_ids_cleanup.persons_without_distinct_ids_cleanup_job,
     ],
+    sensors=[
+        person_property_reconciliation.person_property_reconciliation_scheduler,
+    ],
     resources=resources,
 )

--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -1292,6 +1292,9 @@ class ReconciliationSchedulerConfig(dagster.Config):
     backup_enabled: bool = True
     batch_size: int = 100
 
+    # Resource configuration - the env var name for the PG connection string
+    persons_db_env_var: str = "PERSONS_DB_WRITER_URL"  # Env var for Postgres connection URL
+
 
 def build_reconciliation_run_config(
     config: ReconciliationSchedulerConfig,
@@ -1327,7 +1330,7 @@ def build_reconciliation_run_config(
                     }
                 }
             },
-            "persons_database": {"config": {"connection_url": {"env": "PERSONS_DB_WRITER_URL"}}},
+            "persons_database": {"config": {"connection_url": {"env": config.persons_db_env_var}}},
         },
     }
 
@@ -1408,6 +1411,7 @@ def person_property_reconciliation_scheduler(context: dagster.SensorEvaluationCo
         dry_run=cursor_data.get("dry_run", False),
         backup_enabled=cursor_data.get("backup_enabled", True),
         batch_size=cursor_data.get("batch_size", 100),
+        persons_db_env_var=cursor_data.get("persons_db_env_var", "PERSONS_DB_WRITER_URL"),
     )
 
     # Count active runs for this job

--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -1352,7 +1352,7 @@ def person_property_reconciliation_scheduler(
     Configuration (set via Dagster UI or launchpad):
     - range_start/range_end: Team ID range to process (inclusive)
     - chunk_size: Number of team IDs per job (default 1000)
-    - max_concurrent: Max simultaneous jobs (default 20)
+    - max_concurrent: Max simultaneous jobs (default 5)
     - bug_window_start/end: Time window for the reconciliation
     - dry_run, backup_enabled, batch_size: Passed to each job
     """
@@ -1363,7 +1363,7 @@ def person_property_reconciliation_scheduler(
     if not sensor_config_raw:
         context.log.info(
             "No cursor set. Initialize the sensor by setting cursor to JSON config: "
-            '{"range_start": 1, "range_end": 10000, "chunk_size": 1000, "max_concurrent": 20, '
+            '{"range_start": 1, "range_end": 10000, "chunk_size": 1000, "max_concurrent": 5, '
             '"bug_window_start": "...", "bug_window_end": "...", "dry_run": false, '
             '"backup_enabled": true, "batch_size": 100}'
         )

--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -1268,3 +1268,192 @@ def person_property_reconciliation_job():
     team_ids = get_team_ids_to_reconcile()
     chunks = create_team_chunks(team_ids)
     chunks.map(reconcile_team_chunk)
+
+
+# --- Sensor-based scheduler for automated batch reconciliation ---
+
+
+class ReconciliationSchedulerConfig(dagster.Config):
+    """Configuration for the reconciliation scheduler sensor.
+
+    This sensor automates launching multiple reconciliation jobs across a range
+    of team IDs while respecting concurrency limits.
+    """
+
+    range_start: int  # First team_id (inclusive)
+    range_end: int  # Last team_id (inclusive)
+    chunk_size: int = 1000  # Team ID range per job run
+    max_concurrent: int = 20  # Maximum simultaneous job runs
+
+    # Base job configuration (applied to all runs)
+    bug_window_start: str  # ClickHouse format: "YYYY-MM-DD HH:MM:SS"
+    bug_window_end: str  # ClickHouse format: "YYYY-MM-DD HH:MM:SS"
+    dry_run: bool = False
+    backup_enabled: bool = True
+    batch_size: int = 100
+
+
+def build_reconciliation_run_config(
+    config: ReconciliationSchedulerConfig,
+    min_team_id: int,
+    max_team_id: int,
+) -> dict[str, Any]:
+    """Build run config for a single reconciliation job covering a team ID range."""
+    op_config = {
+        "bug_window_start": config.bug_window_start,
+        "bug_window_end": config.bug_window_end,
+        "min_team_id": min_team_id,
+        "max_team_id": max_team_id,
+        "dry_run": config.dry_run,
+        "backup_enabled": config.backup_enabled,
+        "batch_size": config.batch_size,
+    }
+
+    return {
+        "execution": {"config": {"max_concurrent": config.max_concurrent}},
+        "ops": {
+            "get_team_ids_to_reconcile": {"config": op_config},
+            "reconcile_team_chunk": {"config": op_config},
+        },
+        "resources": {
+            "cluster": {
+                "config": {
+                    "client_settings": {
+                        "lightweight_deletes_sync": "0",
+                        "max_execution_time": "0",
+                        "max_memory_usage": "0",
+                        "mutations_sync": "0",
+                        "receive_timeout": "900",
+                    }
+                }
+            },
+            "persons_database": {"config": {"connection_url": {"env": "PERSONS_DB_WRITER_URL"}}},
+        },
+    }
+
+
+@dagster.sensor(
+    job=person_property_reconciliation_job,
+    minimum_interval_seconds=30,
+    default_status=dagster.DefaultSensorStatus.STOPPED,
+)
+def person_property_reconciliation_scheduler(
+    context: dagster.SensorEvaluationContext,
+) -> dagster.SensorResult:
+    """
+    Sensor that automatically schedules person property reconciliation jobs.
+
+    Splits a team_id range into chunks and launches jobs up to max_concurrent,
+    tracking progress via cursor. Enable via Dagster UI after configuring.
+
+    Cursor format: JSON with 'next_chunk_start' tracking the next range to process.
+    When cursor reaches range_end, the sensor stops yielding new runs.
+
+    Configuration (set via Dagster UI or launchpad):
+    - range_start/range_end: Team ID range to process (inclusive)
+    - chunk_size: Number of team IDs per job (default 1000)
+    - max_concurrent: Max simultaneous jobs (default 20)
+    - bug_window_start/end: Time window for the reconciliation
+    - dry_run, backup_enabled, batch_size: Passed to each job
+    """
+    # Load sensor config - in production this comes from the sensor configuration in UI
+    # For now, we require it to be set via run config or environment
+    sensor_config_raw = context.cursor
+
+    if not sensor_config_raw:
+        context.log.info(
+            "No cursor set. Initialize the sensor by setting cursor to JSON config: "
+            '{"range_start": 1, "range_end": 10000, "chunk_size": 1000, "max_concurrent": 20, '
+            '"bug_window_start": "...", "bug_window_end": "...", "dry_run": false, '
+            '"backup_enabled": true, "batch_size": 100}'
+        )
+        return dagster.SensorResult(run_requests=[], cursor=None)
+
+    try:
+        cursor_data = json.loads(sensor_config_raw)
+    except json.JSONDecodeError:
+        context.log.warning(f"Invalid cursor JSON: {sensor_config_raw}")
+        return dagster.SensorResult(run_requests=[], cursor=sensor_config_raw)
+
+    # Extract config and progress
+    range_start = cursor_data.get("range_start", 1)
+    range_end = cursor_data.get("range_end", 10000)
+    chunk_size = cursor_data.get("chunk_size", 1000)
+    max_concurrent = cursor_data.get("max_concurrent", 20)
+    next_chunk_start = cursor_data.get("next_chunk_start", range_start)
+
+    # Check if we've completed the range
+    if next_chunk_start > range_end:
+        context.log.info(f"Reconciliation complete: processed all teams up to {range_end}")
+        return dagster.SensorResult(run_requests=[], cursor=sensor_config_raw)
+
+    # Build config object for run config generation
+    config = ReconciliationSchedulerConfig(
+        range_start=range_start,
+        range_end=range_end,
+        chunk_size=chunk_size,
+        max_concurrent=max_concurrent,
+        bug_window_start=cursor_data.get("bug_window_start", ""),
+        bug_window_end=cursor_data.get("bug_window_end", ""),
+        dry_run=cursor_data.get("dry_run", False),
+        backup_enabled=cursor_data.get("backup_enabled", True),
+        batch_size=cursor_data.get("batch_size", 100),
+    )
+
+    # Count active runs for this job
+    active_runs = context.instance.get_run_records(
+        dagster.RunsFilter(
+            job_name="person_property_reconciliation_job",
+            statuses=[
+                dagster.DagsterRunStatus.QUEUED,
+                dagster.DagsterRunStatus.NOT_STARTED,
+                dagster.DagsterRunStatus.STARTING,
+                dagster.DagsterRunStatus.STARTED,
+            ],
+        )
+    )
+    active_count = len(active_runs)
+
+    available_slots = max(0, max_concurrent - active_count)
+    if available_slots == 0:
+        context.log.info(f"At max concurrency ({active_count}/{max_concurrent}), waiting for slots")
+        return dagster.SensorResult(run_requests=[], cursor=sensor_config_raw)
+
+    context.log.info(f"Active runs: {active_count}/{max_concurrent}, available slots: {available_slots}")
+
+    # Generate run requests for available slots
+    run_requests: list[dagster.RunRequest] = []
+    current_start = next_chunk_start
+
+    while len(run_requests) < available_slots and current_start <= range_end:
+        chunk_end = min(current_start + chunk_size - 1, range_end)
+
+        run_config = build_reconciliation_run_config(
+            config=config,
+            min_team_id=current_start,
+            max_team_id=chunk_end,
+        )
+
+        run_key = f"reconcile_teams_{current_start}_{chunk_end}"
+        context.log.info(f"Scheduling run for teams {current_start}-{chunk_end}")
+
+        run_requests.append(
+            dagster.RunRequest(
+                run_key=run_key,
+                run_config=run_config,
+                tags={
+                    "reconciliation_range": f"{current_start}-{chunk_end}",
+                    "owner": JobOwners.TEAM_INGESTION.value,
+                },
+            )
+        )
+
+        current_start = chunk_end + 1
+
+    # Update cursor with next chunk to process
+    cursor_data["next_chunk_start"] = current_start
+    new_cursor = json.dumps(cursor_data)
+
+    context.log.info(f"Scheduled {len(run_requests)} runs, next_chunk_start: {current_start}")
+
+    return dagster.SensorResult(run_requests=run_requests, cursor=new_cursor)

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -5320,3 +5320,194 @@ class TestQueryTeamIdsFromClickHouse:
             )
 
         assert "min_team_id (100) cannot be greater than max_team_id (50)" in str(exc_info.value)
+
+
+class TestReconciliationSchedulerSensor:
+    """Tests for the person_property_reconciliation_scheduler sensor."""
+
+    def test_build_reconciliation_run_config(self):
+        """Test that run config is built correctly from scheduler config."""
+        from posthog.dags.person_property_reconciliation import (
+            ReconciliationSchedulerConfig,
+            build_reconciliation_run_config,
+        )
+
+        config = ReconciliationSchedulerConfig(
+            range_start=1,
+            range_end=10000,
+            chunk_size=1000,
+            max_concurrent=20,
+            bug_window_start="2024-01-06 20:01:00",
+            bug_window_end="2024-01-07 14:52:00",
+            dry_run=False,
+            backup_enabled=True,
+            batch_size=100,
+        )
+
+        run_config = build_reconciliation_run_config(config, min_team_id=1, max_team_id=1000)
+
+        assert run_config["ops"]["get_team_ids_to_reconcile"]["config"]["min_team_id"] == 1
+        assert run_config["ops"]["get_team_ids_to_reconcile"]["config"]["max_team_id"] == 1000
+        assert run_config["ops"]["get_team_ids_to_reconcile"]["config"]["bug_window_start"] == "2024-01-06 20:01:00"
+        assert run_config["ops"]["get_team_ids_to_reconcile"]["config"]["dry_run"] is False
+        assert run_config["ops"]["reconcile_team_chunk"]["config"]["backup_enabled"] is True
+        assert run_config["execution"]["config"]["max_concurrent"] == 20
+
+    def test_sensor_no_cursor_returns_empty(self):
+        """Test that sensor returns empty result when no cursor is set."""
+        from dagster import build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        context = build_sensor_context(cursor=None)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert result.run_requests == []
+        assert result.cursor is None
+
+    def test_sensor_invalid_cursor_json_returns_empty(self):
+        """Test that sensor handles invalid JSON cursor gracefully."""
+        from dagster import build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        context = build_sensor_context(cursor="not valid json {")
+        result = person_property_reconciliation_scheduler(context)
+
+        assert result.run_requests == []
+        assert result.cursor == "not valid json {"
+
+    def test_sensor_completed_range_returns_empty(self):
+        """Test that sensor returns empty when range is completed."""
+        from dagster import build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        cursor = json.dumps(
+            {
+                "range_start": 1,
+                "range_end": 1000,
+                "next_chunk_start": 1001,
+                "bug_window_start": "2024-01-06 20:01:00",
+                "bug_window_end": "2024-01-07 14:52:00",
+            }
+        )
+        context = build_sensor_context(cursor=cursor)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert result.run_requests == []
+
+    def test_sensor_at_max_concurrency_returns_empty(self):
+        """Test that sensor returns empty when at max concurrency."""
+        from dagster import DagsterInstance, build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        cursor = json.dumps(
+            {
+                "range_start": 1,
+                "range_end": 10000,
+                "chunk_size": 1000,
+                "max_concurrent": 2,
+                "next_chunk_start": 1,
+                "bug_window_start": "2024-01-06 20:01:00",
+                "bug_window_end": "2024-01-07 14:52:00",
+            }
+        )
+
+        mock_instance = MagicMock(spec=DagsterInstance)
+        mock_instance.get_run_records.return_value = [MagicMock(), MagicMock()]
+
+        context = build_sensor_context(cursor=cursor, instance=mock_instance)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert result.run_requests == []
+
+    def test_sensor_yields_runs_up_to_available_slots(self):
+        """Test that sensor yields correct number of runs based on available slots."""
+        from dagster import DagsterInstance, build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        cursor = json.dumps(
+            {
+                "range_start": 1,
+                "range_end": 5000,
+                "chunk_size": 1000,
+                "max_concurrent": 3,
+                "next_chunk_start": 1,
+                "bug_window_start": "2024-01-06 20:01:00",
+                "bug_window_end": "2024-01-07 14:52:00",
+            }
+        )
+
+        mock_instance = MagicMock(spec=DagsterInstance)
+        mock_instance.get_run_records.return_value = [MagicMock()]
+
+        context = build_sensor_context(cursor=cursor, instance=mock_instance)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert len(result.run_requests) == 2
+        assert result.run_requests[0].run_key == "reconcile_teams_1_1000"
+        assert result.run_requests[1].run_key == "reconcile_teams_1001_2000"
+
+        new_cursor = json.loads(result.cursor)
+        assert new_cursor["next_chunk_start"] == 2001
+
+    def test_sensor_handles_partial_final_chunk(self):
+        """Test that sensor correctly handles a final chunk smaller than chunk_size."""
+        from dagster import DagsterInstance, build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        cursor = json.dumps(
+            {
+                "range_start": 1,
+                "range_end": 1500,
+                "chunk_size": 1000,
+                "max_concurrent": 5,
+                "next_chunk_start": 1001,
+                "bug_window_start": "2024-01-06 20:01:00",
+                "bug_window_end": "2024-01-07 14:52:00",
+            }
+        )
+
+        mock_instance = MagicMock(spec=DagsterInstance)
+        mock_instance.get_run_records.return_value = []
+
+        context = build_sensor_context(cursor=cursor, instance=mock_instance)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert len(result.run_requests) == 1
+        assert result.run_requests[0].run_key == "reconcile_teams_1001_1500"
+
+        new_cursor = json.loads(result.cursor)
+        assert new_cursor["next_chunk_start"] == 1501
+
+    def test_sensor_run_request_has_correct_tags(self):
+        """Test that run requests include expected tags."""
+        from dagster import DagsterInstance, build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        cursor = json.dumps(
+            {
+                "range_start": 1,
+                "range_end": 2000,
+                "chunk_size": 1000,
+                "max_concurrent": 5,
+                "next_chunk_start": 1,
+                "bug_window_start": "2024-01-06 20:01:00",
+                "bug_window_end": "2024-01-07 14:52:00",
+            }
+        )
+
+        mock_instance = MagicMock(spec=DagsterInstance)
+        mock_instance.get_run_records.return_value = []
+
+        context = build_sensor_context(cursor=cursor, instance=mock_instance)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert len(result.run_requests) == 2
+        assert result.run_requests[0].tags["reconciliation_range"] == "1-1000"
+        assert result.run_requests[0].tags["owner"] == "team-ingestion"

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -5363,6 +5363,7 @@ class TestReconciliationSchedulerSensor:
         result = person_property_reconciliation_scheduler(context)
 
         assert isinstance(result, SkipReason)
+        assert result.skip_message is not None
         assert "No cursor set" in result.skip_message
 
     def test_sensor_invalid_cursor_json_returns_skip_reason(self):
@@ -5375,6 +5376,7 @@ class TestReconciliationSchedulerSensor:
         result = person_property_reconciliation_scheduler(context)
 
         assert isinstance(result, SkipReason)
+        assert result.skip_message is not None
         assert "Invalid cursor JSON" in result.skip_message
 
     def test_sensor_completed_range_returns_skip_reason(self):
@@ -5396,6 +5398,7 @@ class TestReconciliationSchedulerSensor:
         result = person_property_reconciliation_scheduler(context)
 
         assert isinstance(result, SkipReason)
+        assert result.skip_message is not None
         assert "complete" in result.skip_message.lower()
 
     def test_sensor_at_max_concurrency_returns_skip_reason(self):
@@ -5423,11 +5426,12 @@ class TestReconciliationSchedulerSensor:
         result = person_property_reconciliation_scheduler(context)
 
         assert isinstance(result, SkipReason)
+        assert result.skip_message is not None
         assert "max concurrency" in result.skip_message.lower()
 
     def test_sensor_yields_runs_up_to_available_slots(self):
         """Test that sensor yields correct number of runs based on available slots."""
-        from dagster import DagsterInstance, build_sensor_context
+        from dagster import DagsterInstance, SensorResult, build_sensor_context
 
         from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
 
@@ -5449,16 +5453,19 @@ class TestReconciliationSchedulerSensor:
         context = build_sensor_context(cursor=cursor, instance=mock_instance)
         result = person_property_reconciliation_scheduler(context)
 
+        assert isinstance(result, SensorResult)
+        assert result.run_requests is not None
         assert len(result.run_requests) == 2
         assert result.run_requests[0].run_key == "reconcile_teams_1_1000"
         assert result.run_requests[1].run_key == "reconcile_teams_1001_2000"
 
+        assert result.cursor is not None
         new_cursor = json.loads(result.cursor)
         assert new_cursor["next_chunk_start"] == 2001
 
     def test_sensor_handles_partial_final_chunk(self):
         """Test that sensor correctly handles a final chunk smaller than chunk_size."""
-        from dagster import DagsterInstance, build_sensor_context
+        from dagster import DagsterInstance, SensorResult, build_sensor_context
 
         from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
 
@@ -5480,15 +5487,18 @@ class TestReconciliationSchedulerSensor:
         context = build_sensor_context(cursor=cursor, instance=mock_instance)
         result = person_property_reconciliation_scheduler(context)
 
+        assert isinstance(result, SensorResult)
+        assert result.run_requests is not None
         assert len(result.run_requests) == 1
         assert result.run_requests[0].run_key == "reconcile_teams_1001_1500"
 
+        assert result.cursor is not None
         new_cursor = json.loads(result.cursor)
         assert new_cursor["next_chunk_start"] == 1501
 
     def test_sensor_run_request_has_correct_tags(self):
         """Test that run requests include expected tags."""
-        from dagster import DagsterInstance, build_sensor_context
+        from dagster import DagsterInstance, SensorResult, build_sensor_context
 
         from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
 
@@ -5510,6 +5520,8 @@ class TestReconciliationSchedulerSensor:
         context = build_sensor_context(cursor=cursor, instance=mock_instance)
         result = person_property_reconciliation_scheduler(context)
 
+        assert isinstance(result, SensorResult)
+        assert result.run_requests is not None
         assert len(result.run_requests) == 2
         assert result.run_requests[0].tags["reconciliation_range"] == "1-1000"
         assert result.run_requests[0].tags["owner"] == "team-ingestion"
@@ -5532,6 +5544,7 @@ class TestReconciliationSchedulerSensor:
         result = person_property_reconciliation_scheduler(context)
 
         assert isinstance(result, SkipReason)
+        assert result.skip_message is not None
         assert "range_start" in result.skip_message
         assert "range_end" in result.skip_message
 
@@ -5554,6 +5567,7 @@ class TestReconciliationSchedulerSensor:
         result = person_property_reconciliation_scheduler(context)
 
         assert isinstance(result, SkipReason)
+        assert result.skip_message is not None
         assert "chunk_size" in result.skip_message
 
     def test_sensor_validates_max_concurrent_positive(self):
@@ -5575,6 +5589,7 @@ class TestReconciliationSchedulerSensor:
         result = person_property_reconciliation_scheduler(context)
 
         assert isinstance(result, SkipReason)
+        assert result.skip_message is not None
         assert "max_concurrent" in result.skip_message
 
     def test_sensor_validates_max_concurrent_cap(self):
@@ -5596,4 +5611,5 @@ class TestReconciliationSchedulerSensor:
         result = person_property_reconciliation_scheduler(context)
 
         assert isinstance(result, SkipReason)
+        assert result.skip_message is not None
         assert "exceeds cap" in result.skip_message.lower()


### PR DESCRIPTION
## Problem
Automate bulk launch of chunked team ID range jobs. Run instructions:

In the UI: Sensors → person_property_reconciliation_scheduler → Edit cursor → paste the JSON → Save → Start sensor.

```
{
  "range_start": 1,
  "range_end": 10000,
  "chunk_size": 1000,
  "max_concurrent_jobs": 5,
  "max_concurrent_tasks": 10,
  "bug_window_start": "2026-01-06 20:01:00",
  "bug_window_end": "2026-01-07 14:52:00",
  "dry_run": false,
  "backup_enabled": true,
  "batch_size": 100
}
```
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
