### PR TITLE
feat(surveys): Improve guided survey wizard UX

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -205,6 +205,7 @@
         "mdast-util-find-and-replace": "^3.0.2",
         "modern-screenshot": "^4.6.7",
         "monaco-editor": "^0.55.1",
+        "motion": "^12.26.1",
         "natural-orderby": "^3.0.2",
         "openai": "^4.81.0",
         "papaparse": "^5.4.1",

--- a/frontend/src/lib/components/EditableField/EditableField.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.tsx
@@ -53,6 +53,8 @@ export interface EditableFieldProps {
     clickToEdit?: boolean
     /** If true, uses a smaller pencil icon. */
     compactIcon?: boolean
+    /** If true, hides the edit icon until hover. */
+    showEditIconOnHover?: boolean
 }
 
 export function EditableField({
@@ -79,6 +81,7 @@ export function EditableField({
     notice,
     clickToEdit = false,
     compactIcon = false,
+    showEditIconOnHover = false,
 }: EditableFieldProps): JSX.Element {
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
     const [localIsEditing, setLocalIsEditing] = useState(mode === 'edit')
@@ -183,6 +186,7 @@ export function EditableField({
                 multiline && 'EditableField--multiline',
                 isEditing && 'EditableField--editing',
                 editingIndication === 'underlined' && 'EditableField--underlined',
+                showEditIconOnHover && 'group/editable',
                 className
             )}
             data-attr={dataAttr}
@@ -288,7 +292,13 @@ export function EditableField({
                             </Tooltip>
                         )}
                         {(!mode || !!onModeToggle) && (
-                            <div className="EditableField__actions">
+                            <div
+                                className={clsx(
+                                    'EditableField__actions',
+                                    showEditIconOnHover &&
+                                        'opacity-0 group-hover/editable:opacity-100 transition-opacity'
+                                )}
+                            >
                                 <LemonButton
                                     title="Edit"
                                     icon={<IconPencil className={compactIcon ? 'w-3 h-3' : undefined} />}

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -744,21 +744,6 @@ export const surveyThemes: SurveyTheme[] = [
     },
     // Dark themes
     {
-        id: 'midnight',
-        name: 'Midnight',
-        description: 'Dark & sophisticated',
-        appearance: {
-            backgroundColor: '#1a1a2e',
-            textColor: '#eaeaea',
-            borderColor: '#4a4a6a',
-            submitButtonColor: '#6366f1',
-            submitButtonTextColor: '#ffffff',
-            ratingButtonColor: '#2d2d44',
-            ratingButtonActiveColor: '#6366f1',
-            inputBackground: '#252540',
-        },
-    },
-    {
         id: 'carbon',
         name: 'Carbon',
         description: 'Dark & neutral',
@@ -771,6 +756,21 @@ export const surveyThemes: SurveyTheme[] = [
             ratingButtonColor: '#262626',
             ratingButtonActiveColor: '#fafafa',
             inputBackground: '#262626',
+        },
+    },
+    {
+        id: 'midnight',
+        name: 'Midnight',
+        description: 'Dark & sophisticated',
+        appearance: {
+            backgroundColor: '#1a1a2e',
+            textColor: '#eaeaea',
+            borderColor: '#4a4a6a',
+            submitButtonColor: '#6366f1',
+            submitButtonTextColor: '#ffffff',
+            ratingButtonColor: '#2d2d44',
+            ratingButtonActiveColor: '#6366f1',
+            inputBackground: '#252540',
         },
     },
     {

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -31,6 +31,14 @@ export const SurveyQuestionLabel: Record<SurveyQuestionType, string> = {
     [SurveyQuestionType.MultipleChoice]: 'Multiple choice select',
 }
 
+export const QUESTION_TYPE_OPTIONS = [
+    { type: SurveyQuestionType.Open, label: 'Open text', icon: <IconComment /> },
+    { type: SurveyQuestionType.Rating, label: 'Rating', icon: <IconAreaChart /> },
+    { type: SurveyQuestionType.SingleChoice, label: 'Single choice', icon: <IconListView /> },
+    { type: SurveyQuestionType.MultipleChoice, label: 'Multiple choice', icon: <IconGridView /> },
+    { type: SurveyQuestionType.Link, label: 'Link / Announcement', icon: <IconLink /> },
+]
+
 // Rating scale constants
 export const SURVEY_RATING_SCALE = {
     EMOJI_3_POINT: 3,

--- a/frontend/src/scenes/surveys/wizard/AddQuestionButton.tsx
+++ b/frontend/src/scenes/surveys/wizard/AddQuestionButton.tsx
@@ -2,40 +2,12 @@ import { AnimatePresence } from 'motion/react'
 import * as motion from 'motion/react-client'
 import { useEffect, useRef, useState } from 'react'
 
-import { IconComment, IconPlus, IconX } from '@posthog/icons'
+import { IconPlus, IconX } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
-
-import { IconAreaChart, IconGridView, IconLink, IconListView } from 'lib/lemon-ui/icons'
 
 import { SurveyQuestionType } from '~/types'
 
-const QUESTION_TYPE_OPTIONS = [
-    {
-        type: SurveyQuestionType.Open,
-        label: 'Open text',
-        icon: <IconComment />,
-    },
-    {
-        type: SurveyQuestionType.Rating,
-        label: 'Rating',
-        icon: <IconAreaChart />,
-    },
-    {
-        type: SurveyQuestionType.SingleChoice,
-        label: 'Single choice',
-        icon: <IconListView />,
-    },
-    {
-        type: SurveyQuestionType.MultipleChoice,
-        label: 'Multiple choice',
-        icon: <IconGridView />,
-    },
-    {
-        type: SurveyQuestionType.Link,
-        label: 'Link / Announcement',
-        icon: <IconLink />,
-    },
-]
+import { QUESTION_TYPE_OPTIONS } from '../constants'
 
 interface AddQuestionButtonProps {
     onAdd: (type: SurveyQuestionType) => void
@@ -54,8 +26,9 @@ export function AddQuestionButton({ onAdd }: AddQuestionButtonProps): JSX.Elemen
 
         if (isExpanded) {
             document.addEventListener('mousedown', handleClickOutside)
-            return () => document.removeEventListener('mousedown', handleClickOutside)
         }
+
+        return () => document.removeEventListener('mousedown', handleClickOutside)
     }, [isExpanded])
 
     const handleAddQuestion = (type: SurveyQuestionType): void => {

--- a/frontend/src/scenes/surveys/wizard/AddQuestionButton.tsx
+++ b/frontend/src/scenes/surveys/wizard/AddQuestionButton.tsx
@@ -1,0 +1,137 @@
+import { AnimatePresence } from 'motion/react'
+import * as motion from 'motion/react-client'
+import { useEffect, useRef, useState } from 'react'
+
+import { IconComment, IconPlus, IconX } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { IconAreaChart, IconGridView, IconLink, IconListView } from 'lib/lemon-ui/icons'
+
+import { SurveyQuestionType } from '~/types'
+
+const QUESTION_TYPE_OPTIONS = [
+    {
+        type: SurveyQuestionType.Open,
+        label: 'Open text',
+        icon: <IconComment />,
+    },
+    {
+        type: SurveyQuestionType.Rating,
+        label: 'Rating',
+        icon: <IconAreaChart />,
+    },
+    {
+        type: SurveyQuestionType.SingleChoice,
+        label: 'Single choice',
+        icon: <IconListView />,
+    },
+    {
+        type: SurveyQuestionType.MultipleChoice,
+        label: 'Multiple choice',
+        icon: <IconGridView />,
+    },
+    {
+        type: SurveyQuestionType.Link,
+        label: 'Link / Announcement',
+        icon: <IconLink />,
+    },
+]
+
+interface AddQuestionButtonProps {
+    onAdd: (type: SurveyQuestionType) => void
+}
+
+export function AddQuestionButton({ onAdd }: AddQuestionButtonProps): JSX.Element {
+    const [isExpanded, setIsExpanded] = useState(false)
+    const containerRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        function handleClickOutside(event: MouseEvent): void {
+            if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+                setIsExpanded(false)
+            }
+        }
+
+        if (isExpanded) {
+            document.addEventListener('mousedown', handleClickOutside)
+            return () => document.removeEventListener('mousedown', handleClickOutside)
+        }
+    }, [isExpanded])
+
+    const handleAddQuestion = (type: SurveyQuestionType): void => {
+        onAdd(type)
+        setIsExpanded(false)
+    }
+
+    return (
+        <div ref={containerRef} className="relative">
+            <AnimatePresence mode="wait">
+                {!isExpanded ? (
+                    <motion.div
+                        key="collapsed"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.15 }}
+                    >
+                        <LemonButton
+                            type="secondary"
+                            icon={<IconPlus />}
+                            onClick={() => setIsExpanded(true)}
+                            fullWidth
+                            center
+                        >
+                            Add question
+                        </LemonButton>
+                    </motion.div>
+                ) : (
+                    <motion.div
+                        key="expanded"
+                        initial={{ opacity: 0, y: -8 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -8 }}
+                        transition={{
+                            type: 'spring',
+                            duration: 0.3,
+                            bounce: 0.2,
+                        }}
+                        className="flex flex-wrap gap-2 p-3 border border-border rounded-lg bg-bg-light"
+                    >
+                        <div className="w-full flex items-center justify-between mb-1">
+                            <p className="text-xs text-secondary">Select question type</p>
+                            <LemonButton
+                                icon={<IconX />}
+                                size="xsmall"
+                                type="tertiary"
+                                onClick={() => setIsExpanded(false)}
+                                tooltip="Cancel"
+                            />
+                        </div>
+                        {QUESTION_TYPE_OPTIONS.map((option, index) => (
+                            <motion.div
+                                key={option.type}
+                                initial={{ opacity: 0, scale: 0.8 }}
+                                animate={{ opacity: 1, scale: 1 }}
+                                transition={{
+                                    type: 'spring',
+                                    duration: 0.25,
+                                    bounce: 0.3,
+                                    delay: index * 0.03,
+                                }}
+                            >
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    icon={option.icon}
+                                    onClick={() => handleAddQuestion(option.type)}
+                                >
+                                    {option.label}
+                                </LemonButton>
+                            </motion.div>
+                        ))}
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/wizard/QuestionTypeChip.tsx
+++ b/frontend/src/scenes/surveys/wizard/QuestionTypeChip.tsx
@@ -1,0 +1,80 @@
+import { IconChevronDown, IconComment } from '@posthog/icons'
+import { LemonDropdown } from '@posthog/lemon-ui'
+
+import { IconAreaChart, IconGridView, IconLink, IconListView } from 'lib/lemon-ui/icons'
+
+import { SurveyQuestionType } from '~/types'
+
+import { SurveyQuestionLabel } from '../constants'
+
+const QUESTION_TYPE_OPTIONS = [
+    {
+        type: SurveyQuestionType.Open,
+        label: 'Open text',
+        icon: <IconComment className="text-sm" />,
+    },
+    {
+        type: SurveyQuestionType.Rating,
+        label: 'Rating',
+        icon: <IconAreaChart className="text-sm" />,
+    },
+    {
+        type: SurveyQuestionType.SingleChoice,
+        label: 'Single choice',
+        icon: <IconListView className="text-sm" />,
+    },
+    {
+        type: SurveyQuestionType.MultipleChoice,
+        label: 'Multiple choice',
+        icon: <IconGridView className="text-sm" />,
+    },
+    {
+        type: SurveyQuestionType.Link,
+        label: 'Link / Announcement',
+        icon: <IconLink className="text-sm" />,
+    },
+]
+
+function getIconForType(type: SurveyQuestionType): JSX.Element {
+    const option = QUESTION_TYPE_OPTIONS.find((o) => o.type === type)
+    return option?.icon || <IconComment className="text-sm" />
+}
+
+interface QuestionTypeChipProps {
+    type: SurveyQuestionType
+    onChange: (newType: SurveyQuestionType) => void
+}
+
+export function QuestionTypeChip({ type, onChange }: QuestionTypeChipProps): JSX.Element {
+    return (
+        <LemonDropdown
+            overlay={
+                <div className="p-1 space-y-0.5">
+                    {QUESTION_TYPE_OPTIONS.map((option) => (
+                        <button
+                            key={option.type}
+                            type="button"
+                            onClick={() => onChange(option.type)}
+                            className={`flex items-center gap-2 w-full px-2 py-1.5 text-left text-sm rounded hover:bg-fill-highlight-100 transition-colors ${
+                                option.type === type ? 'bg-fill-highlight-100 font-medium' : ''
+                            }`}
+                        >
+                            {option.icon}
+                            <span>{option.label}</span>
+                        </button>
+                    ))}
+                </div>
+            }
+            placement="bottom-start"
+        >
+            <button
+                type="button"
+                className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded border border-border bg-bg-light hover:border-border-bold hover:bg-fill-highlight-50 transition-colors cursor-pointer"
+            >
+                {getIconForType(type)}
+                <span>{SurveyQuestionLabel[type]}</span>
+                <IconChevronDown className="text-secondary text-xs" />
+            </button>
+        </LemonDropdown>
+    )
+}

--- a/frontend/src/scenes/surveys/wizard/QuestionTypeChip.tsx
+++ b/frontend/src/scenes/surveys/wizard/QuestionTypeChip.tsx
@@ -1,43 +1,16 @@
+import { cloneElement } from 'react'
+
 import { IconChevronDown, IconComment } from '@posthog/icons'
 import { LemonDropdown } from '@posthog/lemon-ui'
 
-import { IconAreaChart, IconGridView, IconLink, IconListView } from 'lib/lemon-ui/icons'
-
 import { SurveyQuestionType } from '~/types'
 
-import { SurveyQuestionLabel } from '../constants'
-
-const QUESTION_TYPE_OPTIONS = [
-    {
-        type: SurveyQuestionType.Open,
-        label: 'Open text',
-        icon: <IconComment className="text-sm" />,
-    },
-    {
-        type: SurveyQuestionType.Rating,
-        label: 'Rating',
-        icon: <IconAreaChart className="text-sm" />,
-    },
-    {
-        type: SurveyQuestionType.SingleChoice,
-        label: 'Single choice',
-        icon: <IconListView className="text-sm" />,
-    },
-    {
-        type: SurveyQuestionType.MultipleChoice,
-        label: 'Multiple choice',
-        icon: <IconGridView className="text-sm" />,
-    },
-    {
-        type: SurveyQuestionType.Link,
-        label: 'Link / Announcement',
-        icon: <IconLink className="text-sm" />,
-    },
-]
+import { QUESTION_TYPE_OPTIONS, SurveyQuestionLabel } from '../constants'
 
 function getIconForType(type: SurveyQuestionType): JSX.Element {
     const option = QUESTION_TYPE_OPTIONS.find((o) => o.type === type)
-    return option?.icon || <IconComment className="text-sm" />
+    const icon = option?.icon || <IconComment />
+    return cloneElement(icon, { className: 'text-sm' })
 }
 
 interface QuestionTypeChipProps {
@@ -59,7 +32,7 @@ export function QuestionTypeChip({ type, onChange }: QuestionTypeChipProps): JSX
                                 option.type === type ? 'bg-fill-highlight-100 font-medium' : ''
                             }`}
                         >
-                            {option.icon}
+                            {cloneElement(option.icon, { className: 'text-sm' })}
                             <span>{option.label}</span>
                         </button>
                     ))}

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -13,7 +13,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
-import { SurveyQuestionBranchingType } from '~/types'
+import { LinkSurveyQuestion, SurveyQuestionBranchingType, SurveyQuestionType } from '~/types'
 
 import { SurveyAppearancePreview } from '../SurveyAppearancePreview'
 import { NewSurvey } from '../constants'
@@ -51,6 +51,15 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
 
     // Survey form state from surveyLogic
     const { survey } = useValues(surveyLogic)
+
+    // Validate Link questions have valid URLs
+    const hasInvalidLinkUrl = survey.questions.some((q) => {
+        if (q.type === SurveyQuestionType.Link) {
+            const link = (q as LinkSurveyQuestion).link || ''
+            return link && !link.startsWith('https://') && !link.startsWith('mailto:')
+        }
+        return false
+    })
 
     const { currentTeam } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
@@ -202,6 +211,9 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                                     type="primary"
                                     loading={surveyLaunching}
                                     disabled={surveySaving}
+                                    disabledReason={
+                                        hasInvalidLinkUrl ? 'Fix invalid link URLs before launching' : undefined
+                                    }
                                     onClick={handleLaunchClick}
                                 >
                                     Launch survey
@@ -253,13 +265,22 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                                             type="primary"
                                             loading={surveyLaunching}
                                             disabled={surveySaving}
+                                            disabledReason={
+                                                hasInvalidLinkUrl ? 'Fix invalid link URLs before launching' : undefined
+                                            }
                                             onClick={handleLaunchClick}
                                         >
                                             Launch survey
                                         </LemonButton>
                                     )
                                 ) : (
-                                    <LemonButton type="primary" onClick={nextStep}>
+                                    <LemonButton
+                                        type="primary"
+                                        onClick={nextStep}
+                                        disabledReason={
+                                            hasInvalidLinkUrl ? 'Fix invalid link URLs before continuing' : undefined
+                                        }
+                                    >
                                         Continue
                                     </LemonButton>
                                 )}

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -1,7 +1,8 @@
+import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { getNextSurveyStep } from 'posthog-js/dist/surveys-preview'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { IconArrowLeft, IconChevronLeft, IconChevronRight } from '@posthog/icons'
 import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
@@ -11,6 +12,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { SurveyQuestionBranchingType } from '~/types'
 
 import { SurveyAppearancePreview } from '../SurveyAppearancePreview'
@@ -42,7 +44,8 @@ function SurveyWizardComponent({ id }: SurveyWizardLogicProps): JSX.Element {
 }
 
 function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
-    const { currentStep, createdSurvey, surveyLaunching, surveySaving, surveyLoading } = useValues(surveyWizardLogic)
+    const { currentStep, createdSurvey, surveyLaunching, surveySaving, surveyLoading, selectedTemplate } =
+        useValues(surveyWizardLogic)
     const isEditing = id !== 'new'
     const { nextStep, setStep, launchSurvey, saveDraft, updateSurvey } = useActions(surveyWizardLogic)
 
@@ -51,8 +54,19 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
 
     const { currentTeam } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
+    const { isDarkModeOn } = useValues(themeLogic)
 
     const [previewPageIndex, setPreviewPageIndex] = useState(0)
+
+    // Reset preview index if it's out of bounds (e.g., when disabling thank you message)
+    useEffect(() => {
+        const maxIndex = survey.appearance?.displayThankYouMessage
+            ? survey.questions.length
+            : survey.questions.length - 1
+        if (previewPageIndex > maxIndex) {
+            setPreviewPageIndex(Math.max(0, maxIndex))
+        }
+    }, [survey.appearance?.displayThankYouMessage, survey.questions.length, previewPageIndex])
 
     // Show loading state while loading existing survey
     if (isEditing && surveyLoading) {
@@ -143,23 +157,27 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
         )
     }
 
-    // Back button destination
+    // Back button destination with template indicator
     const backButton = isEditing ? (
         <LemonButton type="tertiary" size="small" icon={<IconArrowLeft />} to={urls.survey(id)}>
             Survey
         </LemonButton>
     ) : (
-        <LemonButton type="tertiary" size="small" icon={<IconArrowLeft />} onClick={() => setStep('template')}>
-            Templates
-        </LemonButton>
+        <div className="flex items-center gap-2">
+            <LemonButton type="tertiary" size="small" icon={<IconArrowLeft />} onClick={() => setStep('template')}>
+                Templates
+            </LemonButton>
+            {selectedTemplate && <span className="text-muted text-sm">· {selectedTemplate.templateType}</span>}
+        </div>
     )
 
     // Shared header for all main steps
     const header = (
-        <div className="flex items-center justify-between">
+        <div className="space-y-4">
             {backButton}
-            <WizardStepper currentStep={currentStep} onStepClick={setStep} />
-            <div className="w-20" />
+            <div className="flex justify-center">
+                <WizardStepper currentStep={currentStep} onStepClick={setStep} />
+            </div>
         </div>
     )
 
@@ -261,7 +279,12 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                     {/* Right: Preview */}
                     <div className="lg:col-span-2 hidden lg:block">
                         <div className="sticky top-6">
-                            <div className="flex items-center justify-center p-4 bg-fill-primary rounded-lg min-h-[360px]">
+                            <div
+                                className={clsx(
+                                    'flex items-center justify-center p-4 rounded-lg min-h-[360px] border border-border',
+                                    isDarkModeOn ? 'bg-[#1d1f27]' : 'bg-white'
+                                )}
+                            >
                                 <SurveyAppearancePreview
                                     survey={previewSurvey}
                                     previewPageIndex={previewPageIndex}
@@ -292,21 +315,23 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                                         disabledReason={previewPageIndex === 0 ? 'First question' : undefined}
                                     />
                                     <span className="text-muted text-xs min-w-[60px] text-center">
-                                        {previewPageIndex < previewSurvey.questions.length
-                                            ? `${previewPageIndex + 1} / ${previewSurvey.questions.length}`
-                                            : 'Thanks'}
+                                        {`${previewPageIndex + 1} / ${previewSurvey.questions.length + (previewSurvey.appearance?.displayThankYouMessage ? 1 : 0)}`}
                                     </span>
                                     <LemonButton
                                         type="secondary"
                                         size="small"
                                         icon={<IconChevronRight />}
-                                        onClick={() =>
-                                            setPreviewPageIndex(
-                                                Math.min(previewSurvey.questions.length, previewPageIndex + 1)
-                                            )
-                                        }
+                                        onClick={() => {
+                                            const maxIndex = previewSurvey.appearance?.displayThankYouMessage
+                                                ? previewSurvey.questions.length
+                                                : previewSurvey.questions.length - 1
+                                            setPreviewPageIndex(Math.min(maxIndex, previewPageIndex + 1))
+                                        }}
                                         disabledReason={
-                                            previewPageIndex >= previewSurvey.questions.length
+                                            previewPageIndex >=
+                                            (previewSurvey.appearance?.displayThankYouMessage
+                                                ? previewSurvey.questions.length
+                                                : previewSurvey.questions.length - 1)
                                                 ? 'Last screen'
                                                 : undefined
                                         }

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -63,10 +63,8 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
         const maxIndex = survey.appearance?.displayThankYouMessage
             ? survey.questions.length
             : survey.questions.length - 1
-        if (previewPageIndex > maxIndex) {
-            setPreviewPageIndex(Math.max(0, maxIndex))
-        }
-    }, [survey.appearance?.displayThankYouMessage, survey.questions.length, previewPageIndex])
+        setPreviewPageIndex((current) => (current > maxIndex ? Math.max(0, maxIndex) : current))
+    }, [survey.appearance?.displayThankYouMessage, survey.questions.length])
 
     // Show loading state while loading existing survey
     if (isEditing && surveyLoading) {

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -13,7 +13,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
-import { LinkSurveyQuestion, SurveyQuestionBranchingType, SurveyQuestionType } from '~/types'
+import { SurveyQuestionBranchingType } from '~/types'
 
 import { SurveyAppearancePreview } from '../SurveyAppearancePreview'
 import { NewSurvey } from '../constants'
@@ -44,22 +44,21 @@ function SurveyWizardComponent({ id }: SurveyWizardLogicProps): JSX.Element {
 }
 
 function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
-    const { currentStep, createdSurvey, surveyLaunching, surveySaving, surveyLoading, selectedTemplate } =
-        useValues(surveyWizardLogic)
+    const {
+        currentStep,
+        createdSurvey,
+        surveyLaunching,
+        surveySaving,
+        surveyLoading,
+        selectedTemplate,
+        stepValidationErrors,
+        currentStepHasErrors,
+    } = useValues(surveyWizardLogic)
     const isEditing = id !== 'new'
     const { nextStep, setStep, launchSurvey, saveDraft, updateSurvey } = useActions(surveyWizardLogic)
 
     // Survey form state from surveyLogic
     const { survey } = useValues(surveyLogic)
-
-    // Validate Link questions have valid URLs
-    const hasInvalidLinkUrl = survey.questions.some((q) => {
-        if (q.type === SurveyQuestionType.Link) {
-            const link = (q as LinkSurveyQuestion).link || ''
-            return link && !link.startsWith('https://') && !link.startsWith('mailto:')
-        }
-        return false
-    })
 
     const { currentTeam } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
@@ -183,7 +182,7 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
         <div className="space-y-4">
             {backButton}
             <div className="flex justify-center">
-                <WizardStepper currentStep={currentStep} onStepClick={setStep} />
+                <WizardStepper currentStep={currentStep} onStepClick={setStep} stepErrors={stepValidationErrors} />
             </div>
         </div>
     )
@@ -211,9 +210,7 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                                     type="primary"
                                     loading={surveyLaunching}
                                     disabled={surveySaving}
-                                    disabledReason={
-                                        hasInvalidLinkUrl ? 'Fix invalid link URLs before launching' : undefined
-                                    }
+                                    disabledReason={currentStepHasErrors ? 'Fix errors before launching' : undefined}
                                     onClick={handleLaunchClick}
                                 >
                                     Launch survey
@@ -266,7 +263,7 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                                             loading={surveyLaunching}
                                             disabled={surveySaving}
                                             disabledReason={
-                                                hasInvalidLinkUrl ? 'Fix invalid link URLs before launching' : undefined
+                                                currentStepHasErrors ? 'Fix errors before launching' : undefined
                                             }
                                             onClick={handleLaunchClick}
                                         >
@@ -278,7 +275,7 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                                         type="primary"
                                         onClick={nextStep}
                                         disabledReason={
-                                            hasInvalidLinkUrl ? 'Fix invalid link URLs before continuing' : undefined
+                                            currentStepHasErrors ? 'Fix errors before continuing' : undefined
                                         }
                                     >
                                         Continue

--- a/frontend/src/scenes/surveys/wizard/WizardStepper.tsx
+++ b/frontend/src/scenes/surveys/wizard/WizardStepper.tsx
@@ -1,4 +1,5 @@
-import { IconCheckCircle } from '@posthog/icons'
+import { IconCheckCircle, IconWarning } from '@posthog/icons'
+import { Tooltip } from '@posthog/lemon-ui'
 
 import { cn } from 'lib/utils/css-classes'
 
@@ -29,10 +30,21 @@ const STEP_ORDER: Record<WizardStep, number> = {
 interface WizardStepperProps {
     currentStep: WizardStep
     onStepClick: (step: WizardStep) => void
+    stepErrors?: Record<WizardStep, string[]>
 }
 
-export function WizardStepper({ currentStep, onStepClick }: WizardStepperProps): JSX.Element {
+export function WizardStepper({ currentStep, onStepClick, stepErrors = {} }: WizardStepperProps): JSX.Element {
     const currentOrder = STEP_ORDER[currentStep]
+    const currentStepHasErrors = (stepErrors[currentStep]?.length ?? 0) > 0
+
+    const handleStepClick = (step: WizardStep): void => {
+        // Block navigation if current step has errors (except going back)
+        const targetOrder = STEP_ORDER[step]
+        if (currentStepHasErrors && targetOrder > currentOrder) {
+            return // Don't navigate forward when current step has errors
+        }
+        onStepClick(step)
+    }
 
     return (
         <nav className="flex items-center" aria-label="Survey wizard progress">
@@ -40,6 +52,57 @@ export function WizardStepper({ currentStep, onStepClick }: WizardStepperProps):
                 const stepOrder = STEP_ORDER[step.key]
                 const isCompleted = currentOrder > stepOrder
                 const isCurrent = currentStep === step.key
+                const hasErrors = (stepErrors[step.key]?.length ?? 0) > 0
+                const isBlocked = currentStepHasErrors && stepOrder > currentOrder
+
+                const button = (
+                    <button
+                        type="button"
+                        onClick={() => handleStepClick(step.key)}
+                        disabled={isBlocked}
+                        className={cn(
+                            'group flex items-center gap-1.5 px-2 py-1 rounded',
+                            'transition-all duration-150',
+                            'focus:outline-none focus-visible:ring-1 focus-visible:ring-accent',
+                            isBlocked
+                                ? 'opacity-50 cursor-not-allowed'
+                                : 'hover:bg-fill-button-tertiary-hover active:scale-[0.98]'
+                        )}
+                        aria-current={isCurrent ? 'step' : undefined}
+                    >
+                        {/* Indicator */}
+                        {hasErrors && isCurrent ? (
+                            <IconWarning className="size-5 text-warning" />
+                        ) : isCompleted ? (
+                            <IconCheckCircle className="size-5 text-success" />
+                        ) : (
+                            <span
+                                className={cn(
+                                    'flex items-center justify-center size-5 rounded-full text-xs font-semibold',
+                                    'transition-all duration-150',
+                                    isCurrent && 'bg-accent text-primary-inverse ring-2 ring-accent/25',
+                                    !isCurrent && 'bg-surface-secondary text-secondary border border-primary'
+                                )}
+                            >
+                                {index + 1}
+                            </span>
+                        )}
+
+                        {/* Label */}
+                        <span
+                            className={cn(
+                                'text-sm transition-colors duration-150',
+                                isCurrent && 'font-semibold text-primary',
+                                isCompleted && 'font-medium text-primary',
+                                !isCompleted && !isCurrent && 'text-secondary'
+                            )}
+                        >
+                            {step.label}
+                        </span>
+
+                        {step.optional && <span className="text-xs text-tertiary">optional</span>}
+                    </button>
+                )
 
                 return (
                     <div key={step.key} className="flex items-center">
@@ -48,53 +111,17 @@ export function WizardStepper({ currentStep, onStepClick }: WizardStepperProps):
                             <div
                                 className={cn(
                                     'w-6 h-px transition-colors duration-150',
-                                    isCompleted || isCurrent ? 'bg-success' : 'bg-border-primary'
+                                    hasErrors && isCurrent
+                                        ? 'bg-warning'
+                                        : isCompleted || isCurrent
+                                          ? 'bg-success'
+                                          : 'bg-border-primary'
                                 )}
                             />
                         )}
 
                         {/* Step */}
-                        <button
-                            type="button"
-                            onClick={() => onStepClick(step.key)}
-                            className={cn(
-                                'group flex items-center gap-1.5 px-2 py-1 rounded',
-                                'transition-all duration-150',
-                                'hover:bg-fill-button-tertiary-hover active:scale-[0.98]',
-                                'focus:outline-none focus-visible:ring-1 focus-visible:ring-accent'
-                            )}
-                            aria-current={isCurrent ? 'step' : undefined}
-                        >
-                            {/* Indicator */}
-                            {isCompleted ? (
-                                <IconCheckCircle className="size-5 text-success" />
-                            ) : (
-                                <span
-                                    className={cn(
-                                        'flex items-center justify-center size-5 rounded-full text-xs font-semibold',
-                                        'transition-all duration-150',
-                                        isCurrent && 'bg-accent text-primary-inverse ring-2 ring-accent/25',
-                                        !isCurrent && 'bg-surface-secondary text-secondary border border-primary'
-                                    )}
-                                >
-                                    {index + 1}
-                                </span>
-                            )}
-
-                            {/* Label */}
-                            <span
-                                className={cn(
-                                    'text-sm transition-colors duration-150',
-                                    isCurrent && 'font-semibold text-primary',
-                                    isCompleted && 'font-medium text-primary',
-                                    !isCompleted && !isCurrent && 'text-secondary'
-                                )}
-                            >
-                                {step.label}
-                            </span>
-
-                            {step.optional && <span className="text-xs text-tertiary">optional</span>}
-                        </button>
+                        {isBlocked ? <Tooltip title="Fix errors before proceeding">{button}</Tooltip> : button}
                     </div>
                 )
             })}

--- a/frontend/src/scenes/surveys/wizard/WizardStepper.tsx
+++ b/frontend/src/scenes/surveys/wizard/WizardStepper.tsx
@@ -30,7 +30,7 @@ const STEP_ORDER: Record<WizardStep, number> = {
 interface WizardStepperProps {
     currentStep: WizardStep
     onStepClick: (step: WizardStep) => void
-    stepErrors?: Record<WizardStep, string[]>
+    stepErrors?: Partial<Record<WizardStep, string[]>>
 }
 
 export function WizardStepper({ currentStep, onStepClick, stepErrors = {} }: WizardStepperProps): JSX.Element {

--- a/frontend/src/scenes/surveys/wizard/steps/AppearanceStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/AppearanceStep.tsx
@@ -11,6 +11,7 @@ import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic
 import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import {
     AvailableFeature,
     SurveyAppearance,
@@ -31,9 +32,12 @@ export function AppearanceStep(): JSX.Element {
     const { setSurveyValue } = useActions(surveyLogic)
     const { surveysStylingAvailable } = useValues(surveysLogic)
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
+    const { isDarkModeOn } = useValues(themeLogic)
 
     const [previewPageIndex, setPreviewPageIndex] = useState(0)
-    const [previewBackground, setPreviewBackground] = useState<'light' | 'dark'>('light')
+    const [previewBackground, setPreviewBackground] = useState<'light' | 'dark'>(() =>
+        isDarkModeOn ? 'dark' : 'light'
+    )
     const [selectedThemeId, setSelectedThemeId] = useState<string | null>(() => {
         const currentAppearance = survey.appearance
         if (!currentAppearance) {
@@ -230,39 +234,6 @@ export function AppearanceStep(): JSX.Element {
                                             />
                                         </LemonField.Pure>
                                     </div>
-                                    <LemonField.Pure className="gap-1">
-                                        <div className="flex items-center gap-2">
-                                            <LemonCheckbox
-                                                checked={!!appearance.surveyPopupDelaySeconds}
-                                                onChange={(checked) => {
-                                                    onAppearanceChange({
-                                                        surveyPopupDelaySeconds: checked ? 5 : undefined,
-                                                    })
-                                                }}
-                                                disabled={!surveysStylingAvailable}
-                                            />
-                                            <span className="text-sm">
-                                                Delay survey popup by{' '}
-                                                <LemonInput
-                                                    type="number"
-                                                    size="small"
-                                                    min={1}
-                                                    max={3600}
-                                                    value={appearance.surveyPopupDelaySeconds}
-                                                    onChange={(newValue) => {
-                                                        if (newValue && newValue > 0) {
-                                                            onAppearanceChange({ surveyPopupDelaySeconds: newValue })
-                                                        } else {
-                                                            onAppearanceChange({ surveyPopupDelaySeconds: undefined })
-                                                        }
-                                                    }}
-                                                    className="w-16 inline-block mx-1"
-                                                    disabled={!surveysStylingAvailable}
-                                                />{' '}
-                                                seconds
-                                            </span>
-                                        </div>
-                                    </LemonField.Pure>
                                 </div>
                             ),
                         },

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -4,7 +4,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { useActions, useValues } from 'kea'
 import { AnimatePresence, motion } from 'motion/react'
 
-import { IconPlusSmall, IconRevert, IconTrash } from '@posthog/icons'
+import { IconEmoji, IconPlusSmall, IconRevert, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonInput, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
 
 import { EditableField } from 'lib/components/EditableField/EditableField'
@@ -65,11 +65,11 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
                                         scale: SURVEY_RATING_SCALE.LIKERT_5_POINT,
                                     } as Partial<RatingSurveyQuestion>)
                                 }
-                                className={`px-3 py-2 text-lg transition-colors ${
+                                className={`px-3 py-2 transition-colors ${
                                     isEmoji ? 'bg-fill-highlight-100' : 'hover:bg-fill-highlight-50'
                                 }`}
                             >
-                                😀
+                                <IconEmoji className="text-lg" />
                             </button>
                             <button
                                 type="button"

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -244,27 +244,32 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
     if (question.type === SurveyQuestionType.Link) {
         const linkQuestion = question as LinkSurveyQuestion
         return (
-            <div className="space-y-2 pt-2 border-t border-border mt-3">
-                <div className="flex items-center gap-2">
-                    <span className="text-xs text-secondary shrink-0">Button text:</span>
-                    <LemonInput
-                        size="xsmall"
-                        value={linkQuestion.buttonText || ''}
-                        placeholder="Learn more"
-                        onChange={(val) => onUpdate({ buttonText: val })}
-                        className="flex-1"
-                    />
+            <div className="space-y-3 pt-3 border-t border-border mt-3">
+                <div className="flex items-center gap-3">
+                    <div className="flex-1">
+                        <span className="text-xs text-secondary block mb-1">Button text</span>
+                        <LemonInput
+                            size="xsmall"
+                            value={linkQuestion.buttonText || ''}
+                            placeholder="Learn more"
+                            onChange={(val) => onUpdate({ buttonText: val })}
+                            fullWidth
+                        />
+                    </div>
+                    <div className="flex-1">
+                        <span className="text-xs text-secondary block mb-1">Link URL</span>
+                        <LemonInput
+                            size="xsmall"
+                            value={linkQuestion.link || ''}
+                            placeholder="https://example.com"
+                            onChange={(val) => onUpdate({ link: val })}
+                            fullWidth
+                        />
+                    </div>
                 </div>
-                <div className="flex items-center gap-2">
-                    <span className="text-xs text-secondary shrink-0">Link URL:</span>
-                    <LemonInput
-                        size="xsmall"
-                        value={linkQuestion.link || ''}
-                        placeholder="https://example.com"
-                        onChange={(val) => onUpdate({ link: val })}
-                        className="flex-1"
-                    />
-                </div>
+                <p className="text-xs text-secondary">
+                    Only https:// or mailto: links are supported. Leave empty for announcement-only.
+                </p>
             </div>
         )
     }

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -11,6 +11,7 @@ import { EditableField } from 'lib/components/EditableField/EditableField'
 import { SortableDragIcon } from 'lib/lemon-ui/icons'
 
 import {
+    LinkSurveyQuestion,
     MultipleSurveyQuestion,
     RatingSurveyQuestion,
     SurveyAppearance,
@@ -217,7 +218,7 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
                     <span className="text-xs text-secondary shrink-0">Link URL:</span>
                     <LemonInput
                         size="xsmall"
-                        value={(question as any).link || ''}
+                        value={(question as LinkSurveyQuestion).link || ''}
                         placeholder="https://example.com"
                         onChange={(val) => onUpdate({ link: val })}
                         className="flex-1"

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -92,12 +92,6 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
                         />
                     </div>
                 </div>
-                <LemonCheckbox
-                    label="Submit on select"
-                    checked={!!ratingQuestion.skipSubmitButton}
-                    onChange={(checked) => onUpdate({ skipSubmitButton: checked } as Partial<RatingSurveyQuestion>)}
-                    size="small"
-                />
             </div>
         )
     }
@@ -137,7 +131,6 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
             onUpdate({
                 choices: [...choices, 'Other'],
                 hasOpenChoice: true,
-                skipSubmitButton: false,
             } as Partial<MultipleSurveyQuestion>)
         }
 
@@ -190,15 +183,6 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
                             Add "Other"
                         </LemonButton>
                     )}
-                    <LemonCheckbox
-                        label="Submit on select"
-                        checked={!!choiceQuestion.skipSubmitButton}
-                        onChange={(checked) =>
-                            onUpdate({ skipSubmitButton: checked } as Partial<MultipleSurveyQuestion>)
-                        }
-                        size="small"
-                        disabledReason={hasOpenChoice ? 'Not available with open-ended choice' : undefined}
-                    />
                     <LemonCheckbox
                         label="Shuffle"
                         checked={!!choiceQuestion.shuffleOptions}

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -392,13 +392,13 @@ function SortableQuestionCard({
     onChangeType,
     onDelete,
 }: SortableQuestionCardProps): JSX.Element {
-    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    const { attributes, listeners, setNodeRef, transform, isDragging } = useSortable({
         id: index.toString(),
+        animateLayoutChanges: () => false,
     })
 
     const style = {
         transform: CSS.Translate.toString(transform),
-        transition,
     }
 
     return (

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -212,13 +212,24 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
 
     // Link question options
     if (question.type === SurveyQuestionType.Link) {
+        const linkQuestion = question as LinkSurveyQuestion
         return (
             <div className="space-y-2 pt-2 border-t border-border mt-3">
+                <div className="flex items-center gap-2">
+                    <span className="text-xs text-secondary shrink-0">Button text:</span>
+                    <LemonInput
+                        size="xsmall"
+                        value={linkQuestion.buttonText || ''}
+                        placeholder="Learn more"
+                        onChange={(val) => onUpdate({ buttonText: val })}
+                        className="flex-1"
+                    />
+                </div>
                 <div className="flex items-center gap-2">
                     <span className="text-xs text-secondary shrink-0">Link URL:</span>
                     <LemonInput
                         size="xsmall"
-                        value={(question as LinkSurveyQuestion).link || ''}
+                        value={linkQuestion.link || ''}
                         placeholder="https://example.com"
                         onChange={(val) => onUpdate({ link: val })}
                         className="flex-1"
@@ -422,6 +433,7 @@ export function QuestionsStep(): JSX.Element {
             question: currentQuestion.question,
             description: currentQuestion.description,
             descriptionContentType: currentQuestion.descriptionContentType,
+            optional: currentQuestion.optional,
         } as SurveyQuestion
         setSurveyValue('questions', newQuestions)
     }

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -243,6 +243,9 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
     // Link question options
     if (question.type === SurveyQuestionType.Link) {
         const linkQuestion = question as LinkSurveyQuestion
+        const linkValue = linkQuestion.link || ''
+        const isValidLink = !linkValue || linkValue.startsWith('https://') || linkValue.startsWith('mailto:')
+
         return (
             <div className="space-y-3 pt-3 border-t border-border mt-3">
                 <div className="flex items-center gap-3">
@@ -260,16 +263,21 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
                         <span className="text-xs text-secondary block mb-1">Link URL</span>
                         <LemonInput
                             size="xsmall"
-                            value={linkQuestion.link || ''}
+                            value={linkValue}
                             placeholder="https://example.com"
                             onChange={(val) => onUpdate({ link: val })}
                             fullWidth
+                            status={isValidLink ? 'default' : 'danger'}
                         />
                     </div>
                 </div>
-                <p className="text-xs text-secondary">
-                    Only https:// or mailto: links are supported. Leave empty for announcement-only.
-                </p>
+                {!isValidLink ? (
+                    <p className="text-xs text-danger">Link must start with https:// or mailto:</p>
+                ) : (
+                    <p className="text-xs text-secondary">
+                        Only https:// or mailto: links are supported. Leave empty for announcement-only.
+                    </p>
+                )}
             </div>
         )
     }
@@ -316,6 +324,7 @@ function ConfirmationScreenEditor({ appearance, onUpdate }: ConfirmationScreenEd
                                 saveOnBlur
                                 clickToEdit
                                 compactIcon
+                                showEditIconOnHover
                             />
                             <EditableField
                                 name="confirmation-description"
@@ -326,6 +335,7 @@ function ConfirmationScreenEditor({ appearance, onUpdate }: ConfirmationScreenEd
                                 saveOnBlur
                                 clickToEdit
                                 compactIcon
+                                showEditIconOnHover
                             />
                         </div>
                     </motion.div>
@@ -393,6 +403,7 @@ function SortableQuestionCard({
                         saveOnBlur
                         clickToEdit
                         compactIcon
+                        showEditIconOnHover
                     />
                     <EditableField
                         name={`description-${index}`}
@@ -403,6 +414,7 @@ function SortableQuestionCard({
                         saveOnBlur
                         clickToEdit
                         compactIcon
+                        showEditIconOnHover
                     />
                     <div className="flex items-center gap-2">
                         <QuestionTypeChip type={question.type} onChange={(newType) => onChangeType(index, newType)} />

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
@@ -118,7 +118,7 @@ export function WhenStep(): JSX.Element {
             )}
 
             <div className="border-t border-border pt-6 space-y-2">
-                <label className="text-sm font-medium">Wait before showing</label>
+                <label className="text-sm font-medium">Delay before showing</label>
                 <div className="flex items-center gap-2">
                     <LemonInput
                         type="number"
@@ -127,9 +127,11 @@ export function WhenStep(): JSX.Element {
                         onChange={(val) => setDelaySeconds(Number(val) || 0)}
                         className="w-20"
                     />
-                    <span className="text-secondary text-sm">seconds after trigger</span>
+                    <span className="text-secondary text-sm">seconds after conditions are met</span>
                 </div>
-                <p className="text-muted text-xs">Give users time to settle on the page before showing the survey</p>
+                <p className="text-muted text-xs">
+                    Once a user matches the targeting conditions, wait this long before displaying the survey
+                </p>
             </div>
         </div>
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,6 +844,9 @@ importers:
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
+      motion:
+        specifier: ^12.26.1
+        version: 12.26.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       natural-orderby:
         specifier: ^3.0.2
         version: 3.0.2
@@ -9988,8 +9991,8 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
-  '@types/node@20.19.29':
-    resolution: {integrity: sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==}
+  '@types/node@20.19.28':
+    resolution: {integrity: sha512-VyKBr25BuFDzBFCK5sUM6ZXiWfqgCTwTAOK8qzGV/m9FCirXYDlmczJ+d5dXBAQALGCdRRdbteKYfJ84NGEusw==}
 
   '@types/node@22.15.17':
     resolution: {integrity: sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==}
@@ -13188,6 +13191,20 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  framer-motion@12.26.1:
+    resolution: {integrity: sha512-Uzc8wGldU4FpmGotthjjcj0SZhigcODjqvKT7lzVZHsmYkzQMFfMIv0vHQoXCeoe/Ahxqp4by4A6QbzFA/lblw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
@@ -15832,6 +15849,26 @@ packages:
 
   moo-color@1.0.3:
     resolution: {integrity: sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==}
+
+  motion-dom@12.24.11:
+    resolution: {integrity: sha512-DlWOmsXMJrV8lzZyd+LKjG2CXULUs++bkq8GZ2Sr0R0RRhs30K2wtY+LKiTjhmJU3W61HK+rB0GLz6XmPvTA1A==}
+
+  motion-utils@12.24.10:
+    resolution: {integrity: sha512-x5TFgkCIP4pPsRLpKoI86jv/q8t8FQOiM/0E8QKBzfMozWHfkKap2gA1hOki+B5g3IsBNpxbUnfOum1+dgvYww==}
+
+  motion@12.26.1:
+    resolution: {integrity: sha512-IVhzx9HOQTiJ9ykthMOlZPnLwrkXziN5Q/yebsqBYlFJb2rHP8yhmKc8O/YUT9byPJlxOeqkzfNYCrVKZx8vqg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -20077,10 +20114,12 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.2:
     resolution: {integrity: sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==}
@@ -25181,14 +25220,14 @@ snapshots:
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/instrumentation-amqplib@0.50.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25196,7 +25235,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
       '@types/aws-lambda': 8.10.150
     transitivePeerDependencies:
       - supports-color
@@ -25207,7 +25246,7 @@ snapshots:
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagation-utils': 0.31.3(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25224,7 +25263,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25233,7 +25272,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
       '@types/connect': 3.4.38
     transitivePeerDependencies:
       - supports-color
@@ -25242,7 +25281,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25265,7 +25304,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25274,7 +25313,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25304,7 +25343,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25313,7 +25352,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25322,7 +25361,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
       forwarded-parse: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -25332,7 +25371,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/redis-common': 0.38.0
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25340,7 +25379,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25348,7 +25387,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25357,7 +25396,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25372,7 +25411,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
       '@types/memcached': 2.2.10
     transitivePeerDependencies:
       - supports-color
@@ -25381,7 +25420,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25390,7 +25429,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25398,7 +25437,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
       '@opentelemetry/sql-common': 0.41.0(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
@@ -25407,7 +25446,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
       '@types/mysql': 2.15.27
     transitivePeerDependencies:
       - supports-color
@@ -25416,7 +25455,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25424,7 +25463,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25432,7 +25471,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
       '@types/oracledb': 6.5.2
     transitivePeerDependencies:
       - supports-color
@@ -25463,7 +25502,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/redis-common': 0.38.0
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25472,7 +25511,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25480,7 +25519,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25495,7 +25534,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25503,7 +25542,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/semantic-conventions': 1.38.0
       '@types/tedious': 4.0.14
     transitivePeerDependencies:
       - supports-color
@@ -25595,36 +25634,36 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/resources': 2.3.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/resource-detector-aws@2.3.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/resources': 2.3.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/resource-detector-azure@0.10.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/resources': 2.3.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/resource-detector-container@0.7.3(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/resources': 2.3.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/resource-detector-gcp@0.37.0(@opentelemetry/api@1.9.0)(encoding@0.1.13)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.36.0
+      '@opentelemetry/resources': 2.3.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
       gcp-metadata: 6.1.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
@@ -25732,7 +25771,7 @@ snapshots:
   '@opentelemetry/sql-common@0.41.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
 
   '@orval/angular@8.0.0-rc.5(typescript@5.2.2)':
     dependencies:
@@ -27170,7 +27209,7 @@ snapshots:
   '@radix-ui/react-popper@1.1.2(@types/react-dom@18.3.7(@types/react@17.0.52))(@types/react@17.0.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@floating-ui/react-dom': 2.1.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.3.7(@types/react@17.0.52))(@types/react@17.0.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.52)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@17.0.52)(react@18.2.0)
@@ -27188,7 +27227,7 @@ snapshots:
 
   '@radix-ui/react-popper@1.2.2(@types/react-dom@18.2.14)(@types/react@17.0.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-arrow': 1.1.2(@types/react-dom@18.2.14)(@types/react@17.0.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@17.0.52)(react@18.2.0)
       '@radix-ui/react-context': 1.1.1(@types/react@17.0.52)(react@18.2.0)
@@ -27206,7 +27245,7 @@ snapshots:
 
   '@radix-ui/react-popper@1.2.7(@types/react-dom@18.2.14)(@types/react@17.0.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.2.14)(@types/react@17.0.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@17.0.52)(react@18.2.0)
       '@radix-ui/react-context': 1.1.2(@types/react@17.0.52)(react@18.2.0)
@@ -27224,7 +27263,7 @@ snapshots:
 
   '@radix-ui/react-popper@1.2.8(@types/react-dom@18.2.14)(@types/react@17.0.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.2.14)(@types/react@17.0.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@17.0.52)(react@18.2.0)
       '@radix-ui/react-context': 1.1.2(@types/react@17.0.52)(react@18.2.0)
@@ -29427,7 +29466,7 @@ snapshots:
       commander: 9.4.1
       expect-playwright: 0.8.0
       glob: 10.4.5
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -30564,7 +30603,7 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.19.29':
+  '@types/node@20.19.28':
     dependencies:
       undici-types: 6.21.0
 
@@ -34505,6 +34544,15 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  framer-motion@12.26.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      motion-dom: 12.24.11
+      motion-utils: 12.24.10
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
   fresh@0.5.2: {}
 
   fresh@2.0.0: {}
@@ -34928,7 +34976,7 @@ snapshots:
 
   happy-dom@20.0.11:
     dependencies:
-      '@types/node': 20.19.29
+      '@types/node': 20.19.28
       '@types/whatwg-mimetype': 3.0.2
       whatwg-mimetype: 3.0.0
 
@@ -35827,6 +35875,25 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0:
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
+      exit: 0.1.2
+      import-local: 3.1.0
+      jest-config: 29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
@@ -36264,7 +36331,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -36544,7 +36611,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.4.1
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -36593,6 +36660,18 @@ snapshots:
       jest-util: 30.0.5
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jest@29.7.0:
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      '@jest/types': 29.6.3
+      import-local: 3.1.0
+      jest-cli: 29.7.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest@29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2)):
     dependencies:
@@ -38007,6 +38086,20 @@ snapshots:
     dependencies:
       color-name: 1.1.4
 
+  motion-dom@12.24.11:
+    dependencies:
+      motion-utils: 12.24.10
+
+  motion-utils@12.24.10: {}
+
+  motion@12.26.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      framer-motion: 12.26.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
   mri@1.2.0: {}
 
   ms@2.0.0: {}
@@ -38736,7 +38829,7 @@ snapshots:
 
   path-scurry@2.0.0:
     dependencies:
-      lru-cache: 11.2.4
+      lru-cache: 11.0.2
       minipass: 7.1.2
 
   path-to-regexp@0.1.7: {}
@@ -40457,7 +40550,7 @@ snapshots:
       algoliasearch-helper: 3.16.2(algoliasearch@4.22.1)
       instantsearch.js: 4.65.0(algoliasearch@4.22.1)
       react: 18.2.0
-      use-sync-external-store: 1.6.0(react@18.2.0)
+      use-sync-external-store: 1.5.0(react@18.2.0)
 
   react-instantsearch@7.6.0(algoliasearch@4.22.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -41911,7 +42004,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
       react: 18.2.0
-      use-sync-external-store: 1.6.0(react@18.2.0)
+      use-sync-external-store: 1.5.0(react@18.2.0)
 
   symbol-tree@3.2.4: {}
 
@@ -43466,7 +43559,7 @@ snapshots:
 
   zustand@4.5.6(@types/react@17.0.52)(immer@9.0.21)(react@18.2.0):
     dependencies:
-      use-sync-external-store: 1.6.0(react@18.2.0)
+      use-sync-external-store: 1.5.0(react@18.2.0)
     optionalDependencies:
       '@types/react': 17.0.52
       immer: 9.0.21


### PR DESCRIPTION
## Summary
- Add inline question type selector with QuestionTypeChip dropdown
- Add question-specific editing options (rating scale, choices, link URL)
- Add "Submit on select" option for rating and choice questions
- Add animated confirmation screen toggle with expand/collapse
- Add cancel button to AddQuestionButton expanded state
- Fix preview pagination to count confirmation screen properly
- Default to Clean theme for better compatibility
- Rename Link question type to "Link / Announcement"
- Disable "Submit on select" when open-ended choice is present

<img width="1216" height="987" alt="image" src="https://github.com/user-attachments/assets/f3fcaf91-dab0-4308-a1ed-052a4d29307e" />

## Test plan
- Create a new survey using the wizard
- Verify question type can be changed inline via dropdown chip
- Verify rating questions show display type, scale, and bound labels
- Verify choice questions show choices editor with add/remove
- Verify "Submit on select" checkbox works and is disabled with open-ended choices
- Verify confirmation screen toggle animates smoothly
- Verify preview pagination shows correct counts (e.g., 2/3 with confirmation)