### PR TITLE
chore(rust): comment clarification to trigger rust CI

### DIFF
--- a/rust/Dockerfile.sqlx-migrate
+++ b/rust/Dockerfile.sqlx-migrate
@@ -1,5 +1,5 @@
 # Migration container for running Rust-based database migrations
-# Supports both persons and cyclotron migrations
+# Supports persons, behavioral cohorts, cyclotron migrations
 FROM rust:1.88-bookworm AS builder
 
 RUN cargo install sqlx-cli --version 0.8.0 --features postgres --no-default-features --locked


### PR DESCRIPTION
## Problem

Just a quick chagne to comment under /rust folder to trigger a sqlx migration run against persons db for testing

## Changes

Clarifying comment in a Dockerfile

## How did you test this code?

Tested the migrations out locally and against the dev environment
