### PR TITLE
feat(flags): Update internal dependent flags route

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -296,10 +296,10 @@ describe('featureFlagLogic', () => {
                         200,
                         MOCK_FEATURE_FLAG_STATUS,
                     ],
-                },
-                post: {
-                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${flag.id}/has_active_dependents/`]:
-                        () => [200, { has_active_dependents: true, dependent_flags: MOCK_DEPENDENT_FLAGS }],
+                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${flag.id}/dependent_flags/`]: () => [
+                        200,
+                        MOCK_DEPENDENT_FLAGS,
+                    ],
                 },
             })
 
@@ -328,10 +328,10 @@ describe('featureFlagLogic', () => {
                         200,
                         MOCK_FEATURE_FLAG_STATUS,
                     ],
-                },
-                post: {
-                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${flag.id}/has_active_dependents/`]:
-                        () => [200, { has_active_dependents: true, dependent_flags: MOCK_DEPENDENT_FLAGS }],
+                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${flag.id}/dependent_flags/`]: () => [
+                        200,
+                        MOCK_DEPENDENT_FLAGS,
+                    ],
                 },
             })
 
@@ -357,10 +357,10 @@ describe('featureFlagLogic', () => {
                         200,
                         MOCK_FEATURE_FLAG_STATUS,
                     ],
-                },
-                post: {
-                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${flag.id}/has_active_dependents/`]:
-                        () => [200, { has_active_dependents: false, dependent_flags: [] }],
+                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${flag.id}/dependent_flags/`]: () => [
+                        200,
+                        [],
+                    ],
                 },
             })
 
@@ -386,10 +386,10 @@ describe('featureFlagLogic', () => {
                         200,
                         MOCK_FEATURE_FLAG_STATUS,
                     ],
-                },
-                post: {
-                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${flag.id}/has_active_dependents/`]:
-                        () => [500, { error: 'Internal server error' }],
+                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${flag.id}/dependent_flags/`]: () => [
+                        500,
+                        { error: 'Internal server error' },
+                    ],
                 },
             })
 

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -1164,11 +1164,9 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                 loadDependentFlags: async () => {
                     const { currentProjectId } = values
                     if (currentProjectId && props.id && props.id !== 'new' && props.id !== 'link') {
-                        const response = await api.create(
-                            `api/projects/${currentProjectId}/feature_flags/${props.id}/has_active_dependents/`,
-                            {}
+                        return await api.get(
+                            `api/projects/${currentProjectId}/feature_flags/${props.id}/dependent_flags/`
                         )
-                        return response.dependent_flags || []
                     }
                     return []
                 },

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1753,7 +1753,7 @@ class FeatureFlagViewSet(
     def has_active_dependents(self, request: request.Request, **kwargs):
         """
         Deprecated: Use GET /dependent_flags instead.
-        This will be safe to delete some time after GET /dependent_flags has been live.
+        Safe to delete after usage falls to zero, expected by Jan 22, 2026.
         """
         response = self.dependent_flags(request, **kwargs)
         dependent_flags = response.data

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1731,7 +1731,7 @@ class FeatureFlagViewSet(
 
         return Response({"success": True}, status=200)
 
-    @action(methods=["GET"], detail=True)
+    @action(methods=["GET"], detail=True, required_scopes=["feature_flag:read"])
     def dependent_flags(self, request: request.Request, **kwargs):
         """Get other active flags that depend on this flag."""
         feature_flag: FeatureFlag = self.get_object()

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1757,6 +1757,11 @@ class FeatureFlagViewSet(
         """
         response = self.dependent_flags(request, **kwargs)
         dependent_flags = response.data
+        TOMBSTONE_COUNTER.labels(
+            namespace="feature_flags",
+            operation="has_active_dependents",
+            component="api",
+        ).inc()
         return Response(
             {
                 "has_active_dependents": len(dependent_flags) > 0,

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1749,6 +1749,32 @@ class FeatureFlagViewSet(
             status=200,
         )
 
+    @action(methods=["POST"], detail=True)
+    def has_active_dependents(self, request: request.Request, **kwargs):
+        """
+        Deprecated: Use GET /dependent_flags instead.
+        This will be safe to delete some time after GET /dependent_flags has been live.
+        """
+        response = self.dependent_flags(request, **kwargs)
+        dependent_flags = response.data
+        return Response(
+            {
+                "has_active_dependents": len(dependent_flags) > 0,
+                "dependent_flags": dependent_flags,
+                "warning": (
+                    (
+                        f"This feature flag is used by {len(dependent_flags)} other active "
+                        f"{'flag' if len(dependent_flags) == 1 else 'flags'}. "
+                        f"Disabling it will cause {'that flag' if len(dependent_flags) == 1 else 'those flags'} "
+                        f"to evaluate this condition as false."
+                    )
+                    if dependent_flags
+                    else None
+                ),
+            },
+            status=200,
+        )
+
     @validated_request(
         query_serializer=MyFlagsQuerySerializer,
         responses={

--- a/posthog/api/test/test_feature_flag_dependency_deletion.py
+++ b/posthog/api/test/test_feature_flag_dependency_deletion.py
@@ -260,45 +260,39 @@ class TestFeatureFlagDependencyDeletion(APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_has_active_dependents_with_no_dependencies(self):
-        """Test has_active_dependents returns False with 0 dependent flags."""
+    def test_dependent_flags_with_no_dependencies(self):
+        """Test dependent_flags returns empty list with 0 dependent flags."""
         flag = self.create_flag("standalone_flag")
 
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/feature_flags/{flag.id}/has_active_dependents/",
-            format="json",
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/feature_flags/{flag.id}/dependent_flags/",
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["has_active_dependents"], False)
-        self.assertEqual(len(response.json()["dependent_flags"]), 0)
+        self.assertEqual(response.json(), [])
 
-    def test_has_active_dependents_with_active_dependencies(self):
-        """Test has_active_dependents returns True with 1 active dependent flag."""
+    def test_dependent_flags_with_active_dependencies(self):
+        """Test dependent_flags returns list with 1 active dependent flag."""
         base_flag = self.create_flag("base_flag")
         self.create_flag("dependent_flag", dependencies=[base_flag.id])
 
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/feature_flags/{base_flag.id}/has_active_dependents/",
-            format="json",
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/feature_flags/{base_flag.id}/dependent_flags/",
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["has_active_dependents"], True)
-        self.assertEqual(len(response.json()["dependent_flags"]), 1)
+        self.assertEqual(len(response.json()), 1)
 
-    def test_has_active_dependents_with_inactive_dependencies(self):
-        """Test has_active_dependents returns False when dependent flags are inactive."""
+    def test_dependent_flags_with_inactive_dependencies(self):
+        """Test dependent_flags returns empty list when dependent flags are inactive."""
         base_flag = self.create_flag("base_flag")
         dependent_flag = self.create_flag("dependent_flag", dependencies=[base_flag.id])
         dependent_flag.active = False
         dependent_flag.save()
 
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/feature_flags/{base_flag.id}/has_active_dependents/",
-            format="json",
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/feature_flags/{base_flag.id}/dependent_flags/",
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["has_active_dependents"], False)
-        self.assertEqual(len(response.json()["dependent_flags"]), 0)
+        self.assertEqual(response.json(), [])

--- a/posthog/api/test/test_feature_flag_dependency_deletion.py
+++ b/posthog/api/test/test_feature_flag_dependency_deletion.py
@@ -296,3 +296,20 @@ class TestFeatureFlagDependencyDeletion(APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), [])
+
+    def test_deprecated_has_active_dependents_endpoint(self):
+        """
+        Test the deprecated has_active_dependents endpoint still works.
+        Safe to delete after usage falls to zero, expected by Jan 22, 2026.
+        """
+        base_flag = self.create_flag("base_flag")
+        self.create_flag("dependent_flag", dependencies=[base_flag.id])
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/{base_flag.id}/has_active_dependents/",
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["has_active_dependents"], True)
+        self.assertEqual(len(response.json()["dependent_flags"]), 1)

--- a/products/feature_flags/frontend/generated/api.ts
+++ b/products/feature_flags/frontend/generated/api.ts
@@ -373,6 +373,37 @@ export const featureFlagsDashboardCreate = async (
 }
 
 /**
+ * Get other active flags that depend on this flag.
+ */
+export type featureFlagsDependentFlagsRetrieveResponse200 = {
+    data: void
+    status: 200
+}
+
+export type featureFlagsDependentFlagsRetrieveResponseSuccess = featureFlagsDependentFlagsRetrieveResponse200 & {
+    headers: Headers
+}
+export type featureFlagsDependentFlagsRetrieveResponse = featureFlagsDependentFlagsRetrieveResponseSuccess
+
+export const getFeatureFlagsDependentFlagsRetrieveUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/feature_flags/${id}/dependent_flags/`
+}
+
+export const featureFlagsDependentFlagsRetrieve = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<featureFlagsDependentFlagsRetrieveResponse> => {
+    return apiMutator<featureFlagsDependentFlagsRetrieveResponse>(
+        getFeatureFlagsDependentFlagsRetrieveUrl(projectId, id),
+        {
+            ...options,
+            method: 'GET',
+        }
+    )
+}
+
+/**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
 
 If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
@@ -410,7 +441,8 @@ export const featureFlagsEnrichUsageDashboardCreate = async (
 }
 
 /**
- * Check if this flag has other active flags that depend on it.
+ * Deprecated: Use GET /dependent_flags instead.
+This will be safe to delete some time after GET /dependent_flags has been live.
  */
 export type featureFlagsHasActiveDependentsCreateResponse200 = {
     data: void

--- a/products/feature_flags/frontend/generated/api.ts
+++ b/products/feature_flags/frontend/generated/api.ts
@@ -442,7 +442,7 @@ export const featureFlagsEnrichUsageDashboardCreate = async (
 
 /**
  * Deprecated: Use GET /dependent_flags instead.
-This will be safe to delete some time after GET /dependent_flags has been live.
+Safe to delete after usage falls to zero, expected by Jan 22, 2026.
  */
 export type featureFlagsHasActiveDependentsCreateResponse200 = {
     data: void


### PR DESCRIPTION
## Problem

Just some housekeeping around `POST /has_active_dependents` considering I've been working in this code recently. 

## Changes

1. `has_active_dependents` was not being used anywhere. Probably because it's redundant with an empty dependents array in the response. I've dropped it.
2. `warning` is no longer used as of https://github.com/PostHog/posthog/pull/44969. The frontend is now purely responsible for constructing the warning to the user when disabling a flag.
3. I've collapsed the JSON object into an array considering we no longer need the additional keys.
4. Changed the request method from `POST` to `GET`
5. Renamed the route from `/has_active_dependents` (implies a boolean response) to `/dependent_flags`

The old route will remain (briefly) in place while the update goes live. This is to avoid the case where the frontend releases before Django, or a stale/cached frontend is still hitting the old route. 

## How did you test this code?
Updated tests, verified behavior manually