### PR TITLE
feat: Minimize impersonation notice

### DIFF
--- a/ee/admin/loginas_views.py
+++ b/ee/admin/loginas_views.py
@@ -1,14 +1,16 @@
 import json
 
+import posthoganalytics
 from django.http import Http404, JsonResponse
 from django.views.decorators.http import require_http_methods
-
-import posthoganalytics
 from loginas.utils import is_impersonated_session
 from loginas.views import user_login as loginas_user_login
 
 from posthog.helpers.impersonation import get_original_user_from_session
-from posthog.middleware import IMPERSONATION_READ_ONLY_SESSION_KEY, is_read_only_impersonation
+from posthog.middleware import (
+    IMPERSONATION_READ_ONLY_SESSION_KEY,
+    is_read_only_impersonation,
+)
 from posthog.models import User
 
 
@@ -51,7 +53,9 @@ def upgrade_impersonation(request):
         reason = ""
 
     if not reason:
-        return JsonResponse({"error": "A reason is required to upgrade impersonation"}, status=400)
+        return JsonResponse(
+            {"error": "A reason is required to upgrade impersonation"}, status=400
+        )
 
     staff_user = get_original_user_from_session(request)
     if not staff_user or not staff_user.is_staff:

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
@@ -5,7 +5,9 @@
     border: 1px solid var(--border);
     border-radius: var(--radius);
     box-shadow: var(--shadow-elevation-3000);
-    transition: box-shadow 150ms ease;
+    transition:
+        width 200ms cubic-bezier(0.4, 0, 0.2, 1),
+        box-shadow 150ms ease;
 
     &--read-only {
         .ImpersonationNotice__sidebar {
@@ -43,6 +45,14 @@
             0 8px 24px rgb(0 0 0 / 20%);
     }
 
+    &--minimized {
+        width: auto;
+
+        .ImpersonationNotice__sidebar {
+            border-radius: calc(var(--radius) - 1px) 0 0 calc(var(--radius) - 1px);
+        }
+    }
+
     &__sidebar {
         display: flex;
         flex-shrink: 0;
@@ -60,6 +70,37 @@
 
     &__drag-handle {
         flex-shrink: 0;
+    }
+
+    &__minimized-content {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.5rem;
+        cursor: pointer;
+        animation: ImpersonationNotice__fadeScaleIn 200ms cubic-bezier(0.4, 0, 0.2, 1);
+
+        &:hover {
+            background-color: var(--color-bg-surface-secondary);
+        }
+    }
+
+    &__minimized-icon {
+        flex-shrink: 0;
+        font-size: 1.25rem;
+        transition: transform 150ms ease;
+
+        .ImpersonationNotice__minimized-content:hover & {
+            transform: scale(1.1);
+        }
+    }
+
+    &--read-only &__minimized-icon {
+        color: var(--warning);
+    }
+
+    &--read-write &__minimized-icon {
+        color: var(--danger);
     }
 
     &__main {
@@ -102,5 +143,17 @@
         font-size: 0.8125rem;
         line-height: 1.5;
         color: var(--text-primary);
+    }
+}
+
+@keyframes ImpersonationNotice__fadeScaleIn {
+    from {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+
+    to {
+        opacity: 1;
+        transform: scale(1);
     }
 }

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
@@ -61,6 +61,13 @@ export function ImpersonationNotice(): JSX.Element | null {
         }
     }, [isUpgradeModalOpen, isImpersonationUpgradeInProgress, user?.is_impersonated_read_only])
 
+    // Close modal when upgrade completes successfully
+    useEffect(() => {
+        if (isUpgradeModalOpen && !isImpersonationUpgradeInProgress && user?.is_impersonated_read_only === false) {
+            setIsUpgradeModalOpen(false)
+        }
+    }, [isUpgradeModalOpen, isImpersonationUpgradeInProgress, user?.is_impersonated_read_only])
+
     if (!user?.is_impersonated) {
         return null
     }

--- a/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.ts
+++ b/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.ts
@@ -1,0 +1,81 @@
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+
+import { userLogic } from 'scenes/userLogic'
+
+import { UserType } from '~/types'
+
+import type { impersonationNoticeLogicType } from './impersonationNoticeLogicType'
+
+export const impersonationNoticeLogic = kea<impersonationNoticeLogicType>([
+    path(['layout', 'navigation', 'ImpersonationNotice', 'impersonationNoticeLogic']),
+
+    connect({
+        values: [userLogic, ['user', 'isImpersonationUpgradeInProgress']],
+        actions: [userLogic, ['upgradeImpersonation', 'upgradeImpersonationSuccess']],
+    }),
+
+    actions({
+        minimize: true,
+        maximize: true,
+        openUpgradeModal: true,
+        closeUpgradeModal: true,
+        setPageVisible: (visible: boolean) => ({ visible }),
+        clearPageHiddenAt: true,
+    }),
+
+    reducers({
+        isMinimized: [
+            false,
+            {
+                minimize: () => true,
+                maximize: () => false,
+            },
+        ],
+        isUpgradeModalOpen: [
+            false,
+            {
+                openUpgradeModal: () => true,
+                closeUpgradeModal: () => false,
+            },
+        ],
+        pageHiddenAt: [
+            null as number | null,
+            {
+                // Store timestamp when page becomes hidden - used to work out if we
+                // should auto expand when page regains focus
+                setPageVisible: (state, { visible }) => (visible ? state : Date.now()),
+                clearPageHiddenAt: () => null,
+            },
+        ],
+    }),
+
+    selectors({
+        isReadOnly: [(s) => [s.user], (user: UserType | null): boolean => user?.is_impersonated_read_only ?? true],
+        isImpersonated: [(s) => [s.user], (user: UserType | null): boolean => user?.is_impersonated ?? false],
+    }),
+
+    listeners(({ actions, values }) => ({
+        upgradeImpersonationSuccess: () => {
+            if (values.isUpgradeModalOpen && !values.isReadOnly) {
+                actions.closeUpgradeModal()
+            }
+        },
+        setPageVisible: ({ visible }) => {
+            if (!visible) {
+                return
+            }
+            const { pageHiddenAt } = values
+            actions.clearPageHiddenAt()
+            // Auto-maximize when window regains focus to ensure staff
+            // users are reminded they are impersonating a customer
+            // Only trigger if away for more than 30 seconds though to
+            // avoid being annoying if quickly switching between windows
+            if (values.isMinimized && pageHiddenAt) {
+                const secondsAway = (Date.now() - pageHiddenAt) / 1000
+                if (secondsAway > 30) {
+                    actions.maximize()
+                }
+            }
+        },
+    })),
+])

--- a/frontend/src/lib/components/DraggableWithSnapZones/index.ts
+++ b/frontend/src/lib/components/DraggableWithSnapZones/index.ts
@@ -1,2 +1,2 @@
 export { DraggableWithSnapZones } from './DraggableWithSnapZones'
-export type { DraggableWithSnapZonesProps, SnapPosition } from './DraggableWithSnapZones'
+export type { DraggableWithSnapZonesProps, DraggableWithSnapZonesRef, SnapPosition } from './DraggableWithSnapZones'


### PR DESCRIPTION
This is one of three PRs
- Part 1 - https://github.com/PostHog/posthog/pull/45012
- Part 2 - https://github.com/PostHog/posthog/pull/45044
- Part 3 (this PR)


## Problem

Part 3 of impersonation notice improvements - follows https://github.com/PostHog/posthog/pull/45044.

Avoid taking up loads of screen space by allowing the impersonation notice to be minimized.

## Changes

- Create a new logic for the impersonation notice
- Add minimize feature to the notice - if snapped it will minimize into the snapped position, otherwise to bottom right
- If user leaves the page for >30 seconds, auto expand the notice on return to draw their attention to the fact they're still impersonated


https://github.com/user-attachments/assets/26c96a66-aa15-4855-a700-989d5ff3b767