### PR TITLE
fix(mcp): comply with RFC 9728 for OAuth protected resource metadata discovery

### DIFF
--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -110,16 +110,17 @@ class ActionSerializer(
         if attrs.get("pinned_at") == "":
             attrs["pinned_at"] = None
 
-        colliding_action_ids = list(
-            Action.objects.filter(name=attrs["name"], deleted=False, **include_args)
-            .exclude(**exclude_args)[:1]
-            .values_list("id", flat=True)
-        )
-        if colliding_action_ids:
-            raise serializers.ValidationError(
-                {"name": f"This project already has an action with this name, ID {colliding_action_ids[0]}"},
-                code="unique",
+        if "name" in attrs:
+            colliding_action_ids = list(
+                Action.objects.filter(name=attrs["name"], deleted=False, **include_args)
+                .exclude(**exclude_args)[:1]
+                .values_list("id", flat=True)
             )
+            if colliding_action_ids:
+                raise serializers.ValidationError(
+                    {"name": f"This project already has an action with this name, ID {colliding_action_ids[0]}"},
+                    code="unique",
+                )
 
         return attrs
 


### PR DESCRIPTION
## Problem

MCP clients like v0 strictly follow [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728), which specifies how OAuth protected resource metadata URLs should be constructed. Per RFC 9728 Section 3.1:

> The well-known URL is constructed by inserting `/.well-known/oauth-protected-resource` between the host and the path of the resource URL.

For example:
- Resource: `https://mcp.posthog.com/mcp` → Well-known: `https://mcp.posthog.com/.well-known/oauth-protected-resource/mcp`

Our current implementation serves metadata at `/.well-known/oauth-protected-resource` without the resource path suffix, causing RFC 9728-compliant clients to fail OAuth discovery.

## Changes

1. **Updated well-known endpoint routing** to handle URLs with resource path suffix (RFC 9728 compliance)

2. **Updated 401 WWW-Authenticate header** to include the resource path in the metadata URL

3. **Added `getPublicUrl()` helper** to respect `X-Forwarded-Host` and `X-Forwarded-Proto` headers from reverse proxies. This ensures the `resource` field contains the correct public URL when running behind proxies.

4. **Added tests** for RFC 9728-compliant URL construction

## How did you test this code?

- [x] All 135 tests pass
- [x] Local testing with ngrok tunnel + v0:
  - OAuth discovery succeeds ✅
  - Full OAuth flow completes successfully ✅
  - Resource URL correctly shows `https://` (not `http://localhost`)
- [x] Verified production `mcp.posthog.com/.well-known/oauth-protected-resource/mcp` returns 401 (the bug this fixes)

## Security notes

The `getPublicUrl()` helper trusts `X-Forwarded-*` headers, which is safe because:
- In production, Cloudflare Workers receive these headers from Cloudflare's edge (cannot be spoofed)
- In development, ngrok/cloudflared control these headers
- These URLs are only used for OAuth discovery metadata, not for authentication decisions