### PR TITLE
fix(flags): Use `anon_distinct_id` for EEC flags when no person exists

### DIFF
--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -101,7 +101,7 @@ mod tests {
             .await
             .unwrap();
 
-        let match_result = matcher.get_match(&flag, None, None).unwrap();
+        let match_result = matcher.get_match(&flag, None, None, None).unwrap();
         assert!(match_result.matches);
         assert_eq!(match_result.variant, None);
 
@@ -122,7 +122,7 @@ mod tests {
             .await
             .unwrap();
 
-        let match_result = matcher.get_match(&flag, None, None).unwrap();
+        let match_result = matcher.get_match(&flag, None, None, None).unwrap();
         assert!(!match_result.matches);
         assert_eq!(match_result.variant, None);
 
@@ -143,7 +143,7 @@ mod tests {
             .await
             .unwrap();
 
-        let match_result = matcher.get_match(&flag, None, None).unwrap();
+        let match_result = matcher.get_match(&flag, None, None, None).unwrap();
 
         // Expecting false for non-existent distinct_id
         assert!(!match_result.matches);
@@ -1106,7 +1106,7 @@ mod tests {
             Some(group_type_mapping_cache),
             Some(groups),
         );
-        let variant = matcher.get_matching_variant(&flag, None).unwrap();
+        let variant = matcher.get_matching_variant(&flag, None, &None).unwrap();
         assert!(variant.is_some(), "No variant was selected");
         assert!(
             ["control", "test", "test2"].contains(&variant.unwrap().as_str()),
@@ -1143,7 +1143,7 @@ mod tests {
             None,
         );
 
-        let variant = matcher.get_matching_variant(&flag, None).unwrap();
+        let variant = matcher.get_matching_variant(&flag, None, &None).unwrap();
         assert!(variant.is_some());
         assert!(["control", "test", "test2"].contains(&variant.unwrap().as_str()));
     }
@@ -1194,7 +1194,7 @@ mod tests {
             None,
         );
         let (is_match, reason) = matcher
-            .is_condition_match(&flag, &condition, None, None)
+            .is_condition_match(&flag, &condition, None, None, &None)
             .unwrap();
         assert!(is_match);
         assert_eq!(reason, FeatureFlagMatchReason::ConditionMatch);
@@ -1256,7 +1256,7 @@ mod tests {
             .flag_evaluation_state
             .add_flag_evaluation_result(1, FlagValue::Boolean(true));
         let (is_match, reason) = matcher
-            .is_condition_match(&flag, &condition, None, None)
+            .is_condition_match(&flag, &condition, None, None, &None)
             .unwrap();
         assert!(is_match);
         assert_eq!(reason, FeatureFlagMatchReason::ConditionMatch);
@@ -1440,7 +1440,7 @@ mod tests {
                     None,
                     None,
                 );
-                matcher.get_match(&flag_clone, None, None).unwrap()
+                matcher.get_match(&flag_clone, None, None, None).unwrap()
             }));
         }
 
@@ -1528,7 +1528,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(result.matches);
     }
@@ -1573,7 +1573,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         // With empty distinct_id and 100% rollout, the flag should match
         // This is consistent with the Python implementation
@@ -1620,14 +1620,14 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(!result.matches);
 
         // Now set the rollout percentage to 100%
         flag.filters.groups[0].rollout_percentage = Some(100.0);
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(result.matches);
     }
@@ -1681,7 +1681,7 @@ mod tests {
         // Run the test multiple times to simulate distribution
         for i in 0..1000 {
             matcher.distinct_id = format!("user_{i}");
-            let variant = matcher.get_matching_variant(&flag, None).unwrap();
+            let variant = matcher.get_matching_variant(&flag, None, &None).unwrap();
             match variant.as_deref() {
                 Some("control") => control_count += 1,
                 Some("test") => test_count += 1,
@@ -1752,7 +1752,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(!result.matches);
     }
@@ -1816,7 +1816,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         // The match should fail due to invalid data type
         assert!(!result.matches);
@@ -1863,7 +1863,7 @@ mod tests {
         );
 
         let (is_match, reason) = matcher
-            .is_condition_match(&flag, &flag.filters.groups[0], None, None)
+            .is_condition_match(&flag, &flag.filters.groups[0], None, None, &None)
             .unwrap();
 
         assert!(is_match);
@@ -1947,7 +1947,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(result.matches);
     }
@@ -2180,7 +2180,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let result = matcher.get_match(&flag, None, None).unwrap();
+            let result = matcher.get_match(&flag, None, None, None).unwrap();
             assert_eq!(
                 result.matches,
                 should_match,
@@ -2325,9 +2325,13 @@ mod tests {
             .await
             .unwrap();
 
-        let result_test_id = matcher_test_id.get_match(&flag, None, None).unwrap();
-        let result_example_id = matcher_example_id.get_match(&flag, None, None).unwrap();
-        let result_another_id = matcher_another_id.get_match(&flag, None, None).unwrap();
+        let result_test_id = matcher_test_id.get_match(&flag, None, None, None).unwrap();
+        let result_example_id = matcher_example_id
+            .get_match(&flag, None, None, None)
+            .unwrap();
+        let result_another_id = matcher_another_id
+            .get_match(&flag, None, None, None)
+            .unwrap();
 
         assert!(result_test_id.matches);
         assert!(result_test_id.reason == FeatureFlagMatchReason::SuperConditionValue);
@@ -2431,7 +2435,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(result.matches);
         assert_eq!(result.reason, FeatureFlagMatchReason::SuperConditionValue);
@@ -2572,9 +2576,13 @@ mod tests {
             .await
             .unwrap();
 
-        let result_test_id = matcher_test_id.get_match(&flag, None, None).unwrap();
-        let result_example_id = matcher_example_id.get_match(&flag, None, None).unwrap();
-        let result_another_id = matcher_another_id.get_match(&flag, None, None).unwrap();
+        let result_test_id = matcher_test_id.get_match(&flag, None, None, None).unwrap();
+        let result_example_id = matcher_example_id
+            .get_match(&flag, None, None, None)
+            .unwrap();
+        let result_another_id = matcher_another_id
+            .get_match(&flag, None, None, None)
+            .unwrap();
 
         assert!(!result_test_id.matches);
         assert_eq!(
@@ -2689,7 +2697,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(result.matches);
     }
@@ -2785,7 +2793,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(result.matches);
     }
@@ -2876,7 +2884,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         // The user matches the cohort, but the flag is set to NotIn, so it should evaluate to false
         assert!(!result.matches);
@@ -2998,7 +3006,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(result.matches);
     }
@@ -3094,7 +3102,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         // The user does not match the cohort, and the flag is set to In, so it should evaluate to false
         assert!(!result.matches);
@@ -3190,7 +3198,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(
             result.matches,
@@ -3273,7 +3281,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(
             !result.matches,
@@ -3361,7 +3369,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(
             result.matches,
@@ -3454,7 +3462,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         assert!(
             !result.matches,
@@ -3878,7 +3886,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
 
         // The condition matches and has a variant override, so it should return "control"
         // regardless of what the hash-based variant computation would return
@@ -3934,7 +3942,7 @@ mod tests {
             .unwrap();
 
         let result_invalid = matcher
-            .get_match(&flag_invalid_override, None, None)
+            .get_match(&flag_invalid_override, None, None, None)
             .unwrap();
 
         // The condition matches but has an invalid variant override,
@@ -4109,7 +4117,9 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag_with_holdout, None, None).unwrap();
+        let result = matcher
+            .get_match(&flag_with_holdout, None, None, None)
+            .unwrap();
         assert!(result.matches);
         assert_eq!(result.variant, Some("second-variant".to_string()));
         assert_eq!(result.reason, FeatureFlagMatchReason::ConditionMatch);
@@ -4135,7 +4145,9 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher2.get_match(&flag_with_holdout, None, None).unwrap();
+        let result = matcher2
+            .get_match(&flag_with_holdout, None, None, None)
+            .unwrap();
 
         assert!(result.matches);
         assert_eq!(result.variant, Some("holdout".to_string()));
@@ -4143,7 +4155,7 @@ mod tests {
 
         // same should hold true for a different feature flag when within holdout
         let result = matcher2
-            .get_match(&other_flag_with_holdout, None, None)
+            .get_match(&other_flag_with_holdout, None, None, None)
             .unwrap();
         assert!(result.matches);
         assert_eq!(result.variant, Some("holdout".to_string()));
@@ -4151,7 +4163,7 @@ mod tests {
 
         // Test with matcher1 (outside holdout) to verify different variants
         let result = matcher
-            .get_match(&other_flag_with_holdout, None, None)
+            .get_match(&other_flag_with_holdout, None, None, None)
             .unwrap();
         assert!(result.matches);
         assert_eq!(result.variant, Some("third-variant".to_string()));
@@ -4159,14 +4171,14 @@ mod tests {
 
         // when holdout exists but is zero, should default to regular flag evaluation
         let result = matcher
-            .get_match(&flag_without_holdout, None, None)
+            .get_match(&flag_without_holdout, None, None, None)
             .unwrap();
         assert!(result.matches);
         assert_eq!(result.variant, Some("second-variant".to_string()));
         assert_eq!(result.reason, FeatureFlagMatchReason::ConditionMatch);
 
         let result = matcher2
-            .get_match(&flag_without_holdout, None, None)
+            .get_match(&flag_without_holdout, None, None, None)
             .unwrap();
         assert!(result.matches);
         assert_eq!(result.variant, Some("second-variant".to_string()));
@@ -4239,7 +4251,7 @@ mod tests {
             None,
             None,
         );
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
         assert_eq!(
             result,
             FeatureFlagMatch {
@@ -4262,7 +4274,7 @@ mod tests {
             None,
             None,
         );
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
         assert_eq!(
             result,
             FeatureFlagMatch {
@@ -4285,7 +4297,7 @@ mod tests {
             None,
             None,
         );
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
         assert_eq!(
             result,
             FeatureFlagMatch {
@@ -4387,7 +4399,7 @@ mod tests {
             .unwrap();
 
         // This should not throw DependencyNotFound because we skip dependency graph evaluation for static cohorts
-        let result = matcher.get_match(&flag, None, None);
+        let result = matcher.get_match(&flag, None, None, None);
         assert!(result.is_ok(), "Should not throw DependencyNotFound error");
 
         let match_result = result.unwrap();
@@ -4524,7 +4536,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result_numeric = matcher_numeric.get_match(&flag, None, None).unwrap();
+        let result_numeric = matcher_numeric.get_match(&flag, None, None, None).unwrap();
 
         // Test with string group key (same value)
         let groups_string = HashMap::from([("organization".to_string(), json!("123"))]);
@@ -4544,7 +4556,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result_string = matcher_string.get_match(&flag, None, None).unwrap();
+        let result_string = matcher_string.get_match(&flag, None, None, None).unwrap();
 
         // Both should match and produce the same result
         assert!(result_numeric.matches, "Numeric group key should match");
@@ -4576,7 +4588,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result_float = matcher_float.get_match(&flag, None, None).unwrap();
+        let result_float = matcher_float.get_match(&flag, None, None, None).unwrap();
         assert!(result_float.matches, "Float group key should match");
 
         // Test with invalid group key type (should use empty string and not match this specific case)
@@ -4597,7 +4609,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result_bool = matcher_bool.get_match(&flag, None, None).unwrap();
+        let result_bool = matcher_bool.get_match(&flag, None, None, None).unwrap();
         // Boolean group key should use empty string identifier, which returns hash 0.0, making flag evaluate to false
         assert!(
             !result_bool.matches,
@@ -4741,7 +4753,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
         assert!(result.matches, "Super condition user should match");
         assert_eq!(
             result.reason,
@@ -4766,7 +4778,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
         assert!(!result.matches, "PostHog user should not match");
         assert_eq!(
             result.reason,
@@ -4791,7 +4803,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, None).unwrap();
         assert!(!result.matches, "Regular user should not match");
         assert_eq!(
             result.reason,
@@ -4864,7 +4876,7 @@ mod tests {
             .await
             .unwrap();
 
-        let match_result = matcher.get_match(&flag, None, None).unwrap();
+        let match_result = matcher.get_match(&flag, None, None, None).unwrap();
         assert!(match_result.matches);
         assert_eq!(match_result.variant, None);
     }
@@ -4919,7 +4931,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let high_device_result = matcher.get_match(&flag, None, None).unwrap();
+        let high_device_result = matcher.get_match(&flag, None, None, None).unwrap();
         assert!(
             high_device_result.matches,
             "device-high hash should fall inside rollout"
@@ -4940,7 +4952,9 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let same_device_result = matcher_same_device.get_match(&flag, None, None).unwrap();
+        let same_device_result = matcher_same_device
+            .get_match(&flag, None, None, None)
+            .unwrap();
         assert_eq!(
             high_device_result.matches, same_device_result.matches,
             "device hashing should ignore distinct_id changes"
@@ -4961,7 +4975,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let low_device_result = matcher_low.get_match(&flag, None, None).unwrap();
+        let low_device_result = matcher_low.get_match(&flag, None, None, None).unwrap();
         assert!(
             !low_device_result.matches,
             "device-low hash should fall outside rollout"
@@ -4995,7 +5009,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let match_from_distinct = matcher.get_match(&flag, None, None).unwrap();
+        let match_from_distinct = matcher.get_match(&flag, None, None, None).unwrap();
         assert!(
             match_from_distinct.matches,
             "fallback distinct hash should fall inside rollout"
@@ -5016,7 +5030,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let high_distinct_result = matcher_high.get_match(&flag, None, None).unwrap();
+        let high_distinct_result = matcher_high.get_match(&flag, None, None, None).unwrap();
         assert!(
             !high_distinct_result.matches,
             "fallback distinct hash should fall outside rollout"
@@ -5051,7 +5065,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let high_distinct_result = matcher.get_match(&flag, None, None).unwrap();
+        let high_distinct_result = matcher.get_match(&flag, None, None, None).unwrap();
         assert!(
             !high_distinct_result.matches,
             "distinct-id bucketing should ignore device_id input"
@@ -5072,7 +5086,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let low_distinct_result = matcher_low.get_match(&flag, None, None).unwrap();
+        let low_distinct_result = matcher_low.get_match(&flag, None, None, None).unwrap();
         assert!(
             low_distinct_result.matches,
             "distinct-id bucketing should follow the distinct hash even when device_id exists"
@@ -5735,7 +5749,7 @@ mod tests {
         user_properties.insert("email".to_string(), json!("specific@example.com"));
 
         let result = matcher
-            .get_match(&flag, Some(user_properties), None)
+            .get_match(&flag, Some(user_properties), None, None)
             .unwrap();
         assert!(result.matches, "Flag should match for specific user");
         assert_eq!(
@@ -5764,7 +5778,7 @@ mod tests {
         other_properties.insert("email".to_string(), json!("other@example.com"));
 
         let result2 = matcher2
-            .get_match(&flag, Some(other_properties), None)
+            .get_match(&flag, Some(other_properties), None, None)
             .unwrap();
         assert!(result2.matches, "Flag should match for other user");
         assert_eq!(
@@ -5843,6 +5857,7 @@ mod tests {
             group_property_overrides: None,
             hash_key_overrides: None, // hash_key_overrides (None simulates read failure)
             hash_key_override_error: true, // hash_key_override_error (simulates the error occurred)
+            request_hash_key_override: None,
         };
 
         let response = matcher
@@ -5929,7 +5944,7 @@ mod tests {
             None,
         );
 
-        let match_result = matcher.get_match(&flag, None, None).unwrap();
+        let match_result = matcher.get_match(&flag, None, None, None).unwrap();
         assert!(!match_result.matches, "Disabled flag should not match");
         assert_eq!(
             match_result.reason,

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -87,6 +87,8 @@ pub struct FlagsCanonicalLogLine {
     pub team_id: Option<i32>,
     pub distinct_id: Option<String>,
     pub device_id: Option<String>,
+    /// The anonymous distinct ID sent with the request for experience continuity.
+    pub anon_distinct_id: Option<String>,
 
     // Populated during flag evaluation
     pub flags_evaluated: usize,
@@ -150,6 +152,7 @@ impl Default for FlagsCanonicalLogLine {
             team_id: None,
             distinct_id: None,
             device_id: None,
+            anon_distinct_id: None,
             flags_evaluated: 0,
             flags_experience_continuity: 0,
             flags_disabled: false,
@@ -199,6 +202,7 @@ impl FlagsCanonicalLogLine {
             team_id = self.team_id,
             distinct_id = self.distinct_id.as_deref(),
             device_id = self.device_id.as_deref(),
+            anon_distinct_id = self.anon_distinct_id.as_deref(),
             ip = %self.ip,
             user_agent = user_agent,
             lib = self.lib,
@@ -265,6 +269,7 @@ mod tests {
         assert!(log.team_id.is_none());
         assert!(log.distinct_id.is_none());
         assert!(log.device_id.is_none());
+        assert!(log.anon_distinct_id.is_none());
         assert_eq!(log.flags_evaluated, 0);
         assert_eq!(log.flags_experience_continuity, 0);
         assert!(!log.flags_disabled);

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -113,10 +113,20 @@ async fn process_request_inner(
             .clone()
             .unwrap_or_else(|| "disabled".to_string());
 
-        // Populate canonical log with distinct_id and device_id
+        // Populate canonical log with distinct_id, device_id, and anon_distinct_id
+        // anon_distinct_id uses same precedence as hash_key_override: top-level > person_properties
+        let anon_distinct_id_for_logging = request.anon_distinct_id.clone().or_else(|| {
+            request
+                .person_properties
+                .as_ref()
+                .and_then(|props| props.get("$anon_distinct_id"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        });
         with_canonical_log(|log| {
             log.distinct_id = Some(distinct_id_for_logging.clone());
             log.device_id = request.device_id.clone();
+            log.anon_distinct_id = anon_distinct_id_for_logging;
         });
 
         tracing::debug!(

--- a/rust/feature-flags/tests/test_experience_continuity.rs
+++ b/rust/feature-flags/tests/test_experience_continuity.rs
@@ -535,3 +535,120 @@ async fn test_top_level_anon_distinct_id_takes_precedence() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_experience_continuity_without_person_uses_anon_distinct_id() -> Result<()> {
+    // This test verifies that when:
+    // 1. No person record exists (common during anonymous->identified transition)
+    // 2. The SDK sends both distinct_id and $anon_distinct_id
+    // 3. The flag is multivariate (has variants)
+    // The server should use $anon_distinct_id for variant computation immediately,
+    // ensuring the user sees the same variant they saw while anonymous.
+
+    let context = TestContext::new(None).await;
+    let team = context
+        .insert_new_team(None)
+        .await
+        .expect("Failed to insert team");
+
+    // Create multivariate flag with experience continuity (50/50 split)
+    let flag_row = FeatureFlagRow {
+        id: 105,
+        team_id: team.id,
+        name: Some("No Person EEC Multivariate Test".to_string()),
+        key: "no-person-eec-multivariate-test".to_string(),
+        filters: json!({
+            "groups": [{"rollout_percentage": 100}],
+            "multivariate": {
+                "variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50}
+                ]
+            }
+        }),
+        deleted: false,
+        active: true,
+        ensure_experience_continuity: Some(true),
+        version: Some(1),
+        evaluation_runtime: None,
+        evaluation_tags: None,
+        bucketing_identifier: None,
+    };
+    context.insert_flag(team.id, Some(flag_row)).await?;
+
+    // IMPORTANT: Do NOT create any person record
+    // This simulates the race condition where identify event hasn't been processed yet
+
+    let config = DEFAULT_TEST_CONFIG.clone();
+    let server = ServerHandle::for_config_with_mock_redis(
+        config,
+        vec![],
+        vec![(team.api_token.clone(), team.id)],
+    )
+    .await;
+
+    // Step 1: Get the variant that "anon_user_123" would see
+    let anon_payload = json!({
+        "token": team.api_token,
+        "distinct_id": "anon_user_123",
+    });
+
+    let anon_res = server
+        .send_flags_request(anon_payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(anon_res.status(), StatusCode::OK);
+    let anon_json = anon_res.json::<Value>().await?;
+
+    let expected_variant = anon_json["flags"]["no-person-eec-multivariate-test"]["variant"]
+        .as_str()
+        .expect("Should have a variant");
+
+    // Step 2: Verify a different distinct_id gets a different or same variant (doesn't matter)
+    // but record what it naturally evaluates to
+    let identified_payload = json!({
+        "token": team.api_token,
+        "distinct_id": "identified_user_456",
+    });
+
+    let identified_res = server
+        .send_flags_request(identified_payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(identified_res.status(), StatusCode::OK);
+    let identified_json = identified_res.json::<Value>().await?;
+
+    let identified_natural_variant = identified_json["flags"]["no-person-eec-multivariate-test"]
+        ["variant"]
+        .as_str()
+        .expect("Should have a variant");
+
+    // Step 3: Now call with identified_user_456 as distinct_id but with $anon_distinct_id
+    // pointing to anon_user_123. Without a person record, the server should use
+    // anon_user_123 for variant computation (matching what the anon user saw).
+    let transition_payload = json!({
+        "token": team.api_token,
+        "distinct_id": "identified_user_456",
+        "$anon_distinct_id": "anon_user_123",
+    });
+
+    let transition_res = server
+        .send_flags_request(transition_payload.to_string(), Some("2"), None)
+        .await;
+    assert_eq!(transition_res.status(), StatusCode::OK);
+    let transition_json = transition_res.json::<Value>().await?;
+
+    let transition_variant = transition_json["flags"]["no-person-eec-multivariate-test"]["variant"]
+        .as_str()
+        .expect("Should have a variant");
+
+    // The key assertion: when $anon_distinct_id is provided with no person record,
+    // the variant should match what the anon_distinct_id user saw, NOT what the
+    // distinct_id would naturally evaluate to.
+    assert_eq!(
+        transition_variant, expected_variant,
+        "With $anon_distinct_id provided but no person record, should use $anon_distinct_id for variant hashing. \
+         Expected variant '{expected_variant}' (from anon_user_123), but got '{transition_variant}'. \
+         For reference, identified_user_456 naturally evaluates to '{identified_natural_variant}'."
+    );
+
+    Ok(())
+}

--- a/rust/feature-flags/tests/test_flag_matching_consistency.rs
+++ b/rust/feature-flags/tests/test_flag_matching_consistency.rs
@@ -127,7 +127,7 @@ async fn it_is_consistent_with_rollout_calculation_for_simple_flags() {
             );
             FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None)
         }
-        .get_match(&flags[0], None, None)
+        .get_match(&flags[0], None, None, None)
         .unwrap();
 
         if *result {
@@ -1225,7 +1225,7 @@ async fn it_is_consistent_with_rollout_calculation_for_multivariate_flags() {
             );
             FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None)
         }
-        .get_match(&flags[0], None, None)
+        .get_match(&flags[0], None, None, None)
         .unwrap();
 
         if let Some(variant) = &result {


### PR DESCRIPTION
## Problem

Fixes a bug where feature flags with `ensure_experience_continuity` enabled would return inconsistent variants during anonymous-to-identified user transitions.

When an SDK sends both `distinct_id` and `$anon_distinct_id`, the server should use `$anon_distinct_id` for variant computation to maintain consistent bucketing. However, if no person record existed yet (common due to ingestion delay), the server incorrectly fell back to using `distinct_id`, causing users to see different variants.

Related: https://posthoghelp.zendesk.com/agent/tickets/46671 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49879)

## Changes

Threads the request's `hash_key_override` (`$anon_distinct_id`) through the evaluation chain to `hashed_identifier()`, where it's now used as a fallback for EEC-enabled flags before falling back to `distinct_id`.

Priority for identifier selection is now:
1. DB-stored `hash_key_override` (for consistency across sessions)
2. Request's `$anon_distinct_id` (for first-time EEC evaluations when no person exists)
3. `distinct_id` (final fallback)

Key changes:
- Added `request_hash_key_override` field to `FlagEvaluationOverrides` struct
- Updated `hashed_identifier()` to accept and use the request hash key override
- Propagated the override through `get_match()` and `is_condition_match()` functions
- Added `anon_distinct_id` to the canonical log entry if provided.

## How did you test this code?

- Added integration test `test_experience_continuity_without_person_uses_anon_distinct_id` that verifies the fix by:
  1. Creating an EEC flag with 50% rollout
  2. NOT creating any person record (simulating ingestion delay)
  3. Verifying that with `distinct_id=false_eval_user` and `$anon_distinct_id=true_eval_user`, the flag evaluates using `true_eval_user` (the `$anon_distinct_id`)
- Updated existing unit tests to include the new parameter
- All existing EEC tests continue to pass

## Publish to changelog?

no
