### PR TITLE
feat(customers): Add revenue data from props to group profiles

### DIFF
--- a/frontend/src/scenes/groups/components/GroupCaption.tsx
+++ b/frontend/src/scenes/groups/components/GroupCaption.tsx
@@ -6,14 +6,11 @@ import { Group } from '~/types'
 interface GroupCaptionProps {
     groupData: Group
     groupTypeName: string
-    displayType?: 'col' | 'wrap'
 }
 
-export function GroupCaption({ groupData, groupTypeName, displayType = 'wrap' }: GroupCaptionProps): JSX.Element {
-    const className = displayType === 'col' ? 'flex flex-col' : 'flex items-center flex-wrap'
-
+export function GroupCaption({ groupData, groupTypeName }: GroupCaptionProps): JSX.Element {
     return (
-        <div className={className}>
+        <div className="flex items-center flex-wrap">
             <div className="mr-4">
                 <span className="text-secondary">Type:</span> {groupTypeName}
             </div>

--- a/frontend/src/scenes/groups/components/GroupCaption.tsx
+++ b/frontend/src/scenes/groups/components/GroupCaption.tsx
@@ -11,6 +11,7 @@ interface GroupCaptionProps {
 
 export function GroupCaption({ groupData, groupTypeName, displayType = 'wrap' }: GroupCaptionProps): JSX.Element {
     const className = displayType === 'col' ? 'flex flex-col' : 'flex items-center flex-wrap'
+
     return (
         <div className={className}>
             <div className="mr-4">


### PR DESCRIPTION
## Problem

The current group display in notebooks lacks detailed revenue information. Let's implement that for PostHog first and then expand to all use cases.
 Part of https://github.com/PostHog/posthog/issues/44006
## Changes
Enhanced the group display in notebooks with comprehensive revenue metrics:
- Added Monthly Recurring Revenue (MRR) with trend indicators (up/down/flat)
- Added customer Lifetime Value display
- Added paid products visualization with tags
- Replaced the generic GroupCaption with a more detailed GroupInfo component
- Added tooltips to explain the trends

![image.png](https://app.graphite.com/user-attachments/assets/3723c1aa-75b6-4885-99e7-ed536162a2d5.png)

![image.png](https://app.graphite.com/user-attachments/assets/f9573c2c-6729-446b-b9a9-dd2469df00cd.png)

PS: Potentially not going to work great for customers with anual contracts (yet)
## How did you test this code?

- Added unit tests for all new revenue utility functions
- Tested with various group data scenarios including:
  - Groups with/without MRR data
  - Groups with positive/negative/zero MRR
  - Groups with forecasted MRR changes (up/down/flat)
  - Groups with various paid products
  - Groups with/without lifetime value
- Verified proper formatting of currency values and percentages
- Ensured proper handling of edge cases (null values, non-numeric inputs)

## Publish to changelog?

No