### PR TITLE
feat(dagster): enable fixed team ID list inputs for sensor-triggered person reconciliation

### DIFF
--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -1370,11 +1370,20 @@ class ReconciliationSchedulerConfig(dagster.Config):
 
     This sensor automates launching multiple reconciliation jobs across a range
     of team IDs while respecting concurrency limits.
+
+    You must provide EITHER:
+    - team_ids: explicit list of team IDs to process
+    - OR both range_start and range_end: to scan a team ID range
     """
 
-    range_start: int  # First team_id (inclusive)
-    range_end: int  # Last team_id (inclusive)
-    chunk_size: int = 1000  # Team ID range per job run
+    # Option 1: Explicit list of team IDs
+    team_ids: list[int] | None = None
+
+    # Option 2: Range-based scanning
+    range_start: int | None = None  # First team_id (inclusive)
+    range_end: int | None = None  # Last team_id (inclusive)
+
+    chunk_size: int = 1000  # Teams per job run (for range mode) or list chunk size (for team_ids mode)
     max_concurrent_jobs: int = 5  # Max reconciliation jobs the sensor can schedule at once
     max_concurrent_tasks: int = 10  # Max k8s pods per job (executor concurrency)
 
@@ -1392,20 +1401,28 @@ class ReconciliationSchedulerConfig(dagster.Config):
 
 def build_reconciliation_run_config(
     config: ReconciliationSchedulerConfig,
-    min_team_id: int,
-    max_team_id: int,
+    min_team_id: int | None = None,
+    max_team_id: int | None = None,
+    team_ids: list[int] | None = None,
 ) -> dict[str, Any]:
-    """Build run config for a single reconciliation job covering a team ID range."""
-    op_config = {
+    """Build run config for a single reconciliation job.
+
+    Either provide team_ids (explicit list) OR min_team_id/max_team_id (range scan).
+    """
+    op_config: dict[str, Any] = {
         "bug_window_start": config.bug_window_start,
         "bug_window_end": config.bug_window_end,
-        "min_team_id": min_team_id,
-        "max_team_id": max_team_id,
         "dry_run": config.dry_run,
         "backup_enabled": config.backup_enabled,
         "batch_size": config.batch_size,
         "teams_per_chunk": config.teams_per_chunk,
     }
+
+    if team_ids is not None:
+        op_config["team_ids"] = team_ids
+    else:
+        op_config["min_team_id"] = min_team_id
+        op_config["max_team_id"] = max_team_id
 
     return {
         "execution": {"config": {"max_concurrent": config.max_concurrent_tasks}},
@@ -1440,30 +1457,36 @@ def person_property_reconciliation_scheduler(context: dagster.SensorEvaluationCo
     """
     Sensor that automatically schedules person property reconciliation jobs.
 
-    Splits a team_id range into chunks and launches jobs up to max_concurrent_jobs,
+    Supports two modes:
+    1. team_ids mode: Process an explicit list of team IDs
+    2. range mode: Scan a team_id range (range_start to range_end)
+
+    Splits work into chunks and launches jobs up to max_concurrent_jobs,
     tracking progress via cursor. Enable via Dagster UI after configuring.
 
-    Cursor format: JSON with 'next_chunk_start' tracking the next range to process.
-    When cursor reaches range_end, the sensor stops yielding new runs.
+    Cursor format (team_ids mode):
+        {"team_ids": [1, 2, 3, ...], "next_team_index": 0, ...}
+    Cursor format (range mode):
+        {"range_start": 1, "range_end": 10000, "next_chunk_start": 1, ...}
 
     Configuration (set via Dagster UI or launchpad):
+    - team_ids: Explicit list of team IDs (mutually exclusive with range_start/range_end)
     - range_start/range_end: Team ID range to process (inclusive)
-    - chunk_size: Number of team IDs per job (default 1000)
+    - chunk_size: Number of teams per job (default 1000)
     - max_concurrent_jobs: Max reconciliation jobs sensor can schedule at once (default 5, cap 50)
     - max_concurrent_tasks: Max k8s pods per job / executor concurrency (default 10, cap 100)
     - bug_window_start/end: Time window for the reconciliation
     - dry_run, backup_enabled, batch_size: Passed to each job
     """
-    # Load sensor config - in production this comes from the sensor configuration in UI
-    # For now, we require it to be set via run config or environment
     sensor_config_raw = context.cursor
 
     if not sensor_config_raw:
         return dagster.SkipReason(
-            "No cursor set. Initialize by setting cursor to JSON: "
-            '{"range_start": 1, "range_end": 10000, "chunk_size": 1000, "max_concurrent_jobs": 5, "max_concurrent_tasks": 10, '
-            '"bug_window_start": "...", "bug_window_end": "...", "dry_run": false, '
-            '"backup_enabled": true, "batch_size": 100}'
+            "No cursor set. Initialize by setting cursor to JSON. "
+            'For team_ids mode: {"team_ids": [1, 2, 3], "chunk_size": 100, ...}. '
+            'For range mode: {"range_start": 1, "range_end": 10000, "chunk_size": 1000, ...}. '
+            'Common fields: "max_concurrent_jobs", "max_concurrent_tasks", "bug_window_start", "bug_window_end", '
+            '"dry_run", "backup_enabled", "batch_size"'
         )
 
     try:
@@ -1471,23 +1494,34 @@ def person_property_reconciliation_scheduler(context: dagster.SensorEvaluationCo
     except json.JSONDecodeError:
         return dagster.SkipReason(f"Invalid cursor JSON: {sensor_config_raw[:100]}...")
 
-    # Extract config and progress
-    range_start = cursor_data.get("range_start", 1)
-    range_end = cursor_data.get("range_end", 10000)
+    # Extract common config
     chunk_size = cursor_data.get("chunk_size", 1000)
     max_concurrent_jobs = cursor_data.get("max_concurrent_jobs", 5)
     max_concurrent_tasks = cursor_data.get("max_concurrent_tasks", 10)
     bug_window_start = cursor_data.get("bug_window_start", "")
     bug_window_end = cursor_data.get("bug_window_end", "")
-    next_chunk_start = cursor_data.get("next_chunk_start", range_start)
 
-    # Validate config
+    # Determine mode: team_ids vs range
+    team_ids = cursor_data.get("team_ids")
+    range_start = cursor_data.get("range_start")
+    range_end = cursor_data.get("range_end")
+
+    has_team_ids = team_ids is not None and len(team_ids) > 0
+    has_range = range_start is not None and range_end is not None
+
+    # Validate: must have exactly one mode
+    if has_team_ids and has_range:
+        return dagster.SkipReason(
+            "Invalid config: cannot specify both team_ids and range_start/range_end. Choose one mode."
+        )
+    if not has_team_ids and not has_range:
+        return dagster.SkipReason(
+            "Invalid config: must specify either team_ids (list) OR both range_start and range_end"
+        )
+
+    # Validate common config
     MAX_CONCURRENT_JOBS_CAP = 50
     MAX_CONCURRENT_TASKS_CAP = 100
-    if range_start > range_end:
-        return dagster.SkipReason(
-            f"Invalid config: range_start ({range_start}) cannot be greater than range_end ({range_end})"
-        )
     if chunk_size <= 0:
         return dagster.SkipReason(f"Invalid config: chunk_size must be > 0, got {chunk_size}")
     if max_concurrent_jobs <= 0:
@@ -1507,14 +1541,17 @@ def person_property_reconciliation_scheduler(context: dagster.SensorEvaluationCo
     if not bug_window_end:
         return dagster.SkipReason("Invalid config: bug_window_end is required")
 
-    # Check if we've completed the range
-    if next_chunk_start > range_end:
-        return dagster.SkipReason(f"Reconciliation complete: processed all teams up to {range_end}")
+    # Mode-specific validation
+    if has_range and range_start > range_end:
+        return dagster.SkipReason(
+            f"Invalid config: range_start ({range_start}) cannot be greater than range_end ({range_end})"
+        )
 
     # Build config object for run config generation
     config = ReconciliationSchedulerConfig(
-        range_start=range_start,
-        range_end=range_end,
+        team_ids=team_ids if has_team_ids else None,
+        range_start=range_start if has_range else None,
+        range_end=range_end if has_range else None,
         chunk_size=chunk_size,
         max_concurrent_jobs=max_concurrent_jobs,
         max_concurrent_tasks=max_concurrent_tasks,
@@ -1547,39 +1584,86 @@ def person_property_reconciliation_scheduler(context: dagster.SensorEvaluationCo
 
     context.log.info(f"Active runs: {active_count}/{max_concurrent_jobs}, available slots: {available_slots}")
 
-    # Generate run requests for available slots
+    # Generate run requests based on mode
     run_requests: list[dagster.RunRequest] = []
-    current_start = next_chunk_start
 
-    while len(run_requests) < available_slots and current_start <= range_end:
-        chunk_end = min(current_start + chunk_size - 1, range_end)
+    if has_team_ids:
+        # Team IDs mode: chunk the list
+        next_team_index = cursor_data.get("next_team_index", 0)
 
-        run_config = build_reconciliation_run_config(
-            config=config,
-            min_team_id=current_start,
-            max_team_id=chunk_end,
-        )
+        if next_team_index >= len(team_ids):
+            return dagster.SkipReason(f"Reconciliation complete: processed all {len(team_ids)} teams")
 
-        run_key = f"reconcile_teams_{current_start}_{chunk_end}"
-        context.log.info(f"Scheduling run for teams {current_start}-{chunk_end}")
+        while len(run_requests) < available_slots and next_team_index < len(team_ids):
+            chunk_end_index = min(next_team_index + chunk_size, len(team_ids))
+            chunk_team_ids = team_ids[next_team_index:chunk_end_index]
 
-        run_requests.append(
-            dagster.RunRequest(
-                run_key=run_key,
-                run_config=run_config,
-                tags={
-                    "reconciliation_range": f"{current_start}-{chunk_end}",
-                    "owner": JobOwners.TEAM_INGESTION.value,
-                },
+            run_config = build_reconciliation_run_config(
+                config=config,
+                team_ids=chunk_team_ids,
             )
-        )
 
-        current_start = chunk_end + 1
+            run_key = f"reconcile_team_ids_{next_team_index}_{chunk_end_index - 1}"
+            context.log.info(
+                f"Scheduling run for team_ids[{next_team_index}:{chunk_end_index}] ({len(chunk_team_ids)} teams)"
+            )
 
-    # Update cursor with next chunk to process
-    cursor_data["next_chunk_start"] = current_start
-    new_cursor = json.dumps(cursor_data)
+            run_requests.append(
+                dagster.RunRequest(
+                    run_key=run_key,
+                    run_config=run_config,
+                    tags={
+                        "reconciliation_team_ids_range": f"{next_team_index}-{chunk_end_index - 1}",
+                        "reconciliation_team_count": str(len(chunk_team_ids)),
+                        "owner": JobOwners.TEAM_INGESTION.value,
+                    },
+                )
+            )
 
-    context.log.info(f"Scheduled {len(run_requests)} runs, next_chunk_start: {current_start}")
+            next_team_index = chunk_end_index
+
+        # Update cursor
+        cursor_data["next_team_index"] = next_team_index
+        new_cursor = json.dumps(cursor_data)
+        context.log.info(f"Scheduled {len(run_requests)} runs, next_team_index: {next_team_index}")
+
+    else:
+        # Range mode: existing behavior
+        next_chunk_start = cursor_data.get("next_chunk_start", range_start)
+
+        if next_chunk_start > range_end:
+            return dagster.SkipReason(f"Reconciliation complete: processed all teams up to {range_end}")
+
+        current_start = next_chunk_start
+
+        while len(run_requests) < available_slots and current_start <= range_end:
+            chunk_end = min(current_start + chunk_size - 1, range_end)
+
+            run_config = build_reconciliation_run_config(
+                config=config,
+                min_team_id=current_start,
+                max_team_id=chunk_end,
+            )
+
+            run_key = f"reconcile_teams_{current_start}_{chunk_end}"
+            context.log.info(f"Scheduling run for teams {current_start}-{chunk_end}")
+
+            run_requests.append(
+                dagster.RunRequest(
+                    run_key=run_key,
+                    run_config=run_config,
+                    tags={
+                        "reconciliation_range": f"{current_start}-{chunk_end}",
+                        "owner": JobOwners.TEAM_INGESTION.value,
+                    },
+                )
+            )
+
+            current_start = chunk_end + 1
+
+        # Update cursor
+        cursor_data["next_chunk_start"] = current_start
+        new_cursor = json.dumps(cursor_data)
+        context.log.info(f"Scheduled {len(run_requests)} runs, next_chunk_start: {current_start}")
 
     return dagster.SensorResult(run_requests=run_requests, cursor=new_cursor)

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -5585,7 +5585,7 @@ class TestReconciliationSchedulerSensor:
 
     def test_sensor_completed_range_returns_skip_reason(self):
         """Test that sensor returns SkipReason when range is completed."""
-        from dagster import SkipReason, build_sensor_context
+        from dagster import DagsterInstance, SkipReason, build_sensor_context
 
         from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
 
@@ -5598,7 +5598,11 @@ class TestReconciliationSchedulerSensor:
                 "bug_window_end": "2024-01-07 14:52:00",
             }
         )
-        context = build_sensor_context(cursor=cursor)
+
+        mock_instance = MagicMock(spec=DagsterInstance)
+        mock_instance.get_run_records.return_value = []
+
+        context = build_sensor_context(cursor=cursor, instance=mock_instance)
         result = person_property_reconciliation_scheduler(context)
 
         assert isinstance(result, SkipReason)
@@ -5901,3 +5905,199 @@ class TestReconciliationSchedulerSensor:
         assert isinstance(result, SkipReason)
         assert result.skip_message is not None
         assert "bug_window_end" in result.skip_message
+
+    def test_build_reconciliation_run_config_with_team_ids(self):
+        """Test that run config passes team_ids to op config when provided."""
+        from posthog.dags.person_property_reconciliation import (
+            ReconciliationSchedulerConfig,
+            build_reconciliation_run_config,
+        )
+
+        config = ReconciliationSchedulerConfig(
+            team_ids=[1, 5, 10, 20],
+            chunk_size=100,
+            max_concurrent_jobs=5,
+            max_concurrent_tasks=10,
+            bug_window_start="2024-01-06 20:01:00",
+            bug_window_end="2024-01-07 14:52:00",
+            dry_run=True,
+            backup_enabled=False,
+            batch_size=50,
+        )
+
+        run_config = build_reconciliation_run_config(config, team_ids=[1, 5, 10])
+
+        op_config = run_config["ops"]["get_team_ids_to_reconcile"]["config"]
+        assert op_config["team_ids"] == [1, 5, 10]
+        assert "min_team_id" not in op_config
+        assert "max_team_id" not in op_config
+        assert op_config["bug_window_start"] == "2024-01-06 20:01:00"
+        assert op_config["dry_run"] is True
+        assert run_config["ops"]["reconcile_team_chunk"]["config"]["backup_enabled"] is False
+
+    def test_sensor_with_team_ids_yields_chunked_runs(self):
+        """Test that sensor chunks team_ids list correctly."""
+        from dagster import DagsterInstance, SensorResult, build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        cursor = json.dumps(
+            {
+                "team_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                "chunk_size": 3,
+                "max_concurrent_jobs": 5,
+                "next_team_index": 0,
+                "bug_window_start": "2024-01-06 20:01:00",
+                "bug_window_end": "2024-01-07 14:52:00",
+            }
+        )
+
+        mock_instance = MagicMock(spec=DagsterInstance)
+        mock_instance.get_run_records.return_value = []
+
+        context = build_sensor_context(cursor=cursor, instance=mock_instance)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert isinstance(result, SensorResult)
+        assert result.run_requests is not None
+        assert len(result.run_requests) == 4  # 10 teams / 3 per chunk = 4 chunks (3+3+3+1)
+        assert result.run_requests[0].run_key == "reconcile_team_ids_0_2"
+        assert result.run_requests[1].run_key == "reconcile_team_ids_3_5"
+        assert result.run_requests[2].run_key == "reconcile_team_ids_6_8"
+        assert result.run_requests[3].run_key == "reconcile_team_ids_9_9"
+
+        # Verify first run config has correct team_ids chunk
+        first_run_config = result.run_requests[0].run_config
+        assert first_run_config["ops"]["get_team_ids_to_reconcile"]["config"]["team_ids"] == [1, 2, 3]
+
+    def test_sensor_team_ids_mode_updates_cursor(self):
+        """Test that sensor updates next_team_index in cursor."""
+        from dagster import DagsterInstance, SensorResult, build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        cursor = json.dumps(
+            {
+                "team_ids": [100, 200, 300, 400, 500],
+                "chunk_size": 2,
+                "max_concurrent_jobs": 2,  # Limit to 2 runs
+                "next_team_index": 0,
+                "bug_window_start": "2024-01-06 20:01:00",
+                "bug_window_end": "2024-01-07 14:52:00",
+            }
+        )
+
+        mock_instance = MagicMock(spec=DagsterInstance)
+        mock_instance.get_run_records.return_value = []
+
+        context = build_sensor_context(cursor=cursor, instance=mock_instance)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert isinstance(result, SensorResult)
+        assert result.run_requests is not None
+        assert len(result.run_requests) == 2  # Limited by max_concurrent_jobs
+
+        # Cursor should track progress
+        assert result.cursor is not None
+        new_cursor = json.loads(result.cursor)
+        assert new_cursor["next_team_index"] == 4  # Processed 2 chunks of 2 = 4 teams
+
+    def test_sensor_team_ids_completes_when_list_exhausted(self):
+        """Test that sensor returns SkipReason when all team_ids are processed."""
+        from dagster import DagsterInstance, SkipReason, build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        cursor = json.dumps(
+            {
+                "team_ids": [1, 2, 3],
+                "chunk_size": 10,
+                "next_team_index": 3,  # Already processed all 3
+                "bug_window_start": "2024-01-06 20:01:00",
+                "bug_window_end": "2024-01-07 14:52:00",
+            }
+        )
+
+        mock_instance = MagicMock(spec=DagsterInstance)
+        mock_instance.get_run_records.return_value = []
+
+        context = build_sensor_context(cursor=cursor, instance=mock_instance)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert isinstance(result, SkipReason)
+        assert result.skip_message is not None
+        assert "complete" in result.skip_message.lower()
+        assert "3" in result.skip_message  # Should mention number of teams
+
+    def test_sensor_validates_either_team_ids_or_range_required(self):
+        """Test that sensor rejects cursor with neither team_ids nor range."""
+        from dagster import SkipReason, build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        cursor = json.dumps(
+            {
+                "chunk_size": 100,
+                "bug_window_start": "2024-01-06 20:01:00",
+                "bug_window_end": "2024-01-07 14:52:00",
+            }
+        )
+        context = build_sensor_context(cursor=cursor)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert isinstance(result, SkipReason)
+        assert result.skip_message is not None
+        assert "team_ids" in result.skip_message
+        assert "range_start" in result.skip_message
+
+    def test_sensor_validates_team_ids_and_range_mutually_exclusive(self):
+        """Test that sensor rejects cursor with both team_ids and range."""
+        from dagster import SkipReason, build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        cursor = json.dumps(
+            {
+                "team_ids": [1, 2, 3],
+                "range_start": 1,
+                "range_end": 100,
+                "bug_window_start": "2024-01-06 20:01:00",
+                "bug_window_end": "2024-01-07 14:52:00",
+            }
+        )
+        context = build_sensor_context(cursor=cursor)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert isinstance(result, SkipReason)
+        assert result.skip_message is not None
+        assert "both" in result.skip_message.lower()
+
+    def test_sensor_team_ids_run_request_has_correct_tags(self):
+        """Test that team_ids mode run requests include expected tags."""
+        from dagster import DagsterInstance, SensorResult, build_sensor_context
+
+        from posthog.dags.person_property_reconciliation import person_property_reconciliation_scheduler
+
+        cursor = json.dumps(
+            {
+                "team_ids": [10, 20, 30],
+                "chunk_size": 2,
+                "max_concurrent_jobs": 5,
+                "next_team_index": 0,
+                "bug_window_start": "2024-01-06 20:01:00",
+                "bug_window_end": "2024-01-07 14:52:00",
+            }
+        )
+
+        mock_instance = MagicMock(spec=DagsterInstance)
+        mock_instance.get_run_records.return_value = []
+
+        context = build_sensor_context(cursor=cursor, instance=mock_instance)
+        result = person_property_reconciliation_scheduler(context)
+
+        assert isinstance(result, SensorResult)
+        assert result.run_requests is not None
+        assert len(result.run_requests) == 2
+        assert result.run_requests[0].tags["reconciliation_team_ids_range"] == "0-1"
+        assert result.run_requests[0].tags["reconciliation_team_count"] == "2"
+        assert result.run_requests[0].tags["owner"] == "team-ingestion"


### PR DESCRIPTION
## Problem
The job was altered for cost savings to be triggered by sensor. Now we need the sensor cursor inputs to accept a fixed list of team IDs for spot repair.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add spot repair args with propagation to child jobs to sensor cfg
* Related unit tests and test updates
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI - smoke test in prod coming soon 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
