### PR TITLE
feat(mcp): expose api_token in projects-get response

### DIFF
--- a/services/mcp/typescript/src/schema/projects.ts
+++ b/services/mcp/typescript/src/schema/projects.ts
@@ -4,6 +4,7 @@ export const ProjectSchema = z.object({
     id: z.number(),
     name: z.string(),
     organization: z.string().uuid(),
+    api_token: z.string(),
 })
 
 export type Project = z.infer<typeof ProjectSchema>


### PR DESCRIPTION
## Problem

We just added the MCP as a featured server on Replit (https://docs.replit.com/replitai/mcp/directory). When using it to add error tracking or other SDK integrations to apps, the LLM needs the project API key (`phc_...`) to configure the SDK, but the MCP wasn't exposing it.

## Changes

Added `api_token` to the `ProjectSchema` so the `projects-get` tool now returns the project API key. The API already returns this field - it just wasn't included in the MCP's schema.

## How did you test this code?

- Ran the MCP test suite (`pnpm test` in `services/mcp/typescript`) - all 131 tests pass
- Tested locally with the local MCP  `pnpm dev` via Claude Code and verified `projects-get` now returns `api_token`

## Changelog

No - internal MCP improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)