### PR TITLE
fix(insights): hydrate data viz conditional formatting on mount

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -10,6 +10,7 @@ import {
     reducers,
     selectors,
     sharedListeners,
+    events,
 } from 'kea'
 import { subscriptions } from 'kea-subscriptions'
 import mergeObject from 'lodash.merge'
@@ -274,6 +275,13 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             actions._setQuery(props.query)
         }
     }),
+    events(({ actions, props }) => ({
+        afterMount() {
+            if (props.query) {
+                actions._setQuery(props.query)
+            }
+        },
+    })),
     props({ query: { source: {} } } as DataVisualizationLogicProps),
     actions(({ values }) => ({
         setVisualizationType: (visualizationType: ChartDisplayType) => ({ visualizationType }),


### PR DESCRIPTION
Problem

Conditional formatting for HogQL/Data visualization insights only applied reliably in the SQL editor. On direct insight views and dashboards (especially with dashboard-level filters), conditional formatting often didn’t show because the data visualization logic didn’t hydrate from the initial query on mount.

Users building SQL-based dashboards need conditional formatting to be consistently visible wherever the insight is rendered (editor, insight view, and dashboards), so that “status”-style tables are readable at a glance.

Changes

Update dataVisualizationLogic to call _setQuery in an events.afterMount handler so tableSettings.conditionalFormatting is always hydrated into conditionalFormattingRules on first render.
Keep the existing propsChanged behavior so subsequent query changes still resync all derived state.

How did you test this code?

Locally:
Created a HogQL/Data visualization table with conditional formatting rules and verified they apply in the SQL editor.
Saved as an insight and confirmed conditional formatting appears on:
The direct insight view.
A dashboard card.
After adding/removing dashboard-level filters.
Ran lint/TypeScript checks on the updated logic.


Publish to changelog?

Do not publish to changelog.
