### PR TITLE
fix: on /ai route don't navigate with suggestion click

### DIFF
--- a/frontend/src/scenes/max/components/FloatingSuggestionsDisplay.tsx
+++ b/frontend/src/scenes/max/components/FloatingSuggestionsDisplay.tsx
@@ -4,6 +4,7 @@ import { router } from 'kea-router'
 import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import { cn } from 'lib/utils/css-classes'
+import { removeProjectIdIfPresent } from 'lib/utils/router-utils'
 
 import { QUESTION_SUGGESTIONS_DATA, SuggestionGroup, maxLogic } from '../maxLogic'
 import { maxThreadLogic } from '../maxThreadLogic'
@@ -17,8 +18,10 @@ function useSuggestionHandling(): {
     const { askMax } = useActions(maxThreadLogic)
 
     const handleSuggestionGroupClick = (group: SuggestionGroup): void => {
-        // If it's a product-based skill, open the URL first
-        if (group.url && !router.values.currentLocation.pathname.includes(group.url)) {
+        // If it's a product-based skill, open the URL first (but not when on /ai route)
+        const cleanPath = removeProjectIdIfPresent(router.values.currentLocation.pathname)
+        const isOnAiRoute = cleanPath.startsWith('/ai')
+        if (group.url && !isOnAiRoute && !cleanPath.includes(group.url)) {
             router.actions.push(group.url)
         }
 


### PR DESCRIPTION
## Problem
When on `/ai` clicking things like "session replay" will navigate to `/replay`

## Changes
When on `/ai` clicking a suggestion doesn't route and just fills input

## How did you test this code?
Locally

## Publish to changelog?
No