### PR TITLE
fix(early-access-features): show person display name instead of Unknown

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
@@ -321,6 +321,7 @@ order by count() desc
                     columns: defaultDataTableColumns(NodeKind.ActorsQuery),
                     source: {
                         kind: NodeKind.ActorsQuery,
+                        select: defaultDataTableColumns(NodeKind.ActorsQuery),
                         properties: [],
                     },
                 })

--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -42,6 +42,7 @@ import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { Query } from '~/queries/Query/Query'
+import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { Node, NodeKind, ProductIntentContext, ProductKey, QuerySchema } from '~/queries/schema/schema-general'
 import {
     CyclotronJobFiltersType,
@@ -669,6 +670,7 @@ function PersonsTableByFilter({ recordingsFilters, properties }: PersonsTableByF
         kind: NodeKind.DataTableNode,
         source: {
             kind: NodeKind.ActorsQuery,
+            select: defaultDataTableColumns(NodeKind.ActorsQuery),
             fixedProperties: properties,
         },
         full: true,


### PR DESCRIPTION
## Problem

Early access features persons display was showing unknown for all persons because the ActorsQuery didn't specify select columns, causing a mismatch between frontend rendering expectations and backend defaults.

## Changes

Added explicit select columns using defaultDataTableColumns to match the pattern used in personsSceneLogic.

Before:

<img width="1352" height="930" alt="CleanShot 2026-01-15 at 12 09 38@2x" src="https://github.com/user-attachments/assets/928e8fae-9189-4dfa-aeb7-0970b9ff68bb" />


After:

<img width="1454" height="1068" alt="CleanShot 2026-01-15 at 12 06 30@2x" src="https://github.com/user-attachments/assets/eedca968-5465-49e9-b813-8f4794419e3e" />


## How did you test this code?

locally

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
