### PR TITLE
fix(WA): handle property merging for WebOverviewQuery filters with dashboards'

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
@@ -169,23 +169,10 @@ class TestTrendsDashboardFilters(BaseTest):
 
         assert query_runner.query.dateRange.date_from == "2020-01-09"
         assert query_runner.query.dateRange.date_to == "2020-01-20"
-        assert query_runner.query.properties == PropertyGroupFilter(
-            type=FilterLogicalOperator.AND_,
-            values=[
-                PropertyGroupFilterValue(
-                    type=FilterLogicalOperator.AND_,
-                    values=[
-                        EventPropertyFilter(key="abc", value="foo", operator="exact"),
-                    ],
-                ),
-                PropertyGroupFilterValue(
-                    type=FilterLogicalOperator.AND_,
-                    values=[
-                        EventPropertyFilter(key="xyz", value="bar", operator="regex"),
-                    ],
-                ),
-            ],
-        )
+        assert query_runner.query.properties == [
+            EventPropertyFilter(key="abc", value="foo", operator="exact"),
+            EventPropertyFilter(key="xyz", value="bar", operator="regex"),
+        ]
         assert query_runner.query.breakdownFilter is None
         assert query_runner.query.trendsFilter is None
 

--- a/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
@@ -169,10 +169,23 @@ class TestTrendsDashboardFilters(BaseTest):
 
         assert query_runner.query.dateRange.date_from == "2020-01-09"
         assert query_runner.query.dateRange.date_to == "2020-01-20"
-        assert query_runner.query.properties == [
-            EventPropertyFilter(key="abc", value="foo", operator="exact"),
-            EventPropertyFilter(key="xyz", value="bar", operator="regex"),
-        ]
+        assert query_runner.query.properties == PropertyGroupFilter(
+            type=FilterLogicalOperator.AND_,
+            values=[
+                PropertyGroupFilterValue(
+                    type=FilterLogicalOperator.AND_,
+                    values=[
+                        EventPropertyFilter(key="abc", value="foo", operator="exact"),
+                    ],
+                ),
+                PropertyGroupFilterValue(
+                    type=FilterLogicalOperator.AND_,
+                    values=[
+                        EventPropertyFilter(key="xyz", value="bar", operator="regex"),
+                    ],
+                ),
+            ],
+        )
         assert query_runner.query.breakdownFilter is None
         assert query_runner.query.trendsFilter is None
 

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from time import perf_counter
 from types import UnionType
-from typing import Any, Generic, Optional, Protocol, TypeGuard, TypeVar, Union, cast, get_args
+from typing import Any, Generic, Optional, Protocol, TypeGuard, TypeVar, Union, cast, get_args, get_origin
 
 import structlog
 import posthoganalytics
@@ -1596,25 +1596,39 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         if dashboard_filter.properties:
             if self.query.properties:
                 try:
-                    self.query.properties = PropertyGroupFilter(
-                        type=FilterLogicalOperator.AND_,
-                        values=[
-                            (
-                                PropertyGroupFilterValue(type=FilterLogicalOperator.AND_, values=self.query.properties)
-                                if isinstance(self.query.properties, list)
-                                else PropertyGroupFilterValue(**self.query.properties.model_dump())
-                            ),
-                            PropertyGroupFilterValue(
-                                type=FilterLogicalOperator.AND_, values=dashboard_filter.properties
-                            ),
-                        ],
-                    )
+                    # Check if the query's properties field expects a list (e.g., WebOverviewQuery)
+                    # vs a PropertyGroupFilter (e.g., TrendsQuery)
+                    properties_field = self.query.__class__.model_fields.get("properties")
+                    expects_list = properties_field and get_origin(properties_field.annotation) is list
+
+                    if expects_list and isinstance(self.query.properties, list):
+                        # For queries that expect a list of properties (like WebOverviewQuery),
+                        # merge by concatenating the lists instead of wrapping in PropertyGroupFilter.
+                        # This avoids TypeError when the query later tries to concatenate properties.
+                        self.query.properties = list(self.query.properties) + list(dashboard_filter.properties)
+                    else:
+                        # For queries that accept PropertyGroupFilter, use the AND grouping approach
+                        self.query.properties = PropertyGroupFilter(
+                            type=FilterLogicalOperator.AND_,
+                            values=[
+                                (
+                                    PropertyGroupFilterValue(
+                                        type=FilterLogicalOperator.AND_, values=self.query.properties
+                                    )
+                                    if isinstance(self.query.properties, list)
+                                    else PropertyGroupFilterValue(**self.query.properties.model_dump())
+                                ),
+                                PropertyGroupFilterValue(
+                                    type=FilterLogicalOperator.AND_, values=dashboard_filter.properties
+                                ),
+                            ],
+                        )
                 except:
                     # If pydantic is unhappy about the shape of data, let's ignore property filters and carry on
                     capture_exception()
                     logger.exception("Failed to apply dashboard property filters")
             else:
-                self.query.properties = dashboard_filter.properties
+                self.query.properties = list(dashboard_filter.properties)
         if dashboard_filter.date_from or dashboard_filter.date_to:
             if self.query.dateRange is None:
                 self.query.dateRange = DateRange()

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview_dashboard_filters.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview_dashboard_filters.py
@@ -8,6 +8,18 @@ from posthog.models.utils import uuid7
 
 
 class TestWebOverviewDashboardFilters(ClickhouseTestMixin, APIBaseTest):
+    def test_dashboard_filter_applies_when_no_existing_properties(self):
+        query = WebOverviewQuery(dateRange=DateRange(date_from="-30d"))
+        runner = WebOverviewQueryRunner(team=self.team, query=query)
+
+        runner.apply_dashboard_filters(
+            DashboardFilter(properties=[EventPropertyFilter(key="$browser", value="Chrome", operator="exact")])
+        )
+
+        assert isinstance(runner.query.properties, list)
+        assert len(runner.query.properties) == 1
+        assert runner.query.properties[0].key == "$browser"
+
     def test_dashboard_filter_merges_with_existing_properties_as_list(self):
         # Regression test: apply_dashboard_filters was wrapping properties in PropertyGroupFilter,
         # but WebOverviewQuery.properties expects a list. This caused TypeError when

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview_dashboard_filters.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview_dashboard_filters.py
@@ -9,7 +9,7 @@ from posthog.models.utils import uuid7
 
 class TestWebOverviewDashboardFilters(ClickhouseTestMixin, APIBaseTest):
     def test_dashboard_filter_applies_when_no_existing_properties(self):
-        query = WebOverviewQuery(dateRange=DateRange(date_from="-30d"))
+        query = WebOverviewQuery(dateRange=DateRange(date_from="-30d"), properties=[])
         runner = WebOverviewQueryRunner(team=self.team, query=query)
 
         runner.apply_dashboard_filters(

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview_dashboard_filters.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview_dashboard_filters.py
@@ -1,0 +1,54 @@
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person
+
+from posthog.schema import DashboardFilter, DateRange, EventPropertyFilter, WebOverviewQuery
+
+from posthog.hogql_queries.web_analytics.web_overview import WebOverviewQueryRunner
+from posthog.models.utils import uuid7
+
+
+class TestWebOverviewDashboardFilters(ClickhouseTestMixin, APIBaseTest):
+    def test_dashboard_filter_merges_with_existing_properties_as_list(self):
+        # Regression test: apply_dashboard_filters was wrapping properties in PropertyGroupFilter,
+        # but WebOverviewQuery.properties expects a list. This caused TypeError when
+        # all_properties() tried to do: properties + _test_account_filters
+        query = WebOverviewQuery(
+            dateRange=DateRange(date_from="-30d"),
+            properties=[EventPropertyFilter(key="$pathname", value="/home", operator="exact")],
+        )
+        runner = WebOverviewQueryRunner(team=self.team, query=query)
+
+        runner.apply_dashboard_filters(
+            DashboardFilter(properties=[EventPropertyFilter(key="$browser", value="Chrome", operator="exact")])
+        )
+
+        assert isinstance(runner.query.properties, list)
+        assert len(runner.query.properties) == 2
+        assert runner.query.properties[0].key == "$pathname"
+        assert runner.query.properties[1].key == "$browser"
+
+    def test_dashboard_filter_with_existing_properties_executes(self):
+        s1 = str(uuid7("2023-12-10"))
+        with freeze_time("2023-12-10"):
+            _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={})
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="p1",
+            timestamp="2023-12-10",
+            properties={"$session_id": s1, "$pathname": "/home"},
+        )
+
+        query = WebOverviewQuery(
+            dateRange=DateRange(date_from="-30d"),
+            properties=[EventPropertyFilter(key="$pathname", value="/home", operator="exact")],
+        )
+        runner = WebOverviewQueryRunner(team=self.team, query=query)
+        runner.apply_dashboard_filters(
+            DashboardFilter(properties=[EventPropertyFilter(key="$browser", value="Chrome", operator="exact")])
+        )
+
+        with freeze_time("2023-12-15"):
+            response = runner.calculate()
+
+        assert response.results is not None


### PR DESCRIPTION
## Problem

Error on the dashboard when the dashboard has filters and the web overview component does as well. Zendesk ticket: https://posthoghelp.zendesk.com/agent/tickets/46414 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49684)

## Changes

- Updated apply_dashboard_filters to correctly merge properties as a list for WebOverviewQuery, preventing TypeErrors during concatenation.
- Added regression tests to ensure proper functionality when applying dashboard filters with existing properties.
- Introduced new test cases to validate behavior with DashboardFilter and existing properties.

## How did you test this code?
Test and manually:
Insight with filter:
<img width="999" height="523" alt="Screenshot 2026-01-15 at 2 03 38 PM" src="https://github.com/user-attachments/assets/d0b1d76f-8475-4e25-ab6d-776ab3c11529" />
Bug:
<img width="1259" height="708" alt="Screenshot 2026-01-15 at 2 03 30 PM" src="https://github.com/user-attachments/assets/6c3677e9-04c9-4d70-9677-b9040280f596" />
After with the filters of the dashboard applied:
<img width="1003" height="726" alt="Screenshot 2026-01-15 at 2 02 56 PM" src="https://github.com/user-attachments/assets/3daf1c29-ca0a-4d53-b908-b4aa4e1cdb1c" />
