### PR TITLE
chore(web-analytics): add test for path cleaning in web vitals

### DIFF
--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_vitals_path_breakdown.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_vitals_path_breakdown.ambr
@@ -159,6 +159,38 @@
                      use_hive_partitioning=0
   '''
 # ---
+# name: TestWebVitalsPathBreakdownQueryRunner.test_path_cleaning_filters
+  '''
+  SELECT band AS band,
+         path AS path,
+                 value AS value
+  FROM
+    (SELECT multiIf(ifNull(lessOrEquals(value, 100.0), 0), 'good', ifNull(lessOrEquals(value, 200.0), 0), 'needs_improvements', 'poor') AS band,
+            path AS path,
+                    value AS value
+     FROM
+       (SELECT replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/cleaned\\/\\d+', '/cleaned/<id>') AS path,
+               quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$web_vitals_INP_value'), ''), 'null'), '^"|"$', ''), 'Float64')) AS value
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$web_vitals'), isNotNull(path), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-08 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-15 23:59:59', 'UTC')))), 0), 1))
+        GROUP BY path
+        HAVING ifNull(greaterOrEquals(value, 0), 0)))
+  ORDER BY value ASC,
+           path ASC
+  LIMIT 20 BY band
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
 # name: TestWebVitalsPathBreakdownQueryRunner.test_percentile_is_applied
   '''
   SELECT band AS band,


### PR DESCRIPTION
## Problem

A customer reported that path cleaning was working in Web Analytics but not in Web Vitals. During investigation, I found that the backend code is actually working correctly - path cleaning IS applied when doPathCleaning=True and path_cleaning_filters are configured.

However, there was no test coverage for path cleaning in Web Vitals, which made it harder to verify the feature works. This PR adds that missing test coverage.

The customer issue is still unresolved, but I thought I'd commit these extra tests. 

## Changes

Adds a test test_path_cleaning_filters that:

- Creates Web Vitals events with paths like /cleaned/123, /cleaned/456, /not-cleaned
- Configures a path cleaning rule: \/cleaned\/\d+ → /cleaned/<id>
- Verifies the query correctly groups /cleaned/123 and /cleaned/456 into /cleaned/<id>
- The test snapshot shows the generated SQL includes replaceRegexpAll for the configured regex.

## How did you test this code?

pytest posthog/hogql_queries/web_analytics/test/test_web_vitals_path_breakdown.py::TestWebVitalsPathBreakdownQueryRunner::test_path_cleaning_filters -xvs
Test passes and snapshot shows the correct SQL with replaceRegexpAll applied.

## Publish to changelog?

No