### PR TITLE
feat(clickhouse): add query weight detection from historical execution

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -67,6 +67,9 @@ class ClickHouseUser(StrEnum):
     MAX_AI = "max_ai"
     ENDPOINTS = "endpoints"
 
+    # queries that run for the purpose to prepare a query or decide how to run it
+    META = "meta"
+
     # Dev Operations - do not normally use
     OPS = "ops"
     # Only for migrations - do not normally use

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -111,6 +111,7 @@ class QueryTags(BaseModel):
 
     route_id: Optional[str] = None
     workload: Optional[str] = None  # enum connection.Workload
+    query_weight: Optional[str] = None  # QueryWeight enum value
     dashboard_id: Optional[int] = None
     insight_id: Optional[int] = None
     exported_asset_id: Optional[int] = None

--- a/posthog/clickhouse/query_weight.py
+++ b/posthog/clickhouse/query_weight.py
@@ -1,0 +1,80 @@
+from enum import Enum
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import ClickHouseUser
+
+
+class QueryWeight(Enum):
+    UNSUPPORTED = "unsupported"  # Entity type not supported for weight checking
+    UNDECISIVE = "undecisive"  # No historical data
+    NORMAL = "normal"  # Historical data exists, not heavy
+    HEAVY = "heavy"  # Historical data shows heavy execution
+
+
+# Thresholds
+HEAVY_READ_BYTES = 1_000_000_000_000  # 1TB
+HEAVY_DURATION_MS = 300_000  # 300 seconds
+HEAVY_EXCEPTION_CODES = (241, 159)  # MEMORY_LIMIT_EXCEEDED, TIMEOUT_EXCEEDED
+
+
+def get_query_weight(
+    *,
+    team_id: int,
+    cohort_id: int | None = None,
+    experiment_id: int | None = None,
+    insight_id: int | None = None,
+) -> QueryWeight:
+    """
+    Determine if a query is likely to be heavy based on historical execution.
+
+    Checks the last 7 days of query_log_archive for matching queries.
+    Returns UNDECISIVE if no history or on error, HEAVY if any execution exceeded thresholds,
+    NORMAL otherwise.
+    """
+    if cohort_id is not None:
+        filter_clause = "lc_cohort_id = %(entity_id)s"
+        entity_id = cohort_id
+    elif experiment_id is not None:
+        filter_clause = "lc_experiment_id = %(entity_id)s"
+        entity_id = experiment_id
+    elif insight_id is not None:
+        filter_clause = "lc_insight_id = %(entity_id)s"
+        entity_id = insight_id
+    else:
+        return QueryWeight.UNSUPPORTED
+
+    query = f"""
+        SELECT
+            count() as total_queries,
+            countIf(
+                exception_code IN %(heavy_exception_codes)s
+                OR read_bytes > %(heavy_read_bytes)s
+                OR query_duration_ms > %(heavy_duration_ms)s
+            ) as heavy_queries
+        FROM query_log_archive
+        WHERE team_id = %(team_id)s
+          AND {filter_clause}
+          AND event_date >= today() - 7
+          AND type = 'QueryFinish'
+    """
+
+    try:
+        result = sync_execute(
+            query,
+            {
+                "team_id": team_id,
+                "entity_id": entity_id,
+                "heavy_exception_codes": HEAVY_EXCEPTION_CODES,
+                "heavy_read_bytes": HEAVY_READ_BYTES,
+                "heavy_duration_ms": HEAVY_DURATION_MS,
+            },
+            ch_user=ClickHouseUser.META,
+        )
+    except Exception:
+        return QueryWeight.UNDECISIVE
+
+    if not result or result[0][0] == 0:
+        return QueryWeight.UNDECISIVE
+
+    total_queries, heavy_queries = result[0]
+    return QueryWeight.HEAVY if heavy_queries > 0 else QueryWeight.NORMAL

--- a/posthog/clickhouse/test/test_query_weight.py
+++ b/posthog/clickhouse/test/test_query_weight.py
@@ -1,0 +1,95 @@
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from posthog.clickhouse.query_weight import (
+    HEAVY_DURATION_MS,
+    HEAVY_EXCEPTION_CODES,
+    HEAVY_READ_BYTES,
+    QueryWeight,
+    get_query_weight,
+)
+
+
+class TestGetQueryWeight:
+    @parameterized.expand(
+        [
+            ("cohort_id", {"cohort_id": 123}, "lc_cohort_id = %(entity_id)s"),
+            ("experiment_id", {"experiment_id": 456}, "lc_experiment_id = %(entity_id)s"),
+            ("insight_id", {"insight_id": 789}, "lc_insight_id = %(entity_id)s"),
+        ]
+    )
+    @patch("posthog.clickhouse.query_weight.sync_execute")
+    def test_queries_correct_filter(self, _name, kwargs, expected_filter, mock_sync_execute):
+        mock_sync_execute.return_value = [(10, 0)]
+
+        get_query_weight(team_id=1, **kwargs)
+
+        call_args = mock_sync_execute.call_args
+        query = call_args[0][0]
+        assert expected_filter in query
+
+    def test_returns_unsupported_when_no_entity_id_provided(self):
+        result = get_query_weight(team_id=1)
+        assert result == QueryWeight.UNSUPPORTED
+
+    @parameterized.expand(
+        [
+            ("empty_result", [], QueryWeight.UNDECISIVE),
+            ("zero_queries", [(0, 0)], QueryWeight.UNDECISIVE),
+            ("normal_queries", [(10, 0)], QueryWeight.NORMAL),
+            ("some_heavy", [(10, 3)], QueryWeight.HEAVY),
+            ("all_heavy", [(5, 5)], QueryWeight.HEAVY),
+            ("single_heavy", [(1, 1)], QueryWeight.HEAVY),
+        ]
+    )
+    @patch("posthog.clickhouse.query_weight.sync_execute")
+    def test_return_values(self, _name, db_result, expected, mock_sync_execute):
+        mock_sync_execute.return_value = db_result
+
+        result = get_query_weight(team_id=1, cohort_id=123)
+
+        assert result == expected
+
+    @patch("posthog.clickhouse.query_weight.sync_execute")
+    def test_passes_correct_thresholds(self, mock_sync_execute):
+        mock_sync_execute.return_value = [(10, 0)]
+
+        get_query_weight(team_id=1, cohort_id=123)
+
+        call_args = mock_sync_execute.call_args
+        params = call_args[0][1]
+        assert params["heavy_exception_codes"] == HEAVY_EXCEPTION_CODES
+        assert params["heavy_read_bytes"] == HEAVY_READ_BYTES
+        assert params["heavy_duration_ms"] == HEAVY_DURATION_MS
+
+    @patch("posthog.clickhouse.query_weight.sync_execute")
+    def test_passes_team_id(self, mock_sync_execute):
+        mock_sync_execute.return_value = [(10, 0)]
+
+        get_query_weight(team_id=42, cohort_id=123)
+
+        call_args = mock_sync_execute.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+        assert "team_id = %(team_id)s" in query
+        assert params["team_id"] == 42
+
+    @patch("posthog.clickhouse.query_weight.sync_execute")
+    def test_uses_meta_user(self, mock_sync_execute):
+        from posthog.clickhouse.client.connection import ClickHouseUser
+
+        mock_sync_execute.return_value = [(10, 0)]
+
+        get_query_weight(team_id=1, cohort_id=123)
+
+        call_args = mock_sync_execute.call_args
+        assert call_args.kwargs["ch_user"] == ClickHouseUser.META
+
+    @patch("posthog.clickhouse.query_weight.sync_execute")
+    def test_returns_undecisive_on_exception(self, mock_sync_execute):
+        mock_sync_execute.side_effect = Exception("Database error")
+
+        result = get_query_weight(team_id=1, cohort_id=123)
+
+        assert result == QueryWeight.UNDECISIVE


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
