### PR TITLE
fix(ci): upload snapshot patches even when other tests fail

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -418,7 +418,7 @@ jobs:
                   fi
 
             - name: Upload screenshot patch
-              if: steps.create-patch.outputs.has-changes == 'true'
+              if: steps.create-patch.outputs.has-changes == 'true' && (success() || failure())
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
                   name: playwright-patch

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -351,7 +351,7 @@ jobs:
                   fi
 
             - name: Upload snapshot patch
-              if: steps.create-patch.outputs.has-changes == 'true'
+              if: steps.create-patch.outputs.has-changes == 'true' && (success() || failure())
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
                   name: snapshot-patch-${{ matrix.browser }}-${{ matrix.shard }}


### PR DESCRIPTION
**Problem**

The upload step for snapshot patches was skipped when the job was in failure state (due to other test failures) because it lacked `(success() || failure())` in its condition.

This caused valid snapshot patches to be lost when unrelated tests failed in the same run - the patch was created but never uploaded, so handle-screenshots job received nothing to commit.

**Fix**

Added `(success() || failure())` to the upload step conditions in both Playwright and Storybook workflows. The commit step in handle-screenshots will still validate what to commit - upload is just transport.