### PR TITLE
chore(flags): add more device_id logging

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -900,6 +900,37 @@ impl FeatureFlagMatcher {
             });
         }
         // For person-based flags, empty distinct_id is valid and should continue evaluation
+        if flag.get_group_type_index().is_none() {
+            use crate::flags::flag_models::BucketingIdentifier;
+
+            if flag.get_bucketing_identifier() == BucketingIdentifier::DeviceId {
+                if let Some(device_id) = &self.device_id {
+                    if !device_id.is_empty() {
+                        with_canonical_log(|log| log.flags_device_id_bucketing += 1);
+                    } else {
+                        with_canonical_log(|log| {
+                            tracing::warn!(
+                                flag_key = %flag.key,
+                                team_id = %flag.team_id,
+                                lib = log.lib,
+                                lib_version = log.lib_version.as_deref(),
+                                "Flag configured for device_id bucketing but no device_id provided, falling back to distinct_id"
+                            );
+                        });
+                    }
+                } else {
+                    with_canonical_log(|log| {
+                        tracing::warn!(
+                            flag_key = %flag.key,
+                            team_id = %flag.team_id,
+                            lib = log.lib,
+                            lib_version = log.lib_version.as_deref(),
+                            "Flag configured for device_id bucketing but no device_id provided, falling back to distinct_id"
+                        );
+                    });
+                }
+            }
+        }
 
         let mut highest_match = FeatureFlagMatchReason::NoConditionMatch;
         let mut highest_index = None;
@@ -1300,28 +1331,9 @@ impl FeatureFlagMatcher {
             if feature_flag.get_bucketing_identifier() == BucketingIdentifier::DeviceId {
                 if let Some(device_id) = &self.device_id {
                     if !device_id.is_empty() {
-                        with_canonical_log(|log| log.flags_device_id_bucketing += 1);
                         return Ok(device_id.clone());
                     }
                 }
-                // If device_id bucketing is set but no device_id provided,
-                // fall through to hash_key_overrides or distinct_id
-                let (lib, lib_version) = {
-                    let mut lib: Option<&'static str> = None;
-                    let mut lib_version: Option<String> = None;
-                    with_canonical_log(|log| {
-                        lib = log.lib;
-                        lib_version = log.lib_version.clone();
-                    });
-                    (lib, lib_version)
-                };
-                tracing::warn!(
-                    flag_key = %feature_flag.key,
-                    team_id = %feature_flag.team_id,
-                    lib = lib,
-                    lib_version = lib_version.as_deref(),
-                    "Flag configured for device_id bucketing but no device_id provided, falling back to distinct_id"
-                );
             }
 
             // Use hash key overrides for experience continuity

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1306,9 +1306,20 @@ impl FeatureFlagMatcher {
                 }
                 // If device_id bucketing is set but no device_id provided,
                 // fall through to hash_key_overrides or distinct_id
+                let (lib, lib_version) = {
+                    let mut lib: Option<&'static str> = None;
+                    let mut lib_version: Option<String> = None;
+                    with_canonical_log(|log| {
+                        lib = log.lib;
+                        lib_version = log.lib_version.clone();
+                    });
+                    (lib, lib_version)
+                };
                 tracing::warn!(
                     flag_key = %feature_flag.key,
                     team_id = %feature_flag.team_id,
+                    lib = lib,
+                    lib_version = lib_version.as_deref(),
                     "Flag configured for device_id bucketing but no device_id provided, falling back to distinct_id"
                 );
             }

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1300,6 +1300,7 @@ impl FeatureFlagMatcher {
             if feature_flag.get_bucketing_identifier() == BucketingIdentifier::DeviceId {
                 if let Some(device_id) = &self.device_id {
                     if !device_id.is_empty() {
+                        with_canonical_log(|log| log.flags_device_id_bucketing += 1);
                         return Ok(device_id.clone());
                     }
                 }

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -91,6 +91,8 @@ pub struct FlagsCanonicalLogLine {
     // Populated during flag evaluation
     pub flags_evaluated: usize,
     pub flags_experience_continuity: usize,
+    /// Number of flags that used device_id for bucketing (instead of distinct_id).
+    pub flags_device_id_bucketing: usize,
     pub flags_disabled: bool,
     pub quota_limited: bool,
     /// Source of the flags data: "Redis", "S3", or "Fallback" (PostgreSQL).
@@ -152,6 +154,7 @@ impl Default for FlagsCanonicalLogLine {
             device_id: None,
             flags_evaluated: 0,
             flags_experience_continuity: 0,
+            flags_device_id_bucketing: 0,
             flags_disabled: false,
             quota_limited: false,
             flags_cache_source: None,
@@ -208,6 +211,7 @@ impl FlagsCanonicalLogLine {
             http_status = self.http_status,
             flags_evaluated = self.flags_evaluated,
             flags_experience_continuity = self.flags_experience_continuity,
+            flags_device_id_bucketing = self.flags_device_id_bucketing,
             flags_disabled = self.flags_disabled,
             quota_limited = self.quota_limited,
             flags_cache_source = self.flags_cache_source,
@@ -267,6 +271,7 @@ mod tests {
         assert!(log.device_id.is_none());
         assert_eq!(log.flags_evaluated, 0);
         assert_eq!(log.flags_experience_continuity, 0);
+        assert_eq!(log.flags_device_id_bucketing, 0);
         assert!(!log.flags_disabled);
         assert!(!log.quota_limited);
         assert!(log.flags_cache_source.is_none());
@@ -308,6 +313,7 @@ mod tests {
         log.device_id = Some("device_123".to_string());
         log.flags_evaluated = 10;
         log.flags_experience_continuity = 2;
+        log.flags_device_id_bucketing = 3;
         log.flags_disabled = false;
         log.quota_limited = true;
         log.flags_cache_source = Some("redis");


### PR DESCRIPTION
## Problem

When debugging feature flag evaluation issues related to device_id bucketing, we lacked visibility into:
  1. How many flags are actually using device_id for bucketing in each request
  2. Which SDK libraries/versions are failing to send the device_id field when flags are configured for device_id bucketing

## Changes

- Add flags_device_id_bucketing counter to the canonical log line that tracks how many flags successfully used device_id for bucketing during a request
 - Enhance the fallback warning log (when a flag is configured for device_id bucketing but no device_id is provided) to include lib and lib_version fields, making it easier to identify which SDKs need updates

## How did you test this code?

- Tests passes