### PR TITLE
feat(mcp): add region param for OAuth authorization server routing

### DIFF
--- a/services/mcp/typescript/src/integrations/mcp/index.ts
+++ b/services/mcp/typescript/src/integrations/mcp/index.ts
@@ -9,6 +9,7 @@ import { handleToolError } from '@/integrations/mcp/utils/handleToolError'
 import type { AnalyticsEvent } from '@/lib/analytics'
 import {
     CUSTOM_BASE_URL,
+    getAuthorizationServerUrl,
     getBaseUrlForRegion,
     MCP_DOCS_URL,
     OAUTH_SCOPES_SUPPORTED,
@@ -321,9 +322,8 @@ export default {
 
             // Determine authorization server based on region param.
             // The region param is set by the wizard based on user's cloud region selection.
-            // Invalid/unknown regions safely default to US via toCloudRegion().
-            const regionParam = url.searchParams.get('region')
-            const authorizationServer = CUSTOM_BASE_URL || getBaseUrlForRegion(toCloudRegion(regionParam))
+            // CUSTOM_BASE_URL takes precedence for self-hosted, otherwise routes to US/EU.
+            const authorizationServer = getAuthorizationServerUrl(url.searchParams.get('region'))
 
             return new Response(
                 JSON.stringify({

--- a/services/mcp/typescript/src/integrations/mcp/index.ts
+++ b/services/mcp/typescript/src/integrations/mcp/index.ts
@@ -7,7 +7,13 @@ import { getPostHogClient } from '@/integrations/mcp/utils/client'
 import { formatResponse } from '@/integrations/mcp/utils/formatResponse'
 import { handleToolError } from '@/integrations/mcp/utils/handleToolError'
 import type { AnalyticsEvent } from '@/lib/analytics'
-import { CUSTOM_BASE_URL, MCP_DOCS_URL, OAUTH_SCOPES_SUPPORTED } from '@/lib/constants'
+import {
+    CUSTOM_BASE_URL,
+    MCP_DOCS_URL,
+    OAUTH_SCOPES_SUPPORTED,
+    POSTHOG_EU_BASE_URL,
+    POSTHOG_US_BASE_URL,
+} from '@/lib/constants'
 import { ErrorCode } from '@/lib/errors'
 import { SessionManager } from '@/lib/utils/SessionManager'
 import { StateManager } from '@/lib/utils/StateManager'
@@ -80,12 +86,12 @@ export class MyMCP extends McpAgent<Env> {
     async detectRegion(): Promise<CloudRegion | undefined> {
         const usClient = new ApiClient({
             apiToken: this.requestProperties.apiToken,
-            baseUrl: 'https://us.posthog.com',
+            baseUrl: POSTHOG_US_BASE_URL,
         })
 
         const euClient = new ApiClient({
             apiToken: this.requestProperties.apiToken,
-            baseUrl: 'https://eu.posthog.com',
+            baseUrl: POSTHOG_EU_BASE_URL,
         })
 
         const [usResult, euResult] = await Promise.all([usClient.users().me(), euClient.users().me()])
@@ -111,10 +117,10 @@ export class MyMCP extends McpAgent<Env> {
         const region = (await this.cache.get('region')) || (await this.detectRegion())
 
         if (region === 'eu') {
-            return 'https://eu.posthog.com'
+            return POSTHOG_EU_BASE_URL
         }
 
-        return 'https://us.posthog.com'
+        return POSTHOG_US_BASE_URL
     }
 
     async api(): Promise<ApiClient> {
@@ -314,10 +320,10 @@ export default {
                 // Self-hosted instances use CUSTOM_BASE_URL
                 authorizationServer = CUSTOM_BASE_URL
             } else if (regionParam === 'eu') {
-                authorizationServer = 'https://eu.posthog.com'
+                authorizationServer = POSTHOG_EU_BASE_URL
             } else {
                 // Default to US for 'us', missing, or invalid region values
-                authorizationServer = 'https://us.posthog.com'
+                authorizationServer = POSTHOG_US_BASE_URL
             }
 
             return new Response(

--- a/services/mcp/typescript/src/lib/constants.ts
+++ b/services/mcp/typescript/src/lib/constants.ts
@@ -1,5 +1,9 @@
 import { env } from 'cloudflare:workers'
 
+// Region-specific PostHog API base URLs
+export const POSTHOG_US_BASE_URL = 'https://us.posthog.com'
+export const POSTHOG_EU_BASE_URL = 'https://eu.posthog.com'
+
 export const CUSTOM_BASE_URL = env.POSTHOG_BASE_URL
 
 // OAuth Authorization Server URL (where clients get tokens)

--- a/services/mcp/typescript/src/lib/constants.ts
+++ b/services/mcp/typescript/src/lib/constants.ts
@@ -22,6 +22,14 @@ export const getBaseUrlForRegion = (region: CloudRegion): string => {
 
 export const CUSTOM_BASE_URL = env.POSTHOG_BASE_URL
 
+// Get the authorization server URL for OAuth, respecting CUSTOM_BASE_URL for self-hosted instances
+export const getAuthorizationServerUrl = (regionParam: string | null): string => {
+    if (CUSTOM_BASE_URL) {
+        return CUSTOM_BASE_URL
+    }
+    return getBaseUrlForRegion(toCloudRegion(regionParam))
+}
+
 // OAuth Authorization Server URL (where clients get tokens)
 // Defaults to CUSTOM_BASE_URL if not explicitly set
 export const OAUTH_AUTHORIZATION_SERVER_URL =

--- a/services/mcp/typescript/src/lib/constants.ts
+++ b/services/mcp/typescript/src/lib/constants.ts
@@ -1,8 +1,24 @@
 import { env } from 'cloudflare:workers'
 
+import type { CloudRegion } from '@/tools/types'
+
 // Region-specific PostHog API base URLs
 export const POSTHOG_US_BASE_URL = 'https://us.posthog.com'
 export const POSTHOG_EU_BASE_URL = 'https://eu.posthog.com'
+
+// Normalize a string to a valid CloudRegion, defaulting to 'us'
+export const toCloudRegion = (value: string | undefined | null): CloudRegion => {
+    const normalized = value?.toLowerCase()
+    if (normalized === 'eu') {
+        return 'eu'
+    }
+    return 'us'
+}
+
+// Get the PostHog base URL for a region
+export const getBaseUrlForRegion = (region: CloudRegion): string => {
+    return region === 'eu' ? POSTHOG_EU_BASE_URL : POSTHOG_US_BASE_URL
+}
 
 export const CUSTOM_BASE_URL = env.POSTHOG_BASE_URL
 

--- a/services/mcp/typescript/tests/unit/oauth-region.test.ts
+++ b/services/mcp/typescript/tests/unit/oauth-region.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+describe('OAuth Region Routing', () => {
+    describe('Protected Resource Metadata', () => {
+        const testCases = [
+            {
+                name: 'defaults to US when no region param',
+                params: '',
+                expectedServer: 'https://us.posthog.com',
+            },
+            {
+                name: 'returns EU server when region=eu',
+                params: '?region=eu',
+                expectedServer: 'https://eu.posthog.com',
+            },
+            {
+                name: 'returns EU server when region=EU (case insensitive)',
+                params: '?region=EU',
+                expectedServer: 'https://eu.posthog.com',
+            },
+            {
+                name: 'returns US server when region=us',
+                params: '?region=us',
+                expectedServer: 'https://us.posthog.com',
+            },
+            {
+                name: 'defaults to US for unknown region',
+                params: '?region=unknown',
+                expectedServer: 'https://us.posthog.com',
+            },
+        ]
+
+        it.each(testCases)('$name', ({ params, expectedServer }) => {
+            const url = new URL(`https://mcp.posthog.com/.well-known/oauth-protected-resource${params}`)
+            const regionParam = url.searchParams.get('region')?.toLowerCase()
+
+            let authorizationServer: string
+            if (regionParam === 'eu') {
+                authorizationServer = 'https://eu.posthog.com'
+            } else {
+                authorizationServer = 'https://us.posthog.com'
+            }
+
+            expect(authorizationServer).toBe(expectedServer)
+        })
+    })
+
+    describe('401 Response Metadata URL', () => {
+        const testCases = [
+            {
+                name: 'includes region param in metadata URL when specified',
+                requestUrl: 'https://mcp.posthog.com/mcp?region=eu',
+                expectedMetadataUrl: 'https://mcp.posthog.com/.well-known/oauth-protected-resource?region=eu',
+            },
+            {
+                name: 'no region param in metadata URL when not specified',
+                requestUrl: 'https://mcp.posthog.com/mcp',
+                expectedMetadataUrl: 'https://mcp.posthog.com/.well-known/oauth-protected-resource',
+            },
+            {
+                name: 'preserves region param with other params',
+                requestUrl: 'https://mcp.posthog.com/mcp?features=flags&region=eu',
+                expectedMetadataUrl: 'https://mcp.posthog.com/.well-known/oauth-protected-resource?region=eu',
+            },
+        ]
+
+        it.each(testCases)('$name', ({ requestUrl, expectedMetadataUrl }) => {
+            const url = new URL(requestUrl)
+            const regionParam = url.searchParams.get('region')
+
+            const metadataUrl = new URL('/.well-known/oauth-protected-resource', requestUrl)
+            if (regionParam) {
+                metadataUrl.searchParams.set('region', regionParam)
+            }
+
+            expect(metadataUrl.toString()).toBe(expectedMetadataUrl)
+        })
+    })
+})

--- a/services/mcp/typescript/tests/unit/oauth-region.test.ts
+++ b/services/mcp/typescript/tests/unit/oauth-region.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getBaseUrlForRegion, toCloudRegion } from '@/lib/constants'
+import { getAuthorizationServerUrl, getBaseUrlForRegion, toCloudRegion } from '@/lib/constants'
 
 describe('OAuth Region Routing', () => {
     describe('toCloudRegion', () => {
@@ -26,6 +26,28 @@ describe('OAuth Region Routing', () => {
 
         it('returns US URL for us region', () => {
             expect(getBaseUrlForRegion('us')).toBe('https://us.posthog.com')
+        })
+    })
+
+    describe('getAuthorizationServerUrl', () => {
+        it('returns EU URL when region is eu', () => {
+            expect(getAuthorizationServerUrl('eu')).toBe('https://eu.posthog.com')
+        })
+
+        it('returns EU URL when region is EU (case insensitive)', () => {
+            expect(getAuthorizationServerUrl('EU')).toBe('https://eu.posthog.com')
+        })
+
+        it('returns US URL when region is us', () => {
+            expect(getAuthorizationServerUrl('us')).toBe('https://us.posthog.com')
+        })
+
+        it('returns US URL when region is null', () => {
+            expect(getAuthorizationServerUrl(null)).toBe('https://us.posthog.com')
+        })
+
+        it('returns US URL for unknown region', () => {
+            expect(getAuthorizationServerUrl('unknown')).toBe('https://us.posthog.com')
         })
     })
 

--- a/services/mcp/typescript/tests/unit/oauth-region.test.ts
+++ b/services/mcp/typescript/tests/unit/oauth-region.test.ts
@@ -62,11 +62,17 @@ describe('OAuth Region Routing', () => {
                 requestUrl: 'https://mcp.posthog.com/mcp?features=flags&region=eu',
                 expectedMetadataUrl: 'https://mcp.posthog.com/.well-known/oauth-protected-resource?region=eu',
             },
+            {
+                name: 'normalizes uppercase region to lowercase for consistency',
+                requestUrl: 'https://mcp.posthog.com/mcp?region=EU',
+                expectedMetadataUrl: 'https://mcp.posthog.com/.well-known/oauth-protected-resource?region=eu',
+            },
         ]
 
         it.each(testCases)('$name', ({ requestUrl, expectedMetadataUrl }) => {
             const url = new URL(requestUrl)
-            const regionParam = url.searchParams.get('region')
+            // Normalize to lowercase for consistency with the metadata endpoint
+            const regionParam = url.searchParams.get('region')?.toLowerCase()
 
             const metadataUrl = new URL('/.well-known/oauth-protected-resource', requestUrl)
             if (regionParam) {


### PR DESCRIPTION
## Problem

The MCP server at `mcp.posthog.com` serves both US and EU regions. OAuth tokens are region-specific, so MCP clients need to know which authorization server to use (`us.posthog.com` vs `eu.posthog.com`).

### Why we can't use the existing token-based region detection

The MCP server has a `detectRegion()` function that tries the user's token against both US and EU APIs to see which one accepts it. However, the OAuth protected resource metadata endpoint (`/.well-known/oauth-protected-resource`) is called BEFORE the user has a token - they're asking "where do I log in?" before they've logged in. So we can't use token-based detection for the OAuth flow.

## Changes

- Added region query param support: `?region=eu` routes OAuth to `eu.posthog.com`
- 401 responses now include `WWW-Authenticate` header with `resource_metadata` URL containing region param
- Added `OAUTH_SCOPES_SUPPORTED` constant for protected resource metadata
- Region param is normalized to lowercase for consistency
- Added comprehensive comments explaining the OAuth flow

### URL examples
- `mcp.posthog.com/mcp` → OAuth to `us.posthog.com` (default)
- `mcp.posthog.com/mcp?region=eu` → OAuth to `eu.posthog.com`
- `mcp.posthog.com/mcp?region=us` → OAuth to `us.posthog.com`

## How did you test this code?

```bash
# Start local MCP server
cd services/mcp && pnpm dev

# Test OAuth metadata
curl -s "http://localhost:8787/.well-known/oauth-protected-resource" | jq '.authorization_servers'
# ["https://us.posthog.com"]

curl -s "http://localhost:8787/.well-known/oauth-protected-resource?region=eu" | jq '.authorization_servers'
# ["https://eu.posthog.com"]

# Test 401 WWW-Authenticate header
curl -sI "http://localhost:8787/mcp?region=eu" | grep WWW-Authenticate
# WWW-Authenticate: Bearer resource_metadata="http://localhost:8787/.well-known/oauth-protected-resource?region=eu"
```

Unit tests in `tests/unit/oauth-region.test.ts` cover region routing and case normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)