### PR TITLE
fix(app-metrics): handle division by zero in percentage display

### DIFF
--- a/frontend/src/lib/components/AppMetrics/AppMetricSummary.tsx
+++ b/frontend/src/lib/components/AppMetrics/AppMetricSummary.tsx
@@ -48,6 +48,11 @@ export function AppMetricSummary({
     }, [previousPeriodTimeSeries])
 
     const diff = (total - totalPreviousPeriod) / totalPreviousPeriod
+    const diffForDisplay = isNaN(diff)
+        ? null
+        : diff > 0
+          ? `(+${(diff * 100).toFixed(1)}%)`
+          : `(-${(-diff * 100).toFixed(1)}%)`
 
     // Hide component if hideIfZero is true and there's no data
     if (hideIfZero && !loading && total === 0 && totalPreviousPeriod === 0) {
@@ -65,11 +70,7 @@ export function AppMetricSummary({
                 )}
             </div>
             <div className="flex flex-row justify-end items-center gap-2 text-xs text-muted">
-                {loading ? (
-                    <LemonSkeleton className="w-10 h-4" />
-                ) : (
-                    <>{diff > 0 ? ` (+${(diff * 100).toFixed(1)}%)` : ` (-${(-diff * 100).toFixed(1)}%)`}</>
-                )}
+                {loading ? <LemonSkeleton className="w-10 h-4" /> : <>{diffForDisplay}</>}
             </div>
 
             <div className="flex-1 mt-2">

--- a/frontend/src/lib/components/AppMetrics/AppMetricSummary.tsx
+++ b/frontend/src/lib/components/AppMetrics/AppMetricSummary.tsx
@@ -48,7 +48,7 @@ export function AppMetricSummary({
     }, [previousPeriodTimeSeries])
 
     const diff = (total - totalPreviousPeriod) / totalPreviousPeriod
-    const diffForDisplay = isNaN(diff)
+    const diffForDisplay = !isFinite(diff)
         ? null
         : diff > 0
           ? `(+${(diff * 100).toFixed(1)}%)`


### PR DESCRIPTION
## Problem
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #44576 
Workflow metrics show "-NaN%" in some cases due to division by zero
## Changes

- Check if metric difference is a real number and only display it if it is.
- Reduce complexity in the return statement by extracting the formatting logic for the percentage difference.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- Open workflow tab on a blank project (therefore all metrics are 0), no percentage differences are shown anymore.
- Modify the metrics so there is a relative difference to be calculated -> percentage difference is shown normally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->




<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
