### PR TITLE
feat(logs): add new date range picker for logs filtering

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -283,6 +283,7 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_PROMPTS: 'llm-analytics-prompts', // owner: #team-llm-analytics
     LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT: 'llm-observability-show-input-output', // owner: #team-llm-analytics
     LOGS: 'logs', // owner: #team-logs
+    NEW_LOGS_DATE_RANGE_PICKER: 'new-logs-date-range-picker', // owner: #team-logs
     LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
     MANAGE_INSIGHTS_THROUGH_TERRAFORM: 'manage-insights-through-terraform', // owner: @vasco #team-analytics-platform
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics

--- a/products/logs/frontend/components/LogsFilters/index.tsx
+++ b/products/logs/frontend/components/LogsFilters/index.tsx
@@ -5,18 +5,21 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconPauseCircle, IconPlayCircle } from 'lib/lemon-ui/icons'
 import { Scene } from 'scenes/sceneTypes'
 
 import { LogsFilterGroup } from 'products/logs/frontend/components/filters/LogsFilters/FilterGroup'
 import { DateRangeFilter } from 'products/logs/frontend/filters/DateRangeFilter'
+import { LogsDateRangePicker } from 'products/logs/frontend/filters/LogsDateRangePicker/LogsDateRangePicker'
 import { ServiceFilter } from 'products/logs/frontend/filters/ServiceFilter'
 import { SeverityLevelsFilter } from 'products/logs/frontend/filters/SeverityLevelsFilter'
 import { logsLogic } from 'products/logs/frontend/logsLogic'
 
 export const LogsFilters = (): JSX.Element => {
-    const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsLogic)
-    const { runQuery, zoomDateRange, setLiveTailRunning } = useActions(logsLogic)
+    const newLogsDateRangePicker = useFeatureFlag('NEW_LOGS_DATE_RANGE_PICKER')
+    const { logsLoading, liveTailRunning, liveTailDisabledReason, dateRange } = useValues(logsLogic)
+    const { runQuery, zoomDateRange, setLiveTailRunning, setDateRange } = useActions(logsLogic)
 
     return (
         <div className="flex flex-col gap-y-1.5">
@@ -38,7 +41,11 @@ export const LogsFilters = (): JSX.Element => {
                         type="secondary"
                         onClick={() => zoomDateRange(0.5)}
                     />
-                    <DateRangeFilter />
+
+                    {!newLogsDateRangePicker && <DateRangeFilter />}
+                    {newLogsDateRangePicker && (
+                        <LogsDateRangePicker dateRange={dateRange} setDateRange={setDateRange} />
+                    )}
 
                     <LemonButton
                         size="small"
@@ -46,6 +53,7 @@ export const LogsFilters = (): JSX.Element => {
                         type="secondary"
                         onClick={() => runQuery()}
                         loading={logsLoading || liveTailRunning}
+                        className="min-w-24"
                         disabledReason={liveTailRunning ? 'Disable live tail to manually refresh' : undefined}
                     >
                         {liveTailRunning ? 'Tailing...' : 'Refresh'}

--- a/products/logs/frontend/filters/LogsDateRangePicker/LogsDateRangePicker.tsx
+++ b/products/logs/frontend/filters/LogsDateRangePicker/LogsDateRangePicker.tsx
@@ -1,0 +1,234 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconCalendar, IconClock } from '@posthog/icons'
+import { LemonButton, LemonDivider, LemonInput, Popover } from '@posthog/lemon-ui'
+
+import { RollingDateRangeFilter } from 'lib/components/DateFilter/RollingDateRangeFilter'
+import { dayjs } from 'lib/dayjs'
+import { LemonCalendarSelect } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+
+import { DateRange } from '~/queries/schema/schema-general'
+import { DateMappingOption } from '~/types'
+
+import { TimezoneSelect } from 'products/logs/frontend/components/LogsViewer/TimezoneSelect'
+import { logsViewerSettingsLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerSettingsLogic'
+
+import { LOGS_DATE_OPTIONS } from './constants'
+import { logsDateRangePickerLogic } from './logsDateRangePickerLogic'
+import { DATE_TIME_FORMAT, formatDateRangeLabel, getShortLabel, parseDateExpression } from './utils'
+
+interface DateTimeInputProps {
+    value: string
+    onChange: (value: string) => void
+    placeholder: string
+    timezone: string
+    label: string
+}
+
+const DateTimeInput = ({ value, onChange, placeholder, timezone, label }: DateTimeInputProps): JSX.Element => {
+    const [calendarOpen, setCalendarOpen] = useState(false)
+
+    const parsedValue = parseDateExpression(value, timezone)
+
+    const handleCalendarSelect = (date: dayjs.Dayjs): void => {
+        onChange(date.format(DATE_TIME_FORMAT))
+        setCalendarOpen(false)
+    }
+
+    return (
+        <div className="flex-1">
+            <div className="text-xs text-secondary mb-1">{label}</div>
+            <Popover
+                visible={calendarOpen}
+                onClickOutside={() => setCalendarOpen(false)}
+                placement="bottom-start"
+                overlay={
+                    <LemonCalendarSelect
+                        value={parsedValue}
+                        onChange={handleCalendarSelect}
+                        onClose={() => setCalendarOpen(false)}
+                        granularity="minute"
+                        use24HourFormat
+                    />
+                }
+            >
+                <LemonInput
+                    value={value}
+                    onChange={onChange}
+                    placeholder={placeholder}
+                    suffix={
+                        <LemonButton
+                            size="xsmall"
+                            noPadding
+                            icon={<IconCalendar className="text-secondary" />}
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                setCalendarOpen(true)
+                            }}
+                        />
+                    }
+                />
+            </Popover>
+        </div>
+    )
+}
+
+export interface LogsDateRangePickerProps {
+    dateRange: DateRange
+    setDateRange: (dateRange: DateRange) => void
+}
+
+export const LogsDateRangePicker = ({ dateRange, setDateRange }: LogsDateRangePickerProps): JSX.Element => {
+    const { popoverOpen, customFrom, customTo, history } = useValues(logsDateRangePickerLogic)
+    const { setPopoverOpen, setCustomFrom, setCustomTo, addToHistory } = useActions(logsDateRangePickerLogic)
+    const { timezone } = useValues(logsViewerSettingsLogic)
+    const { setTimezone } = useActions(logsViewerSettingsLogic)
+
+    const handleSelectOption = (option: DateMappingOption): void => {
+        setDateRange({ date_from: option.values[0], date_to: option.values[1] ?? null })
+        addToHistory({ date_from: option.values[0], date_to: option.values[1] ?? null })
+        setPopoverOpen(false)
+    }
+
+    const handleSelectHistory = (historyDateRange: DateRange): void => {
+        setDateRange(historyDateRange)
+        addToHistory(historyDateRange)
+        setPopoverOpen(false)
+    }
+
+    const handleApplyCustom = (): void => {
+        const fromDate = parseDateExpression(customFrom, timezone)
+        const toDate = customTo ? parseDateExpression(customTo, timezone) : null
+
+        if (!fromDate) {
+            lemonToast.error('Invalid start date format. Use formats like "-1h", "-30M", or "YYYY-MM-DD HH:mm"')
+            return
+        }
+
+        if (customTo && !toDate) {
+            lemonToast.error('Invalid end date format. Use formats like "-1h", "-30M", or "YYYY-MM-DD HH:mm"')
+            return
+        }
+
+        if (toDate && fromDate.isAfter(toDate)) {
+            lemonToast.error('Start date must be before end date')
+            return
+        }
+
+        const newDateRange: DateRange = {
+            date_from: fromDate.toISOString(),
+            date_to: toDate ? toDate.toISOString() : null,
+        }
+
+        setDateRange(newDateRange)
+        addToHistory(newDateRange)
+        setPopoverOpen(false)
+    }
+
+    const isOptionSelected = (option: DateMappingOption): boolean => {
+        return dateRange.date_from === option.values[0] && (dateRange.date_to ?? null) === (option.values[1] ?? null)
+    }
+
+    const currentLabel = formatDateRangeLabel(dateRange, timezone, LOGS_DATE_OPTIONS)
+
+    return (
+        <Popover
+            visible={popoverOpen}
+            onClickOutside={() => setPopoverOpen(false)}
+            placement="bottom-end"
+            overlay={
+                <div className="w-fit bg-bg-light rounded-lg overflow-hidden flex flex-row-reverse">
+                    <div className="flex flex-col gap-1 p-3">
+                        <div className="text-xs font-medium text-secondary mb-1">In the last</div>
+                        {LOGS_DATE_OPTIONS.map((option) => (
+                            <LemonButton
+                                key={option.key}
+                                size="small"
+                                type={isOptionSelected(option) ? 'primary' : 'tertiary'}
+                                onClick={() => handleSelectOption(option)}
+                                fullWidth
+                            >
+                                {getShortLabel(option)}
+                            </LemonButton>
+                        ))}
+                        <RollingDateRangeFilter
+                            dateFrom={dateRange.date_from}
+                            selected={true}
+                            dateRangeFilterLabel=""
+                            onChange={(fromDate) => {
+                                setDateRange({ date_from: fromDate, date_to: null })
+                                addToHistory({ date_from: fromDate, date_to: null })
+                            }}
+                            fullWidth
+                            allowedDateOptions={['minutes', 'hours', 'days']}
+                        />
+                    </div>
+
+                    <LemonDivider vertical className="my-3" />
+
+                    <div className="flex flex-col gap-3 p-3 w-fit">
+                        <div className="flex flex-col gap-2">
+                            <div className="text-xs font-medium text-secondary">Custom range</div>
+                            <div className="flex gap-2">
+                                <DateTimeInput
+                                    value={customFrom}
+                                    onChange={setCustomFrom}
+                                    placeholder="-1h, -30M..."
+                                    timezone={timezone}
+                                    label="From"
+                                />
+                                <DateTimeInput
+                                    value={customTo}
+                                    onChange={setCustomTo}
+                                    placeholder="now"
+                                    timezone={timezone}
+                                    label="To"
+                                />
+                            </div>
+                            <LemonButton type="primary" size="small" onClick={handleApplyCustom} fullWidth>
+                                Apply
+                            </LemonButton>
+                        </div>
+
+                        {history.length > 0 && (
+                            <>
+                                <LemonDivider className="my-0" />
+                                <div className="flex flex-col gap-1 flex-1">
+                                    <div className="text-xs font-medium text-secondary">Recent</div>
+                                    {history.map((historyDateRange, index) => (
+                                        <LemonButton
+                                            key={index}
+                                            size="small"
+                                            type="tertiary"
+                                            fullWidth
+                                            icon={<IconClock className="text-secondary" />}
+                                            onClick={() => handleSelectHistory(historyDateRange)}
+                                        >
+                                            <span className="truncate">
+                                                {formatDateRangeLabel(historyDateRange, timezone, LOGS_DATE_OPTIONS)}
+                                            </span>
+                                        </LemonButton>
+                                    ))}
+                                </div>
+                            </>
+                        )}
+
+                        <LemonDivider className="my-0" />
+                        <TimezoneSelect value={timezone} onChange={setTimezone} size="xsmall" />
+                    </div>
+                </div>
+            }
+        >
+            <LemonButton
+                size="small"
+                type="secondary"
+                icon={<IconCalendar />}
+                onClick={() => setPopoverOpen(!popoverOpen)}
+            >
+                {currentLabel}
+            </LemonButton>
+        </Popover>
+    )
+}

--- a/products/logs/frontend/filters/LogsDateRangePicker/constants.ts
+++ b/products/logs/frontend/filters/LogsDateRangePicker/constants.ts
@@ -1,0 +1,15 @@
+import { DateMappingOption } from '~/types'
+
+export const LOGS_DATE_OPTIONS: DateMappingOption[] = [
+    { key: 'Last minute', values: ['-1M'], defaultInterval: 'minute' },
+    { key: 'Last 5 minutes', values: ['-5M'], defaultInterval: 'minute' },
+    { key: 'Last 15 minutes', values: ['-15M'], defaultInterval: 'minute' },
+    { key: 'Last 30 minutes', values: ['-30M'], defaultInterval: 'minute' },
+    { key: 'Last hour', values: ['-1h'], defaultInterval: 'hour' },
+    { key: 'Last 3 hours', values: ['-3h'], defaultInterval: 'hour' },
+    { key: 'Last 6 hours', values: ['-6h'], defaultInterval: 'hour' },
+    { key: 'Last 12 hours', values: ['-12h'], defaultInterval: 'hour' },
+    { key: 'Last 24 hours', values: ['-24h'], defaultInterval: 'hour' },
+    { key: 'Last 3 days', values: ['-3d'], defaultInterval: 'day' },
+    { key: 'Last 7 days', values: ['-7d'], defaultInterval: 'day' },
+]

--- a/products/logs/frontend/filters/LogsDateRangePicker/index.ts
+++ b/products/logs/frontend/filters/LogsDateRangePicker/index.ts
@@ -1,0 +1,2 @@
+export { LogsDateRangePicker } from './LogsDateRangePicker'
+export type { LogsDateRangePickerProps } from './LogsDateRangePicker'

--- a/products/logs/frontend/filters/LogsDateRangePicker/logsDateRangePickerLogic.ts
+++ b/products/logs/frontend/filters/LogsDateRangePicker/logsDateRangePickerLogic.ts
@@ -1,0 +1,49 @@
+import { actions, kea, path, reducers } from 'kea'
+
+import { DateRange } from '~/queries/schema/schema-general'
+
+import type { logsDateRangePickerLogicType } from './logsDateRangePickerLogicType'
+
+const MAX_HISTORY_ITEMS = 5
+
+const dateRangesEqual = (a: DateRange, b: DateRange): boolean => a.date_from === b.date_from && a.date_to === b.date_to
+
+export const logsDateRangePickerLogic = kea<logsDateRangePickerLogicType>([
+    path(['products', 'logs', 'frontend', 'filters', 'LogsDateRangePicker', 'logsDateRangePickerLogic']),
+    actions({
+        setPopoverOpen: (open: boolean) => ({ open }),
+        setCustomFrom: (value: string) => ({ value }),
+        setCustomTo: (value: string) => ({ value }),
+        addToHistory: (dateRange: DateRange) => ({ dateRange }),
+    }),
+    reducers({
+        popoverOpen: [
+            false,
+            {
+                setPopoverOpen: (_, { open }) => open,
+            },
+        ],
+        customFrom: [
+            '',
+            {
+                setCustomFrom: (_, { value }) => value,
+            },
+        ],
+        customTo: [
+            'now',
+            {
+                setCustomTo: (_, { value }) => value,
+            },
+        ],
+        history: [
+            [] as DateRange[],
+            { persist: true },
+            {
+                addToHistory: (state, { dateRange }) => {
+                    const filtered = state.filter((h) => !dateRangesEqual(h, dateRange))
+                    return [dateRange, ...filtered].slice(0, MAX_HISTORY_ITEMS)
+                },
+            },
+        ],
+    }),
+])

--- a/products/logs/frontend/filters/LogsDateRangePicker/utils.test.ts
+++ b/products/logs/frontend/filters/LogsDateRangePicker/utils.test.ts
@@ -1,0 +1,120 @@
+import { DateMappingOption } from '~/types'
+
+import { formatDateRangeLabel, parseDateExpression } from './utils'
+
+const TEST_TIMEZONE = 'UTC'
+
+const TEST_DATE_OPTIONS: DateMappingOption[] = [
+    { key: 'Last 1 hour', values: ['-1h'], defaultInterval: 'hour' },
+    { key: 'Last 24 hours', values: ['-24h'], defaultInterval: 'hour' },
+]
+
+describe('parseDateExpression', () => {
+    beforeEach(() => {
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date('2024-01-15T12:00:00Z'))
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    it.each([
+        ['now', '2024-01-15T12:00:00.000Z'],
+        ['NOW', '2024-01-15T12:00:00.000Z'],
+        ['  now  ', '2024-01-15T12:00:00.000Z'],
+    ])('parses "now" keyword: %s', (input, expected) => {
+        const result = parseDateExpression(input, TEST_TIMEZONE)
+        expect(result?.toISOString()).toBe(expected)
+    })
+
+    it.each([
+        ['-30M', '2024-01-15T11:30:00.000Z', 'minutes'],
+        ['-1h', '2024-01-15T11:00:00.000Z', 'hours'],
+        ['-3h', '2024-01-15T09:00:00.000Z', 'hours'],
+        ['-1d', '2024-01-14T12:00:00.000Z', 'days'],
+        ['-7d', '2024-01-08T12:00:00.000Z', 'days'],
+        ['-1w', '2024-01-08T12:00:00.000Z', 'weeks'],
+        ['-1m', '2023-12-15T12:00:00.000Z', 'months'],
+        ['-1y', '2023-01-15T12:00:00.000Z', 'years'],
+        ['-1q', '2023-10-15T12:00:00.000Z', 'quarters (3 months)'],
+        ['-30s', '2024-01-15T11:59:30.000Z', 'seconds'],
+    ])('parses relative expression %s (%s)', (input, expected) => {
+        const result = parseDateExpression(input, TEST_TIMEZONE)
+        expect(result?.toISOString()).toBe(expected)
+    })
+
+    it.each([
+        ['2024-01-10', '2024-01-10T00:00:00.000Z'],
+        ['2024-01-10T15:30:00', '2024-01-10T15:30:00.000Z'],
+        ['2024-01-10 15:30', '2024-01-10T15:30:00.000Z'],
+    ])('parses absolute date %s', (input, expected) => {
+        const result = parseDateExpression(input, TEST_TIMEZONE)
+        expect(result?.toISOString()).toBe(expected)
+    })
+
+    it.each([
+        ['2024-01-10T15:00:00.000Z', 'UTC', '15:00'],
+        ['2024-01-10T15:00:00.000Z', 'America/New_York', '10:00'],
+        ['2024-01-10T15:00:00.000Z', 'Europe/London', '15:00'],
+        ['2024-01-10T15:00:00.000Z', 'Asia/Tokyo', '00:00'],
+        ['2024-01-10T15:00:00+02:00', 'UTC', '13:00'],
+        ['2024-01-10T15:00:00-05:00', 'UTC', '20:00'],
+    ])('converts ISO string %s to timezone %s showing %s', (input, timezone, expectedTime) => {
+        const result = parseDateExpression(input, timezone)
+        expect(result?.format('HH:mm')).toBe(expectedTime)
+    })
+
+    it.each([['invalid'], [''], ['abc123'], ['--1h'], ['1h']])('returns null for invalid expression: %s', (input) => {
+        const result = parseDateExpression(input, TEST_TIMEZONE)
+        expect(result).toBeNull()
+    })
+})
+
+describe('formatDateRangeLabel', () => {
+    beforeEach(() => {
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date('2024-01-15T12:00:00Z'))
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    it('returns matching option key when date matches', () => {
+        const result = formatDateRangeLabel({ date_from: '-1h', date_to: null }, TEST_TIMEZONE, TEST_DATE_OPTIONS)
+        expect(result).toBe('Last 1 hour')
+    })
+
+    it('formats absolute date range', () => {
+        const result = formatDateRangeLabel(
+            { date_from: '2024-01-10T10:00:00Z', date_to: '2024-01-15T12:00:00Z' },
+            TEST_TIMEZONE,
+            TEST_DATE_OPTIONS
+        )
+        expect(result).toBe('2024-01-10 10:00 - 2024-01-15 12:00')
+    })
+
+    it('uses current time when date_to is null and no option matches', () => {
+        const result = formatDateRangeLabel({ date_from: '2024-01-10T10:00:00Z', date_to: null }, TEST_TIMEZONE, [])
+        expect(result).toBe('2024-01-10 10:00 - 2024-01-15 12:00')
+    })
+
+    it('returns default message when date_from is empty', () => {
+        const result = formatDateRangeLabel({ date_from: '', date_to: null }, TEST_TIMEZONE, TEST_DATE_OPTIONS)
+        expect(result).toBe('Select date range')
+    })
+
+    it.each([
+        ['UTC', '2024-01-10 15:00 - 2024-01-15 12:00'],
+        ['America/New_York', '2024-01-10 10:00 - 2024-01-15 07:00'],
+        ['Asia/Tokyo', '2024-01-11 00:00 - 2024-01-15 21:00'],
+    ])('updates label when timezone changes to %s', (timezone, expectedLabel) => {
+        const result = formatDateRangeLabel(
+            { date_from: '2024-01-10T15:00:00.000Z', date_to: '2024-01-15T12:00:00.000Z' },
+            timezone,
+            TEST_DATE_OPTIONS
+        )
+        expect(result).toBe(expectedLabel)
+    })
+})

--- a/products/logs/frontend/filters/LogsDateRangePicker/utils.ts
+++ b/products/logs/frontend/filters/LogsDateRangePicker/utils.ts
@@ -1,0 +1,83 @@
+import { dayjs, dayjsLocalToTimezone } from 'lib/dayjs'
+
+import { DateRange } from '~/queries/schema/schema-general'
+import { DateMappingOption } from '~/types'
+
+export const DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm'
+
+export function getShortLabel(option: DateMappingOption): string {
+    return option.key.replace(/^Last /, '')
+}
+
+export function formatDateRangeLabel(dateRange: DateRange, timezone: string, dateOptions: DateMappingOption[]): string {
+    const { date_from, date_to } = dateRange
+
+    const matchingOption = dateOptions.find(
+        (o) => o.values[0] === date_from && (o.values[1] ?? null) === (date_to ?? null)
+    )
+    if (matchingOption) {
+        return matchingOption.key
+    }
+
+    const from = date_from ? parseDateExpression(date_from, timezone) : null
+    const to = date_to ? parseDateExpression(date_to, timezone) : dayjs().tz(timezone)
+
+    if (from && to) {
+        return `${from.format(DATE_TIME_FORMAT)} - ${to.format(DATE_TIME_FORMAT)}`
+    }
+
+    if (from) {
+        return `${from.format(DATE_TIME_FORMAT)} - now`
+    }
+
+    return 'Select date range'
+}
+
+const UNIT_MAP: Record<string, 'minute' | 'month' | 'hour' | 'day' | 'week' | 'year' | 'second'> = {
+    M: 'minute',
+    m: 'month',
+    h: 'hour',
+    d: 'day',
+    w: 'week',
+    y: 'year',
+    q: 'month', // 'q' represents quarters; it maps to 'month' and is treated as 3 months via a multiplier in parseDateExpression.
+    s: 'second',
+}
+
+// PostHog convention: M = minutes, m = months (case-sensitive)
+const RELATIVE_DATE_REGEX = /^-(\d+)(M|m|h|d|w|y|q|s)$/
+
+export function parseDateExpression(expr: string, timezone: string): dayjs.Dayjs | null {
+    const trimmed = expr.trim()
+
+    if (trimmed.toLowerCase() === 'now') {
+        return dayjs().tz(timezone)
+    }
+
+    const relativeMatch = trimmed.match(RELATIVE_DATE_REGEX)
+    if (relativeMatch) {
+        const amount = parseInt(relativeMatch[1], 10)
+        const unit = relativeMatch[2]
+        const multiplier = unit === 'q' ? 3 : 1
+        return dayjs()
+            .tz(timezone)
+            .subtract(amount * multiplier, UNIT_MAP[unit])
+    }
+
+    // ISO strings with timezone info (e.g., "2024-01-13T10:00:00.000Z") should be converted to target timezone
+    const isIsoWithTimezone = /^\d{4}-\d{2}-\d{2}T.*(Z|[+-]\d{2}:\d{2})$/.test(trimmed)
+    if (isIsoWithTimezone) {
+        const parsed = dayjs(trimmed).tz(timezone)
+        if (parsed.isValid()) {
+            return parsed
+        }
+    }
+
+    // Local time strings (e.g., "2024-01-13 10:00") should be interpreted in target timezone
+    const parsed = dayjsLocalToTimezone(trimmed, timezone)
+    if (parsed.isValid()) {
+        return parsed
+    }
+
+    return null
+}


### PR DESCRIPTION
## Problem

The current date range picker in the Logs interface lacks flexibility and user-friendly options for selecting time ranges, which is a critical function when analyzing logs data.

## Changes

Added a new date range picker component for the Logs interface that includes:

- Quick selection options for common time ranges (1 minute to 7 days)
- Custom date range input with calendar selection
- Recent date range history for quick access to previously used ranges
- Timezone selection integration
- Support for relative time expressions like "-1h", "-30M"

The new component is behind a feature flag `NEW_LOGS_DATE_RANGE_PICKER` to allow for controlled rollout.

<img width="650" height="534" alt="image" src="https://github.com/user-attachments/assets/bc36b75c-7466-4f57-a56b-8aabd2710bed" />

## How did you test this code?

- Added comprehensive unit tests for date expression parsing and formatting
- Tested various date formats and relative time expressions
- Verified timezone handling works correctly
- Manually tested the UI interactions and verified the component renders correctly
- Tested feature flag toggle to ensure both old and new pickers work properly

## Publish to changelog?

No