### PR TITLE
fix(mcp): exclude gateway key from mcp server preset

### DIFF
--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -147,7 +147,7 @@ export const API_KEY_SCOPE_PRESETS: {
     {
         value: 'mcp_server',
         label: 'MCP Server',
-        scopes: API_SCOPES.map(({ key }) =>
+        scopes: API_SCOPES.filter(({ key }) => !key.includes('llm_gateway')).map(({ key }) =>
             ['feature_flag', 'insight', 'dashboard', 'survey', 'experiment'].includes(key)
                 ? `${key}:write`
                 : `${key}:read`


### PR DESCRIPTION
this is blocked, so we shouldn’t try use it