### PR TITLE
fix: startups and coupon no access banner

### DIFF
--- a/frontend/src/scenes/coupons/CouponRedemption.tsx
+++ b/frontend/src/scenes/coupons/CouponRedemption.tsx
@@ -92,7 +92,7 @@ export function CouponRedemption({
 
     if (!isAdminOrOwner) {
         return (
-            <div className="mx-auto max-w-200 mt-6 px-4">
+            <div className="mx-auto w-full max-w-200 mt-6 px-4">
                 <LemonBanner type="warning">
                     <h2 className="mb-2">Admin or owner permission required</h2>
                     <p>

--- a/frontend/src/scenes/startups/StartupProgram.tsx
+++ b/frontend/src/scenes/startups/StartupProgram.tsx
@@ -86,7 +86,7 @@ export function StartupProgram(): JSX.Element {
     // For YC pages, we show the full page with a status box instead
     if (isCurrentlyOnStartupPlan && !isYC) {
         return (
-            <div className="mx-auto max-w-200 mt-6 px-4">
+            <div className="mx-auto w-full max-w-200 mt-6 px-4">
                 <LemonBanner type="info">
                     <h2 className="mb-2">You are already in the {currentProgramName}</h2>
                     <p>It looks like your organization is already part of our {currentProgramName}.</p>
@@ -108,7 +108,7 @@ export function StartupProgram(): JSX.Element {
     // YC customers can re-apply
     if (wasPreviouslyOnStartupPlan && !isYC) {
         return (
-            <div className="mx-auto max-w-200 mt-6 px-4">
+            <div className="mx-auto w-full max-w-200 mt-6 px-4">
                 <LemonBanner type="info">
                     <h2 className="mb-2">You were already in the Startup Program</h2>
                     <p>
@@ -125,7 +125,7 @@ export function StartupProgram(): JSX.Element {
 
     if (isAnnualPlanCustomer) {
         return (
-            <div className="mx-auto max-w-200 mt-6 px-4">
+            <div className="mx-auto w-full max-w-200 mt-6 px-4">
                 <LemonBanner type="info">
                     <h2 className="mb-2">You are already on an annual plan</h2>
                     <p>
@@ -145,7 +145,7 @@ export function StartupProgram(): JSX.Element {
 
     if (!isAdminOrOwner) {
         return (
-            <div className="mx-auto max-w-200 mt-6 px-4">
+            <div className="mx-auto w-full max-w-200 mt-6 px-4">
                 <LemonBanner type="warning">
                     <h2 className="mb-2">Admin or owner permission required</h2>
                     <p>


### PR DESCRIPTION
## Problem

- `flex flex-col` was added to `SceneLayout` content wrapper, which caused elements using `mx-auto max-w-200` without explicit width to shrink to their content's intrinsic width
- "Admin or owner permission required" banner on startups and coupon pages was invisible

## Changes

- Added `w-full` to containers with so they take full width first
- Fixed in both `StartupProgram.tsx` (4 early return banners) and `CouponRedemption.tsx` (1 banner)

Before

![image.png](https://app.graphite.com/user-attachments/assets/c9f4aeec-13b8-4c8e-907c-aea33e9856ff.png)

After

![image.png](https://app.graphite.com/user-attachments/assets/0c445d58-3e5c-4eb9-bd96-5e328be5142c.png)

## How did you test this code?

Manually