### PR TITLE
fix(embed): process messages concurrently

### DIFF
--- a/rust/embedding-worker/src/lib.rs
+++ b/rust/embedding-worker/src/lib.rs
@@ -48,7 +48,8 @@ pub async fn handle_batch(
         handles.push(async move {
             let mut results = vec![];
             for model in &request.models {
-                let (model, embedding) = handle_single(ctx.clone(), *model, request.clone()).await?;
+                let (model, embedding) =
+                    handle_single(ctx.clone(), *model, request.clone()).await?;
                 results.push(ModelResult {
                     model,
                     outcome: EmbeddingResult::Success { embedding },


### PR DESCRIPTION
The embedding worker went down in late december (root cause unclear, maybe an openai outage or something transient), and while down, managed to build up enough lag that it never recovered. I though that might have been because fetching the input messages from MSK's tiered storage was too slow, and caused the worker to stall, but after running some tests in prod, the actual problem is that the combination of sequential message processing and full batches (due to the built up lag from the transient outage) made the worker stall for more than 30 seconds while processing a single batch. I could reduce the batch size, but the worker already responds to openai rate limits, so it seems more sensible to just make it rip.