### PR TITLE
fix: dont verify for ch streaming

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -439,7 +439,7 @@ def _stream_clickhouse_query(
         data=sql_with_format.encode("utf-8"),
         stream=True,
         timeout=600,
-        verify=False,
+        verify=settings.CLICKHOUSE_CA,
     ) as response:
         if response.status_code != 200:
             error_message = response.text

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -439,6 +439,7 @@ def _stream_clickhouse_query(
         data=sql_with_format.encode("utf-8"),
         stream=True,
         timeout=600,
+        verify=False,
     ) as response:
         if response.status_code != 200:
             error_message = response.text

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -439,7 +439,7 @@ def _stream_clickhouse_query(
         data=sql_with_format.encode("utf-8"),
         stream=True,
         timeout=600,
-        verify=settings.CLICKHOUSE_CA,
+        verify=settings.CLICKHOUSE_VERIFY,
     ) as response:
         if response.status_code != 200:
             error_message = response.text


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Getting the following error in prod after I added CH response streaming for exports: https://github.com/PostHog/posthog/pull/44965 

```
certificate verify failed: self-signed certificate in certificate chain
```

From: https://grafana.prod-us.posthog.dev/goto/s7HoekSDg?orgId=1

## Changes

Don't verify

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

settings.CLICKHOUSE_VERIFY is false in prod

```
kubectl exec -n posthog posthog-query-django-64d66cfc74-2tscr -- env | grep -E "CLICKHOUSE_CA|CLICKHOUSE_VERIFY"
```
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
