### PR TITLE
feat(product tours): add display frequency optoins for announcements, and clarify for tours

### DIFF
--- a/frontend/src/scenes/product-tours/components/AutoShowSection.tsx
+++ b/frontend/src/scenes/product-tours/components/AutoShowSection.tsx
@@ -8,6 +8,7 @@ import {
     LemonCollapse,
     LemonInput,
     LemonInputSelect,
+    LemonSegmentedButton,
     LemonSelect,
     Tooltip,
 } from '@posthog/lemon-ui'
@@ -28,11 +29,15 @@ import {
     ActionType,
     AnyPropertyFilter,
     ProductTourDisplayConditions,
+    ProductTourDisplayFrequency,
     PropertyDefinitionType,
     PropertyType,
     SurveyEventsWithProperties,
     SurveyMatchType,
 } from '~/types'
+
+import { productTourLogic } from '../productTourLogic'
+import { getDefaultDisplayFrequency, getDisplayFrequencyOptions, isAnnouncement } from '../productToursLogic'
 
 type TourTriggerType = 'immediate' | 'event' | 'action'
 
@@ -177,7 +182,10 @@ function EventTriggerContent({ conditions, onChange }: AutoShowSectionProps): JS
     )
 }
 
-export function AutoShowSection({ conditions, onChange }: AutoShowSectionProps): JSX.Element {
+export function AutoShowSection({ conditions, onChange }: AutoShowSectionProps): JSX.Element | null {
+    const { productTourForm, productTour } = useValues(productTourLogic)
+    const { setProductTourFormValue } = useActions(productTourLogic)
+
     // Load recent URLs from property definitions
     const { options } = useValues(propertyDefinitionsModel)
     const { loadPropertyValues } = useActions(propertyDefinitionsModel)
@@ -233,6 +241,12 @@ export function AutoShowSection({ conditions, onChange }: AutoShowSectionProps):
         { value: 'event' as const, label: 'When user sends an event' },
         { value: 'action' as const, label: 'When user performs an action' },
     ]
+
+    if (!productTour) {
+        return null
+    }
+
+    const displayFrequency = productTourForm.content?.displayFrequency
 
     return (
         <div className="space-y-4">
@@ -365,6 +379,28 @@ export function AutoShowSection({ conditions, onChange }: AutoShowSectionProps):
                     />
                     <span className="text-sm">seconds before showing the tour after the conditions are met</span>
                 </div>
+            </div>
+
+            <div>
+                <h5 className="font-semibold mb-2">How often to show</h5>
+                {isAnnouncement(productTour) ? (
+                    <LemonSegmentedButton
+                        value={displayFrequency ?? getDefaultDisplayFrequency(productTour).value}
+                        onChange={(value) =>
+                            setProductTourFormValue('content', {
+                                ...productTourForm.content,
+                                displayFrequency: value as ProductTourDisplayFrequency,
+                            })
+                        }
+                        options={getDisplayFrequencyOptions(productTour)}
+                        fullWidth
+                    />
+                ) : (
+                    <p>
+                        <IconInfo /> Product tours display once per user, until they interact (complete any steps, or
+                        dismiss the tour).
+                    </p>
+                )}
             </div>
         </div>
     )

--- a/frontend/src/scenes/product-tours/productToursLogic.ts
+++ b/frontend/src/scenes/product-tours/productToursLogic.ts
@@ -17,6 +17,7 @@ import {
     ProductTour,
     ProductTourButtonAction,
     ProductTourContent,
+    ProductTourDisplayFrequency,
     ProductTourStepButton,
     ProductTourStepButtons,
     ProgressStatus,
@@ -46,6 +47,52 @@ export const DEFAULT_SECONDARY_BUTTON: ProductTourStepButton = {
     text: 'Learn more',
     action: 'link',
     link: '',
+}
+
+interface ProductTourDisplayFrequencyOption {
+    value: ProductTourDisplayFrequency
+    label: string
+    tooltip?: string
+}
+
+export const BANNER_DISPLAY_FREQUENCY_OPTIONS: ProductTourDisplayFrequencyOption[] = [
+    {
+        value: 'until_interacted',
+        label: 'Until interacted',
+        tooltip: 'Shows until user dismisses or interacts',
+    },
+    {
+        value: 'always',
+        label: 'Always',
+        tooltip: 'Always shows when the rest of your conditions are met. Hides dismiss button.',
+    },
+]
+
+export const ANNOUNCEMENT_DISPLAY_FREQUENCY_OPTIONS: ProductTourDisplayFrequencyOption[] = [
+    { value: 'show_once', label: 'Once', tooltip: "Shows once per user, even if they don't interact" },
+    {
+        value: 'until_interacted',
+        label: 'Until interacted',
+        tooltip: 'Shows repeatedly until user clicks a button or dismisses',
+    },
+]
+
+export function getDisplayFrequencyOptions(tour: Pick<ProductTour, 'content'>): ProductTourDisplayFrequencyOption[] {
+    if (isBannerAnnouncement(tour)) {
+        return BANNER_DISPLAY_FREQUENCY_OPTIONS
+    }
+    if (isAnnouncement(tour)) {
+        return ANNOUNCEMENT_DISPLAY_FREQUENCY_OPTIONS
+    }
+    return []
+}
+
+export function getDefaultDisplayFrequency(tour: Pick<ProductTour, 'content'>): ProductTourDisplayFrequencyOption {
+    const options = getDisplayFrequencyOptions(tour)
+    if (options.length === 0) {
+        throw new Error(`No defaults found for tour type ${tour.content?.type}`)
+    }
+    return options[0]
 }
 
 export function getDefaultTourStepButtons(stepIndex: number, totalSteps: number): ProductTourStepButtons {
@@ -104,6 +151,7 @@ function createDefaultAnnouncementContent(): ProductTourContent {
             showOverlay: false,
             dismissOnClickOutside: false,
         },
+        displayFrequency: 'show_once',
     }
 }
 
@@ -141,6 +189,7 @@ function createDefaultBannerContent(): ProductTourContent {
             dismissOnClickOutside: false,
             whiteLabel: true, // banners simply have no branding
         },
+        displayFrequency: 'until_interacted',
     }
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3434,6 +3434,8 @@ export interface ProductTourAppearance {
 
 export type ProductTourType = 'tour' | 'announcement'
 
+export type ProductTourDisplayFrequency = 'show_once' | 'until_interacted' | 'always'
+
 export interface ProductTourContent {
     type?: ProductTourType
     steps: ProductTourStep[]
@@ -3441,6 +3443,7 @@ export interface ProductTourContent {
     conditions?: ProductTourDisplayConditions
     /** History of step order changes for funnel analysis */
     step_order_history?: StepOrderVersion[]
+    displayFrequency?: ProductTourDisplayFrequency
 }
 
 export interface ProductTour {

--- a/products/product_tours/backend/api/test/test_product_tour.py
+++ b/products/product_tours/backend/api/test/test_product_tour.py
@@ -2,6 +2,7 @@ from posthog.test.base import APIBaseTest
 
 from django.utils import timezone
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models.feature_flag import FeatureFlag
@@ -408,3 +409,83 @@ class TestProductTourInternalTargetingFlag(APIBaseTest):
         assert tour.internal_targeting_flag is not None
         assert tour.internal_targeting_flag.id == flag_id
         assert FeatureFlag.objects.get(id=flag_id).active
+
+    @parameterized.expand(
+        [
+            # (display_frequency, expected_exclusion_key_substrings)
+            ("show_once", ["$product_tour_shown"]),
+            ("until_interacted", ["$product_tour_completed", "$product_tour_dismissed"]),
+            ("always", []),
+            (None, ["$product_tour_completed", "$product_tour_dismissed"]),  # default behavior
+        ]
+    )
+    def test_flag_exclusion_properties_on_create(self, display_frequency, expected_key_substrings):
+        content: dict = {"steps": []}
+        if display_frequency is not None:
+            content["displayFrequency"] = display_frequency
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/product_tours/",
+            data={
+                "name": "Display frequency test",
+                "content": content,
+                "auto_launch": True,
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        tour = ProductTour.objects.get(id=response.json()["id"])
+        assert tour.internal_targeting_flag is not None
+
+        properties = tour.internal_targeting_flag.filters.get("groups", [{}])[0].get("properties", [])
+        property_keys = [p.get("key", "") for p in properties]
+
+        if expected_key_substrings:
+            for substring in expected_key_substrings:
+                assert any(substring in key for key in property_keys), f"Expected {substring} in {property_keys}"
+        else:
+            assert len(properties) == 0, f"Expected no exclusion properties, got {properties}"
+
+    @parameterized.expand(
+        [
+            # (initial_frequency, new_frequency, expected_exclusion_key_substrings)
+            ("show_once", "until_interacted", ["$product_tour_completed", "$product_tour_dismissed"]),
+            ("until_interacted", "show_once", ["$product_tour_shown"]),
+            ("show_once", "always", []),
+            ("always", "until_interacted", ["$product_tour_completed", "$product_tour_dismissed"]),
+        ]
+    )
+    def test_flag_exclusion_properties_updated_on_display_frequency_change(
+        self, initial_frequency, new_frequency, expected_key_substrings
+    ):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/product_tours/",
+            data={
+                "name": "Frequency change test",
+                "content": {"displayFrequency": initial_frequency, "steps": []},
+                "auto_launch": True,
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        tour_id = response.json()["id"]
+        tour = ProductTour.objects.get(id=tour_id)
+
+        # Update displayFrequency
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/product_tours/{tour_id}/",
+            data={"content": {"displayFrequency": new_frequency, "steps": []}},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        assert tour.internal_targeting_flag is not None
+        tour.internal_targeting_flag.refresh_from_db()
+        properties = tour.internal_targeting_flag.filters.get("groups", [{}])[0].get("properties", [])
+        property_keys = [p.get("key", "") for p in properties]
+
+        if expected_key_substrings:
+            for substring in expected_key_substrings:
+                assert any(substring in key for key in property_keys), f"Expected {substring} in {property_keys}"
+        else:
+            assert len(properties) == 0, f"Expected no exclusion properties, got {properties}"


### PR DESCRIPTION
## Problem

the default display frequency for _all_ tours right now (incl announcements & banners) is that we show until the tour is completed or dismissed.

this is fine for tours, but makes no sense for banners or announcements!

depends on https://github.com/PostHog/posthog-js/pull/2908 to actually work

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

this PR introduces the concept of "display frequency" with three options:

1. `always` -> always show, non-dismissible, etc
2. `until_interacted` -> show until user has some interaction with the tour (button click, dismiss, etc)
3. `once` -> only show once, regardless of whether the user interacted

note: without careful UX, **_these options will be confusing_**. so, we only expose certain options and defaults per tour type:

- **modal announcements**:
    - `show_once` (default)
    - `until_interacted`
- **banners**:
    - `until_interacted` (default)
    - `always`
- **tours**: have no options right now, and use `until_interacted` by default.
    - future: we'll probably add all the options, but need to clean up / think through resumeable tours. they are "resumable" now, but only in a given session.

| announcement | banner | tour |
| --- | --- | --- |
| ![Screenshot 2026-01-15 at 9.50.02 AM.png](https://app.graphite.com/user-attachments/assets/ebc0de93-f88c-49f3-a075-3f7ca6ebfeed.png)<br> | ![Screenshot 2026-01-15 at 10.16.40 AM.png](https://app.graphite.com/user-attachments/assets/abe23a3f-7558-49c9-be6c-9e9087772281.png)<br> | ![Screenshot 2026-01-15 at 10.16.03 AM.png](https://app.graphite.com/user-attachments/assets/68f02410-cf4f-4b8c-8197-805dbf96226e.png)<br> |

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no