### PR TITLE
fix(experiments): extremely small p-values not rendering.

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
@@ -5,6 +5,7 @@ import { ExperimentMetricGoal, ExperimentMetricMathType } from '~/types'
 import {
     type ExperimentVariantResult,
     formatChanceToWinForGoal,
+    formatPValue,
     getChanceToWin,
     getDefaultMetricTitle,
     getMetricColors,
@@ -225,5 +226,59 @@ describe('getMetricColors', () => {
         const result = getMetricColors(colors, ExperimentMetricGoal.Decrease)
         expect(result.positive).toBe('#FF0000')
         expect(result.negative).toBe('#00FF00')
+    })
+})
+
+describe('formatPValue', () => {
+    it('returns "—" for null', () => {
+        expect(formatPValue(null)).toBe('—')
+    })
+
+    it('returns "—" for undefined', () => {
+        expect(formatPValue(undefined)).toBe('—')
+    })
+
+    it('returns "< 0.001" for very small p-values', () => {
+        expect(formatPValue(0.0001)).toBe('< 0.001')
+        expect(formatPValue(0.00001)).toBe('< 0.001')
+        expect(formatPValue(4.196532010780629e-11)).toBe('< 0.001')
+        expect(formatPValue(1e-100)).toBe('< 0.001')
+    })
+
+    it('returns 4 decimal places for p-values between 0.001 and 0.01', () => {
+        expect(formatPValue(0.001)).toBe('0.0010')
+        expect(formatPValue(0.005)).toBe('0.0050')
+        expect(formatPValue(0.009)).toBe('0.0090')
+        expect(formatPValue(0.00999)).toBe('0.0100')
+    })
+
+    it('returns 3 decimal places for p-values >= 0.01', () => {
+        expect(formatPValue(0.01)).toBe('0.010')
+        expect(formatPValue(0.05)).toBe('0.050')
+        expect(formatPValue(0.1)).toBe('0.100')
+        expect(formatPValue(0.5)).toBe('0.500')
+        expect(formatPValue(0.999)).toBe('0.999')
+    })
+
+    it('handles edge case of exactly 0.001', () => {
+        expect(formatPValue(0.001)).toBe('0.0010')
+    })
+
+    it('handles edge case of exactly 0.01', () => {
+        expect(formatPValue(0.01)).toBe('0.010')
+    })
+
+    it('handles p-value of 1', () => {
+        expect(formatPValue(1)).toBe('1.000')
+    })
+
+    // Critical test case: p-value of 0 should now be formatted properly
+    it('returns "< 0.001" for p-value of 0', () => {
+        expect(formatPValue(0)).toBe('< 0.001')
+    })
+
+    // Edge case: very close to 0 but not exactly 0
+    it('returns "< 0.001" for Number.MIN_VALUE', () => {
+        expect(formatPValue(Number.MIN_VALUE)).toBe('< 0.001')
     })
 })

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
@@ -230,55 +230,41 @@ describe('getMetricColors', () => {
 })
 
 describe('formatPValue', () => {
-    it('returns "—" for null', () => {
-        expect(formatPValue(null)).toBe('—')
+    it.each([
+        [null, '—'],
+        [undefined, '—'],
+    ])('returns "—" for %p', (input, expected) => {
+        expect(formatPValue(input)).toBe(expected)
     })
 
-    it('returns "—" for undefined', () => {
-        expect(formatPValue(undefined)).toBe('—')
+    it.each([
+        [0, '< 0.001'],
+        [0.0001, '< 0.001'],
+        [0.00001, '< 0.001'],
+        [4.196532010780629e-11, '< 0.001'],
+        [1e-100, '< 0.001'],
+        [Number.MIN_VALUE, '< 0.001'],
+    ])('returns "< 0.001" for very small p-value %p', (input, expected) => {
+        expect(formatPValue(input)).toBe(expected)
     })
 
-    it('returns "< 0.001" for very small p-values', () => {
-        expect(formatPValue(0.0001)).toBe('< 0.001')
-        expect(formatPValue(0.00001)).toBe('< 0.001')
-        expect(formatPValue(4.196532010780629e-11)).toBe('< 0.001')
-        expect(formatPValue(1e-100)).toBe('< 0.001')
+    it.each([
+        [0.001, '0.0010'],
+        [0.005, '0.0050'],
+        [0.009, '0.0090'],
+        [0.00999, '0.0100'],
+    ])('returns 4 decimal places for p-value %p between 0.001 and 0.01', (input, expected) => {
+        expect(formatPValue(input)).toBe(expected)
     })
 
-    it('returns 4 decimal places for p-values between 0.001 and 0.01', () => {
-        expect(formatPValue(0.001)).toBe('0.0010')
-        expect(formatPValue(0.005)).toBe('0.0050')
-        expect(formatPValue(0.009)).toBe('0.0090')
-        expect(formatPValue(0.00999)).toBe('0.0100')
-    })
-
-    it('returns 3 decimal places for p-values >= 0.01', () => {
-        expect(formatPValue(0.01)).toBe('0.010')
-        expect(formatPValue(0.05)).toBe('0.050')
-        expect(formatPValue(0.1)).toBe('0.100')
-        expect(formatPValue(0.5)).toBe('0.500')
-        expect(formatPValue(0.999)).toBe('0.999')
-    })
-
-    it('handles edge case of exactly 0.001', () => {
-        expect(formatPValue(0.001)).toBe('0.0010')
-    })
-
-    it('handles edge case of exactly 0.01', () => {
-        expect(formatPValue(0.01)).toBe('0.010')
-    })
-
-    it('handles p-value of 1', () => {
-        expect(formatPValue(1)).toBe('1.000')
-    })
-
-    // Critical test case: p-value of 0 should now be formatted properly
-    it('returns "< 0.001" for p-value of 0', () => {
-        expect(formatPValue(0)).toBe('< 0.001')
-    })
-
-    // Edge case: very close to 0 but not exactly 0
-    it('returns "< 0.001" for Number.MIN_VALUE', () => {
-        expect(formatPValue(Number.MIN_VALUE)).toBe('< 0.001')
+    it.each([
+        [0.01, '0.010'],
+        [0.05, '0.050'],
+        [0.1, '0.100'],
+        [0.5, '0.500'],
+        [0.999, '0.999'],
+        [1, '1.000'],
+    ])('returns 3 decimal places for p-value %p >= 0.01', (input, expected) => {
+        expect(formatPValue(input)).toBe(expected)
     })
 })

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -149,7 +149,9 @@ export function getNiceTickValues(maxAbsValue: number, tickRangeFactor: number =
 }
 
 export function formatPValue(pValue: number | null | undefined): string {
-    if (!pValue) {
+    // Use explicit null check instead of falsy check
+    // This prevents treating 0 or very small numbers as invalid
+    if (pValue == null) {
         return '—'
     }
 


### PR DESCRIPTION
## Problem

Some extremely small p-values (`e-11` in our case) are getting evaluated as `0` when evaluated for truthiness. 

| smallish p-value ever |
| - |
| <img width="827" height="205" alt="image" src="https://github.com/user-attachments/assets/cfcee398-27e0-42cf-80e6-ef10c2c998c0" /> |

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We've added some tests to the `formatPValue` function and changed the early return from `falsy` to `null`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/a55b4e25-23e5-4e49-997c-062c0f0212c4)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
