### PR TITLE
fix(product-analytics): Properly unmount liveEventsLogic when navigating away

### DIFF
--- a/frontend/src/scenes/activity/live/liveEventsTableSceneLogic.ts
+++ b/frontend/src/scenes/activity/live/liveEventsTableSceneLogic.ts
@@ -1,4 +1,4 @@
-import { connect, kea, path, props, selectors } from 'kea'
+import { events, kea, path, props, selectors } from 'kea'
 
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { Scene } from 'scenes/sceneTypes'
@@ -6,11 +6,9 @@ import { sceneConfigurations } from 'scenes/scenes'
 
 import { Breadcrumb } from '~/types'
 
-import { liveEventsLogic } from './liveEventsLogic'
 import type { liveEventsTableSceneLogicType } from './liveEventsTableSceneLogicType'
 
 export interface LiveEventsTableSceneProps {
-    showLiveStreamErrorToast?: boolean
     tabId?: string
 }
 
@@ -18,10 +16,6 @@ export const liveEventsTableSceneLogic = kea<liveEventsTableSceneLogicType>([
     path(['scenes', 'activity', 'live-events', 'liveEventsTableSceneLogic']),
     tabAwareScene(),
     props({} as LiveEventsTableSceneProps),
-    connect(() => ({
-        values: [liveEventsLogic, ['events', 'filters', 'streamPaused']],
-        actions: [liveEventsLogic, ['pauseStream', 'resumeStream', 'setFilters', 'clearEvents']],
-    })),
     selectors(() => ({
         breadcrumbs: [
             () => [],
@@ -33,5 +27,9 @@ export const liveEventsTableSceneLogic = kea<liveEventsTableSceneLogicType>([
                 },
             ],
         ],
+    })),
+    events(({}) => ({
+        afterMount: () => {},
+        beforeUnmount: () => {},
     })),
 ])

--- a/frontend/src/scenes/activity/live/liveEventsTableSceneLogic.ts
+++ b/frontend/src/scenes/activity/live/liveEventsTableSceneLogic.ts
@@ -1,4 +1,4 @@
-import { events, kea, path, props, selectors } from 'kea'
+import { kea, path, props, selectors } from 'kea'
 
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { Scene } from 'scenes/sceneTypes'
@@ -27,9 +27,5 @@ export const liveEventsTableSceneLogic = kea<liveEventsTableSceneLogicType>([
                 },
             ],
         ],
-    })),
-    events(({}) => ({
-        afterMount: () => {},
-        beforeUnmount: () => {},
     })),
 ])


### PR DESCRIPTION
## Problem
`liveEventsLogic` was not unmounting when navigating away from the live activity feed, causing the SSE connection to stay open indefinitely. 

The root cause was that `liveEventsTableSceneLogic` was connecting to `liveEventsLogic`, keeping it alive as long as the tab existed. Removing this connection allows `liveEventsLogic` to properly unmount when the component unmounts.
  
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Remove the connection to live `liveEventsLogic` in `liveEventsTableSceneLogic`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
