### PR TITLE
feat(flags): display dependent flags

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -109,7 +109,7 @@ import { FeatureFlagStatusIndicator } from './FeatureFlagStatusIndicator'
 import { UserFeedbackSection } from './FeatureFlagUserFeedback'
 import { FeatureFlagVariantsForm, focusVariantKeyField } from './FeatureFlagVariantsForm'
 import { RecentFeatureFlagInsights } from './RecentFeatureFlagInsightsCard'
-import { FeatureFlagLogicProps, featureFlagLogic } from './featureFlagLogic'
+import { DependentFlag, FeatureFlagLogicProps, featureFlagLogic } from './featureFlagLogic'
 import { FeatureFlagsTab, featureFlagsLogic } from './featureFlagsLogic'
 
 const RESOURCE_TYPE = 'feature_flag'
@@ -1035,6 +1035,7 @@ function FeatureFlagRollout({
         variantErrors,
         experiment,
         experimentLoading,
+        dependentFlags,
     } = useValues(featureFlagLogic)
     const { featureFlags } = useValues(enabledFeaturesLogic)
     const { hasAvailableFeature } = useValues(userLogic)
@@ -1224,6 +1225,26 @@ function FeatureFlagRollout({
                                     </div>
                                 </div>
                             </>
+                        )}
+
+                        {dependentFlags.length > 0 && (
+                            <div className="mt-4">
+                                <span className="card-secondary mt-4">Dependent flags</span>
+                                <div className="flex flex-col gap-1">
+                                    {dependentFlags.map((flag: DependentFlag) => (
+                                        <div key={flag.id} className="flex gap-1 items-center">
+                                            <span className="font-normal text-sm">{flag.key}</span>
+                                            <Link
+                                                target="_blank"
+                                                className="font-semibold"
+                                                to={urls.featureFlag(flag.id)}
+                                            >
+                                                <IconOpenInNew fontSize="18" />
+                                            </Link>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
                         )}
                     </div>
                     <SceneDivider />

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -1238,6 +1238,7 @@ function FeatureFlagRollout({
                                                 target="_blank"
                                                 className="font-semibold"
                                                 to={urls.featureFlag(flag.id)}
+                                                aria-label={`Open ${flag.key}`}
                                             >
                                                 <IconOpenInNew fontSize="18" />
                                             </Link>


### PR DESCRIPTION

## Problem

It's hard to identify all the flags which depend on any given flag. Users have to mostly remember which flags depend on another if they want to disable them all.

## Changes

This change displays "Dependent flags" in the feature flag overview if the given flag has any flags which depend on it.

<img width="785" height="372" alt="image" src="https://github.com/user-attachments/assets/6725938f-0b69-4b03-aca0-072f7aefa823" />

## How did you test this code?

Kea logic tests, tested locally
