### PR TITLE
fix(insights): prevent pin button overflow on long breakdown names

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/columns/BreakdownColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/BreakdownColumn.tsx
@@ -22,12 +22,17 @@ export function BreakdownColumnTitle({
     onTogglePin,
 }: BreakdownColumnTitleProps): JSX.Element {
     return (
-        <div className="flex items-center gap-1">
-            <PropertyKeyInfo disableIcon disablePopover value={formatBreakdownType(breakdownFilter)} />
+        <div className="flex items-center gap-1 min-w-0">
+            <PropertyKeyInfo
+                className="min-w-0"
+                disableIcon
+                disablePopover
+                value={formatBreakdownType(breakdownFilter)}
+            />
             {onTogglePin && (
                 <Tooltip title={isPinned ? 'Unpin column' : 'Pin column'}>
                     <span
-                        className="inline-flex items-center justify-center cursor-pointer p-1 -m-1"
+                        className="inline-flex items-center justify-center cursor-pointer p-1 -m-1 shrink-0"
                         onClick={(e) => {
                             e.stopPropagation()
                             onTogglePin()
@@ -53,12 +58,12 @@ export function MultipleBreakdownColumnTitle({
     onTogglePin,
 }: MultipleBreakdownColumnTitleProps): JSX.Element {
     return (
-        <div className="flex items-center gap-1">
-            <PropertyKeyInfo disableIcon disablePopover value={children || 'Breakdown Value'} />
+        <div className="flex items-center gap-1 min-w-0">
+            <PropertyKeyInfo className="min-w-0" disableIcon disablePopover value={children || 'Breakdown Value'} />
             {onTogglePin && (
                 <Tooltip title={isPinned ? 'Unpin column' : 'Pin column'}>
                     <span
-                        className="inline-flex items-center justify-center cursor-pointer p-1 -m-1"
+                        className="inline-flex items-center justify-center cursor-pointer p-1 -m-1 shrink-0"
                         onClick={(e) => {
                             e.stopPropagation()
                             onTogglePin()


### PR DESCRIPTION
Add proper flexbox constraints to breakdown column titles so that the pin button remains visible even with very long breakdown names. The text now truncates properly instead of pushing the button out of view.

## How did you test this code?

locally

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
