### PR TITLE
fix: Deploy node services if Dockerfile changed

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -122,13 +122,13 @@ jobs:
                         "timestamp": "${{ github.event.head_commit.timestamp }}"
                       }
 
-            - name: Check for changes in nodejs directory
+            - name: Check for changes in nodejs directory or Dockerfiles
               id: check_changes_nodejs
               run: |
-                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -q '^nodejs/' && echo true) || echo false)" >> $GITHUB_OUTPUT
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^nodejs/|^Dockerfile$|^Dockerfile\.node$' && echo true) || echo false)" >> $GITHUB_OUTPUT
 
             - name: Trigger Ingestion Cloud deployment
-              if: steps.check_changes_plugins.outputs.changed == 'true'
+              if: steps.check_changes_nodejs.outputs.changed == 'true'
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
               with:
                   token: ${{ steps.deployer.outputs.token }}

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -109,6 +109,7 @@ USER posthog
 ARG COMMIT_HASH
 RUN echo ${COMMIT_HASH:-unknown} > /code/commit.txt
 
+
 # Add in the compiled nodejs & its runtime dependencies from the build stage
 COPY --from=nodejs-build --chown=posthog:posthog /code/rust/cyclotron-node/dist /code/rust/cyclotron-node/dist
 COPY --from=nodejs-build --chown=posthog:posthog /code/rust/cyclotron-node/package.json /code/rust/cyclotron-node/package.json


### PR DESCRIPTION
## Problem

We have an issue on the `.github/workflows/container-images-cd.yml` where we have both a bug in the action as well as we are not listening to Dockerfile changes

## Changes

- Fix ingestion deployment trigger as action was referencing non-existent `check_changes_plugins` step instead of `check_changes_nodejs`
- Trigger ingestion deployment when Dockerfile or Dockerfile.node change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
