### PR TITLE
chore(llma): remove text view feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -277,7 +277,6 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_SESSION_SUMMARIZATION: 'llm-analytics-session-summarization', // owner: #team-llm-analytics
     LLM_ANALYTICS_SESSIONS_VIEW: 'llm-analytics-sessions-view', // owner: #team-llm-analytics
     LLM_ANALYTICS_SUMMARIZATION: 'llm-analytics-summarization', // owner: #team-llm-analytics
-    LLM_ANALYTICS_TEXT_VIEW: 'llm-analytics-text-view', // owner: #team-llm-analytics
     LLM_ANALYTICS_TRANSLATION: 'llm-analytics-translation', // owner: #team-llm-analytics
     LLM_ANALYTICS_PROMPTS: 'llm-analytics-prompts', // owner: #team-llm-analytics
     LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT: 'llm-observability-show-input-output', // owner: #team-llm-analytics

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -842,9 +842,7 @@ const EventContent = React.memo(
                                                         </>
                                                     }
                                                 />
-                                            ) : displayOption === DisplayOption.TextView &&
-                                              (featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TEXT_VIEW] ||
-                                                  featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]) ? (
+                                            ) : displayOption === DisplayOption.TextView ? (
                                                 isLLMEvent(event) &&
                                                 (event.event === '$ai_generation' ||
                                                     event.event === '$ai_span' ||
@@ -1046,7 +1044,6 @@ function CopyTraceButton({ trace, tree }: { trace: LLMTrace; tree: EnrichedTrace
 function DisplayOptionsSelect(): JSX.Element {
     const { displayOption } = useValues(llmAnalyticsTraceLogic)
     const { setDisplayOption } = useActions(llmAnalyticsTraceLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const displayOptions = [
         {
@@ -1061,17 +1058,12 @@ function DisplayOptionsSelect(): JSX.Element {
             tooltip: 'Focus on the most recent input and final output',
             'data-attr': 'llma-trace-display-expand-last',
         },
-        ...(featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TEXT_VIEW] ||
-        featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
-            ? [
-                  {
-                      value: DisplayOption.TextView,
-                      label: 'Text view',
-                      tooltip: 'Simple human readable text view, for humans',
-                      'data-attr': 'llma-trace-display-text-view',
-                  },
-              ]
-            : []),
+        {
+            value: DisplayOption.TextView,
+            label: 'Text view',
+            tooltip: 'Simple human readable text view, for humans',
+            'data-attr': 'llma-trace-display-text-view',
+        },
     ]
 
     return (


### PR DESCRIPTION
## Problem

The text view feature in LLM analytics was gated behind the `llm-analytics-text-view` feature flag during development and is now ready for general availability.

## Changes

- Remove feature flag checks for `LLM_ANALYTICS_TEXT_VIEW` in `LLMAnalyticsTraceScene.tsx`
- Remove the feature flag constant from `constants.tsx`

## How did you test this code?

Code review only - removes conditional logic to make feature always available.

## Publish to changelog?

No