### PR TITLE
Add create and edit actions to PostHog MCP

### DIFF
--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -1,4 +1,74 @@
 {
+    "action-create": {
+        "description": "Create a new action to define complex event matching rules. Actions combine multiple matching conditions (steps) with OR logic - an event matches if any step matches. Use actions to track specific user behaviors like 'Clicked signup button' or 'Visited pricing page'. Each step can match on event type, URL patterns, CSS selectors, element text, and property filters.",
+        "category": "Actions",
+        "feature": "actions",
+        "summary": "Create a new action with event matching rules.",
+        "title": "Create action",
+        "required_scopes": ["action:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "action-delete": {
+        "description": "Delete an action by ID (soft delete - marks as deleted). The action can potentially be restored later if needed.",
+        "category": "Actions",
+        "feature": "actions",
+        "summary": "Delete an action by ID.",
+        "title": "Delete action",
+        "required_scopes": ["action:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "action-get": {
+        "description": "Get details of a specific action by ID, including its matching steps, property filters, and configuration.",
+        "category": "Actions",
+        "feature": "actions",
+        "summary": "Get action details by ID.",
+        "title": "Get action",
+        "required_scopes": ["action:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "actions-get-all": {
+        "description": "Get all actions in the project with optional filtering. Can filter by search term or use pagination. Returns action names, IDs, descriptions, and tags.",
+        "category": "Actions",
+        "feature": "actions",
+        "summary": "Get all actions in the project.",
+        "title": "Get all actions",
+        "required_scopes": ["action:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "action-update": {
+        "description": "Update an existing action by ID. Can update name, description, matching steps, tags, and Slack notification settings. Use action-get first to see current configuration before updating.",
+        "category": "Actions",
+        "feature": "actions",
+        "summary": "Update an existing action.",
+        "title": "Update action",
+        "required_scopes": ["action:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "add-insight-to-dashboard": {
         "description": "Add an existing insight to a dashboard. Requires insight ID and dashboard ID. Optionally supports layout and color customization.",
         "category": "Dashboards",

--- a/services/mcp/typescript/src/schema/actions.ts
+++ b/services/mcp/typescript/src/schema/actions.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod'
+
+// String matching options for action steps
+export const ActionStepMatchingSchema = z.enum(['contains', 'exact', 'regex'])
+export type ActionStepMatching = z.infer<typeof ActionStepMatchingSchema>
+
+// Property filter for action steps
+export const ActionPropertyFilterSchema = z.object({
+    key: z.string().describe('Property key to filter on'),
+    value: z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]).describe('Value to match'),
+    operator: z
+        .enum([
+            'exact',
+            'is_not',
+            'icontains',
+            'not_icontains',
+            'regex',
+            'not_regex',
+            'gt',
+            'lt',
+            'gte',
+            'lte',
+            'is_set',
+            'is_not_set',
+            'is_date_exact',
+            'is_date_before',
+            'is_date_after',
+        ])
+        .optional()
+        .describe('Comparison operator'),
+    type: z.enum(['event', 'person', 'element', 'cohort', 'group']).optional().describe('Property type'),
+})
+
+export type ActionPropertyFilter = z.infer<typeof ActionPropertyFilterSchema>
+
+// Action step schema - matches ActionStepJSON from backend
+export const ActionStepSchema = z.object({
+    event: z
+        .string()
+        .nullish()
+        .describe("Event name to match (e.g., '$pageview', '$autocapture', or custom event name)"),
+    url: z.string().nullish().describe('URL to match (only for $pageview and $autocapture events)'),
+    url_matching: ActionStepMatchingSchema.nullish().describe('URL matching mode'),
+    selector: z.string().nullish().describe('CSS selector to match clicked elements (for $autocapture)'),
+    tag_name: z.string().nullish().describe('HTML tag name to match (deprecated, use selector)'),
+    text: z.string().nullish().describe('Text content to match on clicked elements'),
+    text_matching: ActionStepMatchingSchema.nullish().describe('Text matching mode'),
+    href: z.string().nullish().describe('Link href to match'),
+    href_matching: ActionStepMatchingSchema.nullish().describe('Href matching mode'),
+    properties: z.array(ActionPropertyFilterSchema).nullish().describe('Additional property filters'),
+})
+
+export type ActionStep = z.infer<typeof ActionStepSchema>
+
+// Full action schema for API responses
+export const ActionSchema = z.object({
+    id: z.number(),
+    name: z.string().nullable(),
+    description: z.string().nullish(),
+    steps: z.array(ActionStepSchema).nullish(),
+    created_at: z.string(),
+    created_by: z
+        .object({
+            id: z.number(),
+            uuid: z.string(),
+            email: z.string(),
+            first_name: z.string().nullish(),
+            last_name: z.string().nullish(),
+        })
+        .nullish(),
+    deleted: z.boolean().nullish(),
+    tags: z.array(z.string()).nullish(),
+    pinned_at: z.string().nullish(),
+    post_to_slack: z.boolean().nullish(),
+    slack_message_format: z.string().nullish(),
+    bytecode: z.array(z.any()).nullish(),
+    bytecode_error: z.string().nullish(),
+})
+
+export type Action = z.infer<typeof ActionSchema>
+
+// Simplified action for list view
+export const SimpleActionSchema = z.object({
+    id: z.number(),
+    name: z.string().nullable(),
+    description: z.string().nullish(),
+    created_at: z.string(),
+    tags: z.array(z.string()).nullish(),
+    pinned_at: z.string().nullish(),
+})
+
+export type SimpleAction = z.infer<typeof SimpleActionSchema>
+
+// Input schema for creating an action
+export const CreateActionInputSchema = z.object({
+    name: z.string().min(1).describe('Action name (must be unique within the project)'),
+    description: z.string().optional().describe('Description of what this action tracks'),
+    steps: z
+        .array(ActionStepSchema)
+        .min(1)
+        .describe(
+            'Match conditions for this action. Multiple steps use OR logic - an event matches if any step matches.'
+        ),
+    tags: z.array(z.string()).optional().describe('Tags for organizing actions'),
+    post_to_slack: z.boolean().optional().describe('Send notification to Slack when action is triggered'),
+    slack_message_format: z.string().optional().describe('Custom Slack message format'),
+})
+
+export type CreateActionInput = z.infer<typeof CreateActionInputSchema>
+
+// Input schema for updating an action
+export const UpdateActionInputSchema = z.object({
+    name: z.string().optional().describe('Update action name'),
+    description: z.string().optional().describe('Update description'),
+    steps: z.array(ActionStepSchema).optional().describe('Update match conditions'),
+    tags: z.array(z.string()).optional().describe('Update tags'),
+    post_to_slack: z.boolean().optional().describe('Update Slack notification setting'),
+    slack_message_format: z.string().optional().describe('Update Slack message format'),
+})
+
+export type UpdateActionInput = z.infer<typeof UpdateActionInputSchema>
+
+// Input schema for listing actions
+export const ListActionsInputSchema = z.object({
+    limit: z.number().int().positive().optional().describe('Maximum number of actions to return'),
+    offset: z.number().int().min(0).optional().describe('Number of actions to skip'),
+    search: z.string().optional().describe('Search term to filter actions by name'),
+})
+
+export type ListActionsInput = z.infer<typeof ListActionsInputSchema>

--- a/services/mcp/typescript/src/schema/tool-inputs.ts
+++ b/services/mcp/typescript/src/schema/tool-inputs.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { ActionStepSchema, ListActionsInputSchema, UpdateActionInputSchema } from './actions'
 import {
     AddInsightToDashboardSchema,
     CreateDashboardInputSchema,
@@ -385,6 +386,38 @@ export const SurveyUpdateSchema = UpdateSurveyInputSchema.extend({
 
 export const QueryRunInputSchema = z.object({
     query: InsightQuerySchema,
+})
+
+// Action schemas
+export const ActionGetSchema = z.object({
+    actionId: z.number().describe('The ID of the action to retrieve'),
+})
+
+export const ActionGetAllSchema = z.object({
+    data: ListActionsInputSchema.optional(),
+})
+
+export const ActionCreateSchema = z.object({
+    name: z.string().min(1).describe('Action name (must be unique within the project)'),
+    description: z.string().optional().describe('Description of what this action tracks'),
+    steps: z
+        .array(ActionStepSchema)
+        .min(1)
+        .describe(
+            "Match conditions for this action. Multiple steps use OR logic - an event matches if any step matches. Each step should specify an 'event' (e.g., '$pageview', '$autocapture', or custom event name) and optionally URL/element matching criteria."
+        ),
+    tags: z.array(z.string()).optional().describe('Tags for organizing actions'),
+    post_to_slack: z.boolean().optional().describe('Send notification to Slack when action is triggered'),
+    slack_message_format: z.string().optional().describe('Custom Slack message format'),
+})
+
+export const ActionUpdateSchema = z.object({
+    actionId: z.number().describe('The ID of the action to update'),
+    data: UpdateActionInputSchema.describe('The action data to update'),
+})
+
+export const ActionDeleteSchema = z.object({
+    actionId: z.number().describe('The ID of the action to delete'),
 })
 
 export { LogsQueryInputSchema, LogsListAttributesInputSchema, LogsListAttributeValuesInputSchema }

--- a/services/mcp/typescript/src/tools/actions/create.ts
+++ b/services/mcp/typescript/src/tools/actions/create.ts
@@ -1,0 +1,41 @@
+import type { z } from 'zod'
+
+import { ActionCreateSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ActionCreateSchema
+
+type Params = z.infer<typeof schema>
+
+export const createHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const { name, description, steps, tags, post_to_slack, slack_message_format } = params
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.actions({ projectId }).create({
+        data: {
+            name,
+            description,
+            steps,
+            tags,
+            post_to_slack,
+            slack_message_format,
+        },
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to create action: ${result.error.message}`)
+    }
+
+    return {
+        ...result.data,
+        url: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions/${result.data.id}`,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'action-create',
+    schema,
+    handler: createHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/actions/delete.ts
+++ b/services/mcp/typescript/src/tools/actions/delete.ts
@@ -1,0 +1,29 @@
+import type { z } from 'zod'
+
+import { ActionDeleteSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ActionDeleteSchema
+
+type Params = z.infer<typeof schema>
+
+export const deleteHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const { actionId } = params
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.actions({ projectId }).delete({ actionId })
+
+    if (!result.success) {
+        throw new Error(`Failed to delete action: ${result.error.message}`)
+    }
+
+    return result.data
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'action-delete',
+    schema,
+    handler: deleteHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/actions/get.ts
+++ b/services/mcp/typescript/src/tools/actions/get.ts
@@ -1,0 +1,32 @@
+import type { z } from 'zod'
+
+import { ActionGetSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ActionGetSchema
+
+type Params = z.infer<typeof schema>
+
+export const getHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const { actionId } = params
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.actions({ projectId }).get({ actionId })
+
+    if (!result.success) {
+        throw new Error(`Failed to get action: ${result.error.message}`)
+    }
+
+    return {
+        ...result.data,
+        url: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions/${result.data.id}`,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'action-get',
+    schema,
+    handler: getHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/actions/getAll.ts
+++ b/services/mcp/typescript/src/tools/actions/getAll.ts
@@ -1,0 +1,34 @@
+import type { z } from 'zod'
+
+import { ActionGetAllSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ActionGetAllSchema
+
+type Params = z.infer<typeof schema>
+
+export const getAllHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.actions({ projectId }).list({ params: params.data })
+
+    if (!result.success) {
+        throw new Error(`Failed to get actions: ${result.error.message}`)
+    }
+
+    return {
+        actions: result.data.map((action) => ({
+            ...action,
+            url: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions/${action.id}`,
+        })),
+        count: result.data.length,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'actions-get-all',
+    schema,
+    handler: getAllHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/actions/update.ts
+++ b/services/mcp/typescript/src/tools/actions/update.ts
@@ -1,0 +1,35 @@
+import type { z } from 'zod'
+
+import { ActionUpdateSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ActionUpdateSchema
+
+type Params = z.infer<typeof schema>
+
+export const updateHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const { actionId, data } = params
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.actions({ projectId }).update({
+        actionId,
+        data,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to update action: ${result.error.message}`)
+    }
+
+    return {
+        ...result.data,
+        url: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions/${result.data.id}`,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'action-update',
+    schema,
+    handler: updateHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/index.ts
+++ b/services/mcp/typescript/src/tools/index.ts
@@ -5,6 +5,12 @@ import { hasScopes } from '@/lib/utils/api'
 import { MemoryCache } from '@/lib/utils/cache/MemoryCache'
 import { hash } from '@/lib/utils/helper-functions'
 
+// Actions
+import createAction from './actions/create'
+import deleteAction from './actions/delete'
+import getAction from './actions/get'
+import getAllActions from './actions/getAll'
+import updateAction from './actions/update'
 // Dashboards
 import addInsightToDashboard from './dashboards/addInsight'
 import createDashboard from './dashboards/create'
@@ -70,6 +76,13 @@ import type { Context, Tool, ToolBase, ZodObjectAny } from './types'
 
 // Map of tool names to tool factory functions
 const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
+    // Actions
+    'action-create': createAction,
+    'action-delete': deleteAction,
+    'action-get': getAction,
+    'actions-get-all': getAllActions,
+    'action-update': updateAction,
+
     // Feature Flags
     'feature-flag-get-definition': getFeatureFlagDefinition,
     'feature-flag-get-all': getAllFeatureFlags,


### PR DESCRIPTION
Add CRUD tools for PostHog actions to the MCP:
- action-create: Create a new action with event matching rules
- action-update: Update an existing action
- action-get: Get action details by ID
- actions-get-all: List all actions in project
- action-delete: Soft-delete an action

Includes:
- Action schema definitions with steps, property filters, and matching modes
- API client endpoints for actions CRUD operations
- Tool input schemas with validation
- Tool definitions with required scopes (action:read/write)

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
