### PR TITLE
Fix: thread message markdown parsing to handle newlines

### DIFF
--- a/frontend/src/scenes/max/MarkdownMessage.tsx
+++ b/frontend/src/scenes/max/MarkdownMessage.tsx
@@ -4,7 +4,9 @@ import { memo, useMemo } from 'react'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 
 function parseMarkdownIntoBlocks(markdown: string): string[] {
-    const tokens = marked.lexer(markdown)
+    // Convert single newlines to markdown line breaks (two spaces + newline)
+    const withLineBreaks = markdown.replace(/(?<!\n)\n(?!\n)/g, '  \n')
+    const tokens = marked.lexer(withLineBreaks)
     return tokens.map((token) => token.raw)
 }
 


### PR DESCRIPTION
## Problem
The chat input supports new lines (textarea), but the human message rendered in thread doesn't render it that way (even though content comes in supporting it)

<img width="513" height="508" alt="image" src="https://github.com/user-attachments/assets/066283b3-280b-453f-8f4a-33167a422092" />


## Changes
<img width="518" height="673" alt="image" src="https://github.com/user-attachments/assets/4a673c78-6a99-49a8-b92c-ea2e95e1f7f6" />


## How did you test this code?
Locally, seems fine

## Publish to changelog?
No