### PR TITLE
fix(product tours): disable per-element screenshots, for now

### DIFF
--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -31,6 +31,7 @@ import type { productToursLogicType } from './productToursLogicType'
 import { ElementScreenshot, captureAndUploadElementScreenshot, captureScreenshot, getElementMetadata } from './utils'
 
 const RECENT_GOALS_KEY = 'posthog-product-tours-recent-goals'
+const DISABLE_ELEMENT_SCREENSHOTS = true
 
 export type AIGenerationStep = 'idle' | 'capturing' | 'analyzing' | 'generating' | 'done' | 'error'
 
@@ -556,7 +557,15 @@ export const productToursLogic = kea<productToursLogicType>([
 
             const inferenceData = inferSelector(element)?.selector
 
-            const screenshotPromise = captureAndUploadElementScreenshot(element).catch((e) => {
+            // domToJpeg is extremely heavy and blocking - for complex sites
+            // like the PostHog app, the entire page freezes for multiple seconds
+            // while the screenshot happens. hard-code disabling this for now until
+            // we come up with a better solution.
+            const screenshotPromise = (
+                DISABLE_ELEMENT_SCREENSHOTS
+                    ? Promise.reject('element screenshots disabled')
+                    : captureAndUploadElementScreenshot(element)
+            ).catch((e) => {
                 console.warn('[Product Tours] Failed to capture element screenshot:', e)
                 return null
             })


### PR DESCRIPTION
## Problem

[**_i hate this_** but not sure how to resolve it right now, and it should not be a blocker to shipping the private beta]

we screenshot each element used during product tours. this is great and i want to keep it, BUT domToJpeg is extremely heavy / slow / blocking and makes for a miserable experiencing working in heavy places like the PostHog app

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

hard-code disables element screenshots until we find a better solution

some options:

1. only screenshot once per page, cache, invalidate on page change, and crop the cached screenshot
2. migrate to chrome extension
3. use native screenshot api (requires user permissions if not in an extension)

none of these options are particularly _good_, so i'm disabling for now to fix the UX and give us time to think

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->