### PR TITLE
chore(claude): add PostToolUse hook for ruff linting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,9 +3,6 @@
         "pyright-lsp@claude-plugins-official": true,
         "typescript-lsp@claude-plugins-official": true
     },
-    "permissions": {
-        "allow": ["Bash(flox activate:*)"]
-    },
     "hooks": {
         "PostToolUse": [
             {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "if [[ \"$CLAUDE_FILE_PATHS\" == *.py ]]; then flox activate -- bash -c \"ruff check $CLAUDE_FILE_PATHS --fix && ruff format $CLAUDE_FILE_PATHS\"; fi"
+                        "command": "for f in $CLAUDE_FILE_PATHS; do [[ \"$f\" == *.py ]] && PY_FILES=\"$PY_FILES $f\"; done; [ -n \"$PY_FILES\" ] && flox activate -- bash -c \"ruff check $PY_FILES --fix && ruff format $PY_FILES\""
                     }
                 ]
             }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "for f in $CLAUDE_FILE_PATHS; do [[ \"$f\" == *.py ]] && PY_FILES=\"$PY_FILES $f\"; done; [ -n \"$PY_FILES\" ] && flox activate -- bash -c \"ruff check $PY_FILES --fix && ruff format $PY_FILES\""
+                        "command": "PY_FILES=(); for f in $CLAUDE_FILE_PATHS; do [[ \"$f\" == *.py ]] && PY_FILES+=(\"$f\"); done; [ ${#PY_FILES[@]} -gt 0 ] && flox activate -- bash -c \"ruff check \\\"${PY_FILES[@]}\\\" --fix && ruff format \\\"${PY_FILES[@]}\\\"\""
                     }
                 ]
             }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,21 @@
     "enabledPlugins": {
         "pyright-lsp@claude-plugins-official": true,
         "typescript-lsp@claude-plugins-official": true
+    },
+    "permissions": {
+        "allow": ["Bash(flox activate:*)"]
+    },
+    "hooks": {
+        "PostToolUse": [
+            {
+                "matcher": "(Edit|Write)",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "if [[ \"$CLAUDE_FILE_PATHS\" == *.py ]]; then flox activate -- bash -c \"ruff check $CLAUDE_FILE_PATHS --fix && ruff format $CLAUDE_FILE_PATHS\"; fi"
+                    }
+                ]
+            }
+        ]
     }
 }


### PR DESCRIPTION
Automatically runs ruff check --fix and ruff format on Python files after Edit/Write operations using flox activate.