### PR TITLE
feat(hogql): add ingestion_warnings as system table

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -15,7 +15,7 @@ from posthog.hogql.database.postgres_table import PostgresTable
 
 class IngestionWarningsTable(Table):
     fields: dict[str, FieldOrTable] = {
-        "team_id": IntegerDatabaseField(name="team_id", nullable=False),
+        "team_id": IntegerDatabaseField(name="team_id", nullable=False, hidden=True),
         "source": StringDatabaseField(name="source", nullable=False),
         "type": StringDatabaseField(name="type", nullable=False),
         "details": StringDatabaseField(name="details", nullable=False),

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -3,12 +3,31 @@ from posthog.hogql.database.models import (
     BooleanDatabaseField,
     DateTimeDatabaseField,
     ExpressionField,
+    FieldOrTable,
     IntegerDatabaseField,
     StringDatabaseField,
     StringJSONDatabaseField,
+    Table,
     TableNode,
 )
 from posthog.hogql.database.postgres_table import PostgresTable
+
+
+class IngestionWarningsTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        "team_id": IntegerDatabaseField(name="team_id", nullable=False),
+        "source": StringDatabaseField(name="source", nullable=False),
+        "type": StringDatabaseField(name="type", nullable=False),
+        "details": StringDatabaseField(name="details", nullable=False),
+        "timestamp": DateTimeDatabaseField(name="timestamp", nullable=False),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "ingestion_warnings"
+
+    def to_printed_hogql(self):
+        return "ingestion_warnings"
+
 
 cohorts: PostgresTable = PostgresTable(
     name="cohorts",
@@ -212,6 +231,7 @@ class SystemTables(TableNode):
     children: dict[str, TableNode] = {
         "dashboards": TableNode(name="dashboards", table=dashboards),
         "cohorts": TableNode(name="cohorts", table=cohorts),
+        "ingestion_warnings": TableNode(name="ingestion_warnings", table=IngestionWarningsTable()),
         "insights": TableNode(name="insights", table=insights),
         "experiments": TableNode(name="experiments", table=experiments),
         "exports": TableNode(name="exports", table=exports),

--- a/posthog/hogql/database/schema/test/test_ingestion_warnings.py
+++ b/posthog/hogql/database/schema/test/test_ingestion_warnings.py
@@ -1,0 +1,44 @@
+from posthog.test.base import BaseTest
+
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_and_print_ast
+
+
+class TestIngestionWarningsTable(BaseTest):
+    def test_select_from_ingestion_warnings_system_table(self):
+        db = Database.create_for(team=self.team)
+        context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            database=db,
+        )
+
+        sql = "SELECT source, type, details, timestamp FROM system.ingestion_warnings"
+        query, _ = prepare_and_print_ast(parse_select(sql), context, dialect="clickhouse")
+
+        assert "ingestion_warnings" in query
+        assert "source" in query
+        assert "type" in query
+        assert "details" in query
+        assert "timestamp" in query
+
+    def test_ingestion_warnings_table_is_in_system_tables(self):
+        db = Database.create_for(team=self.team)
+        system_table_names = db.get_system_table_names()
+
+        assert "system.ingestion_warnings" in system_table_names
+
+    def test_ingestion_warnings_table_has_team_id_filter(self):
+        db = Database.create_for(team=self.team)
+        context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            database=db,
+        )
+
+        sql = "SELECT * FROM system.ingestion_warnings"
+        query, _ = prepare_and_print_ast(parse_select(sql), context, dialect="clickhouse")
+
+        assert f"team_id = {self.team.pk}" in query or f"equals(ingestion_warnings.team_id, {self.team.pk})" in query

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -2185,6 +2185,54 @@
           "row_count": null,
           "type": "system"
       },
+      "system.ingestion_warnings": {
+          "fields": {
+              "source": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "source",
+                  "id": null,
+                  "name": "source",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "type",
+                  "id": null,
+                  "name": "type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "details": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "details",
+                  "id": null,
+                  "name": "details",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "timestamp": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "timestamp",
+                  "id": null,
+                  "name": "timestamp",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.ingestion_warnings",
+          "name": "system.ingestion_warnings",
+          "row_count": null,
+          "type": "system"
+      },
       "system.insights": {
           "fields": {
               "id": {
@@ -4650,6 +4698,54 @@
           },
           "id": "system.cohorts",
           "name": "system.cohorts",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.ingestion_warnings": {
+          "fields": {
+              "source": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "source",
+                  "id": null,
+                  "name": "source",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "type",
+                  "id": null,
+                  "name": "type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "details": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "details",
+                  "id": null,
+                  "name": "details",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "timestamp": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "timestamp",
+                  "id": null,
+                  "name": "timestamp",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.ingestion_warnings",
+          "name": "system.ingestion_warnings",
           "row_count": null,
           "type": "system"
       },

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -97,7 +97,7 @@
   
   This is a list of all the available tables in the database:
   ```
-  ['events', 'groups', 'persons', 'sessions', 'query_log', 'system.dashboards', 'system.cohorts', 'system.insights', 'system.experiments', 'system.exports', 'system.data_warehouse_sources', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.insight_variables', 'system.surveys', 'system.teams']
+  ['events', 'groups', 'persons', 'sessions', 'query_log', 'system.dashboards', 'system.cohorts', 'system.ingestion_warnings', 'system.insights', 'system.experiments', 'system.exports', 'system.data_warehouse_sources', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.insight_variables', 'system.surveys', 'system.teams']
   ```
   
   `person` or `event` metadata unspecified above (emails, names, etc.) is stored in `properties` fields, accessed like: `properties.foo.bar`.


### PR DESCRIPTION
Add ingestion_warnings table to the HogQL system tables, allowing users to query ingestion warnings directly via SQL. This enables easier debugging by allowing users to join event data with ingestion warnings.

The table exposes the following fields:
- team_id
- source
- type
- details
- timestamp

Users can now query via: SELECT * FROM system.ingestion_warnings

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
