### PR TITLE
feat(experiments): adding cross-sell tab to feature flags.

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -261,6 +261,7 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING_SPIKE_ALERTING: 'error-tracking-spike-alerting', // owner: #team-error-tracking
     EXPERIMENT_AI_SUMMARY: 'experiment-ai-summary', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_BREAKDOWN_FILTER: 'experiments-breakdown-filter', // owner: @rodrigoi #team-experiments
+    EXPERIMENTS_FF_CROSS_SELL: 'experiments-ff-cross-sell', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_NEW_CALCULATOR: 'experiments-new-calculator', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_EXPOSURE_CRITERIA_COLLAPSABLE: 'experiments-exposure-criteria-collapsable', // owner: #team-experiments

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -101,6 +101,7 @@ import {
 import { FeatureFlagCodeExample } from './FeatureFlagCodeExample'
 import { FeatureFlagConditionWarning } from './FeatureFlagConditionWarning'
 import { FeatureFlagEvaluationTags } from './FeatureFlagEvaluationTags'
+import { ExperimentsTab } from './FeatureFlagExperimentsTab'
 import { FeedbackTab } from './FeatureFlagFeedbackTab'
 import FeatureFlagProjects from './FeatureFlagProjects'
 import { FeatureFlagReleaseConditions } from './FeatureFlagReleaseConditions'
@@ -298,6 +299,21 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
         key: FeatureFlagsTab.FEEDBACK,
         content: <FeedbackTab featureFlag={featureFlag} />,
     })
+
+    if (featureFlags[FEATURE_FLAGS.EXPERIMENTS_FF_CROSS_SELL]) {
+        tabs.push({
+            label: (
+                <div className="flex flex-row">
+                    <div>Experiments</div>
+                    <LemonTag className="ml-2 float-right uppercase" type="primary">
+                        New
+                    </LemonTag>
+                </div>
+            ),
+            key: FeatureFlagsTab.EXPERIMENTS,
+            content: <ExperimentsTab featureFlag={featureFlag} />,
+        })
+    }
 
     return (
         <>

--- a/frontend/src/scenes/feature-flags/FeatureFlagExperimentsTab.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagExperimentsTab.tsx
@@ -1,0 +1,86 @@
+import { useValues } from 'kea'
+
+import { IconArrowRight } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonTable, Link } from '@posthog/lemon-ui'
+
+import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { createdAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+import stringWithWBR from 'lib/utils/stringWithWBR'
+import { StatusTag } from 'scenes/experiments/ExperimentView/components'
+import { experimentsLogic, getExperimentStatus } from 'scenes/experiments/experimentsLogic'
+import { urls } from 'scenes/urls'
+
+import { Experiment, FeatureFlagType } from '~/types'
+
+export function ExperimentsTab({ featureFlag }: { featureFlag: FeatureFlagType }): JSX.Element {
+    const { experiments } = useValues(experimentsLogic)
+    const experimentIds = featureFlag.experiment_set || []
+    const relatedExperiments = experiments.results.filter(
+        (exp) => typeof exp.id === 'number' && experimentIds.includes(exp.id)
+    )
+
+    if (experimentIds.length === 0) {
+        return (
+            <div className="flex flex-col items-center pt-5">
+                <div className="w-full max-w-5xl">
+                    <LemonBanner type="info" className="mb-6">
+                        Create an experiment using this feature flag to test different variants and measure their impact
+                    </LemonBanner>
+                    <div className="border rounded p-6 bg-bg-light flex flex-col items-center gap-4">
+                        <div className="text-muted text-center">
+                            No experiments are using this feature flag yet. Create one to start testing variants.
+                        </div>
+                        <LemonButton type="primary" to={urls.experiment('new')}>
+                            Create experiment
+                        </LemonButton>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-6">
+            <LemonBanner type="info">
+                Showing experiments associated with this feature flag.{' '}
+                <Link to={urls.experiments()}>
+                    See all experiments <IconArrowRight />
+                </Link>
+            </LemonBanner>
+
+            <LemonTable
+                dataSource={relatedExperiments}
+                defaultSorting={{
+                    columnKey: 'created_at',
+                    order: -1,
+                }}
+                rowKey="id"
+                nouns={['experiment', 'experiments']}
+                data-attr="experiments-table"
+                columns={[
+                    {
+                        dataIndex: 'name',
+                        title: 'Name',
+                        render: function RenderName(_, experiment: Experiment) {
+                            return (
+                                <LemonTableLink
+                                    to={urls.experiment(experiment.id)}
+                                    title={stringWithWBR(experiment.name, 17)}
+                                />
+                            )
+                        },
+                    },
+                    {
+                        title: 'Status',
+                        dataIndex: 'id',
+                        render: function RenderStatus(_, experiment: Experiment) {
+                            const status = getExperimentStatus(experiment)
+                            return <StatusTag status={status} />
+                        },
+                    },
+                    createdAtColumn() as any,
+                ]}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/feature-flags/FeatureFlagExperimentsTab.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagExperimentsTab.tsx
@@ -5,6 +5,7 @@ import { LemonBanner, LemonButton, LemonTable, Link } from '@posthog/lemon-ui'
 
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { createdAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+import type { LemonTableColumn } from 'lib/lemon-ui/LemonTable/types'
 import stringWithWBR from 'lib/utils/stringWithWBR'
 import { StatusTag } from 'scenes/experiments/ExperimentView/components'
 import { experimentsLogic, getExperimentStatus } from 'scenes/experiments/experimentsLogic'
@@ -14,12 +15,11 @@ import { Experiment, FeatureFlagType } from '~/types'
 
 export function ExperimentsTab({ featureFlag }: { featureFlag: FeatureFlagType }): JSX.Element {
     const { experiments } = useValues(experimentsLogic)
-    const experimentIds = featureFlag.experiment_set || []
-    const relatedExperiments = experiments.results.filter(
-        (exp) => typeof exp.id === 'number' && experimentIds.includes(exp.id)
+    const relatedExperiments = experiments.results.filter((exp) =>
+        featureFlag.experiment_set?.includes(exp.id as number)
     )
 
-    if (experimentIds.length === 0) {
+    if (relatedExperiments.length === 0) {
         return (
             <div className="flex flex-col items-center pt-5">
                 <div className="w-full max-w-5xl">
@@ -78,7 +78,7 @@ export function ExperimentsTab({ featureFlag }: { featureFlag: FeatureFlagType }
                             return <StatusTag status={status} />
                         },
                     },
-                    createdAtColumn() as any,
+                    createdAtColumn<Experiment>() as LemonTableColumn<Experiment, keyof Experiment | undefined>,
                 ]}
             />
         </div>

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -29,6 +29,7 @@ export enum FeatureFlagsTab {
     PROJECTS = 'projects',
     SCHEDULE = 'schedule',
     FEEDBACK = 'feedback',
+    EXPERIMENTS = 'experiments',
 }
 
 export interface FeatureFlagsResult extends CountedPaginatedResponse<FeatureFlagType> {


### PR DESCRIPTION
## Problem

Although tigtly coupled, there are very few points of contact in the UI between experiments and feature flags. And most are in the experiment side.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are adding a new _Experiments_ tab on the feature flag details scene so we can start performing some experiment management actions (listing linked experiments to a feature flag, create new experiments, etc).

This is just the skeleton, hidden behind a feature flag.

| experiments tab on a feature flag |
| - |
|  <img width="1297" height="771" alt="image" src="https://github.com/user-attachments/assets/40321f5f-d2e2-4148-9e91-16b408cdaea2" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/7e902263-c924-430f-9070-12ba92395cf8)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
