### PR TITLE
fix(marketing-analytics): prevent double-counting Meta Ads conversions

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/adapters/meta_ads.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/meta_ads.py
@@ -127,9 +127,7 @@ class MetaAdsAdapter(MarketingSourceAdapter[MetaAdsConfig]):
     def _build_action_type_filter(self, action_type: str) -> ast.Expr:
         """Build filter condition for a specific action type"""
         return ast.CompareOperation(
-            left=ast.Call(
-                name="JSONExtractString", args=[ast.Field(chain=["x"]), ast.Constant(value="action_type")]
-            ),
+            left=ast.Call(name="JSONExtractString", args=[ast.Field(chain=["x"]), ast.Constant(value="action_type")]),
             op=ast.CompareOperationOp.Eq,
             right=ast.Constant(value=action_type),
         )


### PR DESCRIPTION
## Problem

Meta's actions array contains both "omni_purchase" (comprehensive omnichannel metric) and "purchase" (online-only) action types. When both exist, they represent the same conversion - omni_purchase is a superset that includes purchase.

## Changes

Previously, we summed both values together, causing conversions and conversion values to be double-counted (e.g., $31.02 + $31.02 = $62.04 instead of $31.02).

Now we prefer omni_purchase and only fall back to purchase if omni_purchase returns 0 (for older data or accounts without omnichannel tracking).

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
