### PR TITLE
fix(logs): update date range labels for clarity in LogsDateRangePicker

### DIFF
--- a/products/logs/frontend/filters/LogsDateRangePicker/constants.ts
+++ b/products/logs/frontend/filters/LogsDateRangePicker/constants.ts
@@ -1,11 +1,11 @@
 import { DateMappingOption } from '~/types'
 
 export const LOGS_DATE_OPTIONS: DateMappingOption[] = [
-    { key: 'Last minute', values: ['-1M'], defaultInterval: 'minute' },
+    { key: 'Last 1 minute', values: ['-1M'], defaultInterval: 'minute' },
     { key: 'Last 5 minutes', values: ['-5M'], defaultInterval: 'minute' },
     { key: 'Last 15 minutes', values: ['-15M'], defaultInterval: 'minute' },
     { key: 'Last 30 minutes', values: ['-30M'], defaultInterval: 'minute' },
-    { key: 'Last hour', values: ['-1h'], defaultInterval: 'hour' },
+    { key: 'Last 1 hour', values: ['-1h'], defaultInterval: 'hour' },
     { key: 'Last 3 hours', values: ['-3h'], defaultInterval: 'hour' },
     { key: 'Last 6 hours', values: ['-6h'], defaultInterval: 'hour' },
     { key: 'Last 12 hours', values: ['-12h'], defaultInterval: 'hour' },


### PR DESCRIPTION
## Problem

The date range options in the logs date picker were inconsistent in their naming convention. Some options used "Last X" format while others used "Last 1 X" format.

## Changes

Updated the naming convention for date range options to be more consistent:
- Changed "Last minute" to "Last 1 minute"
- Changed "Last hour" to "Last 1 hour"

This ensures a consistent naming pattern across all time range options in the logs date picker.

## How did you test this code?

Verified that the date range picker displays the updated option names correctly and that the functionality remains unchanged.

## Publish to changelog?

No