### PR TITLE
feat(workflows): Add auth-less endpoint that returns global workflow templates for posthog.com

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -18,6 +18,7 @@ from posthog.api import (
     authentication,
     decide,
     github,
+    hog_flow_template,
     hog_function_template,
     playwright_setup,
     remote_config,
@@ -201,6 +202,10 @@ urlpatterns = [
     opt_slash_path(
         "api/public_hog_function_templates",
         hog_function_template.PublicHogFunctionTemplateViewSet.as_view({"get": "list"}),
+    ),
+    opt_slash_path(
+        "api/public_hog_flow_templates",
+        hog_flow_template.PublicHogFlowTemplateViewSet.as_view({"get": "list", "head": "list"}),
     ),
     # Test setup endpoint (only available in TEST mode)
     path("api/setup_test/<str:test_name>/", csrf_exempt(playwright_setup.setup_test)),

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -205,7 +205,7 @@ urlpatterns = [
     ),
     opt_slash_path(
         "api/public_hog_flow_templates",
-        hog_flow_template.PublicHogFlowTemplateViewSet.as_view({"get": "list", "head": "list"}),
+        hog_flow_template.PublicHogFlowTemplateViewSet.as_view({"get": "list"}),
     ),
     # Test setup endpoint (only available in TEST mode)
     path("api/setup_test/<str:test_name>/", csrf_exempt(playwright_setup.setup_test)),


### PR DESCRIPTION
## Problem

We want to show up to date workflow templates in our docs on posthog.com

## Changes

Expose a new endpoint that requires no auth and returns all global workflow templates. These templates already shouldn't contain any secrets, since we expose them to anyone who creates a posthog account.

## How did you test this code?

Manually with `curl http://localhost:8000/api/public_hog_flow_templates/`