### PR TITLE
fix(llma): Trace sumamrization - reduce max traces per window from 100 to 10

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -7,7 +7,7 @@ from temporalio.common import RetryPolicy
 from products.llm_analytics.backend.summarization.models import GeminiModel, SummarizationMode, SummarizationProvider
 
 # Window processing configuration
-DEFAULT_MAX_TRACES_PER_WINDOW = 100  # Max traces to process per window (conservative for worst-case 30s/trace)
+DEFAULT_MAX_TRACES_PER_WINDOW = 10  # Max traces to process per window (conservative for worst-case 30s/trace)
 DEFAULT_BATCH_SIZE = 3  # Number of traces to process in parallel (reduced to avoid rate limits)
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -323,7 +323,7 @@ class TestBatchTraceSummarizationWorkflow:
         inputs = BatchTraceSummarizationWorkflow.parse_inputs(["123"])
 
         assert inputs.team_id == 123
-        assert inputs.max_traces == 100
+        assert inputs.max_traces == 10
         assert inputs.batch_size == 3
         assert inputs.mode == "detailed"
         assert inputs.window_minutes == 60


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

We want to reduce amount of gemini api requests being made while we still doing dev work on this feature

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
