### PR TITLE
feat(workflows): Make email verification instructions clearer

### DIFF
--- a/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
+++ b/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
@@ -10,24 +10,8 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { DnsRecord, EmailSetupModalLogicProps, emailSetupModalLogic } from './emailSetupModalLogic'
 
 export const EmailSetupModal = (props: EmailSetupModalLogicProps): JSX.Element => {
-    const { integration, integrationLoading, verification, verificationLoading } = useValues(
-        emailSetupModalLogic(props)
-    )
+    const { integration, integrationLoading, verificationLoading, dnsRecords } = useValues(emailSetupModalLogic(props))
     const { verifyDomain, submitEmailSender } = useActions(emailSetupModalLogic(props))
-
-    const parseHostname = (hostname: string, rootDomain: string): { subdomain: string; rootDomain: string } => {
-        if (hostname === '@') {
-            return { subdomain: '@', rootDomain: '' }
-        }
-
-        if (hostname.endsWith(`.${rootDomain}`)) {
-            const subdomain = hostname.slice(0, -rootDomain.length - 1)
-            return { subdomain, rootDomain: `.${rootDomain}` }
-        }
-
-        // Fallback: return as subdomain if we can't parse it
-        return { subdomain: hostname, rootDomain: '' }
-    }
 
     let modalContent = <></>
 
@@ -85,12 +69,8 @@ export const EmailSetupModal = (props: EmailSetupModalLogicProps): JSX.Element =
                             </tr>
                         </thead>
                         <tbody>
-                            {verification?.dnsRecords?.map((record: DnsRecord, index: number) => {
-                                const rootDomain = integration?.config?.domain || ''
-                                const { subdomain, rootDomain: rootDomainSuffix } = parseHostname(
-                                    record.recordHostname,
-                                    rootDomain
-                                )
+                            {dnsRecords?.map((record: DnsRecord, index: number) => {
+                                const { subdomain, rootDomain: rootDomainSuffix } = record.parsedHostname
 
                                 return (
                                     <tr key={index} className="border-b">

--- a/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
+++ b/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
@@ -21,7 +21,7 @@ export const EmailSetupModal = (props: EmailSetupModalLogicProps): JSX.Element =
         }
 
         if (hostname.endsWith(`.${rootDomain}`)) {
-            const subdomain = hostname.slice(0, -(rootDomain.length + 1))
+            const subdomain = hostname.slice(0, -rootDomain.length - 1)
             return { subdomain, rootDomain: `.${rootDomain}` }
         }
 
@@ -105,7 +105,7 @@ export const EmailSetupModal = (props: EmailSetupModalLogicProps): JSX.Element =
                                                             icon={<IconCopy />}
                                                             onClick={() => {
                                                                 void navigator.clipboard.writeText(subdomain)
-                                                                lemonToast.success('Hostname copied to clipboard')
+                                                                lemonToast.success('Name copied to clipboard')
                                                             }}
                                                             tooltip="Copy hostname"
                                                             className="ml-0.5 -mr-0.5"

--- a/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
+++ b/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
@@ -15,6 +15,20 @@ export const EmailSetupModal = (props: EmailSetupModalLogicProps): JSX.Element =
     )
     const { verifyDomain, submitEmailSender } = useActions(emailSetupModalLogic(props))
 
+    const parseHostname = (hostname: string, rootDomain: string): { subdomain: string; rootDomain: string } => {
+        if (hostname === '@') {
+            return { subdomain: '@', rootDomain: '' }
+        }
+
+        if (hostname.endsWith(`.${rootDomain}`)) {
+            const subdomain = hostname.slice(0, -(rootDomain.length + 1))
+            return { subdomain, rootDomain: `.${rootDomain}` }
+        }
+
+        // Fallback: return as subdomain if we can't parse it
+        return { subdomain: hostname, rootDomain: '' }
+    }
+
     let modalContent = <></>
 
     if (!integration) {
@@ -65,64 +79,82 @@ export const EmailSetupModal = (props: EmailSetupModalLogicProps): JSX.Element =
                         <thead>
                             <tr className="border-b">
                                 <th className="py-2 text-left">Type</th>
-                                <th className="py-2 text-left">Hostname</th>
+                                <th className="py-2 text-left">Name</th>
                                 <th className="py-2 text-left">Value</th>
                                 <th className="py-2 text-left">Status</th>
                             </tr>
                         </thead>
                         <tbody>
-                            {verification?.dnsRecords?.map((record: DnsRecord, index: number) => (
-                                <tr key={index} className="border-b">
-                                    <td className="py-2">{record.recordType}</td>
-                                    <td className="py-2 max-w-[8rem]">
-                                        <div className="flex gap-1 justify-between items-center break-all text-wrap">
-                                            <span>{record.recordHostname}</span>
-                                            <LemonButton
-                                                size="small"
-                                                icon={<IconCopy />}
-                                                onClick={() => {
-                                                    void navigator.clipboard.writeText(record.recordHostname)
-                                                    lemonToast.success('Hostname copied to clipboard')
-                                                }}
-                                                tooltip="Copy hostname"
-                                            />
-                                        </div>
-                                    </td>
-                                    <td className="py-2 max-w-[8rem]">
-                                        <div className="flex gap-1 justify-between items-center break-all text-wrap">
-                                            <span>{record.recordValue}</span>
-                                            <LemonButton
-                                                size="small"
-                                                icon={<IconCopy />}
-                                                onClick={() => {
-                                                    void navigator.clipboard.writeText(record.recordValue)
-                                                    lemonToast.success('Value copied to clipboard')
-                                                }}
-                                                tooltip="Copy value"
-                                            />
-                                        </div>
-                                    </td>
-                                    <td className="py-2 w-[10rem]">
-                                        {verificationLoading ? (
-                                            <Spinner className="text-lg" />
-                                        ) : record.status === 'pending' ? (
-                                            <div className="flex gap-1 items-center">
-                                                <IconWarning className="size-6 text-warning" /> Not present
-                                            </div>
-                                        ) : record.status === 'success' ? (
-                                            <div className="flex gap-1 items-center">
-                                                <IconCheckCircle className="size-6 text-success" /> Verified
-                                            </div>
-                                        ) : (
-                                            <Tooltip title="We are unable to verify this record at the moment">
-                                                <div className="flex gap-1 items-center">
-                                                    <IconQuestion className="size-6 text-muted" /> Unknown
+                            {verification?.dnsRecords?.map((record: DnsRecord, index: number) => {
+                                const rootDomain = integration?.config?.domain || ''
+                                const { subdomain, rootDomain: rootDomainSuffix } = parseHostname(
+                                    record.recordHostname,
+                                    rootDomain
+                                )
+
+                                return (
+                                    <tr key={index} className="border-b">
+                                        <td className="py-2">{record.recordType}</td>
+                                        <td className="py-2 max-w-[8rem]">
+                                            <div className="flex gap-0 items-center break-all text-wrap">
+                                                <div className="flex gap-0 items-center bg-bg-light border border-border rounded px-1.5 py-0.5">
+                                                    <span className="font-mono text-sm">{subdomain}</span>
+                                                    {subdomain !== '@' && (
+                                                        <LemonButton
+                                                            size="small"
+                                                            icon={<IconCopy />}
+                                                            onClick={() => {
+                                                                void navigator.clipboard.writeText(subdomain)
+                                                                lemonToast.success('Hostname copied to clipboard')
+                                                            }}
+                                                            tooltip="Copy hostname"
+                                                            className="ml-0.5 -mr-0.5"
+                                                        />
+                                                    )}
                                                 </div>
-                                            </Tooltip>
-                                        )}
-                                    </td>
-                                </tr>
-                            ))}
+                                                {rootDomainSuffix && (
+                                                    <span className="text-muted font-mono text-sm ml-1">
+                                                        {rootDomainSuffix}
+                                                    </span>
+                                                )}
+                                            </div>
+                                        </td>
+                                        <td className="py-2 max-w-[8rem]">
+                                            <div className="flex gap-1 justify-between items-center break-all text-wrap">
+                                                <span>{record.recordValue}</span>
+                                                <LemonButton
+                                                    size="small"
+                                                    icon={<IconCopy />}
+                                                    onClick={() => {
+                                                        void navigator.clipboard.writeText(record.recordValue)
+                                                        lemonToast.success('Value copied to clipboard')
+                                                    }}
+                                                    tooltip="Copy value"
+                                                />
+                                            </div>
+                                        </td>
+                                        <td className="py-2 w-[10rem]">
+                                            {verificationLoading ? (
+                                                <Spinner className="text-lg" />
+                                            ) : record.status === 'pending' ? (
+                                                <div className="flex gap-1 items-center">
+                                                    <IconWarning className="size-6 text-warning" /> Not present
+                                                </div>
+                                            ) : record.status === 'success' ? (
+                                                <div className="flex gap-1 items-center">
+                                                    <IconCheckCircle className="size-6 text-success" /> Verified
+                                                </div>
+                                            ) : (
+                                                <Tooltip title="We are unable to verify this record at the moment">
+                                                    <div className="flex gap-1 items-center">
+                                                        <IconQuestion className="size-6 text-muted" /> Unknown
+                                                    </div>
+                                                </Tooltip>
+                                            )}
+                                        </td>
+                                    </tr>
+                                )
+                            })}
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
## Problem

<img width="1022" height="560" alt="image" src="https://github.com/user-attachments/assets/9bb8f8c0-7572-407e-915a-96a522740267" />

Before our modal encouraged users to copy-paste the fully qualified domain name, which could lead to them creating DNS entries like `_amazonses.example.com.example.com` instead of `_amazonses.example.com`

(eg. here: https://posthoghelp.zendesk.com/agent/tickets/44967 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49570))

## Changes
<img width="1022" height="560" alt="image" src="https://github.com/user-attachments/assets/d8c7c1df-01af-4eeb-a259-4c83b1995a58" />

Now the copy-paste only gives you the subdomain, naturally guiding you towards doing the right thing

## How did you test this code?

Manually
