### PR TITLE
feat(mcp): add actions CRUD and entity search support

### DIFF
--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -747,7 +747,7 @@
         "feature": "search",
         "summary": "Search for entities by name or description.",
         "title": "Search entities",
-        "required_scopes": [],
+        "required_scopes": ["project:read"],
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -670,5 +670,89 @@
             "openWorldHint": true,
             "readOnlyHint": true
         }
+    },
+    "actions-get-all": {
+        "description": "Get all actions in the project. Actions are reusable event definitions that can combine multiple trigger conditions (page views, clicks, form submissions) into a single trackable event for use in insights and funnels. Supports pagination with limit and offset parameters. Note: Search/filtering by name is not supported on this endpoint.",
+        "category": "Actions",
+        "feature": "actions",
+        "summary": "Get all actions in the project.",
+        "title": "Get all actions",
+        "required_scopes": ["action:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "action-get": {
+        "description": "Get a specific action by ID. Returns the action configuration including all steps and their trigger conditions.",
+        "category": "Actions",
+        "feature": "actions",
+        "summary": "Get a specific action by ID.",
+        "title": "Get action",
+        "required_scopes": ["action:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "action-create": {
+        "description": "Create a new action in the project. Actions define reusable event triggers based on page views, clicks, form submissions, or custom events. Each action can have multiple steps (OR conditions). Use actions to create composite events for insights and funnels. Example: Create a 'Sign Up Click' action with steps matching button clicks on the signup page.",
+        "category": "Actions",
+        "feature": "actions",
+        "summary": "Create a new action in the project.",
+        "title": "Create action",
+        "required_scopes": ["action:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "action-update": {
+        "description": "Update an existing action by ID. Can update name, description, steps, tags, and Slack notification settings.",
+        "category": "Actions",
+        "feature": "actions",
+        "summary": "Update an existing action.",
+        "title": "Update action",
+        "required_scopes": ["action:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "action-delete": {
+        "description": "Delete an action by ID (soft delete - marks as deleted). The action will no longer appear in lists but historical data is preserved.",
+        "category": "Actions",
+        "feature": "actions",
+        "summary": "Delete an action by ID.",
+        "title": "Delete action",
+        "required_scopes": ["action:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "entity-search": {
+        "description": "Search for PostHog entities by name or description. Can search across multiple entity types including insights, dashboards, experiments, feature flags, notebooks, actions, cohorts, event definitions, and surveys. Use this to find entities when you know part of their name. Returns matching entities with their IDs and URLs.",
+        "category": "Search",
+        "feature": "search",
+        "summary": "Search for entities by name or description.",
+        "title": "Search entities",
+        "required_scopes": [],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
     }
 }

--- a/services/mcp/typescript/package.json
+++ b/services/mcp/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/agent-toolkit",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "PostHog tools for AI agents",
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/services/mcp/typescript/src/api/client.ts
+++ b/services/mcp/typescript/src/api/client.ts
@@ -1537,12 +1537,27 @@ export class ApiClient {
                 actionId: number
             }): Promise<Result<{ success: boolean; message: string }>> => {
                 try {
+                    // First fetch the action to get its name (required by backend validation)
+                    const getResponse = await fetch(
+                        `${this.baseUrl}/api/projects/${projectId}/actions/${actionId}/`,
+                        {
+                            method: 'GET',
+                            headers: this.buildHeaders(),
+                        }
+                    )
+
+                    if (!getResponse.ok) {
+                        throw new Error(`Failed to fetch action: ${getResponse.statusText}`)
+                    }
+
+                    const action = (await getResponse.json()) as { name: string }
+
                     const response = await fetch(
                         `${this.baseUrl}/api/projects/${projectId}/actions/${actionId}/`,
                         {
                             method: 'PATCH',
                             headers: this.buildHeaders(),
-                            body: JSON.stringify({ deleted: true }),
+                            body: JSON.stringify({ name: action.name, deleted: true }),
                         }
                     )
 

--- a/services/mcp/typescript/src/schema/actions.ts
+++ b/services/mcp/typescript/src/schema/actions.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod'
+
+/**
+ * Action schemas for the PostHog MCP server.
+ *
+ * Actions are reusable event definitions that combine multiple trigger conditions
+ * (page views, clicks, form submissions, etc.) into a single trackable event.
+ */
+
+// Matching type for text/href/url matching
+const MatchingTypeSchema = z.enum(['contains', 'regex', 'exact'])
+
+// Property filter schema for filtering on event properties
+const PropertyFilterSchema = z.object({
+    key: z.string().describe('Property key'),
+    value: z
+        .union([z.string(), z.number(), z.boolean(), z.array(z.string()), z.array(z.number())])
+        .describe('Property value to match'),
+    operator: z
+        .enum([
+            'exact',
+            'is_not',
+            'is_set',
+            'is_not_set',
+            'icontains',
+            'not_icontains',
+            'regex',
+            'not_regex',
+            'gt',
+            'gte',
+            'lt',
+            'lte',
+        ])
+        .optional()
+        .describe('Comparison operator (default: exact)'),
+    type: z.enum(['event', 'person']).optional().describe('Property type'),
+})
+
+// Action step schema - defines a single trigger condition
+export const ActionStepInputSchema = z.object({
+    event: z
+        .string()
+        .optional()
+        .describe("Event name (e.g., '$pageview', '$autocapture', or custom event name)"),
+    properties: z.array(PropertyFilterSchema).optional().describe('Event properties to filter on'),
+    tag_name: z.string().optional().describe('HTML tag name to match (e.g., "button", "a", "input")'),
+    text: z.string().optional().describe('Element text content to match'),
+    text_matching: MatchingTypeSchema.optional().describe('How to match text (default: exact)'),
+    href: z.string().optional().describe('Link href attribute to match'),
+    href_matching: MatchingTypeSchema.optional().describe('How to match href (default: exact)'),
+    selector: z.string().optional().describe('CSS selector to match element'),
+    url: z.string().optional().describe('Page URL to match'),
+    url_matching: MatchingTypeSchema.optional().describe('How to match URL (default: contains)'),
+})
+
+// Create action input schema
+export const CreateActionInputSchema = z.object({
+    name: z.string().min(1).describe('Name of the action (must be unique within the project)'),
+    description: z.string().optional().describe('Description of what this action represents'),
+    steps: z
+        .array(ActionStepInputSchema)
+        .min(1)
+        .describe('Action steps - each step defines a trigger condition. Multiple steps are OR-ed together.'),
+    tags: z.array(z.string()).optional().describe('Tags for organizing actions'),
+    post_to_slack: z.boolean().default(false).optional().describe('Whether to post to Slack when this action is triggered'),
+    slack_message_format: z.string().optional().describe('Custom Slack message format'),
+})
+
+// Update action input schema
+export const UpdateActionInputSchema = z.object({
+    name: z.string().min(1).optional().describe('Updated action name'),
+    description: z.string().optional().nullable().describe('Updated description'),
+    steps: z.array(ActionStepInputSchema).optional().describe('Updated action steps'),
+    tags: z.array(z.string()).optional().describe('Updated tags'),
+    post_to_slack: z.boolean().optional().describe('Whether to post to Slack'),
+    slack_message_format: z.string().optional().describe('Custom Slack message format'),
+    pinned_at: z.string().nullable().optional().describe('Pin timestamp (set to pin, null to unpin)'),
+})
+
+// List actions input schema
+// Note: The PostHog Actions API does not support search filtering natively.
+// Search is available via the global /api/projects/{project_id}/search/?q=&entities=action endpoint
+export const ListActionsInputSchema = z.object({
+    limit: z.number().int().positive().optional().describe('Maximum number of actions to return'),
+    offset: z.number().int().min(0).optional().describe('Number of actions to skip for pagination'),
+})
+
+// Action response schema - permissive to handle API response variations
+export const ActionResponseSchema = z
+    .object({
+        id: z.number(),
+        name: z.string(),
+        description: z.string().optional().nullable(),
+        team_id: z.number(),
+        steps: z.array(z.record(z.any())).optional().nullable(),
+        tags: z.array(z.string()).optional().nullable(),
+        post_to_slack: z.boolean().optional(),
+        slack_message_format: z.string().optional().nullable(),
+        deleted: z.boolean().optional(),
+        pinned_at: z.string().optional().nullable(),
+        created_at: z.string().optional(),
+        created_by: z.record(z.any()).optional().nullable(),
+        is_action: z.boolean().optional(),
+        bytecode_error: z.string().optional().nullable(),
+    })
+    .passthrough() // Allow additional fields from API
+
+// Export types for use in handlers
+export type ActionStepInput = z.infer<typeof ActionStepInputSchema>
+export type CreateActionInput = z.infer<typeof CreateActionInputSchema>
+export type UpdateActionInput = z.infer<typeof UpdateActionInputSchema>
+export type ListActionsInput = z.infer<typeof ListActionsInputSchema>
+export type ActionResponse = z.infer<typeof ActionResponseSchema>

--- a/services/mcp/typescript/src/schema/tool-inputs.ts
+++ b/services/mcp/typescript/src/schema/tool-inputs.ts
@@ -19,6 +19,7 @@ import {
     ListSurveysInputSchema,
     UpdateSurveyInputSchema,
 } from './surveys'
+import { CreateActionInputSchema, ListActionsInputSchema, UpdateActionInputSchema } from './actions'
 
 export const DashboardAddInsightSchema = z.object({
     data: AddInsightToDashboardSchema,
@@ -388,3 +389,46 @@ export const QueryRunInputSchema = z.object({
 })
 
 export { LogsQueryInputSchema, LogsListAttributesInputSchema, LogsListAttributeValuesInputSchema }
+
+// Actions
+export const ActionCreateSchema = CreateActionInputSchema
+
+export const ActionDeleteSchema = z.object({
+    actionId: z.number().int().positive().describe('The ID of the action to delete'),
+})
+
+export const ActionGetSchema = z.object({
+    actionId: z.number().int().positive().describe('The ID of the action to retrieve'),
+})
+
+export const ActionGetAllSchema = z.object({
+    data: ListActionsInputSchema.optional(),
+})
+
+export const ActionUpdateSchema = z.object({
+    actionId: z.number().int().positive().describe('The ID of the action to update'),
+    data: UpdateActionInputSchema,
+})
+
+// Entity Search
+export const EntitySearchSchema = z.object({
+    query: z.string().min(1).describe('Search query to find entities by name or description'),
+    entities: z
+        .array(
+            z.enum([
+                'insight',
+                'dashboard',
+                'experiment',
+                'feature_flag',
+                'notebook',
+                'action',
+                'cohort',
+                'event_definition',
+                'survey',
+            ])
+        )
+        .optional()
+        .describe(
+            'Entity types to search. If not specified, searches all types. Available: insight, dashboard, experiment, feature_flag, notebook, action, cohort, event_definition, survey'
+        ),
+})

--- a/services/mcp/typescript/src/tools/actions/create.ts
+++ b/services/mcp/typescript/src/tools/actions/create.ts
@@ -1,0 +1,33 @@
+import type { z } from 'zod'
+
+import { ActionCreateSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ActionCreateSchema
+
+type Params = z.infer<typeof schema>
+
+export const createHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.actions({ projectId }).create({
+        data: params,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to create action: ${result.error.message}`)
+    }
+
+    return {
+        ...result.data,
+        url: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions/${result.data.id}`,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'action-create',
+    schema,
+    handler: createHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/actions/delete.ts
+++ b/services/mcp/typescript/src/tools/actions/delete.ts
@@ -1,0 +1,30 @@
+import type { z } from 'zod'
+
+import { ActionDeleteSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ActionDeleteSchema
+
+type Params = z.infer<typeof schema>
+
+export const deleteHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.actions({ projectId }).delete({
+        actionId: params.actionId,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to delete action: ${result.error.message}`)
+    }
+
+    return result.data
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'action-delete',
+    schema,
+    handler: deleteHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/actions/get.ts
+++ b/services/mcp/typescript/src/tools/actions/get.ts
@@ -1,0 +1,33 @@
+import type { z } from 'zod'
+
+import { ActionGetSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ActionGetSchema
+
+type Params = z.infer<typeof schema>
+
+export const getHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.actions({ projectId }).get({
+        actionId: params.actionId,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to get action: ${result.error.message}`)
+    }
+
+    return {
+        ...result.data,
+        url: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions/${result.data.id}`,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'action-get',
+    schema,
+    handler: getHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/actions/getAll.ts
+++ b/services/mcp/typescript/src/tools/actions/getAll.ts
@@ -1,0 +1,35 @@
+import type { z } from 'zod'
+
+import { ActionGetAllSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ActionGetAllSchema
+
+type Params = z.infer<typeof schema>
+
+export const getAllHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.actions({ projectId }).list({
+        params: params.data,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to get actions: ${result.error.message}`)
+    }
+
+    const actionsWithUrls = result.data.map((action: { id: number; [key: string]: unknown }) => ({
+        ...action,
+        url: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions/${action.id}`,
+    }))
+
+    return actionsWithUrls
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'actions-get-all',
+    schema,
+    handler: getAllHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/actions/index.ts
+++ b/services/mcp/typescript/src/tools/actions/index.ts
@@ -1,0 +1,5 @@
+export { default as createAction } from './create'
+export { default as deleteAction } from './delete'
+export { default as getAction } from './get'
+export { default as getAllActions } from './getAll'
+export { default as updateAction } from './update'

--- a/services/mcp/typescript/src/tools/actions/update.ts
+++ b/services/mcp/typescript/src/tools/actions/update.ts
@@ -1,0 +1,34 @@
+import type { z } from 'zod'
+
+import { ActionUpdateSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ActionUpdateSchema
+
+type Params = z.infer<typeof schema>
+
+export const updateHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.actions({ projectId }).update({
+        actionId: params.actionId,
+        data: params.data,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to update action: ${result.error.message}`)
+    }
+
+    return {
+        ...result.data,
+        url: `${context.api.getProjectBaseUrl(projectId)}/data-management/actions/${result.data.id}`,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'action-update',
+    schema,
+    handler: updateHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/index.ts
+++ b/services/mcp/typescript/src/tools/index.ts
@@ -64,6 +64,14 @@ import getAllSurveys from './surveys/getAll'
 import surveysGlobalStats from './surveys/global-stats'
 import surveyStats from './surveys/stats'
 import updateSurvey from './surveys/update'
+// Actions
+import createAction from './actions/create'
+import deleteAction from './actions/delete'
+import getAction from './actions/get'
+import getAllActions from './actions/getAll'
+import updateAction from './actions/update'
+// Search
+import entitySearch from './search/entitySearch'
 // Misc
 import { getToolsForFeatures as getFilteredToolNames, getToolDefinition } from './toolDefinitions'
 import type { Context, Tool, ToolBase, ZodObjectAny } from './types'
@@ -140,6 +148,16 @@ const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     'survey-delete': deleteSurvey,
     'surveys-global-stats': surveysGlobalStats,
     'survey-stats': surveyStats,
+
+    // Actions
+    'actions-get-all': getAllActions,
+    'action-get': getAction,
+    'action-create': createAction,
+    'action-update': updateAction,
+    'action-delete': deleteAction,
+
+    // Search
+    'entity-search': entitySearch,
 }
 
 export const getToolsFromContext = async (context: Context, features?: string[]): Promise<Tool<ZodObjectAny>[]> => {

--- a/services/mcp/typescript/src/tools/search/entitySearch.ts
+++ b/services/mcp/typescript/src/tools/search/entitySearch.ts
@@ -1,0 +1,60 @@
+import type { z } from 'zod'
+
+import type { SearchableEntity, SearchResult } from '@/api/client'
+import { EntitySearchSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = EntitySearchSchema
+
+type Params = z.infer<typeof schema>
+
+// Map entity types to their URL paths in PostHog
+const ENTITY_URL_PATHS: Record<string, string> = {
+    insight: 'insights',
+    dashboard: 'dashboard',
+    experiment: 'experiments',
+    feature_flag: 'feature_flags',
+    notebook: 'notebooks',
+    action: 'data-management/actions',
+    cohort: 'cohorts',
+    event_definition: 'data-management/events',
+    survey: 'surveys',
+}
+
+export const entitySearchHandler: ToolBase<typeof schema>['handler'] = async (
+    context: Context,
+    params: Params
+) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.search({ projectId }).query({
+        query: params.query,
+        entities: params.entities as SearchableEntity[] | undefined,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to search entities: ${result.error.message}`)
+    }
+
+    // Enrich results with URLs
+    const resultsWithUrls = result.data.results.map((item: SearchResult) => {
+        const urlPath = ENTITY_URL_PATHS[item.type] || item.type
+        return {
+            ...item,
+            url: `${context.api.getProjectBaseUrl(projectId)}/${urlPath}/${item.result_id}`,
+        }
+    })
+
+    return {
+        results: resultsWithUrls,
+        counts: result.data.counts,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'entity-search',
+    schema,
+    handler: entitySearchHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/search/index.ts
+++ b/services/mcp/typescript/src/tools/search/index.ts
@@ -1,0 +1,1 @@
+export { default as entitySearch } from './entitySearch'

--- a/services/mcp/typescript/tests/shared/test-utils.ts
+++ b/services/mcp/typescript/tests/shared/test-utils.ts
@@ -15,6 +15,7 @@ export interface CreatedResources {
     insights: number[]
     dashboards: number[]
     surveys: string[]
+    actions: number[]
 }
 
 export function validateEnvironmentVariables(): void {
@@ -99,6 +100,15 @@ export async function cleanupResources(
         }
     }
     resources.surveys = []
+
+    for (const actionId of resources.actions) {
+        try {
+            await client.actions({ projectId }).delete({ actionId })
+        } catch (error) {
+            console.warn(`Failed to cleanup action ${actionId}:`, error)
+        }
+    }
+    resources.actions = []
 }
 
 export function parseToolResponse(result: any): any {

--- a/services/mcp/typescript/tests/tools/actions.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/actions.integration.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+    type CreatedResources,
+    TEST_ORG_ID,
+    TEST_PROJECT_ID,
+    cleanupResources,
+    createTestClient,
+    createTestContext,
+    generateUniqueKey,
+    parseToolResponse,
+    setActiveProjectAndOrg,
+    validateEnvironmentVariables,
+} from '@/shared/test-utils'
+import createActionTool from '@/tools/actions/create'
+import deleteActionTool from '@/tools/actions/delete'
+import getActionTool from '@/tools/actions/get'
+import getAllActionsTool from '@/tools/actions/getAll'
+import updateActionTool from '@/tools/actions/update'
+import type { Context } from '@/tools/types'
+
+describe('Actions', { concurrent: false }, () => {
+    let context: Context
+    const createdResources: CreatedResources = {
+        featureFlags: [],
+        insights: [],
+        dashboards: [],
+        surveys: [],
+        actions: [],
+    }
+
+    beforeAll(async () => {
+        validateEnvironmentVariables()
+        const client = createTestClient()
+        context = createTestContext(client)
+        await setActiveProjectAndOrg(context, TEST_PROJECT_ID!, TEST_ORG_ID!)
+    })
+
+    afterEach(async () => {
+        await cleanupResources(context.api, TEST_PROJECT_ID!, createdResources)
+    })
+
+    describe('action-create tool', () => {
+        const createTool = createActionTool()
+
+        it('should create an action with event-based step', async () => {
+            const params = {
+                name: `Test Action ${generateUniqueKey('action')}`,
+                description: 'Integration test action',
+                steps: [
+                    {
+                        event: '$pageview',
+                        url: '/signup',
+                        url_matching: 'contains' as const,
+                    },
+                ],
+                tags: ['test', 'integration'],
+            }
+
+            const result = await createTool.handler(context, params)
+            const actionData = parseToolResponse(result)
+
+            expect(actionData.id).toBeTruthy()
+            expect(actionData.name).toBe(params.name)
+            expect(actionData.description).toBe(params.description)
+            expect(actionData.url).toContain('/data-management/actions/')
+
+            createdResources.actions.push(actionData.id)
+        })
+
+        it('should create an action with autocapture step', async () => {
+            const params = {
+                name: `Click Action ${generateUniqueKey('click')}`,
+                steps: [
+                    {
+                        event: '$autocapture',
+                        tag_name: 'button',
+                        text: 'Sign Up',
+                        text_matching: 'contains' as const,
+                        selector: 'div.signup-form > button',
+                    },
+                ],
+            }
+
+            const result = await createTool.handler(context, params)
+            const actionData = parseToolResponse(result)
+
+            expect(actionData.id).toBeTruthy()
+            expect(actionData.name).toBe(params.name)
+
+            createdResources.actions.push(actionData.id)
+        })
+
+        it('should create an action with multiple steps (OR conditions)', async () => {
+            const params = {
+                name: `Multi-step Action ${generateUniqueKey('multi')}`,
+                description: 'Action with multiple trigger conditions',
+                steps: [
+                    {
+                        event: '$pageview',
+                        url: '/pricing',
+                        url_matching: 'contains' as const,
+                    },
+                    {
+                        event: '$autocapture',
+                        tag_name: 'a',
+                        href: '/pricing',
+                        href_matching: 'contains' as const,
+                    },
+                ],
+            }
+
+            const result = await createTool.handler(context, params)
+            const actionData = parseToolResponse(result)
+
+            expect(actionData.id).toBeTruthy()
+            expect(actionData.name).toBe(params.name)
+            expect(actionData.steps).toHaveLength(2)
+
+            createdResources.actions.push(actionData.id)
+        })
+
+        it('should create an action with custom event', async () => {
+            const params = {
+                name: `Custom Event Action ${generateUniqueKey('custom')}`,
+                steps: [
+                    {
+                        event: 'user_signed_up',
+                    },
+                ],
+            }
+
+            const result = await createTool.handler(context, params)
+            const actionData = parseToolResponse(result)
+
+            expect(actionData.id).toBeTruthy()
+            expect(actionData.name).toBe(params.name)
+
+            createdResources.actions.push(actionData.id)
+        })
+    })
+
+    describe('actions-get-all tool', () => {
+        const getAllTool = getAllActionsTool()
+        const createTool = createActionTool()
+
+        it('should list all actions', async () => {
+            // Create a test action first
+            const createResult = await createTool.handler(context, {
+                name: `List Test Action ${generateUniqueKey('list')}`,
+                steps: [{ event: '$pageview' }],
+            })
+            const createdAction = parseToolResponse(createResult)
+            createdResources.actions.push(createdAction.id)
+
+            // List actions
+            const result = await getAllTool.handler(context, {})
+            const actions = parseToolResponse(result)
+
+            expect(Array.isArray(actions)).toBe(true)
+            expect(actions.some((a: { id: number }) => a.id === createdAction.id)).toBe(true)
+        })
+
+        it('should support pagination', async () => {
+            const result = await getAllTool.handler(context, {
+                data: { limit: 5, offset: 0 },
+            })
+            const actions = parseToolResponse(result)
+
+            expect(Array.isArray(actions)).toBe(true)
+            expect(actions.length).toBeLessThanOrEqual(5)
+        })
+    })
+
+    describe('action-get tool', () => {
+        const getTool = getActionTool()
+        const createTool = createActionTool()
+
+        it('should get a specific action by ID', async () => {
+            // Create a test action first
+            const createResult = await createTool.handler(context, {
+                name: `Get Test Action ${generateUniqueKey('get')}`,
+                description: 'Test description for get',
+                steps: [
+                    {
+                        event: '$pageview',
+                        url: '/test',
+                    },
+                ],
+            })
+            const createdAction = parseToolResponse(createResult)
+            createdResources.actions.push(createdAction.id)
+
+            // Get the action
+            const result = await getTool.handler(context, { actionId: createdAction.id })
+            const actionData = parseToolResponse(result)
+
+            expect(actionData.id).toBe(createdAction.id)
+            expect(actionData.name).toBe(createdAction.name)
+            expect(actionData.description).toBe('Test description for get')
+            expect(actionData.url).toContain('/data-management/actions/')
+        })
+    })
+
+    describe('action-update tool', () => {
+        const updateTool = updateActionTool()
+        const createTool = createActionTool()
+
+        it('should update an action name and description', async () => {
+            // Create a test action first
+            const originalName = `Original Action ${generateUniqueKey('original')}`
+            const createResult = await createTool.handler(context, {
+                name: originalName,
+                steps: [{ event: '$pageview' }],
+            })
+            const createdAction = parseToolResponse(createResult)
+            createdResources.actions.push(createdAction.id)
+
+            // Update the action
+            const updatedName = `Updated Action ${generateUniqueKey('updated')}`
+            const result = await updateTool.handler(context, {
+                actionId: createdAction.id,
+                data: {
+                    name: updatedName,
+                    description: 'Updated description',
+                },
+            })
+            const updatedAction = parseToolResponse(result)
+
+            expect(updatedAction.id).toBe(createdAction.id)
+            expect(updatedAction.name).toBe(updatedName)
+            expect(updatedAction.description).toBe('Updated description')
+        })
+
+        it('should update action steps', async () => {
+            // Create a test action first
+            const createResult = await createTool.handler(context, {
+                name: `Steps Update Action ${generateUniqueKey('steps')}`,
+                steps: [{ event: '$pageview' }],
+            })
+            const createdAction = parseToolResponse(createResult)
+            createdResources.actions.push(createdAction.id)
+
+            // Update with new steps
+            const result = await updateTool.handler(context, {
+                actionId: createdAction.id,
+                data: {
+                    steps: [
+                        {
+                            event: '$pageview',
+                            url: '/updated-page',
+                            url_matching: 'contains' as const,
+                        },
+                        {
+                            event: '$autocapture',
+                            tag_name: 'button',
+                        },
+                    ],
+                },
+            })
+            const updatedAction = parseToolResponse(result)
+
+            expect(updatedAction.id).toBe(createdAction.id)
+            expect(updatedAction.steps).toHaveLength(2)
+        })
+
+        it('should update action tags', async () => {
+            // Create a test action first
+            const createResult = await createTool.handler(context, {
+                name: `Tags Update Action ${generateUniqueKey('tags')}`,
+                steps: [{ event: '$pageview' }],
+                tags: ['original'],
+            })
+            const createdAction = parseToolResponse(createResult)
+            createdResources.actions.push(createdAction.id)
+
+            // Update tags
+            const result = await updateTool.handler(context, {
+                actionId: createdAction.id,
+                data: {
+                    tags: ['updated', 'new-tag'],
+                },
+            })
+            const updatedAction = parseToolResponse(result)
+
+            expect(updatedAction.id).toBe(createdAction.id)
+            expect(updatedAction.tags).toContain('updated')
+            expect(updatedAction.tags).toContain('new-tag')
+        })
+    })
+
+    describe('action-delete tool', () => {
+        const deleteTool = deleteActionTool()
+        const createTool = createActionTool()
+        const getAllTool = getAllActionsTool()
+
+        it('should soft delete an action', async () => {
+            // Create a test action first
+            const createResult = await createTool.handler(context, {
+                name: `Delete Test Action ${generateUniqueKey('delete')}`,
+                steps: [{ event: '$pageview' }],
+            })
+            const createdAction = parseToolResponse(createResult)
+            // Don't add to createdResources since we're deleting it
+
+            // Delete the action
+            const deleteResult = await deleteTool.handler(context, { actionId: createdAction.id })
+            const deleteData = parseToolResponse(deleteResult)
+
+            expect(deleteData.success).toBe(true)
+
+            // Verify it's no longer in the list
+            const listResult = await getAllTool.handler(context, {})
+            const actions = parseToolResponse(listResult)
+            expect(actions.some((a: { id: number }) => a.id === createdAction.id)).toBe(false)
+        })
+    })
+})

--- a/services/mcp/typescript/tests/tools/dashboards.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/dashboards.integration.test.ts
@@ -30,6 +30,7 @@ describe('Dashboards', { concurrent: false }, () => {
         insights: [],
         dashboards: [],
         surveys: [],
+        actions: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/typescript/tests/tools/documentation.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/documentation.integration.test.ts
@@ -20,6 +20,7 @@ describe('Documentation', { concurrent: false }, () => {
         insights: [],
         dashboards: [],
         surveys: [],
+        actions: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/typescript/tests/tools/errorTracking.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/errorTracking.integration.test.ts
@@ -23,6 +23,7 @@ describe('Error Tracking', { concurrent: false }, () => {
         insights: [],
         dashboards: [],
         surveys: [],
+        actions: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/typescript/tests/tools/experiments.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/experiments.integration.test.ts
@@ -27,6 +27,7 @@ describe('Experiments', { concurrent: false }, () => {
         insights: [],
         dashboards: [],
         surveys: [],
+        actions: [],
     }
     const createdExperiments: number[] = []
 

--- a/services/mcp/typescript/tests/tools/featureFlags.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/featureFlags.integration.test.ts
@@ -26,6 +26,7 @@ describe('Feature Flags', { concurrent: false }, () => {
         insights: [],
         dashboards: [],
         surveys: [],
+        actions: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/typescript/tests/tools/insights.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/insights.integration.test.ts
@@ -29,6 +29,7 @@ describe('Insights', { concurrent: false }, () => {
         insights: [],
         dashboards: [],
         surveys: [],
+        actions: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/typescript/tests/tools/llmAnalytics.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/llmAnalytics.integration.test.ts
@@ -21,6 +21,7 @@ describe('LLM Analytics', { concurrent: false }, () => {
         insights: [],
         dashboards: [],
         surveys: [],
+        actions: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/typescript/tests/tools/logs.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/logs.integration.test.ts
@@ -23,6 +23,7 @@ describe('Logs', { concurrent: false }, () => {
         insights: [],
         dashboards: [],
         surveys: [],
+        actions: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/typescript/tests/tools/organizations.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/organizations.integration.test.ts
@@ -23,6 +23,7 @@ describe.skip('Organizations', { concurrent: false }, () => {
         insights: [],
         dashboards: [],
         surveys: [],
+        actions: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/typescript/tests/tools/projects.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/projects.integration.test.ts
@@ -25,6 +25,7 @@ describe('Projects', { concurrent: false }, () => {
         insights: [],
         dashboards: [],
         surveys: [],
+        actions: [],
     }
 
     beforeAll(async () => {

--- a/services/mcp/typescript/tests/tools/query.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/query.integration.test.ts
@@ -41,6 +41,7 @@ describe('Query Integration Tests', () => {
             insights: [],
             dashboards: [],
             surveys: [],
+        actions: [],
         }
     })
 

--- a/services/mcp/typescript/tests/tools/surveys.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/surveys.integration.test.ts
@@ -28,6 +28,7 @@ describe('Surveys', { concurrent: false }, () => {
         insights: [],
         dashboards: [],
         surveys: [],
+        actions: [],
     }
 
     beforeAll(async () => {


### PR DESCRIPTION
## Problem

MCP users cannot create or manage Actions programmatically. When tracking autocapture events via `data-attr` attributes, users must manually create Actions in the PostHog UI before they can create insights that use them via MCP.

Closes #44745

## Changes

Add Actions CRUD support to the MCP server:
- `action-get` - Get action details by ID
- `action-create` - Create actions with autocapture/custom event matching, CSS selectors, URL matching
- `action-update` - Update existing actions
- `action-delete` - Soft delete actions
- `actions-get-all` - List all actions with pagination

Add generic entity search tool:
- `entity-search` - Search across PostHog entities (insights, dashboards, experiments, feature flags, actions, cohorts, surveys, etc.) using the global search API

Files added/modified:
- `src/schema/actions.ts` - Zod schemas for action input/output
- `src/api/client.ts` - Added `actions()` and `search()` methods
- `src/tools/actions/*.ts` - Tool handlers
- `src/tools/search/entitySearch.ts` - Entity search handler
- `schema/tool-definitions.json` - Tool definitions
- `tests/tools/actions.integration.test.ts` - Integration tests

## How did you test this code?

- Added integration tests for all action CRUD operations
- TypeScript compilation passes for all new code
- Followed existing patterns from feature flags, surveys, and insights implementations

### Local MCP testing

Tested locally against a local PostHog instance:

| Tool | Status |
|------|--------|
| actions-get-all | Working |
| action-get | Working |
| action-create | Working |
| action-update | Working |
| action-delete | Working |

Note: `entity-search` returns 403 with Personal API Keys because the backend `SearchViewSet` uses `scope_object = "INTERNAL"`. This should work in production since the hosted MCP server uses OAuth tokens which bypass this restriction.

## Publish to changelog?

no