### PR TITLE
feat(logs): reduce layout shift by keeping query button text static

### DIFF
--- a/products/logs/frontend/components/LogsFilters/index.tsx
+++ b/products/logs/frontend/components/LogsFilters/index.tsx
@@ -48,7 +48,7 @@ export const LogsFilters = (): JSX.Element => {
                         loading={logsLoading || liveTailRunning}
                         disabledReason={liveTailRunning ? 'Disable live tail to manually refresh' : undefined}
                     >
-                        {liveTailRunning ? 'Tailing...' : logsLoading ? 'Loading...' : 'Search'}
+                        {liveTailRunning ? 'Tailing...' : 'Refresh'}
                     </LemonButton>
                     <AppShortcut
                         name="LogsLiveTail"


### PR DESCRIPTION
## Problem

The current refresh button causes layout shift when switching between 'search' and 'loading', additionally, this button is closer to 'refresh' functionality than search.

## Changes

Updated the button text in the LogsFilters component to consistently show "Refresh" instead of "Loading..." when logs are loading but live tail is not running. This provides clearer user feedback about the action the button will perform.

Before, the button text would change between three states:

- "Tailing..." when live tail is running
- "Loading..." when logs are loading
- "Search" when idle

Now, the button text is:

- "Tailing..." when live tail is running
- "Refresh" in all other states

## How did you test this code?

Tested the component in various states:

- When logs are loading
- When live tail is running
- When the component is in idle state

Verified that the button text displays correctly in each scenario and that the functionality remains unchanged.

## Publish to changelog?

No