### PR TITLE
fix: Set local clickhouse to 25.8.11.66 to match prod

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -237,7 +237,7 @@ runs:
 
         - name: Upload updated timing data as artifacts
           uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-          if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.8.12.129' }}
+          if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:25.8.11.66' }}
           with:
               name: timing_data-${{ inputs.segment }}-${{ inputs.group }}
               path: .test_durations

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -491,7 +491,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.12.12']
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.8.12.129']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:25.8.11.66']
                 segment: ['Core']
                 person-on-events: [false]
                 # :NOTE: Keep concurrency and groups in sync
@@ -542,121 +542,121 @@ jobs:
                 include:
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 1
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 2
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 3
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 4
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 5
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 6
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 7
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 8
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 9
                     - segment: 'Core'
                       person-on-events: true
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 10
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 1
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 2
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 3
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 4
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 5
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 6
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 7
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 8
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 9
                     - segment: 'Temporal'
                       person-on-events: false
-                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.11.66'
                       python-version: '3.12.12'
                       concurrency: 10
                       group: 10
@@ -944,7 +944,7 @@ jobs:
             - name: Upload updated timing data as artifacts
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               # Only upload timing data on main branch to avoid artifact bloat from PRs
-              if: ${{ github.ref == 'refs/heads/master' && needs.changes.outputs.backend == 'true' && !matrix.person-on-events && matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:25.8.12.129' }}
+              if: ${{ github.ref == 'refs/heads/master' && needs.changes.outputs.backend == 'true' && !matrix.person-on-events && matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:25.8.11.66' }}
               with:
                   name: timing_data-${{ matrix.segment }}-${{ matrix.group }}
                   path: .test_durations
@@ -1104,7 +1104,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.8.12.129']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:25.8.11.66']
         if: needs.changes.outputs.backend == 'true'
         runs-on: depot-ubuntu-latest
         steps:

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -74,7 +74,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                clickhouse-server-image: ['clickhouse/clickhouse-server:25.8.12.129']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:25.8.11.66']
         if: needs.changes.outputs.dagster == 'true'
         runs-on: depot-ubuntu-latest
         steps:

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -146,7 +146,7 @@ jobs:
             - name: Stop/Start stack with Docker Compose
               shell: bash
               run: |
-                  export CLICKHOUSE_SERVER_IMAGE=clickhouse/clickhouse-server:25.8.12.129
+                  export CLICKHOUSE_SERVER_IMAGE=clickhouse/clickhouse-server:25.8.11.66
                   export DOCKER_REGISTRY_PREFIX="us-east1-docker.pkg.dev/posthog-301601/mirror/"
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -137,7 +137,7 @@ services:
         # Note: please keep the default version in sync across
         #       `posthog` and the `charts-clickhouse` repos
         #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:25.8.12.129}
+        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:25.8.11.66}
         restart: on-failure
         environment:
             CLICKHOUSE_SKIP_USER_SETUP: 1

--- a/ee/clickhouse/test/test_error.py
+++ b/ee/clickhouse/test/test_error.py
@@ -49,7 +49,7 @@ from posthog.errors import ch_error_type, wrap_query_error
         ),
         (
             ServerException(
-                "Code: 439. DB::Exception: Cannot schedule a task: cannot allocate thread (threads=36, jobs=36). (CANNOT_SCHEDULE_TASK) (version 25.8.12.129 (official build))",
+                "Code: 439. DB::Exception: Cannot schedule a task: cannot allocate thread (threads=36, jobs=36). (CANNOT_SCHEDULE_TASK) (version 25.8.11.66 (official build))",
                 code=439,
             ),
             "ClickHouseAtCapacity",
@@ -59,7 +59,7 @@ from posthog.errors import ch_error_type, wrap_query_error
         ),
         (
             ServerException(
-                "Code: 159. DB::Exception: Timeout exceeded: elapsed 60.046752587 seconds, maximum: 60. (TIMEOUT_EXCEEDED) (version 25.8.12.129 (official build))",
+                "Code: 159. DB::Exception: Timeout exceeded: elapsed 60.046752587 seconds, maximum: 60. (TIMEOUT_EXCEEDED) (version 25.8.11.66 (official build))",
                 code=159,
             ),
             "ClickHouseQueryTimeOut",

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -149,7 +149,7 @@ def test_clickhouse_memory_limit_exceeded_error(clickhouse_client):
         return_value=(
             MagicMock(
                 status_code=500,
-                text="Code: 241. DB::Exception: (total) memory limit exceeded: would use 99.97 GiB (attempt to allocate chunk of 12.26 MiB bytes), current RSS: 111.22 GiB, maximum: 111.19 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing MergeSortingTransform. (MEMORY_LIMIT_EXCEEDED) (version 25.8.12.129 (official build))",
+                text="Code: 241. DB::Exception: (total) memory limit exceeded: would use 99.97 GiB (attempt to allocate chunk of 12.26 MiB bytes), current RSS: 111.22 GiB, maximum: 111.19 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing MergeSortingTransform. (MEMORY_LIMIT_EXCEEDED) (version 25.8.11.66 (official build))",
             )
         ),
     ):


### PR DESCRIPTION
## Problem

We have a clickhouse version mismatch, and this let through a serious bug which CI did not catch

## Changes

Revert ch version in docker compose files

## How did you test this code?

Existing tests should pass

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
