### PR TITLE
chore(flags): Add dedicated Celery queues for feature flags (Phase 1)

### DIFF
--- a/bin/celery-queues.env
+++ b/bin/celery-queues.env
@@ -2,4 +2,4 @@
 # Important: Add new queues to make Celery consume tasks from them.
 
 # NOTE: Keep in sync with posthog/tasks/utils.py
-CELERY_WORKER_QUEUES=celery,stats,email,analytics_queries,analytics_limited,long_running,exports,subscription_delivery,usage_reports,session_replay_embeddings,session_replay_general,session_replay_persistence,integrations
+CELERY_WORKER_QUEUES=celery,stats,email,analytics_queries,analytics_limited,long_running,exports,subscription_delivery,usage_reports,session_replay_embeddings,session_replay_general,session_replay_persistence,integrations,feature-flags,feature-flags-long-running

--- a/bin/celery-queues.env
+++ b/bin/celery-queues.env
@@ -2,4 +2,4 @@
 # Important: Add new queues to make Celery consume tasks from them.
 
 # NOTE: Keep in sync with posthog/tasks/utils.py
-CELERY_WORKER_QUEUES=celery,stats,email,analytics_queries,analytics_limited,long_running,exports,subscription_delivery,usage_reports,session_replay_embeddings,session_replay_general,session_replay_persistence,integrations,feature-flags,feature-flags-long-running
+CELERY_WORKER_QUEUES=celery,stats,email,analytics_queries,analytics_limited,long_running,exports,subscription_delivery,usage_reports,session_replay_embeddings,session_replay_general,session_replay_persistence,integrations,feature_flags,feature_flags_long_running

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -121,7 +121,7 @@ def refresh_expiring_flags_cache_entries() -> None:
         raise
 
 
-@shared_task(bind=True, base=PushGatewayTask, ignore_result=True, queue=CeleryQueue.DEFAULT.value)
+@shared_task(bind=True, base=PushGatewayTask, ignore_result=True, queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value)
 def cleanup_stale_flags_expiry_tracking_task(self: PushGatewayTask) -> None:
     """
     Periodic task to clean up stale entries in the flags cache expiry tracking sorted set.

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -133,12 +133,19 @@ def cleanup_stale_flags_expiry_tracking_task(self: PushGatewayTask) -> None:
         logger.info("Flags Redis URL not set, skipping flags expiry tracking cleanup")
         return
 
+    duration_gauge = Gauge(
+        "posthog_cleanup_stale_flags_expiry_duration_seconds",
+        "Duration of cleanup_stale_flags_expiry_tracking_task",
+        registry=self.metrics_registry,
+    )
     entries_cleaned_gauge = Gauge(
         "posthog_cleanup_stale_flags_expiry_entries_cleaned",
         "Number of stale expiry tracking entries cleaned up",
         registry=self.metrics_registry,
     )
 
+    start_time = time.time()
     removed_count = cleanup_stale_expiry_tracking()
+    duration_gauge.set(time.time() - start_time)
     entries_cleaned_gauge.set(removed_count)
     logger.info("Completed flags expiry tracking cleanup", removed_count=removed_count)

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -133,19 +133,12 @@ def cleanup_stale_flags_expiry_tracking_task(self: PushGatewayTask) -> None:
         logger.info("Flags Redis URL not set, skipping flags expiry tracking cleanup")
         return
 
-    duration_gauge = Gauge(
-        "posthog_cleanup_stale_flags_expiry_duration_seconds",
-        "Duration of cleanup_stale_flags_expiry_tracking_task",
-        registry=self.metrics_registry,
-    )
     entries_cleaned_gauge = Gauge(
         "posthog_cleanup_stale_flags_expiry_entries_cleaned",
         "Number of stale expiry tracking entries cleaned up",
         registry=self.metrics_registry,
     )
 
-    start_time = time.time()
     removed_count = cleanup_stale_expiry_tracking()
-    duration_gauge.set(time.time() - start_time)
     entries_cleaned_gauge.set(removed_count)
     logger.info("Completed flags expiry tracking cleanup", removed_count=removed_count)

--- a/posthog/tasks/utils.py
+++ b/posthog/tasks/utils.py
@@ -104,3 +104,5 @@ class CeleryQueue(Enum):
     SESSION_REPLAY_PERSISTENCE = "session_replay_persistence"
     SESSION_REPLAY_GENERAL = "session_replay_general"
     INTEGRATIONS = "integrations"
+    FEATURE_FLAGS = "feature-flags"
+    FEATURE_FLAGS_LONG_RUNNING = "feature-flags-long-running"

--- a/posthog/tasks/utils.py
+++ b/posthog/tasks/utils.py
@@ -104,5 +104,5 @@ class CeleryQueue(Enum):
     SESSION_REPLAY_PERSISTENCE = "session_replay_persistence"
     SESSION_REPLAY_GENERAL = "session_replay_general"
     INTEGRATIONS = "integrations"
-    FEATURE_FLAGS = "feature-flags"
-    FEATURE_FLAGS_LONG_RUNNING = "feature-flags-long-running"
+    FEATURE_FLAGS = "feature_flags"
+    FEATURE_FLAGS_LONG_RUNNING = "feature_flags_long_running"


### PR DESCRIPTION
## Problem

Feature flag tasks currently run on the default Celery queue, which means they compete with unrelated tasks for worker resources. This can lead to delays in flag cache updates during periods of high task volume.

This is Phase 1 of adding dedicated Celery queues for feature flags. We're starting with a single task migration to validate the new queue infrastructure before migrating additional tasks.

## Changes

- Add two new Celery queues: `feature-flags` and `feature-flags-long-running`
- Migrate `cleanup_stale_flags_expiry_tracking_task` to `feature-flags-long-running` queue
- Add duration metric (`posthog_cleanup_stale_flags_expiry_duration_seconds`) to track task execution time

The `feature-flags` queue is defined but intentionally unused in this PR—it will be used for quick, high-volume tasks (like `update_team_flags_cache`) in a future phase.

## How did you test this code?

- Verified queue names are consistent between `celery-queues.env` and `CeleryQueue` enum
- Confirmed `time` module is already imported in `feature_flags.py`
- Code review of changes against existing patterns

## Publish to changelog?

No
