### PR TITLE
feat(surveys): update summary feedback to use posthog survey

### DIFF
--- a/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
@@ -1,5 +1,5 @@
 import { useValues } from 'kea'
-import posthog from 'posthog-js'
+import { useThumbSurvey } from 'posthog-js/react/surveys'
 import { useCallback, useEffect, useState } from 'react'
 
 import {
@@ -22,6 +22,7 @@ import { surveyLogic } from 'scenes/surveys/surveyLogic'
 
 const MIN_RESPONSES_FOR_SUMMARY = 10
 const NEW_RESPONSES_THRESHOLD = 5
+const OPEN_QUESTION_SUMMARY_SURVEY_ID = '019bb5a3-1677-0000-63dd-00f241c1710a'
 
 interface SummaryData {
     content: string
@@ -48,7 +49,6 @@ export function OpenQuestionSummaryV2({
     const [summary, setSummary] = useState<SummaryData | null>(null)
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<string | null>(null)
-    const [rating, setRating] = useState<'good' | 'bad' | null>(null)
     const [showConsentPopover, setShowConsentPopover] = useState(false)
     const [isExpanded, setIsExpanded] = useState(true)
 
@@ -105,19 +105,18 @@ export function OpenQuestionSummaryV2({
     const handleDismissPopover = (): void => {
         setShowConsentPopover(false)
     }
-
-    const submitRating = (newRating: 'good' | 'bad'): void => {
-        if (rating) {
-            return
-        }
-        setRating(newRating)
-        posthog.capture('ai_survey_summary_rated', {
-            survey_id: survey.id,
-            question_id: questionId,
-            answer_rating: newRating,
+    const {
+        respond: submitRating,
+        response: rating,
+        triggerRef,
+    } = useThumbSurvey({
+        surveyId: OPEN_QUESTION_SUMMARY_SURVEY_ID,
+        properties: {
+            customer_survey_id: survey.id,
+            customer_question_id: questionId,
             $ai_trace_id: summary?.traceId,
-        })
-    }
+        },
+    })
 
     if (!shouldShowSummary) {
         return null
@@ -265,24 +264,24 @@ export function OpenQuestionSummaryV2({
                                 </AIConsentPopoverWrapper>
                             )}
                         </div>
-                        <div className="flex items-center gap-1">
+                        <div className="flex items-center gap-1" ref={triggerRef}>
                             {rating === null && <span>Was this helpful?</span>}
-                            {rating !== 'bad' && (
+                            {rating !== 'down' && (
                                 <LemonButton
-                                    icon={rating === 'good' ? <IconThumbsUpFilled /> : <IconThumbsUp />}
+                                    icon={rating === 'up' ? <IconThumbsUpFilled /> : <IconThumbsUp />}
                                     type="tertiary"
                                     size="xsmall"
                                     tooltip="Good summary"
-                                    onClick={() => submitRating('good')}
+                                    onClick={() => submitRating('up')}
                                 />
                             )}
-                            {rating !== 'good' && (
+                            {rating !== 'up' && (
                                 <LemonButton
-                                    icon={rating === 'bad' ? <IconThumbsDownFilled /> : <IconThumbsDown />}
+                                    icon={rating === 'down' ? <IconThumbsDownFilled /> : <IconThumbsDown />}
                                     type="tertiary"
                                     size="xsmall"
                                     tooltip="Bad summary"
-                                    onClick={() => submitRating('bad')}
+                                    onClick={() => submitRating('down')}
                                 />
                             )}
                         </div>


### PR DESCRIPTION
### update https://us.posthog.com/project/2/surveys/019bb5a3-1677-0000-63dd-00f241c1710a before merging :white_check_mark:

## Problem

survey summaries have user feedback, but it's not routed through posthog surveys (and we own those!!)

depends on https://github.com/PostHog/posthog-js/pull/2882

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

update survey AI summary to use posthog surveys for feedback 😎

tied to https://us.posthog.com/project/2/surveys/019bb5a3-1677-0000-63dd-00f241c1710a, which does not yet actually use thumb rating scale, depends on the prev PR in the stack

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no