### PR TITLE
fix: correctly display sso enforcement error on failed passkey auth

### DIFF
--- a/frontend/src/scenes/authentication/passkeyLogic.ts
+++ b/frontend/src/scenes/authentication/passkeyLogic.ts
@@ -31,11 +31,13 @@ const WEBAUTHN_ERROR_MESSAGES: Record<string, string> = {
 }
 
 function getPasskeyErrorMessage(error: any): string {
+    // handle SimpleWebAuthn errors
     if (error?.name && WEBAUTHN_ERROR_MESSAGES[error.name]) {
         return WEBAUTHN_ERROR_MESSAGES[error.name]
     }
 
-    return error?.detail || 'Passkey authentication failed. Please try again.'
+    // handle API errors
+    return error?.detail || error?.data?.error || error?.message || 'Passkey authentication failed. Please try again.'
 }
 
 export const passkeyLogic = kea<passkeyLogicType>([

--- a/posthog/api/webauthn.py
+++ b/posthog/api/webauthn.py
@@ -356,7 +356,7 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
         sso_enforcement = OrganizationDomain.objects.get_sso_enforcement_for_email_address(user.email)
         if sso_enforcement:
             return Response(
-                {"error": f"You can only login with SSO for this account ({sso_enforcement})."},
+                {"error": "You can only login with SSO for this account."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return None


### PR DESCRIPTION
## Problem

Some passkey errors were not being properly displayed in the frontend. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Simplify SSO enforcement error message for passkeys.
- Add additional error message checks for failed passkey auth.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
