### PR TITLE
chore(livestream): Only log when a team drops events

### DIFF
--- a/livestream/events/filter.go
+++ b/livestream/events/filter.go
@@ -91,7 +91,7 @@ func uuidFromDistinctId(teamId int, distinctId string) string {
 func removeSubscription(subID uint64, subs []Subscription) []Subscription {
 	for i, sub := range subs {
 		if subID == sub.SubID {
-			if dropped := sub.DroppedEvents.Load(); dropped >= 0 {
+			if dropped := sub.DroppedEvents.Load(); dropped > 0 {
 				log.Printf("Team %d Distinct Id %s dropped %d events", sub.TeamId, sub.DistinctId, dropped)
 			}
 			metrics.SubTotal.Dec()

--- a/livestream/events/filter.go
+++ b/livestream/events/filter.go
@@ -92,7 +92,7 @@ func removeSubscription(subID uint64, subs []Subscription) []Subscription {
 	for i, sub := range subs {
 		if subID == sub.SubID {
 			if dropped := sub.DroppedEvents.Load(); dropped > 0 {
-				log.Printf("Team %d Distinct Id %s dropped %d events", sub.TeamId, sub.DistinctId, dropped)
+				log.Printf("Team %d dropped %d events", sub.TeamId, dropped)
 			}
 			metrics.SubTotal.Dec()
 			return slices.Delete(subs, i, i+1)


### PR DESCRIPTION
## Problem
Logging is too noisy

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Only log that a team dropped events if the drop count is > 0.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
