### PR TITLE
feat(admin): autofill zendesk ticket when impersonating

### DIFF
--- a/posthog/templates/admin/posthog/user/change_form.html
+++ b/posthog/templates/admin/posthog/user/change_form.html
@@ -30,6 +30,17 @@
         // Add read-only toggle to loginas modal
         const reasonField = document.getElementById("loginas-reason");
         if (reasonField) {
+            const ticketParam = new URLSearchParams(window.location.search).get('ticket');
+
+            // Pre-fill reason field when modal opens (after loginas clears it)
+            if (ticketParam) {
+                document.getElementById("loginas-link")?.addEventListener("click", () => {
+                    setTimeout(() => {
+                        reasonField.value = `For ticket ${ticketParam}`;
+                    }, 0);
+                });
+            }
+
             const div = document.createElement("div");
             div.style.marginTop = "10px";
             div.innerHTML = '<label><input type="checkbox" id="loginas-read-only" checked> Read-only mode (recommended)</label>';


### PR DESCRIPTION
This change uses the `ticket` query param, when present, to autofill the impersonation reason.

<img width="477" height="285" alt="Screenshot 2026-01-12 at 10 35 49" src="https://github.com/user-attachments/assets/f8b277c8-d6c7-4236-a405-78522e9e17ca" />
