### PR TITLE
fix(dashboard): move dash title editing to Kea logic, fix autosave bug

### DIFF
--- a/frontend/src/layout/scenes/components/sceneTitleEditorLogic.ts
+++ b/frontend/src/layout/scenes/components/sceneTitleEditorLogic.ts
@@ -1,0 +1,100 @@
+import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+
+import type { sceneTitleEditorLogicType } from './sceneTitleEditorLogicType'
+
+export interface SceneTitleEditorLogicProps {
+    /** Unique identifier for this editor instance (e.g., 'dashboard-123-name') */
+    id: string
+    /** Callback to persist the value */
+    onChange?: (value: string) => void
+    /** Debounce time in ms */
+    debounceMs?: number
+    /** If true, only saves on blur (not on every change) */
+    saveOnBlur?: boolean
+}
+
+export const sceneTitleEditorLogic = kea<sceneTitleEditorLogicType>([
+    path(['layout', 'scenes', 'components', 'sceneTitleEditorLogic']),
+    props({} as SceneTitleEditorLogicProps),
+    key((props) => props.id),
+
+    actions({
+        /** Set the value from user input */
+        setValue: (value: string) => ({ value }),
+        /** Called when prop value changes - listener will decide whether to sync */
+        onPropValueChange: (value: string) => ({ value }),
+        /** Internal: sync value from persisted (only called when not editing) */
+        syncValue: (value: string) => ({ value }),
+        /** Set editing state */
+        setIsEditing: (isEditing: boolean) => ({ isEditing }),
+        /** Trigger save with debounce (for non-saveOnBlur mode) */
+        triggerDebouncedSave: (value: string) => ({ value }),
+        /** Trigger save on blur (for saveOnBlur mode) */
+        triggerBlurSave: (value: string) => ({ value }),
+        /** Actually persist the value */
+        persistValue: (value: string) => ({ value }),
+    }),
+
+    reducers({
+        /** The current value being edited (local state) */
+        value: [
+            '' as string,
+            {
+                setValue: (_, { value }) => value,
+                syncValue: (_, { value }) => value,
+            },
+        ],
+        /** Whether the user is actively editing */
+        isEditing: [
+            false,
+            {
+                setIsEditing: (_, { isEditing }) => isEditing,
+            },
+        ],
+        /** The last persisted value (from props) - always tracks prop */
+        persistedValue: [
+            '' as string,
+            {
+                onPropValueChange: (_, { value }) => value,
+            },
+        ],
+    }),
+
+    selectors({
+        hasUnsavedChanges: [
+            (s) => [s.value, s.persistedValue],
+            (value, persistedValue) => value !== persistedValue,
+        ],
+    }),
+
+    listeners(({ actions, values, props }) => ({
+        triggerDebouncedSave: async ({ value }, breakpoint) => {
+            // Use Kea breakpoint for debouncing - cancels previous pending saves
+            await breakpoint(props.debounceMs ?? 100)
+            actions.persistValue(value)
+        },
+        triggerBlurSave: async ({ value }, breakpoint) => {
+            // Small debounce for blur saves to handle rapid blur/focus events
+            await breakpoint(props.debounceMs ?? 100)
+            actions.persistValue(value)
+        },
+        persistValue: ({ value }) => {
+            if (props.onChange) {
+                props.onChange(value)
+            }
+        },
+        setValue: ({ value }) => {
+            // Only trigger debounced save if NOT in saveOnBlur mode
+            if (!props.saveOnBlur) {
+                actions.triggerDebouncedSave(value)
+            }
+        },
+        onPropValueChange: ({ value }) => {
+            // Only sync to local value if NOT currently editing
+            if (!values.isEditing) {
+                actions.syncValue(value)
+            }
+            // persistedValue is always updated via reducer
+        },
+    })),
+])


### PR DESCRIPTION
Context here https://posthog.slack.com/archives/C0368RPHLQH/p1768414121490159

This moves the local state management for dashboard name/description editing from React useState/useDebouncedCallback to a dedicated Kea logic with proper breakpoints.

The bug: when typing in the title/description field, the debounced save would trigger an API update, and when the response came back, the useEffect that synced props to local state would overwrite any text typed after the save was triggered, causing text loss.

The fix: the new sceneTitleEditorLogic tracks isEditing state and only syncs from props to local state when NOT actively editing. Kea breakpoints are used for debouncing which properly cancels pending saves on new input.

This approach:
- Centralizes editable field state management in Kea
- Uses Kea breakpoints for proper debounce handling
- Preserves user input during editing until they finish (blur or close)
- Maintains the existing saveOnBlur and forceEdit behaviors

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
