### PR TITLE
fix: allow switching orgs during read-only impersonation

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -917,6 +917,9 @@ class ImpersonationReadOnlyMiddleware:
         if self._is_path_allowlisted(request.path):
             return self.get_response(request)
 
+        if self._is_allowed_users_request(request):
+            return self.get_response(request)
+
         return JsonResponse(
             {
                 "type": "authentication_error",
@@ -934,6 +937,24 @@ class ImpersonationReadOnlyMiddleware:
             elif path.startswith(allowed_path):
                 return True
         return False
+
+    def _is_allowed_users_request(self, request: HttpRequest) -> bool:
+        """
+        Allow switching organizations.
+
+        Switching occurs via a PATCH to /api/users/@me/ that only contains `set_current_organization`.
+        """
+        if request.method != "PATCH":
+            return False
+
+        if request.path not in ("/api/users/@me/", "/api/users/@me"):
+            return False
+
+        try:
+            body = json.loads(request.body)
+            return isinstance(body, dict) and set(body.keys()) == {"set_current_organization"}
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return False
 
 
 IMPERSONATION_BLOCKED_PATHS: list[str] = [

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -801,6 +801,31 @@ class TestImpersonationReadOnlyMiddleware(APIBaseTest):
         # Verify we're back to original user
         assert self.client.get("/api/users/@me").json()["email"] == self.user.email
 
+    def test_read_only_impersonation_allows_set_current_organization(self):
+        """Verify read-only impersonation allows PATCH with only set_current_organization."""
+        self.login_as_other_user_read_only()
+
+        response = self.client.patch(
+            "/api/users/@me/",
+            data={"set_current_organization": str(self.organization.id)},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+
+    def test_read_only_impersonation_blocks_set_current_organization_with_other_fields(self):
+        """Verify read-only impersonation blocks PATCH with set_current_organization plus other fields."""
+        self.login_as_other_user_read_only()
+
+        response = self.client.patch(
+            "/api/users/@me/",
+            data={"set_current_organization": str(self.organization.id), "first_name": "Hacked"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+        assert response.json()["code"] == "impersonation_read_only"
+
 
 @override_settings(IMPERSONATION_TIMEOUT_SECONDS=100)
 @override_settings(IMPERSONATION_IDLE_TIMEOUT_SECONDS=20)


### PR DESCRIPTION
This specific write should be allowed, otherwise switching orgs is blocked.