### PR TITLE
fix(llma): remove top-level umap import reintroduced by #43489

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/clustering.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/clustering.py
@@ -7,7 +7,6 @@ from sklearn.cluster import HDBSCAN, KMeans
 from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
 from sklearn.metrics import silhouette_score
-from umap import UMAP
 
 from posthog.temporal.llm_analytics.trace_clustering.models import HDBSCANResult, KMeansResult
 


### PR DESCRIPTION
## Summary
- Remove the top-level `from umap import UMAP` import that was accidentally re-added by #43489
- This fixes the nginx unit crash caused by numba caching issues at Django startup

## Context
PR #44628 fixed this issue by making the umap import lazy (only importing inside functions that use it). However, #43489 re-introduced the top-level import, causing the same crash to occur again in production.

The lazy imports inside `compute_2d_coordinates()` and `reduce_dimensions_for_clustering()` are already in place - this top-level import was unnecessary and harmful.

## Test plan
- [x] Verify no top-level umap imports exist in the file
- [ ] Deploy and confirm nginx unit pods no longer crash