### PR TITLE
fix(ci): add password and error handling to schema dump

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -411,10 +411,16 @@ jobs:
 
             - name: Dump migrated schema
               if: github.event_name == 'push'
+              env:
+                  PGPASSWORD: posthog
               run: |
+                  set -e
+                  set -o pipefail
                   # Dump schema + django_migrations data so Django knows which migrations are applied
                   (pg_dump --schema-only --clean -h localhost -U posthog posthog && \
                    pg_dump --data-only --table=django_migrations -h localhost -U posthog posthog) | gzip > schema.sql.gz
+                  # Verify the dump is valid
+                  gunzip -t schema.sql.gz
 
             - name: Upload migrated schema artifact
               if: github.event_name == 'push'

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -426,8 +426,14 @@ db:
         cmd: |
             set -e
             mkdir -p .postgres-backups
-            echo "Downloading pre-migrated schema from CI..."
-            gh run download --name migrated-schema -R PostHog/posthog -D /tmp/migrated-schema-dl
+            echo "Finding latest CI run with migrated-schema artifact..."
+            RUN_ID=$(gh api 'repos/PostHog/posthog/actions/artifacts?name=migrated-schema&per_page=10' --jq '[.artifacts[] | select(.expired == false and .size_in_bytes > 10000)] | .[0].workflow_run.id')
+            if [ -z "$RUN_ID" ]; then
+                echo "❌ No migrated-schema artifact found. Has CI run on master yet?"
+                exit 1
+            fi
+            echo "Downloading from run $RUN_ID..."
+            gh run download "$RUN_ID" --name migrated-schema -R PostHog/posthog -D /tmp/migrated-schema-dl
             mv /tmp/migrated-schema-dl/schema.sql.gz .postgres-backups/schema-latest.sql.gz
             rm -rf /tmp/migrated-schema-dl
             echo "✅ Downloaded to .postgres-backups/schema-latest.sql.gz"


### PR DESCRIPTION
Follow-up to #44610 - the schema dump was producing empty files because pg_dump failed silently without PGPASSWORD.

**Fixes**
- Add `PGPASSWORD` env var for pg_dump authentication
- Add `set -e` and `pipefail` for proper error handling
- Add `gunzip -t` to verify dump validity before upload
- Fix `hogli db:download-schema` to query artifacts API directly instead of paginating through all artifacts (was timing out due to thousands of timing_data artifacts)

**Testing**
Temporarily enabled dump/upload on this PR branch to verify it works. Will remove that condition before merge.