### PR TITLE
fix: clicking view events in the persons modal willnow select the event

### DIFF
--- a/frontend/src/scenes/retention/retentionModalLogic.ts
+++ b/frontend/src/scenes/retention/retentionModalLogic.ts
@@ -98,7 +98,7 @@ export const retentionModalLogic = kea<retentionModalLogicType>([
         ],
         insightEventsQueryUrl: [
             (s) => [s.actorsQuery],
-            (actorsQuery: ActorsQuery): string | null => {
+            (actorsQuery): string | null => {
                 if (!actorsQuery) {
                     return null
                 }
@@ -108,13 +108,26 @@ export const retentionModalLogic = kea<retentionModalLogicType>([
 
                 const { includeRecordings, ...insightActorsQuery } = source.source as InsightActorsQuery
 
+                // Extract event name from the RetentionQuery
+                // interval 0 = targetEntity (initial cohort), interval > 0 = returningEntity
+                const retentionQuery = insightActorsQuery.source as RetentionQuery
+                const interval = insightActorsQuery.interval ?? 0
+                const entity =
+                    interval === 0
+                        ? retentionQuery.retentionFilter?.targetEntity
+                        : retentionQuery.retentionFilter?.returningEntity
+
+                const eventName = entity?.type === 'events' && entity?.id ? String(entity.id) : undefined
+
                 const query: DataTableNode = {
                     kind: NodeKind.DataTableNode,
                     source: {
                         kind: NodeKind.EventsQuery,
                         source: insightActorsQuery,
                         select: ['*', 'event', 'person', 'timestamp'],
-                        after: 'all', // Show all events by default because date range is filtered by the source
+                        // Show all events by default because date range is filtered by the source
+                        after: 'all',
+                        event: eventName,
                     },
                     full: true,
                 }

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -23,6 +23,7 @@ import {
     InsightActorsQueryOptions,
     InsightActorsQueryOptionsResponse,
     NodeKind,
+    TrendsQuery,
     insightActorsQueryOptionsResponseKeys,
 } from '~/queries/schema/schema-general'
 import { setLatestVersionsOnQuery } from '~/queries/utils'
@@ -389,7 +390,6 @@ export const personsModalLogic = kea<personsModalLogicType>([
                     return null
                 }
 
-                // Generate insight events query from actors query
                 const { select: _select, ...source } = actorsQuery
 
                 const kind =
@@ -401,13 +401,20 @@ export const personsModalLogic = kea<personsModalLogicType>([
 
                 const { includeRecordings, ...insightActorsQuery } = source.source as InsightActorsQuery
 
+                const trendsQuery = insightActorsQuery.source as TrendsQuery
+                const seriesIndex = insightActorsQuery.series ?? 0
+                const seriesNode = trendsQuery.series?.[seriesIndex]
+                const eventName = seriesNode && 'event' in seriesNode ? seriesNode.event : undefined
+
                 const query: DataTableNode = {
                     kind: NodeKind.DataTableNode,
                     source: {
                         kind: NodeKind.EventsQuery,
                         source: insightActorsQuery,
                         select: ['*', 'event', 'person', 'timestamp'],
-                        after: 'all', // Show all events by default because date range is filtered by the source
+                        // Show all events by default because date range is filtered by the source
+                        after: 'all',
+                        event: eventName,
                     },
                     full: true,
                 }


### PR DESCRIPTION
i clicked "view events" in the persons modal and it didn't select the event in the UI (although the query it ran was correct)

so i thought it was broken even when it wasn't

let's correctly select the event

| before | after |
| - | - |
|![2026-01-13 19 53 30](https://github.com/user-attachments/assets/b1203d52-f554-43a6-a091-1bf7a53003c3)|![2026-01-13 19 54 04](https://github.com/user-attachments/assets/077bccf5-2198-4cde-84b6-075a1ce49466)|

