### PR TITLE
fix: Fix incorrect assumptions about `uiHost`/`apiHost` on toolbar

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -19,7 +19,6 @@ import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { isDomain, isURL } from 'lib/utils'
-import { apiHostOrigin } from 'lib/utils/apiHost'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { addProductIntent } from 'lib/utils/product-intents'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -133,11 +132,6 @@ const _buildToolbarUserIntent = (options?: BuildToolbarParamsOptions): ToolbarUs
 function buildToolbarParams(options?: BuildToolbarParamsOptions): ToolbarParams {
     return {
         userIntent: _buildToolbarUserIntent(options),
-        // Make sure to pass the app url, otherwise the api_host will be used by
-        // the toolbar, which isn't correct when used behind a reverse proxy as
-        // we require e.g. SSO login to the app, which will not work when placed
-        // behind a proxy unless we register each domain with the OAuth2 client.
-        apiURL: apiHostOrigin(),
         ...(options?.actionId ? { actionId: options.actionId } : {}),
         ...(options?.experimentId ? { experimentId: options.experimentId } : {}),
         ...(options?.productTourId && options.productTourId !== 'new' ? { productTourId: options.productTourId } : {}),

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -19,6 +19,7 @@ import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { isDomain, isURL } from 'lib/utils'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { addProductIntent } from 'lib/utils/product-intents'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -132,6 +133,9 @@ const _buildToolbarUserIntent = (options?: BuildToolbarParamsOptions): ToolbarUs
 function buildToolbarParams(options?: BuildToolbarParamsOptions): ToolbarParams {
     return {
         userIntent: _buildToolbarUserIntent(options),
+        // Keeping this as backward compatibility, but we don't use it anymore in the toolbar
+        // and instead depend on the `posthog`'s instance configuration
+        apiURL: apiHostOrigin(),
         ...(options?.actionId ? { actionId: options.actionId } : {}),
         ...(options?.experimentId ? { experimentId: options.experimentId } : {}),
         ...(options?.productTourId && options.productTourId !== 'new' ? { productTourId: options.productTourId } : {}),

--- a/frontend/src/lib/components/HedgehogBuddy/sprites/sprites.tsx
+++ b/frontend/src/lib/components/HedgehogBuddy/sprites/sprites.tsx
@@ -33,9 +33,10 @@ export type AccessoryInfo = {
 
 // If loaded via the toolbar the root domain won't be app.posthog.com and so the assets won't load
 // Simple workaround is we detect if the domain is localhost and if not we just use https://us.posthog.com
+// since that will have appropriate assets.
 const baseSpritePath = (): string => {
     let path = `/static/hedgehog/sprites`
-    const toolbarAPIUrl = toolbarConfigLogic.findMounted()?.values.apiURL
+    const toolbarAPIUrl = toolbarConfigLogic.findMounted()?.values.apiHost
 
     if (inStorybook()) {
         // Nothing to do

--- a/frontend/src/toolbar/ToolbarApp.tsx
+++ b/frontend/src/toolbar/ToolbarApp.tsx
@@ -16,7 +16,7 @@ import { webVitalsToolbarLogic } from './web-vitals/webVitalsToolbarLogic'
 type HTMLElementWithShadowRoot = HTMLElement & { shadowRoot: ShadowRoot }
 
 export function ToolbarApp(props: ToolbarProps = {}): JSX.Element {
-    const { apiURL } = useValues(toolbarConfigLogic(props))
+    const { apiHost } = useValues(toolbarConfigLogic(props))
 
     const shadowRef = useRef<HTMLElementWithShadowRoot | null>(null)
     const [didLoadStyles, setDidLoadStyles] = useState(false)
@@ -42,7 +42,8 @@ export function ToolbarApp(props: ToolbarProps = {}): JSX.Element {
                   // this ensures that we bust the cache periodically
                   const timestampToNearestFiveMinutes =
                       Math.floor(Date.now() / fiveMinutesInMillis) * fiveMinutesInMillis
-                  styleLink.href = `${apiURL}/static/toolbar.css?t=${timestampToNearestFiveMinutes}`
+                  // Load CSS from API host (where static assets are served, same place as the JS was loaded from)
+                  styleLink.href = `${apiHost}/static/toolbar.css?t=${timestampToNearestFiveMinutes}`
                   styleLink.onload = () => setDidLoadStyles(true)
                   const shadowRoot =
                       shadowRef.current?.shadowRoot || window.document.getElementById(TOOLBAR_ID)?.shadowRoot

--- a/frontend/src/toolbar/actions/ActionsToolbarMenu.tsx
+++ b/frontend/src/toolbar/actions/ActionsToolbarMenu.tsx
@@ -24,7 +24,7 @@ const ActionsListToolbarMenu = (): JSX.Element => {
     const { newAction } = useActions(actionsTabLogic)
     const { allActions, sortedActions, allActionsLoading } = useValues(actionsLogic)
 
-    const { apiURL } = useValues(toolbarConfigLogic)
+    const { uiHost } = useValues(toolbarConfigLogic)
 
     useOnMountEffect(getActions)
 
@@ -53,7 +53,7 @@ const ActionsListToolbarMenu = (): JSX.Element => {
             </ToolbarMenu.Body>
             <ToolbarMenu.Footer>
                 <div className="flex items-center justify-between flex-1">
-                    <Link to={`${apiURL}${urls.actions()}`} target="_blank" className="text-primary">
+                    <Link to={`${uiHost}${urls.actions()}`} target="_blank" className="text-primary">
                         View &amp; edit all actions <IconOpenInNew />
                     </Link>
                     <LemonButton type="primary" size="small" onClick={() => newAction()} icon={<IconPlus />}>

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -97,7 +97,16 @@ export const actionsTabLogic = kea<actionsTabLogicType>([
     connect(() => ({
         values: [
             toolbarConfigLogic,
-            ['dataAttributes', 'apiURL', 'temporaryToken', 'buttonVisible', 'userIntent', 'actionId', 'dataAttributes'],
+            [
+                'dataAttributes',
+                'apiHost',
+                'uiHost',
+                'temporaryToken',
+                'buttonVisible',
+                'userIntent',
+                'actionId',
+                'dataAttributes',
+            ],
             actionsLogic,
             ['allActions'],
         ],
@@ -205,7 +214,7 @@ export const actionsTabLogic = kea<actionsTabLogicType>([
                     steps: formValues.steps?.map(stepToDatabaseFormat) || [],
                     creation_context: values.automaticActionCreationEnabled ? 'onboarding' : null,
                 }
-                const { apiURL, temporaryToken } = values
+                const { temporaryToken, apiHost } = values
                 const { selectedActionId } = values
 
                 const findUniqueActionName = (baseName: string, index = 0): string => {
@@ -224,12 +233,12 @@ export const actionsTabLogic = kea<actionsTabLogicType>([
                 let response: ActionType
                 if (selectedActionId && selectedActionId !== 'new') {
                     response = await api.update(
-                        `${apiURL}/api/projects/@current/actions/${selectedActionId}/?temporary_token=${temporaryToken}`,
+                        `${apiHost}/api/projects/@current/actions/${selectedActionId}/?temporary_token=${temporaryToken}`,
                         actionToSave
                     )
                 } else {
                     response = await api.create(
-                        `${apiURL}/api/projects/@current/actions/?temporary_token=${temporaryToken}`,
+                        `${apiHost}/api/projects/@current/actions/?temporary_token=${temporaryToken}`,
                         actionToSave
                     )
                 }
@@ -242,7 +251,7 @@ export const actionsTabLogic = kea<actionsTabLogicType>([
                     lemonToast.success('Action saved', {
                         button: {
                             label: 'Open in PostHog',
-                            action: () => window.open(`${apiURL}${urls.action(response.id)}`, '_blank'),
+                            action: () => window.open(`${values.uiHost}${urls.action(response.id)}`, '_blank'),
                         },
                     })
                 }

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -97,16 +97,7 @@ export const actionsTabLogic = kea<actionsTabLogicType>([
     connect(() => ({
         values: [
             toolbarConfigLogic,
-            [
-                'dataAttributes',
-                'apiHost',
-                'uiHost',
-                'temporaryToken',
-                'buttonVisible',
-                'userIntent',
-                'actionId',
-                'dataAttributes',
-            ],
+            ['dataAttributes', 'apiHost', 'uiHost', 'temporaryToken', 'buttonVisible', 'userIntent', 'actionId'],
             actionsLogic,
             ['allActions'],
         ],

--- a/frontend/src/toolbar/experiments/ExperimentsToolbarMenu.tsx
+++ b/frontend/src/toolbar/experiments/ExperimentsToolbarMenu.tsx
@@ -22,7 +22,7 @@ const ExperimentsListToolbarMenu = (): JSX.Element => {
     const { newExperiment } = useActions(experimentsTabLogic)
     const { setSearchTerm } = useActions(experimentsLogic)
     const { allExperiments, sortedExperiments, allExperimentsLoading } = useValues(experimentsLogic)
-    const { apiURL } = useValues(toolbarConfigLogic)
+    const { uiHost } = useValues(toolbarConfigLogic)
 
     const isWebExperimentsDisabled = Boolean(window?.parent?.posthog?.config?.disable_web_experiments)
 
@@ -68,7 +68,7 @@ const ExperimentsListToolbarMenu = (): JSX.Element => {
             </ToolbarMenu.Body>
             <ToolbarMenu.Footer>
                 <div className="flex items-center justify-between flex-1">
-                    <Link to={`${apiURL}${urls.experiments()}`} target="_blank">
+                    <Link to={`${uiHost}${urls.experiments()}`} target="_blank">
                         View &amp; edit all experiments <IconOpenInNew />
                     </Link>
                     <LemonButton type="primary" size="small" onClick={() => newExperiment()} icon={<IconPlus />}>

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -103,7 +103,8 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
             toolbarConfigLogic,
             [
                 'dataAttributes',
-                'apiURL',
+                'apiHost',
+                'uiHost',
                 'temporaryToken',
                 'buttonVisible',
                 'userIntent',
@@ -191,19 +192,19 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                 // This property is only used in the editor to undo transforms
                 delete experimentToSave.original_html_state
 
-                const { apiURL, temporaryToken } = values
+                const { apiHost, uiHost, temporaryToken } = values
                 const { selectedExperimentId } = values
 
                 let response: WebExperiment
                 try {
                     if (selectedExperimentId && selectedExperimentId !== 'new') {
                         response = await api.update(
-                            `${apiURL}/api/projects/@current/web_experiments/${selectedExperimentId}/?temporary_token=${temporaryToken}`,
+                            `${apiHost}/api/projects/@current/web_experiments/${selectedExperimentId}/?temporary_token=${temporaryToken}`,
                             experimentToSave
                         )
                     } else {
                         response = await api.create(
-                            `${apiURL}/api/projects/@current/web_experiments/?temporary_token=${temporaryToken}`,
+                            `${apiHost}/api/projects/@current/web_experiments/?temporary_token=${temporaryToken}`,
                             experimentToSave
                         )
                     }
@@ -214,7 +215,7 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                     lemonToast.success('Experiment saved', {
                         button: {
                             label: 'Open in PostHog',
-                            action: () => window.open(`${apiURL}${urls.experiment(response.id)}`, '_blank'),
+                            action: () => window.open(`${uiHost}${urls.experiment(response.id)}`, '_blank'),
                         },
                     })
                     breakpoint()

--- a/frontend/src/toolbar/flags/FlagsToolbarMenu.tsx
+++ b/frontend/src/toolbar/flags/FlagsToolbarMenu.tsx
@@ -32,7 +32,7 @@ export const FlagsToolbarMenu = (): JSX.Element => {
         setPayloadEditorOpen,
         clearAllOverrides,
     } = useActions(flagsToolbarLogic)
-    const { apiURL, posthog: posthogClient, toolbarFlagsKey } = useValues(toolbarConfigLogic)
+    const { uiHost, posthog: posthogClient, toolbarFlagsKey } = useValues(toolbarConfigLogic)
     const { openPayloadEditors } = useValues(flagsToolbarLogic)
 
     useOnMountEffect(() => {
@@ -86,7 +86,7 @@ export const FlagsToolbarMenu = (): JSX.Element => {
                                         <div className="flex-1 truncate">
                                             <Link
                                                 className="font-medium"
-                                                to={`${apiURL}${
+                                                to={`${uiHost}${
                                                     feature_flag.id
                                                         ? urls.featureFlag(feature_flag.id)
                                                         : urls.featureFlags()

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -417,12 +417,12 @@ export const productToursLogic = kea<productToursLogicType>([
                 }
 
                 const savedTour = await response.json()
-                const { apiURL } = values
+                const { uiHost } = values
 
                 lemonToast.success(isUpdate ? 'Tour updated' : 'Tour created', {
                     button: {
                         label: 'Open in PostHog',
-                        action: () => window.open(`${apiURL}${urls.productTour(savedTour.id)}`, '_blank'),
+                        action: () => window.open(`${uiHost}${urls.productTour(savedTour.id)}`, '_blank'),
                     },
                 })
                 actions.loadTours()
@@ -434,7 +434,7 @@ export const productToursLogic = kea<productToursLogicType>([
     })),
 
     connect(() => ({
-        values: [toolbarConfigLogic, ['dataAttributes', 'apiURL', 'userIntent', 'productTourId', 'posthog']],
+        values: [toolbarConfigLogic, ['dataAttributes', 'uiHost', 'userIntent', 'productTourId', 'posthog']],
     })),
 
     selectors({

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -39,9 +39,43 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
 
     selectors({
         posthog: [(s) => [s.props], (props) => props.posthog ?? null],
-        apiURL: [
+        // UI host for navigation links (actions, feature flags, experiments, etc.)
+        // Uses posthog.config.ui_host if available, otherwise falls back to props.apiURL for backwards compatibility
+        uiHost: [
             (s) => [s.props],
-            (props: ToolbarProps) => `${props.apiURL?.endsWith('/') ? props.apiURL.replace(/\/+$/, '') : props.apiURL}`,
+            (props: ToolbarProps): string => {
+                if (props.posthog?.config?.ui_host) {
+                    return props.posthog.config.ui_host
+                }
+
+                // Fallback: if apiURL prop is set, use it (backwards compatibility)
+                if (props.apiURL) {
+                    const url = props.apiURL.endsWith('/') ? props.apiURL.replace(/\/+$/, '') : props.apiURL
+                    return url
+                }
+
+                // Final fallback: current origin
+                return window.location.origin
+            },
+        ],
+        // API host for API calls and static assets (CSS)
+        // Uses posthog.config.api_host if available, otherwise falls back to props.apiURL for backwards compatibility
+        apiHost: [
+            (s) => [s.props],
+            (props: ToolbarProps): string => {
+                if (props.posthog?.config?.api_host) {
+                    return props.posthog.config.api_host
+                }
+
+                // Fallback: if apiURL prop is set, use it (backwards compatibility)
+                if (props.apiURL) {
+                    const url = props.apiURL.endsWith('/') ? props.apiURL.replace(/\/+$/, '') : props.apiURL
+                    return url
+                }
+
+                // Final fallback: current origin
+                return window.location.origin
+            },
         ],
         dataAttributes: [(s) => [s.props], (props): string[] => props.dataAttributes ?? []],
         isAuthenticated: [(s) => [s.temporaryToken], (temporaryToken) => !!temporaryToken],
@@ -53,7 +87,8 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
             toolbarPosthogJS.capture('toolbar authenticate', { is_authenticated: values.isAuthenticated })
             const encodedUrl = encodeURIComponent(window.location.href)
             actions.persistConfig()
-            window.location.href = `${values.apiURL}/authorize_and_redirect/?redirect=${encodedUrl}`
+            // Use UI host for auth redirects (SSO/login)
+            window.location.href = `${values.uiHost}/authorize_and_redirect/?redirect=${encodedUrl}`
         },
         logout: () => {
             toolbarPosthogJS.capture('toolbar logout')
@@ -94,6 +129,7 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
                 toolbarPosthogJS.identify(distinctId, props.userEmail ? { email: props.userEmail } : {})
             }
         }
+
         toolbarPosthogJS.capture('toolbar loaded', { is_authenticated: values.isAuthenticated })
     }),
 ])
@@ -111,7 +147,7 @@ export async function toolbarFetch(
     urlConstruction: 'full' | 'use-as-provided' = 'full'
 ): Promise<Response> {
     const temporaryToken = toolbarConfigLogic.findMounted()?.values.temporaryToken
-    const apiURL = toolbarConfigLogic.findMounted()?.values.apiURL
+    const apiHost = toolbarConfigLogic.findMounted()?.values.apiHost
 
     let fullUrl: string
     if (urlConstruction === 'use-as-provided') {
@@ -119,7 +155,7 @@ export async function toolbarFetch(
     } else {
         const { pathname, searchParams } = combineUrl(url)
         const params = { ...searchParams, temporary_token: temporaryToken }
-        fullUrl = `${apiURL}${pathname}${encodeParams(params, '?')}`
+        fullUrl = `${apiHost}${pathname}${encodeParams(params, '?')}`
     }
 
     const payloadData = payload
@@ -160,16 +196,16 @@ export interface ToolbarMediaUploadResponse {
  */
 export async function toolbarUploadMedia(file: File): Promise<{ id: string; url: string; fileName: string }> {
     const temporaryToken = toolbarConfigLogic.findMounted()?.values.temporaryToken
-    const apiURL = toolbarConfigLogic.findMounted()?.values.apiURL
+    const apiHost = toolbarConfigLogic.findMounted()?.values.apiHost
 
-    if (!temporaryToken || !apiURL) {
+    if (!temporaryToken || !apiHost) {
         throw new Error('Toolbar not authenticated')
     }
 
     const formData = new FormData()
     formData.append('image', file)
 
-    const url = `${apiURL}/api/projects/@current/uploaded_media/${encodeParams({ temporary_token: temporaryToken }, '?')}`
+    const url = `${apiHost}/api/projects/@current/uploaded_media/${encodeParams({ temporary_token: temporaryToken }, '?')}`
 
     const response = await fetch(url, {
         method: 'POST',

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -45,13 +45,12 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
             (s) => [s.props],
             (props: ToolbarProps): string => {
                 if (props.posthog?.config?.ui_host) {
-                    return props.posthog.config.ui_host
+                    return props.posthog.config.ui_host.replace(/\/+$/, '')
                 }
 
                 // Fallback: if apiURL prop is set, use it (backwards compatibility)
                 if (props.apiURL) {
-                    const url = props.apiURL.endsWith('/') ? props.apiURL.replace(/\/+$/, '') : props.apiURL
-                    return url
+                    return props.apiURL.replace(/\/+$/, '')
                 }
 
                 // Final fallback: current origin
@@ -64,13 +63,12 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
             (s) => [s.props],
             (props: ToolbarProps): string => {
                 if (props.posthog?.config?.api_host) {
-                    return props.posthog.config.api_host
+                    return props.posthog.config.api_host.replace(/\/+$/, '')
                 }
 
                 // Fallback: if apiURL prop is set, use it (backwards compatibility)
                 if (props.apiURL) {
-                    const url = props.apiURL.endsWith('/') ? props.apiURL.replace(/\/+$/, '') : props.apiURL
-                    return url
+                    return props.apiURL.replace(/\/+$/, '')
                 }
 
                 // Final fallback: current origin

--- a/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.tsx
+++ b/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.tsx
@@ -22,7 +22,7 @@ const ALL_METRICS: WebVitalsMetric[] = ['INP', 'LCP', 'FCP', 'CLS']
 
 export const WebVitalsToolbarMenu = (): JSX.Element => {
     const { localWebVitals, remoteWebVitals } = useValues(webVitalsToolbarLogic)
-    const { posthog, apiURL } = useValues(toolbarConfigLogic)
+    const { posthog, uiHost } = useValues(toolbarConfigLogic)
 
     return (
         <ToolbarMenu>
@@ -73,7 +73,7 @@ export const WebVitalsToolbarMenu = (): JSX.Element => {
 
             <ToolbarMenu.Footer>
                 <div className="flex flex-row justify-between w-full">
-                    <Link to={`${apiURL}${urls.webAnalyticsWebVitals()}`} target="_blank">
+                    <Link to={`${uiHost}${urls.webAnalyticsWebVitals()}`} target="_blank">
                         View all metrics
                     </Link>
                     <Link to="https://posthog.com/docs/web-analytics/web-vitals" target="_blank">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -776,8 +776,10 @@ export type ToolbarSource = 'url' | 'localstorage'
 export type ToolbarVersion = 'toolbar'
 
 export type ExperimentIdType = number | 'new' | 'web'
+
 /* sync with posthog-js */
 export interface ToolbarParams {
+    /** @deprecated, not needed if `posthog` is passed as prop instead */
     apiURL?: string
     token?: string /** public posthog-js token */
     temporaryToken?: string /** private temporary user token */


### PR DESCRIPTION
We made a big mess with `uiHost` and `apiHost` in the toolbar. We're only getting the UI host in the initialization script (look at posthog-js) but we're using it both to redirect to posthog (should be UI Host) and also download CSS (should be API host to match JS assets).

To fix that, rather than looking at the prop we're passing in we can be much smarter and just use the `posthog` instance instead and use the more accurate between `uiHost`/`apiHost`. This means we don't use the prop anymore but we gotta keep it there for older `posthog-js` instances where we don't have access to `posthog`