### PR TITLE
feat: implement lazy loading for screenshots in heatmap task

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -247,7 +247,7 @@ class SessionRecordingSerializer(serializers.ModelSerializer, UserAccessControlS
             SessionRecordingExternalReferenceSerializer,
         )
 
-        references = obj.external_references.select_related("integration").all()  # type: ignore[attr-defined]
+        references = obj.external_references.select_related("integration").all()
         return list(SessionRecordingExternalReferenceSerializer(references, many=True, context=self.context).data)
 
     class Meta:

--- a/posthog/tasks/heatmap_screenshot.py
+++ b/posthog/tasks/heatmap_screenshot.py
@@ -2,16 +2,17 @@ import structlog
 import posthoganalytics
 from celery import shared_task
 
-from posthog.exceptions_capture import capture_exception
-from posthog.heatmaps.heatmaps_utils import DEFAULT_TARGET_WIDTHS, is_url_allowed, should_block_url
-from posthog.models.heatmap_saved import HeatmapSnapshot, SavedHeatmap
-from posthog.tasks.utils import CeleryQueue
-
 from playwright.sync_api import (
     Page,
     TimeoutError as PlaywrightTimeoutError,
     sync_playwright,
 )
+
+from posthog.exceptions_capture import capture_exception
+from posthog.heatmaps.heatmaps_utils import DEFAULT_TARGET_WIDTHS
+from posthog.models.heatmap_saved import HeatmapSnapshot, SavedHeatmap
+from posthog.security.url_validation import is_url_allowed, should_block_url
+from posthog.tasks.utils import CeleryQueue
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/tasks/heatmap_screenshot.py
+++ b/posthog/tasks/heatmap_screenshot.py
@@ -1,16 +1,17 @@
 import structlog
 import posthoganalytics
 from celery import shared_task
-from playwright.sync_api import (
-    Page,
-    TimeoutError as PlaywrightTimeoutError,
-    sync_playwright,
-)
 
 from posthog.exceptions_capture import capture_exception
 from posthog.heatmaps.heatmaps_utils import DEFAULT_TARGET_WIDTHS, is_url_allowed, should_block_url
 from posthog.models.heatmap_saved import HeatmapSnapshot, SavedHeatmap
 from posthog.tasks.utils import CeleryQueue
+
+from playwright.sync_api import (
+    Page,
+    TimeoutError as PlaywrightTimeoutError,
+    sync_playwright,
+)
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/tasks/heatmap_screenshot.py
+++ b/posthog/tasks/heatmap_screenshot.py
@@ -1,7 +1,6 @@
 import structlog
 import posthoganalytics
 from celery import shared_task
-
 from playwright.sync_api import (
     Page,
     TimeoutError as PlaywrightTimeoutError,

--- a/posthog/tasks/heatmap_screenshot.py
+++ b/posthog/tasks/heatmap_screenshot.py
@@ -1,17 +1,16 @@
 import structlog
 import posthoganalytics
 from celery import shared_task
-
-from posthog.exceptions_capture import capture_exception
-from posthog.heatmaps.heatmaps_utils import DEFAULT_TARGET_WIDTHS, is_url_allowed, should_block_url
-from posthog.models.heatmap_saved import HeatmapSnapshot, SavedHeatmap
-from posthog.tasks.utils import CeleryQueue
-
 from playwright.sync_api import (
     Page,
     TimeoutError as PlaywrightTimeoutError,
     sync_playwright,
 )
+
+from posthog.exceptions_capture import capture_exception
+from posthog.heatmaps.heatmaps_utils import DEFAULT_TARGET_WIDTHS, is_url_allowed, should_block_url
+from posthog.models.heatmap_saved import HeatmapSnapshot, SavedHeatmap
+from posthog.tasks.utils import CeleryQueue
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/tasks/heatmap_screenshot.py
+++ b/posthog/tasks/heatmap_screenshot.py
@@ -127,9 +127,12 @@ def _trigger_lazy_loading(page: Page) -> None:
                 const scrollStep = viewportHeight * 0.8;
                 let lastScrollHeight = 0;
                 let currentScrollHeight = document.body.scrollHeight;
+                let iterations = 0;
+                const maxIterations = 20;
 
-                // Keep scrolling until the page stops growing
-                while (currentScrollHeight > lastScrollHeight) {
+                // Keep scrolling until the page stops growing or max iterations reached
+                while (currentScrollHeight > lastScrollHeight && iterations < maxIterations) {
+                    iterations++;
                     for (let y = 0; y < currentScrollHeight; y += scrollStep) {
                         window.scrollTo(0, y);
                         await new Promise(r => setTimeout(r, 100));


### PR DESCRIPTION
## Problem

Images are not being resized during the screenshot.

Zendesk ticket: https://posthoghelp.zendesk.com/agent/tickets/44813. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50169) 


## Changes

Added a new function to trigger lazy loading of images before taking screenshots. This includes scrolling through the page to activate intersection observers, forcing lazy-loaded images to load, and ensuring all images are fully loaded before capturing the screenshot.

## How did you test this code?
I was able to reproduce it, the problem was resizing the view port with `set_viewport_size` cause that elements with 100hv use a lot more space. 

Also there are some css loading for elements and stuff so I simulate scrolling down and up as a user would do to load all the content and css.

Before:
<img width="1240" height="703" alt="image" src="https://github.com/user-attachments/assets/16697a18-6391-4993-acb0-a2ba9c010ea0" />

<img width="1024" height="10427" alt="image" src="https://github.com/user-attachments/assets/55ace5b2-86c4-4430-b6e5-11351863f92d" />


After:
<img width="1220" height="662" alt="image" src="https://github.com/user-attachments/assets/4e7690ce-f59c-472a-8615-a90ec64e56d6" />

<img width="1024" height="6265" alt="image" src="https://github.com/user-attachments/assets/e8668248-c417-4303-ad16-a5ad6727cb77" />


