### PR TITLE
Trace view clusters tab flag

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -697,8 +697,17 @@ const EventContent = React.memo(
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SUMMARIZATION] ||
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
 
+        const showClustersTab = isTraceLevel(event) && !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB]
+
         // Check if we're viewing a trace with actual content vs. a pseudo-trace (grouping of generations w/o input/output state)
         const isTopLevelTraceWithoutContent = !event || (!isLLMEvent(event) && !event.inputState && !event.outputState)
+
+        // If the URL forces the "clusters" tab but the feature flag is off, fall back to a safe default.
+        useEffect(() => {
+            if (viewMode === TraceViewMode.Clusters && !showClustersTab) {
+                setViewMode(TraceViewMode.Conversation)
+            }
+        }, [setViewMode, showClustersTab, viewMode])
 
         // Only pre-load for generation events ($ai_input/$ai_output_choices).
         // TODO: Figure out why spans can't load properties async
@@ -963,7 +972,7 @@ const EventContent = React.memo(
                                           },
                                       ]
                                     : []),
-                                ...(isTraceLevel(event)
+                                ...(showClustersTab
                                     ? [
                                           {
                                               key: TraceViewMode.Clusters,


### PR DESCRIPTION
## Problem

The "Clusters" tab on the LLM analytics trace view was not consistently gated by the `LLM_ANALYTICS_CLUSTERS_TAB` feature flag, unlike the main "Clusters" tab on the LLM analytics page. This could lead to inconsistent UI behavior and potential access to an unreleased feature.

Additionally, if a user navigated directly to a URL with `?tab=clusters` while the feature flag was disabled, the UI could get stuck on a hidden tab.

## Changes

-   The "Clusters" tab in the LLM analytics trace view is now conditionally rendered based on the `FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB` feature flag.
-   Implemented a fallback mechanism: if the URL specifies `?tab=clusters` but the feature flag is disabled, the view automatically switches to the "Conversation" tab to prevent a stuck UI.

## How did you test this code?

-   Manually tested by enabling and disabling the `LLM_ANALYTICS_CLUSTERS_TAB` feature flag and verifying the "Clusters" tab's visibility on the LLM trace view page.
-   Manually tested navigating to a trace view URL with `?tab=clusters` while the feature flag was off, ensuring the view correctly defaulted to the "Conversation" tab.
-   Ran `yarn typecheck` and `yarn lint` to ensure no regressions.

## Publish to changelog?

no

---
<a href="https://cursor.com/background-agent?bcId=bc-c1ce27e7-817d-4303-9e56-ccc8a6721dec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1ce27e7-817d-4303-9e56-ccc8a6721dec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

