### PR TITLE
feat(phai): unified context for listing and searching models

### DIFF
--- a/ee/hogai/artifacts/handlers/base.py
+++ b/ee/hogai/artifacts/handlers/base.py
@@ -99,6 +99,15 @@ class ArtifactHandler(ABC, Generic[T_Stored, T_Enriched]):
         """
         return self.content_class.model_validate(data)
 
+    @abstractmethod
+    def get_metadata(self, content: T_Stored) -> dict[str, Any]:
+        """
+        Extract display metadata from artifact content.
+
+        Returns dict with type-specific fields for display (e.g., name, description, title).
+        """
+        ...
+
 
 # Single registry mapping content class -> handler instance
 HANDLER_REGISTRY: dict[type, ArtifactHandler] = {}

--- a/ee/hogai/artifacts/handlers/notebook.py
+++ b/ee/hogai/artifacts/handlers/notebook.py
@@ -126,6 +126,11 @@ class NotebookHandler(ArtifactHandler[StoredNotebookArtifactContent, NotebookArt
             title=content.title,
         )
 
+    def get_metadata(self, content: StoredNotebookArtifactContent) -> dict[str, Any]:
+        return {
+            "title": content.title,
+        }
+
     async def _list_visualization_contents(
         self,
         artifact_ids: list[str],

--- a/ee/hogai/artifacts/handlers/visualization.py
+++ b/ee/hogai/artifacts/handlers/visualization.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import cast
+from typing import Any, cast
 
 from posthoganalytics import capture_exception
 from pydantic import ValidationError
@@ -92,6 +92,12 @@ class VisualizationHandler(ArtifactHandler[VisualizationArtifactContent, Visuali
     ) -> VisualizationArtifactContent:
         """No enrichment needed for visualizations."""
         return content
+
+    def get_metadata(self, content: VisualizationArtifactContent) -> dict[str, Any]:
+        return {
+            "name": content.name,
+            "description": content.description,
+        }
 
     def _from_state(
         self, artifact_id: str, messages: Sequence[AssistantMessageUnion]

--- a/ee/hogai/context/entity_search/__init__.py
+++ b/ee/hogai/context/entity_search/__init__.py
@@ -1,0 +1,3 @@
+from .context import EntitySearchContext
+
+__all__ = ["EntitySearchContext"]

--- a/ee/hogai/context/entity_search/context.py
+++ b/ee/hogai/context/entity_search/context.py
@@ -1,0 +1,405 @@
+from datetime import timedelta
+from typing import Any, Literal
+
+from django.conf import settings
+from django.db.models import Max
+from django.utils import timezone
+from pydantic import ValidationError
+
+from ee.hogai.context.context import AssistantContextManager
+from posthog.api.search import EntityConfig, search_entities
+from posthog.models import (
+    Action,
+    Cohort,
+    Dashboard,
+    Experiment,
+    FeatureFlag,
+    Insight,
+    Survey,
+    Team,
+    User,
+)
+from posthog.rbac.user_access_control import UserAccessControl
+from posthog.schema import (
+    InsightVizNode,
+    NotebookArtifactContent,
+    VisualizationArtifactContent,
+)
+from posthog.sync import database_sync_to_async
+
+ENTITY_MAP: dict[str, EntityConfig] = {
+    "insight": {
+        "klass": Insight,
+        "search_fields": {"name": "A", "description": "C", "query_metadata": "B"},
+        "extra_fields": ["name", "description", "query_metadata", "query"],
+        "filters": {"deleted": False, "saved": True},
+    },
+    "dashboard": {
+        "klass": Dashboard,
+        "search_fields": {"name": "A", "description": "C"},
+        "extra_fields": ["name", "description"],
+        "filters": {"deleted": False},
+    },
+    "experiment": {
+        "klass": Experiment,
+        "search_fields": {"name": "A", "description": "C"},
+        "extra_fields": ["name", "description"],
+        "filters": {"deleted": False},
+    },
+    "feature_flag": {
+        "klass": FeatureFlag,
+        "search_fields": {"key": "A", "name": "C"},
+        "extra_fields": ["key", "name"],
+        "filters": {"deleted": False},
+    },
+    "action": {
+        "klass": Action,
+        "search_fields": {"name": "A", "description": "C"},
+        "extra_fields": ["name", "description"],
+        "filters": {"deleted": False},
+    },
+    "cohort": {
+        "klass": Cohort,
+        "search_fields": {"name": "A", "description": "C", "filters": "B"},
+        "extra_fields": ["name", "description", "filters"],
+        "filters": {"deleted": False},
+    },
+    "survey": {
+        "klass": Survey,
+        "search_fields": {"name": "A", "description": "C"},
+        "extra_fields": ["name", "description"],
+        "filters": {"archived": False},
+    },
+}
+"""
+Map of entity names to their class, search_fields and extra_fields.
+
+The value in search_fields corresponds to the PostgreSQL weighting i.e. A, B, C or D.
+"""
+
+EXCLUDE_FROM_DISPLAY: dict[str, set[str]] = {
+    "insight": {"query", "query_metadata"},
+}
+"""Fields to exclude from display output per entity type (they're still used for search ranking)."""
+
+INSIGHTS_CUTOFF_DAYS = 180
+"""Only include insights viewed within this many days."""
+
+
+class EntitySearchContext:
+    """Context manager for searching/listing and formatting Django models."""
+
+    def __init__(
+        self, team: Team, user: User, context_manager: AssistantContextManager
+    ):
+        self._team = team
+        self._user = user
+        self._context_manager = context_manager
+
+    @property
+    def user_access_control(self) -> UserAccessControl:
+        # The `search_entities` function uses this field for access control.
+        return UserAccessControl(
+            user=self._user, team=self._team, organization_id=self._team.organization.id
+        )
+
+    async def search_entities(
+        self,
+        entity_types: set[str] | Literal["all"],
+        query: str,
+    ) -> tuple[list[dict], dict[str, int | None]]:
+        """
+        Search for entities by query and entity types.
+
+        Args:
+            entity_types: Set of entity type strings to search or "all" to search all entities
+            query: Search query string
+
+        Returns:
+            Tuple of (results list, counts dict)
+        """
+        if entity_types == "all":
+            entity_types = set(ENTITY_MAP.keys())
+
+        results, counts, _ = await database_sync_to_async(
+            search_entities, thread_sensitive=False
+        )(
+            entity_types,
+            query,
+            self._team.project_id,
+            self,  # type: ignore
+            ENTITY_MAP,
+        )
+        return results, counts
+
+    async def list_entities(
+        self,
+        entity_type: str,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """
+        List entities with pagination support, sorted by updated_at DESC.
+
+        Args:
+            entity_type: Type of entity to list (insight, dashboard, artifact, etc.)
+            limit: Number of entities to return
+            offset: Number of entities to skip
+
+        Returns:
+            Tuple of (entities list, total count)
+        """
+        all_entities: list[dict[str, Any]] = []
+
+        if entity_type == "artifact":
+            (
+                artifacts,
+                total_count,
+            ) = await self._context_manager.artifacts.aget_conversation_artifacts(
+                limit, offset
+            )
+
+            # Convert artifacts to the same format as database entities
+            for artifact in artifacts:
+                try:
+                    extra_fields: dict[str, Any] = {}
+                    content = artifact.content
+                    match content:
+                        case VisualizationArtifactContent():
+                            extra_fields = {
+                                "name": content.name,
+                                "description": content.description,
+                            }
+                        case NotebookArtifactContent():
+                            extra_fields = {
+                                "title": content.title,
+                            }
+                    all_entities.append(
+                        {
+                            "type": "artifact",
+                            "result_id": artifact.id,
+                            "extra_fields": extra_fields,
+                        }
+                    )
+                except ValidationError:
+                    # Skip artifacts that can't be parsed
+                    continue
+        elif entity_type == "insight":
+            # Use specialized queryset filtered by recent view time
+            return await self._list_insights(limit, offset)
+        else:
+            # Fetch database entities
+            db_results, _, total_count = await database_sync_to_async(
+                search_entities, thread_sensitive=False
+            )(
+                entities={entity_type},
+                query=None,  # No search query, just listing
+                project_id=self._team.project_id,
+                view=self,  # type: ignore
+                entity_map=ENTITY_MAP,
+                limit=limit,
+                offset=offset,
+            )
+            all_entities.extend(db_results)
+
+        return all_entities, total_count
+
+    def format_entities(self, entities: list[dict]) -> str:
+        """
+        Format a list of entities as a CSV-like pipe-separated matrix.
+
+        Args:
+            entities: List of entity result dicts
+
+        Returns:
+            Pipe-separated matrix string with header row
+        """
+        if not entities:
+            return ""
+
+        # Determine if we have multiple entity types
+        entity_types = {e["type"] for e in entities}
+        multiple_types = len(entity_types) > 1
+
+        # Collect all extra field keys across all entities (excluding standard columns)
+        standard_columns = {"name", "id", "url", "type"}
+        extra_columns: set[str] = set()
+        for entity in entities:
+            entity_type = entity["type"]
+            exclude_fields = EXCLUDE_FROM_DISPLAY.get(entity_type, set())
+            extra_fields = entity.get("extra_fields", {})
+            for key in extra_fields:
+                if key not in standard_columns and key not in exclude_fields:
+                    extra_columns.add(key)
+
+        # Build column order: ID, Name, extra fields alphabetically, URL last
+        extra_columns_sorted = sorted(extra_columns)
+
+        # Build rows
+        rows: list[str] = []
+
+        if multiple_types:
+            # Header with Entity type column - each row will have its own type_id
+            header_cols = [
+                "entity_type",
+                "entity_id",
+                "name",
+                *extra_columns_sorted,
+                "url",
+            ]
+            rows.append("|".join(header_cols))
+        else:
+            # Single type: add type header line and use type-specific id column
+            single_type = next(iter(entity_types))
+            rows.append(f"entity_type: {single_type}")
+            # Header with type-specific id column (e.g., insight_id, dashboard_id)
+            header_cols = [f"{single_type}_id", "name", *extra_columns_sorted, "url"]
+            rows.append("|".join(header_cols))
+
+        # Data rows
+        for entity in entities:
+            row_values = self._get_entity_row_values(
+                entity, extra_columns_sorted, multiple_types
+            )
+            rows.append("|".join(row_values))
+
+        return "\n".join(rows)
+
+    async def _list_insights(
+        self, limit: int = 100, offset: int = 0
+    ) -> tuple[list[dict[str, Any]], int]:
+        """
+        List insights filtered by recent view time (same queryset as InsightSearchNode).
+        Only includes insights viewed within INSIGHTS_CUTOFF_DAYS.
+
+        Returns:
+            Tuple of (entities list in format_entities format, total count)
+        """
+        return await database_sync_to_async(
+            self._list_insights_sync, thread_sensitive=False
+        )(limit, offset)
+
+    def _list_insights_sync(
+        self, limit: int = 100, offset: int = 0
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Sync implementation of _list_insights for use with database_sync_to_async."""
+        cutoff_date = timezone.now() - timedelta(days=INSIGHTS_CUTOFF_DAYS)
+        queryset = (
+            Insight.objects.filter(team=self._team, deleted=False)
+            .annotate(latest_view_time=Max("insightviewed__last_viewed_at"))
+            .filter(latest_view_time__gte=cutoff_date)
+            .order_by("-latest_view_time")
+        )
+        # Apply access control filtering
+        queryset = self.user_access_control.filter_queryset_by_access_level(queryset)
+
+        total_count = queryset.count()
+        insights = list(
+            queryset[offset : offset + limit].values(
+                "id", "name", "description", "query", "derived_name", "short_id"
+            )
+        )
+
+        all_entities: list[dict[str, Any]] = []
+        for insight in insights:
+            all_entities.append(
+                {
+                    "type": "insight",
+                    "result_id": insight["short_id"],
+                    "extra_fields": {
+                        "name": insight["name"] or insight["derived_name"] or "Unnamed",
+                        "description": insight["description"],
+                        "insight_type": self._extract_insight_type(insight["query"]),
+                    },
+                }
+            )
+
+        return all_entities, total_count
+
+    def _get_entity_row_values(
+        self, result: dict, extra_columns: list[str], include_type: bool
+    ) -> list[str]:
+        """
+        Get the row values for an entity.
+
+        Args:
+            result: Entity result dict with 'type', 'result_id', and 'extra_fields'
+            extra_columns: List of extra column names to include
+            include_type: Whether to include the entity type as first column
+
+        Returns:
+            List of escaped string values for the row
+        """
+        entity_type = result["type"]
+        result_id = result["result_id"]
+        extra_fields = result.get("extra_fields", {})
+
+        # Get name (from extra_fields or generate default)
+        name = extra_fields.get("name", f"{entity_type.upper()} {result_id}")
+
+        # Get URL if available
+        try:
+            url = self._build_url(entity_type, result_id, self._team.id)
+        except ValueError:
+            url = ""
+
+        # Build row values: Entity type (if multiple), ID, Name, extra fields, URL last
+        values: list[str] = []
+        if include_type:
+            values.append(self._escape_value(entity_type.replace("_", " ").title()))
+        values.append(self._escape_value(result_id))
+        values.append(self._escape_value(name))
+
+        # Add extra field values
+        exclude_fields = EXCLUDE_FROM_DISPLAY.get(entity_type, set())
+        for col in extra_columns:
+            if col in exclude_fields:
+                values.append("-")
+            else:
+                val = extra_fields.get(col)
+                values.append(self._escape_value(val))
+
+        # URL goes last
+        values.append(self._escape_value(url))
+
+        return values
+
+    def _escape_value(self, value: Any) -> str:
+        """Escape a value for CSV output, quoting if it contains pipe characters."""
+        if value is None or value == "":
+            return "-"
+        str_val = str(value)
+        return f'"{str_val}"' if "|" in str_val else str_val
+
+    def _extract_insight_type(self, query: Any) -> str | None:
+        """Extract human-readable insight type from an InsightVizNode query."""
+        try:
+            node = InsightVizNode.model_validate(query)
+            return node.source.kind.lower().replace("query", "")
+        except ValidationError:
+            return None
+
+    def _build_url(self, entity_type: str, result_id: str, team_id: int) -> str:
+        """Build a URL for an entity based on its type and ID."""
+        base_url = f"{settings.SITE_URL}/project/{team_id}"
+        match entity_type:
+            case "insight":
+                return f"{base_url}/insights/{result_id}"
+            case "dashboard":
+                return f"{base_url}/dashboard/{result_id}"
+            case "experiment":
+                return f"{base_url}/experiments/{result_id}"
+            case "feature_flag":
+                return f"{base_url}/feature_flags/{result_id}"
+            case "notebook":
+                return f"{base_url}/notebooks/{result_id}"
+            case "action":
+                return f"{base_url}/data-management/actions/{result_id}"
+            case "cohort":
+                return f"{base_url}/cohorts/{result_id}"
+            case "survey":
+                return f"{base_url}/surveys/{result_id}"
+            case "error_tracking_issue":
+                return f"{base_url}/error_tracking/{result_id}"
+            case _:
+                raise ValueError(f"Unknown entity type: {entity_type}")

--- a/ee/hogai/context/entity_search/test/test_context.py
+++ b/ee/hogai/context/entity_search/test/test_context.py
@@ -391,7 +391,7 @@ class TestEntitySearchContext(NonAtomicBaseTest):
 
         mock_artifacts_manager = MagicMock()
         mock_artifact = MagicMock()
-        mock_artifact.short_id = "abc123"
+        mock_artifact.artifact_id = "abc123"
         mock_artifact.content = VisualizationArtifactContent(
             name="Test Artifact", description="Test description", query=HogQLQuery(query="SELECT 1")
         )
@@ -408,31 +408,12 @@ class TestEntitySearchContext(NonAtomicBaseTest):
         assert entities[0]["result_id"] == "abc123"
         assert entities[0]["extra_fields"]["name"] == "Test Artifact"
 
-    async def test_list_entities_artifact_handles_document_content(self):
-        from posthog.schema import DocumentArtifactContent
-
-        mock_artifacts_manager = MagicMock()
-        mock_artifact = MagicMock()
-        mock_artifact.short_id = "doc123"
-        mock_artifact.content = DocumentArtifactContent(blocks=[])
-        mock_artifacts_manager.aget_conversation_artifacts = AsyncMock(return_value=([mock_artifact], 1))
-
-        self.context_manager.artifacts = mock_artifacts_manager
-
-        entities, total = await self.context.list_entities("artifact", limit=10, offset=0)
-
-        assert len(entities) == 1
-        assert total == 1
-        assert entities[0]["type"] == "artifact"
-        assert entities[0]["result_id"] == "doc123"
-        assert entities[0]["extra_fields"] == {}
-
     async def test_list_entities_artifact_skips_invalid_content(self):
         from pydantic import ValidationError
 
         mock_artifacts_manager = MagicMock()
         mock_artifact = MagicMock()
-        mock_artifact.short_id = "invalid123"
+        mock_artifact.artifact_id = "invalid123"
 
         type(mock_artifact).content = PropertyMock(side_effect=ValidationError.from_exception_data("test", []))
         mock_artifacts_manager.aget_conversation_artifacts = AsyncMock(return_value=([mock_artifact], 1))

--- a/ee/hogai/context/entity_search/test/test_context.py
+++ b/ee/hogai/context/entity_search/test/test_context.py
@@ -1,0 +1,445 @@
+import pytest
+from posthog.test.base import NonAtomicBaseTest
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+from django.conf import settings
+from django.utils import timezone
+
+from parameterized import parameterized
+
+from posthog.models import Action, Cohort, Dashboard, Experiment, FeatureFlag, Insight, Survey
+from posthog.models.insight import InsightViewed
+
+from ee.hogai.context import AssistantContextManager
+from ee.hogai.context.entity_search import EntitySearchContext
+
+
+class TestEntitySearchContext(NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        self.context_manager = AssistantContextManager(self.team, self.user, {})
+        self.context = EntitySearchContext(
+            team=self.team,
+            user=self.user,
+            context_manager=self.context_manager,
+        )
+
+    @parameterized.expand(
+        [
+            ("insight", "test_insight_id", "/project/{team_id}/insights/test_insight_id"),
+            ("dashboard", "test_dashboard_id", "/project/{team_id}/dashboard/test_dashboard_id"),
+            ("experiment", "test_experiment_id", "/project/{team_id}/experiments/test_experiment_id"),
+            ("feature_flag", "test_flag_id", "/project/{team_id}/feature_flags/test_flag_id"),
+            ("action", "test_action_id", "/project/{team_id}/data-management/actions/test_action_id"),
+            ("cohort", "test_cohort_id", "/project/{team_id}/cohorts/test_cohort_id"),
+            ("survey", "test_survey_id", "/project/{team_id}/surveys/test_survey_id"),
+            ("error_tracking_issue", "test_issue_id", "/project/{team_id}/error_tracking/test_issue_id"),
+            ("notebook", "test_notebook_id", "/project/{team_id}/notebooks/test_notebook_id"),
+        ]
+    )
+    def test_build_url(self, entity_type, result_id, expected_path):
+        url = self.context._build_url(entity_type, result_id, self.team.id)
+        expected_url = f"{settings.SITE_URL}{expected_path.format(team_id=self.team.id)}"
+        assert url == expected_url
+
+    def test_build_url_unknown_entity_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown entity type"):
+            self.context._build_url("unknown_type", "123", self.team.id)
+
+    def test_format_entities_single_type(self):
+        entities = [
+            {
+                "type": "dashboard",
+                "result_id": "456",
+                "extra_fields": {"name": "Test Dashboard", "description": "A dashboard"},
+            },
+            {"type": "dashboard", "result_id": "789", "extra_fields": {"name": "Another Dashboard"}},
+        ]
+        formatted = self.context.format_entities(entities)
+        lines = formatted.split("\n")
+        assert lines[0] == "entity_type: dashboard"
+        assert "dashboard_id|name|description|url" in lines[1]
+        assert "456|Test Dashboard|A dashboard|" in lines[2]
+        assert "789|Another Dashboard|-|" in lines[3]  # Empty description shows as dash
+
+    def test_format_entities_multiple_types(self):
+        entities = [
+            {"type": "dashboard", "result_id": "456", "extra_fields": {"name": "Test Dashboard"}},
+            {"type": "insight", "result_id": "123", "extra_fields": {"name": "Test Insight"}},
+        ]
+        formatted = self.context.format_entities(entities)
+        lines = formatted.split("\n")
+        assert "entity_type|entity_id|name|url" in lines[0]
+        assert "Dashboard|456|Test Dashboard|" in lines[1]
+        assert "Insight|123|Test Insight|" in lines[2]
+
+    def test_format_entities_includes_id(self):
+        entities = [
+            {"type": "dashboard", "result_id": "456", "extra_fields": {"name": "Test Dashboard"}},
+        ]
+        formatted = self.context.format_entities(entities)
+        assert "456|Test Dashboard|" in formatted
+
+    def test_format_entities_excludes_query_for_insights(self):
+        entities = [
+            {
+                "type": "insight",
+                "result_id": "123",
+                "extra_fields": {"name": "Test Insight", "query": {"kind": "TrendsQuery"}},
+            },
+        ]
+        formatted = self.context.format_entities(entities)
+        assert "TrendsQuery" not in formatted
+        assert "Test Insight" in formatted
+
+    def test_format_entities_displays_insight_type_when_present(self):
+        entities = [
+            {
+                "type": "insight",
+                "result_id": "123",
+                "extra_fields": {
+                    "name": "Test Insight",
+                    "insight_type": "trends",
+                },
+            },
+        ]
+        formatted = self.context.format_entities(entities)
+        assert "insight_type" in formatted
+        assert "trends" in formatted
+
+    @parameterized.expand(
+        [
+            ("TrendsQuery", "trends"),
+            ("FunnelsQuery", "funnels"),
+            ("RetentionQuery", "retention"),
+            ("PathsQuery", "paths"),
+            ("StickinessQuery", "stickiness"),
+            ("LifecycleQuery", "lifecycle"),
+        ]
+    )
+    def test_extract_insight_type_strips_query_suffix(self, source_kind, expected):
+        # Build a valid InsightVizNode with minimal required fields for each query type
+        source: dict = {"kind": source_kind}
+        if source_kind == "TrendsQuery":
+            source["series"] = []
+        elif source_kind == "FunnelsQuery":
+            source["series"] = []
+            source["funnelsFilter"] = {}
+        elif source_kind == "RetentionQuery":
+            source["retentionFilter"] = {}
+        elif source_kind == "PathsQuery":
+            source["pathsFilter"] = {}
+        elif source_kind == "StickinessQuery":
+            source["series"] = []
+            source["stickinessFilter"] = {}
+        elif source_kind == "LifecycleQuery":
+            source["series"] = []
+            source["lifecycleFilter"] = {}
+        query = {"kind": "InsightVizNode", "source": source}
+        assert self.context._extract_insight_type(query) == expected
+
+    def test_extract_insight_type_returns_none_for_non_insight_viz_node(self):
+        assert self.context._extract_insight_type({"kind": "DataTableNode"}) is None
+        assert self.context._extract_insight_type({"kind": "TrendsQuery"}) is None
+        assert self.context._extract_insight_type(None) is None
+        assert self.context._extract_insight_type({}) is None
+
+    def test_format_entities_does_not_exclude_fields_for_other_entities(self):
+        entities = [
+            {
+                "type": "cohort",
+                "result_id": "456",
+                "extra_fields": {"name": "Test Cohort", "filters": {"properties": []}},
+            },
+        ]
+        formatted = self.context.format_entities(entities)
+        assert "filters" in formatted
+
+    def test_format_entities_escapes_pipe_characters(self):
+        entities = [
+            {
+                "type": "dashboard",
+                "result_id": "456",
+                "extra_fields": {"name": "Test|Dashboard", "description": "Has|pipes"},
+            },
+        ]
+        formatted = self.context.format_entities(entities)
+        assert '"Test|Dashboard"' in formatted
+        assert '"Has|pipes"' in formatted
+
+    def test_format_entities_empty_list(self):
+        formatted = self.context.format_entities([])
+        assert formatted == ""
+
+    async def test_insight_filters_exclude_deleted(self):
+        await Insight.objects.acreate(
+            team=self.team, name="active insight", deleted=False, saved=True, created_by=self.user
+        )
+        await Insight.objects.acreate(
+            team=self.team, name="deleted insight", deleted=True, saved=True, created_by=self.user
+        )
+
+        results, _ = await self.context.search_entities({"insight"}, "insight")
+
+        result_names = [r["extra_fields"].get("name", "") for r in results]
+        assert "deleted insight" not in result_names
+
+    async def test_insight_filters_exclude_unsaved(self):
+        await Insight.objects.acreate(
+            team=self.team, name="saved insight", deleted=False, saved=True, created_by=self.user
+        )
+        await Insight.objects.acreate(
+            team=self.team, name="unsaved insight", deleted=False, saved=False, created_by=self.user
+        )
+
+        results, _ = await self.context.search_entities({"insight"}, "insight")
+
+        result_names = [r["extra_fields"].get("name", "") for r in results]
+        assert "unsaved insight" not in result_names
+
+    async def test_dashboard_filters_exclude_deleted(self):
+        await Dashboard.objects.acreate(team=self.team, name="active dashboard", deleted=False, created_by=self.user)
+        await Dashboard.objects.acreate(team=self.team, name="deleted dashboard", deleted=True, created_by=self.user)
+
+        results, _ = await self.context.search_entities({"dashboard"}, "dashboard")
+
+        result_names = [r["extra_fields"].get("name", "") for r in results]
+        assert "deleted dashboard" not in result_names
+
+    async def test_experiment_filters_exclude_deleted(self):
+        flag1 = await FeatureFlag.objects.acreate(team=self.team, key="flag1", created_by=self.user)
+        flag2 = await FeatureFlag.objects.acreate(team=self.team, key="flag2", created_by=self.user)
+        await Experiment.objects.acreate(
+            team=self.team, name="active experiment", deleted=False, created_by=self.user, feature_flag=flag1
+        )
+        await Experiment.objects.acreate(
+            team=self.team, name="deleted experiment", deleted=True, created_by=self.user, feature_flag=flag2
+        )
+
+        results, _ = await self.context.search_entities({"experiment"}, "experiment")
+
+        result_names = [r["extra_fields"].get("name", "") for r in results]
+        assert "deleted experiment" not in result_names
+
+    async def test_feature_flag_filters_exclude_deleted(self):
+        await FeatureFlag.objects.acreate(
+            team=self.team, key="active_flag", name="active flag", deleted=False, created_by=self.user
+        )
+        await FeatureFlag.objects.acreate(
+            team=self.team, key="deleted_flag", name="deleted flag", deleted=True, created_by=self.user
+        )
+
+        results, _ = await self.context.search_entities({"feature_flag"}, "flag")
+
+        result_keys = [r["extra_fields"].get("key", "") for r in results]
+        result_names = [r["extra_fields"].get("name", "") for r in results]
+        assert "deleted_flag" not in result_keys
+        assert "deleted flag" not in result_names
+
+    async def test_action_filters_exclude_deleted(self):
+        await Action.objects.acreate(team=self.team, name="active action", deleted=False, created_by=self.user)
+        await Action.objects.acreate(team=self.team, name="deleted action", deleted=True, created_by=self.user)
+
+        results, _ = await self.context.search_entities({"action"}, "action")
+
+        result_names = [r["extra_fields"].get("name", "") for r in results]
+        assert "deleted action" not in result_names
+
+    async def test_cohort_filters_exclude_deleted(self):
+        await Cohort.objects.acreate(team=self.team, name="active cohort", deleted=False, created_by=self.user)
+        await Cohort.objects.acreate(team=self.team, name="deleted cohort", deleted=True, created_by=self.user)
+
+        results, _ = await self.context.search_entities({"cohort"}, "cohort")
+
+        result_names = [r["extra_fields"].get("name", "") for r in results]
+        assert "deleted cohort" not in result_names
+
+    async def test_survey_filters_exclude_archived(self):
+        await Survey.objects.acreate(
+            team=self.team,
+            name="active survey",
+            archived=False,
+            created_by=self.user,
+            type=Survey.SurveyType.POPOVER,
+        )
+        await Survey.objects.acreate(
+            team=self.team,
+            name="archived survey",
+            archived=True,
+            created_by=self.user,
+            type=Survey.SurveyType.POPOVER,
+        )
+
+        results, _ = await self.context.search_entities({"survey"}, "survey")
+
+        result_names = [r["extra_fields"].get("name", "") for r in results]
+        assert "archived survey" not in result_names
+
+    async def test_all_entity_types_respect_filters_exclude_deleted(self):
+        await Insight.objects.acreate(
+            team=self.team, name="deleted insight", deleted=True, saved=True, created_by=self.user
+        )
+        await Dashboard.objects.acreate(team=self.team, name="deleted dashboard", deleted=True, created_by=self.user)
+        await Action.objects.acreate(team=self.team, name="deleted action", deleted=True, created_by=self.user)
+        await Cohort.objects.acreate(team=self.team, name="deleted cohort", deleted=True, created_by=self.user)
+        await Survey.objects.acreate(
+            team=self.team,
+            name="archived survey",
+            archived=True,
+            created_by=self.user,
+            type=Survey.SurveyType.POPOVER,
+        )
+
+        results, _ = await self.context.search_entities("all", "deleted")
+
+        result_names = [r["extra_fields"].get("name", "") for r in results]
+        assert "deleted insight" not in result_names
+        assert "deleted dashboard" not in result_names
+        assert "deleted action" not in result_names
+        assert "deleted cohort" not in result_names
+        assert "archived survey" not in result_names
+
+    async def test_list_entities_insight(self):
+        insight1 = await Insight.objects.acreate(
+            team=self.team, name="List Insight 1", deleted=False, saved=True, created_by=self.user
+        )
+        insight2 = await Insight.objects.acreate(
+            team=self.team, name="List Insight 2", deleted=False, saved=True, created_by=self.user
+        )
+        # list_entities for insights filters by recent views
+        await InsightViewed.objects.acreate(
+            team=self.team, user=self.user, insight=insight1, last_viewed_at=timezone.now()
+        )
+        await InsightViewed.objects.acreate(
+            team=self.team, user=self.user, insight=insight2, last_viewed_at=timezone.now()
+        )
+
+        entities, total = await self.context.list_entities("insight", limit=10, offset=0)
+
+        assert len(entities) == 2
+        assert total == 2
+        entity_names = [e["extra_fields"].get("name", "") for e in entities]
+        assert "List Insight 1" in entity_names
+        assert "List Insight 2" in entity_names
+
+    async def test_list_entities_insight_applies_access_control(self):
+        insight1 = await Insight.objects.acreate(
+            team=self.team, name="Accessible Insight", deleted=False, saved=True, created_by=self.user
+        )
+        insight2 = await Insight.objects.acreate(
+            team=self.team, name="Restricted Insight", deleted=False, saved=True, created_by=self.user
+        )
+        await InsightViewed.objects.acreate(
+            team=self.team, user=self.user, insight=insight1, last_viewed_at=timezone.now()
+        )
+        await InsightViewed.objects.acreate(
+            team=self.team, user=self.user, insight=insight2, last_viewed_at=timezone.now()
+        )
+
+        # Mock filter_queryset_by_access_level to filter out insight2
+        def mock_filter(qs):
+            return qs.exclude(id=insight2.id)
+
+        with patch.object(
+            EntitySearchContext,
+            "user_access_control",
+            new_callable=PropertyMock,
+        ) as mock_uac:
+            mock_uac.return_value.filter_queryset_by_access_level = mock_filter
+
+            entities, total = await self.context.list_entities("insight", limit=10, offset=0)
+
+            assert len(entities) == 1
+            assert total == 1
+            assert entities[0]["extra_fields"]["name"] == "Accessible Insight"
+
+    async def test_list_entities_dashboard(self):
+        await Dashboard.objects.acreate(team=self.team, name="List Dashboard", deleted=False, created_by=self.user)
+
+        entities, total = await self.context.list_entities("dashboard", limit=10, offset=0)
+
+        assert len(entities) == 1
+        assert total == 1
+        assert entities[0]["extra_fields"]["name"] == "List Dashboard"
+
+    async def test_list_entities_pagination(self):
+        for i in range(5):
+            insight = await Insight.objects.acreate(
+                team=self.team, name=f"Paginated Insight {i}", deleted=False, saved=True, created_by=self.user
+            )
+            # list_entities for insights filters by recent views
+            await InsightViewed.objects.acreate(
+                team=self.team, user=self.user, insight=insight, last_viewed_at=timezone.now()
+            )
+
+        entities_page1, total = await self.context.list_entities("insight", limit=2, offset=0)
+        assert len(entities_page1) == 2
+        assert total == 5
+
+        entities_page2, total = await self.context.list_entities("insight", limit=2, offset=2)
+        assert len(entities_page2) == 2
+        assert total == 5
+
+        entities_page3, total = await self.context.list_entities("insight", limit=2, offset=4)
+        assert len(entities_page3) == 1
+        assert total == 5
+
+    async def test_list_entities_artifact_delegates_to_artifacts_manager(self):
+        from posthog.schema import HogQLQuery, VisualizationArtifactContent
+
+        mock_artifacts_manager = MagicMock()
+        mock_artifact = MagicMock()
+        mock_artifact.short_id = "abc123"
+        mock_artifact.content = VisualizationArtifactContent(
+            name="Test Artifact", description="Test description", query=HogQLQuery(query="SELECT 1")
+        )
+        mock_artifacts_manager.aget_conversation_artifacts = AsyncMock(return_value=([mock_artifact], 1))
+
+        self.context_manager.artifacts = mock_artifacts_manager
+
+        entities, total = await self.context.list_entities("artifact", limit=10, offset=0)
+
+        mock_artifacts_manager.aget_conversation_artifacts.assert_called_once_with(10, 0)
+        assert len(entities) == 1
+        assert total == 1
+        assert entities[0]["type"] == "artifact"
+        assert entities[0]["result_id"] == "abc123"
+        assert entities[0]["extra_fields"]["name"] == "Test Artifact"
+
+    async def test_list_entities_artifact_handles_document_content(self):
+        from posthog.schema import DocumentArtifactContent
+
+        mock_artifacts_manager = MagicMock()
+        mock_artifact = MagicMock()
+        mock_artifact.short_id = "doc123"
+        mock_artifact.content = DocumentArtifactContent(blocks=[])
+        mock_artifacts_manager.aget_conversation_artifacts = AsyncMock(return_value=([mock_artifact], 1))
+
+        self.context_manager.artifacts = mock_artifacts_manager
+
+        entities, total = await self.context.list_entities("artifact", limit=10, offset=0)
+
+        assert len(entities) == 1
+        assert total == 1
+        assert entities[0]["type"] == "artifact"
+        assert entities[0]["result_id"] == "doc123"
+        assert entities[0]["extra_fields"] == {}
+
+    async def test_list_entities_artifact_skips_invalid_content(self):
+        from pydantic import ValidationError
+
+        mock_artifacts_manager = MagicMock()
+        mock_artifact = MagicMock()
+        mock_artifact.short_id = "invalid123"
+
+        type(mock_artifact).content = PropertyMock(side_effect=ValidationError.from_exception_data("test", []))
+        mock_artifacts_manager.aget_conversation_artifacts = AsyncMock(return_value=([mock_artifact], 1))
+
+        self.context_manager.artifacts = mock_artifacts_manager
+
+        entities, total = await self.context.list_entities("artifact", limit=10, offset=0)
+
+        assert len(entities) == 0
+        assert total == 1


### PR DESCRIPTION
## Problem

Unifies through the context how we search and paginate entities, so they use the same interface.

Stack: 2/4.

## Changes

- Added the entities context that has two primary methods: search and list.
- Updated the insights listing to match what we came up with in insights search, so we don't overload the context with useless data.

## How did you test this code?

Unit tests
