### PR TITLE
fix(ci): add Slack alerts for Rust container build failures

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -157,7 +157,7 @@ jobs:
               with:
                   posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
                   event: 'posthog-rust-image-build'
-                  properties: '{"status": "failure", "commit_hash": "${{ github.sha }}"}'
+                  properties: '{"status": "failure", "commit_hash": "${{ github.sha }}", "image": "${{ matrix.image }}"}'
 
             - name: Container image digest
               id: digest

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -157,7 +157,7 @@ jobs:
               with:
                   posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
                   event: 'posthog-rust-image-build'
-                  properties: '{"status": "failure", "image": "${{ matrix.image }}", "commit_hash": "${{ github.sha }}", "runId": "${{ github.run_id }}"}'
+                  properties: '{"status": "failure", "commit_hash": "${{ github.sha }}"}'
 
             - name: Container image digest
               id: digest

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -151,6 +151,14 @@ jobs:
                       SCCACHE_WEBDAV_ENDPOINT=${{ steps.sccache.outputs.endpoint }}
                       SCCACHE_WEBDAV_TOKEN=${{ steps.sccache.outputs.token }}
 
+            - name: report failure
+              if: failure()
+              uses: PostHog/posthog-github-action@8c42e50f2c52e002eabb9bee3f69b152ee8fc1dd # v1.0.1
+              with:
+                  posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
+                  event: 'posthog-rust-image-build'
+                  properties: '{"status": "failure", "image": "${{ matrix.image }}", "commit_hash": "${{ github.sha }}", "runId": "${{ github.run_id }}"}'
+
             - name: Container image digest
               id: digest
               run: |


### PR DESCRIPTION
## Problem

Rust container builds were failing silently. The main PostHog container build alerts on failure, but Rust services (capture, cymbal, feature-flags, etc.) didn't have this alerting configured.

## Changes

- Adds a `report failure` step to the Rust container build workflow
- Sends `posthog-rust-image-build` event to PostHog on failure, which triggers a Slack alert via a destination (configured separately in PostHog)
- Matches the existing pattern used in `container-images-cd.yml` for the main PostHog image

## How did you test this code?

- [ ] Created PostHog destination matching on `posthog-rust-image-build` event
- [ ] Will verify Slack alert fires when a Rust build fails

## Publish to changelog?

no
