### PR TITLE
feat: disable passkey management for sso enforced users

### DIFF
--- a/frontend/src/scenes/settings/user/PasskeySettings.tsx
+++ b/frontend/src/scenes/settings/user/PasskeySettings.tsx
@@ -1,7 +1,9 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { LemonSkeleton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonSkeleton } from '@posthog/lemon-ui'
+
+import { userLogic } from 'scenes/userLogic'
 
 import { PasskeyAddForm, PasskeyAddFormEmpty } from './PasskeyAddForm'
 import { PasskeyList } from './PasskeyList'
@@ -10,6 +12,7 @@ import { passkeySettingsLogic } from './passkeySettingsLogic'
 
 export function PasskeySettings(): JSX.Element {
     const { passkeys, passkeysLoading } = useValues(passkeySettingsLogic)
+    const { user } = useValues(userLogic)
     const { loadPasskeys } = useActions(passkeySettingsLogic)
 
     useEffect(() => {
@@ -26,10 +29,16 @@ export function PasskeySettings(): JSX.Element {
     }
 
     const hasExistingPasskeys = passkeys.length > 0
+    const hasSSOEnforcement = !!user?.has_sso_enforcement
 
     return (
         <div className="space-y-4">
-            {hasExistingPasskeys ? <PasskeyAddForm /> : <PasskeyAddFormEmpty />}
+            {hasSSOEnforcement && (
+                <LemonBanner type="warning">
+                    Passkeys can't be added because your organization requires SSO.
+                </LemonBanner>
+            )}
+            {!hasSSOEnforcement && (hasExistingPasskeys ? <PasskeyAddForm /> : <PasskeyAddFormEmpty />)}
             {hasExistingPasskeys && <PasskeyList />}
             <PasskeyModals />
         </div>


### PR DESCRIPTION
## Problem

Users targeted by SSO enforcement can't sign in using passkeys so we shouldn't let them manage passkeys.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Add additional viewset validations to prevent sso enforced users from registering passkeys
- Update frontend to disable passkey management for sso enforced users

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

1. Manually
2. Backend tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
