### PR TITLE
feat(llma): add data-attr to trace view tabs for autocapture

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -827,6 +827,7 @@ const EventContent = React.memo(
                                 {
                                     key: TraceViewMode.Conversation,
                                     label: 'Conversation',
+                                    'data-attr': 'llma-trace-conversation-tab',
                                     content: (
                                         <>
                                             {isTopLevelTraceWithoutContent ? (
@@ -916,6 +917,7 @@ const EventContent = React.memo(
                                 {
                                     key: TraceViewMode.Raw,
                                     label: 'Raw',
+                                    'data-attr': 'llma-trace-raw-tab',
                                     content: (
                                         <div className="p-2">
                                             <JSONViewer src={event} collapsed={2} />
@@ -934,6 +936,7 @@ const EventContent = React.memo(
                                                       </LemonTag>
                                                   </>
                                               ),
+                                              'data-attr': 'llma-trace-summary-tab',
                                               content: (
                                                   <SummaryViewDisplay
                                                       trace={!isLLMEvent(event) ? event : undefined}
@@ -950,6 +953,7 @@ const EventContent = React.memo(
                                           {
                                               key: TraceViewMode.Evals,
                                               label: 'Evaluations',
+                                              'data-attr': 'llma-trace-evals-tab',
                                               content: (
                                                   <EvalsTabContent
                                                       generationEventId={event.id}


### PR DESCRIPTION
## Problem

Need to track tab engagement in LLM analytics trace view for GA metrics.

Part of #44733

## Changes

Add `data-attr` attributes to all trace view tabs (Conversation, Raw, Summary, Evaluations) to enable PostHog autocapture tracking.

## How did you test this code?

Manually verified data-attr attributes are present in the rendered DOM when viewing a trace.

## Publish to changelog?

No