### PR TITLE
fix: restrict playground usage

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5170,6 +5170,22 @@ const api = {
                         onError(new RateLimitError(parseInt(retryAfter, 10)))
                         abortController.abort()
                     }
+                } else if (!response.ok) {
+                    let errorData: any = {}
+                    try {
+                        errorData = await response.json()
+                    } catch {
+                        // If JSON parsing fails, leave errorData empty
+                    }
+                    onError(
+                        new ApiError(
+                            errorData.error || `Request failed with status ${response.status}`,
+                            response.status,
+                            response.headers,
+                            errorData
+                        )
+                    )
+                    abortController.abort()
                 }
             },
             onmessage: onMessage,

--- a/products/llm_analytics/backend/api/proxy.py
+++ b/products/llm_analytics/backend/api/proxy.py
@@ -130,6 +130,13 @@ class LLMProxyViewSet(viewsets.ViewSet):
             if not request.user or not request.user.is_authenticated:
                 return Response({"error": "You are not authorized to use this feature"}, status=401)
 
+            organization = request.user.organization
+            if not organization or not organization.customer_id:
+                return Response(
+                    {"error": "The playground requires a valid payment method on file to prevent abuse."},
+                    status=402,
+                )
+
             serializer = serializer_class(data=request.data)
             if not serializer.is_valid():
                 return Response({"error": serializer.errors}, status=400)

--- a/products/llm_analytics/frontend/LLMAnalyticsPlaygroundScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsPlaygroundScene.tsx
@@ -14,6 +14,7 @@ import {
     LemonTableColumns,
     LemonTag,
     LemonTextArea,
+    Link,
 } from '@posthog/lemon-ui'
 
 import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
@@ -63,10 +64,29 @@ function RateLimitBanner(): JSX.Element | null {
     )
 }
 
+function SubscriptionRequiredBanner(): JSX.Element | null {
+    const { subscriptionRequired } = useValues(llmAnalyticsPlaygroundLogic)
+
+    if (!subscriptionRequired && false) {
+        return null
+    }
+
+    return (
+        <LemonBanner type="warning" className="mb-4">
+            The playground requires a{' '}
+            <Link to="/organization/billing" className="font-semibold">
+                valid payment method
+            </Link>{' '}
+            on file to prevent abuse.
+        </LemonBanner>
+    )
+}
+
 function PlaygroundLayout(): JSX.Element {
     return (
         <div className="flex flex-col min-h-[calc(100vh-120px)] relative">
             <RateLimitBanner />
+            <SubscriptionRequiredBanner />
 
             {/* Main conversation area - full width */}
             <div className="flex flex-col border rounded overflow-hidden flex-1">


### PR DESCRIPTION
Uses the presence of `customer_id` as a proxy to determine whether the org is Free vs PAYG or subscribed. Did not find any other method to easily check for this on the backend without major changes. Should allow us to filter out bot accounts.