### PR TITLE
fix(experiments): auto-refresh memory leaks

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { IconRefresh } from '@posthog/icons'
 import { LemonBadge, LemonButton, LemonSwitch } from '@posthog/lemon-ui'
@@ -109,9 +109,15 @@ export const ExperimentReloadAction = ({
         onRefresh: onClick,
     })
 
-    usePageVisibilityCb((pageIsVisible) => {
-        setPageVisibility(pageIsVisible)
-    })
+    // Memoize the page visibility callback to prevent unnecessary event listener churn
+    const handlePageVisibilityChange = useCallback(
+        (pageIsVisible: boolean) => {
+            setPageVisibility(pageIsVisible)
+        },
+        [setPageVisibility]
+    )
+
+    usePageVisibilityCb(handlePageVisibilityChange)
 
     // Stop auto-refresh interval when component unmounts (e.g., navigating away)
     useEffect(() => {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -927,6 +927,12 @@ export const experimentLogic = kea<experimentLogicType>([
                 setAutoRefresh: (_, { enabled, interval }) => ({ enabled, interval }),
             },
         ],
+        isPageVisible: [
+            true as boolean,
+            {
+                setPageVisibility: (_, { visible }) => visible,
+            },
+        ],
     }),
     listeners(({ values, actions, cache }) => ({
         beforeUnmount: () => {
@@ -1118,9 +1124,9 @@ export const experimentLogic = kea<experimentLogicType>([
                     actions.loadExposures(forceRefresh),
                 ])
             } finally {
-                // Always set up auto-refresh if enabled, even if metrics fail to load
-                // This ensures the interval keeps trying to refresh
-                if (values.autoRefresh.enabled && values.experiment?.start_date) {
+                // Only set up auto-refresh if enabled AND page is visible
+                // This prevents the interval from restarting when async operations complete after the page becomes invisible
+                if (values.autoRefresh.enabled && values.experiment?.start_date && values.isPageVisible) {
                     actions.resetAutoRefreshInterval()
                 }
             }


### PR DESCRIPTION
## Problem

There's a race condition among the tab visibility checks, the metric refresh, and the auto reload timer that, under certain conditions, could cause a reinitialization of the refresh interval without cleaning up the visibility check instances, potentially causing a memory leak.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

We are promoting the visibility check to the kea logic state level, so we can perform a check before refreshing the interval if a refresh is executing.

We also create a stable reference to the visibility handler to prevent performance issues during page re-rendering.

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/94221752-db2d-4de1-aebd-307bdd056395)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
