### PR TITLE
fix: upgrade libpq5 version in sqlx-migrator Dockerfile

### DIFF
--- a/rust/Dockerfile.sqlx-migrate
+++ b/rust/Dockerfile.sqlx-migrate
@@ -9,7 +9,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates=20230311+deb12u1 \
-    libpq5=15.14-0+deb12u1 \
+    libpq5=15.15-0+deb12u1 \
     postgresql-client=15+248+deb12u1 \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem
Some code that is breaking `kafka-deduplicator` never made it into deploy because CI is failing on the `sqlx-migrator` build since yesterday due to a library import being unavailable.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Upgrade `libpq5` in `Dockerfile.sqlx-migrator` 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
