### PR TITLE
fix(vercel): rename plan from "PostHog" to "Pay-as-you-go"

### DIFF
--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -223,8 +223,8 @@ class VercelIntegration:
             {
                 "id": "posthog-usage-based",
                 "type": "subscription",
-                "name": "PostHog",
-                "description": "Usage-based analytics. First 1M events free. View pricing: https://posthog.com/pricing",
+                "name": "Pay-as-you-go",
+                "description": "Usage-based pricing. View pricing: https://posthog.com/pricing",
                 "scope": "installation",
                 "paymentMethodRequired": True,
                 "preauthorizationAmount": 0.5,


### PR DESCRIPTION
## Problem

The Vercel marketplace plan was named "PostHog" but should match the pricing page on posthog.com which calls it "Pay-as-you-go".

## Changes

- Renamed plan name from "PostHog" to "Pay-as-you-go"
- Updated description from "Usage-based analytics. First 1M events free." to "Usage-based pricing." (matching the style on posthog.com)

## How did you test this code?

- Code inspection - simple string change
- The plan ID (`posthog-usage-based`) remains unchanged so existing installations are unaffected
- Looked in Vercel with the ngrok running (see screenshots)

<img width="594" height="462" alt="image" src="https://github.com/user-attachments/assets/3d91c0c9-e5a1-47db-8390-8afc0c9e028e" />

<img width="587" height="783" alt="image" src="https://github.com/user-attachments/assets/567a65f7-d4cc-49d8-bc33-deafc8e2c78b" />

<img width="621" height="753" alt="image" src="https://github.com/user-attachments/assets/ca0e7046-df17-4435-9c49-629ae8e4746f" />


🤖 Generated with [Claude Code](https://claude.ai/code)