### PR TITLE
chore(customers): Polish customer profiles

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -58,7 +58,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
     } = props
 
     const mountedNotebookLogic = useMountedLogic(notebookLogic)
-    const { isEditable, editingNodeIds, containerSize, notebook } = useValues(mountedNotebookLogic)
+    const { isEditable, editingNodeIds, containerSize, notebook, mode } = useValues(mountedNotebookLogic)
     const { unregisterNodeLogic, insertComment, selectComment } = useActions(notebookLogic)
     const [slashCommandsPopoverVisible, setSlashCommandsPopoverVisible] = useState<boolean>(false)
 
@@ -185,6 +185,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
     ]
 
     const hasMenu = menuItems.some((x) => !!x)
+    const isInCanvas = mode === 'canvas'
 
     return (
         <NotebookNodeContext.Provider value={nodeLogic}>
@@ -239,6 +240,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
                                                 ) : null}
 
                                                 {isEditable && Settings ? (
+                                                {(isEditable || isInCanvas) && Settings ? (
                                                     <LemonButton
                                                         onClick={() => toggleEditing()}
                                                         size="small"

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -78,6 +78,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
         pythonRunQueued,
         settingsPlacement: resolvedSettingsPlacement,
         sourceComment,
+        customMenuItems,
     } = useValues(nodeLogic)
     const {
         setRef,
@@ -152,7 +153,8 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
     const pythonIsStale = pythonExecutionCodeHash !== null && pythonExecutionCodeHash !== pythonCodeHash
     const pythonIsFresh = pythonExecutionCodeHash !== null && pythonExecutionCodeHash === pythonCodeHash
 
-    const menuItems: LemonMenuItems = [
+    // TODO: Add list on non-copyable nodes
+    const defaultMenuItems: LemonMenuItems = [
         {
             label: 'Copy',
             onClick: () => copyToClipboard(),
@@ -183,6 +185,8 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
             : null,
         isEditable ? { label: 'Remove', onClick: () => deleteNode(), sideIcon: <IconX />, status: 'danger' } : null,
     ]
+
+    const menuItems = customMenuItems ?? defaultMenuItems
 
     const hasMenu = menuItems.some((x) => !!x)
     const isInCanvas = mode === 'canvas'

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -243,7 +243,6 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
                                                     />
                                                 ) : null}
 
-                                                {isEditable && Settings ? (
                                                 {(isEditable || isInCanvas) && Settings ? (
                                                     <LemonButton
                                                         onClick={() => toggleEditing()}

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
@@ -1,8 +1,9 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { PropsWithChildren, useEffect } from 'react'
+import { PropsWithChildren } from 'react'
 
 import { IconX } from '@posthog/icons'
 
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { groupLogic } from 'scenes/groups/groupLogic'
 
 import { Query } from '~/queries/Query/Query'
@@ -43,7 +44,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeIssuesAttribute
     const logicKey = getLogicKey({ tabId, personId, groupKey })
     const { removeNode } = useActions(customerProfileLogic)
 
-    useEffect(() => {
+    useOnMountEffect(() => {
         setMenuItems([
             {
                 label: 'Remove',
@@ -52,7 +53,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeIssuesAttribute
                 status: 'danger',
             },
         ])
-    }, [removeNode, setMenuItems])
+    })
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
@@ -52,7 +52,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeIssuesAttribute
                 status: 'danger',
             },
         ])
-    }, [setMenuItems])
+    }, [removeNode, setMenuItems])
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
@@ -1,5 +1,7 @@
-import { BindLogic, useValues } from 'kea'
-import { PropsWithChildren } from 'react'
+import { BindLogic, useActions, useValues } from 'kea'
+import { PropsWithChildren, useEffect } from 'react'
+
+import { IconX } from '@posthog/icons'
 
 import { groupLogic } from 'scenes/groups/groupLogic'
 
@@ -7,6 +9,7 @@ import { Query } from '~/queries/Query/Query'
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { InsightLogicProps } from '~/types'
 
+import { customerProfileLogic } from 'products/customer_analytics/frontend/customerProfileLogic'
 import { issueFiltersLogic } from 'products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic'
 import { issueQueryOptionsLogic } from 'products/error_tracking/frontend/components/IssueQueryOptions/issueQueryOptionsLogic'
 import { ErrorTrackingSetupPrompt } from 'products/error_tracking/frontend/components/SetupPrompt/SetupPrompt'
@@ -36,7 +39,20 @@ const ContextualFilters = ({ children, logicKey }: PropsWithChildren<{ logicKey:
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeIssuesAttributes>): JSX.Element | null => {
     const { personId, groupKey, groupTypeIndex, tabId } = attributes
     const { expanded } = useValues(notebookNodeLogic)
+    const { setMenuItems } = useActions(notebookNodeLogic)
     const logicKey = getLogicKey({ tabId, personId, groupKey })
+    const { removeNode } = useActions(customerProfileLogic)
+
+    useEffect(() => {
+        setMenuItems([
+            {
+                label: 'Remove',
+                onClick: () => removeNode(NotebookNodeType.Issues),
+                sideIcon: <IconX />,
+                status: 'danger',
+            },
+        ])
+    }, [setMenuItems])
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -1,9 +1,9 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { useEffect } from 'react'
 
 import { IconX } from '@posthog/icons'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { groupLogic } from 'scenes/groups/groupLogic'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -43,7 +43,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttribu
     const attachTo = groupTypeIndex !== undefined && groupKey ? groupLogic({ groupTypeIndex, groupKey }) : undefined
     const { removeNode } = useActions(customerProfileLogic)
 
-    useEffect(() => {
+    useOnMountEffect(() => {
         setMenuItems([
             {
                 label: 'Remove',
@@ -52,7 +52,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttribu
                 status: 'danger',
             },
         ])
-    }, [removeNode, setMenuItems])
+    })
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -1,4 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { IconX } from '@posthog/icons'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { groupLogic } from 'scenes/groups/groupLogic'
@@ -16,6 +19,7 @@ import { EventPropertyFilters } from '~/queries/nodes/EventsNode/EventPropertyFi
 import { TracesQuery } from '~/queries/schema/schema-general'
 import { isTracesQuery } from '~/queries/utils'
 
+import { customerProfileLogic } from 'products/customer_analytics/frontend/customerProfileLogic'
 import { LLMAnalyticsSetupPrompt } from 'products/llm_analytics/frontend/LLMAnalyticsSetupPrompt'
 import { useTracesQueryContext } from 'products/llm_analytics/frontend/LLMAnalyticsTracesScene'
 import { llmAnalyticsLogic } from 'products/llm_analytics/frontend/llmAnalyticsLogic'
@@ -27,6 +31,7 @@ import { getLogicKey } from './utils'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttributes>): JSX.Element | null => {
     const { expanded } = useValues(notebookNodeLogic)
+    const { setMenuItems } = useActions(notebookNodeLogic)
     const { groupKey, groupTypeIndex, personId, tabId } = attributes
     const group = groupKey && groupTypeIndex !== undefined ? { groupKey, groupTypeIndex } : undefined
     const logicKey = getLogicKey({ groupKey, personId, tabId })
@@ -36,6 +41,18 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttribu
     const { tracesQuery } = useValues(logic)
     const context = useTracesQueryContext()
     const attachTo = groupTypeIndex !== undefined && groupKey ? groupLogic({ groupTypeIndex, groupKey }) : undefined
+    const { removeNode } = useActions(customerProfileLogic)
+
+    useEffect(() => {
+        setMenuItems([
+            {
+                label: 'Remove',
+                onClick: () => removeNode(NotebookNodeType.LLMTrace),
+                sideIcon: <IconX />,
+                status: 'danger',
+            },
+        ])
+    }, [setMenuItems])
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -52,7 +52,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttribu
                 status: 'danger',
             },
         ])
-    }, [setMenuItems])
+    }, [removeNode, setMenuItems])
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
@@ -67,7 +67,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonFeedAttri
                 status: 'danger',
             },
         ])
-    }, [setMenuItems])
+    }, [removeNode, setMenuItems])
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
@@ -1,5 +1,7 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
 
+import { IconX } from '@posthog/icons'
 import { LemonSkeleton } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
@@ -7,6 +9,8 @@ import { NotebookNodeProps, NotebookNodeType } from 'scenes/notebooks/types'
 import { personLogic } from 'scenes/persons/personLogic'
 
 import { PersonType } from '~/types'
+
+import { customerProfileLogic } from 'products/customer_analytics/frontend/customerProfileLogic'
 
 import { createPostHogWidgetNode } from '../NodeWrapper'
 import { notebookNodeLogic } from '../notebookNodeLogic'
@@ -48,9 +52,22 @@ const Feed = ({ person }: FeedProps): JSX.Element => {
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonFeedAttributes>): JSX.Element | null => {
     const { id, distinctId } = attributes
     const { expanded } = useValues(notebookNodeLogic)
+    const { setMenuItems } = useActions(notebookNodeLogic)
+    const { removeNode } = useActions(customerProfileLogic)
 
     const logic = personLogic({ id, distinctId })
     const { person, personLoading } = useValues(logic)
+
+    useEffect(() => {
+        setMenuItems([
+            {
+                label: 'Remove',
+                onClick: () => removeNode(NotebookNodeType.PersonFeed),
+                sideIcon: <IconX />,
+                status: 'danger',
+            },
+        ])
+    }, [setMenuItems])
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed.tsx
@@ -1,10 +1,10 @@
 import { useActions, useValues } from 'kea'
-import { useEffect } from 'react'
 
 import { IconX } from '@posthog/icons'
 import { LemonSkeleton } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { NotebookNodeProps, NotebookNodeType } from 'scenes/notebooks/types'
 import { personLogic } from 'scenes/persons/personLogic'
 
@@ -58,7 +58,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonFeedAttri
     const logic = personLogic({ id, distinctId })
     const { person, personLoading } = useValues(logic)
 
-    useEffect(() => {
+    useOnMountEffect(() => {
         setMenuItems([
             {
                 label: 'Remove',
@@ -67,7 +67,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonFeedAttri
                 status: 'danger',
             },
         ])
-    }, [removeNode, setMenuItems])
+    })
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -1,9 +1,9 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { useEffect } from 'react'
 
 import { IconPlusSmall, IconRefresh, IconX } from '@posthog/icons'
 
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { UsageMetricsConfig, UsageMetricsModal } from 'scenes/settings/environment/UsageMetricsConfig'
 import { usageMetricsConfigLogic } from 'scenes/settings/environment/usageMetricsConfigLogic'
 
@@ -49,7 +49,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
     const { openModal } = useActions(usageMetricsConfigLogic(usageMetricsConfigLogicProps))
     const { removeNode } = useActions(customerProfileLogic)
 
-    useEffect(() => {
+    useOnMountEffect(() => {
         setActions([
             {
                 text: 'Add metric',
@@ -81,7 +81,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
                 status: 'danger',
             },
         ])
-    }, [removeNode, setActions, setMenuItems, loadData, openModal])
+    })
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { IconPlusSmall, IconRefresh } from '@posthog/icons'
+import { IconPlusSmall, IconRefresh, IconX } from '@posthog/icons'
 
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { UsageMetricsConfig, UsageMetricsModal } from 'scenes/settings/environment/UsageMetricsConfig'
@@ -14,6 +14,7 @@ import {
     UsageMetricCard,
     UsageMetricCardSkeleton,
 } from 'products/customer_analytics/frontend/components/UsageMetricCard'
+import { customerProfileLogic } from 'products/customer_analytics/frontend/customerProfileLogic'
 
 import { NotebookNodeAttributeProperties, NotebookNodeProps, NotebookNodeType } from '../types'
 import { createPostHogWidgetNode } from './NodeWrapper'
@@ -21,7 +22,7 @@ import { notebookNodeLogic } from './notebookNodeLogic'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAttributes>): JSX.Element | null => {
     const { expanded } = useValues(notebookNodeLogic)
-    const { setActions, toggleEditing } = useActions(notebookNodeLogic)
+    const { setActions, setMenuItems } = useActions(notebookNodeLogic)
     const { personId, groupKey, groupTypeIndex, tabId } = attributes
     const dataNodeLogicProps = personId
         ? {
@@ -46,6 +47,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
     const { loadData } = useActions(logic)
     const usageMetricsConfigLogicProps = { logicKey: attributes.nodeId }
     const { openModal } = useActions(usageMetricsConfigLogic(usageMetricsConfigLogicProps))
+    const { removeNode } = useActions(customerProfileLogic)
 
     useEffect(() => {
         setActions([
@@ -60,7 +62,26 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
                 onClick: loadData,
             },
         ])
-    }, [setActions, loadData, toggleEditing])
+
+        setMenuItems([
+            {
+                label: 'Add metric',
+                sideIcon: <IconPlusSmall />,
+                onClick: openModal,
+            },
+            {
+                label: 'Refresh',
+                sideIcon: <IconRefresh />,
+                onClick: () => loadData(),
+            },
+            {
+                label: 'Remove',
+                onClick: () => removeNode(NotebookNodeType.UsageMetrics),
+                sideIcon: <IconX />,
+                status: 'danger',
+            },
+        ])
+    }, [setActions, setMenuItems, loadData, openModal])
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -81,7 +81,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
                 status: 'danger',
             },
         ])
-    }, [setActions, setMenuItems, loadData, openModal])
+    }, [removeNode, setActions, setMenuItems, loadData, openModal])
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeZendeskTickets.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeZendeskTickets.tsx
@@ -36,7 +36,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeZendeskTicketsA
                 status: 'danger',
             },
         ])
-    }, [setMenuItems])
+    }, [removeNode, setMenuItems])
 
     const query = personId
         ? zendeskPersonTicketsQuery({ personId, status, priority, orderBy, orderDirection })

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeZendeskTickets.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeZendeskTickets.tsx
@@ -1,4 +1,7 @@
-import { BindLogic, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { IconX } from '@posthog/icons'
 
 import { ZendeskSourceSetupPrompt } from 'scenes/data-pipelines/ZendeskSourceSetupPrompt'
 
@@ -6,6 +9,7 @@ import { Query } from '~/queries/Query/Query'
 
 import { ZendeskTicketsFilters } from 'products/customer_analytics/frontend/components/ZendeskTicketsFilters/ZendeskTicketsFilters'
 import { zendeskTicketsFiltersLogic } from 'products/customer_analytics/frontend/components/ZendeskTicketsFilters/zendeskTicketsFiltersLogic'
+import { customerProfileLogic } from 'products/customer_analytics/frontend/customerProfileLogic'
 import {
     useZendeskTicketsQueryContext,
     zendeskGroupTicketsQuery,
@@ -19,7 +23,20 @@ import { notebookNodeLogic } from './notebookNodeLogic'
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeZendeskTicketsAttributes>): JSX.Element | null => {
     const { personId, groupKey, nodeId } = attributes
     const { expanded } = useValues(notebookNodeLogic)
+    const { setMenuItems } = useActions(notebookNodeLogic)
     const { status, priority, orderBy, orderDirection } = useValues(zendeskTicketsFiltersLogic({ logicKey: nodeId }))
+    const { removeNode } = useActions(customerProfileLogic)
+
+    useEffect(() => {
+        setMenuItems([
+            {
+                label: 'Remove',
+                onClick: () => removeNode(NotebookNodeType.ZendeskTickets),
+                sideIcon: <IconX />,
+                status: 'danger',
+            },
+        ])
+    }, [setMenuItems])
 
     const query = personId
         ? zendeskPersonTicketsQuery({ personId, status, priority, orderBy, orderDirection })

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeZendeskTickets.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeZendeskTickets.tsx
@@ -1,8 +1,8 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { useEffect } from 'react'
 
 import { IconX } from '@posthog/icons'
 
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { ZendeskSourceSetupPrompt } from 'scenes/data-pipelines/ZendeskSourceSetupPrompt'
 
 import { Query } from '~/queries/Query/Query'
@@ -27,7 +27,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeZendeskTicketsA
     const { status, priority, orderBy, orderDirection } = useValues(zendeskTicketsFiltersLogic({ logicKey: nodeId }))
     const { removeNode } = useActions(customerProfileLogic)
 
-    useEffect(() => {
+    useOnMountEffect(() => {
         setMenuItems([
             {
                 label: 'Remove',
@@ -36,7 +36,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeZendeskTicketsA
                 status: 'danger',
             },
         ])
-    }, [removeNode, setMenuItems])
+    })
 
     const query = personId
         ? zendeskPersonTicketsQuery({ personId, status, priority, orderBy, orderDirection })

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeLogic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeLogic.ts
@@ -15,6 +15,8 @@ import {
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
+import { LemonMenuItems } from '@posthog/lemon-ui'
+
 import { JSONContent, RichContentNode } from 'lib/components/RichContentEditor/types'
 import { hashCodeForString } from 'lib/utils'
 
@@ -101,6 +103,7 @@ export const notebookNodeLogic = kea<notebookNodeLogicType>([
         setExpanded: (expanded: boolean) => ({ expanded }),
         setResizeable: (resizeable: boolean) => ({ resizeable }),
         setActions: (actions: (NotebookNodeAction | undefined)[]) => ({ actions }),
+        setMenuItems: (menuItems: LemonMenuItems | null) => ({ menuItems }),
         insertAfter: (content: JSONContent) => ({ content }),
         insertAfterLastNodeOfType: (nodeType: string, content: JSONContent) => ({ content, nodeType }),
         updateAttributes: (attributes: Partial<NotebookNodeAttributes<any>>) => ({ attributes }),
@@ -166,6 +169,12 @@ export const notebookNodeLogic = kea<notebookNodeLogicType>([
             [] as NotebookNodeAction[],
             {
                 setActions: (_, { actions }) => actions.filter((x) => !!x) as NotebookNodeAction[],
+            },
+        ],
+        customMenuItems: [
+            null as LemonMenuItems | null,
+            {
+                setMenuItems: (_, { menuItems }) => menuItems,
             },
         ],
         messageListeners: [

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeLogic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeLogic.ts
@@ -14,9 +14,9 @@ import {
 } from 'kea'
 import posthog from 'posthog-js'
 
-import api from 'lib/api'
 import { LemonMenuItems } from '@posthog/lemon-ui'
 
+import api from 'lib/api'
 import { JSONContent, RichContentNode } from 'lib/components/RichContentEditor/types'
 import { hashCodeForString } from 'lib/utils'
 

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -62,7 +62,7 @@ const CustomDocument = ExtensionDocument.extend({
 })
 
 export function Editor(): JSX.Element {
-    const { shortId, mode } = useValues(notebookLogic)
+    const { shortId, mode, isEditable } = useValues(notebookLogic)
     const { setEditor, onEditorUpdate, onEditorSelectionUpdate, setTableOfContents, insertComment } =
         useActions(notebookLogic)
     const hasCollapsibleSections = useFeatureFlag('NOTEBOOKS_COLLAPSIBLE_SECTIONS')
@@ -156,6 +156,7 @@ export function Editor(): JSX.Element {
         <RichContentEditor
             logicKey={`Notebook.${shortId}`}
             extensions={extensions}
+            disabled={!isEditable}
             className="NotebookEditor flex flex-col flex-1"
             onUpdate={onEditorUpdate}
             onSelectionUpdate={onEditorSelectionUpdate}

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -548,15 +548,16 @@ export const notebookLogic = kea<notebookLogicType>([
         isEditable: [
             (s) => [s.shouldBeEditable, s.previewContent, s.notebook, s.mode],
             (shouldBeEditable, previewContent, notebook, mode) =>
-                mode === 'canvas' ||
-                (shouldBeEditable &&
-                    !previewContent &&
-                    !!notebook?.user_access_level &&
-                    accessLevelSatisfied(
-                        AccessControlResourceType.Notebook,
-                        notebook.user_access_level,
-                        AccessControlLevel.Editor
-                    )),
+                shouldBeEditable &&
+                (mode === 'canvas' ||
+                    (shouldBeEditable &&
+                        !previewContent &&
+                        !!notebook?.user_access_level &&
+                        accessLevelSatisfied(
+                            AccessControlResourceType.Notebook,
+                            notebook.user_access_level,
+                            AccessControlLevel.Editor
+                        ))),
         ],
 
         insightShortIdsInNotebook: [

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -550,8 +550,7 @@ export const notebookLogic = kea<notebookLogicType>([
             (shouldBeEditable, previewContent, notebook, mode) =>
                 shouldBeEditable &&
                 (mode === 'canvas' ||
-                    (shouldBeEditable &&
-                        !previewContent &&
+                    (!previewContent &&
                         !!notebook?.user_access_level &&
                         accessLevelSatisfied(
                             AccessControlResourceType.Notebook,

--- a/products/customer_analytics/frontend/components/CustomerProfileMenu.tsx
+++ b/products/customer_analytics/frontend/components/CustomerProfileMenu.tsx
@@ -38,7 +38,7 @@ export function CustomerProfileMenu(): JSX.Element | null {
     }
 
     return (
-        <>
+        <div className="flex flex-row items-center">
             <LemonMenu items={items} closeOnClickInside={false}>
                 <LemonButton type="secondary" icon={<IconGear />} children="Edit profile" sideIcon={null} />
             </LemonMenu>
@@ -60,6 +60,6 @@ export function CustomerProfileMenu(): JSX.Element | null {
                     />
                 </>
             )}
-        </>
+        </div>
     )
 }


### PR DESCRIPTION
## Problem

There are a few UX problems with customer profile views:
- People can hit backspace and delete the whole content
- Whenever they click the three-dot menu, the actions that are there do not really reflect the behavior that's intended for the profile canvases

Let's change that by making the canvases really non-editable whenever they are set to be non-editable and also add a way to customize which actions should be displayed in each notebook node. 

## Changes

- Added custom menu items support for notebook nodes
- Enabled settings button visibility in canvas mode even when not in edit mode
- Implemented custom menu items for profile-specific nodes (PersonFeed, Issues, LLMTrace, UsageMetrics, ZendeskTickets)
- Added ability to remove nodes directly from the customer profile
- Fixed isEditable logic to properly handle canvas mode

https://www.loom.com/share/a8646334818e449f85491e2c05932a21
## How did you test this code?

I tested this by:
- Verifying that settings buttons appear in canvas mode
- Confirming that custom menu items work correctly for each node type
- Testing the remove functionality for each node type in the customer profile
- Ensuring that the default menu items still work correctly for other node types

## Publish to changelog?

No