### PR TITLE
feat(saved-insights): add sorting to name column in saved insights

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -782,7 +782,7 @@ export function SavedInsights(): JSX.Element {
                     </>
                 )
             },
-            sorter: (a, b) => a.name.localeCompare(b.name),
+            sorter: (a, b) => (a.name || summarizeInsight(a.query)).localeCompare(b.name || summarizeInsight(b.query)),
         },
         ...(hasTagging
             ? [

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -782,6 +782,7 @@ export function SavedInsights(): JSX.Element {
                     </>
                 )
             },
+            sorter: (a, b) => a.name.localeCompare(b.name),
         },
         ...(hasTagging
             ? [


### PR DESCRIPTION
## Problem
Currently there's no way to filter insights by name.
Closes #25750
## Changes
<!-- If there are frontend changes, please include screenshots. -->
- Adds the sorter to the `Name` column
<img width="1137" height="948" alt="Screenshot 2026-01-11 at 4 41 02 PM" src="https://github.com/user-attachments/assets/f6e408e0-9d72-4215-928f-293aa46f7eee" />

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
1 - Created some Insights with different alphabet letters
2 - Tested that clicking in the sort arrows ensures the correct sorting

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
