### PR TITLE
feat(gateway): handle output token limiting for streams

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import litellm
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
 from llm_gateway.api.handler import ANTHROPIC_CONFIG, handle_llm_request
@@ -15,7 +15,6 @@ anthropic_router = APIRouter()
 async def _handle_anthropic_messages(
     body: AnthropicMessagesRequest,
     user: RateLimitedUser,
-    http_request: Request,
     product: str = "llm_gateway",
 ) -> dict[str, Any] | StreamingResponse:
     data = body.model_dump(exclude_none=True)
@@ -28,7 +27,6 @@ async def _handle_anthropic_messages(
         provider_config=ANTHROPIC_CONFIG,
         llm_call=litellm.anthropic_messages,
         product=product,
-        http_request=http_request,
     )
 
 
@@ -36,17 +34,15 @@ async def _handle_anthropic_messages(
 async def anthropic_messages(
     body: AnthropicMessagesRequest,
     user: RateLimitedUser,
-    request: Request,
 ) -> dict[str, Any] | StreamingResponse:
-    return await _handle_anthropic_messages(body, user, request)
+    return await _handle_anthropic_messages(body, user)
 
 
 @anthropic_router.post("/{product}/v1/messages", response_model=None)
 async def anthropic_messages_with_product(
     body: AnthropicMessagesRequest,
     user: RateLimitedUser,
-    request: Request,
     product: str,
 ) -> dict[str, Any] | StreamingResponse:
     validate_product(product)
-    return await _handle_anthropic_messages(body, user, request, product=product)
+    return await _handle_anthropic_messages(body, user, product=product)

--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -1,11 +1,13 @@
 import asyncio
+import json
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
+import litellm
 import structlog
-from fastapi import HTTPException, Request
+from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 
 from llm_gateway.analytics import get_analytics_service
@@ -19,6 +21,7 @@ from llm_gateway.metrics.prometheus import (
     REQUEST_COUNT,
     REQUEST_LATENCY,
     STREAMING_CLIENT_DISCONNECT,
+    STREAMING_USAGE_EXTRACTION,
     TIME_TO_FIRST_CHUNK,
     TOKENS_INPUT,
     TOKENS_OUTPUT,
@@ -29,18 +32,115 @@ from llm_gateway.streaming.sse import format_sse_stream
 logger = structlog.get_logger(__name__)
 
 
-async def adjust_output_throttles(request: Request, actual_output_tokens: int) -> None:
-    """Adjust all output throttles after response completes."""
-    throttle_context = getattr(request.state, "throttle_context", None)
-    if not throttle_context or not throttle_context.request_id:
+def _extract_usage_from_sse_bytes(chunks: list[bytes]) -> tuple[int | None, int | None]:
+    """Extract usage from raw SSE bytes (for passthrough providers like Anthropic).
+
+    Anthropic SSE format:
+    - message_start: {"type": "message_start", "message": {..., "usage": {"input_tokens": X}}}
+    - message_delta: {"type": "message_delta", "usage": {"output_tokens": Y}}
+    """
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+    for chunk in chunks:
+        try:
+            text = chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+            for line in text.split("\n"):
+                if not line.startswith("data: "):
+                    continue
+                data_str = line[6:].strip()
+                if not data_str or data_str == "[DONE]":
+                    continue
+                data = json.loads(data_str)
+
+                if data.get("type") == "message_start":
+                    message = data.get("message", {})
+                    usage = message.get("usage", {})
+                    input_tokens = usage.get("input_tokens")
+                elif data.get("type") == "message_delta":
+                    usage = data.get("usage", {})
+                    if "output_tokens" in usage:
+                        output_tokens = usage.get("output_tokens")
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+
+    return input_tokens, output_tokens
+
+
+def _record_token_metrics(
+    provider: str, model: str, product: str, input_tokens: int | None, output_tokens: int | None
+) -> None:
+    """Record token usage metrics if values are within valid range."""
+    if input_tokens is not None and 0 <= input_tokens <= 1_000_000:
+        TOKENS_INPUT.labels(provider=provider, model=model, product=product).inc(input_tokens)
+    if output_tokens is not None and 0 <= output_tokens <= 1_000_000:
+        TOKENS_OUTPUT.labels(provider=provider, model=model, product=product).inc(output_tokens)
+
+
+def _extract_streaming_usage(
+    collected_chunks: list[Any], messages: list[Any], provider: str, model: str, product: str
+) -> None:
+    """Extract and log usage from streaming response chunks."""
+    if not collected_chunks:
+        logger.warning(
+            "streaming_usage_missing",
+            provider=provider,
+            model=model,
+            reason="no chunks collected during stream",
+            chunk_count=0,
+        )
+        STREAMING_USAGE_EXTRACTION.labels(provider=provider, status="no_chunks").inc()
         return
 
-    output_throttles = getattr(request.app.state, "output_throttles", [])
-    for throttle in output_throttles:
-        try:
-            await throttle.adjust_after_response(throttle_context.request_id, actual_output_tokens)
-        except Exception:
-            logger.warning("failed_to_adjust_output_throttle", throttle=type(throttle).__name__)
+    is_passthrough = isinstance(collected_chunks[0], bytes)
+
+    if is_passthrough:
+        input_tokens, output_tokens = _extract_usage_from_sse_bytes(collected_chunks)
+    else:
+        input_tokens, output_tokens = None, None
+        complete = litellm.stream_chunk_builder(collected_chunks, messages=messages)
+        if complete and complete.usage:
+            input_tokens = complete.usage.prompt_tokens
+            output_tokens = complete.usage.completion_tokens
+
+    has_input = input_tokens is not None
+    has_output = output_tokens is not None
+
+    if has_input and has_output:
+        logger.info(
+            "streaming_usage",
+            provider=provider,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            passthrough=is_passthrough,
+        )
+        _record_token_metrics(provider, model, product, input_tokens, output_tokens)
+        STREAMING_USAGE_EXTRACTION.labels(provider=provider, status="success").inc()
+    elif has_input or has_output:
+        status = "partial_input_only" if has_input else "partial_output_only"
+        missing = "output_tokens" if has_input else "input_tokens"
+        logger.warning(
+            "streaming_usage_partial",
+            provider=provider,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            reason=f"{missing} missing from response",
+            passthrough=is_passthrough,
+            chunk_count=len(collected_chunks),
+        )
+        STREAMING_USAGE_EXTRACTION.labels(provider=provider, status=status).inc()
+    else:
+        logger.warning(
+            "streaming_usage_missing",
+            provider=provider,
+            model=model,
+            reason="no usage data found in response",
+            passthrough=is_passthrough,
+            chunk_count=len(collected_chunks),
+        )
+        STREAMING_USAGE_EXTRACTION.labels(provider=provider, status="missing").inc()
 
 
 @dataclass
@@ -81,7 +181,6 @@ async def handle_llm_request(
     provider_config: ProviderConfig,
     llm_call: Callable[..., Awaitable[Any]],
     product: str = "llm_gateway",
-    http_request: Request | None = None,
 ) -> dict[str, Any] | StreamingResponse:
     settings = get_settings()
     start_time = time.monotonic()
@@ -103,7 +202,6 @@ async def handle_llm_request(
             start_time=start_time,
             timeout=settings.streaming_timeout,
             product=product,
-            http_request=http_request,
         )
 
     CONCURRENT_REQUESTS.labels(provider=provider_config.name, model=model, product=product).inc()
@@ -117,7 +215,6 @@ async def handle_llm_request(
             start_time=start_time,
             timeout=settings.request_timeout,
             product=product,
-            http_request=http_request,
         )
 
     except TimeoutError:
@@ -157,8 +254,9 @@ async def _handle_streaming_request(
     start_time: float,
     timeout: float,
     product: str = "llm_gateway",
-    http_request: Request | None = None,
 ) -> StreamingResponse:
+    collected_chunks: list[Any] = []
+
     async def stream_generator() -> AsyncGenerator[bytes, None]:
         ACTIVE_STREAMS.labels(provider=provider_config.name, model=model, product=product).inc()
         CONCURRENT_REQUESTS.labels(provider=provider_config.name, model=model, product=product).inc()
@@ -167,10 +265,17 @@ async def _handle_streaming_request(
         first_chunk_received = False
         error: Exception | None = None
 
+        async def collect_chunks_wrapper(
+            llm_response: AsyncGenerator[Any, None],
+        ) -> AsyncGenerator[Any, None]:
+            async for chunk in llm_response:
+                collected_chunks.append(chunk)
+                yield chunk
+
         try:
             response = await asyncio.wait_for(llm_call(**request_data), timeout=timeout)
 
-            async for chunk in format_sse_stream(response):
+            async for chunk in format_sse_stream(collect_chunks_wrapper(response)):
                 if not first_chunk_received:
                     first_chunk_received = True
                     time_to_first = time.monotonic() - provider_start
@@ -215,6 +320,25 @@ async def _handle_streaming_request(
             ).observe(time.monotonic() - start_time)
 
             try:
+                _extract_streaming_usage(
+                    collected_chunks=collected_chunks,
+                    messages=request_data.get("messages", []),
+                    provider=provider_config.name,
+                    model=model,
+                    product=product,
+                )
+            except Exception as usage_error:
+                logger.error(
+                    "streaming_usage_parse_failed",
+                    provider=provider_config.name,
+                    model=model,
+                    error=str(usage_error),
+                    error_type=type(usage_error).__name__,
+                    chunk_count=len(collected_chunks) if collected_chunks else 0,
+                )
+                STREAMING_USAGE_EXTRACTION.labels(provider=provider_config.name, status="error").inc()
+
+            try:
                 analytics = get_analytics_service()
                 if analytics:
                     latency_seconds = time.monotonic() - start_time
@@ -250,7 +374,6 @@ async def _handle_non_streaming_request(
     start_time: float,
     timeout: float,
     product: str = "llm_gateway",
-    http_request: Request | None = None,
 ) -> dict[str, Any]:
     provider_start = time.monotonic()
     response_dict: dict[str, Any] | None = None
@@ -281,9 +404,6 @@ async def _handle_non_streaming_request(
                 TOKENS_INPUT.labels(provider=provider_config.name, model=model, product=product).inc(input_tokens)
             if 0 <= output_tokens <= 1_000_000:
                 TOKENS_OUTPUT.labels(provider=provider_config.name, model=model, product=product).inc(output_tokens)
-
-            if http_request and output_tokens is not None:
-                await adjust_output_throttles(http_request, output_tokens)
 
         REQUEST_LATENCY.labels(
             endpoint=provider_config.endpoint_name,

--- a/services/llm-gateway/src/llm_gateway/api/openai.py
+++ b/services/llm-gateway/src/llm_gateway/api/openai.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import litellm
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
 from llm_gateway.api.handler import OPENAI_CONFIG, OPENAI_RESPONSES_CONFIG, handle_llm_request
@@ -22,7 +22,6 @@ def _normalize_model_name(model: str) -> str:
 async def _handle_chat_completions(
     body: ChatCompletionRequest,
     user: RateLimitedUser,
-    http_request: Request,
     product: str = "llm_gateway",
 ) -> dict[str, Any] | StreamingResponse:
     data = body.model_dump(exclude_none=True)
@@ -35,14 +34,12 @@ async def _handle_chat_completions(
         provider_config=OPENAI_CONFIG,
         llm_call=litellm.acompletion,
         product=product,
-        http_request=http_request,
     )
 
 
 async def _handle_responses(
     body: ResponsesRequest,
     user: RateLimitedUser,
-    http_request: Request,
     product: str = "llm_gateway",
 ) -> dict[str, Any] | StreamingResponse:
     """Handle OpenAI Responses API request.
@@ -65,7 +62,6 @@ async def _handle_responses(
             provider_config=OPENAI_RESPONSES_CONFIG,
             llm_call=litellm.aresponses,
             product=product,
-            http_request=http_request,
         )
         return result
     except Exception:
@@ -76,57 +72,51 @@ async def _handle_responses(
 async def chat_completions(
     body: ChatCompletionRequest,
     user: RateLimitedUser,
-    request: Request,
 ) -> dict[str, Any] | StreamingResponse:
-    return await _handle_chat_completions(body, user, request)
+    return await _handle_chat_completions(body, user)
 
 
 @openai_router.post("/{product}/v1/chat/completions", response_model=None)
 async def chat_completions_with_product(
     body: ChatCompletionRequest,
     user: RateLimitedUser,
-    request: Request,
     product: str,
 ) -> dict[str, Any] | StreamingResponse:
     validate_product(product)
-    return await _handle_chat_completions(body, user, request, product=product)
+    return await _handle_chat_completions(body, user, product=product)
 
 
 @openai_router.post("/v1/responses", response_model=None)
 async def responses_v1(
     body: ResponsesRequest,
     user: RateLimitedUser,
-    request: Request,
 ) -> dict[str, Any] | StreamingResponse:
-    return await _handle_responses(body, user, request)
+    return await _handle_responses(body, user)
 
 
 @openai_router.post("/{product}/v1/responses", response_model=None)
 async def responses_v1_with_product(
     body: ResponsesRequest,
     user: RateLimitedUser,
-    request: Request,
     product: str,
 ) -> dict[str, Any] | StreamingResponse:
     validate_product(product)
-    return await _handle_responses(body, user, request, product=product)
+    return await _handle_responses(body, user, product=product)
 
 
 @openai_router.post("/responses", response_model=None)
 async def responses(
     body: ResponsesRequest,
     user: RateLimitedUser,
-    request: Request,
 ) -> dict[str, Any] | StreamingResponse:
-    return await _handle_responses(body, user, request)
+    return await _handle_responses(body, user)
 
 
 @openai_router.post("/{product}/responses", response_model=None)
 async def responses_with_product(
     body: ResponsesRequest,
     user: RateLimitedUser,
-    request: Request,
     product: str,
 ) -> dict[str, Any] | StreamingResponse:
     validate_product(product)
-    return await _handle_responses(body, user, request, product=product)
+    return await _handle_responses(body, user, product=product)

--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -99,14 +99,7 @@ async def enforce_throttles(
     if body:
         try:
             data: dict[str, Any] = json.loads(body)
-            # HOTFIX: Don't reserve output tokens for streaming requests.
-            # Streaming doesn't release reservations after completion, causing
-            # rapid rate limit exhaustion. Disable until proper fix is implemented.
-            # TODO: Extract actual output tokens from stream and release properly.
-            is_streaming = data.get("stream", False)
-            if not is_streaming:
-                max_output_tokens = data.get("max_tokens")
-
+            max_output_tokens = data.get("max_tokens")
             if model and "messages" in data:
                 token_counter = getattr(request.app.state, "token_counter", None)
                 if token_counter:

--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -11,7 +11,7 @@ from llm_gateway.auth.service import AuthService, get_auth_service
 from llm_gateway.products.config import check_product_access
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import ThrottleContext
-from llm_gateway.request_context import get_request_id
+from llm_gateway.request_context import get_request_id, set_throttle_context
 
 
 async def get_db_pool(request: Request) -> "asyncpg.Pool[asyncpg.Record]":  # noqa: UP037
@@ -116,6 +116,7 @@ async def enforce_throttles(
         request_id=get_request_id() or None,
     )
     request.state.throttle_context = context
+    set_throttle_context(runner, context)
     result = await runner.check(context)
 
     if not result.allowed:

--- a/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
+++ b/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
@@ -107,7 +107,10 @@ DB_POOL_EXHAUSTED = Counter(
 STREAMING_USAGE_EXTRACTION = Counter(
     "llm_gateway_streaming_usage_extraction_total",
     "Streaming usage extraction results",
-    labelnames=["provider", "status"],  # status: success, partial_input_only, partial_output_only, missing, no_chunks, error
+    labelnames=[
+        "provider",
+        "status",
+    ],  # status: success, partial_input_only, partial_output_only, missing, no_chunks, error
 )
 
 

--- a/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
+++ b/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
@@ -104,6 +104,12 @@ DB_POOL_EXHAUSTED = Counter(
     "Database pool exhaustion events",
 )
 
+STREAMING_USAGE_EXTRACTION = Counter(
+    "llm_gateway_streaming_usage_extraction_total",
+    "Streaming usage extraction results",
+    labelnames=["provider", "status"],  # status: success, partial_input_only, partial_output_only, missing, no_chunks, error
+)
+
 
 def get_instrumentator() -> Instrumentator:
     return Instrumentator(

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/runner.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/runner.py
@@ -31,3 +31,11 @@ class ThrottleRunner:
                 )
                 return result
         return ThrottleResult.allow()
+
+    async def record_output_tokens(self, context: ThrottleContext, actual_tokens: int) -> None:
+        """Record actual output tokens after response completes."""
+        from llm_gateway.rate_limiting.model_throttles import OutputTokenThrottle
+
+        for throttle in self._throttles:
+            if isinstance(throttle, OutputTokenThrottle):
+                await throttle.record_output_tokens(context, actual_tokens)

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/token_bucket.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/token_bucket.py
@@ -33,6 +33,10 @@ class TokenBucketLimiter:
                 return True
             return False
 
+    def would_allow(self, key: str, tokens: float = 1.0) -> bool:
+        """Check if tokens would be allowed WITHOUT consuming them."""
+        return self.get_remaining(key) >= tokens
+
     def get_remaining(self, key: str) -> float:
         """Get remaining tokens in bucket for a key."""
         now = time.monotonic()

--- a/services/llm-gateway/src/llm_gateway/request_context.py
+++ b/services/llm-gateway/src/llm_gateway/request_context.py
@@ -1,6 +1,15 @@
+from __future__ import annotations
+
 from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from llm_gateway.rate_limiting.runner import ThrottleRunner
+    from llm_gateway.rate_limiting.throttles import ThrottleContext
 
 request_id_var: ContextVar[str] = ContextVar("request_id", default="")
+throttle_runner_var: ContextVar[ThrottleRunner | None] = ContextVar("throttle_runner", default=None)
+throttle_context_var: ContextVar[ThrottleContext | None] = ContextVar("throttle_context", default=None)
 
 
 def get_request_id() -> str:
@@ -9,3 +18,16 @@ def get_request_id() -> str:
 
 def set_request_id(request_id: str) -> None:
     request_id_var.set(request_id)
+
+
+def set_throttle_context(runner: ThrottleRunner, context: ThrottleContext) -> None:
+    throttle_runner_var.set(runner)
+    throttle_context_var.set(context)
+
+
+async def record_output_tokens(output_tokens: int) -> None:
+    """Record actual output tokens for rate limiting. Call after streaming completes."""
+    runner = throttle_runner_var.get()
+    context = throttle_context_var.get()
+    if runner and context:
+        await runner.record_output_tokens(context, output_tokens)

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -25,16 +25,12 @@ def create_test_app(mock_db_pool: MagicMock) -> FastAPI:
     async def test_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         app.state.db_pool = mock_db_pool
         app.state.redis = None
-        output_throttles = [
-            ProductModelOutputTokenThrottle(redis=None),
-            UserModelOutputTokenThrottle(redis=None),
-        ]
-        app.state.output_throttles = output_throttles
         app.state.throttle_runner = ThrottleRunner(
             throttles=[
                 ProductModelInputTokenThrottle(redis=None),
                 UserModelInputTokenThrottle(redis=None),
-                *output_throttles,
+                ProductModelOutputTokenThrottle(redis=None),
+                UserModelOutputTokenThrottle(redis=None),
             ]
         )
         yield

--- a/services/llm-gateway/tests/integration/test_streaming_usage.py
+++ b/services/llm-gateway/tests/integration/test_streaming_usage.py
@@ -1,0 +1,85 @@
+"""
+Integration tests for streaming usage logging.
+
+Tests that stream_chunk_builder correctly extracts token usage from streaming responses.
+
+Run with: ANTHROPIC_API_KEY=... pytest tests/integration/test_streaming_usage.py -v -s
+"""
+
+import os
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+import structlog
+from anthropic import Anthropic
+
+ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+
+pytestmark = pytest.mark.skipif(not ANTHROPIC_API_KEY, reason="ANTHROPIC_API_KEY not set")
+
+
+class TestStreamingUsageLogging:
+    def test_streaming_request_logs_usage(self, anthropic_client: Anthropic):
+        """Verify that streaming requests log input and output tokens."""
+        log_output = StringIO()
+
+        structlog.configure(
+            processors=[
+                structlog.processors.add_log_level,
+                structlog.processors.JSONRenderer(),
+            ],
+            wrapper_class=structlog.make_filtering_bound_logger(0),
+            context_class=dict,
+            logger_factory=structlog.PrintLoggerFactory(log_output),
+            cache_logger_on_first_use=False,
+        )
+
+        with anthropic_client.messages.stream(
+            model="claude-3-5-haiku-20241022",
+            messages=[{"role": "user", "content": "Say 'hello world' and nothing else."}],
+            max_tokens=20,
+        ) as stream:
+            text = stream.get_final_text()
+
+        assert text is not None
+        assert len(text) > 0
+
+        logs = log_output.getvalue()
+        print(f"\n=== Captured logs ===\n{logs}\n=== End logs ===\n")
+
+        assert "streaming_usage" in logs or "input_tokens" in logs, (
+            f"Expected streaming_usage log entry with token counts. Got:\n{logs}"
+        )
+
+    def test_non_streaming_logs_usage(self, anthropic_client: Anthropic):
+        """Verify that non-streaming requests also track usage."""
+        response = anthropic_client.messages.create(
+            model="claude-3-5-haiku-20241022",
+            messages=[{"role": "user", "content": "Say 'test' and nothing else."}],
+            max_tokens=10,
+        )
+
+        assert response.usage is not None
+        assert response.usage.input_tokens > 0
+        assert response.usage.output_tokens > 0
+        print(f"\nNon-streaming usage: input={response.usage.input_tokens}, output={response.usage.output_tokens}")
+
+    def test_streaming_returns_complete_response(self, anthropic_client: Anthropic):
+        """Verify streaming collects all chunks and returns complete text."""
+        with anthropic_client.messages.stream(
+            model="claude-3-5-haiku-20241022",
+            messages=[{"role": "user", "content": "Count from 1 to 5, separated by commas."}],
+            max_tokens=50,
+        ) as stream:
+            text = stream.get_final_text()
+            message = stream.get_final_message()
+
+        print(f"\nStreaming response text: {text}")
+        print(f"Final message usage: {message.usage}")
+
+        assert text is not None
+        assert "1" in text and "5" in text
+        assert message.usage is not None
+        assert message.usage.input_tokens > 0
+        assert message.usage.output_tokens > 0

--- a/services/llm-gateway/tests/integration/test_streaming_usage.py
+++ b/services/llm-gateway/tests/integration/test_streaming_usage.py
@@ -1,17 +1,14 @@
 """
-Integration tests for streaming usage logging.
+Integration tests for streaming usage extraction.
 
-Tests that stream_chunk_builder correctly extracts token usage from streaming responses.
+Tests that the gateway correctly proxies streaming responses and extracts usage data.
 
 Run with: ANTHROPIC_API_KEY=... pytest tests/integration/test_streaming_usage.py -v -s
 """
 
 import os
-from io import StringIO
-from unittest.mock import patch
 
 import pytest
-import structlog
 from anthropic import Anthropic
 
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
@@ -19,41 +16,26 @@ ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 pytestmark = pytest.mark.skipif(not ANTHROPIC_API_KEY, reason="ANTHROPIC_API_KEY not set")
 
 
-class TestStreamingUsageLogging:
-    def test_streaming_request_logs_usage(self, anthropic_client: Anthropic):
-        """Verify that streaming requests log input and output tokens."""
-        log_output = StringIO()
-
-        structlog.configure(
-            processors=[
-                structlog.processors.add_log_level,
-                structlog.processors.JSONRenderer(),
-            ],
-            wrapper_class=structlog.make_filtering_bound_logger(0),
-            context_class=dict,
-            logger_factory=structlog.PrintLoggerFactory(log_output),
-            cache_logger_on_first_use=False,
-        )
-
+class TestStreamingUsageExtraction:
+    def test_streaming_returns_usage_in_final_message(self, anthropic_client: Anthropic):
+        """Verify streaming through gateway returns complete response with usage."""
         with anthropic_client.messages.stream(
             model="claude-3-5-haiku-20241022",
             messages=[{"role": "user", "content": "Say 'hello world' and nothing else."}],
             max_tokens=20,
         ) as stream:
             text = stream.get_final_text()
+            message = stream.get_final_message()
 
         assert text is not None
         assert len(text) > 0
+        assert message.usage is not None
+        assert message.usage.input_tokens > 0
+        assert message.usage.output_tokens > 0
+        print(f"\nStreaming usage: input={message.usage.input_tokens}, output={message.usage.output_tokens}")
 
-        logs = log_output.getvalue()
-        print(f"\n=== Captured logs ===\n{logs}\n=== End logs ===\n")
-
-        assert "streaming_usage" in logs or "input_tokens" in logs, (
-            f"Expected streaming_usage log entry with token counts. Got:\n{logs}"
-        )
-
-    def test_non_streaming_logs_usage(self, anthropic_client: Anthropic):
-        """Verify that non-streaming requests also track usage."""
+    def test_non_streaming_returns_usage(self, anthropic_client: Anthropic):
+        """Verify non-streaming requests through gateway return usage."""
         response = anthropic_client.messages.create(
             model="claude-3-5-haiku-20241022",
             messages=[{"role": "user", "content": "Say 'test' and nothing else."}],
@@ -64,22 +46,3 @@ class TestStreamingUsageLogging:
         assert response.usage.input_tokens > 0
         assert response.usage.output_tokens > 0
         print(f"\nNon-streaming usage: input={response.usage.input_tokens}, output={response.usage.output_tokens}")
-
-    def test_streaming_returns_complete_response(self, anthropic_client: Anthropic):
-        """Verify streaming collects all chunks and returns complete text."""
-        with anthropic_client.messages.stream(
-            model="claude-3-5-haiku-20241022",
-            messages=[{"role": "user", "content": "Count from 1 to 5, separated by commas."}],
-            max_tokens=50,
-        ) as stream:
-            text = stream.get_final_text()
-            message = stream.get_final_message()
-
-        print(f"\nStreaming response text: {text}")
-        print(f"Final message usage: {message.usage}")
-
-        assert text is not None
-        assert "1" in text and "5" in text
-        assert message.usage is not None
-        assert message.usage.input_tokens > 0
-        assert message.usage.output_tokens > 0

--- a/services/llm-gateway/tests/test_metrics.py
+++ b/services/llm-gateway/tests/test_metrics.py
@@ -11,6 +11,7 @@ from llm_gateway.metrics.prometheus import (
     REQUEST_COUNT,
     REQUEST_LATENCY,
     STREAMING_CLIENT_DISCONNECT,
+    STREAMING_USAGE_EXTRACTION,
     TIME_TO_FIRST_CHUNK,
     TOKENS_INPUT,
     TOKENS_OUTPUT,
@@ -39,6 +40,7 @@ class TestMetricsConfiguration:
             pytest.param(TIME_TO_FIRST_CHUNK, {"provider", "model", "product"}, id="time_to_first_chunk"),
             pytest.param(DB_POOL_SIZE, {"state"}, id="db_pool_size"),
             pytest.param(PROVIDER_LATENCY, {"provider", "model", "product"}, id="provider_latency"),
+            pytest.param(STREAMING_USAGE_EXTRACTION, {"provider", "status"}, id="streaming_usage_extraction"),
         ],
     )
     def test_metric_has_correct_labels(self, metric, expected_labels: set[str]) -> None:

--- a/services/llm-gateway/tests/test_request_context.py
+++ b/services/llm-gateway/tests/test_request_context.py
@@ -1,0 +1,58 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from llm_gateway.rate_limiting.throttles import ThrottleContext
+from llm_gateway.request_context import (
+    record_output_tokens,
+    set_throttle_context,
+    throttle_context_var,
+    throttle_runner_var,
+)
+
+
+def make_mock_user() -> MagicMock:
+    user = MagicMock()
+    user.user_id = 1
+    user.team_id = 1
+    user.application_id = None
+    user.auth_method = "api_key"
+    return user
+
+
+class TestRecordOutputTokens:
+    @pytest.fixture(autouse=True)
+    def reset_context_vars(self) -> None:
+        throttle_runner_var.set(None)
+        throttle_context_var.set(None)
+
+    async def test_record_output_tokens_calls_runner(self) -> None:
+        mock_runner = MagicMock()
+        mock_runner.record_output_tokens = AsyncMock()
+
+        context = ThrottleContext(
+            user=make_mock_user(),
+            product="llm_gateway",
+            model="claude-3-5-haiku-20241022",
+            input_tokens=100,
+            max_output_tokens=1000,
+        )
+
+        set_throttle_context(mock_runner, context)
+
+        await record_output_tokens(500)
+
+        mock_runner.record_output_tokens.assert_called_once_with(context, 500)
+
+    async def test_record_output_tokens_no_op_without_context(self) -> None:
+        # Should not raise when no context is set
+        await record_output_tokens(500)
+
+    async def test_record_output_tokens_no_op_with_partial_context(self) -> None:
+        # Only runner set, no context
+        mock_runner = MagicMock()
+        throttle_runner_var.set(mock_runner)
+
+        await record_output_tokens(500)
+
+        mock_runner.record_output_tokens.assert_not_called()

--- a/services/llm-gateway/tests/test_throttles.py
+++ b/services/llm-gateway/tests/test_throttles.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from llm_gateway.api.handler import adjust_output_throttles
 from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.rate_limiting.model_throttles import (
     ProductModelInputTokenThrottle,
@@ -182,61 +179,3 @@ class TestThrottleContext:
         assert context.input_tokens == 1000
         assert context.max_output_tokens == 4096
         assert context.request_id == "req-123"
-
-
-class TestAdjustOutputThrottles:
-    @pytest.mark.asyncio
-    async def test_adjusts_throttles_when_context_has_request_id(self) -> None:
-        mock_throttle = MagicMock()
-        mock_throttle.adjust_after_response = AsyncMock()
-
-        mock_request = MagicMock()
-        mock_request.state.throttle_context = MagicMock(request_id="req-123")
-        mock_request.app.state.output_throttles = [mock_throttle]
-
-        await adjust_output_throttles(mock_request, actual_output_tokens=500)
-
-        mock_throttle.adjust_after_response.assert_called_once_with("req-123", 500)
-
-    @pytest.mark.asyncio
-    async def test_skips_when_no_throttle_context(self) -> None:
-        mock_throttle = MagicMock()
-        mock_throttle.adjust_after_response = AsyncMock()
-
-        mock_request = MagicMock()
-        mock_request.state.throttle_context = None
-        mock_request.app.state.output_throttles = [mock_throttle]
-
-        await adjust_output_throttles(mock_request, actual_output_tokens=500)
-
-        mock_throttle.adjust_after_response.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_skips_when_no_request_id(self) -> None:
-        mock_throttle = MagicMock()
-        mock_throttle.adjust_after_response = AsyncMock()
-
-        mock_request = MagicMock()
-        mock_request.state.throttle_context = MagicMock(request_id=None)
-        mock_request.app.state.output_throttles = [mock_throttle]
-
-        await adjust_output_throttles(mock_request, actual_output_tokens=500)
-
-        mock_throttle.adjust_after_response.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_continues_on_throttle_error(self) -> None:
-        failing_throttle = MagicMock()
-        failing_throttle.adjust_after_response = AsyncMock(side_effect=Exception("boom"))
-
-        succeeding_throttle = MagicMock()
-        succeeding_throttle.adjust_after_response = AsyncMock()
-
-        mock_request = MagicMock()
-        mock_request.state.throttle_context = MagicMock(request_id="req-123")
-        mock_request.app.state.output_throttles = [failing_throttle, succeeding_throttle]
-
-        await adjust_output_throttles(mock_request, actual_output_tokens=500)
-
-        failing_throttle.adjust_after_response.assert_called_once()
-        succeeding_throttle.adjust_after_response.assert_called_once()


### PR DESCRIPTION
The previous logic involved reservations and was complex and error prone.

This simplifies things and parses the token output from the response chunks for streams.