### PR TITLE
chore(flags): Add pipelining support to Rust `RedisClient`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1372,6 +1372,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-named-pipe",
+ "hyper-rustls 0.27.5",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls 0.23.7",
+ "rustls-native-certs 0.8.1",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "bon"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,6 +2119,7 @@ dependencies = [
  "async-trait",
  "redis",
  "serde-pickle",
+ "testcontainers",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2730,6 +2781,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2808,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -3119,6 +3187,18 @@ checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3941,6 +4021,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,6 +4129,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -4230,6 +4340,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -4719,6 +4830,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
+ "redox_syscall 0.5.18",
 ]
 
 [[package]]
@@ -5675,9 +5787,34 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax 0.8.5",
+ "structmeta",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -6749,11 +6886,29 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -6765,6 +6920,26 @@ dependencies = [
  "getrandom 0.2.12",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -7296,6 +7471,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7526,6 +7725,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7544,6 +7754,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.12.1",
+ "schemars 0.9.0",
+ "schemars 1.1.0",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -8080,6 +8321,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8524,6 +8788,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8786,6 +9079,21 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
 ]
 
 [[package]]
@@ -9157,6 +9465,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -9636,6 +9945,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9877,6 +10195,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -145,3 +145,4 @@ clickhouse = { version = "0.13.2", features = [
 fernet = "0.2"
 tiktoken-rs = "0.7.0"
 sha2 = "0.10"
+testcontainers = "0.23"

--- a/rust/common/redis/Cargo.toml
+++ b/rust/common/redis/Cargo.toml
@@ -16,4 +16,5 @@ zstd = "0.13"
 
 [dev-dependencies]
 tokio = { workspace = true }
+testcontainers = { workspace = true }
 

--- a/rust/common/redis/src/pipeline.rs
+++ b/rust/common/redis/src/pipeline.rs
@@ -92,7 +92,7 @@ pub enum PipelineCommand {
 
 /// A Redis pipeline that batches multiple commands into a single round-trip.
 ///
-/// Create a pipeline using [`Client::pipeline()`], add commands using the builder
+/// Create a pipeline using [`ClientPipelineExt::pipeline()`], add commands using the builder
 /// methods, then call [`execute()`](Pipeline::execute) to send all commands at once.
 ///
 /// # Example

--- a/rust/common/redis/src/pipeline.rs
+++ b/rust/common/redis/src/pipeline.rs
@@ -1,0 +1,479 @@
+//! Redis pipeline support for batching multiple commands into a single round-trip.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use common_redis::{Client, Pipeline, PipelineResult};
+//!
+//! async fn example(client: &impl Client) -> Result<(), CustomRedisError> {
+//!     let results = client.pipeline()
+//!         .set("key1", "value1")
+//!         .set("key2", "value2")
+//!         .get("key3")
+//!         .execute()
+//!         .await?;
+//!
+//!     // results[0] = Ok(PipelineResult::Ok)
+//!     // results[1] = Ok(PipelineResult::Ok)
+//!     // results[2] = Ok(PipelineResult::String("...")) or Err(NotFound)
+//!     Ok(())
+//! }
+//! ```
+
+use crate::{Client, CustomRedisError, RedisValueFormat};
+
+/// Result type for individual pipeline operations.
+///
+/// Each variant corresponds to the return type of a Redis command.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PipelineResult {
+    /// Success with no return value (SET, DEL, HINCRBY, etc.)
+    Ok,
+    /// String value (GET)
+    String(String),
+    /// Raw bytes (GET raw bytes)
+    Bytes(Vec<u8>),
+    /// Boolean result (SET NX EX)
+    Bool(bool),
+    /// Count result (SCARD)
+    Count(u64),
+    /// List of strings (ZRANGEBYSCORE)
+    Strings(Vec<String>),
+}
+
+/// Internal representation of a pipeline command.
+#[derive(Debug, Clone)]
+pub enum PipelineCommand {
+    Get {
+        key: String,
+        format: RedisValueFormat,
+    },
+    GetRawBytes {
+        key: String,
+    },
+    Set {
+        key: String,
+        value: String,
+        format: RedisValueFormat,
+    },
+    SetEx {
+        key: String,
+        value: String,
+        seconds: u64,
+        format: RedisValueFormat,
+    },
+    SetNxEx {
+        key: String,
+        value: String,
+        seconds: u64,
+        format: RedisValueFormat,
+    },
+    Del {
+        key: String,
+    },
+    HGet {
+        key: String,
+        field: String,
+    },
+    HIncrBy {
+        key: String,
+        field: String,
+        count: i32,
+    },
+    Scard {
+        key: String,
+    },
+    ZRangeByScore {
+        key: String,
+        min: String,
+        max: String,
+    },
+}
+
+/// A Redis pipeline that batches multiple commands into a single round-trip.
+///
+/// Create a pipeline using [`Client::pipeline()`], add commands using the builder
+/// methods, then call [`execute()`](Pipeline::execute) to send all commands at once.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let results = client.pipeline()
+///     .set("key1", "value1")
+///     .set("key2", "value2")
+///     .get("key3")
+///     .execute()
+///     .await?;
+/// ```
+pub struct Pipeline<C> {
+    client: C,
+    commands: Vec<PipelineCommand>,
+}
+
+impl<C> Pipeline<C> {
+    /// Create a new pipeline for the given client.
+    pub fn new(client: C) -> Self {
+        Self {
+            client,
+            commands: Vec::new(),
+        }
+    }
+
+    /// Add a GET command to the pipeline.
+    pub fn get(self, key: impl Into<String>) -> Self {
+        self.get_with_format(key, RedisValueFormat::default())
+    }
+
+    /// Add a GET command with a specific format to the pipeline.
+    pub fn get_with_format(mut self, key: impl Into<String>, format: RedisValueFormat) -> Self {
+        self.commands.push(PipelineCommand::Get {
+            key: key.into(),
+            format,
+        });
+        self
+    }
+
+    /// Add a GET command for raw bytes to the pipeline.
+    pub fn get_raw_bytes(mut self, key: impl Into<String>) -> Self {
+        self.commands
+            .push(PipelineCommand::GetRawBytes { key: key.into() });
+        self
+    }
+
+    /// Add a SET command to the pipeline.
+    pub fn set(self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.set_with_format(key, value, RedisValueFormat::default())
+    }
+
+    /// Add a SET command with a specific format to the pipeline.
+    pub fn set_with_format(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+        format: RedisValueFormat,
+    ) -> Self {
+        self.commands.push(PipelineCommand::Set {
+            key: key.into(),
+            value: value.into(),
+            format,
+        });
+        self
+    }
+
+    /// Add a SETEX command (SET with expiration) to the pipeline.
+    pub fn setex(self, key: impl Into<String>, value: impl Into<String>, seconds: u64) -> Self {
+        self.setex_with_format(key, value, seconds, RedisValueFormat::default())
+    }
+
+    /// Add a SETEX command with a specific format to the pipeline.
+    pub fn setex_with_format(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+        seconds: u64,
+        format: RedisValueFormat,
+    ) -> Self {
+        self.commands.push(PipelineCommand::SetEx {
+            key: key.into(),
+            value: value.into(),
+            seconds,
+            format,
+        });
+        self
+    }
+
+    /// Add a SET NX EX command (SET if not exists with expiration) to the pipeline.
+    pub fn set_nx_ex(self, key: impl Into<String>, value: impl Into<String>, seconds: u64) -> Self {
+        self.set_nx_ex_with_format(key, value, seconds, RedisValueFormat::default())
+    }
+
+    /// Add a SET NX EX command with a specific format to the pipeline.
+    pub fn set_nx_ex_with_format(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+        seconds: u64,
+        format: RedisValueFormat,
+    ) -> Self {
+        self.commands.push(PipelineCommand::SetNxEx {
+            key: key.into(),
+            value: value.into(),
+            seconds,
+            format,
+        });
+        self
+    }
+
+    /// Add a DEL command to the pipeline.
+    pub fn del(mut self, key: impl Into<String>) -> Self {
+        self.commands.push(PipelineCommand::Del { key: key.into() });
+        self
+    }
+
+    /// Add an HGET command to the pipeline.
+    pub fn hget(mut self, key: impl Into<String>, field: impl Into<String>) -> Self {
+        self.commands.push(PipelineCommand::HGet {
+            key: key.into(),
+            field: field.into(),
+        });
+        self
+    }
+
+    /// Add an HINCRBY command to the pipeline.
+    pub fn hincrby(mut self, key: impl Into<String>, field: impl Into<String>, count: i32) -> Self {
+        self.commands.push(PipelineCommand::HIncrBy {
+            key: key.into(),
+            field: field.into(),
+            count,
+        });
+        self
+    }
+
+    /// Add an SCARD command to the pipeline.
+    pub fn scard(mut self, key: impl Into<String>) -> Self {
+        self.commands
+            .push(PipelineCommand::Scard { key: key.into() });
+        self
+    }
+
+    /// Add a ZRANGEBYSCORE command to the pipeline.
+    pub fn zrangebyscore(
+        mut self,
+        key: impl Into<String>,
+        min: impl Into<String>,
+        max: impl Into<String>,
+    ) -> Self {
+        self.commands.push(PipelineCommand::ZRangeByScore {
+            key: key.into(),
+            min: min.into(),
+            max: max.into(),
+        });
+        self
+    }
+
+    /// Get the commands in this pipeline.
+    pub fn into_commands(self) -> (C, Vec<PipelineCommand>) {
+        (self.client, self.commands)
+    }
+
+    /// Check if the pipeline is empty.
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty()
+    }
+
+    /// Get the number of commands in the pipeline.
+    pub fn len(&self) -> usize {
+        self.commands.len()
+    }
+}
+
+impl<C: Client> Pipeline<C> {
+    /// Execute all commands in the pipeline as a single batch.
+    ///
+    /// Returns a vector of results in the same order as commands were added.
+    /// Each result is either `Ok(PipelineResult)` or `Err(CustomRedisError)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection fails. Individual command failures
+    /// are returned as `Err` in the result vector.
+    pub async fn execute(
+        self,
+    ) -> Result<Vec<Result<PipelineResult, CustomRedisError>>, CustomRedisError> {
+        let (client, commands) = self.into_commands();
+        // Handle empty pipelines here to avoid unnecessary round-trips.
+        // This is the single check point - implementations can assume non-empty.
+        if commands.is_empty() {
+            return Ok(Vec::new());
+        }
+        client.execute_pipeline(commands).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pipeline_builder_commands() {
+        // Create a dummy pipeline to test the builder
+        struct DummyClient;
+
+        let pipeline = Pipeline::new(DummyClient)
+            .set("key1", "value1")
+            .set("key2", "value2")
+            .get("key3");
+
+        assert_eq!(pipeline.len(), 3);
+        assert!(!pipeline.is_empty());
+
+        let (_, commands) = pipeline.into_commands();
+        assert_eq!(commands.len(), 3);
+
+        assert!(
+            matches!(&commands[0], PipelineCommand::Set { key, value, .. } if key == "key1" && value == "value1")
+        );
+        assert!(
+            matches!(&commands[1], PipelineCommand::Set { key, value, .. } if key == "key2" && value == "value2")
+        );
+        assert!(matches!(&commands[2], PipelineCommand::Get { key, .. } if key == "key3"));
+    }
+
+    #[test]
+    fn test_pipeline_empty() {
+        struct DummyClient;
+        let pipeline = Pipeline::new(DummyClient);
+        assert!(pipeline.is_empty());
+        assert_eq!(pipeline.len(), 0);
+    }
+
+    #[test]
+    fn test_pipeline_all_commands() {
+        struct DummyClient;
+
+        let pipeline = Pipeline::new(DummyClient)
+            .get("k1")
+            .get_with_format("k2", RedisValueFormat::Utf8)
+            .get_raw_bytes("k3")
+            .set("k4", "v4")
+            .set_with_format("k5", "v5", RedisValueFormat::Utf8)
+            .setex("k6", "v6", 60)
+            .setex_with_format("k7", "v7", 60, RedisValueFormat::Utf8)
+            .set_nx_ex("k8", "v8", 60)
+            .set_nx_ex_with_format("k9", "v9", 60, RedisValueFormat::Utf8)
+            .del("k10")
+            .hget("k11", "f11")
+            .hincrby("k12", "f12", 5)
+            .scard("k13")
+            .zrangebyscore("k14", "0", "100");
+
+        assert_eq!(pipeline.len(), 14);
+    }
+
+    #[test]
+    fn test_pipeline_result_equality() {
+        assert_eq!(PipelineResult::Ok, PipelineResult::Ok);
+        assert_eq!(
+            PipelineResult::String("test".to_string()),
+            PipelineResult::String("test".to_string())
+        );
+        assert_ne!(
+            PipelineResult::String("test1".to_string()),
+            PipelineResult::String("test2".to_string())
+        );
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use crate::{ClientPipelineExt, CustomRedisError, MockRedisClient};
+
+    #[tokio::test]
+    async fn test_mock_pipeline_set_and_get() {
+        let mut client = MockRedisClient::new();
+        client.set_ret("key1", Ok(()));
+        client.set_ret("key2", Ok(()));
+        client.get_ret("key3", Ok("value3".to_string()));
+
+        let results = client
+            .pipeline()
+            .set("key1", "value1")
+            .set("key2", "value2")
+            .get("key3")
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
+        assert!(matches!(results[0], Ok(PipelineResult::Ok)));
+        assert!(matches!(results[1], Ok(PipelineResult::Ok)));
+        assert!(matches!(&results[2], Ok(PipelineResult::String(s)) if s == "value3"));
+    }
+
+    #[tokio::test]
+    async fn test_mock_pipeline_partial_failure() {
+        let mut client = MockRedisClient::new();
+        client.set_ret("key1", Ok(()));
+        // key2 not configured, will return NotFound
+        client.get_ret("key3", Ok("value3".to_string()));
+
+        let results = client
+            .pipeline()
+            .set("key1", "value1")
+            .get("key2") // This will fail
+            .get("key3")
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
+        assert!(matches!(results[0], Ok(PipelineResult::Ok)));
+        assert!(matches!(results[1], Err(CustomRedisError::NotFound)));
+        assert!(matches!(&results[2], Ok(PipelineResult::String(s)) if s == "value3"));
+    }
+
+    #[tokio::test]
+    async fn test_mock_pipeline_empty() {
+        let client = MockRedisClient::new();
+
+        let results = client.pipeline().execute().await.unwrap();
+
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mock_pipeline_records_calls() {
+        let mut client = MockRedisClient::new();
+        client.set_ret("key1", Ok(()));
+        client.get_ret("key2", Ok("value2".to_string()));
+
+        let _results = client
+            .pipeline()
+            .set("key1", "value1")
+            .get("key2")
+            .execute()
+            .await
+            .unwrap();
+
+        let calls = client.get_calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].op, "pipeline_set");
+        assert_eq!(calls[0].key, "key1");
+        assert_eq!(calls[1].op, "pipeline_get");
+        assert_eq!(calls[1].key, "key2");
+    }
+
+    #[tokio::test]
+    async fn test_mock_pipeline_all_result_types() {
+        let mut client = MockRedisClient::new();
+        client.get_ret("get_key", Ok("string_value".to_string()));
+        client.set_ret("set_key", Ok(()));
+        client.del_ret("del_key", Ok(()));
+        client.set_nx_ex_ret("nx_key", Ok(true));
+        client.scard_ret("scard_key", Ok(42));
+        client.zrangebyscore_ret("zset_key", vec!["a".to_string(), "b".to_string()]);
+
+        let results = client
+            .pipeline()
+            .get("get_key")
+            .set("set_key", "value")
+            .del("del_key")
+            .set_nx_ex("nx_key", "value", 60)
+            .scard("scard_key")
+            .zrangebyscore("zset_key", "0", "100")
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 6);
+        assert!(matches!(&results[0], Ok(PipelineResult::String(s)) if s == "string_value"));
+        assert!(matches!(results[1], Ok(PipelineResult::Ok)));
+        assert!(matches!(results[2], Ok(PipelineResult::Ok)));
+        assert!(matches!(results[3], Ok(PipelineResult::Bool(true))));
+        assert!(matches!(results[4], Ok(PipelineResult::Count(42))));
+        assert!(
+            matches!(&results[5], Ok(PipelineResult::Strings(v)) if v == &vec!["a".to_string(), "b".to_string()])
+        );
+    }
+}

--- a/rust/common/redis/src/read_write.rs
+++ b/rust/common/redis/src/read_write.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::warn;
 
+use crate::pipeline::{PipelineCommand, PipelineResult};
 use crate::{Client, CompressionConfig, CustomRedisError, RedisClient, RedisValueFormat};
 
 /// Configuration for creating a ReadWriteClient with separate primary and replica URLs.
@@ -84,6 +85,10 @@ impl ReadWriteClientConfig {
 ///
 /// Read operations automatically fall back to the writer if the reader fails,
 /// providing resilience against reader replica failures.
+///
+/// **Pipeline Routing:** All pipeline commands are routed to the primary (writer) since
+/// pipelines can contain a mix of read and write operations. This ensures consistency
+/// and simplifies routing logic.
 ///
 /// # Examples
 ///
@@ -472,12 +477,24 @@ impl Client for ReadWriteClient {
     async fn batch_del(&self, keys: Vec<String>) -> Result<(), CustomRedisError> {
         self.writer.batch_del(keys).await
     }
+
+    /// Execute a pipeline of commands.
+    ///
+    /// All pipeline commands are routed to the primary (writer) since pipelines
+    /// can contain a mix of read and write operations. This ensures consistency
+    /// and avoids complex routing logic for mixed pipelines.
+    async fn execute_pipeline(
+        &self,
+        commands: Vec<PipelineCommand>,
+    ) -> Result<Vec<Result<PipelineResult, CustomRedisError>>, CustomRedisError> {
+        self.writer.execute_pipeline(commands).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::MockRedisClient;
+    use crate::{ClientPipelineExt, MockRedisClient, PipelineResult};
 
     fn create_test_client(
         reader_setup: impl FnOnce(&mut MockRedisClient),
@@ -828,5 +845,118 @@ mod tests {
 
         let result = client.mget(vec!["key1".to_string()]).await;
         assert!(matches!(result, Err(CustomRedisError::ParseError(_))));
+    }
+
+    // Pipeline routing tests - verify all pipeline commands go to writer (primary)
+
+    #[tokio::test]
+    async fn test_pipeline_routes_all_commands_to_writer() {
+        // Clone mocks before wrapping so we can inspect calls after test
+        // (MockRedisClient uses Arc<Mutex<Vec<_>>> internally, so clones share state)
+        let reader_mock = MockRedisClient::new();
+        let reader_inspector = reader_mock.clone();
+
+        let mut writer_mock = MockRedisClient::new();
+        writer_mock.get_ret("key1", Ok("writer_value".to_string()));
+        writer_mock.set_ret("key2", Ok(()));
+        let writer_inspector = writer_mock.clone();
+
+        // Coerce to trait objects
+        let reader: Arc<dyn Client + Send + Sync> = Arc::new(reader_mock);
+        let writer: Arc<dyn Client + Send + Sync> = Arc::new(writer_mock);
+
+        let client = ReadWriteClient::new(reader, writer);
+
+        // Execute mixed read/write pipeline
+        let results = client
+            .pipeline()
+            .get("key1") // Read operation
+            .set("key2", "value2") // Write operation
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert!(matches!(
+            &results[0],
+            Ok(PipelineResult::String(s)) if s == "writer_value"
+        ));
+        assert!(matches!(results[1], Ok(PipelineResult::Ok)));
+
+        // Verify ALL commands went to writer, not reader
+        let writer_calls = writer_inspector.get_calls();
+        assert_eq!(
+            writer_calls.len(),
+            2,
+            "Writer should handle all pipeline commands"
+        );
+        assert_eq!(writer_calls[0].op, "pipeline_get");
+        assert_eq!(writer_calls[0].key, "key1");
+        assert_eq!(writer_calls[1].op, "pipeline_set");
+        assert_eq!(writer_calls[1].key, "key2");
+
+        // Verify reader was NOT called
+        let reader_calls = reader_inspector.get_calls();
+        assert_eq!(
+            reader_calls.len(),
+            0,
+            "Reader should never be called for pipelines"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_does_not_fallback_to_reader_on_error() {
+        // Configure reader with good data but writer returns error
+        let mut reader_mock = MockRedisClient::new();
+        reader_mock.get_ret("key1", Ok("reader_value".to_string()));
+        let reader_inspector = reader_mock.clone();
+
+        // Writer has no configured response, will return NotFound
+        let writer_mock = MockRedisClient::new();
+
+        let reader: Arc<dyn Client + Send + Sync> = Arc::new(reader_mock);
+        let writer: Arc<dyn Client + Send + Sync> = Arc::new(writer_mock);
+
+        let client = ReadWriteClient::new(reader, writer);
+
+        // Pipeline should use writer and return its error, NOT fallback to reader
+        let results = client.pipeline().get("key1").execute().await.unwrap();
+
+        assert_eq!(results.len(), 1);
+        // Should get writer's NotFound error, not reader's success
+        assert!(
+            matches!(&results[0], Err(CustomRedisError::NotFound)),
+            "Pipeline should return writer's error, not fallback to reader"
+        );
+
+        // Verify reader was never consulted
+        let reader_calls = reader_inspector.get_calls();
+        assert_eq!(
+            reader_calls.len(),
+            0,
+            "Reader should never be called for pipeline operations"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_empty_does_not_call_either_client() {
+        let reader_mock = MockRedisClient::new();
+        let reader_inspector = reader_mock.clone();
+
+        let writer_mock = MockRedisClient::new();
+        let writer_inspector = writer_mock.clone();
+
+        let reader: Arc<dyn Client + Send + Sync> = Arc::new(reader_mock);
+        let writer: Arc<dyn Client + Send + Sync> = Arc::new(writer_mock);
+
+        let client = ReadWriteClient::new(reader, writer);
+
+        let results = client.pipeline().execute().await.unwrap();
+
+        assert!(results.is_empty());
+
+        // Neither client should be called for empty pipeline
+        assert_eq!(reader_inspector.get_calls().len(), 0);
+        assert_eq!(writer_inspector.get_calls().len(), 0);
     }
 }


### PR DESCRIPTION
## Problem

When we need to run multiple Redis operations back-to-back, each command requires a network round-trip. It would be ideal if we could batch them into a single network round-trip for reduced latency.

This isn't used right now, but is needed for an upcoming feature (local eval port to Rust). Yes, I'm shaving some yaks.

## Changes

The implementation uses the redis crate's native pipeline support and maintains compatibility with existing code - all changes are additive.

- Add `execute_pipeline` method to `Client` trait
- Add Pipeline builder with fluent API for all Redis commands
- Add `PipelineCommand` enum and `PipelineResult` types
- Implement pipelining for `RedisClient`, `MockRedisClient`, `ReadWriteClient`
- Add `ClientPipelineExt` trait for convenient `.pipeline()` builder method

## How did you test this code?

Unit Tests

## Publish to changelog?

No