### PR TITLE
chore: Add support for OVH cloud regions

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -132,12 +132,27 @@ export function BatchExportsEditFields({
                                         { value: 'me-south-1', label: 'Middle East (Bahrain)' },
                                         { value: 'me-central-1', label: 'Middle East (Riyadh)' },
                                         { value: 'sa-east-1', label: 'South America (São Paulo)' },
+                                        // Cloudflare R2
                                         { value: 'auto', label: 'Automatic (AUTO)' },
                                         { value: 'apac', label: 'Asia Pacific (APAC)' },
                                         { value: 'eeur', label: 'Eastern Europe (EEUR)' },
                                         { value: 'enam', label: 'Eastern North America (ENAM)' },
                                         { value: 'weur', label: 'Western Europe (WEUR)' },
                                         { value: 'wnam', label: 'Western North America (WNAM)' },
+                                        // OVH Cloud
+                                        { value: 'gra', label: 'Gravelines (GRA)' },
+                                        { value: 'rbx', label: 'Roubaix (RBX)' },
+                                        { value: 'sbg', label: 'Strasbourg (SBG)' },
+                                        { value: 'eu-west-par', label: 'Paris (PAR)' },
+                                        { value: 'eu-south-mil', label: 'Milan (MIL)' },
+                                        { value: 'de', label: 'Frankfurt (DE)' },
+                                        { value: 'uk', label: 'London (UK)' },
+                                        { value: 'waw', label: 'Warsaw (WAW)' },
+                                        { value: 'bhs', label: 'Beauharnois (BHS)' },
+                                        { value: 'ca-east-tor', label: 'Toronto (TOR)' },
+                                        { value: 'sgp', label: 'Singapore (SGP)' },
+                                        { value: 'ap-southeast-syd', label: 'Sydney (SYD)' },
+                                        { value: 'ap-south-mum', label: 'Mumbai (MUM)' },
                                     ]}
                                 />
                             </LemonField>


### PR DESCRIPTION
## Problem

OVH cloud has s3 compatible storage, but has a bunch of regions we need to add to the region dropdown.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add all the regions from: https://help.ovhcloud.com/csm/en-public-cloud-storage-s3-location.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I didn't.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
