### PR TITLE
fix: session profile not loading sessions fix

### DIFF
--- a/frontend/src/scenes/sessions/components/SessionEventsList.tsx
+++ b/frontend/src/scenes/sessions/components/SessionEventsList.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { IconCollapse, IconExpand, IconSort } from '@posthog/icons'
 import { LemonButton, LemonCard } from '@posthog/lemon-ui'
 
-import { RecordingEventType } from '~/types'
+import { RecordingEventType, SessionEventType } from '~/types'
 
 import { sessionProfileLogic } from '../sessionProfileLogic'
 import { SessionEventItem } from './SessionEventItem'
@@ -124,10 +124,10 @@ export function SessionEventsList(): JSX.Element {
                     className="p-2 space-y-1 max-h-[600px] overflow-y-auto bg-primary border-t border-border"
                     onScroll={handleScroll}
                 >
-                    {sessionEvents?.map((event, index) => (
+                    {sessionEvents?.map((event: SessionEventType, index: number) => (
                         <SessionEventItem
                             key={event.id}
-                            event={{ ...event, fullyLoaded: true } as RecordingEventType}
+                            event={event as RecordingEventType}
                             index={index}
                             isExpanded={expandedIndices.has(index)}
                             onToggleExpand={handleToggleExpand}


### PR DESCRIPTION
## Problem

Event properties/metadata/flags/raw tabs were not displaying data when expanding events on the session profile activity page.
https://posthoghelp.zendesk.com/agent/tickets/46746 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49720)

<img width="2046" height="662" alt="image" src="https://github.com/user-attachments/assets/d0497a8d-8eab-4248-b077-e55a45d387fb" />


## Changes

Removed hardcoded fullyLoaded: true override in `SessionEventsList.tsx` that was preventing loadEventDetails from being called when expanding an event. The issue is that handleToggle in `SessionEventItem` checks `!event.fullyLoaded` before calling `onLoadEventDetails`, but we were always passing `fullyLoaded: true`, so the full properties were never fetched.


<img width="2244" height="608" alt="image" src="https://github.com/user-attachments/assets/6c295adf-1d27-4dd0-b3ff-56321264555e" />


## How did you test this code?

enabled session-explorer feature flag locally
navigated to activity/sessions
checked a session id to get to the profile page
expanded events and verified props 

## Publish to changelog?

no
