### PR TITLE
fix(workflows): exclude cohorts from workflow filters

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
@@ -77,11 +77,9 @@ export function HogFlowPropertyFilters({ actionId, filters, setFilters }: HogFlo
                 TaxonomicFilterGroupType.EventProperties,
                 TaxonomicFilterGroupType.EventFeatureFlags,
                 TaxonomicFilterGroupType.PersonProperties,
-                TaxonomicFilterGroupType.Cohorts,
                 TaxonomicFilterGroupType.HogQLExpression,
                 TaxonomicFilterGroupType.EventMetadata,
             ]}
-            hideBehavioralCohorts
             metadataSource={{ kind: NodeKind.ActorsQuery }}
         />
     )


### PR DESCRIPTION
Cohorts were incorrectly shown as an option in workflow filters (e.g., conditional branches). However, workflows compile filters to real-time bytecode that doesn't support cohort lookups, causing runtime errors when users selected cohorts.

This removes cohorts from the taxonomic group types in HogFlowPropertyFilters, preventing users from selecting them in the first place.