### PR TITLE
feat(surveys): add thumbs up/down survey question type

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -148,6 +148,10 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
     const canSkipSubmitButton = canQuestionSkipSubmitButton(question)
     const shouldShowNpsCheckbox =
         question.type === SurveyQuestionType.Rating && question.scale === SURVEY_RATING_SCALE.NPS_10_POINT
+    const isThumbSurvey =
+        question.type === SurveyQuestionType.Rating &&
+        question.display === 'emoji' &&
+        question.scale === SURVEY_RATING_SCALE.THUMB_2_POINT
 
     const confirmQuestionTypeChange = (
         index: number,
@@ -297,14 +301,16 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                 />
                             </LemonField>
                         </div>
-                        <div className="flex flex-row gap-4">
-                            <LemonField name="lowerBoundLabel" label="Lower bound label" className="w-1/2">
-                                <LemonInput value={question.lowerBoundLabel || ''} />
-                            </LemonField>
-                            <LemonField name="upperBoundLabel" label="Upper bound label" className="w-1/2">
-                                <LemonInput value={question.upperBoundLabel || ''} />
-                            </LemonField>
-                        </div>
+                        {!isThumbSurvey && (
+                            <div className="flex flex-row gap-4">
+                                <LemonField name="lowerBoundLabel" label="Lower bound label" className="w-1/2">
+                                    <LemonInput value={question.lowerBoundLabel || ''} />
+                                </LemonField>
+                                <LemonField name="upperBoundLabel" label="Upper bound label" className="w-1/2">
+                                    <LemonInput value={question.upperBoundLabel || ''} />
+                                </LemonField>
+                            </div>
+                        )}
                         {shouldShowNpsCheckbox && (
                             <LemonField name="isNpsQuestion">
                                 {({ value: isNpsQuestion, onChange: toggleIsNpsQuestion }) => (

--- a/frontend/src/scenes/surveys/components/question-branching/QuestionBranchingInput.tsx
+++ b/frontend/src/scenes/surveys/components/question-branching/QuestionBranchingInput.tsx
@@ -142,6 +142,11 @@ function getResponseConfiguration(
     if (question.type === SurveyQuestionType.Rating) {
         // Handle different rating scales with appropriate groupings
         switch (question.scale) {
+            case 2:
+                return [
+                    { value: 'positive', label: '1 (Thumbs up)' },
+                    { value: 'negative', label: '2 (Thumbs down)' },
+                ]
             case 3:
                 return [
                     { value: 'negative', label: '1 (Negative)' },

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -41,6 +41,7 @@ export const QUESTION_TYPE_OPTIONS = [
 
 // Rating scale constants
 export const SURVEY_RATING_SCALE = {
+    THUMB_2_POINT: 2,
     EMOJI_3_POINT: 3,
     LIKERT_5_POINT: 5,
     LIKERT_7_POINT: 7,
@@ -656,6 +657,7 @@ export const SURVEY_TYPE_LABEL_MAP = {
 export const LOADING_SURVEY_RESULTS_TOAST_ID = 'survey-results-loading'
 
 export const SCALE_LABELS: Record<SurveyRatingScaleValue, string> = {
+    [SURVEY_RATING_SCALE.THUMB_2_POINT]: '1-2 (thumbs up/down)',
     [SURVEY_RATING_SCALE.EMOJI_3_POINT]: '1 - 3',
     [SURVEY_RATING_SCALE.LIKERT_5_POINT]: '1 - 5',
     [SURVEY_RATING_SCALE.LIKERT_7_POINT]: '1 - 7',
@@ -664,6 +666,7 @@ export const SCALE_LABELS: Record<SurveyRatingScaleValue, string> = {
 
 export const SCALE_OPTIONS = {
     EMOJI: [
+        { label: SCALE_LABELS[SURVEY_RATING_SCALE.THUMB_2_POINT], value: SURVEY_RATING_SCALE.THUMB_2_POINT },
         { label: SCALE_LABELS[SURVEY_RATING_SCALE.EMOJI_3_POINT], value: SURVEY_RATING_SCALE.EMOJI_3_POINT },
         { label: SCALE_LABELS[SURVEY_RATING_SCALE.LIKERT_5_POINT], value: SURVEY_RATING_SCALE.LIKERT_5_POINT },
     ],

--- a/frontend/src/scenes/surveys/surveyVersionRequirements.ts
+++ b/frontend/src/scenes/surveys/surveyVersionRequirements.ts
@@ -12,7 +12,14 @@ import {
     SurveyType,
 } from '~/types'
 
-export type SurveySdkType = 'posthog-js' | 'posthog-react-native' | 'posthog-ios' | 'posthog-android'
+import { SURVEY_RATING_SCALE } from './constants'
+
+export type SurveySdkType =
+    | 'posthog-js'
+    | 'posthog-react-native'
+    | 'posthog-ios'
+    | 'posthog-android'
+    | 'posthog_flutter'
 
 export type SdkVersionRequirements = Partial<Record<SurveySdkType, string>>
 
@@ -127,6 +134,15 @@ export const SURVEY_SDK_REQUIREMENTS: SurveyFeatureRequirement[] = [
             s.appearance?.textColor !== undefined ||
             s.appearance?.inputTextColor !== undefined ||
             s.appearance?.submitButtonTextColor !== undefined,
+    },
+    {
+        feature: 'Thumbs up/down question',
+        sdkVersions: { 'posthog-js': '1.326.0', 'posthog-react-native': '4.19.0' },
+        unsupportedSdks: ['posthog-android', 'posthog_flutter', 'posthog-ios'],
+        check: (s) =>
+            s.questions.some(
+                (q) => q.type === SurveyQuestionType.Rating && q.scale === SURVEY_RATING_SCALE.THUMB_2_POINT
+            ),
     },
 ]
 


### PR DESCRIPTION
# 🚨 wait for https://github.com/PostHog/posthog-js/pull/2881

### also update https://us.posthog.com/project/2/surveys/019bb5a3-1677-0000-63dd-00f241c1710a before merging the next one!

## Problem

surveys need a :+1::-1: option!

my ideal use-case here is for llm generations, where the thumbs are in your UI and they trigger a posthog survey on click. more PRs soon :eyes:

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds new emoji rating scale for 1-2 (thumbs)

|  |  |
| --- | --- |
| ![Screenshot 2026-01-12 at 1.37.11 PM.png](https://app.graphite.com/user-attachments/assets/9cfe9f2a-bb0b-4ddb-8b3e-b250a9d3192e.png)<br> | ![Screenshot 2026-01-12 at 1.37.15 PM.png](https://app.graphite.com/user-attachments/assets/cd311f1b-894e-4953-b06e-c773e8c20f22.png)<br> |

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

yes

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->