### PR TITLE
chore: Add context to build and push container image step

### DIFF
--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -114,6 +114,7 @@ jobs:
               id: build
               uses: depot/build-push-action@9785b135c3c76c33db102e45be96a25ab55cd507 # v1.16.2
               with:
+                  context: .
                   buildx-fallback: false
                   project: '00mrvlsdvh'
                   push: true


### PR DESCRIPTION
Per suggestion from the good guys over at depot.dev to try and fix https://github.com/PostHog/posthog/actions/runs/21007624794
