### PR TITLE
fix(endpoints): show error when playground JSON payload is invalid

### DIFF
--- a/products/endpoints/frontend/endpoint-tabs/EndpointPlayground.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointPlayground.tsx
@@ -184,8 +184,10 @@ fetch(url, {
 
 export function EndpointPlayground({ tabId }: EndpointPlaygroundProps): JSX.Element {
     const { endpoint } = useValues(endpointLogic({ tabId }))
-    const { payloadJson, endpointResult, endpointResultLoading } = useValues(endpointSceneLogic({ tabId }))
-    const { setPayloadJson, loadEndpointResult } = useActions(endpointSceneLogic({ tabId }))
+    const { payloadJson, payloadJsonError, endpointResult, endpointResultLoading } = useValues(
+        endpointSceneLogic({ tabId })
+    )
+    const { setPayloadJson, setPayloadJsonError, loadEndpointResult } = useActions(endpointSceneLogic({ tabId }))
     const { setActiveCodeExampleTab, setSelectedCodeExampleVersion } = useActions(endpointLogic({ tabId }))
     const { activeCodeExampleTab, selectedCodeExampleVersion } = useValues(endpointLogic({ tabId }))
 
@@ -197,8 +199,8 @@ export function EndpointPlayground({ tabId }: EndpointPlaygroundProps): JSX.Elem
         let data: any = {}
         try {
             data = payloadJson && payloadJson.trim() !== '' ? JSON.parse(payloadJson) : {}
-        } catch (error) {
-            console.error('Invalid JSON:', error)
+        } catch {
+            setPayloadJsonError('Invalid JSON in request payload')
             return
         }
 
@@ -287,6 +289,7 @@ export function EndpointPlayground({ tabId }: EndpointPlaygroundProps): JSX.Elem
                         onChange={(value) => setPayloadJson(value ?? '')}
                         maxHeight={400}
                     />
+                    {payloadJsonError && <LemonField.Pure error={payloadJsonError} />}
 
                     <LemonButton
                         type="primary"

--- a/products/endpoints/frontend/endpointSceneLogic.tsx
+++ b/products/endpoints/frontend/endpointSceneLogic.tsx
@@ -66,6 +66,7 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
         setLocalQuery: (query: Node | null) => ({ query }),
         setActiveTab: (tab: EndpointTab) => ({ tab }),
         setPayloadJson: (value: string) => ({ value }),
+        setPayloadJsonError: (error: string | null) => ({ error }),
         setCacheAge: (cacheAge: number | null) => ({ cacheAge }),
         setSyncFrequency: (syncFrequency: DataWarehouseSyncInterval | null) => ({ syncFrequency }),
         setIsMaterialized: (isMaterialized: boolean | null) => ({ isMaterialized }),
@@ -88,6 +89,13 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             '' as string,
             {
                 setPayloadJson: (_, { value }) => value,
+            },
+        ],
+        payloadJsonError: [
+            null as string | null,
+            {
+                setPayloadJsonError: (_, { error }) => error,
+                setPayloadJson: () => null,
             },
         ],
         cacheAge: [


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Previously, attempting to execute an endpoint with invalid JSON in the playground would silently fail. Now it displays an error message to the user.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- add error lemon field when JSON is invalid
<img width="349" height="201" alt="image" src="https://github.com/user-attachments/assets/ce31722a-6202-4685-9821-cd2b47ebfc7f" />

## How did you test this code?
locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
nah