### PR TITLE
chore: add endpoints use case to auth in CLI

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # posthog-cli
 
-# 0.5.23
+# 0.5.24
 
 - chore: add endpoints use case to cli auth flow
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 0.5.23
 
+- chore: add endpoints use case to cli auth flow
+
+# 0.5.23
+
 - feat: add experimental commands for endpoints management
 
 # 0.5.22

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1566,7 +1566,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.23"
+version = "0.5.24"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.23"
+version = "0.5.24"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/login.rs
+++ b/cli/src/login.rs
@@ -39,7 +39,7 @@ pub fn login(host_override: Option<String>) -> Result<()> {
     if !io::stdout().is_terminal() {
         bail!("Failed to login. If you are running on a CI, skip this step and use POSTHOG_CLI_HOST, POSTHOG_CLI_ENV_ID, POSTHOG_CLI_TOKEN env variables when running commands")
     }
-    login_with_use_cases(host_override, vec!["schema", "error_tracking"])
+    login_with_use_cases(host_override, vec!["schema", "error_tracking", "endpoints"])
 }
 
 pub fn login_with_use_cases(host_override: Option<String>, use_cases: Vec<&str>) -> Result<()> {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
when logging in from the CLI, make it easy to also include endpoints scope
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- `endpoints` to the `use_case` URL param

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->
nah

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
