### PR TITLE
fix(heatmaps): restore scroll depth extraction and opt-in check

### DIFF
--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
@@ -8,7 +8,7 @@ import { EventPipelineRunner, EventPipelineRunnerOptions } from '../../worker/in
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
-import { PipelineResult, isOkResult } from '../pipelines/results'
+import { PipelineResult, drop, isOkResult } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export interface EventPipelineRunnerHeatmapStepInput {
@@ -35,6 +35,11 @@ export function createEventPipelineRunnerHeatmapStep<TInput extends EventPipelin
         input: TInput
     ): Promise<PipelineResult<EventPipelineRunnerHeatmapStepResult<TInput>>> {
         const { normalizedEvent, timestamp, team, headers, groupStoreForBatch } = input
+
+        // Skip heatmap processing if team has explicitly opted out
+        if (team.heatmaps_opt_in === false) {
+            return drop('heatmap_opt_in_disabled')
+        }
 
         const runner = new EventPipelineRunner(
             config,

--- a/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
+++ b/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
@@ -24,8 +24,12 @@ export function createExtractHeatmapDataStep<TInput extends ExtractHeatmapDataSt
     ): Promise<PipelineResult<ExtractHeatmapDataStepResult<TInput>>> {
         const { preparedEvent } = input
 
-        // Early return if there's no heatmap data to process
-        if (!preparedEvent.properties?.['$heatmap_data']) {
+        // Early return if there's no heatmap data AND no scroll depth data to process
+        const hasHeatmapData = preparedEvent.properties?.['$heatmap_data']
+        const hasScrollDepthData =
+            preparedEvent.properties?.['$prev_pageview_pathname'] && preparedEvent.properties?.['$current_url']
+
+        if (!hasHeatmapData && !hasScrollDepthData) {
             return Promise.resolve(ok({ ...input, preparedEvent }))
         }
 


### PR DESCRIPTION
Two bugs were introduced in the refactor PR #43078:

1. Early return in extract-heatmap-data-step skipped scroll depth extraction when $heatmap_data was absent, even though scroll depth data comes from $prev_pageview_pathname/$prev_pageview_max_scroll
2. Server-side heatmaps_opt_in check was removed, breaking defense- in-depth (SDK respects /decide but server should also enforce)

Fixes both issues and adds regression tests.

## How did you test this code?

tests

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
