### PR TITLE
feat(llma): switch cluster labeling agent from Claude to OpenAI GPT-5.1

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/README.md
+++ b/posthog/temporal/llm_analytics/trace_clustering/README.md
@@ -140,7 +140,7 @@ The workflow uses **three separate activities** with independent timeouts and re
 
 **Activity 2 (Label)** - LangGraph agent:
 
-- Runs a multi-turn LangGraph agent powered by Claude Sonnet 4 (`claude-sonnet-4-20250514`)
+- Runs a multi-turn LangGraph agent powered by OpenAI GPT-5.1 (`gpt-5.1`)
 - Agent explores clusters using tools (overview, trace titles, trace details)
 - Iteratively generates distinctive labels for each cluster
 - Ensures labels differentiate clusters from each other
@@ -187,7 +187,7 @@ The workflow uses **three separate activities** with independent timeouts and re
 **`labeling_agent/`** - LangGraph agent for cluster labeling:
 
 - Multi-turn agent that explores clusters and generates distinctive labels
-- Uses Claude Sonnet 4 with 6 tools for cluster exploration
+- Uses OpenAI GPT-5.1 with 6 tools for cluster exploration
 - See `labeling_agent/README.md` for detailed architecture
 
 **`event_emission.py`** - Event building and emission:
@@ -345,7 +345,7 @@ Key constants in `constants.py`:
 | `MIN_TRACES_FOR_CLUSTERING`         | 20                                | Minimum traces required for workflow          |
 | `COMPUTE_ACTIVITY_TIMEOUT`          | 120s                              | Clustering compute timeout                    |
 | `EMIT_ACTIVITY_TIMEOUT`             | 60s                               | Event emission timeout                        |
-| `LABELING_AGENT_MODEL`              | claude-sonnet-4-20250514          | Claude model for labeling agent               |
+| `LABELING_AGENT_MODEL`              | gpt-5.1                           | OpenAI model for labeling agent               |
 | `LABELING_AGENT_MAX_ITERATIONS`     | 50                                | Max agent iterations before finalization      |
 | `LABELING_AGENT_RECURSION_LIMIT`    | 150                               | LangGraph recursion limit                     |
 | `LABELING_AGENT_TIMEOUT`            | 600.0                             | Full agent run timeout (seconds)              |
@@ -420,7 +420,7 @@ Test coverage:
 - **hdbscan**: Density-based clustering algorithm
 - **umap-learn**: Dimensionality reduction for clustering and visualization
 - **numpy**: Vector operations and distance calculations
-- **langchain-anthropic**: Claude API integration for labeling agent
+- **langchain-openai**: OpenAI API integration for labeling agent
 - **langgraph**: Agent orchestration framework
 - **Temporal**: Workflow orchestration
 

--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -77,7 +77,7 @@ ALLOWED_TEAM_IDS: list[int] = [
 ]
 
 # Cluster labeling agent configuration
-LABELING_AGENT_MODEL = "claude-sonnet-4-5"  # Claude Sonnet 4.5 for reasoning
+LABELING_AGENT_MODEL = "gpt-5.1"  # OpenAI GPT-5.1 for reasoning
 LABELING_AGENT_MAX_ITERATIONS = 50  # Max agent iterations before forced finalization
 LABELING_AGENT_RECURSION_LIMIT = 150  # LangGraph recursion limit (> 2 * max_iterations)
 LABELING_AGENT_TIMEOUT = 600.0  # 10 minutes for full agent run

--- a/posthog/temporal/llm_analytics/trace_clustering/labeling_agent/README.md
+++ b/posthog/temporal/llm_analytics/trace_clustering/labeling_agent/README.md
@@ -109,11 +109,11 @@ The system prompt guides the agent through a two-phase approach:
 
 From `constants.py`:
 
-| Constant                         | Value                      | Description                        |
-| -------------------------------- | -------------------------- | ---------------------------------- |
-| `LABELING_AGENT_MODEL`           | `gpt-5.1`                  | OpenAI model for reasoning         |
-| `LABELING_AGENT_RECURSION_LIMIT` | 150                        | Max graph steps before forced stop |
-| `LABELING_AGENT_TIMEOUT`         | 600.0                      | LLM request timeout (seconds)      |
+| Constant                         | Value     | Description                        |
+| -------------------------------- | --------- | ---------------------------------- |
+| `LABELING_AGENT_MODEL`           | `gpt-5.1` | OpenAI model for reasoning         |
+| `LABELING_AGENT_RECURSION_LIMIT` | 150       | Max graph steps before forced stop |
+| `LABELING_AGENT_TIMEOUT`         | 600.0     | LLM request timeout (seconds)      |
 
 ## Usage
 

--- a/posthog/temporal/llm_analytics/trace_clustering/labeling_agent/README.md
+++ b/posthog/temporal/llm_analytics/trace_clustering/labeling_agent/README.md
@@ -111,7 +111,7 @@ From `constants.py`:
 
 | Constant                         | Value                      | Description                        |
 | -------------------------------- | -------------------------- | ---------------------------------- |
-| `LABELING_AGENT_MODEL`           | `claude-sonnet-4-20250514` | Claude model for reasoning         |
+| `LABELING_AGENT_MODEL`           | `gpt-5.1`                  | OpenAI model for reasoning         |
 | `LABELING_AGENT_RECURSION_LIMIT` | 150                        | Max graph steps before forced stop |
 | `LABELING_AGENT_TIMEOUT`         | 600.0                      | LLM request timeout (seconds)      |
 

--- a/posthog/temporal/llm_analytics/trace_clustering/labeling_agent/graph.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/labeling_agent/graph.py
@@ -6,8 +6,8 @@ from typing import Any
 from django.conf import settings
 
 import structlog
-from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import HumanMessage
+from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
 from posthog.cloud_utils import is_cloud
@@ -19,16 +19,16 @@ from posthog.temporal.llm_analytics.trace_clustering.models import ClusterLabel,
 logger = structlog.get_logger(__name__)
 
 
-def _get_llm(model: str, timeout: float) -> ChatAnthropic:
-    """Create an Anthropic chat client for the labeling agent."""
+def _get_llm(model: str, timeout: float) -> ChatOpenAI:
+    """Create an OpenAI chat client for the labeling agent."""
     if not settings.DEBUG and not is_cloud():
         raise Exception("AI features are only available in PostHog Cloud")
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
-        raise Exception("Anthropic API key is not configured")
+        raise Exception("OpenAI API key is not configured")
 
-    return ChatAnthropic(
+    return ChatOpenAI(
         model=model,
         api_key=api_key,
         timeout=timeout,


### PR DESCRIPTION
## Problem

The trace clustering labeling agent fails in production with "Anthropic API key is not configured" error. OpenAI API keys are already configured in the production environment.

## Changes

- Switch from `langchain-anthropic` (`ChatAnthropic`) to `langchain-openai` (`ChatOpenAI`)
- Change model from `claude-sonnet-4-5` to `gpt-5.1`
- Update documentation in README files

Cost comparison:
| Model | Input (per MTok) | Output (per MTok) |
|-------|------------------|-------------------|
| Claude Sonnet 4.5 (old) | $3.00 | $15.00 |
| GPT-5.1 (new) | $1.25 | $10.00 |

## How did you test this code?

- Ran existing test suite: `pytest posthog/temporal/llm_analytics/trace_clustering/tests/test_labeling_agent.py` (23 tests pass)
- Verified imports and linting with ruff

## Publish to changelog?

No