### PR TITLE
fix(surveys): fix ai consent popover visibility

### DIFF
--- a/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
@@ -165,7 +165,11 @@ export function OpenQuestionSummaryV2({
                             <IconSparkles className="text-warning" />
                             <span className="font-semibold">Response summary</span>
                         </div>
-                        <AIConsentPopoverWrapper showArrow onDismiss={handleDismissPopover}>
+                        <AIConsentPopoverWrapper
+                            showArrow
+                            onDismiss={handleDismissPopover}
+                            hidden={!showConsentPopover}
+                        >
                             <LemonButton
                                 type="secondary"
                                 size="small"


### PR DESCRIPTION
## Problem

once shown, the AI consent popover in survey response page is stuck visible

context: https://posthog.slack.com/archives/C07QD3LT8U9/p1768350334049179

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

passes visibility state to the popover wrapper so it'll hide when it should hide

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->