### PR TITLE
chore(cdp): cleanup fallback for geoip plugin creation

### DIFF
--- a/posthog/models/test/test_hog_function.py
+++ b/posthog/models/test/test_hog_function.py
@@ -328,31 +328,19 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
         assert transformations.count() == 0
 
     @patch("posthog.plugins.plugin_server_api.get_hog_function_templates")
-    def test_geoip_transformation_fallback_when_sync_fails(self, mock_get_templates):
-        # Mock sync failure
+    def test_geoip_transformation_not_created_when_sync_fails(self, mock_get_templates):
         mock_get_templates.side_effect = Exception("Network error")
 
         with self.settings(DISABLE_MMDB=False):
             team = Team.objects.create_with_data(
-                organization=self.org, name="Test Team Fallback", initiating_user=self.user
+                organization=self.org, name="Test Team Sync Fail", initiating_user=self.user
             )
 
-        # Should have created using fallback method
         transformations = HogFunction.objects.filter(team=team, type="transformation")
-        assert transformations.count() == 1
-        geoip = transformations.first()
-        assert geoip
-        assert geoip.name == "GeoIP"
-        assert geoip.description == "Enrich events with GeoIP data"
-        assert geoip.icon_url == "/static/transformations/geoip.png"
-        assert geoip.enabled
-        assert geoip.execution_order == 1
-        assert geoip.template_id == "plugin-posthog-plugin-geoip"  # Old plugin template ID
-        assert geoip.hog == "return event"  # Simple hog code for fallback
+        assert transformations.count() == 0
 
     @patch("posthog.plugins.plugin_server_api.get_hog_function_templates")
-    def test_geoip_transformation_fallback_when_template_not_found(self, mock_get_templates):
-        # Mock empty response (no templates)
+    def test_geoip_transformation_not_created_when_template_not_found(self, mock_get_templates):
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = []
@@ -363,18 +351,11 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
                 organization=self.org, name="Test Team No Template", initiating_user=self.user
             )
 
-        # Should have created using fallback method
         transformations = HogFunction.objects.filter(team=team, type="transformation")
-        assert transformations.count() == 1
-        geoip = transformations.first()
-        assert geoip
-        assert geoip.name == "GeoIP"
-        assert geoip.description == "Enrich events with GeoIP data"
-        assert geoip.template_id == "plugin-posthog-plugin-geoip"
+        assert transformations.count() == 0
 
     @patch("posthog.plugins.plugin_server_api.get_hog_function_templates")
-    def test_geoip_transformation_fallback_when_hog_code_invalid(self, mock_get_templates):
-        # Mock template with invalid Hog code that will fail validation
+    def test_geoip_transformation_not_created_when_hog_code_invalid(self, mock_get_templates):
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = [
@@ -383,7 +364,7 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
                 "name": "GeoIP",
                 "description": "Adds geoip data to the event",
                 "type": "transformation",
-                "code": "invalid {{ hog code that will fail",  # Invalid code
+                "code": "invalid {{ hog code that will fail",
                 "inputs_schema": [],
                 "status": "stable",
                 "free": True,
@@ -399,14 +380,8 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
                 organization=self.org, name="Test Team Invalid Code", initiating_user=self.user
             )
 
-        # Should have created using fallback method due to validation failure
         transformations = HogFunction.objects.filter(team=team, type="transformation")
-        assert transformations.count() == 1
-        geoip = transformations.first()
-        assert geoip
-        assert geoip.name == "GeoIP"
-        assert geoip.template_id == "plugin-posthog-plugin-geoip"  # Fallback template
-        assert geoip.hog == "return event"  # Simple valid code
+        assert transformations.count() == 0
 
     def test_hog_function_file_system(self):
         hog_function_3 = HogFunction.objects.create(


### PR DESCRIPTION
## Problem

Graphs look all good 

<img width="1339" height="199" alt="Screenshot 2026-01-13 at 10 14 27" src="https://github.com/user-attachments/assets/2b502095-119c-49d0-8d37-890abbd0083a" />

let's clean this up.

## Changes

- cleans up falling back to old plugin creation
- keeps counter for completely failed geo ip transformation creation so we can alert on it

## How did you test this code?

- adjusted tests