### PR TITLE
fix(data-warehouse): exclude managed viewsets from alerts

### DIFF
--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -461,12 +461,17 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         try:
             results = []
 
-            # Get failed materializations from DataWarehouseSavedQuery
-            failed_materializations = DataWarehouseSavedQuery.objects.filter(
-                team_id=self.team_id,
-                deleted=False,
-            ).filter(
-                Q(status=DataWarehouseSavedQuery.Status.FAILED) | Q(is_materialized=False, latest_error__isnull=False)
+            # Get failed materializations from DataWarehouseSavedQuery (excluding managed viewsets like revenue analytics)
+            failed_materializations = (
+                DataWarehouseSavedQuery.objects.filter(
+                    team_id=self.team_id,
+                    deleted=False,
+                )
+                .exclude(origin=DataWarehouseSavedQuery.Origin.MANAGED_VIEWSET)
+                .filter(
+                    Q(status=DataWarehouseSavedQuery.Status.FAILED)
+                    | Q(is_materialized=False, latest_error__isnull=False)
+                )
             )
 
             for query in failed_materializations:


### PR DESCRIPTION
## Problem

Customers are seeing alerts in the Pipeline status side panel for failed materialized views that were automatically created by PostHog (e.g., for revenue analytics). These managed views are not user-created and users cannot directly manage or fix them, so showing these failures creates confusion and unnecessary noise in the pipeline status alerts.

Here's a ticket where a user experienced this issue: https://posthoghelp.zendesk.com/agent/tickets/46922 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49027)

## Changes

Excludes materialized views with origin=managed_viewset from the data_health_issues API endpoint. This ensures only user-created materialized views (from the data warehouse UI or API) appear in the Pipeline status panel when they fail. PostHog-managed views like revenue analytics are now filtered out.

## How did you test this code?

This hasn't been tested.

## Publish to changelog?

no