### PR TITLE
chore(docker): update pinned Debian bookworm packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,8 +101,8 @@ RUN apt-get update && \
     "librdkafka1=2.10.1-1.cflt~deb12" \
     "librdkafka++1=2.10.1-1.cflt~deb12" \
     "librdkafka-dev=2.10.1-1.cflt~deb12" \
-    "libssl-dev=3.0.17-1~deb12u2" \
-    "libssl3=3.0.17-1~deb12u2" \
+    "libssl-dev=3.0.18-1~deb12u1" \
+    "libssl3=3.0.18-1~deb12u1" \
     "zlib1g-dev" \
     && \
     rm -rf /var/lib/apt/lists/*
@@ -251,11 +251,11 @@ RUN apt-get update && \
     "libxmlsec1-dev=1.2.37-2" \
     "libxml2" \
     "gettext-base" \
-    "ffmpeg=7:5.1.7-0+deb12u1" \
+    "ffmpeg=7:5.1.8-0+deb12u1" \
     "librdkafka1=2.10.1-1.cflt~deb12" \
     "librdkafka++1=2.10.1-1.cflt~deb12" \
-    "libssl-dev=3.0.17-1~deb12u2" \
-    "libssl3=3.0.17-1~deb12u2" \
+    "libssl-dev=3.0.18-1~deb12u1" \
+    "libssl3=3.0.18-1~deb12u1" \
     "libjemalloc2" \
     && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -29,8 +29,8 @@ RUN apt-get update && \
     "librdkafka1=2.10.1-1.cflt~deb12" \
     "librdkafka++1=2.10.1-1.cflt~deb12" \
     "librdkafka-dev=2.10.1-1.cflt~deb12" \
-    "libssl-dev=3.0.17-1~deb12u2" \
-    "libssl3=3.0.17-1~deb12u2" \
+    "libssl-dev=3.0.18-1~deb12u1" \
+    "libssl3=3.0.18-1~deb12u1" \
     "zlib1g-dev" \
     && \
     rm -rf /var/lib/apt/lists/*
@@ -91,7 +91,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends --allow-downgrades \
     "librdkafka1=2.10.1-1.cflt~deb12" \
     "librdkafka++1=2.10.1-1.cflt~deb12" \
-    "libssl3=3.0.17-1~deb12u2" \
+    "libssl3=3.0.18-1~deb12u1" \
     "curl" \
     "gettext-base" \
     && \


### PR DESCRIPTION
## Problem

Docker builds are failing with exit code 100 because pinned Debian bookworm package versions no longer exist in the repos.

```
E: Version '7:5.1.7-0+deb12u1' for 'ffmpeg' was not found
```

## Changes

Updates pinned versions in `Dockerfile` and `Dockerfile.node`:

| Package | Old | New |
|---------|-----|-----|
| libssl3 | 3.0.17-1~deb12u2 | 3.0.18-1~deb12u1 |
| libssl-dev | 3.0.17-1~deb12u2 | 3.0.18-1~deb12u1 |
| ffmpeg | 7:5.1.7-0+deb12u1 | 7:5.1.8-0+deb12u1 |

## How did you test this code?

Verified new versions exist via https://packages.debian.org/bookworm/ and tested locally:

```bash
docker run --rm --platform linux/amd64 debian:bookworm bash -c "
apt-get update -qq && apt-get install -y --no-install-recommends --dry-run \
  'libssl3=3.0.18-1~deb12u1' \
  'libssl-dev=3.0.18-1~deb12u1' \
  'ffmpeg=7:5.1.8-0+deb12u1'
"
# SUCCESS: All fixed versions available
```

## Publish to changelog?

no
