### PR TITLE
fix: team delete with already deleted batch export

### DIFF
--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -2,10 +2,14 @@ import time
 from datetime import timedelta
 from typing import Any
 
+import structlog
+
 from posthog.batch_exports.service import BatchExportServiceScheduleNotFound, batch_export_delete_schedule
 from posthog.cache_utils import cache_for
 from posthog.models.async_migration import is_async_migration_complete
 from posthog.temporal.common.client import sync_connect
+
+logger = structlog.get_logger(__name__)
 
 actions_that_require_current_team = [
     "rotate_secret_token",
@@ -113,9 +117,11 @@ def delete_batch_exports(team_ids: list[int]):
 
         try:
             batch_export_delete_schedule(temporal, str(schedule_id))
-        except BatchExportServiceScheduleNotFound:
-            # Schedule may have been manually deleted
-            pass
+        except BatchExportServiceScheduleNotFound as e:
+            logger.warning(
+                "Schedule not found during team deletion",
+                schedule_id=e.schedule_id,
+            )
 
 
 can_enable_actor_on_events = False


### PR DESCRIPTION
## Problem

Project deletion fails when batch exports were previously deleted:
https://posthoghelp.zendesk.com/agent/tickets/46442 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49771)

Error: `workflow not found for ID: temporal-sys-scheduler:0196cdba-59c1-0001-3ef7-355ef9a63b86`

## Changes
- Filter out soft-deleted batch exports (`deleted=False`)
- Handle `BatchExportServiceScheduleNotFound` exception for edge cases

> NOTE: The fix handles the case where batch export Temporal schedules are missing, but I'm not entirely clear on the root cause. There may be an issue with cascade deletion for batch exports, or somehow we're ending up with orphaned records without Temporal schedules.