### PR TITLE
feat(customers): Add revenue data to power users table

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -397,20 +397,13 @@ export function renderColumn(
     } else if (key === 'group_name' && isGroupsQuery(query.source)) {
         const key = (record as any[])[1] // 'key' is the second column in the groups query
         return <Link to={urls.group(query.source.group_type_index, key, true)}>{value}</Link>
-    } else if (trimQuotes(key).endsWith('$virt_mrr')) {
-        if (value === null || value === undefined) {
-            return '—'
-        }
-        const baseCurrency = context?.baseCurrency || CurrencyCode.USD
-        return formatCurrency(Number(value), baseCurrency)
-    } else if (trimQuotes(key).endsWith('$virt_revenue')) {
+    } else if (trimQuotes(key).endsWith('$virt_mrr') || trimQuotes(key).endsWith('$virt_revenue')) {
         if (value === null || value === undefined) {
             return '—'
         }
         const baseCurrency = context?.baseCurrency || CurrencyCode.USD
         return formatCurrency(Number(value), baseCurrency)
     }
-
     if (typeof value === 'object') {
         return <JSONViewer src={value} name={null} collapsed={Object.keys(value).length > 10 ? 0 : 1} />
     } else if (

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -12,6 +12,7 @@ import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { autoCaptureEventToDescription, isURL } from 'lib/utils'
 import { COUNTRY_CODE_TO_LONG_NAME, countryCodeToFlag } from 'lib/utils/geography/country'
+import { formatCurrency } from 'lib/utils/geography/currency'
 import { GroupActorDisplay } from 'scenes/persons/GroupActorDisplay'
 import { PersonDisplay, PersonDisplayProps } from 'scenes/persons/PersonDisplay'
 import { urls } from 'scenes/urls'
@@ -20,6 +21,7 @@ import { errorColumn, loadingColumn } from '~/queries/nodes/DataTable/dataTableL
 import { renderHogQLX } from '~/queries/nodes/HogQLX/render'
 import { DeletePersonButton } from '~/queries/nodes/PersonsNode/DeletePersonButton'
 import {
+    CurrencyCode,
     DataTableNode,
     EventsQueryPersonColumn,
     HasPropertiesNode,
@@ -395,6 +397,18 @@ export function renderColumn(
     } else if (key === 'group_name' && isGroupsQuery(query.source)) {
         const key = (record as any[])[1] // 'key' is the second column in the groups query
         return <Link to={urls.group(query.source.group_type_index, key, true)}>{value}</Link>
+    } else if (trimQuotes(key).endsWith('$virt_mrr')) {
+        if (value === null || value === undefined) {
+            return '—'
+        }
+        const baseCurrency = context?.baseCurrency || CurrencyCode.USD
+        return formatCurrency(Number(value), baseCurrency)
+    } else if (trimQuotes(key).endsWith('$virt_revenue')) {
+        if (value === null || value === undefined) {
+            return '—'
+        }
+        const baseCurrency = context?.baseCurrency || CurrencyCode.USD
+        return formatCurrency(Number(value), baseCurrency)
     }
 
     if (typeof value === 'object') {

--- a/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
@@ -67,6 +67,10 @@ export function renderColumnMeta<T extends DataVisualizationNode | DataTableNode
         title = 'Event'
     } else if (key === 'person') {
         title = 'Person'
+    } else if (trimQuotes(key).endsWith('$virt_mrr')) {
+        title = 'MRR'
+    } else if (trimQuotes(key).endsWith('$virt_revenue')) {
+        title = 'Lifetime value'
     } else if (key.startsWith('properties.')) {
         title = (
             <PropertyKeyInfo

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -4,6 +4,7 @@ import { ExpandableConfig } from 'lib/lemon-ui/LemonTable'
 
 import { QueryFeature } from '~/queries/nodes/DataTable/queryFeatures'
 import {
+    CurrencyCode,
     DataTableNode,
     DataVisualizationNode,
     InsightActorsQuery,
@@ -59,6 +60,8 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     dataTableRowsTransformer?: (rows: DataTableRow[]) => DataTableRow[]
     /** Compare filter for Web Analytics queries */
     compareFilter?: any
+    /** Base currency for formatting monetary values */
+    baseCurrency?: CurrencyCode
 }
 
 export type QueryContextColumnTitleComponent = ComponentType<{

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -13,6 +13,7 @@ import { capitalizeFirstLetter } from 'lib/utils'
 import { GroupsIntroduction } from 'scenes/groups/GroupsIntroduction'
 import { PersonsManagementSceneTabs } from 'scenes/persons-management/PersonsManagementSceneTabs'
 import { SceneExport } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -48,6 +49,7 @@ export function GroupsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
 
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
     const { aggregationLabel } = useValues(groupsModel)
+    const { baseCurrency } = useValues(teamLogic)
     const hasCustomerAnalyticsEnabled = useFeatureFlag('CUSTOMER_ANALYTICS')
 
     if (groupTypeIndex === undefined) {
@@ -137,6 +139,7 @@ export function GroupsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
                     ),
                     columns,
                     groupTypeLabel: groupTypeNamePlural,
+                    baseCurrency,
                 }}
                 dataAttr="groups-table"
             />

--- a/frontend/src/scenes/persons/PersonsScene.tsx
+++ b/frontend/src/scenes/persons/PersonsScene.tsx
@@ -41,7 +41,7 @@ export function PersonsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
     const { query } = useValues(personsSceneLogic)
     const { setQuery } = useActions(personsSceneLogic)
     const { resetDeletedDistinctId } = useAsyncActions(personsSceneLogic)
-    const { currentTeam } = useValues(teamLogic)
+    const { currentTeam, baseCurrency } = useValues(teamLogic)
     const { loadConfigs } = useActions(customerProfileConfigLogic({ scope: CustomerProfileScope.PERSON }))
 
     useOnMountEffect(() => {
@@ -122,6 +122,7 @@ export function PersonsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
                             to get things moving
                         </>
                     ),
+                    baseCurrency,
                 }}
                 dataAttr="persons-table"
             />

--- a/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
@@ -53,7 +53,7 @@ export function ActiveUsersInsights(): JSX.Element {
 
 function PowerUsersTable(): JSX.Element {
     const { businessType, customerLabel, dauSeries, selectedGroupType, tabId } = useValues(customerAnalyticsSceneLogic)
-    const { isRevenueAnalyticsEnabled } = useValues(revenueAnalyticsLogic)
+    const { isRevenueAnalyticsEnabled, baseCurrency } = useValues(revenueAnalyticsLogic)
     const uniqueKey = `power-users-${tabId}`
     const insightProps: InsightLogicProps<InsightVizNode> = {
         dataNodeCollectionId: CUSTOMER_ANALYTICS_DATA_COLLECTION_NODE_ID,
@@ -116,6 +116,7 @@ function PowerUsersTable(): JSX.Element {
                         group: { title: customerLabel.singular },
                     },
                     insightProps,
+                    baseCurrency,
                 }}
             />
         </>

--- a/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
@@ -8,6 +8,8 @@ import { Query } from '~/queries/Query/Query'
 import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { ChartDisplayType, InsightLogicProps } from '~/types'
 
+import { revenueAnalyticsLogic } from 'products/revenue_analytics/frontend/revenueAnalyticsLogic'
+
 import { CUSTOMER_ANALYTICS_DATA_COLLECTION_NODE_ID } from '../../constants'
 import { InsightDefinition, customerAnalyticsSceneLogic } from '../../customerAnalyticsSceneLogic'
 import { buildDashboardItemId, isPageviewWithoutFilters } from '../../utils'
@@ -51,6 +53,7 @@ export function ActiveUsersInsights(): JSX.Element {
 
 function PowerUsersTable(): JSX.Element {
     const { businessType, customerLabel, dauSeries, selectedGroupType, tabId } = useValues(customerAnalyticsSceneLogic)
+    const { isRevenueAnalyticsEnabled } = useValues(revenueAnalyticsLogic)
     const uniqueKey = `power-users-${tabId}`
     const insightProps: InsightLogicProps<InsightVizNode> = {
         dataNodeCollectionId: CUSTOMER_ANALYTICS_DATA_COLLECTION_NODE_ID,
@@ -60,6 +63,7 @@ function PowerUsersTable(): JSX.Element {
     const isB2c = businessType === 'b2c'
     const buttonTo = isB2c ? urls.persons() : urls.groups(selectedGroupType)
     const tooltip = isB2c ? 'Open people list' : `Open ${customerLabel.plural} list`
+    const revenueFields = isRevenueAnalyticsEnabled ? ['$virt_mrr', '$virt_revenue'] : []
 
     const query = {
         kind: NodeKind.DataTableNode,
@@ -68,8 +72,8 @@ function PowerUsersTable(): JSX.Element {
         source: {
             kind: NodeKind.ActorsQuery,
             select: isB2c
-                ? ['person_display_name -- Person', 'event_count', 'last_seen']
-                : ['group', 'event_count', 'last_seen'],
+                ? ['person_display_name -- Person', 'event_count', ...revenueFields, 'last_seen']
+                : ['group', 'event_count', ...revenueFields, 'last_seen'],
             source: {
                 kind: NodeKind.InsightActorsQuery,
                 source: {


### PR DESCRIPTION
## Problem

We don't show any revenue data in customer analytics. Let's change that by adding mrr and ltv in power users table.

Closes https://github.com/PostHog/posthog/issues/45050
## Changes

- Added support for formatting monetary values in the data table
- Added special handling for `$virt_mrr` and `$virt_revenue` virtual fields
- Updated column titles to display "MRR" and "Lifetime value" for these fields
- Added revenue fields to the Power Users table when Revenue Analytics is enabled
- Added a `baseCurrency` property to the query context to control currency formatting

## How did you test this code?

## Publish to changelog?
Yes