### PR TITLE
fix(phai): Improve tool definition lookup logic

### DIFF
--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -961,8 +961,12 @@ export const AI_GENERALLY_CANNOT: string[] = [
 ]
 
 export function getToolDefinitionFromToolCall(toolCall: EnhancedToolCall): ToolDefinition | null {
-    const identifier = toolCall.args.kind ?? toolCall.name
-    return getToolDefinition(identifier as string)
+    const definition = getToolDefinition(toolCall.name)
+    // Only use args.kind for subtool lookup if the parent tool has subtools
+    if (definition?.subtools && typeof toolCall.args.kind === 'string') {
+        return definition.subtools[toolCall.args.kind] ?? definition
+    }
+    return definition
 }
 
 export function getToolDefinition(identifier: string): ToolDefinition | null {


### PR DESCRIPTION
## Problem

Tools with kind were overwriting regular formatting.

Example

<img width="504" height="166" alt="Screenshot 2026-01-13 at 21 03 54" src="https://github.com/user-attachments/assets/f58e89e4-0407-42a8-bf35-9a7a1b2363d1" />

After

<img width="285" height="163" alt="Screenshot 2026-01-13 at 20 58 21" src="https://github.com/user-attachments/assets/1cbd8ecb-cca8-4a33-a6d6-c9d8bc494fb2" />

## Changes

- Updated `getToolDefinitionFromToolCall` to prioritize `toolCall.name` for fetching tool definitions.
- Added logic to check for subtools only if the parent tool has them, using `args.kind` for subtool lookup when applicable.

