### PR TITLE
feat(logs): add history tracking for filters

### DIFF
--- a/products/logs/frontend/components/LogsFilters/index.tsx
+++ b/products/logs/frontend/components/LogsFilters/index.tsx
@@ -11,6 +11,7 @@ import { Scene } from 'scenes/sceneTypes'
 
 import { LogsFilterGroup } from 'products/logs/frontend/components/filters/LogsFilters/FilterGroup'
 import { DateRangeFilter } from 'products/logs/frontend/filters/DateRangeFilter'
+import { FilterHistoryDropdown } from 'products/logs/frontend/filters/FilterHistoryDropdown'
 import { LogsDateRangePicker } from 'products/logs/frontend/filters/LogsDateRangePicker/LogsDateRangePicker'
 import { ServiceFilter } from 'products/logs/frontend/filters/ServiceFilter'
 import { SeverityLevelsFilter } from 'products/logs/frontend/filters/SeverityLevelsFilter'
@@ -27,6 +28,7 @@ export const LogsFilters = (): JSX.Element => {
                 <div className="flex gap-x-1 gap-y-2 flex-wrap">
                     <SeverityLevelsFilter />
                     <ServiceFilter />
+                    <FilterHistoryDropdown />
                 </div>
                 <div className="flex gap-x-1">
                     <LemonButton

--- a/products/logs/frontend/filters/FilterHistoryDropdown.tsx
+++ b/products/logs/frontend/filters/FilterHistoryDropdown.tsx
@@ -60,8 +60,19 @@ const formatHistoryEntryDetails = (entry: LogsFiltersHistoryEntry): string => {
 
 const formatServiceNames = (entry: LogsFiltersHistoryEntry): string => {
     const { filters } = entry
-    if (filters.serviceNames && filters.serviceNames.length > 0) {
-        return filters.serviceNames.join(', ')
+    const serviceNames = filters.serviceNames
+
+    if (serviceNames && serviceNames.length > 0) {
+        const maxDisplayed = 3
+        const displayedNames = serviceNames.slice(0, maxDisplayed)
+        const remainingCount = serviceNames.length - displayedNames.length
+        const baseText = displayedNames.join(', ')
+
+        if (remainingCount > 0) {
+            return `${baseText} and ${remainingCount} more`
+        }
+
+        return baseText
     }
     return 'All services'
 }

--- a/products/logs/frontend/filters/FilterHistoryDropdown.tsx
+++ b/products/logs/frontend/filters/FilterHistoryDropdown.tsx
@@ -1,0 +1,125 @@
+import { useActions, useValues } from 'kea'
+
+import { IconClock, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonMenu, LemonMenuSection } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+import { capitalizeFirstLetter } from 'lib/utils'
+
+import { AnyPropertyFilter } from '~/types'
+
+import { logsLogic } from '../logsLogic'
+import { LogsFiltersHistoryEntry } from '../types'
+
+const formatDateRange = (dateRange: LogsFiltersHistoryEntry['filters']['dateRange']): string => {
+    const from = dateRange.date_from || 'any'
+    const to = dateRange.date_to || 'now'
+    return `${from} → ${to}`
+}
+
+const isPropertyFilter = (v: unknown): v is AnyPropertyFilter => {
+    return typeof v === 'object' && v !== null && 'key' in v
+}
+
+const formatFilterGroupValues = (filterGroup: LogsFiltersHistoryEntry['filters']['filterGroup']): string[] => {
+    const group = filterGroup?.values?.[0]
+    if (!group || !('values' in group)) {
+        return []
+    }
+
+    return group.values.filter(isPropertyFilter).map((filter) => {
+        const key = filter.key || '?'
+        const value = Array.isArray(filter.value) ? filter.value.join(', ') : String(filter.value ?? '')
+        const truncatedValue = value.length > 15 ? `${value.slice(0, 15)}...` : value
+        return `${key}=${truncatedValue}`
+    })
+}
+
+const formatHistoryEntryDetails = (entry: LogsFiltersHistoryEntry): string => {
+    const parts: string[] = []
+    const { filters } = entry
+
+    parts.push(formatDateRange(filters.dateRange))
+
+    if (filters.severityLevels && filters.severityLevels.length > 0) {
+        parts.push(filters.severityLevels.map((l) => capitalizeFirstLetter(l)).join(', '))
+    }
+
+    if (filters.searchTerm) {
+        const truncated = filters.searchTerm.length > 20 ? `${filters.searchTerm.slice(0, 20)}...` : filters.searchTerm
+        parts.push(`"${truncated}"`)
+    }
+
+    const attributeFilters = formatFilterGroupValues(filters.filterGroup)
+    if (attributeFilters.length > 0) {
+        parts.push(attributeFilters.join(', '))
+    }
+
+    return parts.join(' | ')
+}
+
+const formatServiceNames = (entry: LogsFiltersHistoryEntry): string => {
+    const { filters } = entry
+    if (filters.serviceNames && filters.serviceNames.length > 0) {
+        return filters.serviceNames.join(', ')
+    }
+    return 'All services'
+}
+
+const formatRelativeTime = (timestamp: number): string => {
+    return dayjs(timestamp).fromNow()
+}
+
+const HistoryEntryButton = ({
+    entry,
+    onClick,
+}: {
+    entry: LogsFiltersHistoryEntry
+    onClick: () => void
+}): JSX.Element => {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="flex flex-col gap-0.5 w-full text-left px-2 py-1.5 rounded cursor-pointer hover:bg-fill-highlight-100 transition-colors"
+        >
+            <span className="text-xs text-muted font-medium">{formatServiceNames(entry)}</span>
+            <span className="text-sm">{formatHistoryEntryDetails(entry)}</span>
+            <span className="text-xs text-muted">{formatRelativeTime(entry.timestamp)}</span>
+        </button>
+    )
+}
+
+export const FilterHistoryDropdown = (): JSX.Element | null => {
+    const { filterHistory, hasFilterHistory } = useValues(logsLogic)
+    const { restoreFiltersFromHistory, clearFilterHistory } = useActions(logsLogic)
+
+    if (!hasFilterHistory) {
+        return null
+    }
+
+    const sections: LemonMenuSection[] = [
+        {
+            title: 'Recent filters',
+            items: filterHistory.map((entry, index) => ({
+                label: () => <HistoryEntryButton entry={entry} onClick={() => restoreFiltersFromHistory(index)} />,
+            })),
+        },
+        {
+            items: [
+                {
+                    label: 'Clear history',
+                    icon: <IconTrash />,
+                    onClick: () => clearFilterHistory(),
+                    status: 'danger' as const,
+                },
+            ],
+        },
+    ]
+
+    return (
+        <LemonMenu items={sections}>
+            <LemonButton icon={<IconClock />} size="small" type="secondary" tooltip="Filter history" />
+        </LemonMenu>
+    )
+}

--- a/products/logs/frontend/logsLogic.test.ts
+++ b/products/logs/frontend/logsLogic.test.ts
@@ -6,8 +6,10 @@ import { lemonToast } from '@posthog/lemon-ui'
 import { useMocks } from '~/mocks/jest'
 import { LogMessage } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
+import { FilterLogicalOperator } from '~/types'
 
 import { logsLogic } from './logsLogic'
+import { LogsFilters } from './types'
 
 jest.mock('@posthog/lemon-ui', () => ({
     ...jest.requireActual('@posthog/lemon-ui'),
@@ -321,6 +323,152 @@ describe('logsLogic', () => {
             }).toFinishAllListeners()
 
             expect(logic.values.severityLevels).toEqual(expected)
+        })
+    })
+
+    describe('filter history', () => {
+        const createFilters = (searchTerm: string): LogsFilters => ({
+            dateRange: { date_from: '-1h', date_to: null },
+            searchTerm,
+            severityLevels: [],
+            serviceNames: [],
+            filterGroup: { type: FilterLogicalOperator.And, values: [] },
+        })
+
+        beforeEach(async () => {
+            logic.actions.clearFilterHistory()
+            await expectLogic(logic).toFinishAllListeners()
+        })
+
+        describe('pushToFilterHistory', () => {
+            it('adds entry to empty history', async () => {
+                const filters = createFilters('test query')
+
+                await expectLogic(logic, () => {
+                    logic.actions.pushToFilterHistory(filters)
+                }).toMatchValues({
+                    filterHistory: [{ filters, timestamp: expect.any(Number) }],
+                })
+            })
+
+            it('prepends new entries to history', async () => {
+                const filters1 = createFilters('first')
+                const filters2 = createFilters('second')
+
+                logic.actions.pushToFilterHistory(filters1)
+                await expectLogic(logic).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.pushToFilterHistory(filters2)
+                }).toMatchValues({
+                    filterHistory: [
+                        { filters: filters2, timestamp: expect.any(Number) },
+                        { filters: filters1, timestamp: expect.any(Number) },
+                    ],
+                })
+            })
+
+            it('deduplicates consecutive identical filters', async () => {
+                const filters = createFilters('same query')
+
+                logic.actions.pushToFilterHistory(filters)
+                await expectLogic(logic).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.pushToFilterHistory(filters)
+                }).toMatchValues({
+                    filterHistory: [{ filters, timestamp: expect.any(Number) }],
+                })
+
+                expect(logic.values.filterHistory).toHaveLength(1)
+            })
+
+            it('limits history to 10 entries', async () => {
+                for (let i = 0; i < 15; i++) {
+                    logic.actions.pushToFilterHistory(createFilters(`query ${i}`))
+                }
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(logic.values.filterHistory).toHaveLength(10)
+                expect(logic.values.filterHistory[0].filters.searchTerm).toBe('query 14')
+                expect(logic.values.filterHistory[9].filters.searchTerm).toBe('query 5')
+            })
+        })
+
+        describe('clearFilterHistory', () => {
+            it('clears all history entries', async () => {
+                logic.actions.pushToFilterHistory(createFilters('query 1'))
+                logic.actions.pushToFilterHistory(createFilters('query 2'))
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(logic.values.filterHistory).toHaveLength(2)
+
+                await expectLogic(logic, () => {
+                    logic.actions.clearFilterHistory()
+                }).toMatchValues({
+                    filterHistory: [],
+                })
+            })
+        })
+
+        describe('restoreFiltersFromHistory', () => {
+            it('restores filters from history entry', async () => {
+                const filters = createFilters('restored query')
+                filters.severityLevels = ['error', 'warn']
+
+                logic.actions.pushToFilterHistory(filters)
+                await expectLogic(logic).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.restoreFiltersFromHistory(0)
+                })
+                    .toDispatchActions(['restoreFiltersFromHistory', 'setFilters'])
+                    .toMatchValues({
+                        searchTerm: 'restored query',
+                        severityLevels: ['error', 'warn'],
+                    })
+            })
+
+            it('does not push to history when restoring', async () => {
+                const filters1 = createFilters('first')
+                const filters2 = createFilters('second')
+
+                logic.actions.pushToFilterHistory(filters1)
+                logic.actions.pushToFilterHistory(filters2)
+                await expectLogic(logic).toFinishAllListeners()
+
+                const historyLengthBefore = logic.values.filterHistory.length
+
+                await expectLogic(logic, () => {
+                    logic.actions.restoreFiltersFromHistory(1)
+                }).toFinishAllListeners()
+
+                expect(logic.values.filterHistory).toHaveLength(historyLengthBefore)
+            })
+
+            it('does nothing for invalid index', async () => {
+                logic.actions.pushToFilterHistory(createFilters('test'))
+                await expectLogic(logic).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.restoreFiltersFromHistory(99)
+                })
+                    .toDispatchActions(['restoreFiltersFromHistory'])
+                    .toNotHaveDispatchedActions(['setFilters'])
+            })
+        })
+
+        describe('hasFilterHistory selector', () => {
+            it('returns false when history is empty', () => {
+                expect(logic.values.hasFilterHistory).toBe(false)
+            })
+
+            it('returns true when history has entries', async () => {
+                logic.actions.pushToFilterHistory(createFilters('test'))
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(logic.values.hasFilterHistory).toBe(true)
+            })
         })
     })
 })

--- a/products/logs/frontend/types.ts
+++ b/products/logs/frontend/types.ts
@@ -1,5 +1,19 @@
+import { DateRange, LogsQuery } from '~/queries/schema/schema-general'
 import { LogMessage } from '~/queries/schema/schema-general'
-import { JsonType } from '~/types'
+import { JsonType, UniversalFiltersGroup } from '~/types'
+
+export interface LogsFilters {
+    dateRange: DateRange
+    searchTerm: LogsQuery['searchTerm']
+    severityLevels: LogsQuery['severityLevels']
+    serviceNames: LogsQuery['serviceNames']
+    filterGroup: UniversalFiltersGroup
+}
+
+export interface LogsFiltersHistoryEntry {
+    filters: LogsFilters
+    timestamp: number
+}
 
 export type ParsedLogMessage = Omit<LogMessage, 'attributes'> & {
     attributes: Record<string, string>


### PR DESCRIPTION
## Problem

Users need a way to quickly access their recent filter configurations when working with logs. Currently, there's no way to recall previously used filter combinations without manually re-entering them.

## Changes

Added a filter history feature to the Logs interface that:

- Stores up to 10 recent filter configurations
- Displays them in a dropdown menu with relevant details
- Allows users to restore previous filter states with a single click
- Includes a "Clear history" option to reset the history

![image.png](https://app.graphite.com/user-attachments/assets/051d4490-eee3-49be-a07b-25ed78baec58.png)

## How did you test this code?

- Tested filter history persistence by applying various filter combinations and verifying they appear in the dropdown
- Verified that clicking on a history entry correctly restores all filter parameters
- Confirmed that duplicate filter entries aren't added to avoid clutter
- Tested the clear history functionality
- Verified that filter history is properly persisted between page reloads

## Add to changelog?

YES