### PR TITLE
fix: survey response limit UI bug

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -916,6 +916,9 @@ export const surveyLogic = kea<surveyLogicType>([
                 actions.updateSurvey(updates)
             },
             loadSurveySuccess: () => {
+                // Initialize dataCollectionType from survey data (using selector pattern for consistency)
+                actions.setDataCollectionType(values.derivedDataCollectionType)
+
                 // Trigger stats loading after survey loads
                 if (values.survey.id !== NEW_SURVEY.id && values.survey.start_date) {
                     actions.loadSurveyBaseStats()
@@ -1425,6 +1428,21 @@ export const surveyLogic = kea<surveyLogicType>([
                     survey.response_sampling_limit &&
                     survey.response_sampling_limit > 0
                 )
+            },
+        ],
+        derivedDataCollectionType: [
+            (s) => [s.surveyUsesAdaptiveLimit, s.surveyUsesLimit, s.isAdaptiveLimitFFEnabled],
+            (
+                surveyUsesAdaptiveLimit: boolean,
+                surveyUsesLimit: boolean,
+                isAdaptiveLimitFFEnabled: boolean
+            ): DataCollectionType => {
+                if (isAdaptiveLimitFFEnabled && surveyUsesAdaptiveLimit) {
+                    return 'until_adaptive_limit'
+                } else if (surveyUsesLimit) {
+                    return 'until_limit'
+                }
+                return 'until_stopped'
             },
         ],
         surveyShufflingQuestionsAvailable: [


### PR DESCRIPTION
Initialize dataCollectionType from survey data when survey loads. This ensures the correct option is selected in the UI after page reload.

Uses a selector pattern (derivedDataCollectionType) that reuses existing selectors (surveyUsesLimit, surveyUsesAdaptiveLimit) for consistency.

## Problem

https://posthoghelp.zendesk.com/agent/tickets/46694 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49489)

When users set a response limit on a survey (e.g., "Stop displaying the survey after reaching 250 completed surveys") and reload the page, the UI incorrectly defaults back to showing "Keep collecting responses until the survey is stopped" even though the backend has the correct `responses_limit` value saved. This creates confusion as users think their setting wasn't saved, when in reality it's just a UI state initialization bug.

The `dataCollectionType` reducer state was not being initialized from the survey data when the survey loads, causing it to always default to `'until_stopped'` regardless of the actual survey configuration.

## Changes

- Added `derivedDataCollectionType` selector that derives the data collection type from survey data by reusing existing selectors (`surveyUsesLimit`, `surveyUsesAdaptiveLimit`, `isAdaptiveLimitFFEnabled`)
- Initialize `dataCollectionType` in the `loadSurveySuccess` listener using the derived selector value
- Follows the existing selector pattern used throughout the survey editor for consistency

**Code changes:**
- Added selector in `selectors` section (reuses existing boolean selectors)
- Added initialization in `loadSurveySuccess` listener

## How did you test this code?

1. Set a response limit on a survey (e.g., 250 responses)
2. Saved the survey
3. Reloaded the page
4. Verified that the correct option "Stop displaying the survey after reaching a certain number of completed surveys" is now selected with the limit value displayed
6. Tested with no limit set - correctly defaults to "Keep collecting responses until the survey is stopped"

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No - this is a bug fix, not a user-facing feature.