### PR TITLE
fix(data-modeling): fix "no log files" error from deltalake 

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -545,9 +545,6 @@ async def materialize_model(
 
         if delta_table is None:
             error_message = "Query returned no results. Check that the query returns data before materializing."
-            saved_query.latest_error = error_message
-            await database_sync_to_async(saved_query.save)()
-            await mark_job_as_failed(job, error_message, logger)
             raise NonRetryableException(f"Query for model {model_label} failed: {error_message}")
     except Exception as e:
         error_message = str(e)

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -544,12 +544,14 @@ async def materialize_model(
         await logger.adebug(f"Finished writing to delta table. row_count={row_count}")
 
         if delta_table is None:
-            delta_table = deltalake.DeltaTable(table_uri=table_uri, storage_options=storage_options)
+            error_message = "Query returned no results. Check that the query returns data before materializing."
+            saved_query.latest_error = error_message
+            await database_sync_to_async(saved_query.save)()
+            await mark_job_as_failed(job, error_message, logger)
+            raise NonRetryableException(f"Query for model {model_label} failed: {error_message}")
     except Exception as e:
         error_message = str(e)
-
         await logger.aerror(f"Error materializing model {model_label}: {error_message}")
-
         if "Query exceeds memory limits" in error_message:
             error_message = f"Query exceeded memory limit. Try reducing its scope by changing the time range."
             saved_query.latest_error = error_message
@@ -609,7 +611,9 @@ async def materialize_model(
             await logger.aerror("Failed to materialize model with unexpected error: %s", str(e))
             await database_sync_to_async(saved_query.save)()
             await mark_job_as_failed(job, error_message, logger)
-            raise Exception(f"Failed to materialize model {model_label}: {error_message}") from e
+            if isinstance(e, NonRetryableException):
+                raise NonRetryableException(error_message)
+            raise Exception(error_message) from e
 
     data_modeling_job = await database_sync_to_async(DataModelingJob.objects.get)(id=job.id)
     if data_modeling_job.status == DataModelingJob.Status.CANCELLED:

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -35,6 +35,7 @@ from posthog.temporal.data_modeling.run_workflow import (
     CleanupRunningJobsActivityInputs,
     CreateJobModelInputs,
     ModelNode,
+    NonRetryableException,
     RunDagActivityInputs,
     RunWorkflow,
     RunWorkflowInputs,
@@ -1643,6 +1644,57 @@ async def test_materialize_model_with_plain_datetime(ateam, bucket_name, minio_c
 
         await database_sync_to_async(job.refresh_from_db)()
         assert job.status == DataModelingJob.Status.COMPLETED
+
+
+async def test_materialize_model_empty_results(ateam, bucket_name, minio_client):
+    """Test that materialize_model raises NonRetryableException when query returns no results."""
+    query = "SELECT 1 as test_column FROM events WHERE 1 = 0"
+    saved_query = await DataWarehouseSavedQuery.objects.acreate(
+        team=ateam,
+        name="empty_results_test_model",
+        query={"query": query, "kind": "HogQLQuery"},
+    )
+
+    async def mock_hogql_table(*args, **kwargs):
+        return
+        yield  # makes this a generator but nothing is ever yielded because of the return
+
+    with (
+        override_settings(
+            BUCKET_URL=f"s3://{bucket_name}",
+            DATAWAREHOUSE_LOCAL_ACCESS_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+            DATAWAREHOUSE_LOCAL_ACCESS_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+            DATAWAREHOUSE_LOCAL_BUCKET_REGION="us-east-1",
+            DATAWAREHOUSE_BUCKET_DOMAIN="objectstorage:19000",
+        ),
+        unittest.mock.patch("posthog.temporal.data_modeling.run_workflow.hogql_table", mock_hogql_table),
+        unittest.mock.patch("posthog.temporal.data_modeling.run_workflow.get_query_row_count", return_value=0),
+    ):
+        job = await database_sync_to_async(DataModelingJob.objects.create)(
+            team=ateam,
+            status=DataModelingJob.Status.RUNNING,
+            workflow_id="test_workflow",
+        )
+
+        with pytest.raises(NonRetryableException) as exc_info:
+            await materialize_model(
+                saved_query.id.hex,
+                ateam,
+                saved_query,
+                job,
+                unittest.mock.AsyncMock(),
+            )
+
+        assert "returned no results" in str(exc_info.value)
+
+        await database_sync_to_async(job.refresh_from_db)()
+        assert job.status == DataModelingJob.Status.FAILED
+        assert job.error is not None
+        assert "returned no results" in job.error
+
+        await database_sync_to_async(saved_query.refresh_from_db)()
+        assert saved_query.latest_error is not None
+        assert "returned no results" in saved_query.latest_error
 
 
 child_ducklake_workflow_runs: list[dict] = []


### PR DESCRIPTION
## Problem

When a matview is synced the following was happening:

1. the s3 table is deleted (including deltalake log files)
2. the query is run and iterated over to materialize data into the s3 bucket
3. if the delta table is still none (not initialized during the above iterating) it is created directly using the s3 uri

however, this fails because the s3 uri won't exist if the iterator has 0 iterations (hence, the "no log files" error)

(for additional context this is affecting 800 / 1800 of the rev analytics saved queries)

## Changes

Treat a `None` delta table as an empty query result from running the query. This is nonretryable. The result is also a much clearer error message in the ui for the user. So if my assumption is incorrect about empty results customers can quickly tell us.

## How did you test this code?

Added a unit test for empty query results. Ran manually e2e to very that `select 1 where 1 = 0` fails with nonretryable status in temporal due to empty results (not due to "no log files")

## Publish to changelog?

No