### PR TITLE
feat: new SQL tab button

### DIFF
--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -7,7 +7,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import React, { useEffect, useRef, useState } from 'react'
 
-import { IconPlus, IconX } from '@posthog/icons'
+import { IconPlus, IconServer, IconX } from '@posthog/icons'
 
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
@@ -33,7 +33,7 @@ export interface SceneTabsProps {
 }
 
 export function SceneTabs({ className }: SceneTabsProps): JSX.Element {
-    const { tabs, firstTabIsActive } = useValues(sceneLogic)
+    const { tabs, firstTabIsActive, isInSQLContext } = useValues(sceneLogic)
     const { newTab, reorderTabs } = useActions(sceneLogic)
     const { mobileLayout } = useValues(navigationLogic)
     const { showLayoutNavBar } = useActions(panelLayoutLogic)
@@ -143,26 +143,73 @@ export function SceneTabs({ className }: SceneTabsProps): JSX.Element {
                                 )
                             })}
                         </div>
-                        <AppShortcut name="NewTab" keybind={[keyBinds.newTab]} intent="New tab" interaction="click">
-                            <Link
-                                to={urls.newTab()}
-                                data-attr="scene-tab-new-button"
-                                onClick={(e) => {
-                                    e.preventDefault()
-                                    newTab()
-                                }}
-                                tooltip="New tab"
-                                tooltipCloseDelayMs={0}
-                                buttonProps={{
-                                    size: 'sm',
-                                    className:
-                                        'p-1 flex flex-row items-center gap-1 cursor-pointer rounded-lg border-b z-20 ml-px',
-                                    iconOnly: true,
-                                }}
-                            >
-                                <IconPlus className="!ml-0" fontSize={14} />
-                            </Link>
-                        </AppShortcut>
+                        {isInSQLContext ? (
+                            <>
+                                <Link
+                                    to={urls.sqlEditor()}
+                                    onClick={(e) => {
+                                        e.preventDefault()
+                                        newTab(urls.sqlEditor())
+                                    }}
+                                    buttonProps={{
+                                        size: 'sm',
+                                        className: 'p-1',
+                                        iconOnly: true,
+                                    }}
+                                    className="z-20 ml-px border-b rounded-lg"
+                                    tooltip="New SQL tab"
+                                    tooltipCloseDelayMs={0}
+                                >
+                                    <IconServer className="!ml-0" fontSize={14} />
+                                </Link>
+                                <AppShortcut
+                                    name="NewTab"
+                                    keybind={[keyBinds.newTab]}
+                                    intent="New tab"
+                                    interaction="click"
+                                >
+                                    <Link
+                                        to={urls.newTab()}
+                                        data-attr="scene-tab-new-button"
+                                        onClick={(e) => {
+                                            e.preventDefault()
+                                            newTab()
+                                        }}
+                                        tooltip="New blank tab"
+                                        tooltipCloseDelayMs={0}
+                                        buttonProps={{
+                                            size: 'sm',
+                                            className: 'p-1',
+                                            iconOnly: true,
+                                        }}
+                                        className="z-20 border-b rounded-lg"
+                                    >
+                                        <IconPlus className="!ml-0" fontSize={14} />
+                                    </Link>
+                                </AppShortcut>
+                            </>
+                        ) : (
+                            <AppShortcut name="NewTab" keybind={[keyBinds.newTab]} intent="New tab" interaction="click">
+                                <Link
+                                    to={urls.newTab()}
+                                    data-attr="scene-tab-new-button"
+                                    onClick={(e) => {
+                                        e.preventDefault()
+                                        newTab()
+                                    }}
+                                    tooltip="New tab"
+                                    tooltipCloseDelayMs={0}
+                                    buttonProps={{
+                                        size: 'sm',
+                                        className:
+                                            'p-1 flex flex-row items-center gap-1 cursor-pointer rounded-lg border-b z-20 ml-px',
+                                        iconOnly: true,
+                                    }}
+                                >
+                                    <IconPlus className="!ml-0" fontSize={14} />
+                                </Link>
+                            </AppShortcut>
+                        )}
                     </div>
                 </SortableContext>
             </DndContext>

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -838,6 +838,16 @@ export const sceneLogic = kea<sceneLogicType>([
                 return activeTabId === tabs[0]?.id
             },
         ],
+        isInSQLContext: [
+            (s) => [s.activeTab],
+            (activeTab: SceneTab | null): boolean => {
+                return (
+                    activeTab?.sceneId === Scene.SQLEditor ||
+                    activeTab?.sceneId === Scene.DataWarehouse ||
+                    activeTab?.sceneId === Scene.DataWarehouseSource
+                )
+            },
+        ],
     }),
     listeners(({ values, actions, cache, props, selectors }) => ({
         [NEW_INTERNAL_TAB]: (payload) => {


### PR DESCRIPTION
## Problem

Might just be me but when I'm writing a SQL query, the most common thing I want to do is write another one. And I'd rather avoid having to go through the whole new tab flow to do it!

## Changes

Add a SQL editor icon next to the new tab `+` button, which opens another SQL editor tab. I've made it context aware, so it's only displayed when you're already in a SQL/data warehouse context.

<img width="674" height="270" alt="CleanShot 2026-01-12 at 11 36 03@2x" src="https://github.com/user-attachments/assets/a6c10ccd-5f22-47ca-a508-99fd9dac5199" />


## How did you test this code?

Locally