### PR TITLE
chore(ph-ai): remove stale flags

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -317,14 +317,10 @@ export const FEATURE_FLAGS = {
     PRODUCT_TOURS: 'product-tours-2025', // owner: @adboio #team-surveys
     PRODUCT_TOURS_RICH_TEXT: 'product-tours-rich-text', // owner: @adboio #team-surveys
     POSTHOG_AI_BILLING_DISPLAY: 'posthog-ai-billing-display', // owner: #team-posthog-ai
-    POSTHOG_AI_BILLING_USAGE_COMMAND: 'posthog-ai-billing-usage-command', // owner: #team-posthog-ai
-    POSTHOG_AI_BILLING_USAGE_REPORT: 'posthog-ai-billing-usage-report', // owner: #team-posthog-ai
     POSTHOG_AI_CHANGELOG: 'posthog-ai-changelog', // owner: #team-posthog-ai
     POSTHOG_AI_ALERTS: 'posthog-ai-alerts', // owner: #team-posthog-ai
     POSTHOG_AI_CONVERSATION_FEEDBACK_CONFIG: 'posthog-ai-conversation-feedback-config', // owner: #team-posthog-ai
     POSTHOG_AI_CONVERSATION_FEEDBACK_LLMA_SESSIONS: 'posthog-ai-conversation-feedback-llma-sessions', // owner: #team-posthog-ai
-    POSTHOG_AI_FEEDBACK_COMMAND: 'posthog-ai-feedback-command', // owner: #team-posthog-ai
-    POSTHOG_AI_TICKET_COMMAND: 'posthog-ai-ticket-command', // owner: #team-posthog-ai
     POSTHOG_AI_UPSERT_DASHBOARD: 'phai-upsert-dashboards', // owner: #team-posthog-ai
     QUERY_EXECUTION_DETAILS: 'query-execution-details', // owner: @sakce
     RECORDINGS_PLAYER_EVENT_PROPERTY_EXPANSION: 'recordings-player-event-property-expansion', // owner: @pauldambra #team-replay
@@ -367,7 +363,6 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_MARKETING: 'marketing-analytics', // owner: @jabahamondes #team-web-analytics
     NEW_TEAM_CORE_EVENTS: 'new-team-core-events', // owner: @jabahamondes #team-web-analytics
     WEB_ANALYTICS_OPEN_AS_INSIGHT: 'web-analytics-open-as-insight', // owner: @lricoy #team-web-analytics
-    WEB_ANALYTICS_POSTHOG_AI: 'web-analytics-posthog-ai', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_FILTERS_V2: 'web-analytics-filters-v2', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_SESSION_PROPERTY_CHARTS: 'web-analytics-session-property-charts', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_TILE_TOGGLES: 'web-analytics-tile-toggles', // owner: @lricoy #team-web-analytics

--- a/frontend/src/scenes/max/slash-commands.tsx
+++ b/frontend/src/scenes/max/slash-commands.tsx
@@ -1,6 +1,6 @@
 import { IconActivity, IconMemory, IconRocket, IconSupport, IconThumbsUp } from '@posthog/icons'
 
-import { FEATURE_FLAGS, FeatureFlagKey } from 'lib/constants'
+import { FeatureFlagKey } from 'lib/constants'
 
 import { SlashCommandName } from '~/queries/schema/schema-assistant-messages'
 
@@ -34,20 +34,17 @@ export const MAX_SLASH_COMMANDS: SlashCommand[] = [
         name: SlashCommandName.SlashUsage,
         description: 'View AI credit usage for this conversation',
         icon: <IconActivity />,
-        flag: FEATURE_FLAGS.POSTHOG_AI_BILLING_USAGE_COMMAND,
     },
     {
         name: SlashCommandName.SlashFeedback,
         arg: '[your feedback]',
         description: 'Share feedback about your PostHog AI experience',
         icon: <IconThumbsUp />,
-        flag: FEATURE_FLAGS.POSTHOG_AI_FEEDBACK_COMMAND,
     },
     {
         name: SlashCommandName.SlashTicket,
         description: 'Create a support ticket with a summary of this conversation',
         icon: <IconSupport />,
-        flag: FEATURE_FLAGS.POSTHOG_AI_TICKET_COMMAND,
         requiresIdle: true,
         requiresPaidPlan: true,
     },

--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -133,11 +133,6 @@ const WebAnalyticsAIFilters = ({ children }: { children: JSX.Element }): JSX.Ele
     } = useValues(webAnalyticsLogic)
     const { setDates, setWebAnalyticsFilters, setIsPathCleaningEnabled, setCompareFilter } =
         useActions(webAnalyticsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-
-    if (!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_POSTHOG_AI]) {
-        return children
-    }
 
     return (
         <MaxTool


### PR DESCRIPTION
## Problem

Removed several feature flags that are no longer needed for PostHog AI functionality and web analytics.

## Changes

- Removed unused feature flags:
  - `POSTHOG_AI_BILLING_USAGE_COMMAND`
  - `POSTHOG_AI_BILLING_USAGE_REPORT`
  - `POSTHOG_AI_FEEDBACK_COMMAND`
  - `POSTHOG_AI_TICKET_COMMAND`
  - `WEB_ANALYTICS_POSTHOG_AI`
- Removed feature flag dependencies from slash commands in the Max interface
- Removed conditional rendering based on the `WEB_ANALYTICS_POSTHOG_AI` feature flag in the WebAnalyticsFilters component

## How did you test this code?

Verified that all the flags were rolled out to 100% of users and stale.

## Publish to changelog?

No