### PR TITLE
CI and bot feedback

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -697,7 +697,11 @@ const EventContent = React.memo(
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SUMMARIZATION] ||
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
 
-        const showClustersTab = isTraceLevel(event) && featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB]
+        const showClustersTab = !!(
+            event &&
+            isTraceLevel(event) &&
+            featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB]
+        )
 
         // Check if we're viewing a trace with actual content vs. a pseudo-trace (grouping of generations w/o input/output state)
         const isTopLevelTraceWithoutContent = !event || (!isLLMEvent(event) && !event.inputState && !event.outputState)

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -697,6 +697,8 @@ const EventContent = React.memo(
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SUMMARIZATION] ||
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
 
+        const showClustersTab = isTraceLevel(event) && featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB]
+
         // Check if we're viewing a trace with actual content vs. a pseudo-trace (grouping of generations w/o input/output state)
         const isTopLevelTraceWithoutContent = !event || (!isLLMEvent(event) && !event.inputState && !event.outputState)
 
@@ -963,7 +965,7 @@ const EventContent = React.memo(
                                           },
                                       ]
                                     : []),
-                                ...(isTraceLevel(event)
+                                ...(showClustersTab
                                     ? [
                                           {
                                               key: TraceViewMode.Clusters,


### PR DESCRIPTION
## Problem

CI was failing on `PostHog/posthog#44849` due to a TypeScript error (`TS2345`) in `LLMAnalyticsTraceScene.tsx`. The `isTraceLevel(event)` function was being called with an `event` that could be `null`, leading to a type error and a potential runtime crash identified by the Greptile bot.

## Changes

Introduced a null-check for the `event` variable before calling `isTraceLevel(event)` when computing `showClustersTab` in `LLMAnalyticsTraceScene.tsx`. This ensures `isTraceLevel` only receives a non-null argument.

## How did you test this code?

Verified locally by running frontend TypeScript checks after applying the fix. The original PR's CI will also validate this change.

## Publish to changelog?

no

---
<a href="https://cursor.com/background-agent?bcId=bc-0264626d-d126-4489-8617-2b91b6cd4030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0264626d-d126-4489-8617-2b91b6cd4030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

