### PR TITLE
fix: we shouldn't accept filters like that, and in the UI we don't use it anyway

### DIFF
--- a/ee/api/rbac/role.py
+++ b/ee/api/rbac/role.py
@@ -85,9 +85,6 @@ class RoleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     queryset = Role.objects.all()
     permission_classes = [RolePermissions, TimeSensitiveActionPermission]
 
-    def safely_get_queryset(self, queryset):
-        return queryset.filter(**self.request.GET.dict())
-
 
 class RoleMembershipSerializer(serializers.ModelSerializer):
     user = UserBasicSerializer(read_only=True)


### PR DESCRIPTION
we accept external data and pass it to filtering

the robot says

```python
def safely_get_queryset(self, queryset):
    return queryset.filter(**self.request.GET.dict())
```
**Attack Example:**
```
GET /api/roles/?id__gte=1&name__regex=^.*
GET /api/roles/?created_at__year=2024&id__in=1,2,3
GET /api/roles/?organization__name__icontains=secret
```
we aren't using this filtering from the UI - i don't _think_
so let's just remove it?
could there be API clients using it?