### PR TITLE
chore(cdp): Deprecate legacy URL Normalizer plugin, promote hog version

### DIFF
--- a/nodejs/src/cdp/legacy-plugins/_transformations/posthog-url-normalizer-plugin/template.ts
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/posthog-url-normalizer-plugin/template.ts
@@ -6,7 +6,7 @@ export const posthogUrlNormalizerPlugin: LegacyTransformationPlugin = {
     processEvent,
     template: {
         free: true,
-        status: 'stable',
+        status: 'deprecated',
         type: 'transformation',
         id: 'plugin-posthog-url-normalizer-plugin',
         name: 'URL Normalizer',

--- a/nodejs/src/cdp/templates/_transformations/url-normalization/url-normalization.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/url-normalization/url-normalization.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'alpha',
+    status: 'beta',
     type: 'transformation',
     id: 'template-url-normalization',
     name: 'URL Normalization',


### PR DESCRIPTION
## Problem

The URL Normalization hog template is now the preferred option. The legacy plugin version is deprecated to avoid having two similar options listed.

## Changes

* Does what it says

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
