### PR TITLE
fix(product tours): fix django admin, dont load all surveys

### DIFF
--- a/posthog/admin/admins/product_tour_admin.py
+++ b/posthog/admin/admins/product_tour_admin.py
@@ -25,6 +25,12 @@ class ProductTourAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         return ProductTour.all_objects.all()
 
+    def get_exclude(self, request, obj=None):
+        exclude = list(super().get_exclude(request, obj) or [])
+        if obj:
+            exclude.extend(["linked_surveys"])
+        return exclude
+
     def get_form(self, request, obj=None, change=False, **kwargs):
         form = super().get_form(request, obj, **kwargs)
         for field in ["start_date", "end_date"]:


### PR DESCRIPTION
## Problem
django admin for tours is very slow
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
exclude linked surveys from product tour admin (same thing we had to do for surveys a while back, so we aren't querying a ton of everything all the time)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
manul testing

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
