### PR TITLE
chore(gateway): add error details and retry header to rate limited

### DIFF
--- a/services/llm-gateway/src/llm_gateway/rate_limiting/middleware.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/middleware.py
@@ -7,9 +7,10 @@ from llm_gateway.rate_limiting.redis_limiter import RateLimiter
 logger = structlog.get_logger(__name__)
 
 
-async def check_rate_limit(user: AuthenticatedUser, limiter: RateLimiter) -> bool:
+async def check_rate_limit(user: AuthenticatedUser, limiter: RateLimiter) -> tuple[bool, str | None]:
+    """Check rate limit for user. Returns (allowed, exceeded_scope)."""
     allowed, scope = await limiter.check(user.user_id)
     if not allowed and scope:
         RATE_LIMIT_EXCEEDED.labels(scope=scope).inc()
         logger.warning("rate_limit_exceeded", user_id=user.user_id, scope=scope)
-    return allowed
+    return allowed, scope


### PR DESCRIPTION
The LLM Gateway API should follow standards. This includes consistent error message keys and proper HTTP headers for rate limiting responses.

This adds the Retry-After header to 429 responses:

- Returns 60 seconds when burst limit is exceeded
- Returns 3600 seconds when sustained limit is exceeded

The header value is hardcoded rather than querying Redis for the actual TTL. Checking Redis would add latency to every rate-limited response, but we can add Redis TTL lookups in the future if needed.

  Changes:

  - `middleware.py`: Returns which limit was exceeded (burst or sustained)
  - `dependencies.py`: Adds Retry-After header based on the exceeded limit's window
  - `conftest.py`: Adds `rate_limited_client` fixture for testing both limit types
  - `test_rate_limiting.py`: Adds test for header and response body validation