### PR TITLE
fix(insights): use correct timestamp for all time queries

### DIFF
--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -147,14 +147,11 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
     def to_queries(self) -> list[ast.SelectQuery | ast.SelectSetQuery]:
         queries = []
         with self.timings.measure("trends_to_query"):
-            earliest_timestamp = self._earliest_timestamp
             for series in self.series:
                 if not series.is_previous_period_series:
                     query_date_range = self.query_date_range
                 else:
                     query_date_range = self.query_previous_date_range
-
-                query_date_range._earliest_timestamp_fallback = earliest_timestamp
 
                 query_builder = TrendsQueryBuilder(
                     trends_query=series.overriden_query or self.query,
@@ -686,6 +683,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
             interval=interval,
             now=datetime.now(),
             exact_timerange=self.exact_timerange,
+            earliest_timestamp_fallback=self._earliest_timestamp,
         )
 
     @cached_property
@@ -699,6 +697,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
                 now=datetime.now(),
                 compare_to=self.query.compareFilter.compare_to,
                 exact_timerange=self.exact_timerange,
+                earliest_timestamp_fallback=self._earliest_timestamp,
             )
         return QueryPreviousPeriodDateRange(
             date_range=self.query.dateRange,
@@ -706,6 +705,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
             interval=self.query.interval,
             now=datetime.now(),
             exact_timerange=self.exact_timerange,
+            earliest_timestamp_fallback=self._earliest_timestamp,
         )
 
     def series_event(self, series: Union[EventsNode, ActionsNode, DataWarehouseNode, GroupNode]) -> str | None:


### PR DESCRIPTION
When using "All time" date range with a data warehouse table/view, the query was incorrectly using the earliest timestamp from the PostHog events table instead of from the data warehouse table itself.

This happened because QueryDateRange was created without the earliest_timestamp_fallback parameter, causing it to fall back to querying the events table when date_from == "all".

The fix passes earliest_timestamp_fallback when creating QueryDateRange objects, ensuring the correct timestamp is available from initialization.

## Problem

I found this issue while investigating this ticket: https://posthoghelp.zendesk.com/agent/tickets/47188 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49726)

Customers using data warehouse tables/views with "All time" date range were seeing incorrect date filtering. The query was using the earliest timestamp from the PostHog events table instead of from their data warehouse table, causing data to be filtered out unexpectedly.

For example, if a customer's PostHog events started on 2024-09-26 but their data warehouse table had data going back to 2020, the "All time" query would only show data from 2024-09-26 onwards.

## Changes

When creating QueryDateRange objects in TrendsQueryRunner, we now pass earliest_timestamp_fallback=self._earliest_timestamp at initialization time. Previously, this was being set later in to_queries(), but other code paths (like _refresh_frequency()) could call date_from() before that, causing it to fall back to the team's earliest event timestamp from the events table.

This follows the same pattern already used in LifecycleQueryRunner.

## How did you test this code?

Ran existing tests test_trends_data_warehouse_all_time and test_trends_events_and_data_warehouse_all_time which specifically test this scenario - both pass
Ran all 16 data warehouse query tests - all pass
Ran 188 trends tests (excluding materialized column tests due to local connection issues) - all pass
Ran 31 query_date_range tests - all pass

## Publish to changelog?

no
