### PR TITLE
feat(llma): add feedback UI for summarization

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -827,6 +827,7 @@ const EventContent = React.memo(
                                 {
                                     key: TraceViewMode.Conversation,
                                     label: 'Conversation',
+                                    'data-attr': 'llma-trace-conversation-tab',
                                     content: (
                                         <>
                                             {isTopLevelTraceWithoutContent ? (
@@ -916,6 +917,7 @@ const EventContent = React.memo(
                                 {
                                     key: TraceViewMode.Raw,
                                     label: 'Raw',
+                                    'data-attr': 'llma-trace-raw-tab',
                                     content: (
                                         <div className="p-2">
                                             <JSONViewer src={event} collapsed={2} />
@@ -934,6 +936,7 @@ const EventContent = React.memo(
                                                       </LemonTag>
                                                   </>
                                               ),
+                                              'data-attr': 'llma-trace-summary-tab',
                                               content: (
                                                   <SummaryViewDisplay
                                                       trace={!isLLMEvent(event) ? event : undefined}
@@ -950,6 +953,7 @@ const EventContent = React.memo(
                                           {
                                               key: TraceViewMode.Evals,
                                               label: 'Evaluations',
+                                              'data-attr': 'llma-trace-evals-tab',
                                               content: (
                                                   <EvalsTabContent
                                                       generationEventId={event.id}

--- a/products/llm_analytics/frontend/summary-view/SummaryViewDisplay.tsx
+++ b/products/llm_analytics/frontend/summary-view/SummaryViewDisplay.tsx
@@ -5,6 +5,7 @@
  */
 import { useActions, useValues } from 'kea'
 
+import { IconThumbsDown, IconThumbsUp } from '@posthog/icons'
 import { LemonButton, LemonSegmentedButton } from '@posthog/lemon-ui'
 
 import { Spinner } from 'lib/lemon-ui/Spinner'
@@ -34,8 +35,8 @@ interface SummaryViewLogicValues {
 
 export function SummaryViewDisplay({ trace, event, tree, autoGenerate }: SummaryViewDisplayProps): JSX.Element {
     const logic = summaryViewLogic({ trace, event, tree, autoGenerate })
-    const { summaryData, summaryDataLoading, summaryMode } = useValues(logic)
-    const { generateSummary, setSummaryMode, regenerateSummary } = useActions(logic)
+    const { summaryData, summaryDataLoading, summaryMode, feedbackGiven } = useValues(logic)
+    const { generateSummary, setSummaryMode, regenerateSummary, reportFeedback } = useActions(logic)
     const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
     // Compute derived values from props
@@ -222,7 +223,37 @@ export function SummaryViewDisplay({ trace, event, tree, autoGenerate }: Summary
 
                     <div className="flex-none">
                         <div className="prose prose-sm max-w-none border rounded p-4 bg-bg-light overflow-x-auto">
-                            <SummaryRenderer summary={summaryData.summary} trace={trace} event={event} tree={tree} />
+                            <SummaryRenderer
+                                summary={summaryData.summary}
+                                trace={trace}
+                                event={event}
+                                tree={tree}
+                                headerActions={
+                                    <div className="flex gap-1 items-center not-prose">
+                                        <span className="text-muted text-xs mr-1">
+                                            {feedbackGiven !== null ? 'Thanks!' : 'Helpful?'}
+                                        </span>
+                                        <LemonButton
+                                            size="xsmall"
+                                            icon={<IconThumbsUp />}
+                                            onClick={() => reportFeedback(true)}
+                                            tooltip="Helpful"
+                                            disabled={feedbackGiven !== null}
+                                            active={feedbackGiven === true}
+                                            data-attr="llma-summary-feedback-positive"
+                                        />
+                                        <LemonButton
+                                            size="xsmall"
+                                            icon={<IconThumbsDown />}
+                                            onClick={() => reportFeedback(false)}
+                                            tooltip="Not helpful"
+                                            disabled={feedbackGiven !== null}
+                                            active={feedbackGiven === false}
+                                            data-attr="llma-summary-feedback-negative"
+                                        />
+                                    </div>
+                                }
+                            />
                         </div>
                     </div>
 

--- a/products/llm_analytics/frontend/summary-view/components/SummaryRenderer.tsx
+++ b/products/llm_analytics/frontend/summary-view/components/SummaryRenderer.tsx
@@ -15,9 +15,10 @@ export interface SummaryRendererProps {
     trace?: LLMTrace
     event?: LLMTraceEvent
     tree?: any[]
+    headerActions?: React.ReactNode
 }
 
-export function SummaryRenderer({ summary, trace, event, tree }: SummaryRendererProps): JSX.Element {
+export function SummaryRenderer({ summary, trace, event, tree, headerActions }: SummaryRendererProps): JSX.Element {
     const logic = summaryViewLogic({ trace, event, tree })
     const { isFlowExpanded, isSummaryExpanded, isNotesExpanded } = useValues(logic)
     const { toggleFlowExpanded, toggleSummaryExpanded, toggleNotesExpanded } = useActions(logic)
@@ -31,8 +32,11 @@ export function SummaryRenderer({ summary, trace, event, tree }: SummaryRenderer
 
     return (
         <div className="space-y-4">
-            {/* Title */}
-            <h3 className="text-lg font-semibold">{summary.title}</h3>
+            {/* Title with optional actions */}
+            <div className="flex items-center justify-between gap-4">
+                <h3 className="text-lg font-semibold m-0">{summary.title}</h3>
+                {headerActions}
+            </div>
 
             {/* Flow Diagram - Collapsible ASCII */}
             <div className="border border-border rounded">


### PR DESCRIPTION
## Problem

Need user feedback on AI-generated summaries to measure quality and improve the feature for GA.

Part of #44733

## Changes

- Add thumbs up/down buttons in the summary header next to the title
- Track `llma summarization feedback` event with rating, entity type, and mode
- Feedback state resets when a new summary is generated

## How did you test this code?

Manually tested by generating a summary and clicking feedback buttons. Verified event captured in PostHog.

## Publish to changelog?

No