### PR TITLE
feat: link support directly to user's Admin page

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -99,7 +99,7 @@ function getDjangoAdminLink(
     if (!user || !cloudRegion) {
         return ''
     }
-    const link = `http://go/admin${cloudRegion}/${user.email}`
+    const link = `https://${cloudRegion.toLowerCase()}.posthog.com/admin/posthog/user/${user.id}/change/`
     return `\nAdmin: ${link} (organization ID ${currentOrganization?.id}: ${currentOrganization?.name}, project ID ${currentTeam?.id}: ${currentTeam?.name})`
 }
 


### PR DESCRIPTION
Rather than opening a search page with the user's email address filled in, this link will directly open the user's Admin page.

Before: https://us.posthog.com/admin/posthog/user/?q=user@example.com
After: https://us.posthog.com/admin/posthog/user/123/change/