### PR TITLE
chore(product tours): minor UX enhancements

### DIFF
--- a/frontend/src/scenes/product-tours/components/AutoShowSection.tsx
+++ b/frontend/src/scenes/product-tours/components/AutoShowSection.tsx
@@ -237,7 +237,7 @@ export function AutoShowSection({ conditions, onChange }: AutoShowSectionProps):
     return (
         <div className="space-y-4">
             <div>
-                <h5 className="font-semibold mb-2">URL targeting</h5>
+                <h5 className="font-semibold mb-2">Where to show</h5>
                 <div className="flex gap-2 items-center">
                     <span className="text-sm whitespace-nowrap">URL</span>
                     <LemonSelect

--- a/frontend/src/scenes/product-tours/components/ProductTourPreview.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductTourPreview.tsx
@@ -26,7 +26,7 @@ export function ProductTourPreview({
         if (ref.current) {
             renderProductTourPreview({
                 step: (prepareStep ? prepareStepForRender(step) : step) as any,
-                appearance: appearance as any,
+                appearance: { ...appearance, zIndex: 1 } as any,
                 parentElement: ref.current,
                 stepIndex,
                 totalSteps,
@@ -47,7 +47,7 @@ export function BannerPreviewWrapper({
     return (
         <div>
             <div className="text-xs text-muted uppercase tracking-wide mb-3">Preview</div>
-            <div className="bg-[#f0f0f0] overflow-hidden">
+            <div className="bg-[#f0f0f0] overflow-hidden p-4 -m-4">
                 {step && <ProductTourPreview step={step} appearance={appearance} />}
             </div>
         </div>

--- a/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
@@ -23,7 +23,7 @@ import {
     productToursLogic,
 } from '../productToursLogic'
 
-function ProductTourStatusTag({ tour }: { tour: ProductTour }): JSX.Element {
+export function ProductTourStatusTag({ tour }: { tour: ProductTour }): JSX.Element {
     const status = getProductTourStatus(tour)
 
     const statusConfig: Record<

--- a/frontend/src/scenes/product-tours/productTourLogic.ts
+++ b/frontend/src/scenes/product-tours/productTourLogic.ts
@@ -383,12 +383,6 @@ export const productTourLogic = kea<productTourLogicType>([
         ],
     }),
     listeners(({ actions, values }) => ({
-        submitProductTourFormSuccess: () => {
-            // don't navigate away if we're on steps page, it's a weird UX
-            if (values.editTab !== ProductTourEditTab.Steps) {
-                actions.editingProductTour(false)
-            }
-        },
         launchProductTour: async () => {
             if (values.productTour) {
                 await api.productTours.update(values.productTour.id, {
@@ -444,8 +438,8 @@ export const productTourLogic = kea<productTourLogicType>([
             }
         },
         editingProductTour: ({ editing }) => {
-            if (editing && values.productTour) {
-                // Reset form to current tour values when entering edit mode
+            // Only reset form when transitioning from not-editing to editing
+            if (editing && !values.isEditingProductTour && values.productTour) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 ;(actions.setProductTourFormValues as any)({
                     name: values.productTour.name,

--- a/frontend/src/scenes/product-tours/productToursLogic.ts
+++ b/frontend/src/scenes/product-tours/productToursLogic.ts
@@ -242,7 +242,7 @@ export const productToursLogic = kea<productToursLogicType>([
                     content: createDefaultAnnouncementContent(),
                 })
                 actions.loadProductTours()
-                router.actions.push(urls.productTour(announcement.id))
+                router.actions.push(urls.productTour(announcement.id, 'edit=true&tab=steps'))
             } catch {
                 lemonToast.error('Failed to create announcement')
             }
@@ -254,7 +254,7 @@ export const productToursLogic = kea<productToursLogicType>([
                     content: createDefaultBannerContent(),
                 })
                 actions.loadProductTours()
-                router.actions.push(urls.productTour(banner.id))
+                router.actions.push(urls.productTour(banner.id, 'edit=true&tab=steps'))
             } catch {
                 lemonToast.error('Failed to create banner')
             }

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -208,7 +208,8 @@ export const urls = {
     hogFunction: (id: string, tab?: HogFunctionSceneTab): string => `/functions/${id}${tab ? `?tab=${tab}` : ''}`,
     hogFunctionNew: (templateId: string): string => `/functions/new/${templateId}`,
     productTours: (): string => '/product_tours',
-    productTour: (id: string): string => `/product_tours/${id}`,
+    productTour: (id: string, params?: string): string =>
+        `/product_tours/${id}${params ? `?${params.startsWith('?') ? params.slice(1) : params}` : ''}`,
     organizationDeactivated: (): string => '/organization-deactivated',
     approvals: (): string => '/settings/organization-approvals#change-requests',
     approval: (id: string): string => `/approvals/${id}`,

--- a/frontend/src/toolbar/product-tours/ProductToursEditingBar.tsx
+++ b/frontend/src/toolbar/product-tours/ProductToursEditingBar.tsx
@@ -15,6 +15,7 @@ import {
 import { LemonButton, LemonInput, LemonMenu, Tooltip } from '@posthog/lemon-ui'
 
 import { Spinner } from 'lib/lemon-ui/Spinner'
+import { cn } from 'lib/utils/css-classes'
 
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
 
@@ -112,6 +113,8 @@ export function ProductToursEditingBar(): JSX.Element | null {
         return null
     }
 
+    const isFreshTour = stepCount === 0 && editorState.mode === 'idle'
+
     return (
         <>
             <div
@@ -135,9 +138,6 @@ export function ProductToursEditingBar(): JSX.Element | null {
 
                 {/* Center: Step buttons with titles */}
                 <div className="flex-1 flex items-center justify-center gap-1.5">
-                    {stepCount === 0 && editorState.mode === 'idle' && (
-                        <span className="text-muted text-sm">Click + to start adding steps</span>
-                    )}
                     {steps.map((step: TourStep, index: number) => {
                         const isActive = editingStepIndex === index
                         const isDragging = dragIndex === index
@@ -206,17 +206,17 @@ export function ProductToursEditingBar(): JSX.Element | null {
                         items={[
                             {
                                 icon: <IconCursorClick />,
-                                label: 'Element step',
+                                label: 'Element tooltip',
                                 onClick: () => addStep('element'),
                             },
                             {
                                 icon: <IconMessage />,
-                                label: 'Modal step',
+                                label: 'Pop-up',
                                 onClick: () => addStep('modal'),
                             },
                             {
                                 icon: <IconQuestion />,
-                                label: 'Survey step',
+                                label: 'Survey',
                                 onClick: () => addStep('survey'),
                             },
                         ]}
@@ -226,8 +226,14 @@ export function ProductToursEditingBar(): JSX.Element | null {
                         <button
                             type="button"
                             disabled={aiGenerating || editorState.mode !== 'idle'}
-                            className="w-6 h-6 rounded-md border border-dashed border-border flex items-center justify-center text-muted hover:border-primary hover:text-primary transition-colors disabled:opacity-50 ml-1"
+                            className={cn(
+                                isFreshTour ? 'py-2 px-4' : 'w-6 h-6',
+                                'cursor-pointer rounded-md border border-dashed border-border flex items-center justify-center text-muted hover:border-primary hover:text-primary transition-colors disabled:opacity-50 ml-1'
+                            )}
                         >
+                            {isFreshTour && (
+                                <span className="text-muted text-sm mr-2">Click to start adding steps</span>
+                            )}
                             <IconPlus className="w-3 h-3" />
                         </button>
                     </LemonMenu>
@@ -265,7 +271,7 @@ export function ProductToursEditingBar(): JSX.Element | null {
                     </LemonButton>
 
                     <LemonButton size="small" type="secondary" icon={<IconX />} onClick={() => selectTour(null)}>
-                        Discard
+                        Cancel
                     </LemonButton>
 
                     <LemonButton

--- a/frontend/src/toolbar/product-tours/TourGoalModal.tsx
+++ b/frontend/src/toolbar/product-tours/TourGoalModal.tsx
@@ -1,8 +1,10 @@
 import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
 
 import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
 
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
+import { TOOLBAR_ID } from '~/toolbar/utils'
 
 import { productToursLogic } from './productToursLogic'
 
@@ -20,6 +22,31 @@ export function TourGoalModal(): JSX.Element | null {
     const { closeGoalModal, setAIGoal, startFromGoalModal } = useActions(productToursLogic)
 
     const canProceed = aiGoal.trim().length > 0
+
+    // prevent main doc from stealing focus while tour modal is open
+    useEffect(() => {
+        if (!goalModalOpen) {
+            return
+        }
+
+        const toolbarHost = document.getElementById(TOOLBAR_ID)
+        const toolbarContainer = toolbarHost?.parentElement
+
+        // mark everything _except_ the toolbar as inert
+        const elementsToRestore: HTMLElement[] = []
+        document.body.childNodes.forEach((node) => {
+            if (node instanceof HTMLElement && node !== toolbarContainer && !node.inert) {
+                node.inert = true
+                elementsToRestore.push(node)
+            }
+        })
+
+        return () => {
+            elementsToRestore.forEach((el) => {
+                el.inert = false
+            })
+        }
+    }, [goalModalOpen])
 
     return (
         <LemonModal

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3429,6 +3429,7 @@ export interface ProductTourAppearance {
     whiteLabel?: boolean
     /** defaults to true, auto-set to false for announcements/banners */
     dismissOnClickOutside?: boolean
+    zIndex?: number
 }
 
 export type ProductTourType = 'tour' | 'announcement'


### PR DESCRIPTION
## Problem

product tours needs some UX love!

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

minor improvements:

- persists tour state across tab switches (e.g. customization/content/config)
- makes entire "click + to add..." clickable when starting a tour in the toolbar
- ensures tour title modal maintains focus while the user's page loads in the background
- when creating an announcement, go straight into the content editor, instead of clicking create -> edit -> content
- adds tour status bage to edit page
- fix drop shadow on banner preview
- remove auto-redirect on tour save (it was inconsistent, and also just unnecessary)
- hide FF conditions behind a toggle -- it's big and overwhelming, and probably not needed in a lot of cases, so i think this reduces cognitive load
- add API trigger docs on display conditions
- fix z-index on tour preview steps (they were covering things like dropdowns) - pending [SDK update](https://github.com/PostHog/posthog-js/pull/2899)
- rename element step types for clarity

### auto-show conditions

| wax off | wax on |
| --- | --- |
| ![Screenshot 2026-01-14 at 10.34.11 AM.png](https://app.graphite.com/user-attachments/assets/4b8ee3f4-0713-41de-b6d3-f20bb0a44a9c.png)<br> | ![Screenshot 2026-01-14 at 10.34.16 AM.png](https://app.graphite.com/user-attachments/assets/c2ec7760-c036-463e-95c1-735a6be2b9fe.png)<br> |

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

### edit page status badge

![Screenshot 2026-01-14 at 10.35.53 AM.png](https://app.graphite.com/user-attachments/assets/cebcaa21-f942-4b2f-9708-2da1378745ce.png)

### api trigger docs

![Screenshot 2026-01-14 at 10.48.40 AM.png](https://app.graphite.com/user-attachments/assets/0f6d15f6-07cb-443f-8d86-55cc3847d735.png)

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->