### PR TITLE
chore(data-pipelines): extract common pipeline utilities to shared module

### DIFF
--- a/posthog/temporal/data_imports/pipelines/common/extract.py
+++ b/posthog/temporal/data_imports/pipelines/common/extract.py
@@ -1,0 +1,167 @@
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, NoReturn
+
+from django.conf import settings
+
+import posthoganalytics
+from structlog.typing import FilteringBoundLogger
+from temporalio import activity
+
+from posthog.exceptions_capture import capture_exception
+from posthog.redis import get_client
+from posthog.temporal.data_imports.util import NonRetryableException
+
+if TYPE_CHECKING:
+    from posthog.temporal.data_imports.pipelines.pipeline_sync import PipelineInputs
+    from posthog.temporal.data_imports.workflow_activities.import_data_sync import ImportDataActivityInputs
+
+    from products.data_warehouse.backend.models import ExternalDataSource
+
+
+@contextmanager
+def get_redis_client():
+    redis_client = None
+    try:
+        if not settings.DATA_WAREHOUSE_REDIS_HOST or not settings.DATA_WAREHOUSE_REDIS_PORT:
+            raise Exception(
+                "Missing env vars for dwh row tracking: DATA_WAREHOUSE_REDIS_HOST or DATA_WAREHOUSE_REDIS_PORT"
+            )
+
+        redis_client = get_client(f"redis://{settings.DATA_WAREHOUSE_REDIS_HOST}:{settings.DATA_WAREHOUSE_REDIS_PORT}/")
+        redis_client.ping()
+    except Exception as e:
+        capture_exception(e)
+
+    try:
+        yield redis_client
+    finally:
+        pass
+
+
+def build_non_retryable_errors_redis_key(team_id: int, source_id: str, run_id: str) -> str:
+    return f"posthog:data_warehouse:non_retryable_errors:{team_id}:{source_id}:{run_id}"
+
+
+def trim_source_job_inputs(source: "ExternalDataSource") -> None:
+    if not source.job_inputs:
+        return
+
+    did_update_inputs = False
+    for key, value in source.job_inputs.items():
+        if isinstance(value, str):
+            if value.startswith(" ") or value.endswith(" "):
+                source.job_inputs[key] = value.strip()
+                did_update_inputs = True
+
+    if did_update_inputs:
+        source.save()
+
+
+def report_heartbeat_timeout(inputs: "ImportDataActivityInputs", logger: FilteringBoundLogger) -> None:
+    logger.debug("Checking for heartbeat timeout reporting...")
+
+    try:
+        info = activity.info()
+        heartbeat_timeout = info.heartbeat_timeout
+        current_attempt_scheduled_time = info.current_attempt_scheduled_time
+
+        if not heartbeat_timeout:
+            logger.debug(f"No heartbeat timeout set for this activity: {heartbeat_timeout}")
+            return
+
+        if not current_attempt_scheduled_time:
+            logger.debug(f"No current attempt scheduled time set for this activity: {current_attempt_scheduled_time}")
+            return
+
+        if info.attempt < 2:
+            logger.debug("First attempt of activity, no heartbeat timeout to report.")
+            return
+
+        heartbeat_details = info.heartbeat_details
+        if not isinstance(heartbeat_details, tuple | list) or len(heartbeat_details) < 1:
+            logger.debug(
+                f"No heartbeat details found to analyze for timeout: {heartbeat_details}. Class: {heartbeat_details.__class__.__name__}"
+            )
+            return
+
+        last_heartbeat = heartbeat_details[-1]
+        logger.debug(f"Resuming activity after failure. Last heartbeat details: {last_heartbeat}")
+
+        if not isinstance(last_heartbeat, dict):
+            logger.debug(
+                f"Last heartbeat details not in expected format (dict). Found: {type(last_heartbeat)}: {last_heartbeat}"
+            )
+            return
+
+        last_heartbeat_host = last_heartbeat.get("host", None)
+        last_heartbeat_timestamp = last_heartbeat.get("ts", None)
+
+        logger.debug(f"Last heartbeat was {last_heartbeat}")
+
+        if last_heartbeat_host is None or last_heartbeat_timestamp is None:
+            logger.debug("Incomplete heartbeat details. No host or timestamp found.")
+            return
+
+        try:
+            last_heartbeat_timestamp = float(last_heartbeat_timestamp)
+        except (TypeError, ValueError):
+            logger.debug(f"Last heartbeat timestamp could not be converted to float: {last_heartbeat_timestamp}")
+            return
+
+        gap_between_beats = current_attempt_scheduled_time.timestamp() - float(last_heartbeat_timestamp)
+        if gap_between_beats > heartbeat_timeout.total_seconds():
+            logger.debug(
+                "Last heartbeat was longer ago than the heartbeat timeout allows. Likely due to a pod OOM or restart.",
+                last_heartbeat_host=last_heartbeat_host,
+                last_heartbeat_timestamp=last_heartbeat_timestamp,
+                gap_between_beats=gap_between_beats,
+                heartbeat_timeout_seconds=heartbeat_timeout.total_seconds(),
+            )
+
+            posthoganalytics.capture(
+                "dwh_pod_heartbeat_timeout",
+                distinct_id=None,
+                properties={
+                    "team_id": inputs.team_id,
+                    "schema_id": str(inputs.schema_id),
+                    "source_id": str(inputs.source_id),
+                    "run_id": inputs.run_id,
+                    "host": last_heartbeat_host,
+                    "gap_between_beats": gap_between_beats,
+                    "heartbeat_timeout_seconds": heartbeat_timeout.total_seconds(),
+                    "task_queue": info.task_queue,
+                    "workflow_id": info.workflow_id,
+                    "workflow_run_id": info.workflow_run_id,
+                    "workflow_type": info.workflow_type,
+                    "attempt": info.attempt,
+                },
+            )
+        else:
+            logger.debug("Last heartbeat was within the heartbeat timeout window. No action needed.")
+    except Exception as e:
+        logger.debug(f"Error while reporting heartbeat timeout: {e}", exc_info=e)
+
+
+def handle_non_retryable_error(
+    job_inputs: "PipelineInputs",
+    error_msg: str,
+    logger: FilteringBoundLogger,
+    error: Exception,
+) -> NoReturn:
+    with get_redis_client() as redis_client:
+        if redis_client is None:
+            logger.debug(f"Failed to get Redis client for non-retryable error tracking. error={error_msg}")
+            raise NonRetryableException() from error
+
+        retry_key = build_non_retryable_errors_redis_key(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id
+        )
+        attempts = redis_client.incr(retry_key)
+
+        if attempts <= 3:
+            redis_client.expire(retry_key, 86400)  # Expire after 24 hours
+            logger.debug(f"Non-retryable error attempt {attempts}/3, retrying. error={error_msg}")
+            raise error
+
+    logger.debug(f"Non-retryable error after {attempts} runs, giving up. error={error_msg}")
+    raise NonRetryableException() from error

--- a/posthog/temporal/data_imports/pipelines/common/load.py
+++ b/posthog/temporal/data_imports/pipelines/common/load.py
@@ -1,0 +1,54 @@
+from typing import TYPE_CHECKING, Any, Literal
+
+from django.db.models import F
+
+import pyarrow as pa
+import pyarrow.compute as pc
+from structlog.types import FilteringBoundLogger
+
+from posthog.temporal.data_imports.pipelines.pipeline.utils import normalize_column_name
+
+from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
+from products.data_warehouse.backend.models.external_data_schema import ExternalDataSchema, process_incremental_value
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+if TYPE_CHECKING:
+    from products.data_warehouse.backend.models import ExternalDataSchema
+
+
+def update_job_row_count(job_id: str, count: int, logger: FilteringBoundLogger) -> None:
+    logger.debug(f"Updating rows_synced with +{count}")
+    ExternalDataJob.objects.filter(id=job_id).update(rows_synced=F("rows_synced") + count)
+
+
+def get_incremental_field_value(
+    schema: "ExternalDataSchema | None", table: pa.Table, aggregate: Literal["max"] | Literal["min"] = "max"
+) -> Any:
+    if schema is None or schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH:
+        return None
+
+    incremental_field_name: str | None = schema.sync_type_config.get("incremental_field")
+    if incremental_field_name is None:
+        return None
+
+    column = table[normalize_column_name(incremental_field_name)]
+    processed_column = pa.array(
+        [process_incremental_value(val, schema.incremental_field_type) for val in column.to_pylist()]
+    )
+
+    if aggregate == "max":
+        last_value = pc.max(processed_column)
+    elif aggregate == "min":
+        last_value = pc.min(processed_column)
+    else:
+        raise Exception(f"Unsupported aggregate function for get_incremental_field_value: {aggregate}")
+
+    return last_value.as_py()
+
+
+def supports_partial_data_loading(schema: "ExternalDataSchema") -> bool:
+    """
+    We should be able to roll this out to all source types in the future.
+    Currently only Stripe sources support partial data loading.
+    """
+    return schema.source.source_type == ExternalDataSourceType.STRIPE

--- a/posthog/temporal/data_imports/pipelines/common/load.py
+++ b/posthog/temporal/data_imports/pipelines/common/load.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from django.db.models import F
 
@@ -12,9 +12,6 @@ from products.data_warehouse.backend.models.external_data_job import ExternalDat
 from products.data_warehouse.backend.models.external_data_schema import ExternalDataSchema, process_incremental_value
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
-if TYPE_CHECKING:
-    from products.data_warehouse.backend.models import ExternalDataSchema
-
 
 def update_job_row_count(job_id: str, count: int, logger: FilteringBoundLogger) -> None:
     logger.debug(f"Updating rows_synced with +{count}")
@@ -22,7 +19,7 @@ def update_job_row_count(job_id: str, count: int, logger: FilteringBoundLogger) 
 
 
 def get_incremental_field_value(
-    schema: "ExternalDataSchema | None", table: pa.Table, aggregate: Literal["max"] | Literal["min"] = "max"
+    schema: ExternalDataSchema | None, table: pa.Table, aggregate: Literal["max"] | Literal["min"] = "max"
 ) -> Any:
     if schema is None or schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH:
         return None
@@ -46,7 +43,7 @@ def get_incremental_field_value(
     return last_value.as_py()
 
 
-def supports_partial_data_loading(schema: "ExternalDataSchema") -> bool:
+def supports_partial_data_loading(schema: ExternalDataSchema) -> bool:
     """
     We should be able to roll this out to all source types in the future.
     Currently only Stripe sources support partial data loading.

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -1,23 +1,23 @@
 import uuid
 import dataclasses
-from contextlib import contextmanager
-from typing import Any, NoReturn, Optional
+from typing import Any, Optional
 
-from django.conf import settings
 from django.db import close_old_connections
 from django.db.models import Prefetch
 
-import posthoganalytics
 from structlog.contextvars import bind_contextvars
 from structlog.typing import FilteringBoundLogger
 from temporalio import activity
 
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
-from posthog.exceptions_capture import capture_exception
-from posthog.redis import get_client
 from posthog.temporal.common.heartbeat_sync import HeartbeaterSync
 from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.shutdown import ShutdownMonitor
+from posthog.temporal.data_imports.pipelines.common.extract import (
+    handle_non_retryable_error,
+    report_heartbeat_timeout,
+    trim_source_job_inputs,
+)
 from posthog.temporal.data_imports.pipelines.pipeline.pipeline import PipelineNonDLT
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.pipelines.pipeline_sync import PipelineInputs
@@ -25,9 +25,8 @@ from posthog.temporal.data_imports.row_tracking import setup_row_tracking
 from posthog.temporal.data_imports.sources import SourceRegistry
 from posthog.temporal.data_imports.sources.common.base import ResumableSource
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from posthog.temporal.data_imports.util import NonRetryableException
 
-from products.data_warehouse.backend.models import ExternalDataJob, ExternalDataSource
+from products.data_warehouse.backend.models import ExternalDataJob
 from products.data_warehouse.backend.models.external_data_schema import ExternalDataSchema, process_incremental_value
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
@@ -53,139 +52,13 @@ class ImportDataActivityInputs:
         }
 
 
-@contextmanager
-def _get_redis():
-    redis_client = None
-    try:
-        if not settings.DATA_WAREHOUSE_REDIS_HOST or not settings.DATA_WAREHOUSE_REDIS_PORT:
-            raise Exception(
-                "Missing env vars for dwh row tracking: DATA_WAREHOUSE_REDIS_HOST or DATA_WAREHOUSE_REDIS_PORT"
-            )
-
-        redis_client = get_client(f"redis://{settings.DATA_WAREHOUSE_REDIS_HOST}:{settings.DATA_WAREHOUSE_REDIS_PORT}/")
-        redis_client.ping()
-    except Exception as e:
-        capture_exception(e)
-
-    try:
-        yield redis_client
-    finally:
-        pass
-
-
-def _non_retryable_errors_key(job_inputs: PipelineInputs) -> str:
-    return (
-        f"posthog:data_warehouse:non_retryable_errors:{job_inputs.team_id}:{job_inputs.source_id}:{job_inputs.run_id}"
-    )
-
-
-def _trim_source_job_inputs(source: ExternalDataSource) -> None:
-    if not source.job_inputs:
-        return
-
-    did_update_inputs = False
-    for key, value in source.job_inputs.items():
-        if isinstance(value, str):
-            if value.startswith(" ") or value.endswith(" "):
-                source.job_inputs[key] = value.strip()
-                did_update_inputs = True
-
-    if did_update_inputs:
-        source.save()
-
-
-def _report_heartbeat_timeout(inputs: ImportDataActivityInputs, logger: FilteringBoundLogger) -> None:
-    logger.debug("Checking for heartbeat timeout reporting...")
-
-    try:
-        info = activity.info()
-        heartbeat_timeout = info.heartbeat_timeout
-        current_attempt_scheduled_time = info.current_attempt_scheduled_time
-
-        if not heartbeat_timeout:
-            logger.debug(f"No heartbeat timeout set for this activity: {heartbeat_timeout}")
-            return
-
-        if not current_attempt_scheduled_time:
-            logger.debug(f"No current attempt scheduled time set for this activity: {current_attempt_scheduled_time}")
-            return
-
-        if info.attempt < 2:
-            logger.debug(f"First attempt of activity, no heartbeat timeout to report.")
-            return
-
-        heartbeat_details = info.heartbeat_details
-        if not isinstance(heartbeat_details, tuple | list) or len(heartbeat_details) < 1:
-            logger.debug(
-                f"No heartbeat details found to analyze for timeout: {heartbeat_details}. Class: {heartbeat_details.__class__.__name__}"
-            )
-            return
-
-        last_heartbeat = heartbeat_details[-1]
-        logger.debug(f"Resuming activity after failure. Last heartbeat details: {last_heartbeat}")
-
-        if not isinstance(last_heartbeat, dict):
-            logger.debug(
-                f"Last heartbeat details not in expected format (dict). Found: {type(last_heartbeat)}: {last_heartbeat}"
-            )
-            return
-
-        last_heartbeat_host = last_heartbeat.get("host", None)
-        last_heartbeat_timestamp = last_heartbeat.get("ts", None)
-
-        logger.debug(f"Last heartbeat was {last_heartbeat}")
-
-        if last_heartbeat_host is None or last_heartbeat_timestamp is None:
-            logger.debug(f"Incomplete heartbeat details. No host or timestamp found.")
-            return
-
-        try:
-            last_heartbeat_timestamp = float(last_heartbeat_timestamp)
-        except (TypeError, ValueError):
-            logger.debug(f"Last heartbeat timestamp could not be converted to float: {last_heartbeat_timestamp}")
-            return
-
-        gap_between_beats = current_attempt_scheduled_time.timestamp() - float(last_heartbeat_timestamp)
-        if gap_between_beats > heartbeat_timeout.total_seconds():
-            logger.debug(
-                "Last heartbeat was longer ago than the heartbeat timeout allows. Likely due to a pod OOM or restart.",
-                last_heartbeat_host=last_heartbeat_host,
-                last_heartbeat_timestamp=last_heartbeat_timestamp,
-                gap_between_beats=gap_between_beats,
-                heartbeat_timeout_seconds=heartbeat_timeout.total_seconds(),
-            )
-
-            posthoganalytics.capture(
-                "dwh_pod_heartbeat_timeout",
-                distinct_id=None,
-                properties={
-                    "team_id": inputs.team_id,
-                    "schema_id": str(inputs.schema_id),
-                    "source_id": str(inputs.source_id),
-                    "run_id": inputs.run_id,
-                    "host": last_heartbeat_host,
-                    "gap_between_beats": gap_between_beats,
-                    "heartbeat_timeout_seconds": heartbeat_timeout.total_seconds(),
-                    "task_queue": info.task_queue,
-                    "workflow_id": info.workflow_id,
-                    "workflow_run_id": info.workflow_run_id,
-                    "workflow_type": info.workflow_type,
-                    "attempt": info.attempt,
-                },
-            )
-        else:
-            logger.debug("Last heartbeat was within the heartbeat timeout window. No action needed.")
-    except Exception as e:
-        logger.debug(f"Error while reporting heartbeat timeout: {e}", exc_info=e)
-
-
 @activity.defn
 def import_data_activity_sync(inputs: ImportDataActivityInputs):
     bind_contextvars(team_id=inputs.team_id)
     logger = LOGGER.bind()
     tag_queries(team_id=inputs.team_id, product=Product.WAREHOUSE, feature=Feature.IMPORT_PIPELINE)
 
-    _report_heartbeat_timeout(inputs, logger)
+    report_heartbeat_timeout(inputs, logger)
 
     with HeartbeaterSync(factor=30, logger=logger), ShutdownMonitor() as shutdown_monitor:
         close_old_connections()
@@ -208,7 +81,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             dataset_name=model.folder_path(),
         )
 
-        _trim_source_job_inputs(model.pipeline)
+        trim_source_job_inputs(model.pipeline)
 
         schema: ExternalDataSchema | None = model.schema
         assert schema is not None
@@ -285,26 +158,6 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             raise ValueError(f"Source type {model.pipeline.source_type} not supported")
 
 
-def _handle_non_retryable_error(
-    job_inputs: PipelineInputs, error_msg: str, logger: FilteringBoundLogger, error: Exception
-) -> NoReturn:
-    with _get_redis() as redis_client:
-        if redis_client is None:
-            logger.debug(f"Failed to get Redis client for non-retryable error tracking. error={error_msg}")
-            raise NonRetryableException() from error
-
-        retry_key = _non_retryable_errors_key(job_inputs)
-        attempts = redis_client.incr(retry_key)
-
-        if attempts <= 3:
-            redis_client.expire(retry_key, 86400)  # Expire after 24 hours
-            logger.debug(f"Non-retryable error attempt {attempts}/3, retrying. error={error_msg}")
-            raise
-
-    logger.debug(f"Non-retryable error after {attempts} runs, giving up. error={error_msg}")
-    raise NonRetryableException() from error
-
-
 def _run(
     job_inputs: PipelineInputs,
     source: SourceResponse,
@@ -328,7 +181,7 @@ def _run(
             non_retryable_error in error_msg for non_retryable_error in non_retryable_errors.keys()
         )
         if is_non_retryable_error:
-            _handle_non_retryable_error(job_inputs, error_msg, logger, e)
+            handle_non_retryable_error(job_inputs, error_msg, logger, e)
         else:
             logger.debug(
                 "Error encountered during import_data_activity_sync - re-raising",

--- a/posthog/temporal/tests/data_imports/test_import_data.py
+++ b/posthog/temporal/tests/data_imports/test_import_data.py
@@ -263,7 +263,7 @@ def test_report_heartbeat_timeout_first_attempt(team):
     mock_info.current_attempt_scheduled_time = datetime.now()
 
     with mock.patch(
-        "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
+        "posthog.temporal.data_imports.pipelines.common.extract.activity.info", return_value=mock_info
     ) as mock_activity_info:
         from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
@@ -288,7 +288,7 @@ def test_report_heartbeat_timeout_no_heartbeat_timeout(team):
     mock_info.current_attempt_scheduled_time = datetime.now()
 
     with mock.patch(
-        "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
+        "posthog.temporal.data_imports.pipelines.common.extract.activity.info", return_value=mock_info
     ) as mock_activity_info:
         from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
@@ -313,7 +313,7 @@ def test_report_heartbeat_timeout_no_current_attempt_scheduled_time(team):
     mock_info.current_attempt_scheduled_time = None  # No current attempt scheduled time
 
     with mock.patch(
-        "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
+        "posthog.temporal.data_imports.pipelines.common.extract.activity.info", return_value=mock_info
     ) as mock_activity_info:
         from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
@@ -341,7 +341,7 @@ def test_report_heartbeat_timeout_no_heartbeat_details(team):
     mock_info.heartbeat_details = None  # No heartbeat details
 
     with mock.patch(
-        "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
+        "posthog.temporal.data_imports.pipelines.common.extract.activity.info", return_value=mock_info
     ) as mock_activity_info:
         from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
@@ -369,7 +369,7 @@ def test_report_heartbeat_timeout_heartbeat_details_are_not_a_tuple(team):
     mock_info.heartbeat_details = 123  # Not a tuple
 
     with mock.patch(
-        "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
+        "posthog.temporal.data_imports.pipelines.common.extract.activity.info", return_value=mock_info
     ) as mock_activity_info:
         from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
@@ -397,7 +397,7 @@ def test_report_heartbeat_timeout_heartbeat_details_last_item_is_not_a_dict(team
     mock_info.heartbeat_details = ({"host": "value"}, "not_a_dict")  # Last item is not a dict
 
     with mock.patch(
-        "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
+        "posthog.temporal.data_imports.pipelines.common.extract.activity.info", return_value=mock_info
     ) as mock_activity_info:
         from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
@@ -425,7 +425,7 @@ def test_report_heartbeat_timeout_heartbeat_details_missing_host_or_ts(team):
     mock_info.heartbeat_details = ({"some_other_key": "value"},)  # Missing 'ts' and 'host' key
 
     with mock.patch(
-        "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
+        "posthog.temporal.data_imports.pipelines.common.extract.activity.info", return_value=mock_info
     ) as mock_activity_info:
         from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
@@ -452,7 +452,7 @@ def test_report_heartbeat_timeout_heartbeat_within_timeout(team):
     mock_info.heartbeat_details = ({"host": "value", "ts": datetime.now().timestamp()},)  # Valid heartbeat details
 
     with mock.patch(
-        "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
+        "posthog.temporal.data_imports.pipelines.common.extract.activity.info", return_value=mock_info
     ) as mock_activity_info:
         from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
@@ -483,11 +483,11 @@ def test_report_heartbeat_timeout_heartbeat_not_within_timeout(team):
 
         with (
             mock.patch(
-                "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info",
+                "posthog.temporal.data_imports.pipelines.common.extract.activity.info",
                 return_value=mock_info,
             ) as mock_activity_info,
             mock.patch(
-                "posthog.temporal.data_imports.workflow_activities.import_data_sync.posthoganalytics.capture"
+                "posthog.temporal.data_imports.pipelines.common.extract.posthoganalytics.capture"
             ) as mock_posthog_capture,
         ):
             from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout

--- a/posthog/temporal/tests/data_imports/test_import_data.py
+++ b/posthog/temporal/tests/data_imports/test_import_data.py
@@ -265,9 +265,9 @@ def test_report_heartbeat_timeout_first_attempt(team):
     with mock.patch(
         "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
     ) as mock_activity_info:
-        from posthog.temporal.data_imports.workflow_activities.import_data_sync import _report_heartbeat_timeout
+        from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
-        _report_heartbeat_timeout(activity_inputs, logger)
+        report_heartbeat_timeout(activity_inputs, logger)
 
         mock_activity_info.assert_called_once()
         logger.debug.assert_any_call("Checking for heartbeat timeout reporting...")
@@ -290,9 +290,9 @@ def test_report_heartbeat_timeout_no_heartbeat_timeout(team):
     with mock.patch(
         "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
     ) as mock_activity_info:
-        from posthog.temporal.data_imports.workflow_activities.import_data_sync import _report_heartbeat_timeout
+        from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
-        _report_heartbeat_timeout(activity_inputs, logger)
+        report_heartbeat_timeout(activity_inputs, logger)
 
         mock_activity_info.assert_called_once()
         logger.debug.assert_any_call("Checking for heartbeat timeout reporting...")
@@ -315,9 +315,9 @@ def test_report_heartbeat_timeout_no_current_attempt_scheduled_time(team):
     with mock.patch(
         "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
     ) as mock_activity_info:
-        from posthog.temporal.data_imports.workflow_activities.import_data_sync import _report_heartbeat_timeout
+        from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
-        _report_heartbeat_timeout(activity_inputs, logger)
+        report_heartbeat_timeout(activity_inputs, logger)
 
         mock_activity_info.assert_called_once()
         logger.debug.assert_any_call("Checking for heartbeat timeout reporting...")
@@ -343,9 +343,9 @@ def test_report_heartbeat_timeout_no_heartbeat_details(team):
     with mock.patch(
         "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
     ) as mock_activity_info:
-        from posthog.temporal.data_imports.workflow_activities.import_data_sync import _report_heartbeat_timeout
+        from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
-        _report_heartbeat_timeout(activity_inputs, logger)
+        report_heartbeat_timeout(activity_inputs, logger)
 
         mock_activity_info.assert_called_once()
         logger.debug.assert_any_call("Checking for heartbeat timeout reporting...")
@@ -371,9 +371,9 @@ def test_report_heartbeat_timeout_heartbeat_details_are_not_a_tuple(team):
     with mock.patch(
         "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
     ) as mock_activity_info:
-        from posthog.temporal.data_imports.workflow_activities.import_data_sync import _report_heartbeat_timeout
+        from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
-        _report_heartbeat_timeout(activity_inputs, logger)
+        report_heartbeat_timeout(activity_inputs, logger)
 
         mock_activity_info.assert_called_once()
         logger.debug.assert_any_call("Checking for heartbeat timeout reporting...")
@@ -399,9 +399,9 @@ def test_report_heartbeat_timeout_heartbeat_details_last_item_is_not_a_dict(team
     with mock.patch(
         "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
     ) as mock_activity_info:
-        from posthog.temporal.data_imports.workflow_activities.import_data_sync import _report_heartbeat_timeout
+        from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
-        _report_heartbeat_timeout(activity_inputs, logger)
+        report_heartbeat_timeout(activity_inputs, logger)
 
         mock_activity_info.assert_called_once()
         logger.debug.assert_any_call("Checking for heartbeat timeout reporting...")
@@ -427,9 +427,9 @@ def test_report_heartbeat_timeout_heartbeat_details_missing_host_or_ts(team):
     with mock.patch(
         "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
     ) as mock_activity_info:
-        from posthog.temporal.data_imports.workflow_activities.import_data_sync import _report_heartbeat_timeout
+        from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
-        _report_heartbeat_timeout(activity_inputs, logger)
+        report_heartbeat_timeout(activity_inputs, logger)
 
         mock_activity_info.assert_called_once()
         logger.debug.assert_any_call("Checking for heartbeat timeout reporting...")
@@ -454,9 +454,9 @@ def test_report_heartbeat_timeout_heartbeat_within_timeout(team):
     with mock.patch(
         "posthog.temporal.data_imports.workflow_activities.import_data_sync.activity.info", return_value=mock_info
     ) as mock_activity_info:
-        from posthog.temporal.data_imports.workflow_activities.import_data_sync import _report_heartbeat_timeout
+        from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
-        _report_heartbeat_timeout(activity_inputs, logger)
+        report_heartbeat_timeout(activity_inputs, logger)
 
         mock_activity_info.assert_called_once()
         logger.debug.assert_any_call("Checking for heartbeat timeout reporting...")
@@ -490,9 +490,9 @@ def test_report_heartbeat_timeout_heartbeat_not_within_timeout(team):
                 "posthog.temporal.data_imports.workflow_activities.import_data_sync.posthoganalytics.capture"
             ) as mock_posthog_capture,
         ):
-            from posthog.temporal.data_imports.workflow_activities.import_data_sync import _report_heartbeat_timeout
+            from posthog.temporal.data_imports.pipelines.common.extract import report_heartbeat_timeout
 
-            _report_heartbeat_timeout(activity_inputs, logger)
+            report_heartbeat_timeout(activity_inputs, logger)
 
             mock_activity_info.assert_called_once()
             logger.debug.assert_any_call("Checking for heartbeat timeout reporting...")


### PR DESCRIPTION
This PR extracts common utility functions from the data imports pipeline code into a shared `common/` module, we want to reuse this code on the new pipeline architecture.

  ## Notes
  * This is a pure refactoring with no behavioral changes
  * Removed unused `_update_last_synced_at_sync` function that was dead code

## Changes
  Created a new `common/` module under `posthog/temporal/data_imports/pipelines/` with logical separation:

  - **`common/extract.py`**: Functions related to data extraction
    - `get_redis_client()` - Redis connection context manager
    - `build_non_retryable_errors_redis_key()` - Redis key builder
    - `trim_source_job_inputs()` - Input sanitization
    - `report_heartbeat_timeout()` - Heartbeat timeout reporting
    - `handle_non_retryable_error()` - Error handling with retry logic

  - **`common/load.py`**: Functions related to data loading
    - `update_job_row_count()` - Job row count updates
    - `get_incremental_field_value()` - Incremental field value extraction
    - `supports_partial_data_loading()` - Partial data loading support check