### PR TITLE
feat: spark joy by adding a key sequence for going to the SQL editor

### DIFF
--- a/frontend/src/layout/GlobalShortcuts.tsx
+++ b/frontend/src/layout/GlobalShortcuts.tsx
@@ -68,5 +68,17 @@ export function GlobalShortcuts(): null {
         callback: toggleZenMode,
     })
 
+    useAppShortcut({
+        name: 'SQLEditor',
+        keybind: [keyBinds.sqlEditor],
+        intent: 'Open SQL editor',
+        interaction: 'function',
+        callback: () => {
+            if (removeProjectIdIfPresent(router.values.location.pathname) !== urls.sqlEditor()) {
+                router.actions.push(urls.sqlEditor())
+            }
+        },
+    })
+
     return null
 }

--- a/frontend/src/lib/components/AppShortcuts/AppShortcutMenu.tsx
+++ b/frontend/src/lib/components/AppShortcuts/AppShortcutMenu.tsx
@@ -260,22 +260,54 @@ export function AppShortcutMenu(): JSX.Element | null {
                                                     </span>
                                                     <span className="ml-auto flex items-center gap-1">
                                                         {(shortcut.keybind as string[][]).map(
-                                                            (keybindOption, index) => (
-                                                                <React.Fragment key={index}>
-                                                                    {index > 0 && (
-                                                                        <span className="text-xs opacity-75">or</span>
-                                                                    )}
-                                                                    <KeyboardShortcut
-                                                                        {...Object.fromEntries(
-                                                                            keybindOption.map((key: string) => [
-                                                                                key,
-                                                                                true,
-                                                                            ])
+                                                            (keybindOption, index) => {
+                                                                const isSequence = keybindOption.includes('then')
+                                                                if (isSequence) {
+                                                                    // Render sequence shortcuts as "s → q → l"
+                                                                    const keys = keybindOption.filter(
+                                                                        (k) => k !== 'then'
+                                                                    )
+                                                                    return (
+                                                                        <React.Fragment key={index}>
+                                                                            {index > 0 && (
+                                                                                <span className="text-xs opacity-75">
+                                                                                    or
+                                                                                </span>
+                                                                            )}
+                                                                            <kbd className="KeyboardShortcut gap-x-0.5 text-xs">
+                                                                                {keys.map((key, keyIndex) => (
+                                                                                    <React.Fragment key={key}>
+                                                                                        {keyIndex > 0 && (
+                                                                                            <span className="opacity-50">
+                                                                                                {' '}
+                                                                                            </span>
+                                                                                        )}
+                                                                                        <span>{key}</span>
+                                                                                    </React.Fragment>
+                                                                                ))}
+                                                                            </kbd>
+                                                                        </React.Fragment>
+                                                                    )
+                                                                }
+                                                                return (
+                                                                    <React.Fragment key={index}>
+                                                                        {index > 0 && (
+                                                                            <span className="text-xs opacity-75">
+                                                                                or
+                                                                            </span>
                                                                         )}
-                                                                        className="text-xs"
-                                                                    />
-                                                                </React.Fragment>
-                                                            )
+                                                                        <KeyboardShortcut
+                                                                            {...Object.fromEntries(
+                                                                                keybindOption.map((key: string) => [
+                                                                                    key,
+                                                                                    true,
+                                                                                ])
+                                                                            )}
+                                                                            className="text-xs"
+                                                                        />
+                                                                    </React.Fragment>
+                                                                )
+                                                            }
                                                         )}
                                                     </span>
                                                 </ButtonPrimitive>

--- a/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
+++ b/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
@@ -27,6 +27,38 @@ interface AppShortcutWithCallback extends AppShortcutBase {
 
 export type AppShortcutType = AppShortcutWithRef | AppShortcutWithCallback
 
+function isSequenceKeybind(keybind: string[]): boolean {
+    return keybind.includes('then')
+}
+
+function getSequenceKeys(keybind: string[]): string[] {
+    return keybind.filter((key) => key !== 'then')
+}
+
+function triggerShortcut(shortcut: AppShortcutType): void {
+    if (shortcut.interaction === 'click') {
+        shortcut.ref.current?.click()
+    } else if (shortcut.interaction === 'focus') {
+        shortcut.ref.current?.focus()
+    } else if (shortcut.interaction === 'function') {
+        shortcut.callback()
+    }
+}
+
+function isEditableElement(target: EventTarget | null): boolean {
+    if (!target || !(target instanceof HTMLElement)) {
+        return false
+    }
+    const tagName = target.tagName.toLowerCase()
+    return (
+        tagName === 'input' ||
+        tagName === 'textarea' ||
+        tagName === 'select' ||
+        target.isContentEditable ||
+        target.closest('.monaco-editor') !== null
+    )
+}
+
 export const appShortcutLogic = kea<appShortcutLogicType>([
     path(['lib', 'components', 'AppShortcuts', 'appShortcutLogic']),
     actions({
@@ -54,16 +86,21 @@ export const appShortcutLogic = kea<appShortcutLogicType>([
         ],
     }),
     afterMount(({ values, cache }) => {
-        // register keyboard shortcuts
+        // Sequence shortcut state
+        cache.sequenceKeys = [] as string[]
+        cache.sequenceShortcut = null as AppShortcutType | null
+        cache.sequenceLastKeyTime = 0
+
         cache.onKeyDown = (event: KeyboardEvent) => {
             const commandKey = event.metaKey || event.ctrlKey
 
+            // Handle modifier-based shortcuts (Cmd+K, etc.)
             if (commandKey) {
-                // Build current key combination in the same order as shortcuts are defined
-                const pressedKeys: string[] = []
+                // Reset any in-progress sequence
+                cache.sequenceKeys = []
+                cache.sequenceShortcut = null
 
-                pressedKeys.push('command')
-
+                const pressedKeys: string[] = ['command']
                 if (event.shiftKey) {
                     pressedKeys.push('shift')
                 }
@@ -71,45 +108,89 @@ export const appShortcutLogic = kea<appShortcutLogicType>([
                     pressedKeys.push('option')
                 }
 
-                // Handle special key mappings
+                // Handle Alt key combinations - event.key can change with Alt held
                 let keyToAdd = event.key.toLowerCase()
-
-                // Handle Alt key combinations - sometimes event.key changes with Alt
                 if (event.altKey) {
-                    // For Alt+letter combinations, the event.key might be different
-                    // Use event.code instead for more reliable detection
                     const codeMatch = event.code.match(/^Key([A-Z])$/)
                     if (codeMatch) {
                         keyToAdd = codeMatch[1].toLowerCase()
                     } else if (event.code === 'Tab') {
                         keyToAdd = 'tab'
                     }
-                    // For other keys, keep using event.key.toLowerCase()
                 }
 
                 pressedKeys.push(keyToAdd)
                 const pressedKeyString = pressedKeys.join('+')
 
-                // Find matching shortcut
-                const matchingShortcut = values.registeredAppShortcuts.find((shortcut) => {
-                    return shortcut.keybind.some((keybind) => {
-                        const shortcutKeyString = keybind.map((k: string) => k.toLowerCase()).join('+')
-                        return shortcutKeyString === pressedKeyString
-                    })
-                })
+                const matchingShortcut = values.registeredAppShortcuts.find((shortcut) =>
+                    shortcut.keybind.some(
+                        (keybind) =>
+                            !isSequenceKeybind(keybind) &&
+                            keybind.map((k) => k.toLowerCase()).join('+') === pressedKeyString
+                    )
+                )
 
                 if (matchingShortcut) {
                     event.preventDefault()
                     event.stopPropagation()
-
-                    if (matchingShortcut.interaction === 'click') {
-                        matchingShortcut.ref.current?.click()
-                    } else if (matchingShortcut.interaction === 'focus') {
-                        matchingShortcut.ref.current?.focus()
-                    } else if (matchingShortcut.interaction === 'function') {
-                        matchingShortcut.callback()
-                    }
+                    triggerShortcut(matchingShortcut)
                 }
+                return
+            }
+
+            // Handle sequence shortcuts (no modifier keys, not in editable elements)
+            if (isEditableElement(event.target) || event.altKey) {
+                return
+            }
+
+            const now = Date.now()
+            const key = event.key.toLowerCase()
+
+            // Reset if too much time has passed (1.5s)
+            if (now - cache.sequenceLastKeyTime > 1500) {
+                cache.sequenceKeys = []
+                cache.sequenceShortcut = null
+            }
+            cache.sequenceLastKeyTime = now
+
+            // Build up the sequence
+            cache.sequenceKeys.push(key)
+
+            // Look for a matching sequence shortcut
+            const matchingShortcut = values.registeredAppShortcuts.find((shortcut) =>
+                shortcut.keybind.some((keybind) => {
+                    if (!isSequenceKeybind(keybind)) {
+                        return false
+                    }
+                    const sequenceKeys = getSequenceKeys(keybind)
+                    // Check if our current keys match the end of a sequence
+                    if (cache.sequenceKeys.length > sequenceKeys.length) {
+                        return false
+                    }
+                    return sequenceKeys
+                        .slice(0, cache.sequenceKeys.length)
+                        .every((k: string, i: number) => k === cache.sequenceKeys[i])
+                })
+            )
+
+            if (matchingShortcut) {
+                const keybind = matchingShortcut.keybind.find((kb) => isSequenceKeybind(kb))!
+                const sequenceKeys = getSequenceKeys(keybind)
+
+                if (cache.sequenceKeys.length === sequenceKeys.length) {
+                    // Sequence complete
+                    event.preventDefault()
+                    cache.sequenceKeys = []
+                    cache.sequenceShortcut = null
+                    triggerShortcut(matchingShortcut)
+                } else {
+                    // Partial match - keep tracking
+                    cache.sequenceShortcut = matchingShortcut
+                }
+            } else {
+                // No match - reset
+                cache.sequenceKeys = []
+                cache.sequenceShortcut = null
             }
         }
 

--- a/frontend/src/lib/components/AppShortcuts/shortcuts.ts
+++ b/frontend/src/lib/components/AppShortcuts/shortcuts.ts
@@ -1,6 +1,8 @@
 export const baseModifier: string[] = ['command', 'option']
 
 export const keyBinds: Record<string, string[]> = {
+    // Sequence shortcuts: use 'then' between keys (e.g., type "sql" to open SQL editor)
+    sqlEditor: ['s', 'then', 'q', 'then', 'l'],
     recentItems: [...baseModifier, 'y'],
     newTab: [...baseModifier, 't'],
     closeActiveTab: [...baseModifier, 'w'],


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
we keep looking for the sql editor 😥 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- add a hook that listens to key presses outside the textboxes
- add a shortcut to globalshortcuts with this hook to go to the SQL editor on `s - q - l`

## How did you test this code?
- played around locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
nah, this is an easter egg