### PR TITLE
feat(endpoints): enable proper endpoints versioning

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -100,7 +100,7 @@ import {
     EarlyAccessFeatureType,
     EmailSenderDomainStatus,
     EndpointType,
-    EndpointVersion,
+    EndpointVersionType,
     EventDefinition,
     EventDefinitionMetrics,
     EventDefinitionType,
@@ -1942,11 +1942,23 @@ const api = {
         async getMaterializationStatus(name: string): Promise<EndpointType['materialization']> {
             return await new ApiRequest().endpointDetail(name).withAction('materialization_status').get()
         },
-        async listVersions(name: string): Promise<EndpointVersion[]> {
+        async listVersions(name: string): Promise<EndpointVersionType[]> {
             return await new ApiRequest().endpointDetail(name).withAction('versions').get()
         },
-        async getVersion(name: string, version: number): Promise<EndpointVersion> {
+        async getVersion(name: string, version: number): Promise<EndpointVersionType> {
             return await new ApiRequest().endpointDetail(name).withAction(`versions/${version}`).get()
+        },
+        async updateVersion(
+            name: string,
+            version: number,
+            data: Partial<
+                Pick<
+                    EndpointVersionType,
+                    'is_materialized' | 'sync_frequency' | 'description' | 'cache_age_seconds' | 'is_active'
+                >
+            >
+        ): Promise<EndpointVersionType> {
+            return await new ApiRequest().endpointDetail(name).withAction(`versions/${version}`).update({ data })
         },
     },
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2249,6 +2249,22 @@ export interface EndpointMaterializationType {
     sync_frequency?: DataWarehouseSyncInterval
 }
 
+export interface EndpointVersionType {
+    id: string
+    version: number
+    query: HogQLQuery | InsightQueryNode
+    description: string
+    created_at: string
+    created_by: UserBasicType | null
+    cache_age_seconds: number
+    is_materialized: boolean
+    is_active: boolean
+    sync_frequency?: DataWarehouseSyncInterval
+    last_materialized_at?: string
+    materialization_error?: string
+    materialization?: EndpointMaterializationType
+}
+
 export interface DashboardBasicType extends WithAccessControl {
     id: number
     name: string

--- a/products/endpoints/backend/migrations/0009_endpointversion_version_fields.py
+++ b/products/endpoints/backend/migrations/0009_endpointversion_version_fields.py
@@ -1,0 +1,85 @@
+# Generated migration for adding version-specific fields to EndpointVersion
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("endpoints", "0008_endpoint_last_executed_at"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="endpointversion",
+            name="cache_age_seconds",
+            field=models.IntegerField(
+                default=300,
+                help_text="Cache age in seconds when this version was created",
+            ),
+        ),
+        migrations.AddField(
+            model_name="endpointversion",
+            name="is_materialized",
+            field=models.BooleanField(
+                default=False,
+                help_text="Whether this version's query results are materialized",
+            ),
+        ),
+        migrations.AddField(
+            model_name="endpointversion",
+            name="sync_frequency",
+            field=models.CharField(
+                max_length=20,
+                null=True,
+                blank=True,
+                help_text="Sync frequency for materialization (hourly, daily, weekly)",
+            ),
+        ),
+        migrations.AddField(
+            model_name="endpointversion",
+            name="last_materialized_at",
+            field=models.DateTimeField(
+                null=True,
+                blank=True,
+                help_text="When this version was last materialized",
+            ),
+        ),
+        migrations.AddField(
+            model_name="endpointversion",
+            name="materialization_error",
+            field=models.TextField(
+                null=True,
+                blank=True,
+                help_text="Error message from last materialization attempt",
+            ),
+        ),
+        migrations.AddField(
+            model_name="endpointversion",
+            name="saved_query",
+            field=models.ForeignKey(
+                null=True,
+                blank=True,
+                on_delete=models.SET_NULL,
+                to="data_warehouse.datawarehousesavedquery",
+                related_name="endpoint_versions",
+                help_text="The underlying materialized view for this version",
+            ),
+        ),
+        migrations.AddField(
+            model_name="endpointversion",
+            name="description",
+            field=models.TextField(
+                blank=True,
+                default="",
+                help_text="Optional description or notes for this version",
+            ),
+        ),
+        migrations.AddField(
+            model_name="endpointversion",
+            name="is_active",
+            field=models.BooleanField(
+                default=True,
+                help_text="Whether this version is available for execution via the API",
+            ),
+        ),
+    ]

--- a/products/endpoints/backend/migrations/max_migration.txt
+++ b/products/endpoints/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0008_endpoint_last_executed_at
+0009_endpointversion_version_fields

--- a/products/endpoints/frontend/EndpointHeader.tsx
+++ b/products/endpoints/frontend/EndpointHeader.tsx
@@ -1,10 +1,11 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { EndpointRequest } from '~/queries/schema/schema-general'
 import { isInsightVizNode } from '~/queries/utils'
+import { EndpointVersionType } from '~/types'
 
 import { endpointLogic } from './endpointLogic'
 import { endpointSceneLogic } from './endpointSceneLogic'
@@ -14,38 +15,89 @@ export interface EndpointSceneHeaderProps {
 }
 
 export const EndpointSceneHeader = ({ tabId }: EndpointSceneHeaderProps): JSX.Element => {
-    const { endpoint, endpointLoading, localQuery, cacheAge, syncFrequency, isMaterialized } = useValues(
-        endpointSceneLogic({ tabId })
-    )
+    const {
+        endpoint,
+        endpointLoading,
+        localQuery,
+        cacheAge,
+        syncFrequency,
+        isMaterialized,
+        versionDescription,
+        isViewingOldVersion,
+        viewingVersion,
+        selectedVersionData,
+    } = useValues(endpointSceneLogic({ tabId }))
     const { endpointName, endpointDescription } = useValues(endpointLogic({ tabId }))
     const { setEndpointDescription, updateEndpoint } = useActions(endpointLogic({ tabId }))
-    const { setLocalQuery, setCacheAge, setSyncFrequency, setIsMaterialized } = useActions(
-        endpointSceneLogic({ tabId })
-    )
+    const {
+        setLocalQuery,
+        setCacheAge,
+        setSyncFrequency,
+        setIsMaterialized,
+        setVersionDescription,
+        returnToCurrentVersion,
+        updateVersionMaterialization,
+    } = useActions(endpointSceneLogic({ tabId }))
 
-    const hasNameChange = endpointName && endpointName !== endpoint?.name
-    const hasDescriptionChange = endpointDescription !== null && endpointDescription !== endpoint?.description
-    const hasQueryChange = localQuery !== null
-    const hasCacheAgeChange = cacheAge !== (endpoint?.cache_age_seconds ?? null)
-    const hasSyncFrequencyChange = syncFrequency !== (endpoint?.materialization?.sync_frequency ?? null)
-    const hasIsMaterializedChange = isMaterialized !== null && isMaterialized !== endpoint?.is_materialized
+    // For old versions, compare against selectedVersionData; for current, compare against endpoint
+    const baseData = isViewingOldVersion ? selectedVersionData : endpoint
+    const hasNameChange = !isViewingOldVersion && endpointName && endpointName !== endpoint?.name
+    const hasDescriptionChange =
+        !isViewingOldVersion && endpointDescription !== null && endpointDescription !== endpoint?.description
+    const hasVersionDescriptionChange =
+        isViewingOldVersion && versionDescription !== null && versionDescription !== selectedVersionData?.description
+    const hasQueryChange = !isViewingOldVersion && localQuery !== null
+    const hasCacheAgeChange = cacheAge !== null && cacheAge !== (baseData?.cache_age_seconds ?? null)
+    const hasSyncFrequencyChange =
+        syncFrequency !== null &&
+        syncFrequency !==
+            (isViewingOldVersion
+                ? (selectedVersionData?.sync_frequency ?? null)
+                : (endpoint?.materialization?.sync_frequency ?? null))
+    const hasIsMaterializedChange =
+        isMaterialized !== null &&
+        isMaterialized !== (isViewingOldVersion ? selectedVersionData?.is_materialized : endpoint?.is_materialized)
     const hasChanges =
         hasNameChange ||
         hasDescriptionChange ||
+        hasVersionDescriptionChange ||
         hasQueryChange ||
         hasCacheAgeChange ||
         hasSyncFrequencyChange ||
         hasIsMaterializedChange
 
     const handleSave = (): void => {
+        if (!endpoint) {
+            return
+        }
+
+        // If viewing old version, only update version-specific fields
+        if (isViewingOldVersion && viewingVersion !== null) {
+            const updatePayload: Partial<
+                Pick<EndpointVersionType, 'is_materialized' | 'sync_frequency' | 'description' | 'cache_age_seconds'>
+            > = {}
+            if (hasIsMaterializedChange) {
+                updatePayload.is_materialized = isMaterialized ?? false
+            }
+            if (hasSyncFrequencyChange) {
+                updatePayload.sync_frequency = syncFrequency ?? undefined
+            }
+            if (hasVersionDescriptionChange) {
+                updatePayload.description = versionDescription ?? ''
+            }
+            if (hasCacheAgeChange) {
+                updatePayload.cache_age_seconds = cacheAge ?? undefined
+            }
+            // Update will reload version data and reset state automatically
+            updateVersionMaterialization(viewingVersion, updatePayload)
+            return
+        }
+
+        // Current version update
         let queryToSave = (localQuery || endpoint?.query) as any
 
         if (queryToSave && isInsightVizNode(queryToSave)) {
             queryToSave = queryToSave.source
-        }
-
-        if (!endpoint) {
-            return
         }
 
         const updatePayload: Partial<EndpointRequest> = {
@@ -63,22 +115,54 @@ export const EndpointSceneHeader = ({ tabId }: EndpointSceneHeaderProps): JSX.El
         if (!endpoint) {
             return
         }
-        setEndpointDescription(endpoint.description || '')
-        setCacheAge(endpoint.cache_age_seconds ?? null)
-        setSyncFrequency(endpoint.materialization?.sync_frequency ?? null)
-        setIsMaterialized(null)
-        setLocalQuery(null)
+        // Reset to original values
+        if (isViewingOldVersion && selectedVersionData) {
+            // For old versions, reset to version data
+            setCacheAge(null)
+            setSyncFrequency(null)
+            setIsMaterialized(null)
+            setVersionDescription(null)
+        } else {
+            // For current version, reset to endpoint data
+            setEndpointDescription(endpoint.description || '')
+            setCacheAge(null)
+            setSyncFrequency(null)
+            setIsMaterialized(null)
+            setLocalQuery(null)
+        }
     }
 
     return (
         <>
+            {isViewingOldVersion && (
+                <div className="sticky top-0 z-10 mb-4">
+                    <LemonBanner
+                        type="warning"
+                        action={{
+                            children: `Return to latest version (v${endpoint?.current_version})`,
+                            onClick: returnToCurrentVersion,
+                        }}
+                    >
+                        <strong>Viewing historical version v{viewingVersion}</strong>
+                        <div className="text-sm">
+                            You can edit this endpoint version, but changing the query simply creates a new version.
+                        </div>
+                    </LemonBanner>
+                </div>
+            )}
             <SceneTitleSection
                 name={endpointName || endpoint?.name}
-                description={endpointDescription || endpoint?.description}
+                description={
+                    isViewingOldVersion
+                        ? (versionDescription ?? selectedVersionData?.description)
+                        : (endpointDescription ?? endpoint?.description)
+                }
                 resourceType={{ type: 'endpoints' }}
-                canEdit
+                canEdit={true}
                 // onNameChange={} - we explicitly disallow this
-                onDescriptionChange={(description) => setEndpointDescription(description)}
+                onDescriptionChange={(description) =>
+                    isViewingOldVersion ? setVersionDescription(description) : setEndpointDescription(description)
+                }
                 isLoading={endpointLoading}
                 renameDebounceMs={200}
                 actions={

--- a/products/endpoints/frontend/endpoint-tabs/EndpointOverview.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointOverview.tsx
@@ -6,6 +6,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
 import { endpointLogic } from '../endpointLogic'
+import { endpointSceneLogic } from '../endpointSceneLogic'
 
 interface EndpointOverviewProps {
     tabId: string
@@ -13,29 +14,36 @@ interface EndpointOverviewProps {
 
 export function EndpointOverview({ tabId }: EndpointOverviewProps): JSX.Element {
     const { endpoint } = useValues(endpointLogic({ tabId }))
+    const { viewingVersion, isViewingOldVersion, selectedVersionData } = useValues(endpointSceneLogic({ tabId }))
 
     if (!endpoint) {
         return <></>
     }
 
     const hasParameters = endpoint.parameters && Object.keys(endpoint.parameters).length > 0
+    const displayedVersion = isViewingOldVersion && viewingVersion ? viewingVersion : endpoint.current_version
+
+    // When viewing an old version, show the version's is_active status; otherwise show endpoint status
+    const displayIsActive =
+        isViewingOldVersion && selectedVersionData ? selectedVersionData.is_active : endpoint.is_active
+    const statusLabel = isViewingOldVersion ? 'Version status' : 'Status'
 
     return (
         <div className="grid gap-2 overflow-hidden grid-cols-1 min-[1200px]:grid-cols-[1fr_26rem]">
             <div className="flex flex-col gap-0 overflow-hidden">
                 <div className="inline-flex deprecated-space-x-8">
-                    <div className="flex flex-col">
-                        <LemonLabel>Status</LemonLabel>
-                        <LemonTag type={endpoint.is_active ? 'success' : 'danger'}>
-                            <b className="uppercase">{endpoint.is_active ? 'Active' : 'Inactive'}</b>
+                    <div className="flex flex-col gap-1">
+                        <LemonLabel>{statusLabel}</LemonLabel>
+                        <LemonTag type={displayIsActive ? 'success' : 'danger'} className="w-fit">
+                            {displayIsActive ? 'Active' : 'Inactive'}
                         </LemonTag>
                     </div>
                     <div className="flex flex-col">
                         <LemonLabel info="Versions auto-increment when the query changes. Access older versions via the 'version' parameter in requests. Useful for gradual rollouts and rollbacks.">
-                            Current version
+                            {isViewingOldVersion ? 'Viewing version' : 'Latest version'}
                         </LemonLabel>
                         <div className="flex items-center gap-2">
-                            <span className="text-sm font-semibold">v{endpoint.current_version}</span>
+                            <span className="text-sm font-semibold">v{displayedVersion}</span>
                             <span className="text-xs text-muted">({endpoint.versions_count} total)</span>
                         </div>
                     </div>

--- a/products/endpoints/frontend/endpoint-tabs/EndpointPlayground.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointPlayground.tsx
@@ -184,7 +184,7 @@ fetch(url, {
 
 export function EndpointPlayground({ tabId }: EndpointPlaygroundProps): JSX.Element {
     const { endpoint } = useValues(endpointLogic({ tabId }))
-    const { payloadJson, payloadJsonError, endpointResult, endpointResultLoading } = useValues(
+    const { payloadJson, payloadJsonError, endpointResult, endpointResultLoading, viewingVersion } = useValues(
         endpointSceneLogic({ tabId })
     )
     const { setPayloadJson, setPayloadJsonError, loadEndpointResult } = useActions(endpointSceneLogic({ tabId }))
@@ -224,16 +224,19 @@ export function EndpointPlayground({ tabId }: EndpointPlaygroundProps): JSX.Elem
         return <></>
     }
 
+    // Use selected version from dropdown, or fall back to viewing version if we're viewing an old version
+    const effectiveVersion = selectedCodeExampleVersion ?? viewingVersion ?? endpoint.current_version
+
     const getCodeExample = (tab: CodeExampleTab): string => {
         switch (tab) {
             case 'terminal':
-                return generateTerminalExample(endpoint, selectedCodeExampleVersion)
+                return generateTerminalExample(endpoint, effectiveVersion)
             case 'python':
-                return generatePythonExample(endpoint, selectedCodeExampleVersion)
+                return generatePythonExample(endpoint, effectiveVersion)
             case 'nodejs':
-                return generateNodeExample(endpoint, selectedCodeExampleVersion)
+                return generateNodeExample(endpoint, effectiveVersion)
             default:
-                return generateTerminalExample(endpoint, selectedCodeExampleVersion)
+                return generateTerminalExample(endpoint, effectiveVersion)
         }
     }
 
@@ -255,7 +258,7 @@ export function EndpointPlayground({ tabId }: EndpointPlaygroundProps): JSX.Elem
         const version = i + 1
         return {
             value: version,
-            label: version === endpoint.current_version ? `v${version} (Current)` : `v${version}`,
+            label: version === endpoint.current_version ? `v${version} (Latest)` : `v${version}`,
         }
     })
 
@@ -359,7 +362,7 @@ export function EndpointPlayground({ tabId }: EndpointPlaygroundProps): JSX.Elem
                     <LemonSelect
                         options={versionOptions}
                         onChange={setSelectedCodeExampleVersion}
-                        value={selectedCodeExampleVersion || endpoint.current_version}
+                        value={effectiveVersion}
                         placeholder="Select version"
                     />
                     <LemonSelect

--- a/products/endpoints/frontend/endpoint-tabs/EndpointQuery.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointQuery.tsx
@@ -33,7 +33,9 @@ interface EndpointQueryProps {
 
 export function EndpointQuery({ tabId }: EndpointQueryProps): JSX.Element {
     const { endpoint } = useValues(endpointLogic({ tabId }))
-    const { queryToRender, endpointLoading } = useValues(endpointSceneLogic({ tabId }))
+    const { queryToRender, currentQuery, endpointLoading, isViewingOldVersion } = useValues(
+        endpointSceneLogic({ tabId })
+    )
     const { setLocalQuery } = useActions(endpointSceneLogic({ tabId }))
     const { newTab } = useActions(sceneLogic)
 
@@ -45,7 +47,7 @@ export function EndpointQuery({ tabId }: EndpointQueryProps): JSX.Element {
         )
     }
 
-    if (!endpoint || !queryToRender) {
+    if (!endpoint || !queryToRender || !currentQuery) {
         return <div>No query available</div>
     }
 
@@ -54,8 +56,8 @@ export function EndpointQuery({ tabId }: EndpointQueryProps): JSX.Element {
     }
 
     // If it's a HogQL query, show the code editor
-    if (isHogQLQuery(endpoint.query)) {
-        const hogqlQuery = endpoint.query as HogQLQuery
+    if (isHogQLQuery(currentQuery)) {
+        const hogqlQuery = currentQuery as HogQLQuery
         const variables = hogqlQuery.variables || {}
 
         const handleEditQuery = (): void => {
@@ -67,7 +69,16 @@ export function EndpointQuery({ tabId }: EndpointQueryProps): JSX.Element {
                 <div className="flex-1 flex flex-col gap-2">
                     <CodeEditor value={hogqlQuery.query} language="hogQL" height="300px" options={{ readOnly: true }} />
                     <div>
-                        <LemonButton type="secondary" onClick={handleEditQuery} sideIcon={<IconOpenInNew />}>
+                        <LemonButton
+                            type="secondary"
+                            onClick={handleEditQuery}
+                            sideIcon={<IconOpenInNew />}
+                            disabledReason={
+                                isViewingOldVersion
+                                    ? 'Return to the latest version to edit this query and create a new version.'
+                                    : undefined
+                            }
+                        >
                             Edit query in SQL Editor
                         </LemonButton>
                     </div>
@@ -104,8 +115,8 @@ export function EndpointQuery({ tabId }: EndpointQueryProps): JSX.Element {
         <div>
             <Query
                 query={queryToRender}
-                editMode={true}
-                setQuery={handleQueryChange}
+                editMode={!isViewingOldVersion}
+                setQuery={isViewingOldVersion ? undefined : handleQueryChange}
                 context={{ showOpenEditorButton: false }}
             />
         </div>

--- a/products/endpoints/frontend/endpoint-tabs/EndpointVersions.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointVersions.tsx
@@ -1,0 +1,245 @@
+import { useActions, useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { LemonButton, LemonDialog, LemonTable, type LemonTableColumns, LemonTag } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
+import { urls } from 'scenes/urls'
+
+import type { EndpointMaterializationType, EndpointVersionType } from '~/types'
+
+import { endpointLogic } from '../endpointLogic'
+import { endpointSceneLogic } from '../endpointSceneLogic'
+
+interface EndpointVersionsProps {
+    tabId: string
+}
+
+function getMaterializationStatusDisplay(
+    isMaterialized: boolean,
+    materialization?: EndpointMaterializationType
+): { label: string; type: 'success' | 'warning' | 'danger' | 'default' } {
+    if (!isMaterialized) {
+        return { label: 'Disabled', type: 'default' }
+    }
+
+    const status = materialization?.status?.toLowerCase()
+
+    switch (status) {
+        case 'completed':
+            return {
+                label: 'Active',
+                type: 'success',
+            }
+        case 'running':
+            return { label: 'Running', type: 'warning' }
+        case 'pending':
+            return { label: 'Pending', type: 'warning' }
+        case 'failed':
+            return { label: 'Failed', type: 'danger' }
+        default:
+            return { label: 'Unknown', type: 'default' }
+    }
+}
+
+export function EndpointVersions({ tabId }: EndpointVersionsProps): JSX.Element {
+    const { endpoint } = useValues(endpointLogic({ tabId }))
+    const { versions, versionsLoading, viewingVersion } = useValues(endpointSceneLogic({ tabId }))
+    const { selectVersion, updateVersionMaterialization } = useActions(endpointSceneLogic({ tabId }))
+    const { confirmToggleActive } = useActions(endpointLogic({ tabId }))
+    const sortedVersions = useMemo(() => [...versions].sort((a, b) => b.version - a.version), [versions])
+
+    if (!endpoint) {
+        return <></>
+    }
+
+    const handleToggleVersionActive = (item: EndpointVersionType, isLatest: boolean): void => {
+        if (isLatest) {
+            confirmToggleActive(endpoint)
+            return
+        }
+        const isActivating = !item.is_active
+        LemonDialog.open({
+            title: isActivating ? 'Activate version?' : 'Deactivate version?',
+            content: (
+                <div className="text-sm text-secondary">
+                    {isActivating
+                        ? `Version ${item.version} will be accessible via the API.`
+                        : `Version ${item.version} will no longer be accessible via the API.`}
+                </div>
+            ),
+            primaryButton: {
+                children: isActivating ? 'Activate' : 'Deactivate',
+                type: 'primary',
+                status: isActivating ? undefined : 'danger',
+                onClick: () => updateVersionMaterialization(item.version, { is_active: isActivating }),
+                size: 'small',
+            },
+            secondaryButton: {
+                children: 'Cancel',
+                type: 'tertiary',
+                size: 'small',
+            },
+        })
+    }
+
+    const handleToggleMaterialization = (item: EndpointVersionType, isMaterialized: boolean): void => {
+        const isEnabling = !isMaterialized
+        LemonDialog.open({
+            title: isEnabling ? 'Enable materialization?' : 'Disable materialization?',
+            content: (
+                <div className="text-sm text-secondary">
+                    {isEnabling
+                        ? `Version ${item.version} results will be pre-computed and cached.`
+                        : `Version ${item.version} will run queries on demand.`}
+                </div>
+            ),
+            primaryButton: {
+                children: isEnabling ? 'Enable' : 'Disable',
+                type: 'primary',
+                status: isEnabling ? undefined : 'danger',
+                onClick: () => updateVersionMaterialization(item.version, { is_materialized: isEnabling }),
+                size: 'small',
+            },
+            secondaryButton: {
+                children: 'Cancel',
+                type: 'tertiary',
+                size: 'small',
+            },
+        })
+    }
+
+    const columns: LemonTableColumns<EndpointVersionType> = [
+        {
+            title: 'Version',
+            dataIndex: 'version',
+            render: function RenderVersion(_, item) {
+                const isLatest = item.version === endpoint.current_version
+                const isViewing = viewingVersion === item.version
+                const versionUrl = isLatest
+                    ? urls.endpoint(endpoint.name)
+                    : `${urls.endpoint(endpoint.name)}?version=${item.version}`
+
+                return (
+                    <LemonTableLink
+                        to={versionUrl}
+                        title={
+                            <div className="flex items-center gap-2">
+                                <span>v{item.version}</span>
+                                {isViewing && (
+                                    <LemonTag size="small" type="warning">
+                                        Currently viewing
+                                    </LemonTag>
+                                )}
+                            </div>
+                        }
+                        description={
+                            item.description
+                                ? item.description.length > 40
+                                    ? `${item.description.slice(0, 40)}...`
+                                    : item.description
+                                : undefined
+                        }
+                    />
+                )
+            },
+        },
+        {
+            title: 'Created at',
+            dataIndex: 'created_at',
+            render: function RenderCreatedAt(_, item) {
+                return item.created_at ? <TZLabel time={item.created_at} /> : <span className="text-muted">—</span>
+            },
+        },
+        {
+            title: 'Created by',
+            dataIndex: 'created_by',
+            render: function RenderCreatedBy(_, item) {
+                return item.created_by ? (
+                    <ProfilePicture user={item.created_by} size="md" showName />
+                ) : (
+                    <span className="text-muted">—</span>
+                )
+            },
+        },
+        {
+            title: 'Active',
+            align: 'center',
+            render: function RenderActive(_, item) {
+                const isLatest = item.version === endpoint.current_version
+                const active = isLatest ? endpoint.is_active : item.is_active
+
+                return (
+                    <LemonTag type={active ? 'success' : 'default'} size="small">
+                        {active ? 'Active' : 'Inactive'}
+                    </LemonTag>
+                )
+            },
+        },
+        {
+            title: 'Materialization',
+            align: 'center',
+            render: function RenderMaterialization(_, item) {
+                const isLatest = item.version === endpoint.current_version
+                const isMaterialized = isLatest ? endpoint.is_materialized : item.is_materialized
+                const materialization = isLatest ? endpoint.materialization : item.materialization
+
+                const { label, type } = getMaterializationStatusDisplay(isMaterialized, materialization)
+
+                return (
+                    <LemonTag type={type} size="small">
+                        {label}
+                    </LemonTag>
+                )
+            },
+        },
+        {
+            key: 'actions',
+            width: 0,
+            render: function RenderActions(_, item) {
+                const isLatest = item.version === endpoint.current_version
+                const active = isLatest ? endpoint.is_active : item.is_active
+                const materialized = isLatest ? endpoint.is_materialized : item.is_materialized
+
+                return (
+                    <More
+                        overlay={
+                            <>
+                                <LemonButton onClick={() => selectVersion(item.version)} fullWidth>
+                                    View endpoint version
+                                </LemonButton>
+                                <LemonButton onClick={() => handleToggleVersionActive(item, isLatest)} fullWidth>
+                                    {active ? 'Deactivate' : 'Activate'} endpoint version
+                                </LemonButton>
+                                <LemonButton onClick={() => handleToggleMaterialization(item, materialized)} fullWidth>
+                                    {materialized
+                                        ? 'Disable version materialization'
+                                        : 'Enable version materialization'}
+                                </LemonButton>
+                            </>
+                        }
+                    />
+                )
+            },
+        },
+    ]
+
+    return (
+        <div className="max-w-5xl">
+            <p className="text-muted mb-3">
+                Versions are created automatically when the query changes. Click on a version to view its details.
+            </p>
+            <LemonTable
+                dataSource={sortedVersions}
+                columns={columns}
+                loading={versionsLoading}
+                rowKey="version"
+                pagination={{ pageSize: 10, hideOnSinglePage: true }}
+                emptyState="No versions yet"
+            />
+        </div>
+    )
+}

--- a/products/endpoints/frontend/endpointLogic.tsx
+++ b/products/endpoints/frontend/endpointLogic.tsx
@@ -57,7 +57,11 @@ export const endpointLogic = kea<endpointLogicType>([
         endpointName: [null as string | null, { setEndpointName: (_, { endpointName }) => endpointName }],
         endpointDescription: [
             null as string | null,
-            { setEndpointDescription: (_, { endpointDescription }) => endpointDescription },
+            {
+                setEndpointDescription: (_, { endpointDescription }) => endpointDescription,
+                loadEndpointSuccess: () => null, // Reset to null so it falls back to endpoint.description
+                updateEndpointSuccess: () => null, // Reset after successful update
+            },
         ],
         activeCodeExampleTab: ['terminal' as CodeExampleTab, { setActiveCodeExampleTab: (_, { tab }) => tab }],
         selectedCodeExampleVersion: [
@@ -184,6 +188,8 @@ export const endpointLogic = kea<endpointLogicType>([
                 }
             },
             updateEndpointSuccess: ({ response, showViewButton }) => {
+                // Update the local endpoint state with the response to avoid stale data
+                actions.loadEndpointSuccess(response)
                 if (showViewButton) {
                     lemonToast.success(<>Endpoint updated</>, {
                         button: {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
while endpoints can be updated and a new version is auto-incremented, we want to enable materializing older versions too (use case: mobile/desktop apps that can't roll out updates to all users might have to keep using an older version of an endpoint)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- add a versions table to the Configuration tab
- allow viewing an older endpoint version

## How did you test this code?
locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
