### PR TITLE
feat: fix Dagster job integration tests using ClickhouseCluster in local runs

### DIFF
--- a/posthog/dags/tests/conftest.py
+++ b/posthog/dags/tests/conftest.py
@@ -7,14 +7,43 @@ from collections.abc import Iterator
 
 import pytest
 from posthog.test.base import reset_clickhouse_database
+from unittest.mock import patch
 
 from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
 
 
+def _patched_get_cluster_hosts(self, client, cluster, retry_policy=None):
+    """
+    Patch for local macOS Docker testing: use host_name instead of host_address.
+
+    On macOS with Docker Desktop, system.clusters returns Docker-internal IPs
+    (192.168.x.x) which aren't routable from the host. Using host_name returns
+    "clickhouse" which resolves via /etc/hosts (set up by flox) to 127.0.0.1.
+    """
+    return client.execute(
+        """
+        SELECT host_name, port, shard_num, replica_num, getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role
+        FROM clusterAllReplicas(%(name)s, system.clusters)
+        WHERE name = %(name)s and is_local
+        ORDER BY shard_num, replica_num
+        """,
+        {"name": cluster},
+    )
+
+
 @pytest.fixture
 def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
+    """
+    Cluster fixture with macOS Docker-compatible hostname resolution.
+    Patches ClickhouseCluster to use host_name instead of host_address.
+    """
     reset_clickhouse_database()
     try:
-        yield get_cluster()
+        with patch.object(
+            ClickhouseCluster,
+            "_ClickhouseCluster__get_cluster_hosts",
+            _patched_get_cluster_hosts,
+        ):
+            yield get_cluster()
     finally:
         reset_clickhouse_database()


### PR DESCRIPTION
## Problem
Running `posthog/dags/tests/` integration tests using `ClickhouseCluster` were having issues because `host_address` check at init returns the Docker-internal IP vs. local hostname.

We'd like to be able to execute these tests locally (macOS) as well as in CI as needed on the fly.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Make `conftest.py` setup for Dagster jobs more flexible for `ClickhouseCluster` when `DEBUG` is set
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally ran all relevant Dagster integration tests ✅ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
