### PR TITLE
feat(surveys): scheduled task for survey recommendations

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -67,6 +67,7 @@ from posthog.tasks.team_metadata import cleanup_stale_expiry_tracking_task, refr
 from posthog.utils import get_crontab, get_instance_region
 
 from products.endpoints.backend.tasks import deactivate_stale_materializations
+from products.surveys.backend.tasks import cleanup_stale_recommendations, generate_survey_recommendations_for_all_teams
 
 TWENTY_FOUR_HOURS = 24 * 60 * 60
 
@@ -514,4 +515,16 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="5", minute="0"),
         deactivate_stale_materializations.s(),
         name="deactivate stale endpoint materializations",
+    )
+
+    # Survey recommendations - generate daily, cleanup weekly
+    sender.add_periodic_task(
+        crontab(hour="6", minute="0"),
+        generate_survey_recommendations_for_all_teams.s(),
+        name="generate survey recommendations for all teams",
+    )
+    sender.add_periodic_task(
+        crontab(day_of_week="sun", hour="7", minute="0"),
+        cleanup_stale_recommendations.s(),
+        name="cleanup stale survey recommendations",
     )

--- a/products/surveys/backend/tasks.py
+++ b/products/surveys/backend/tasks.py
@@ -1,0 +1,113 @@
+from django.db.models import Q
+
+import structlog
+import posthoganalytics
+from celery import shared_task
+
+from posthog.models import Team
+
+from products.surveys.backend.models import SurveyRecommendation
+
+logger = structlog.get_logger(__name__)
+
+SURVEY_RECOMMENDATIONS_FEATURE_FLAG = "survey-recommendations"
+
+
+@shared_task(ignore_result=True, max_retries=1)
+def generate_survey_recommendations_for_team(team_id: int) -> None:
+    try:
+        team = Team.objects.get(id=team_id)
+    except Team.DoesNotExist:
+        logger.warning("Team not found for survey recommendations", team_id=team_id)
+        return
+
+    try:
+        from products.surveys.backend.recommendations import generate_recommendations
+
+        saved_count = generate_recommendations(team)
+
+        logger.info(
+            "Survey recommendations generated",
+            team_id=team_id,
+            saved_count=saved_count,
+        )
+
+    except Exception as e:
+        logger.exception(
+            "Failed to generate survey recommendations",
+            team_id=team_id,
+            error=str(e),
+        )
+        raise
+
+
+@shared_task(ignore_result=True)
+def generate_survey_recommendations_for_all_teams() -> None:
+    from posthog.caching.utils import active_teams
+
+    team_ids = active_teams()
+    teams = Team.objects.filter(id__in=team_ids).only("id", "organization_id")
+
+    enabled_teams = [
+        team
+        for team in teams
+        if posthoganalytics.feature_enabled(
+            SURVEY_RECOMMENDATIONS_FEATURE_FLAG,
+            str(team.organization_id),
+            groups={"organization": str(team.organization_id)},
+            group_properties={"organization": {"id": str(team.organization_id)}},
+            send_feature_flag_events=False,
+        )
+    ]
+
+    logger.info(
+        "Scheduling survey recommendations for teams",
+        total_active_teams=len(team_ids),
+        enabled_teams=len(enabled_teams),
+    )
+
+    for i, team in enumerate(enabled_teams):
+        delay_seconds = i * 30
+        generate_survey_recommendations_for_team.apply_async(
+            args=[team.id],
+            countdown=delay_seconds,
+        )
+
+
+@shared_task(ignore_result=True)
+def cleanup_stale_recommendations() -> None:
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    now = timezone.now()
+    cutoff = now - timedelta(days=30)
+
+    orphaned_count = (
+        SurveyRecommendation.objects.filter(
+            status=SurveyRecommendation.Status.ACTIVE,
+        )
+        .filter(
+            Q(source_insight__isnull=False, source_insight__deleted=True)
+            | Q(source_feature_flag__isnull=False, source_feature_flag__deleted=True)
+            | Q(source_experiment__isnull=False, source_experiment__feature_flag__deleted=True)
+        )
+        .update(
+            status=SurveyRecommendation.Status.DISMISSED,
+            dismissed_at=now,
+        )
+    )
+
+    if orphaned_count:
+        logger.info("Dismissed orphaned survey recommendations", count=orphaned_count)
+
+    stale_count = SurveyRecommendation.objects.filter(
+        status=SurveyRecommendation.Status.ACTIVE,
+        created_at__lt=cutoff,
+    ).update(
+        status=SurveyRecommendation.Status.DISMISSED,
+        dismissed_at=now,
+    )
+
+    if stale_count:
+        logger.info("Dismissed stale survey recommendations", count=stale_count)

--- a/products/surveys/backend/test/test_tasks.py
+++ b/products/surveys/backend/test/test_tasks.py
@@ -1,0 +1,147 @@
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from posthog.models import FeatureFlag, Organization, Team
+
+from products.surveys.backend.models import SurveyRecommendation
+from products.surveys.backend.tasks import (
+    cleanup_stale_recommendations,
+    generate_survey_recommendations_for_all_teams,
+    generate_survey_recommendations_for_team,
+)
+
+
+class TestCleanupStaleRecommendations(BaseTest):
+    def _create_recommendation(self, **kwargs):
+        defaults = {
+            "team": self.team,
+            "recommendation_type": SurveyRecommendation.RecommendationType.LOW_CONVERSION_FUNNEL,
+            "survey_defaults": {"name": "Test"},
+            "display_context": {"title": "Test"},
+            "score": 50,
+            "status": SurveyRecommendation.Status.ACTIVE,
+        }
+        defaults.update(kwargs)
+        return SurveyRecommendation.objects.create(**defaults)
+
+    def test_dismisses_recommendations_with_deleted_insight(self):
+        from posthog.models import Insight
+
+        insight = Insight.objects.create(team=self.team, deleted=True)
+        rec = self._create_recommendation(source_insight=insight)
+
+        cleanup_stale_recommendations()
+
+        rec.refresh_from_db()
+        self.assertEqual(rec.status, SurveyRecommendation.Status.DISMISSED)
+        self.assertIsNotNone(rec.dismissed_at)
+
+    def test_dismisses_recommendations_with_deleted_feature_flag(self):
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            deleted=True,
+            created_by=self.user,
+        )
+        rec = self._create_recommendation(source_feature_flag=flag)
+
+        cleanup_stale_recommendations()
+
+        rec.refresh_from_db()
+        self.assertEqual(rec.status, SurveyRecommendation.Status.DISMISSED)
+
+    def test_dismisses_old_unconverted_recommendations(self):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        rec = self._create_recommendation()
+        SurveyRecommendation.objects.filter(id=rec.id).update(created_at=timezone.now() - timedelta(days=31))
+
+        cleanup_stale_recommendations()
+
+        rec.refresh_from_db()
+        self.assertEqual(rec.status, SurveyRecommendation.Status.DISMISSED)
+
+    def test_keeps_recent_recommendations(self):
+        rec = self._create_recommendation()
+
+        cleanup_stale_recommendations()
+
+        rec.refresh_from_db()
+        self.assertEqual(rec.status, SurveyRecommendation.Status.ACTIVE)
+
+
+class TestGenerateSurveyRecommendationsForTeam(BaseTest):
+    def test_returns_early_when_team_does_not_exist(self):
+        with patch("products.surveys.backend.tasks.logger") as mock_logger:
+            generate_survey_recommendations_for_team(999999)
+            mock_logger.warning.assert_called_once()
+            self.assertIn("Team not found", str(mock_logger.warning.call_args))
+
+    @patch("products.surveys.backend.recommendations.generate_recommendations")
+    def test_calls_generator_for_valid_team(self, mock_generate):
+        mock_generate.return_value = 3
+
+        generate_survey_recommendations_for_team(self.team.id)
+
+        mock_generate.assert_called_once_with(self.team)
+
+    @patch("products.surveys.backend.recommendations.generate_recommendations")
+    def test_logs_error_when_generator_fails(self, mock_generate):
+        mock_generate.side_effect = Exception("Test error")
+
+        with (
+            patch("products.surveys.backend.tasks.logger") as mock_logger,
+            self.assertRaises(Exception),
+        ):
+            generate_survey_recommendations_for_team(self.team.id)
+            mock_logger.exception.assert_called_once()
+
+
+class TestGenerateSurveyRecommendationsForAllTeams(BaseTest):
+    @patch("products.surveys.backend.tasks.generate_survey_recommendations_for_team.apply_async")
+    @patch("posthoganalytics.feature_enabled")
+    @patch("posthog.caching.utils.active_teams")
+    def test_only_spawns_tasks_for_enabled_teams(self, mock_active_teams, mock_feature_enabled, mock_apply_async):
+        org2 = Organization.objects.create(name="Org 2")
+        team2 = Team.objects.create(organization=org2, name="Team 2")
+
+        mock_active_teams.return_value = [self.team.id, team2.id]
+        mock_feature_enabled.side_effect = lambda key, distinct_id, **kwargs: distinct_id == str(org2.id)
+
+        generate_survey_recommendations_for_all_teams()
+
+        self.assertEqual(mock_apply_async.call_count, 1)
+        mock_apply_async.assert_called_with(args=[team2.id], countdown=0)
+
+    @patch("products.surveys.backend.tasks.generate_survey_recommendations_for_team.apply_async")
+    @patch("posthoganalytics.feature_enabled")
+    @patch("posthog.caching.utils.active_teams")
+    def test_spawns_no_tasks_when_flag_disabled_for_all(
+        self, mock_active_teams, mock_feature_enabled, mock_apply_async
+    ):
+        mock_active_teams.return_value = [self.team.id]
+        mock_feature_enabled.return_value = False
+
+        generate_survey_recommendations_for_all_teams()
+
+        mock_apply_async.assert_not_called()
+
+    @patch("products.surveys.backend.tasks.generate_survey_recommendations_for_team.apply_async")
+    @patch("posthoganalytics.feature_enabled")
+    @patch("posthog.caching.utils.active_teams")
+    def test_staggers_task_execution(self, mock_active_teams, mock_feature_enabled, mock_apply_async):
+        team2 = Team.objects.create(organization=self.organization, name="Team 2")
+        team3 = Team.objects.create(organization=self.organization, name="Team 3")
+
+        mock_active_teams.return_value = [self.team.id, team2.id, team3.id]
+        mock_feature_enabled.return_value = True
+
+        generate_survey_recommendations_for_all_teams()
+
+        self.assertEqual(mock_apply_async.call_count, 3)
+        calls = mock_apply_async.call_args_list
+        self.assertEqual(calls[0][1]["countdown"], 0)
+        self.assertEqual(calls[1][1]["countdown"], 30)
+        self.assertEqual(calls[2][1]["countdown"], 60)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

sample set of recommendations (2 passes, on hogli dev demo data):

```
- Critical decline in weekly signups to zero (score: 100.0, status: active)
  Type: declining_feature
  Source: insight=1, exp=None, flag=None
  Context: Weekly signups remain at zero from Dec 14 through Jan 11, 2026. Over one month with no new user acquisition represents a critical business issue requiring immediate user feedback to understand barriers to signup.
  Suggested survey:
  {'name': 'Feedback: Critical decline in weekly signups to zero', 'type': 'popover', 'questions': [{'type': 'open', 'question': 'What prevented you from completing your signup, or what issues did you encounter during the signup process?'}], 'linked_insight_id': 1}


- File upload feature usage dropped to zero (score: 100.0, status: active)
  Type: declining_feature
  Source: insight=6, exp=None, flag=None
  Context: File uploads remain at zero bytes from Dec 14 through Jan 11, 2026. Over one month without any file upload activity indicates complete abandonment of a core feature, requiring urgent investigation into usability or technical issues.
  Suggested survey:
  {'name': 'Feedback: File upload feature usage dropped to zero', 'type': 'popover', 'questions': [{'type': 'open', 'question': 'Have you tried uploading files recently? If so, what issues or friction did you experience?'}], 'linked_insight_id': 6}


- Activation funnel shows no conversions (score: 95.0, status: active)
  Type: low_conversion_funnel
  Source: insight=3, exp=None, flag=None
  Context: The activation funnel continues to show no data for the last month, with zero users progressing through signup → file interaction → upgrade. This complete funnel breakdown requires user feedback to identify where friction is occurring.
  Suggested survey:
  {'name': 'Feedback: Activation funnel shows no conversions', 'type': 'popover', 'questions': [{'type': 'open', 'question': 'What would help you get more value from the product after signing up?'}], 'linked_insight_id': 3}


- Gather feedback on performance issue product tour (score: 70.0, status: active)
  Type: feature_flag_feedback
  Source: insight=None, exp=None, flag=851
  Context: The product tour for performance issues remains at 100% rollout. Gathering feedback will validate whether this tour effectively helps users recognize and address performance problems.
  Suggested survey:
  {'name': 'Feedback: Gather feedback on performance issue product tour', 'type': 'popover', 'questions': [{'type': 'open', 'question': 'Did the performance issue tour help you understand and address performance problems in your setup?'}]}


- Validate web analytics session property charts feature (score: 65.0, status: active)
  Type: feature_flag_feedback
  Source: insight=None, exp=None, flag=850
  Context: The web analytics session property charts feature remains at 100% rollout. Early feedback will help validate if this feature meets user needs and identify potential improvements.
  Suggested survey:
  {'name': 'Feedback: Validate web analytics session property charts feature', 'type': 'popover', 'questions': [{'type': 'open', 'question': 'How useful are the session property charts in web analytics for your analysis needs?'}]}```

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
