### PR TITLE
feat(event-pipeline): Add heatmap processing logic based on team optin status

### DIFF
--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
@@ -8,7 +8,7 @@ import { EventPipelineRunner, EventPipelineRunnerOptions } from '../../worker/in
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
-import { PipelineResult, isOkResult } from '../pipelines/results'
+import { PipelineResult, drop, isOkResult } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export interface EventPipelineRunnerHeatmapStepInput {
@@ -35,6 +35,11 @@ export function createEventPipelineRunnerHeatmapStep<TInput extends EventPipelin
         input: TInput
     ): Promise<PipelineResult<EventPipelineRunnerHeatmapStepResult<TInput>>> {
         const { normalizedEvent, timestamp, team, headers, groupStoreForBatch } = input
+
+        // Skip heatmap processing if team has explicitly opted out
+        if (team.heatmaps_opt_in === false) {
+            return drop('heatmap_opt_in_disabled')
+        }
 
         const runner = new EventPipelineRunner(
             config,


### PR DESCRIPTION
Fix copied from https://github.com/PostHog/posthog/pull/44846, introduced in the refactor PR https://github.com/PostHog/posthog/pull/43078

## Problem

People were not able to opt out from heatmaps

## Changes

Add heatmap processing logic based on team optin status

- Implemented logic to skip heatmap processing if heatmaps_opt_in is set to false for a team, returning a drop result with reason 'heatmap_opt_in_disabled'.
- Added test cases to verify behavior when heatmaps_opt_in is false and when it is null (default), ensuring correct processing flow.


## How did you test this code?
Added a new test