### PR TITLE
chore: enabling auto-materialization on insight-based endpoints is not UX friendly yet

### DIFF
--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -265,9 +265,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 team=self.team,
             )
 
-            # Auto-enable materialization if endpoint can be materialized
             can_materialize, _ = endpoint.can_materialize()
-            if can_materialize:
+            if can_materialize and endpoint.query.get("kind") == "HogQLQuery":
                 try:
                     sync_frequency = data.sync_frequency or DataWarehouseSyncInterval.FIELD_24HOUR
                     self._enable_materialization(endpoint, sync_frequency, request)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
insight based endpoints materialize into S3 tables, so when executing them the results are shaped differently. **for now**, and this is not documented properly. 
so i don't want to cause frustration when someone new creates an insight-based endpoint.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- only auto-materialize a hogql based endpoint

## How did you test this code?
- locally creating an insight-based endpoint didn't auto-materialize
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->
no

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
