### PR TITLE
chore: Add stranded migration detection and sync tools with Docker fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 !bin
 !common/hogvm
 !common/esbuilder
+!common/migration_utils
 !common/plugin_transpiler/*.*
 !common/plugin_transpiler/src
 !common/tailwind

--- a/Dockerfile
+++ b/Dockerfile
@@ -188,6 +188,7 @@ ENV PATH=/python-runtime/bin:$PATH \
 COPY manage.py manage.py
 COPY common/esbuilder common/esbuilder
 COPY common/hogvm common/hogvm/
+COPY common/migration_utils common/migration_utils/
 COPY posthog posthog/
 COPY products/ products/
 COPY ee ee/
@@ -376,6 +377,7 @@ COPY --chown=posthog:posthog manage.py manage.py
 COPY --chown=posthog:posthog posthog posthog/
 COPY --chown=posthog:posthog ee ee/
 COPY --chown=posthog:posthog common/hogvm common/hogvm/
+COPY --chown=posthog:posthog common/migration_utils common/migration_utils/
 COPY --chown=posthog:posthog products products/
 
 # Setup ENV.

--- a/common/hogli/commands.py
+++ b/common/hogli/commands.py
@@ -39,5 +39,9 @@ from __future__ import annotations
 # def example_hello(name: str, greeting: str) -> None:
 #     """Say hello to someone."""
 #     click.echo(f"{greeting}, {name}!")
-# Import commands from other modules to register them
-from hogli import doctor  # noqa: F401
+# Side-effect imports: these modules use @cli.command() decorators that register
+# commands with the CLI group when imported. The imports appear unused but are required.
+from hogli import (
+    doctor,  # noqa: F401
+    migrations,  # noqa: F401
+)

--- a/common/hogli/core/command_types.py
+++ b/common/hogli/core/command_types.py
@@ -138,6 +138,47 @@ class Command:
         return cmd
 
 
+def _run_prechecks(prechecks: list[dict[str, Any]], yes: bool = False) -> bool:
+    """Run prechecks and prompt user if issues are found.
+
+    Returns True if prechecks passed or user chose to continue, False if user aborted.
+    """
+    for check in prechecks:
+        check_type = check.get("type")
+
+        if check_type == "migrations":
+            # Check for orphaned migrations (in DB but not in code)
+            # Pending migrations are fine - they'll be applied by manage.py migrate
+            try:
+                from hogli.migrations import _compute_migration_diff, _get_cached_migration
+
+                diff = _compute_migration_diff()
+
+                if diff.orphaned:
+                    click.echo()
+                    click.secho("⚠️  Orphaned migrations detected!", fg="yellow", bold=True)
+                    click.echo("These migrations are applied in the DB but don't exist in code.")
+                    click.echo("They were likely applied on another branch.\n")
+
+                    for m in diff.orphaned:
+                        cached = "cached" if _get_cached_migration(m.app, m.name) else "not cached"
+                        click.echo(f"    {m.app}: {m.name} ({cached})")
+                    click.echo()
+
+                    click.echo("Run 'hogli migrations:sync' to roll them back.\n")
+
+                    if not yes:
+                        if not click.confirm("Continue anyway?", default=False):
+                            click.echo("Aborted. Run 'hogli migrations:sync' first.")
+                            return False
+
+            except Exception as e:
+                # Don't block start if migration check fails (e.g., DB not running)
+                click.secho(f"⚠️  Could not check migrations: {e}", fg="yellow", err=True)
+
+    return True
+
+
 class BinScriptCommand(Command):
     """Command that delegates to a shell script in bin/."""
 
@@ -169,6 +210,11 @@ class BinScriptCommand(Command):
         @click.pass_context
         def cmd(ctx: click.Context, yes: bool) -> None:
             try:
+                # Run any prechecks before confirming/executing
+                prechecks = self.config.get("prechecks", [])
+                if prechecks and not _run_prechecks(prechecks, yes=yes):
+                    raise SystemExit(1)
+
                 self._confirm(yes=yes)
                 self.execute(*ctx.args)
             except SystemExit:

--- a/common/hogli/migrations.py
+++ b/common/hogli/migrations.py
@@ -1,0 +1,952 @@
+"""Django migration management for branch switching in worktrees.
+
+This module provides commands to sync Django migrations when working across
+multiple git worktrees that share the same database. It detects migrations
+that are applied in the database but don't exist in the current code (orphaned),
+and migrations that exist in code but aren't applied yet (pending).
+
+Commands:
+    hogli migrations:status      - Show migration diff between DB and code
+    hogli migrations:down        - Roll back orphaned migrations
+    hogli migrations:up          - Apply pending migrations
+    hogli migrations:sync        - Smart sync: down + up in one step
+    hogli migrations:cache-sync  - Populate cache from currently applied migrations
+
+Migration File Caching:
+    When migrations are applied, their files are cached to ~/.cache/posthog-migrations/.
+    This allows proper rollback even after switching to a branch where the migration
+    file doesn't exist. If a migration isn't cached, the tool will search git history
+    and provide manual instructions.
+
+For worktrees, simply run after switching to a worktree:
+    hogli migrations:sync
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import quote
+
+import click
+from hogli.core.cli import cli
+from hogli.core.manifest import REPO_ROOT
+from migration_utils import (
+    MIGRATION_CACHE_DIR,
+    get_cache_path as _get_cache_path,
+    get_cached_migration as _get_cached_migration,
+    get_managed_app_paths,
+    hidden_conflicting_migrations,
+    temporary_max_migration,
+    temporary_migration_file,
+)
+
+# Pattern to match migration files (0001_initial.py, etc.)
+MIGRATION_PATTERN = re.compile(r"^(\d{4})_.+\.py$")
+
+
+@dataclass
+class MigrationInfo:
+    """Information about a single migration."""
+
+    app: str
+    name: str
+    exists_in_code: bool = False
+    applied_in_db: bool = False
+
+
+@dataclass
+class MigrationResult:
+    """Result from applying migrations."""
+
+    success: bool
+    error_type: str | None = None  # "duplicate_column", "duplicate_table", "other"
+    error_message: str | None = None
+    failed_migration: tuple[str, str] | None = None  # (app, name)
+
+
+@dataclass
+class MigrationDiff:
+    """Diff between database and code migration states."""
+
+    # Migrations applied in DB but not in code (need rollback)
+    orphaned: list[MigrationInfo] = field(default_factory=list)
+    # Migrations in code but not applied (need apply)
+    pending: list[MigrationInfo] = field(default_factory=list)
+    # Migrations that are in sync
+    synced: list[MigrationInfo] = field(default_factory=list)
+
+
+def _cache_migration(app: str, name: str, source_path: Path) -> bool:
+    """Cache a migration file for later rollback with CLI feedback."""
+    from migration_utils import cache_migration_file
+
+    try:
+        if not cache_migration_file(app, name, source_path):
+            click.secho(f"  ⚠ Could not cache {app}.{name}", fg="yellow", err=True)
+            return False
+        return True
+    except OSError as e:
+        click.secho(f"  ⚠ {e}", fg="yellow", err=True)
+        return False
+
+
+def _find_migration_branch(app: str, name: str) -> str | None:
+    """Search git history to find which branch has this migration file."""
+    all_apps = get_managed_app_paths(REPO_ROOT)
+    migrations_dir = all_apps.get(app)
+    if not migrations_dir:
+        return None
+
+    # Get relative path from repo root
+    try:
+        rel_path = migrations_dir.relative_to(REPO_ROOT) / f"{name}.py"
+    except ValueError:
+        return None
+
+    try:
+        # Find branches that contain this file
+        result = subprocess.run(
+            ["git", "log", "--all", "--source", "--pretty=format:%S", "--", str(rel_path)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        if result.stdout.strip():
+            # Return the first branch found
+            branch = result.stdout.strip().split("\n")[0]
+            # Clean up refs/heads/ or refs/remotes/ prefix
+            if branch.startswith("refs/heads/"):
+                branch = branch[len("refs/heads/") :]
+            elif branch.startswith("refs/remotes/origin/"):
+                branch = branch[len("refs/remotes/origin/") :]
+            return branch
+    except subprocess.CalledProcessError:
+        # If the git command fails (e.g. not a git repo or no history), we
+        # intentionally ignore the error and fall back to returning None.
+        pass
+    return None
+
+
+def _fetch_and_cache_migration_from_git(app: str, name: str, branch: str) -> bool:
+    """Fetch a migration file from a git branch and cache it.
+
+    This allows rolling back migrations that were applied on other branches
+    without having to manually switch branches.
+
+    Returns True if successful, False otherwise.
+    """
+    all_apps = get_managed_app_paths(REPO_ROOT)
+    migrations_dir = all_apps.get(app)
+    if not migrations_dir:
+        return False
+
+    # Get relative path from repo root
+    try:
+        rel_path = migrations_dir.relative_to(REPO_ROOT) / f"{name}.py"
+    except ValueError:
+        return False
+
+    # Try fetching from remote first (in case branch isn't checked out locally)
+    for ref in [f"origin/{branch}", branch]:
+        try:
+            result = subprocess.run(
+                ["git", "show", f"{ref}:{rel_path}"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            content = result.stdout
+
+            # Cache the content
+            cache_path = _get_cache_path(app, name)
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.write_text(content)
+            return True
+        except subprocess.CalledProcessError:
+            continue
+
+    return False
+
+
+def _get_previous_migration(app: str, migration_name: str) -> str:
+    """Get the migration that should be active after rolling back the given one.
+
+    Returns 'zero' if this is the first migration or we can't determine the previous one.
+
+    Only considers migrations that are applied in the DB, since we're rolling back
+    an applied migration and need to target another applied migration.
+    """
+    # Only use DB migrations - we're rolling back to another applied migration
+    db_migrations = _get_migrations_in_db().get(app, set())
+    all_migrations = sorted(db_migrations)
+
+    if not all_migrations:
+        return "zero"
+
+    # Find the migration before the one we're rolling back
+    try:
+        idx = all_migrations.index(migration_name)
+        if idx == 0:
+            return "zero"
+        return all_migrations[idx - 1]
+    except ValueError:
+        # Migration not found in DB, return zero
+        return "zero"
+
+
+def _get_subprocess_env() -> dict[str, str]:
+    """Get environment for subprocess calls that need hogli module access."""
+    env = dict(os.environ)
+    env["DJANGO_SETTINGS_MODULE"] = "posthog.settings"
+    # Ensure common/ is in PYTHONPATH so hogli module is importable
+    common_path = str(REPO_ROOT / "common")
+    existing_path = env.get("PYTHONPATH", "")
+    # Use os.pathsep for cross-platform compatibility (: on Unix, ; on Windows)
+    env["PYTHONPATH"] = f"{common_path}{os.pathsep}{existing_path}" if existing_path else common_path
+    return env
+
+
+# Pattern to extract migration being applied from Django output
+# Matches lines like "Applying posthog.0952_add_billable_action..."
+_APPLYING_PATTERN = re.compile(r"Applying (\w+)\.(\d{4}_[^.]+)\.\.\.")
+
+
+def _parse_migration_error(stderr: str, stdout: str) -> MigrationResult:
+    """Parse migration error output to detect recoverable situations.
+
+    Detects DuplicateColumn and DuplicateTable errors from PostgreSQL,
+    which indicate the schema already exists (likely applied on another branch).
+    """
+    combined = f"{stdout}\n{stderr}"
+
+    # Find which migration was being applied when error occurred
+    failed_migration: tuple[str, str] | None = None
+    for match in _APPLYING_PATTERN.finditer(combined):
+        # Keep the last match (the one being applied when it failed)
+        failed_migration = (match.group(1), match.group(2))
+
+    # Check for duplicate column error
+    if ("DuplicateColumn" in stderr) or ('column "' in stderr and "already exists" in stderr):
+        return MigrationResult(
+            success=False,
+            error_type="duplicate_column",
+            error_message=stderr.strip(),
+            failed_migration=failed_migration,
+        )
+
+    # Check for duplicate table/relation error
+    if ("DuplicateTable" in stderr) or ('relation "' in stderr and "already exists" in stderr):
+        return MigrationResult(
+            success=False,
+            error_type="duplicate_table",
+            error_message=stderr.strip(),
+            failed_migration=failed_migration,
+        )
+
+    # Generic error
+    return MigrationResult(
+        success=False,
+        error_type="other",
+        error_message=stderr.strip() if stderr.strip() else "Unknown error",
+        failed_migration=failed_migration,
+    )
+
+
+def _fake_migration(app: str, name: str) -> bool:
+    """Mark a migration as applied without running the SQL.
+
+    Uses Django's --fake flag to record the migration in django_migrations
+    without executing any database operations.
+    """
+    try:
+        subprocess.run(
+            [sys.executable, "manage.py", "migrate", app, name, "--fake", "--no-input"],
+            cwd=REPO_ROOT,
+            env=_get_subprocess_env(),
+            check=True,
+            capture_output=True,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _run_django_migrate(app: str, target: str) -> bool:
+    """Run Django migrate command. Returns True on success."""
+    try:
+        subprocess.run(
+            [sys.executable, "manage.py", "migrate", app, target, "--no-input", "--skip-checks", "--skip-orphan-check"],
+            cwd=REPO_ROOT,
+            env=_get_subprocess_env(),
+            check=True,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _rollback_migration_with_cache(app: str, name: str, dry_run: bool = False) -> bool:
+    """Roll back a single migration using its cached file.
+
+    Uses context managers to ensure proper cleanup of temporary files,
+    hidden migrations, and max_migration.txt regardless of success or failure.
+    """
+    cache_path = _get_cached_migration(app, name)
+    if not cache_path:
+        return False
+
+    all_apps = get_managed_app_paths(REPO_ROOT)
+    migrations_dir = all_apps.get(app)
+    if not migrations_dir:
+        return False
+
+    target_path = migrations_dir / f"{name}.py"
+    previous = _get_previous_migration(app, name)
+
+    if dry_run:
+        click.echo(f"  [DRY RUN] Copy {cache_path} → {target_path}")
+        click.echo(f"  [DRY RUN] python manage.py migrate {app} {previous}")
+        click.echo(f"  [DRY RUN] Remove {target_path}")
+        return True
+
+    try:
+        with (
+            hidden_conflicting_migrations(migrations_dir, name),
+            temporary_migration_file(cache_path, target_path),
+            temporary_max_migration(migrations_dir, name),
+        ):
+            return _run_django_migrate(app, previous)
+    except Exception as e:
+        click.secho(f"  ⚠ Rollback failed for {app}.{name}: {e}", fg="red", err=True)
+        return False
+
+
+def _fetch_uncached_from_git(uncached: list[MigrationInfo], cached: list[MigrationInfo]) -> list[MigrationInfo]:
+    """Try to fetch uncached migrations from git history.
+
+    Moves successfully fetched migrations from uncached to cached list.
+    Returns the list of migrations that are still uncached.
+    """
+    if not uncached:
+        return []
+
+    click.echo("Attempting to fetch uncached migrations from git…\n")
+    still_uncached: list[MigrationInfo] = []
+
+    for m in uncached:
+        branch = _find_migration_branch(m.app, m.name)
+        if branch:
+            click.echo(f"  Fetching {m.app}.{m.name} from {branch}…")
+            if _fetch_and_cache_migration_from_git(m.app, m.name, branch):
+                click.secho(f"  ✓ Cached {m.app}.{m.name}", fg="green")
+                cached.append(m)
+            else:
+                click.secho(f"  ✗ Could not fetch {m.app}.{m.name}", fg="red")
+                still_uncached.append(m)
+        else:
+            click.secho(f"  ✗ Could not find branch for {m.app}.{m.name}", fg="red")
+            still_uncached.append(m)
+
+    click.echo()
+    return still_uncached
+
+
+def _show_manual_rollback_instructions(uncached: list[MigrationInfo], command_name: str) -> None:
+    """Show manual rollback instructions for uncached migrations and exit."""
+    click.secho("⚠ Some migrations are not cached and cannot be auto-rolled back:\n", fg="yellow")
+
+    for m in uncached:
+        branch = _find_migration_branch(m.app, m.name)
+        previous = _get_previous_migration(m.app, m.name)
+
+        click.echo(f"  {m.app}.{m.name}:")
+        if branch:
+            click.echo(f"    Found on branch: {branch}")
+            click.echo("    To roll back properly:")
+            click.echo("      1. git stash  # if you have changes")
+            click.echo(f"      2. git checkout {branch}")
+            click.echo(f"      3. python manage.py migrate {m.app} {previous}")
+            click.echo("      4. git checkout -")
+            click.echo("      5. git stash pop  # if you stashed")
+        else:
+            click.echo("    Could not find branch containing this migration.")
+            click.echo(f"    Target migration for rollback: {m.app} {previous}")
+        click.echo()
+
+    click.echo("After manual rollback, run 'hogli migrations:sync' again.\n")
+    click.echo("Or use --force to skip schema rollback (just removes DB records):")
+    click.secho(f"  hogli {command_name} --force\n", fg="yellow")
+    raise SystemExit(1)
+
+
+def _get_migrations_in_code(app: str, migrations_dir: Path) -> set[str]:
+    """Get migration names that exist in code for an app."""
+    migrations: set[str] = set()
+    if not migrations_dir.exists():
+        return migrations
+
+    for file in migrations_dir.iterdir():
+        if file.is_file():
+            match = MIGRATION_PATTERN.match(file.name)
+            if match:
+                # Strip .py extension
+                migrations.add(file.stem)
+    return migrations
+
+
+def _get_database_url() -> str:
+    """Get the PostgreSQL connection URL from environment."""
+    # Check for explicit DATABASE_URL first
+    if url := os.environ.get("DATABASE_URL"):
+        return url
+
+    # Build from individual components (PostHog's typical setup)
+    host = os.environ.get("PGHOST", "localhost")
+    port = os.environ.get("PGPORT", "5432")
+    user = os.environ.get("PGUSER", "posthog")
+    password = os.environ.get("PGPASSWORD", "posthog")
+    database = os.environ.get("PGDATABASE", "posthog")
+
+    # URL-encode all components to handle special characters
+    encoded_user = quote(user, safe="")
+    encoded_password = quote(password, safe="")
+    encoded_host = quote(host, safe="")
+    encoded_database = quote(database, safe="")
+
+    return f"postgresql://{encoded_user}:{encoded_password}@{encoded_host}:{port}/{encoded_database}"
+
+
+def _get_migrations_in_db() -> dict[str, set[str]]:
+    """Query the database for applied migrations.
+
+    Returns a dict mapping app labels to sets of migration names.
+    Queries postgres directly for speed (bypasses Django setup).
+    """
+    try:
+        import psycopg
+    except ImportError:
+        click.secho("psycopg not installed. Run: pip install psycopg", fg="red", err=True)
+        raise SystemExit(1)
+
+    try:
+        db_url = _get_database_url()
+        with psycopg.connect(db_url) as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT app, name FROM django_migrations")
+                rows = cur.fetchall()
+
+        migrations: dict[str, set[str]] = {}
+        for app, name in rows:
+            if app not in migrations:
+                migrations[app] = set()
+            migrations[app].add(name)
+        return migrations
+    except psycopg.OperationalError as e:
+        click.secho(f"Failed to connect to database: {e}", fg="red", err=True)
+        raise SystemExit(1) from e
+    except Exception as e:
+        click.secho(f"Failed to query database: {e}", fg="red", err=True)
+        raise SystemExit(1) from e
+
+
+def _compute_migration_diff() -> MigrationDiff:
+    """Compute the diff between database and code migration states.
+
+    Only tracks apps that we manage (posthog, ee, rbac, products/*).
+    Third-party apps (django, axes, social_django, etc.) are ignored.
+    """
+    diff = MigrationDiff()
+
+    # Get all migration apps we manage
+    all_apps = get_managed_app_paths(REPO_ROOT)
+    managed_app_names = set(all_apps.keys())
+
+    # Get migrations in code
+    code_migrations: dict[str, set[str]] = {}
+    for app, migrations_dir in all_apps.items():
+        code_migrations[app] = _get_migrations_in_code(app, migrations_dir)
+
+    # Get migrations in database (only for apps we manage)
+    all_db_migrations = _get_migrations_in_db()
+    db_migrations = {app: names for app, names in all_db_migrations.items() if app in managed_app_names}
+
+    # Only process apps we manage
+    for app in sorted(managed_app_names):
+        in_code = code_migrations.get(app, set())
+        in_db = db_migrations.get(app, set())
+
+        # Orphaned: in DB but not in code
+        for name in sorted(in_db - in_code):
+            diff.orphaned.append(MigrationInfo(app=app, name=name, exists_in_code=False, applied_in_db=True))
+
+        # Pending: in code but not in DB
+        for name in sorted(in_code - in_db):
+            diff.pending.append(MigrationInfo(app=app, name=name, exists_in_code=True, applied_in_db=False))
+
+        # Synced: in both
+        for name in sorted(in_code & in_db):
+            diff.synced.append(MigrationInfo(app=app, name=name, exists_in_code=True, applied_in_db=True))
+
+    return diff
+
+
+def _remove_orphaned_migrations(orphaned: list[MigrationInfo], dry_run: bool = False) -> bool:
+    """Remove orphaned migrations from the database.
+
+    Since the migration files don't exist in the current code, we can't use
+    Django's migrate command to roll them back. Instead, we directly delete
+    the records from django_migrations table.
+
+    WARNING: This only removes the migration record. It does NOT undo any
+    schema changes the migration made. For no-op test migrations this is fine.
+    For real migrations, the schema changes remain but won't cause issues
+    as long as the code doesn't depend on them.
+    """
+    if not orphaned:
+        return True
+
+    try:
+        import psycopg
+    except ImportError:
+        click.secho("psycopg not installed.", fg="red", err=True)
+        return False
+
+    if dry_run:
+        for m in orphaned:
+            click.echo(f"  [DRY RUN] DELETE FROM django_migrations WHERE app='{m.app}' AND name='{m.name}'")
+        return True
+
+    try:
+        db_url = _get_database_url()
+        with psycopg.connect(db_url) as conn:
+            with conn.cursor() as cur:
+                for m in orphaned:
+                    cur.execute(
+                        "DELETE FROM django_migrations WHERE app = %s AND name = %s",
+                        (m.app, m.name),
+                    )
+                    click.echo(f"  Removed: {m.app}.{m.name}")
+            conn.commit()
+        return True
+    except Exception as e:
+        click.secho(f"Failed to remove orphaned migrations: {e}", fg="red", err=True)
+        return False
+
+
+def _apply_migrations(pending: list[MigrationInfo] | None = None, dry_run: bool = False) -> MigrationResult:
+    """Apply all pending migrations and cache them for later rollback.
+
+    Returns a MigrationResult with structured error information if the migration fails.
+    """
+    if dry_run:
+        click.echo("  [DRY RUN] python manage.py migrate --no-input")
+        return MigrationResult(success=True)
+
+    result = subprocess.run(
+        [sys.executable, "manage.py", "migrate", "--no-input"],
+        cwd=REPO_ROOT,
+        env=_get_subprocess_env(),
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        return _parse_migration_error(result.stderr, result.stdout)
+
+    # Cache the migration files that were just applied
+    if pending:
+        all_apps = get_managed_app_paths(REPO_ROOT)
+        for m in pending:
+            migrations_dir = all_apps.get(m.app)
+            if migrations_dir:
+                source_path = migrations_dir / f"{m.name}.py"
+                if source_path.exists():
+                    _cache_migration(m.app, m.name, source_path)
+
+    return MigrationResult(success=True)
+
+
+@cli.command(name="migrations:status", help="Show migration diff between database and code")
+def migrations_status() -> None:
+    """Show which migrations are orphaned, pending, or synced."""
+    click.echo("\nAnalyzing migrations…\n")
+
+    diff = _compute_migration_diff()
+
+    if diff.orphaned:
+        click.secho("Orphaned migrations (in DB but not in code):", fg="yellow", bold=True)
+        click.echo("  These were likely applied on another branch.\n")
+        for m in diff.orphaned:
+            click.echo(f"    {m.app}: {m.name}")
+        click.echo()
+
+    if diff.pending:
+        click.secho("Pending migrations (in code but not applied):", fg="blue", bold=True)
+        click.echo("  These need to be applied.\n")
+        for m in diff.pending:
+            click.echo(f"    {m.app}: {m.name}")
+        click.echo()
+
+    if not diff.orphaned and not diff.pending:
+        click.secho("✓ Migrations are in sync", fg="green", bold=True)
+        click.echo(f"  {len(diff.synced)} migration(s) applied and present in code.")
+    else:
+        click.echo("Run 'hogli migrations:sync' to fix, or use 'down'/'up' individually.")
+
+
+@cli.command(name="migrations:down", help="Roll back orphaned migrations")
+@click.option("--dry-run", "-n", is_flag=True, help="Show what would be done without executing")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
+@click.option("--force", "-f", is_flag=True, help="Force removal without schema rollback (just deletes DB records)")
+def migrations_down(dry_run: bool, yes: bool, force: bool) -> None:
+    """Roll back migrations that are applied but don't exist in code."""
+    click.echo("\nAnalyzing migrations…\n")
+
+    if dry_run:
+        click.secho("[DRY RUN MODE - No changes will be made]\n", fg="yellow")
+
+    diff = _compute_migration_diff()
+
+    if not diff.orphaned:
+        click.secho("✓ No orphaned migrations to roll back", fg="green")
+        return
+
+    # Categorize orphaned migrations by whether we can roll them back
+    cached: list[MigrationInfo] = []
+    uncached: list[MigrationInfo] = []
+
+    for m in diff.orphaned:
+        if _get_cached_migration(m.app, m.name):
+            cached.append(m)
+        else:
+            uncached.append(m)
+
+    # Show what we found
+    click.secho("Orphaned migrations to roll back:", fg="yellow", bold=True)
+    for m in diff.orphaned:
+        cache_status = "cached" if m in cached else "not cached"
+        click.echo(f"    {m.app}: {m.name} ({cache_status})")
+    click.echo()
+
+    # Try to fetch uncached migrations from git
+    if uncached and not force:
+        uncached = _fetch_uncached_from_git(uncached, cached)
+
+    # If there are still uncached migrations and not forcing, show instructions
+    if uncached and not force:
+        _show_manual_rollback_instructions(uncached, "migrations:down")
+
+    # Proceed with rollback
+    if not yes and not dry_run:
+        if force and uncached:
+            click.secho(
+                "\n⚠ WARNING: --force will only remove DB records.\n"
+                "Schema changes from these migrations will remain!\n",
+                fg="red",
+            )
+        if not click.confirm("Proceed?", default=False):
+            click.echo("Aborted.")
+            raise SystemExit(1)
+
+    # Roll back cached migrations properly
+    if cached:
+        click.echo("\nRolling back cached migrations…")
+        for m in cached:
+            click.echo(f"  Rolling back {m.app}.{m.name}…")
+            if not _rollback_migration_with_cache(m.app, m.name, dry_run=dry_run):
+                click.secho(f"  Failed to roll back {m.app}.{m.name}", fg="red")
+                raise SystemExit(1)
+            if not dry_run:
+                click.secho(f"  ✓ Rolled back {m.app}.{m.name}", fg="green")
+
+    # For uncached migrations (only if --force), just remove DB records
+    if uncached and force:
+        click.echo("\nRemoving uncached migration records (schema changes remain)…")
+        if not _remove_orphaned_migrations(uncached, dry_run=dry_run):
+            click.secho("Failed to remove orphaned migrations", fg="red")
+            raise SystemExit(1)
+
+    click.echo()
+    click.secho("✓ Orphaned migrations handled", fg="green", bold=True)
+
+
+def _handle_duplicate_error(result: MigrationResult, pending: list[MigrationInfo], dry_run: bool, yes: bool) -> bool:
+    """Handle duplicate column/table errors by offering to fake the migration.
+
+    Returns True if the user chose to fake and we should retry migrations.
+    Returns False if the user declined or faking failed.
+    """
+    if not result.failed_migration:
+        click.secho("Could not determine which migration failed.", fg="red")
+        click.echo(f"\nError: {result.error_message}")
+        return False
+
+    app, name = result.failed_migration
+    error_desc = "column" if result.error_type == "duplicate_column" else "table/relation"
+
+    click.secho(f"\n⚠ Schema {error_desc} already exists for {app}.{name}", fg="yellow")
+    click.echo("This migration was likely applied on another branch without syncing.\n")
+
+    if dry_run:
+        click.echo(f"[DRY RUN] Would offer to fake {app}.{name}")
+        return False
+
+    # Ask user if they want to fake the migration
+    if yes or click.confirm(f"Fake this migration (mark as applied without running SQL)?", default=True):
+        click.echo(f"  Faking {app}.{name}…")
+        if _fake_migration(app, name):
+            click.secho(f"  ✓ Faked {app}.{name}", fg="green")
+
+            # Cache the migration file before removing from pending list.
+            # This ensures we can roll it back later if we switch to a branch
+            # that doesn't have this migration file.
+            all_apps = get_managed_app_paths(REPO_ROOT)
+            migrations_dir = all_apps.get(app)
+            if migrations_dir:
+                source_path = migrations_dir / f"{name}.py"
+                if source_path.exists():
+                    _cache_migration(app, name, source_path)
+
+            # Remove from pending so _apply_migrations doesn't try to cache it again
+            for m in pending[:]:
+                if m.app == app and m.name == name:
+                    pending.remove(m)
+                    break
+
+            return True  # Signal to retry remaining migrations
+        else:
+            click.secho(f"  ✗ Failed to fake {app}.{name}", fg="red")
+            return False
+    else:
+        click.echo(f"\nTo fix manually: python manage.py migrate {app} {name} --fake")
+        return False
+
+
+@cli.command(name="migrations:up", help="Apply pending migrations")
+@click.option("--dry-run", "-n", is_flag=True, help="Show what would be done without executing")
+@click.option("--yes", "-y", is_flag=True, help="Auto-confirm faking migrations with duplicate schema")
+def migrations_up(dry_run: bool, yes: bool) -> None:
+    """Apply migrations that exist in code but aren't applied."""
+    click.echo("\nApplying pending migrations…\n")
+
+    if dry_run:
+        click.secho("[DRY RUN MODE - No changes will be made]\n", fg="yellow")
+
+    diff = _compute_migration_diff()
+
+    if not diff.pending:
+        click.secho("✓ No pending migrations to apply", fg="green")
+        return
+
+    click.secho("Pending migrations to apply:", fg="blue", bold=True)
+    for m in diff.pending:
+        click.echo(f"    {m.app}: {m.name}")
+    click.echo()
+
+    pending = list(diff.pending)  # Make a mutable copy
+
+    while True:
+        result = _apply_migrations(pending=pending, dry_run=dry_run)
+
+        if result.success:
+            break
+
+        # Check for recoverable duplicate schema errors
+        if result.error_type in ("duplicate_column", "duplicate_table"):
+            if _handle_duplicate_error(result, pending, dry_run, yes):
+                # User chose to fake, retry remaining migrations
+                click.echo("\nRetrying remaining migrations…\n")
+                continue
+            else:
+                raise SystemExit(1)
+        else:
+            # Non-recoverable error
+            click.secho("Failed to apply migrations", fg="red")
+            if result.error_message:
+                click.echo(f"\n{result.error_message}")
+            raise SystemExit(1)
+
+    if not dry_run:
+        click.secho("✓ Migrations applied and cached", fg="green", bold=True)
+
+
+@cli.command(name="migrations:sync", help="Sync migrations: roll back orphaned, apply pending")
+@click.option("--dry-run", "-n", is_flag=True, help="Show what would be done without executing")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
+@click.option("--force", "-f", is_flag=True, help="Force sync even if some migrations can't be properly rolled back")
+def migrations_sync(dry_run: bool, yes: bool, force: bool) -> None:
+    """Smart sync: roll back orphaned migrations, then apply pending ones.
+
+    This is the recommended command when switching between worktrees or branches.
+    It handles both directions automatically.
+
+    Migration files are cached when applied, enabling proper schema rollback later.
+    If a migration isn't cached, instructions for manual rollback are shown.
+
+    For worktrees, just run after cd-ing to the worktree:
+        hogli migrations:sync
+    """
+    click.echo("\nAnalyzing migrations…\n")
+
+    if dry_run:
+        click.secho("[DRY RUN MODE - No changes will be made]\n", fg="yellow")
+
+    diff = _compute_migration_diff()
+
+    if not diff.orphaned and not diff.pending:
+        click.secho("✓ Migrations are already in sync", fg="green", bold=True)
+        click.echo(f"  {len(diff.synced)} migration(s) applied and present in code.")
+        return
+
+    # Categorize orphaned migrations
+    cached: list[MigrationInfo] = []
+    uncached: list[MigrationInfo] = []
+
+    for m in diff.orphaned:
+        if _get_cached_migration(m.app, m.name):
+            cached.append(m)
+        else:
+            uncached.append(m)
+
+    # Show what will happen
+    if diff.orphaned:
+        click.secho("Orphaned migrations to roll back:", fg="yellow", bold=True)
+        for m in diff.orphaned:
+            cache_status = "cached" if m in cached else "not cached"
+            click.echo(f"    {m.app}: {m.name} ({cache_status})")
+        click.echo()
+
+    if diff.pending:
+        click.secho("Pending migrations to apply:", fg="blue", bold=True)
+        for m in diff.pending:
+            click.echo(f"    {m.app}: {m.name}")
+        click.echo()
+
+    # Try to fetch uncached migrations from git
+    if uncached and not force:
+        uncached = _fetch_uncached_from_git(uncached, cached)
+
+    # If there are still uncached migrations and not forcing, show instructions
+    if uncached and not force:
+        _show_manual_rollback_instructions(uncached, "migrations:sync")
+
+    if not yes and not dry_run:
+        if force and uncached:
+            click.secho(
+                "\n⚠ WARNING: --force will only remove DB records for uncached migrations.\n"
+                "Schema changes from those migrations will remain!\n",
+                fg="red",
+            )
+        if not click.confirm("Proceed with sync?", default=True):
+            click.echo("Aborted.")
+            raise SystemExit(1)
+
+    # Step 1: Roll back orphaned migrations
+    if diff.orphaned:
+        click.echo("\n" + "─" * 40)
+        click.secho("Step 1: Rolling back orphaned migrations", fg="yellow", bold=True)
+        click.echo()
+
+        # Roll back cached migrations properly
+        for m in cached:
+            click.echo(f"  Rolling back {m.app}.{m.name}…")
+            if not _rollback_migration_with_cache(m.app, m.name, dry_run=dry_run):
+                click.secho(f"  Failed to roll back {m.app}.{m.name}", fg="red")
+                raise SystemExit(1)
+            if not dry_run:
+                click.secho(f"  ✓ Rolled back {m.app}.{m.name}", fg="green")
+
+        # Remove uncached migrations (only records, if --force)
+        if uncached and force:
+            click.echo("\n  Removing uncached migration records…")
+            if not _remove_orphaned_migrations(uncached, dry_run=dry_run):
+                click.secho("Failed to remove orphaned migrations", fg="red")
+                raise SystemExit(1)
+
+    # Step 2: Apply pending
+    if diff.pending:
+        click.echo("\n" + "─" * 40)
+        click.secho("Step 2: Applying pending migrations", fg="blue", bold=True)
+        click.echo()
+
+        pending = list(diff.pending)  # Make a mutable copy
+
+        while True:
+            result = _apply_migrations(pending=pending, dry_run=dry_run)
+
+            if result.success:
+                break
+
+            # Check for recoverable duplicate schema errors
+            if result.error_type in ("duplicate_column", "duplicate_table"):
+                if _handle_duplicate_error(result, pending, dry_run, yes):
+                    # User chose to fake, retry remaining migrations
+                    click.echo("\nRetrying remaining migrations…\n")
+                    continue
+                else:
+                    raise SystemExit(1)
+            else:
+                # Non-recoverable error
+                click.secho("Failed to apply migrations", fg="red")
+                if result.error_message:
+                    click.echo(f"\n{result.error_message}")
+                raise SystemExit(1)
+
+        if not dry_run:
+            click.secho("  ✓ Migrations applied and cached", fg="green")
+
+    click.echo("\n" + "─" * 40)
+    click.secho("✓ Sync complete", fg="green", bold=True)
+
+
+@cli.command(name="migrations:cache-sync", help="Populate cache from currently applied migrations")
+def migrations_cache_sync() -> None:
+    """Cache all currently applied migrations that exist in code.
+
+    This bootstraps the cache so that future rollbacks can work properly.
+    Run this once after setting up hogli, or after pulling new migrations.
+    """
+    click.echo("\nCaching applied migrations…\n")
+
+    diff = _compute_migration_diff()
+    all_apps = get_managed_app_paths(REPO_ROOT)
+
+    cached_count = 0
+    already_cached = 0
+    missing_count = 0
+
+    for m in diff.synced:
+        # Check if already cached
+        if _get_cached_migration(m.app, m.name):
+            already_cached += 1
+            continue
+
+        # Find the source file
+        migrations_dir = all_apps.get(m.app)
+        if not migrations_dir:
+            missing_count += 1
+            continue
+
+        source_path = migrations_dir / f"{m.name}.py"
+        if not source_path.exists():
+            missing_count += 1
+            continue
+
+        # Cache it
+        if _cache_migration(m.app, m.name, source_path):
+            cached_count += 1
+            click.echo(f"  Cached: {m.app}.{m.name}")
+        else:
+            click.secho(f"  Failed to cache: {m.app}.{m.name}", fg="red")
+
+    click.echo()
+    click.secho(f"✓ Cache sync complete", fg="green", bold=True)
+    click.echo(f"  New: {cached_count}, Already cached: {already_cached}, Missing: {missing_count}")
+    click.echo(f"  Cache location: {MIGRATION_CACHE_DIR}")

--- a/common/hogli/migrations.py
+++ b/common/hogli/migrations.py
@@ -152,6 +152,10 @@ def _fetch_and_cache_migration_from_git(app: str, name: str, branch: str) -> boo
     except ValueError:
         return False
 
+    # Validate branch name to prevent issues with special characters
+    if not re.match(r"^[a-zA-Z0-9/_.-]+$", branch):
+        return False
+
     # Try fetching from remote first (in case branch isn't checked out locally)
     for ref in [f"origin/{branch}", branch]:
         try:

--- a/common/hogli/tests/test_migrations.py
+++ b/common/hogli/tests/test_migrations.py
@@ -1,0 +1,210 @@
+"""Tests for migration management - security-critical validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from parameterized import parameterized
+
+
+class TestPathTraversalValidation:
+    """Test path validation prevents directory traversal and injection attacks."""
+
+    @parameterized.expand(
+        [
+            # Valid cases - standard PostHog apps
+            ("posthog", "0001_initial"),
+            ("ee", "0952_add_sync_test_branch_two"),
+            ("rbac", "0123_some_migration_name"),
+            # Valid cases - product apps
+            ("web_analytics", "0001_initial"),
+            ("data_warehouse", "0042_add_feature"),
+            # Valid cases - edge cases for valid patterns
+            ("a", "0001_a"),  # Single char app name
+            ("app123", "9999_migration_name_with_underscores"),
+        ]
+    )
+    def test_valid_inputs_pass_validation(self, app: str, name: str) -> None:
+        """Valid app names and migration names should pass validation."""
+        from migration_utils import validate_migration_path_components
+
+        # Should not raise
+        validate_migration_path_components(app, name)
+
+    @parameterized.expand(
+        [
+            # Path traversal via app name
+            ("../etc", "0001_passwd", "app"),
+            ("posthog/../../../etc", "0001_test", "app"),
+            ("..", "0001_test", "app"),
+            ("posthog/../../bad", "0001_test", "app"),
+            ("./posthog", "0001_test", "app"),
+            # Path traversal via migration name
+            ("posthog", "../../../etc/passwd", "migration"),
+            ("posthog", "0001_../../bad", "migration"),
+            ("posthog", "0001_test/../../../etc", "migration"),
+            ("posthog", "./0001_test", "migration"),
+        ]
+    )
+    def test_path_traversal_rejected(self, app: str, name: str, _field: str) -> None:
+        """Path traversal attempts should raise ValueError."""
+        from migration_utils import validate_migration_path_components
+
+        with pytest.raises(ValueError):
+            validate_migration_path_components(app, name)
+
+    @parameterized.expand(
+        [
+            # Shell injection via app name
+            ("posthog;rm -rf /", "0001_test", "app"),
+            ("posthog|whoami", "0001_test", "app"),
+            ("posthog`id`", "0001_test", "app"),
+            ("posthog$(whoami)", "0001_test", "app"),
+            ("posthog&echo", "0001_test", "app"),
+            # Shell injection via migration name
+            ("posthog", "0001_test;DROP TABLE", "migration"),
+            ("posthog", "0001_test|cat /etc/passwd", "migration"),
+            ("posthog", "0001_`id`", "migration"),
+            ("posthog", "0001_$(whoami)", "migration"),
+        ]
+    )
+    def test_shell_injection_rejected(self, app: str, name: str, _field: str) -> None:
+        """Shell metacharacters should raise ValueError."""
+        from migration_utils import validate_migration_path_components
+
+        with pytest.raises(ValueError):
+            validate_migration_path_components(app, name)
+
+    @parameterized.expand(
+        [
+            # Invalid app name formats
+            ("", "0001_test", "Empty app name"),
+            ("123app", "0001_test", "App starting with number"),
+            ("app-name", "0001_test", "App with hyphen"),
+            ("app.name", "0001_test", "App with dot"),
+            ("app name", "0001_test", "App with space"),
+            # Invalid migration name formats
+            ("posthog", "", "Empty migration name"),
+            ("posthog", "0001", "Missing description after number"),
+            ("posthog", "001_test", "Wrong digit count (3)"),
+            ("posthog", "00001_test", "Wrong digit count (5)"),
+            ("posthog", "test_0001", "Number not at start"),
+            ("posthog", "0001-test", "Hyphen instead of underscore"),
+            ("posthog", "0001_test.py", "Includes file extension"),
+            ("posthog", "0001 test", "Space in name"),
+            ("posthog", "0001_Test-Name", "Hyphen in description"),
+        ]
+    )
+    def test_invalid_format_rejected(self, app: str, name: str, _description: str) -> None:
+        """Invalid format patterns should raise ValueError."""
+        from migration_utils import validate_migration_path_components
+
+        with pytest.raises(ValueError):
+            validate_migration_path_components(app, name)
+
+
+class TestIsValidMigrationPath:
+    """Test the bool-returning validation function."""
+
+    @parameterized.expand(
+        [
+            # Valid cases
+            ("posthog", "0001_initial", True),
+            ("ee", "0952_add_feature", True),
+            # Invalid cases - path traversal
+            ("../etc", "0001_passwd", False),
+            ("posthog", "../../../etc/passwd", False),
+            # Invalid cases - shell injection
+            ("posthog;rm", "0001_test", False),
+            ("posthog", "0001_;DROP", False),
+            # Invalid cases - format
+            ("", "0001_test", False),
+            ("posthog", "", False),
+            ("123app", "0001_test", False),
+            ("posthog", "001_test", False),
+        ]
+    )
+    def test_is_valid_migration_path(self, app: str, name: str, expected: bool) -> None:
+        """Test the bool-returning validation function."""
+        from migration_utils import is_valid_migration_path
+
+        result = is_valid_migration_path(app, name)
+        assert result is expected
+
+
+class TestCachePathSecurity:
+    """Test that cache path generation is secure."""
+
+    def test_get_cache_path_validates_inputs(self) -> None:
+        """get_cache_path should validate before constructing path."""
+        from migration_utils import get_cache_path
+
+        # Valid input should return a path
+        path = get_cache_path("posthog", "0001_initial")
+        assert "posthog" in str(path)
+        assert "0001_initial.py" in str(path)
+
+        # Invalid input should raise
+        with pytest.raises(ValueError):
+            get_cache_path("../etc", "0001_passwd")
+
+        with pytest.raises(ValueError):
+            get_cache_path("posthog", "../../../etc/passwd")
+
+    def test_cache_path_stays_within_cache_dir(self) -> None:
+        """Cache path should always be under MIGRATION_CACHE_DIR."""
+        from migration_utils import MIGRATION_CACHE_DIR, get_cache_path
+
+        path = get_cache_path("posthog", "0001_initial")
+
+        # Resolve to absolute and check it's under cache dir
+        resolved = path.resolve()
+        cache_resolved = MIGRATION_CACHE_DIR.resolve()
+
+        # Use is_relative_to() for proper path boundary checks
+        # (startswith can have false positives like /tmp/cacheevil matching /tmp/cache)
+        assert resolved.is_relative_to(cache_resolved)
+
+
+class TestSharedMigrationUtils:
+    """Test the shared migration_utils module directly."""
+
+    def test_validate_raises_for_invalid_app(self) -> None:
+        """validate_migration_path_components should raise for invalid app."""
+        from migration_utils import validate_migration_path_components
+
+        with pytest.raises(ValueError, match="Invalid app name"):
+            validate_migration_path_components("../bad", "0001_test")
+
+    def test_validate_raises_for_invalid_migration(self) -> None:
+        """validate_migration_path_components should raise for invalid migration."""
+        from migration_utils import validate_migration_path_components
+
+        with pytest.raises(ValueError, match="Invalid migration name"):
+            validate_migration_path_components("posthog", "bad_name")
+
+    def test_is_valid_returns_bool(self) -> None:
+        """is_valid_migration_path should return bool without raising."""
+        from migration_utils import is_valid_migration_path
+
+        assert is_valid_migration_path("posthog", "0001_initial") is True
+        assert is_valid_migration_path("../etc", "0001_passwd") is False
+        assert is_valid_migration_path("posthog", "bad") is False
+
+    def test_get_cached_migration_returns_none_for_invalid(self) -> None:
+        """get_cached_migration should return None for invalid inputs."""
+        from migration_utils import get_cached_migration
+
+        # Invalid inputs should return None (not raise)
+        assert get_cached_migration("../etc", "0001_passwd") is None
+        assert get_cached_migration("posthog", "bad") is None
+
+    def test_cache_migration_file_returns_false_for_invalid(self) -> None:
+        """cache_migration_file should return False for invalid inputs."""
+        from pathlib import Path
+
+        from migration_utils import cache_migration_file
+
+        # Invalid inputs should return False (not raise)
+        assert cache_migration_file("../etc", "0001_passwd", Path("/fake")) is False
+        assert cache_migration_file("posthog", "bad", Path("/fake")) is False

--- a/common/migration_utils/__init__.py
+++ b/common/migration_utils/__init__.py
@@ -208,7 +208,11 @@ def temporary_migration_file(cache_path: Path, target_path: Path) -> Iterator[No
 
 @contextmanager
 def temporary_max_migration(migrations_dir: Path, migration_name: str) -> Iterator[None]:
-    """Context manager that temporarily updates max_migration.txt and restores it after."""
+    """Context manager that temporarily updates max_migration.txt and restores it after.
+
+    Only modifies the file if it already exists - creating it when absent could
+    confuse Django into thinking the app uses squashed migrations.
+    """
     max_migration_path = migrations_dir / "max_migration.txt"
     original_value = None
 

--- a/common/migration_utils/__init__.py
+++ b/common/migration_utils/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import re
 import shutil
+import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -250,4 +251,11 @@ def hidden_conflicting_migrations(migrations_dir: Path, migration_name: str) -> 
     finally:
         for original, hidden_path in hidden:
             if hidden_path.exists():
-                hidden_path.rename(original)
+                if original.exists():
+                    # Another process created a file at the original path - don't overwrite
+                    warnings.warn(
+                        f"Cannot restore {hidden_path} - {original} already exists",
+                        stacklevel=2,
+                    )
+                else:
+                    hidden_path.rename(original)

--- a/common/migration_utils/__init__.py
+++ b/common/migration_utils/__init__.py
@@ -1,0 +1,249 @@
+"""Shared utilities for Django migration management.
+
+This module contains common constants, patterns, and functions used by both:
+- hogli/migrations.py (CLI tool)
+- posthog/management/commands/migrate.py (Django command extension)
+
+Centralizing this code ensures consistent validation and caching behavior.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+# Cache directory for migration files
+# Used for storing migration files so they can be rolled back after branch switching
+MIGRATION_CACHE_DIR = Path.home() / ".cache" / "posthog-migrations"
+
+# Pattern to validate migration names (without .py extension)
+# Must start with 4 digits, underscore, then alphanumeric/underscores only
+# Examples: "0001_initial", "0952_add_sync_test_branch_two"
+MIGRATION_NAME_PATTERN = re.compile(r"^(\d{4})_[a-zA-Z0-9_]+$")
+
+# Pattern to validate app names (valid Python package names)
+# Must start with letter, then letters/numbers/underscores
+# Examples: "posthog", "ee", "web_analytics"
+APP_NAME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
+
+
+def validate_migration_path_components(app: str, name: str) -> None:
+    """Validate app and migration name to prevent path traversal attacks.
+
+    This is a security-critical function. Both app and migration names are used
+    to construct file paths for caching. Invalid characters could allow writing
+    files outside the cache directory.
+
+    Args:
+        app: The Django app label (e.g., "posthog", "ee")
+        name: The migration name without .py extension (e.g., "0001_initial")
+
+    Raises:
+        ValueError: If either component contains invalid characters
+    """
+    if not APP_NAME_PATTERN.match(app):
+        raise ValueError(f"Invalid app name: {app}")
+    if not MIGRATION_NAME_PATTERN.match(name):
+        raise ValueError(f"Invalid migration name: {name}")
+
+
+def is_valid_migration_path(app: str, name: str) -> bool:
+    """Check if app and migration name are valid (non-raising version).
+
+    Args:
+        app: The Django app label
+        name: The migration name without .py extension
+
+    Returns:
+        True if both components are valid, False otherwise
+    """
+    try:
+        validate_migration_path_components(app, name)
+        return True
+    except ValueError:
+        return False
+
+
+def get_cache_path(app: str, name: str) -> Path:
+    """Get the cache path for a migration file.
+
+    Validates inputs before constructing path to prevent path traversal.
+
+    Args:
+        app: The Django app label
+        name: The migration name without .py extension
+
+    Returns:
+        Path to the cached migration file
+
+    Raises:
+        ValueError: If app or name contains invalid characters
+    """
+    validate_migration_path_components(app, name)
+    return MIGRATION_CACHE_DIR / app / f"{name}.py"
+
+
+def get_cached_migration(app: str, name: str) -> Path | None:
+    """Get a cached migration file if it exists.
+
+    Args:
+        app: The Django app label
+        name: The migration name without .py extension
+
+    Returns:
+        Path to cached file if it exists, None otherwise.
+        Returns None if validation fails (invalid app/name).
+    """
+    try:
+        cache_path = get_cache_path(app, name)
+        return cache_path if cache_path.exists() else None
+    except ValueError:
+        return None
+
+
+def cache_migration_file(app: str, name: str, source_path: Path) -> bool:
+    """Cache a migration file for later rollback.
+
+    Creates the cache directory structure if needed and copies the migration
+    file to the cache location.
+
+    Args:
+        app: The Django app label
+        name: The migration name without .py extension
+        source_path: Path to the source migration file
+
+    Returns:
+        True if caching succeeded, False if app name is invalid
+
+    Raises:
+        OSError: If creating the cache directory or copying the file fails
+    """
+    try:
+        cache_path = get_cache_path(app, name)
+    except ValueError:
+        return False
+
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, cache_path)
+        return True
+    except OSError as e:
+        raise OSError(f"Failed to cache {app}.{name}: {e}") from e
+
+
+# Core PostHog apps that have migrations we manage
+# These are always included; product apps are discovered dynamically
+CORE_MANAGED_APPS = frozenset({"posthog", "ee", "rbac"})
+
+
+def discover_product_apps(base_dir: Path) -> set[str]:
+    """Discover product apps with migrations in products/*/backend/migrations/.
+
+    Args:
+        base_dir: The repository root directory
+
+    Returns:
+        Set of product app names that have migration directories
+    """
+    apps: set[str] = set()
+    products_dir = base_dir / "products"
+    if products_dir.exists():
+        for product_dir in products_dir.iterdir():
+            if product_dir.is_dir():
+                migrations_dir = product_dir / "backend" / "migrations"
+                if migrations_dir.exists():
+                    apps.add(product_dir.name)
+    return apps
+
+
+def get_managed_app_names(base_dir: Path) -> set[str]:
+    """Get all managed app names (core + product apps).
+
+    Args:
+        base_dir: The repository root directory
+
+    Returns:
+        Set of app names we manage migrations for
+    """
+    return set(CORE_MANAGED_APPS) | discover_product_apps(base_dir)
+
+
+def get_managed_app_paths(base_dir: Path) -> dict[str, Path]:
+    """Get all managed apps with their migration directory paths.
+
+    Args:
+        base_dir: The repository root directory
+
+    Returns:
+        Dict mapping app names to their migration directories
+    """
+    apps = {
+        "posthog": base_dir / "posthog" / "migrations",
+        "ee": base_dir / "ee" / "migrations",
+        "rbac": base_dir / "posthog" / "rbac" / "migrations",
+    }
+
+    # Add product apps using the shared discovery function
+    for product_name in discover_product_apps(base_dir):
+        apps[product_name] = base_dir / "products" / product_name / "backend" / "migrations"
+
+    return apps
+
+
+# Context managers for rollback operations
+
+
+@contextmanager
+def temporary_migration_file(cache_path: Path, target_path: Path) -> Iterator[None]:
+    """Context manager that copies a cached migration to target and cleans up after."""
+    shutil.copy2(cache_path, target_path)
+    try:
+        yield
+    finally:
+        target_path.unlink(missing_ok=True)
+
+
+@contextmanager
+def temporary_max_migration(migrations_dir: Path, migration_name: str) -> Iterator[None]:
+    """Context manager that temporarily updates max_migration.txt and restores it after."""
+    max_migration_path = migrations_dir / "max_migration.txt"
+    original_value = None
+
+    if max_migration_path.exists():
+        original_value = max_migration_path.read_text().strip()
+        max_migration_path.write_text(f"{migration_name}\n")
+
+    try:
+        yield
+    finally:
+        if original_value is not None:
+            max_migration_path.write_text(f"{original_value}\n")
+
+
+@contextmanager
+def hidden_conflicting_migrations(migrations_dir: Path, migration_name: str) -> Iterator[None]:
+    """Context manager that hides conflicting migrations and restores them after.
+
+    Conflicting migrations are those with the same number prefix but different names.
+    For example, 0952_add_feature conflicts with 0952_other_feature.
+    """
+    migration_prefix = migration_name.split("_")[0]
+    hidden: list[tuple[Path, Path]] = []
+
+    try:
+        # Hide conflicting migrations inside try block so partial failures
+        # still trigger cleanup of already-hidden files
+        for migration_file in migrations_dir.glob(f"{migration_prefix}_*.py"):
+            if migration_file.name != f"{migration_name}.py":
+                hidden_path = migration_file.with_suffix(".py.hidden")
+                migration_file.rename(hidden_path)
+                hidden.append((migration_file, hidden_path))
+
+        yield
+    finally:
+        for original, hidden_path in hidden:
+            if hidden_path.exists():
+                hidden_path.rename(original)

--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,12 @@
 
 import os
 import sys
+from pathlib import Path
+
+# Add common/ to path so migration_utils module is importable (used by custom migrate command)
+_common_path = str(Path(__file__).parent / "common")
+if _common_path not in sys.path:
+    sys.path.insert(0, _common_path)
 
 
 def main():

--- a/posthog/management/commands/migrate.py
+++ b/posthog/management/commands/migrate.py
@@ -1,0 +1,304 @@
+"""Custom migrate command with migration caching for worktree workflows.
+
+Extends Django's migrate command to:
+1. Check for orphaned migrations before applying new ones
+2. Offer to automatically roll back orphaned migrations
+3. Cache migration files after applying them for later rollback
+
+This enables proper schema rollback when switching between branches/worktrees
+that have different migrations applied.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import shutil
+import warnings
+import subprocess
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.commands.migrate import Command as DjangoMigrateCommand
+from django.db import DEFAULT_DB_ALIAS
+from django.db.migrations.recorder import MigrationRecorder
+
+from migration_utils import (
+    MIGRATION_CACHE_DIR,
+    get_cached_migration,
+    get_managed_app_names,
+    hidden_conflicting_migrations,
+    is_valid_migration_path,
+    temporary_max_migration,
+    temporary_migration_file,
+)
+
+
+def get_managed_apps() -> set[str]:
+    """Get apps we manage migrations for (PostHog apps, not third-party)."""
+    try:
+        return get_managed_app_names(Path(settings.BASE_DIR))
+    except Exception as e:
+        warnings.warn(f"Could not scan product apps for migrations: {e}", stacklevel=2)
+        return {"posthog", "ee", "rbac"}
+
+
+def get_app_migrations_dir(app_label: str) -> Path | None:
+    """Get the migrations directory for an app."""
+    try:
+        from django.apps import apps
+
+        app_config = apps.get_app_config(app_label)
+        return Path(app_config.path) / "migrations"
+    except LookupError:
+        return None
+
+
+def cache_migration(app_label: str, migration_name: str) -> bool:
+    """Cache a migration file for later rollback.
+
+    Validates inputs to prevent path traversal attacks.
+    """
+    # Validate inputs to prevent path traversal
+    if not is_valid_migration_path(app_label, migration_name):
+        return False
+
+    migrations_dir = get_app_migrations_dir(app_label)
+    if not migrations_dir:
+        return False
+
+    source_path = migrations_dir / f"{migration_name}.py"
+    if not source_path.exists():
+        return False
+
+    cache_path = MIGRATION_CACHE_DIR / app_label / f"{migration_name}.py"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        shutil.copy2(source_path, cache_path)
+        return True
+    except Exception as e:
+        warnings.warn(f"Could not cache migration {app_label}.{migration_name}: {e}", stacklevel=2)
+        return False
+
+
+def get_orphaned_migrations(connection) -> list[tuple[str, str]]:
+    """Find migrations applied in DB but not present in code.
+
+    Returns list of (app_label, migration_name) tuples.
+    """
+    from django.db.migrations.loader import MigrationLoader
+
+    loader = MigrationLoader(connection, ignore_no_migrations=True)
+    recorder = MigrationRecorder(connection)
+    applied = recorder.applied_migrations()
+    managed_apps = get_managed_apps()
+
+    orphaned = []
+    for app_label, migration_name in applied:
+        # Only check apps we manage
+        if app_label not in managed_apps:
+            continue
+
+        # Check if migration exists in the loader's disk migrations
+        if (app_label, migration_name) not in loader.disk_migrations:
+            orphaned.append((app_label, migration_name))
+
+    return orphaned
+
+
+def get_previous_migration(app_label: str, migration_name: str, connection) -> str:
+    """Get the migration to roll back to (the one before the given migration)."""
+    from django.db.migrations.loader import MigrationLoader
+
+    loader = MigrationLoader(connection, ignore_no_migrations=True)
+    recorder = MigrationRecorder(connection)
+    applied = recorder.applied_migrations()
+
+    # Get all applied migrations for this app, sorted
+    app_migrations = sorted([name for app, name in applied if app == app_label])
+
+    if not app_migrations:
+        return "zero"
+
+    try:
+        idx = app_migrations.index(migration_name)
+        if idx == 0:
+            return "zero"
+        return app_migrations[idx - 1]
+    except ValueError:
+        # Migration not in list, check disk migrations
+        disk_migrations = sorted([name for app, name in loader.disk_migrations if app == app_label])
+        return disk_migrations[-1] if disk_migrations else "zero"
+
+
+def rollback_orphaned_migration(app_label: str, migration_name: str, previous: str, stdout) -> bool:
+    """Roll back a single orphaned migration using its cached file.
+
+    Uses context managers to ensure proper cleanup of temporary files,
+    hidden migrations, and max_migration.txt regardless of success or failure.
+
+    Returns True on success, False on failure.
+    """
+    cache_path = get_cached_migration(app_label, migration_name)
+    if not cache_path:
+        return False
+
+    migrations_dir = get_app_migrations_dir(app_label)
+    if not migrations_dir:
+        return False
+
+    target_path = migrations_dir / f"{migration_name}.py"
+
+    try:
+        with (
+            hidden_conflicting_migrations(migrations_dir, migration_name),
+            temporary_migration_file(cache_path, target_path),
+            temporary_max_migration(migrations_dir, migration_name),
+        ):
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "manage.py",
+                    "migrate",
+                    app_label,
+                    previous,
+                    "--no-input",
+                    "--skip-orphan-check",
+                    "--skip-checks",
+                ],
+                cwd=settings.BASE_DIR,
+                env={**os.environ, "DJANGO_SETTINGS_MODULE": "posthog.settings"},
+                capture_output=True,
+                text=True,
+            )
+
+            if result.returncode != 0:
+                stdout.write(f"    Error: {result.stderr.strip()}")
+                return False
+
+            return True
+    except Exception as e:
+        # Log with traceback so cleanup failures don't mask the original error
+        warnings.warn(f"Rollback failed for {app_label}.{migration_name}: {e}", stacklevel=2)
+        stdout.write(f"    Error: {e}")
+        return False
+
+
+class Command(DjangoMigrateCommand):
+    """Extended migrate command with caching and orphan detection."""
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--skip-orphan-check",
+            action="store_true",
+            help="Skip checking for orphaned migrations before migrating.",
+        )
+
+    def handle(self, *args, **options):
+        database = options.get("database", DEFAULT_DB_ALIAS)
+        interactive = options.get("interactive", True)
+        skip_orphan_check = options.get("skip_orphan_check", False)
+
+        # Get connection for orphan check
+        from django.db import connections
+
+        connection = connections[database]
+
+        # Check for orphaned migrations before proceeding
+        if not skip_orphan_check and not options.get("check_unapplied"):
+            try:
+                orphaned = get_orphaned_migrations(connection)
+                if orphaned:
+                    self.stdout.write("")
+                    self.stdout.write(self.style.WARNING("⚠️  Orphaned migrations detected!"))
+                    self.stdout.write("These migrations are applied in the DB but don't exist in code.")
+                    self.stdout.write("They were likely applied on another branch.\n")
+
+                    # Categorize by whether we can auto-fix
+                    cached_orphans = []
+                    uncached_orphans = []
+                    for app_label, migration_name in orphaned:
+                        cached = get_cached_migration(app_label, migration_name)
+                        if cached:
+                            cached_orphans.append((app_label, migration_name))
+                        else:
+                            uncached_orphans.append((app_label, migration_name))
+                        status = "cached" if cached else "not cached"
+                        self.stdout.write(f"    {app_label}: {migration_name} ({status})")
+
+                    self.stdout.write("")
+
+                    if interactive:
+                        # Offer to fix if all orphans are cached
+                        if cached_orphans and not uncached_orphans:
+                            self.stdout.write("All orphaned migrations are cached and can be rolled back.\n")
+                            choice = input("Roll back now and continue? [Y/n/abort] ").strip().lower()
+
+                            if choice in ("", "y", "yes"):
+                                self.stdout.write("")
+                                self.stdout.write(self.style.MIGRATE_HEADING("Rolling back orphaned migrations…"))
+
+                                for app_label, migration_name in cached_orphans:
+                                    previous = get_previous_migration(app_label, migration_name, connection)
+                                    self.stdout.write(f"  Rolling back {app_label}.{migration_name}…")
+
+                                    if rollback_orphaned_migration(app_label, migration_name, previous, self.stdout):
+                                        self.stdout.write(
+                                            self.style.SUCCESS(f"  ✓ Rolled back {app_label}.{migration_name}")
+                                        )
+                                    else:
+                                        self.stdout.write(
+                                            self.style.ERROR(f"  ✗ Failed to roll back {app_label}.{migration_name}")
+                                        )
+                                        self.stdout.write("Aborted.")
+                                        return
+
+                                self.stdout.write("")
+                            elif choice in ("n", "no"):
+                                # Continue without rolling back
+                                self.stdout.write("Continuing without rolling back…\n")
+                            else:
+                                self.stdout.write("Aborted.")
+                                return
+                        else:
+                            # Some uncached - can't auto-fix all
+                            if uncached_orphans:
+                                self.stdout.write(
+                                    self.style.WARNING(
+                                        "Some migrations are not cached and cannot be auto-rolled back.\n"
+                                        "Run 'hogli migrations:sync' for manual instructions.\n"
+                                    )
+                                )
+                            confirm = input("Continue anyway? [y/N] ")
+                            if confirm.lower() not in ("y", "yes"):
+                                self.stdout.write("Aborted.")
+                                return
+                    else:
+                        # Non-interactive mode: warn but continue
+                        self.stdout.write(
+                            self.style.WARNING(
+                                "Continuing in non-interactive mode. Run 'hogli migrations:sync' after to clean up."
+                            )
+                        )
+            except Exception as e:
+                # Don't block migrations if orphan check fails
+                self.stdout.write(self.style.WARNING(f"⚠️  Could not check for orphaned migrations: {e}"))
+
+        # Get migrations that will be applied (before running migrate)
+        recorder = MigrationRecorder(connection)
+        applied_before = set(recorder.applied_migrations())
+
+        # Run the actual migrate command
+        super().handle(*args, **options)
+
+        # Cache any newly applied migrations
+        applied_after = set(recorder.applied_migrations())
+        newly_applied = applied_after - applied_before
+        managed_apps = get_managed_apps()
+
+        for app_label, migration_name in newly_applied:
+            if app_label in managed_apps:
+                if cache_migration(app_label, migration_name):
+                    self.stdout.write(self.style.SUCCESS(f"  Cached: {app_label}.{migration_name}"))

--- a/posthog/management/commands/migrate.py
+++ b/posthog/management/commands/migrate.py
@@ -240,6 +240,9 @@ class Command(DjangoMigrateCommand):
                                 self.stdout.write("")
                                 self.stdout.write(self.style.MIGRATE_HEADING("Rolling back orphaned migrations…"))
 
+                                # Sort in reverse order so dependent migrations are rolled back first
+                                # (e.g., 0004 must be rolled back before 0003)
+                                cached_orphans.sort(key=lambda x: x[1], reverse=True)
                                 for app_label, migration_name in cached_orphans:
                                     previous = get_previous_migration(app_label, migration_name, connection)
                                     self.stdout.write(f"  Rolling back {app_label}.{migration_name}…")


### PR DESCRIPTION
## Problem

See #43946 for the problem statement.

## Changes

Re-applies #43946 which was reverted in #44675, along with the Docker fix from #44676 (also reverted in #44688).

Changes from #43946:
- hogli migrations:status/down/up/sync commands for manual control
- Custom manage.py migrate command that detects orphaned migrations (applied in DB but missing from code) and offers to auto-fix
- Migration file caching to ~/.cache/posthog-migrations/
- Auto-fetch uncached migrations from git before rollback
- Auto-detect and offer to fake migrations with duplicate schema errors

Docker fix from #44676:
- Add common/migration_utils to Dockerfile (both posthog-build and final stages)
- Add common/migration_utils to .dockerignore allowlist

The Docker fix addresses the ModuleNotFoundError that broke deployments when the wait-for-migrations init container tried to import migration_utils.
## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No