### PR TITLE
fix: wrong import on migrate command

### DIFF
--- a/posthog/management/commands/migrate.py
+++ b/posthog/management/commands/migrate.py
@@ -23,7 +23,7 @@ from django.core.management.commands.migrate import Command as DjangoMigrateComm
 from django.db import DEFAULT_DB_ALIAS
 from django.db.migrations.recorder import MigrationRecorder
 
-from migration_utils import (
+from common.migration_utils import (
     MIGRATION_CACHE_DIR,
     get_cached_migration,
     get_managed_app_names,


### PR DESCRIPTION
## Problem

The import path for migration utilities is incorrect, causing issues with the migration command.

## Changes

Updated the import path for migration utilities from `migration_utils` to `common.migration_utils` in the migrate.py command file.

## How did you test this code?

Verified that the Django migration command works correctly with the updated import path by running migrations locally.

## Publish to changelog?

No