### PR TITLE
fix(batch-exports): Check for empty S3 credentials in the API

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -293,7 +293,7 @@ export function BatchExportsEditFields({
                             name="endpoint_url"
                             label="Endpoint URL"
                             showOptional
-                            info={<>Only required if exporting to an S3-compatible blob storage (like MinIO)</>}
+                            info={<>Only required if exporting to an S3-compatible blob storage (like Google Cloud Storage, Cloudflare R2, MinIO, or others)</>}
                         >
                             <LemonInput placeholder={isNew ? 'e.g. https://your-minio-host:9000' : ''} />
                         </LemonField>

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -295,7 +295,7 @@ export function BatchExportsEditFields({
                             showOptional
                             info={<>Only required if exporting to an S3-compatible blob storage (like MinIO)</>}
                         >
-                            <LemonInput placeholder={isNew ? 'e.g. https://your-minio-host:9000' : 'Leave unchanged'} />
+                            <LemonInput placeholder={isNew ? 'e.g. https://your-minio-host:9000' : ''} />
                         </LemonField>
 
                         <LemonField

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -293,7 +293,12 @@ export function BatchExportsEditFields({
                             name="endpoint_url"
                             label="Endpoint URL"
                             showOptional
-                            info={<>Only required if exporting to an S3-compatible blob storage (like Google Cloud Storage, Cloudflare R2, MinIO, or others)</>}
+                            info={
+                                <>
+                                    Only required if exporting to an S3-compatible blob storage (like Google Cloud
+                                    Storage, Cloudflare R2, MinIO, or others)
+                                </>
+                            }
                         >
                             <LemonInput placeholder={isNew ? 'e.g. https://your-minio-host:9000' : ''} />
                         </LemonField>

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -698,6 +698,40 @@ def test_create_s3_batch_export_validates_file_format_and_compression(
         assert response.json()["detail"] == expected_error_message
 
 
+def test_create_s3_batch_export_validates_missing_inputs(client: HttpClient, temporal, organization, team, user):
+    """Test creating a BatchExport with S3 destination validates that expected inputs are not empty."""
+
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "events/",
+            "aws_access_key_id": "",
+            "aws_secret_access_key": "",
+            "file_format": "JSONLines",
+            "compression": "gzip",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-s3-bucket",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    client.force_login(user)
+
+    response = create_batch_export(
+        client,
+        team.pk,
+        batch_export_data,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "The following inputs are empty: ['aws_access_key_id', 'aws_secret_access_key']"
+
+
 @pytest.mark.parametrize(
     "type,config,expected_error_message",
     [

--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -712,3 +712,48 @@ def test_can_patch_redshift_batch_export(client: HttpClient, temporal, organizat
     batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
     assert batch_export["destination"]["type"] == "Redshift"
     assert batch_export["destination"]["config"]["copy_inputs"]["s3_bucket"] == "my-new-production-s3-bucket"
+
+
+def test_updating_s3_batch_export_validates_missing_inputs(client: HttpClient, temporal, organization, team, user):
+    """Test updating a BatchExport with S3 destination validates that expected inputs are not empty."""
+
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "events/",
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+            "file_format": "JSONLines",
+            "compression": "gzip",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-s3-bucket",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    client.force_login(user)
+
+    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+
+    response = patch_batch_export(
+        client,
+        team.pk,
+        batch_export["id"],
+        {
+            "destination": {
+                "type": "S3",
+                "config": {
+                    "bucket_name": "my-new-bucket",
+                    "aws_access_key_id": "",
+                    "aws_secret_access_key": "",
+                },
+            },
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "The following inputs are empty: ['aws_access_key_id', 'aws_secret_access_key']"

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -436,7 +436,7 @@ class BatchExportSerializer(serializers.ModelSerializer):
             empty_inputs = []
             for required_input in required_non_empty_inputs:
                 value = config.get(required_input)
-                if value is not None and value.strip() == "":
+                if isinstance(value, str) and value.strip() == "":
                     empty_inputs.append(required_input)
             if empty_inputs:
                 raise serializers.ValidationError(f"The following inputs are empty: {empty_inputs}")

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -436,7 +436,7 @@ class BatchExportSerializer(serializers.ModelSerializer):
             empty_inputs = []
             for required_input in required_non_empty_inputs:
                 value = config.get(required_input)
-                if isinstance(value, str) and value.strip() == "":
+                if value is not None and isinstance(value, str) and value.strip() == "":
                     empty_inputs.append(required_input)
             if empty_inputs:
                 raise serializers.ValidationError(f"The following inputs are empty: {empty_inputs}")

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -454,6 +454,10 @@ class BatchExportSerializer(serializers.ModelSerializer):
                     f"Compression {compression} is not supported for file format {file_format}. Supported compressions are {SUPPORTED_COMPRESSIONS[file_format]}"
                 )
 
+            # if someone is trying to reset the endpoint url, then we need to convert empty string to None
+            if merged_config.get("endpoint_url") == "":
+                destination_attrs["config"]["endpoint_url"] = None
+
         if destination_type == BatchExportDestination.Destination.DATABRICKS:
             team_id = self.context["team_id"]
             team = Team.objects.get(id=team_id)

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -426,13 +426,13 @@ class BatchExportSerializer(serializers.ModelSerializer):
         if destination_type == BatchExportDestination.Destination.S3:
             # we already validate the required inputs in BatchExportDestinationSerializer::validate
             # so here we just ensure that the inputs are not empty
-            required_non_empty_inputs = [
+            required_non_empty_inputs = (
                 "bucket_name",
                 "region",
                 "prefix",
                 "aws_access_key_id",
                 "aws_secret_access_key",
-            ]
+            )
             empty_inputs = []
             for required_input in required_non_empty_inputs:
                 value = config.get(required_input)


### PR DESCRIPTION
## Problem

In PR #44649 we check for empty S3 credentials inside the batch export workflow itself, however, we should also check for this at the API-level to catch this earlier.

## Changes

The `BatchExportDestinationSerializer` already checks for missing inputs, so we just add some validation to the S3 destination config to ensure required fields are not empty (or just whitespace).

When testing, I also realized it's not possible to clear the `endpoint_url` in case you set this but then wanted to clear it. So added the ability to do this too.

## How did you test this code?

Added some new tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

