### PR TITLE
feat(endpoints): add duplicate endpoint action to table menu

### DIFF
--- a/products/endpoints/frontend/Endpoints.tsx
+++ b/products/endpoints/frontend/Endpoints.tsx
@@ -12,10 +12,14 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { atColumn, createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { OutputTab } from 'scenes/data-warehouse/editor/outputPaneLogic'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { isHogQLQuery } from '~/queries/utils'
 import { EndpointType } from '~/types'
+
+import { EndpointFromInsightModal } from './EndpointFromInsightModal'
 
 import { humanizeQueryKind } from './common'
 import { endpointLogic } from './endpointLogic'
@@ -41,7 +45,8 @@ export const EndpointsTable = ({ tabId }: EndpointsTableProps): JSX.Element => {
     const { setFilters, loadEndpoints } = useActions(endpointsLogic({ tabId }))
     const { endpoints, allEndpointsLoading, filters } = useValues(endpointsLogic({ tabId }))
 
-    const { deleteEndpoint, confirmToggleActive } = useActions(endpointLogic({ tabId }))
+    const { deleteEndpoint, confirmToggleActive, setDuplicateEndpoint } = useActions(endpointLogic({ tabId }))
+    const { duplicateEndpoint } = useValues(endpointLogic({ tabId }))
 
     const handleDelete = (endpointName: string): void => {
         LemonDialog.open({
@@ -70,6 +75,16 @@ export const EndpointsTable = ({ tabId }: EndpointsTableProps): JSX.Element => {
 
     const handleEndpointActivation = (endpoint: EndpointType): void => {
         confirmToggleActive(endpoint)
+    }
+
+    const handleDuplicate = (endpoint: EndpointType): void => {
+        if (isHogQLQuery(endpoint.query)) {
+            router.actions.push(
+                urls.sqlEditor(endpoint.query.query, undefined, undefined, undefined, OutputTab.Endpoint)
+            )
+        } else {
+            setDuplicateEndpoint(endpoint)
+        }
     }
 
     const columns: LemonTableColumns<EndpointType> = [
@@ -156,6 +171,9 @@ export const EndpointsTable = ({ tabId }: EndpointsTableProps): JSX.Element => {
                             >
                                 View usage
                             </LemonButton>
+                            <LemonButton onClick={() => handleDuplicate(record)} fullWidth>
+                                Duplicate endpoint
+                            </LemonButton>
 
                             <LemonDivider />
                             <LemonButton
@@ -218,6 +236,15 @@ export const EndpointsTable = ({ tabId }: EndpointsTableProps): JSX.Element => {
                 emptyState="No endpoints matching your filters!"
                 nouns={['endpoint', 'endpoints']}
             />
+            {duplicateEndpoint && (
+                <EndpointFromInsightModal
+                    isOpen={!!duplicateEndpoint}
+                    closeModal={() => setDuplicateEndpoint(null)}
+                    tabId={tabId}
+                    insightQuery={duplicateEndpoint.query}
+                    insightShortId={duplicateEndpoint.derived_from_insight ?? undefined}
+                />
+            )}
         </SceneContent>
     )
 }

--- a/products/endpoints/frontend/Endpoints.tsx
+++ b/products/endpoints/frontend/Endpoints.tsx
@@ -20,7 +20,6 @@ import { isHogQLQuery } from '~/queries/utils'
 import { EndpointType } from '~/types'
 
 import { EndpointFromInsightModal } from './EndpointFromInsightModal'
-
 import { humanizeQueryKind } from './common'
 import { endpointLogic } from './endpointLogic'
 import { endpointsLogic } from './endpointsLogic'

--- a/products/endpoints/frontend/endpointLogic.tsx
+++ b/products/endpoints/frontend/endpointLogic.tsx
@@ -152,6 +152,7 @@ export const endpointLogic = kea<endpointLogicType>([
             createEndpointSuccess: ({ response }) => {
                 actions.setEndpointName('')
                 actions.setEndpointDescription('')
+                actions.loadEndpoints()
                 lemonToast.success(<>Endpoint created</>, {
                     button: {
                         label: 'View',

--- a/products/endpoints/frontend/endpointLogic.tsx
+++ b/products/endpoints/frontend/endpointLogic.tsx
@@ -36,6 +36,7 @@ export const endpointLogic = kea<endpointLogicType>([
         setSelectedCodeExampleVersion: (version: number | null) => ({ version }),
         setIsUpdateMode: (isUpdateMode: boolean) => ({ isUpdateMode }),
         setSelectedEndpointName: (selectedEndpointName: string | null) => ({ selectedEndpointName }),
+        setDuplicateEndpoint: (endpoint: EndpointType | null) => ({ endpoint }),
         createEndpoint: (request: EndpointRequest) => ({ request }),
         createEndpointSuccess: (response: any) => ({ response }),
         createEndpointFailure: () => ({}),
@@ -72,6 +73,12 @@ export const endpointLogic = kea<endpointLogicType>([
             null as string | null,
             {
                 setSelectedEndpointName: (_, { selectedEndpointName }) => selectedEndpointName,
+            },
+        ],
+        duplicateEndpoint: [
+            null as EndpointType | null,
+            {
+                setDuplicateEndpoint: (_, { endpoint }) => endpoint,
             },
         ],
     }),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Feedback from a customer suggesting it'd be cool to be able to duplicate, considering we can't handle different time granularities easily.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

HogQL-based endpoints navigate to SQL editor with query prefilled on the Endpoint output tab. Insight-based endpoints open the existing modal with the query prefilled for creating a new endpoint.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
