### PR TITLE
fix: Revert "fix(hogvm): prevent null coercion in TypeScript comparison operators"

### DIFF
--- a/common/hogvm/python/test/test_execute.py
+++ b/common/hogvm/python/test/test_execute.py
@@ -139,69 +139,6 @@ class TestBytecodeExecute:
         else:
             raise AssertionError("Expected Exception not raised")
 
-    def test_null_comparison_handling(self):
-        # Equality comparisons with null should work
-        assert self._run("null == null") is True
-        assert self._run("null != null") is False
-        assert self._run("null == 1") is False
-        assert self._run("null != 1") is True
-
-        # Ordering comparisons with null should raise TypeError
-        try:
-            self._run("null <= 18")
-        except TypeError as e:
-            assert "'<=' not supported between instances of 'NoneType' and 'int'" in str(e)
-        else:
-            raise AssertionError("Expected TypeError not raised")
-
-        try:
-            self._run("null < 18")
-        except TypeError as e:
-            assert "'<' not supported between instances of 'NoneType' and 'int'" in str(e)
-        else:
-            raise AssertionError("Expected TypeError not raised")
-
-        try:
-            self._run("null >= 18")
-        except TypeError as e:
-            assert "'>=' not supported between instances of 'NoneType' and 'int'" in str(e)
-        else:
-            raise AssertionError("Expected TypeError not raised")
-
-        try:
-            self._run("null > 18")
-        except TypeError as e:
-            assert "'>' not supported between instances of 'NoneType' and 'int'" in str(e)
-        else:
-            raise AssertionError("Expected TypeError not raised")
-
-        # Ordering comparisons with null in mixed-type scenarios should also raise TypeError
-        try:
-            self._run("null <= '18'")
-        except TypeError as e:
-            assert "'<=' not supported between instances of 'NoneType' and 'str'" in str(e)
-        else:
-            raise AssertionError("Expected TypeError not raised")
-
-        try:
-            self._run("5 > null")
-        except TypeError as e:
-            assert "'>' not supported between instances of 'int' and 'NoneType'" in str(e)
-        else:
-            raise AssertionError("Expected TypeError not raised")
-
-        # Comparing null with itself should also raise TypeError
-        try:
-            self._run("null <= null")
-        except TypeError as e:
-            assert "'<=' not supported between instances of 'NoneType' and 'NoneType'" in str(e)
-        else:
-            raise AssertionError("Expected TypeError not raised")
-
-        # Valid comparisons should still work
-        assert self._run("5 <= 18") is True
-        assert self._run("20 > 18") is True
-
     def test_memory_limits_1(self):
         # let string := 'banana'
         # for (let i := 0; i < 100; i := i + 1) {

--- a/common/hogvm/typescript/src/__tests__/execute.test.ts
+++ b/common/hogvm/typescript/src/__tests__/execute.test.ts
@@ -133,46 +133,6 @@ describe('hogvm execute', () => {
         )
     })
 
-    test('null comparison handling', () => {
-        const options = {}
-
-        // Equality operations should work with null (existing behavior)
-        expect(execSync(['_h', op.NULL, op.INTEGER, 1, op.EQ], options)).toBe(false)
-        expect(execSync(['_h', op.NULL, op.INTEGER, 1, op.NOT_EQ], options)).toBe(true)
-        expect(execSync(['_h', op.NULL, op.NULL, op.EQ], options)).toBe(true)
-        expect(execSync(['_h', op.NULL, op.NULL, op.NOT_EQ], options)).toBe(false)
-
-        // Ordering comparisons with null should throw
-        expect(() => execSync(['_h', op.NULL, op.INTEGER, 18, op.LT_EQ], options)).toThrow(
-            'Cannot compare null or undefined values'
-        )
-        expect(() => execSync(['_h', op.NULL, op.INTEGER, 18, op.LT], options)).toThrow(
-            'Cannot compare null or undefined values'
-        )
-        expect(() => execSync(['_h', op.NULL, op.INTEGER, 18, op.GT_EQ], options)).toThrow(
-            'Cannot compare null or undefined values'
-        )
-        expect(() => execSync(['_h', op.NULL, op.INTEGER, 18, op.GT], options)).toThrow(
-            'Cannot compare null or undefined values'
-        )
-
-        // Ordering comparisons with null in mixed-type scenarios should also throw
-        expect(() => execSync(['_h', op.NULL, op.STRING, '18', op.LT_EQ], options)).toThrow(
-            'Cannot compare null or undefined values'
-        )
-        expect(() => execSync(['_h', op.INTEGER, 5, op.NULL, op.GT], options)).toThrow(
-            'Cannot compare null or undefined values'
-        )
-        expect(() => execSync(['_h', op.NULL, op.NULL, op.LT_EQ], options)).toThrow(
-            'Cannot compare null or undefined values'
-        )
-
-        // Valid comparisons should still work (stack order: right, left, op)
-        expect(execSync(['_h', op.INTEGER, 18, op.INTEGER, 5, op.LT_EQ], options)).toBe(true) // 5 <= 18
-        expect(execSync(['_h', op.INTEGER, 18, op.INTEGER, 20, op.GT], options)).toBe(true) // 20 > 18
-        expect(execSync(['_h', op.INTEGER, 10, op.INTEGER, 5, op.LT], options)).toBe(true) // 5 < 10
-    })
-
     test('async limits', async () => {
         const callSleep = [
             33,

--- a/common/hogvm/typescript/src/execute.ts
+++ b/common/hogvm/typescript/src/execute.ts
@@ -414,19 +414,19 @@ export function exec(input: any[] | VMState | Bytecodes, options?: ExecOptions):
                     pushStack(temp !== temp2)
                     break
                 case Operation.GT:
-                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack(), true)
+                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack())
                     pushStack(temp > temp2)
                     break
                 case Operation.GT_EQ:
-                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack(), true)
+                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack())
                     pushStack(temp >= temp2)
                     break
                 case Operation.LT:
-                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack(), true)
+                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack())
                     pushStack(temp < temp2)
                     break
                 case Operation.LT_EQ:
-                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack(), true)
+                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack())
                     pushStack(temp <= temp2)
                     break
                 case Operation.LIKE:

--- a/common/hogvm/typescript/src/utils.ts
+++ b/common/hogvm/typescript/src/utils.ts
@@ -203,14 +203,7 @@ export function calculateCost(object: any, marked: Set<any> | undefined = undefi
     return COST_PER_UNIT
 }
 
-export function unifyComparisonTypes(left: any, right: any, isOrderComparison: boolean = false): [any, any] {
-    // Check for null/undefined only in ordering comparisons (<, >, <=, >=)
-    // Equality comparisons (==, !=) should allow null
-    // This matches Python's behavior where None ordering comparisons raise TypeError
-    if (isOrderComparison && (left === null || left === undefined || right === null || right === undefined)) {
-        throw new HogVMException('Cannot compare null or undefined values')
-    }
-
+export function unifyComparisonTypes(left: any, right: any): [any, any] {
     if (typeof left === 'number' && typeof right === 'string') {
         return [left, Number(right)]
     }


### PR DESCRIPTION
Reverts PostHog/posthog#44602

Tests are failing: https://github.com/PostHog/posthog/actions/runs/20924630132/job/60125502885

Summary of all failing tests
FAIL src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.test.ts
  ● ip-anonymization.template › should handle invalid IP address format

    expect(received).toBeUndefined()

    Received: "Cannot compare null or undefined values"

```
      69 |
      70 |             expect(response.finished).toBe(true)
    > 71 |             expect(response.error).toBeUndefined()
         |                                    ^
      72 |             expect(response.execResult).toMatchObject({
      73 |                 properties: {
      74 |                     $ip: invalidIP,
```

      at Object.<anonymous> (src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.test.ts:71:36)

