### PR TITLE
fix: shift parameters into query parameters

### DIFF
--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -812,25 +812,28 @@ def find_partitions_to_cleanup(
     cluster: dagster.ResourceParam[ClickhouseCluster],
 ) -> list[int]:
     """Find partitions that contain old events for the specified teams."""
-    team_ids_str = ", ".join(str(tid) for tid in config.team_ids)
-
     query = f"""
         SELECT toYYYYMM(timestamp) as partition, count(1) as rows
         FROM {EVENTS_DATA_TABLE()}
-        WHERE team_id IN ({team_ids_str})
-        AND age('month', timestamp, now()) >= {config.min_age_months}
+        WHERE team_id IN %(team_ids)s
+        AND age('month', timestamp, now()) >= %(min_age_months)s
         GROUP BY partition
         ORDER BY partition DESC
     """
 
-    results = cluster.any_host_by_role(Query(query), NodeRole.DATA).result()
+    parameters = {
+        "team_ids": list(config.team_ids),
+        "min_age_months": config.min_age_months,
+    }
+
+    results = cluster.any_host_by_role(Query(query, parameters=parameters), NodeRole.DATA).result()
     partitions = [partition for partition, _rows in results]
 
     context.add_output_metadata(
         {
             "partitions_found": dagster.MetadataValue.int(len(partitions)),
             "partitions": dagster.MetadataValue.text(", ".join(str(p) for p in partitions)),
-            "team_ids": dagster.MetadataValue.text(team_ids_str),
+            "team_ids": dagster.MetadataValue.text(", ".join(str(tid) for tid in config.team_ids)),
         }
     )
 
@@ -849,7 +852,6 @@ def cleanup_old_events_by_partition(
         context.log.info("No partitions found to clean up")
         return
 
-    team_ids_str = ", ".join(str(tid) for tid in config.team_ids)
     total_partitions = len(partitions)
 
     for idx, partition in enumerate(partitions, 1):
@@ -857,10 +859,14 @@ def cleanup_old_events_by_partition(
 
         delete_mutation_runner = LightweightDeleteMutationRunner(
             table=EVENTS_DATA_TABLE(),
-            predicate=f"""
-                team_id IN ({team_ids_str})
-                AND age('month', timestamp, now()) >= {config.min_age_months}
+            predicate="""
+                team_id IN %(team_ids)s
+                AND age('month', timestamp, now()) >= %(min_age_months)s
             """,
+            parameters={
+                "team_ids": list(config.team_ids),
+                "min_age_months": config.min_age_months,
+            },
             partition=str(partition),
             settings={"lightweight_deletes_sync": 0},
         )
@@ -878,7 +884,7 @@ def cleanup_old_events_by_partition(
     context.add_output_metadata(
         {
             "partitions_processed": dagster.MetadataValue.int(total_partitions),
-            "team_ids": dagster.MetadataValue.text(team_ids_str),
+            "team_ids": dagster.MetadataValue.text(", ".join(str(tid) for tid in config.team_ids)),
         }
     )
 

--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -822,7 +822,7 @@ def find_partitions_to_cleanup(
     """
 
     parameters = {
-        "team_ids": list(config.team_ids),
+        "team_ids": config.team_ids,
         "min_age_months": config.min_age_months,
     }
 

--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -864,7 +864,7 @@ def cleanup_old_events_by_partition(
                 AND age('month', timestamp, now()) >= %(min_age_months)s
             """,
             parameters={
-                "team_ids": list(config.team_ids),
+                "team_ids": config.team_ids,
                 "min_age_months": config.min_age_months,
             },
             partition=str(partition),

--- a/posthog/dags/tests/__snapshots__/test_deletes.ambr
+++ b/posthog/dags/tests/__snapshots__/test_deletes.ambr
@@ -3,8 +3,8 @@
   list([
     '''
       DELETE FROM posthog_test.sharded_events IN PARTITION '202408' WHERE 
-                      team_id IN (400, 401)
-                      AND age('month', timestamp, now()) >= 13
+                      team_id IN %(team_ids)s
+                      AND age('month', timestamp, now()) >= %(min_age_months)s
                   
     ''',
   ])


### PR DESCRIPTION
using templating into strings in queries == sql injection risk

even if things are internal now we risk a human or robot doing copy pasta in future  
so we're moving everything to a good pattern so when a human or robot copy it they do the right thing

