### PR TITLE
chore: Add list of non copyable notebook nodes

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -161,7 +161,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
     const pythonIsStale = pythonExecutionCodeHash !== null && pythonExecutionCodeHash !== pythonCodeHash
     const pythonIsFresh = pythonExecutionCodeHash !== null && pythonExecutionCodeHash === pythonCodeHash
 
-    // TODO: Add list on non-copyable nodes
+    const defaultMenuItems: LemonMenuItems = [
     const defaultMenuItems: LemonMenuItems = [
         !NON_COPYABLE_NODES.includes(nodeType)
             ? {

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -40,6 +40,14 @@ import {
 } from '../types'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 
+const NON_COPYABLE_NODES = [
+    NotebookNodeType.PersonProperties,
+    NotebookNodeType.Person,
+    NotebookNodeType.GroupProperties,
+    NotebookNodeType.Group,
+    NotebookNodeType.RelatedGroups,
+]
+
 function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperProps<T>): JSX.Element {
     const {
         nodeType,
@@ -155,11 +163,13 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
 
     // TODO: Add list on non-copyable nodes
     const defaultMenuItems: LemonMenuItems = [
-        {
-            label: 'Copy',
-            onClick: () => copyToClipboard(),
-            sideIcon: <IconCopy />,
-        },
+        !NON_COPYABLE_NODES.includes(nodeType)
+            ? {
+                  label: 'Copy',
+                  onClick: () => copyToClipboard(),
+                  sideIcon: <IconCopy />,
+              }
+            : null,
         isEditable && isResizeable
             ? {
                   label: 'Reset height to default',

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -162,7 +162,6 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
     const pythonIsFresh = pythonExecutionCodeHash !== null && pythonExecutionCodeHash === pythonCodeHash
 
     const defaultMenuItems: LemonMenuItems = [
-    const defaultMenuItems: LemonMenuItems = [
         !NON_COPYABLE_NODES.includes(nodeType)
             ? {
                   label: 'Copy',


### PR DESCRIPTION
## Problem

Some notebook nodes break the notebook when copied and pasted. This PR disables the ability to copy certain node types until we fix the pasting functionality.

## Changes

Added a list of non-copyable node types and conditionally render the "Copy" menu item only for nodes that are safe to copy. The following node types are now excluded from copying:
- PersonProperties
- Person
- GroupProperties
- Group
- RelatedGroups

## How did you test this code?

Verified that the "Copy" option no longer appears in the menu for the specified node types, while remaining available for other node types.