### PR TITLE
fix(vercel): auto-link trusted Vercel users on multiple installations

### DIFF
--- a/ee/api/vercel/README.md
+++ b/ee/api/vercel/README.md
@@ -31,9 +31,9 @@ LOCAL_HTTPS=1
 DEBUG=1
 
 # ngrok tunnel URLs for HTTPS local development (update with your ngrok URL)
+SITE_URL=https://your-ngrok-tunnel.ngrok-free.dev
 JS_URL=https://your-ngrok-tunnel.ngrok-free.dev
 WEBPACK_HOT_RELOAD_HOST=0.0.0.0
-NGROK_ORIGIN=https://your-ngrok-tunnel.ngrok-free.dev
 
 # Vercel integration credentials (automatically loaded from 1Password)
 VERCEL_CLIENT_INTEGRATION_ID="op://General/Vercel Client Integration Secret/client id"

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -1011,8 +1011,12 @@ class VercelIntegration:
             if not config:
                 continue
             user_mappings = config.get("user_mappings", {})
-            if user.pk in (int(v) for v in user_mappings.values()):
-                return True
+            for v in user_mappings.values():
+                try:
+                    if int(v) == user.pk:
+                        return True
+                except (ValueError, TypeError):
+                    capture_exception(ValueError(f"Corrupted user_mapping value: {v}"))
         return False
 
     @staticmethod

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -300,7 +300,7 @@ class VercelIntegration:
                 user = existing_user
                 user_created = False
                 if VercelIntegration._user_has_any_vercel_mapping(existing_user):
-                    VercelIntegration._ensure_user_membership(
+                    VercelIntegration._add_user_to_organization(
                         existing_user, organization, OrganizationMembership.Level.OWNER
                     )
                     should_create_mapping = True
@@ -863,7 +863,7 @@ class VercelIntegration:
                 )
 
                 intended_level = VercelIntegration._determine_membership_level(request.user.email, installation)
-                created = VercelIntegration._ensure_user_membership(
+                created = VercelIntegration._add_user_to_organization(
                     request.user, installation.organization, intended_level
                 )
 
@@ -907,7 +907,7 @@ class VercelIntegration:
         return OrganizationMembership.Level.MEMBER
 
     @staticmethod
-    def _ensure_user_membership(
+    def _add_user_to_organization(
         user: User, organization: Organization, level: OrganizationMembership.Level
     ) -> tuple[OrganizationMembership, bool]:
         membership, created = OrganizationMembership.objects.get_or_create(
@@ -1063,7 +1063,7 @@ class VercelIntegration:
             )
             created = True
 
-        VercelIntegration._ensure_user_membership(user, organization, level)
+        VercelIntegration._add_user_to_organization(user, organization, level)
 
         return user, created
 

--- a/ee/vercel/test/test_integration.py
+++ b/ee/vercel/test/test_integration.py
@@ -264,6 +264,88 @@ class TestVercelIntegration(TestCase):
 
         mock_report.assert_not_called()
 
+    @patch("ee.vercel.integration.report_user_signed_up")
+    def test_sso_requires_login_for_external_existing_user(self, mock_report):
+        """Security test: External users (not created by Vercel) must prove ownership via login."""
+        from ee.vercel.integration import RequiresExistingUserLogin
+
+        # Create an external user (not through Vercel)
+        external_user = User.objects.create_user(
+            email="external@example.com", password="external", first_name="External"
+        )
+
+        # Now try to install Vercel integration with that email
+        installation_id = self.NEW_INSTALLATION_ID
+        payload = {
+            **self.payload,
+            "account": {
+                **self.payload["account"],
+                "contact": {"email": "external@example.com", "name": "External User"},
+            },
+        }
+        user_claims = self._create_user_claims("vercel_external_user")
+        user_claims.installation_id = installation_id
+        user_claims.user_email = "external@example.com"
+
+        VercelIntegration.upsert_installation(installation_id, payload, user_claims)
+
+        installation = OrganizationIntegration.objects.get(integration_id=installation_id)
+
+        # External user should NOT have mapping created (security measure)
+        assert "user_mappings" not in installation.config or "vercel_external_user" not in installation.config.get(
+            "user_mappings", {}
+        )
+
+        # External user should NOT be added to org automatically
+        assert not OrganizationMembership.objects.filter(
+            user=external_user, organization=installation.organization
+        ).exists()
+
+        # SSO should require login for external user
+        sso_claims = self._create_user_claims("vercel_external_user")
+        sso_claims.installation_id = installation_id
+        sso_claims.user_email = "external@example.com"
+
+        with self.assertRaises(RequiresExistingUserLogin):
+            VercelIntegration._find_sso_user(sso_claims)
+
+    @patch("ee.vercel.integration.report_user_signed_up")
+    def test_sso_works_for_trusted_vercel_user_second_installation(self, mock_report):
+        """E2E: Trusted Vercel user's second installation should auto-link and SSO should work."""
+        from ee.vercel.integration import RequiresExistingUserLogin
+
+        # First installation - creates user with mapping
+        first_installation_id = self.NEW_INSTALLATION_ID
+        first_user_claims = self._create_user_claims("vercel_user_abc")
+        first_user_claims.installation_id = first_installation_id
+
+        VercelIntegration.upsert_installation(first_installation_id, self.payload, first_user_claims)
+        user = User.objects.get(email=self.payload["account"]["contact"]["email"])
+
+        # Second installation - same email, different installation
+        second_installation_id = "icfg_second_install_12345678"
+        second_payload = {**self.payload, "account": {**self.payload["account"], "name": "Second Org"}}
+        second_user_claims = self._create_user_claims("vercel_user_xyz")
+        second_user_claims.installation_id = second_installation_id
+
+        VercelIntegration.upsert_installation(second_installation_id, second_payload, second_user_claims)
+
+        # Verify installation created mapping and membership
+        second_installation = OrganizationIntegration.objects.get(integration_id=second_installation_id)
+        assert second_installation.config["user_mappings"].get("vercel_user_xyz") == user.pk
+        membership = OrganizationMembership.objects.get(user=user, organization=second_installation.organization)
+        assert membership.level == OrganizationMembership.Level.OWNER
+
+        # SSO should work without requiring login
+        sso_claims = self._create_user_claims("vercel_user_xyz")
+        sso_claims.installation_id = second_installation_id
+
+        try:
+            sso_user = VercelIntegration._find_sso_user(sso_claims)
+            assert sso_user.pk == user.pk
+        except RequiresExistingUserLogin:
+            self.fail("SSO should NOT require login for trusted Vercel user")
+
     @patch("ee.vercel.integration.capture_exception")
     def test_upsert_installation_integrity_error(self, mock_capture):
         error_user_claims = self._create_user_claims("error_user_999")

--- a/ee/vercel/test/test_integration.py
+++ b/ee/vercel/test/test_integration.py
@@ -349,8 +349,8 @@ class TestVercelIntegration(TestCase):
     @patch("ee.vercel.integration.report_user_signed_up")
     @patch("ee.vercel.integration.BillingManager")
     @patch("ee.vercel.integration.get_cached_instance_license")
-    def test_billing_failure_does_not_delete_trusted_vercel_user(self, mock_license, mock_billing, mock_report):
-        """Billing failure during second installation should NOT delete the trusted user."""
+    def test_billing_failure_does_not_delete_existing_user(self, mock_license, mock_billing, mock_report):
+        """Billing failure should NOT delete existing users (only newly created ones)."""
         # First installation - creates user with mapping
         first_installation_id = self.NEW_INSTALLATION_ID
         first_user_claims = self._create_user_claims("vercel_user_billing")

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1,3 +1,4 @@
+import os
 import re
 import json
 import time
@@ -770,6 +771,13 @@ class CSPMiddleware:
                 resource_url = "https://*.dev.posthog.dev"
 
             connect_debug_url = "ws://localhost:8234" if settings.DEBUG or settings.TEST else ""
+
+            frame_ancestors = "https://posthog.com https://preview.posthog.com https://vercel.com"
+            if settings.DEBUG:
+                ngrok_origin = os.environ.get("NGROK_ORIGIN", "")
+                if ngrok_origin:
+                    frame_ancestors = f"{frame_ancestors} {ngrok_origin}"
+
             csp_parts = [
                 "default-src 'self'",
                 f"style-src 'self' 'unsafe-inline' {resource_url} https://fonts.googleapis.com",
@@ -780,7 +788,7 @@ class CSPMiddleware:
                 "object-src 'none'",
                 "media-src https://res.cloudinary.com",
                 f"img-src 'self' data: {resource_url} https://posthog.com https://www.gravatar.com https://res.cloudinary.com https://platform.slack-edge.com https://raw.githubusercontent.com",
-                "frame-ancestors https://posthog.com https://preview.posthog.com",
+                f"frame-ancestors {frame_ancestors}",
                 f"connect-src 'self' https://status.posthog.com {resource_url} {connect_debug_url} https://raw.githubusercontent.com https://api.github.com",
                 # allow all sites for displaying heatmaps
                 "frame-src https:",

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1,4 +1,3 @@
-import os
 import re
 import json
 import time
@@ -771,13 +770,6 @@ class CSPMiddleware:
                 resource_url = "https://*.dev.posthog.dev"
 
             connect_debug_url = "ws://localhost:8234" if settings.DEBUG or settings.TEST else ""
-
-            frame_ancestors = "https://posthog.com https://preview.posthog.com https://vercel.com"
-            if settings.DEBUG:
-                ngrok_origin = os.environ.get("NGROK_ORIGIN", "")
-                if ngrok_origin:
-                    frame_ancestors = f"{frame_ancestors} {ngrok_origin}"
-
             csp_parts = [
                 "default-src 'self'",
                 f"style-src 'self' 'unsafe-inline' {resource_url} https://fonts.googleapis.com",
@@ -788,7 +780,7 @@ class CSPMiddleware:
                 "object-src 'none'",
                 "media-src https://res.cloudinary.com",
                 f"img-src 'self' data: {resource_url} https://posthog.com https://www.gravatar.com https://res.cloudinary.com https://platform.slack-edge.com https://raw.githubusercontent.com",
-                f"frame-ancestors {frame_ancestors}",
+                "frame-ancestors https://posthog.com https://preview.posthog.com https://vercel.com",
                 f"connect-src 'self' https://status.posthog.com {resource_url} {connect_debug_url} https://raw.githubusercontent.com https://api.github.com",
                 # allow all sites for displaying heatmaps
                 "frame-src https:",


### PR DESCRIPTION
## Problem

When a user created by Vercel installs the integration again (creating a second org), they were being treated as an external user requiring login verification. This broke SSO for subsequent installations.

From Slack:
> "When testing, you installed the integration multiple times, which created separate organizations in PostHog. The first installation created your user account, but when the second installation happened, the system saw your user already existed and skipped creating the necessary link between your Vercel account and PostHog user."

https://posthog.slack.com/archives/C08LYBQ58N5/p1768412566192139?thread_ts=1768189766.727799&cid=C08LYBQ58N5

## Changes

- Added `_user_has_any_vercel_mapping()` helper to check if a user has any Vercel mapping across all installations
- Modified `upsert_installation()` to distinguish between:
  - **Trusted Vercel users** (have existing mapping) → auto-linked with membership and mapping
  - **External users** (no Vercel mapping) → require login verification (security maintained)

## How did you test this code?

Added two new tests:
- `test_sso_requires_login_for_external_existing_user` - Security test ensuring external users still require login
- `test_sso_works_for_trusted_vercel_user_second_installation` - E2E test verifying the fix works

All 73 Vercel tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)