### PR TITLE
fix: hypercache does not match remote config

### DIFF
--- a/posthog/storage/team_metadata_cache.py
+++ b/posthog/storage/team_metadata_cache.py
@@ -140,7 +140,15 @@ def _serialize_team_field(field: str, value: Any) -> Any:
     elif field == "organization_id":
         return str(value) if value else None
     elif field == "session_recording_sample_rate":
-        return float(value) if value is not None else None
+        # Match the logic in decide.py and remote_config.py:
+        # - Convert Decimal to string directly (preserves precision like "1.00")
+        # - Return None for 100% sampling (no sampling needed)
+        if value is not None:
+            str_value = str(value)
+            if str_value == "1.00":
+                return None
+            return str_value
+        return None
     return value
 
 

--- a/posthog/storage/test/test_team_metadata_cache.py
+++ b/posthog/storage/test/test_team_metadata_cache.py
@@ -2,6 +2,7 @@
 Tests for team metadata HyperCache functionality.
 """
 
+from decimal import Decimal
 from typing import Any
 
 from posthog.test.base import BaseTest
@@ -9,9 +10,12 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+from parameterized import parameterized
+
 from posthog.models.team.team import Team
 from posthog.storage.team_metadata_cache import (
     TEAM_METADATA_FIELDS,
+    _serialize_team_field,
     clear_team_metadata_cache,
     get_team_metadata,
     get_teams_with_expiring_caches,
@@ -464,3 +468,59 @@ class TestTeamMetadataGracePeriod(BaseTest):
         from posthog.storage.team_metadata_cache import TEAM_HYPERCACHE_MANAGEMENT_CONFIG
 
         self.assertIsNotNone(TEAM_HYPERCACHE_MANAGEMENT_CONFIG.get_team_ids_to_skip_fix_fn)
+
+
+class TestSampleRateSerializationForRustCompatibility(BaseTest):
+    """
+    Test that session_recording_sample_rate serialization is compatible with Rust.
+
+    The Rust flags service (session_recording.rs) compares sr.to_string() against "1.00"
+    to decide whether to return null for 100% sampling.
+
+    For the cache path, we store None directly for 100% sampling to avoid precision issues
+    when Rust deserializes floats. For other values, we store strings with fixed precision.
+
+    See: rust/feature-flags/src/handler/session_recording.rs:18 (SAMPLE_RATE_FULL = "1.00")
+    """
+
+    @parameterized.expand(
+        [
+            # 100% sampling should be None (no sampling = record everything)
+            ("100% should serialize to None (no sampling needed)", Decimal("1.00"), None),
+            # Other values should be strings with 2 decimal places for Rust compatibility
+            ("80% should be string with precision", Decimal("0.80"), "0.80"),
+            ("50% should be string with precision", Decimal("0.50"), "0.50"),
+            ("0% should be string '0.00'", Decimal("0.00"), "0.00"),
+            ("None should remain None", None, None),
+        ]
+    )
+    def test_sample_rate_serialization_matches_rust_expectations(
+        self, _name: str, db_value: Decimal | None, expected: str | None
+    ) -> None:
+        """
+        Verify sample rate serialization produces values compatible with Rust.
+
+        - 100% (1.00) should become None so Rust returns null to SDKs
+        - Other values should be strings like "0.80" so Rust can pass them through
+        - None should remain None
+        """
+        result = _serialize_team_field("session_recording_sample_rate", db_value)
+
+        assert result == expected
+
+    def test_sample_rate_schema_prevents_more_than_two_decimal_places(self) -> None:
+        """
+        Verify the DB schema prevents storing values with more than 2 decimal places.
+
+        This is a regression test - our serialization logic relies on the fact that
+        values like 0.996 (which would round to "1.00" as a string) cannot be stored.
+        If this test fails, the serialization logic needs to handle rounding.
+        """
+        from django.core.exceptions import ValidationError
+
+        self.team.session_recording_sample_rate = Decimal("0.996")
+
+        with self.assertRaises(ValidationError) as context:
+            self.team.full_clean()
+
+        self.assertIn("session_recording_sample_rate", str(context.exception))


### PR DESCRIPTION
within minutes of the flags service changing to use the hypercache

we were incorrectly recording _millions_ of recordings

because the return values were not the same for the service before and after the change

previously a value of 1.00 for sample rate was correctly returned to the SDKs as "sampling is not onfigured"

now we would return "sampling is configured, return everything"

🫠

this is very wrong, and giving a bad time to users