### PR TITLE
fix(surveys): only show guided editor for Popover survey type

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -307,7 +307,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                     forceEdit
                     actions={
                         <>
-                            {guidedEditorEnabled && (
+                            {guidedEditorEnabled && survey.type === SurveyType.Popover && (
                                 <LemonButton
                                     data-attr="switch-to-wizard"
                                     type="tertiary"

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -50,6 +50,7 @@ import {
     SurveyEventName,
     SurveyEventProperties,
     SurveyQuestionType,
+    SurveyType,
 } from '~/types'
 
 import { SurveyHeadline } from './SurveyHeadline'
@@ -177,8 +178,16 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                                 >
                                     <LemonButton
                                         data-attr="edit-survey"
-                                        onClick={guidedEditorEnabled ? undefined : () => editingSurvey(true)}
-                                        to={guidedEditorEnabled ? urls.surveyWizard(id) : undefined}
+                                        onClick={
+                                            guidedEditorEnabled && survey.type === SurveyType.Popover
+                                                ? undefined
+                                                : () => editingSurvey(true)
+                                        }
+                                        to={
+                                            guidedEditorEnabled && survey.type === SurveyType.Popover
+                                                ? urls.surveyWizard(id)
+                                                : undefined
+                                        }
                                         type="secondary"
                                         size="small"
                                     >


### PR DESCRIPTION
## Summary
- Only show the guided editor option for Popover surveys
- API, Feedback Button (Widget), and Hosted (ExternalSurvey) surveys don't work well with the guided editor

## Changes
- SurveyView.tsx: Only use guided editor for Edit button when survey.type === Popover
- SurveyEdit.tsx: Only show "Guided editor" link when survey.type === Popover