### PR TITLE
feat(logs): remove _part_offset optimization from logs query

### DIFF
--- a/products/logs/backend/explain.py
+++ b/products/logs/backend/explain.py
@@ -170,7 +170,7 @@ def fetch_log_by_uuid(team: Team, uuid: str, timestamp: str) -> dict | None:
             uuid,
             timestamp,
             body,
-            mapFilter((k, v) -> not(has(resource_attributes, k)), attributes),
+            attributes,
             severity_text,
             service_name,
             resource_attributes,


### PR DESCRIPTION
## Problem

Before clickhouse 25.12, lazy materialization didn't work properly - this meant it had to fetch all log columns during the filter step even those that aren't filtered on. there was a workaround involving subqueries and _part_offset

This was fixed here in 25.12 https://github.com/ClickHouse/ClickHouse/pull/90309/changes so we can now remove the hack

## Changes

remove hacky _part_offset subquery in the logs query running
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
connected local to prod, verified the queries are faster without the "optimization"

there's no logic change so existing tests cover behaviour and verify no changes
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
