### PR TITLE
chore(llm-analytics): remove alpha tag from summarization

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -926,14 +926,7 @@ const EventContent = React.memo(
                                     ? [
                                           {
                                               key: TraceViewMode.Summary,
-                                              label: (
-                                                  <>
-                                                      Summary{' '}
-                                                      <LemonTag className="ml-1" type="completion">
-                                                          Alpha
-                                                      </LemonTag>
-                                                  </>
-                                              ),
+                                              label: 'Summary',
                                               content: (
                                                   <SummaryViewDisplay
                                                       trace={!isLLMEvent(event) ? event : undefined}


### PR DESCRIPTION
## Problem

Preparing trace summarization for GA release.

Part of #44733

## Changes

Remove the "Alpha" LemonTag from the Summary tab label in the trace view.

## How did you test this code?

Visual verification that tab displays "Summary" without the Alpha tag.

## Publish to changelog?

No - this is just removing the alpha indicator, the feature itself will be announced via changelog.