### PR TITLE
chore(infra): Add Grafana MCP server wrapper scripts

### DIFF
--- a/infra-scripts/mcp/README.md
+++ b/infra-scripts/mcp/README.md
@@ -1,0 +1,193 @@
+# MCP Server Scripts
+
+Scripts for connecting AI assistants (Claude Code, Cursor, etc.) to PostHog's internal Grafana instances via the [Grafana MCP server](https://github.com/grafana/mcp-grafana).
+
+## Why these scripts exist
+
+PostHog's Grafana instances are protected by Cognito OAuth at the AWS ALB level. This authentication method doesn't support Bearer token authentication, which the Grafana MCP server requires. These scripts work around this by:
+
+1. Creating a kubectl port-forward to access Grafana directly within the K8s cluster
+2. Using a Grafana service account token for authentication
+3. Managing tokens securely via macOS Keychain
+
+## Prerequisites
+
+- **kubectl** configured with access to PostHog K8s clusters
+- **AWS SSO** session active (`aws sso login`)
+- **mcp-grafana** binary installed
+- **macOS** (for Keychain-based token storage) or Linux with environment variables
+
+### Installing mcp-grafana
+
+```bash
+go install github.com/grafana/mcp-grafana/cmd/mcp-grafana@latest
+```
+
+Make sure `$GOPATH/bin` (usually `~/go/bin`) is in your PATH.
+
+## Setup
+
+### 1. Create Grafana service account tokens
+
+For each region you need access to, create a service account token in Grafana:
+
+1. Go to **Administration > Service accounts**
+2. Create a new service account (or use an existing one)
+3. Add a token with appropriate permissions (typically Viewer or Editor)
+4. Copy the token
+
+### 2. Store tokens in Keychain (macOS)
+
+Add these scripts to your PATH, then store your tokens:
+
+```bash
+# Add to PATH (add this to your ~/.zshrc or ~/.bashrc)
+export PATH="$PATH:/path/to/posthog/infra-scripts/mcp"
+
+# Store tokens
+grafana-token us <your-us-token>
+grafana-token eu <your-eu-token>
+grafana-token dev <your-dev-token>  # optional
+```
+
+### 3. Configure your MCP client
+
+#### Claude Code
+
+Add to your Claude Code MCP configuration (`~/.claude/settings.json` or project's `.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "grafana": {
+      "command": "/path/to/posthog/infra-scripts/mcp/mcp-grafana-wrapper.sh",
+      "args": []
+    }
+  }
+}
+```
+
+#### Cursor / VS Code
+
+Add to your MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "grafana": {
+      "command": "/path/to/posthog/infra-scripts/mcp/mcp-grafana-wrapper.sh",
+      "args": []
+    }
+  }
+}
+```
+
+## Usage
+
+### Switching regions
+
+Use the `grafana-region` command to switch between PostHog environments:
+
+```bash
+grafana-region          # Show current region
+grafana-region us       # Switch to prod-us (us-east-1)
+grafana-region eu       # Switch to prod-eu (eu-central-1)
+grafana-region dev      # Switch to dev environment
+```
+
+**Important: Restart required after switching regions**
+
+MCP servers are initialized once when your AI assistant starts. The region is read from `~/.grafana-region` at startup, so changing the region file while the assistant is running has no effect until you restart.
+
+To restart and apply the new region:
+
+- **Claude Code**: Type `/exit` to quit, then restart Claude Code
+- **Cursor**: Close and reopen the editor, or restart the MCP server from settings
+- **VS Code**: Reload the window (`Cmd+Shift+P` → "Developer: Reload Window")
+
+### Checking token status
+
+```bash
+grafana-token           # Show status of all tokens
+grafana-token us        # Check if US token is configured
+```
+
+### Port forwarding
+
+The wrapper script automatically manages kubectl port-forwards:
+
+- **US**: localhost:13000
+- **EU**: localhost:13001
+- **dev**: localhost:13002
+
+Port-forwards persist between MCP client restarts. If you need to restart them:
+
+```bash
+# Find and kill existing port-forwards
+pkill -f "kubectl.*port-forward.*grafana"
+```
+
+## Linux support
+
+On Linux, Keychain is not available. Instead, set the `GRAFANA_SERVICE_ACCOUNT_TOKEN` environment variable before starting your MCP client:
+
+```bash
+export GRAFANA_SERVICE_ACCOUNT_TOKEN="your-token-here"
+```
+
+You may want to use a secrets manager or encrypted file for production use.
+
+## Troubleshooting
+
+### "Cannot connect to K8s cluster"
+
+Your AWS SSO session may have expired:
+
+```bash
+aws sso login
+```
+
+### "mcp-grafana not found"
+
+Install it with:
+
+```bash
+go install github.com/grafana/mcp-grafana/cmd/mcp-grafana@latest
+```
+
+Or set `MCP_GRAFANA_BIN` to the full path of the binary.
+
+### "Could not retrieve token from keychain"
+
+Store your token first:
+
+```bash
+grafana-token us <your-token>
+```
+
+### Port-forward not working
+
+Check if there's a stale port-forward process:
+
+```bash
+# Check for existing port-forwards
+ps aux | grep "kubectl.*port-forward.*grafana"
+
+# Kill stale processes
+pkill -f "kubectl.*port-forward.*grafana"
+
+# Remove stale PID files
+rm -f ~/.local/run/grafana-port-forward-*.pid
+```
+
+## Available Grafana MCP tools
+
+Once connected, you'll have access to Grafana MCP tools including:
+
+- Dashboard search and retrieval
+- Prometheus/Loki querying
+- Alert rule listing
+- Incident management
+- On-call schedule viewing
+
+See the [mcp-grafana documentation](https://github.com/grafana/mcp-grafana) for the full list of available tools.

--- a/infra-scripts/mcp/README.md
+++ b/infra-scripts/mcp/README.md
@@ -36,21 +36,30 @@ For each region you need access to, create a service account token in Grafana:
 3. Add a token with appropriate permissions (typically Viewer or Editor)
 4. Copy the token
 
-### 2. Store tokens in Keychain (macOS)
+### 2. Add scripts to your PATH
 
-Add these scripts to your PATH, then store your tokens:
+Add the following to your shell config file (`~/.zshrc`, `~/.bashrc`, or equivalent):
 
 ```bash
-# Add to PATH (add this to your ~/.zshrc or ~/.bashrc)
-export PATH="$PATH:/path/to/posthog/infra-scripts/mcp"
+# PostHog infra scripts (grafana-region, grafana-token, etc.)
+export PATH="$HOME/dev/posthog/posthog/infra-scripts/mcp:$PATH"
+```
 
-# Store tokens
+Adjust the path if your PostHog repo is in a different location. Then reload your shell:
+
+```bash
+source ~/.zshrc  # or ~/.bashrc
+```
+
+### 3. Store tokens in Keychain (macOS)
+
+```bash
 grafana-token us <your-us-token>
 grafana-token eu <your-eu-token>
 grafana-token dev <your-dev-token>  # optional
 ```
 
-### 3. Configure your MCP client
+### 4. Configure your MCP client
 
 #### Claude Code
 
@@ -60,7 +69,7 @@ Add to your Claude Code MCP configuration (`~/.claude/settings.json` or project'
 {
   "mcpServers": {
     "grafana": {
-      "command": "/path/to/posthog/infra-scripts/mcp/mcp-grafana-wrapper.sh",
+      "command": "/Users/YOUR_USERNAME/dev/posthog/posthog/infra-scripts/mcp/mcp-grafana-wrapper.sh",
       "args": []
     }
   }
@@ -75,7 +84,7 @@ Add to your MCP settings:
 {
   "mcpServers": {
     "grafana": {
-      "command": "/path/to/posthog/infra-scripts/mcp/mcp-grafana-wrapper.sh",
+      "command": "/Users/YOUR_USERNAME/dev/posthog/posthog/infra-scripts/mcp/mcp-grafana-wrapper.sh",
       "args": []
     }
   }

--- a/infra-scripts/mcp/grafana-region
+++ b/infra-scripts/mcp/grafana-region
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Switch Grafana MCP server between prod-us, prod-eu, and dev regions
+#
+# Usage:
+#   grafana-region         # Show current region
+#   grafana-region us      # Switch to prod-us
+#   grafana-region eu      # Switch to prod-eu
+#   grafana-region dev     # Switch to dev
+#
+# After switching, restart your MCP client (e.g., Claude Code: /exit)
+
+REGION_FILE="$HOME/.grafana-region"
+
+show_current() {
+    if [ -f "$REGION_FILE" ] && [ -s "$REGION_FILE" ]; then
+        local region=$(head -n1 "$REGION_FILE" | tr -cd '[:alnum:]')
+        echo "Current Grafana region: $region"
+    else
+        echo "Current Grafana region: us (default)"
+    fi
+}
+
+show_usage() {
+    echo "Usage: grafana-region [us|eu|dev]"
+    echo ""
+    echo "Commands:"
+    echo "  (no args)  Show current region"
+    echo "  us         Switch to prod-us (us-east-1)"
+    echo "  eu         Switch to prod-eu (eu-central-1)"
+    echo "  dev        Switch to dev (us-east-1)"
+    echo ""
+    echo "After switching, restart your MCP client to apply the change."
+}
+
+case "${1:-}" in
+    "")
+        show_current
+        ;;
+    us|eu|dev)
+        echo "$1" > "$REGION_FILE"
+        echo "Switched Grafana region to: $1"
+        echo ""
+        echo "Restart your MCP client to apply the change."
+        ;;
+    -h|--help)
+        show_usage
+        ;;
+    *)
+        echo "Error: Invalid region '$1'. Must be 'us', 'eu', or 'dev'." >&2
+        echo ""
+        show_usage
+        exit 1
+        ;;
+esac

--- a/infra-scripts/mcp/grafana-token
+++ b/infra-scripts/mcp/grafana-token
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Manage Grafana service account tokens in macOS Keychain
+#
+# Usage:
+#   grafana-token                  # Show status of all tokens
+#   grafana-token us               # Show if US token exists
+#   grafana-token eu               # Show if EU token exists
+#   grafana-token dev              # Show if dev token exists
+#   grafana-token us <token>       # Set prod-us token
+#   grafana-token eu <token>       # Set prod-eu token
+#   grafana-token dev <token>      # Set dev token
+#
+# Note: This script requires macOS (uses Keychain).
+# On Linux, set the GRAFANA_SERVICE_ACCOUNT_TOKEN environment variable instead.
+
+set -euo pipefail
+
+# Check for macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "Error: This script requires macOS Keychain." >&2
+    echo "On Linux, set the GRAFANA_SERVICE_ACCOUNT_TOKEN environment variable." >&2
+    exit 1
+fi
+
+show_status() {
+    echo "Grafana Token Status:"
+    echo ""
+
+    if security find-generic-password -a "$USER" -s "grafana-service-account-token-us" &>/dev/null; then
+        echo "  US (prod-us):  configured"
+    else
+        echo "  US (prod-us):  not configured"
+    fi
+
+    if security find-generic-password -a "$USER" -s "grafana-service-account-token-eu" &>/dev/null; then
+        echo "  EU (prod-eu):  configured"
+    else
+        echo "  EU (prod-eu):  not configured"
+    fi
+
+    if security find-generic-password -a "$USER" -s "grafana-service-account-token-dev" &>/dev/null; then
+        echo "  dev:           configured"
+    else
+        echo "  dev:           not configured"
+    fi
+}
+
+show_usage() {
+    echo "Usage: grafana-token [us|eu|dev] [token]"
+    echo ""
+    echo "Commands:"
+    echo "  (no args)        Show token status for all regions"
+    echo "  us               Show if US token is configured"
+    echo "  eu               Show if EU token is configured"
+    echo "  dev              Show if dev token is configured"
+    echo "  us <token>       Set prod-us token"
+    echo "  eu <token>       Set prod-eu token"
+    echo "  dev <token>      Set dev token"
+    echo ""
+    echo "After setting a token, restart your MCP client to pick it up."
+    echo ""
+    echo "To create a service account token in Grafana:"
+    echo "  1. Go to Administration > Service accounts"
+    echo "  2. Create a new service account or use an existing one"
+    echo "  3. Add a token with appropriate permissions"
+}
+
+case "${1:-}" in
+    "")
+        show_status
+        ;;
+    us|eu|dev)
+        REGION="$1"
+        SERVICE="grafana-service-account-token-$REGION"
+
+        if [ -z "${2:-}" ]; then
+            # Just check if token exists
+            if security find-generic-password -a "$USER" -s "$SERVICE" &>/dev/null; then
+                echo "Token for $REGION: configured"
+            else
+                echo "Token for $REGION: not configured"
+            fi
+        else
+            TOKEN="$2"
+
+            # Delete existing token if present (security add doesn't update)
+            security delete-generic-password -a "$USER" -s "$SERVICE" 2>/dev/null || true
+
+            # Add new token (use stdin to avoid token appearing in process list)
+            printf '%s' "$TOKEN" | security add-generic-password -a "$USER" -s "$SERVICE" -w
+
+            echo "Token for $REGION saved to Keychain."
+            echo ""
+            echo "Restart your MCP client to pick up the new token."
+        fi
+        ;;
+    -h|--help)
+        show_usage
+        ;;
+    *)
+        echo "Error: Invalid region '$1'. Must be 'us', 'eu', or 'dev'." >&2
+        echo ""
+        show_usage
+        exit 1
+        ;;
+esac

--- a/infra-scripts/mcp/mcp-grafana-wrapper.sh
+++ b/infra-scripts/mcp/mcp-grafana-wrapper.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Wrapper script for mcp-grafana that uses kubectl port-forward to bypass ALB Cognito auth
+#
+# PostHog's Grafana instances require Cognito OAuth at the ALB level, which doesn't
+# support Bearer token authentication. This script creates a port-forward to access
+# Grafana directly within the K8s cluster, enabling the MCP server to authenticate
+# with a service account token.
+#
+# Supports switching between prod-us, prod-eu, and dev regions via ~/.grafana-region file.
+# Use `grafana-region us`, `grafana-region eu`, or `grafana-region dev` to switch,
+# then restart your MCP client.
+#
+# Prerequisites:
+#   - kubectl configured with access to PostHog K8s clusters
+#   - AWS SSO session active (`aws sso login`)
+#   - mcp-grafana binary installed (go install github.com/grafana/mcp-grafana/cmd/mcp-grafana@latest)
+#   - Grafana service account token stored in macOS Keychain (see grafana-token script)
+
+set -euo pipefail
+
+# Region configuration
+REGION_FILE="$HOME/.grafana-region"
+DEFAULT_REGION="us"
+
+# Runtime directory for PID files (user-private, not world-writable /tmp)
+RUNTIME_DIR="$HOME/.local/run"
+mkdir -p "$RUNTIME_DIR" && chmod 700 "$RUNTIME_DIR"
+
+# Read current region (default to us if file missing or empty)
+if [ -f "$REGION_FILE" ] && [ -s "$REGION_FILE" ]; then
+    CURRENT_REGION=$(head -n1 "$REGION_FILE" | tr -cd '[:alnum:]')
+else
+    CURRENT_REGION="$DEFAULT_REGION"
+fi
+
+# Validate region
+if [[ "$CURRENT_REGION" != "us" && "$CURRENT_REGION" != "eu" && "$CURRENT_REGION" != "dev" ]]; then
+    echo "Error: Invalid region '$CURRENT_REGION' in $REGION_FILE. Must be 'us', 'eu', or 'dev'." >&2
+    exit 1
+fi
+
+# Look up kubectl context dynamically from ~/.kube/config by matching cluster name pattern
+# This avoids hardcoding AWS account IDs and cluster ARNs in the script
+get_k8s_context() {
+    local pattern
+    case "$1" in
+        # us matches posthog-prod but not posthog-prod-eu
+        us)  pattern='posthog-prod$' ;;
+        eu)  pattern='posthog-prod-eu' ;;
+        dev) pattern='posthog-dev' ;;
+        *)   return 1 ;;
+    esac
+    kubectl config get-contexts -o name 2>/dev/null | grep -E "$pattern" | head -1
+}
+
+# Region-specific configuration
+case "$CURRENT_REGION" in
+    us)
+        LOCAL_PORT=13000
+        KEYCHAIN_SERVICE="grafana-service-account-token-us"
+        PID_FILE="$RUNTIME_DIR/grafana-port-forward-us.pid"
+        ;;
+    eu)
+        LOCAL_PORT=13001
+        KEYCHAIN_SERVICE="grafana-service-account-token-eu"
+        PID_FILE="$RUNTIME_DIR/grafana-port-forward-eu.pid"
+        ;;
+    dev)
+        LOCAL_PORT=13002
+        KEYCHAIN_SERVICE="grafana-service-account-token-dev"
+        PID_FILE="$RUNTIME_DIR/grafana-port-forward-dev.pid"
+        ;;
+esac
+
+# Look up the K8s context dynamically
+K8S_CONTEXT=$(get_k8s_context "$CURRENT_REGION")
+if [ -z "$K8S_CONTEXT" ]; then
+    echo "Error: No kubectl context found for region '$CURRENT_REGION'" >&2
+    echo "You may need to run: aws eks update-kubeconfig --name <cluster-name> --profile <profile>" >&2
+    echo "Available contexts: $(kubectl config get-contexts -o name 2>/dev/null | tr '\n' ' ')" >&2
+    exit 1
+fi
+
+GRAFANA_NAMESPACE="monitoring"
+GRAFANA_SERVICE="grafana"
+
+# Find mcp-grafana binary
+if [ -n "${MCP_GRAFANA_BIN:-}" ]; then
+    MCP_GRAFANA="$MCP_GRAFANA_BIN"
+elif command -v mcp-grafana &> /dev/null; then
+    MCP_GRAFANA="mcp-grafana"
+else
+    echo "Error: mcp-grafana not found." >&2
+    echo "Install it with: go install github.com/grafana/mcp-grafana/cmd/mcp-grafana@latest" >&2
+    echo "Or set MCP_GRAFANA_BIN environment variable to the binary path." >&2
+    exit 1
+fi
+
+# Get the service account token from keychain (macOS only)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    export GRAFANA_SERVICE_ACCOUNT_TOKEN="$(security find-generic-password -a "$USER" -s "$KEYCHAIN_SERVICE" -w 2>/dev/null)"
+else
+    # On Linux, fall back to environment variable
+    if [ -z "${GRAFANA_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+        echo "Error: GRAFANA_SERVICE_ACCOUNT_TOKEN environment variable not set." >&2
+        echo "On Linux, set this variable to your Grafana service account token." >&2
+        exit 1
+    fi
+fi
+
+if [ -z "$GRAFANA_SERVICE_ACCOUNT_TOKEN" ]; then
+    echo "Error: Could not retrieve $KEYCHAIN_SERVICE from keychain" >&2
+    echo "Add it with: grafana-token $CURRENT_REGION <your-token>" >&2
+    exit 1
+fi
+
+# Check if kubectl is available
+if ! command -v kubectl &> /dev/null; then
+    echo "Error: kubectl is not installed or not in PATH" >&2
+    exit 1
+fi
+
+# Function to check if port-forward is already running and healthy
+is_port_forward_healthy() {
+    # Check if PID file exists and process is running
+    if [ -f "$PID_FILE" ]; then
+        local pid=$(cat "$PID_FILE")
+        if kill -0 "$pid" 2>/dev/null && ps -p "$pid" -o command= | grep -q "kubectl.*port-forward"; then
+            # Process exists, check if port is actually listening
+            if command -v nc &> /dev/null; then
+                if nc -z localhost "$LOCAL_PORT" 2>/dev/null; then
+                    return 0
+                fi
+            elif timeout 1 bash -c "</dev/tcp/localhost/$LOCAL_PORT" 2>/dev/null; then
+                # Fallback for systems without nc
+                return 0
+            fi
+        fi
+        # PID file exists but process is dead or port not listening, clean up
+        rm -f "$PID_FILE"
+    fi
+    return 1
+}
+
+# Function to start port-forward
+start_port_forward() {
+    # Check if we can connect to the cluster (use /healthz for faster response)
+    if ! kubectl --context="$K8S_CONTEXT" get --raw /healthz &> /dev/null; then
+        echo "Error: Cannot connect to K8s cluster ($CURRENT_REGION). Ensure kubectl is configured and K8S_CONTEXT ('$K8S_CONTEXT') is valid." >&2
+        echo "Also ensure your AWS SSO session is active (try: aws sso login)." >&2
+        exit 1
+    fi
+
+    # Start port-forward in background (not tied to this script's lifecycle)
+    nohup kubectl --context="$K8S_CONTEXT" port-forward -n "$GRAFANA_NAMESPACE" "svc/$GRAFANA_SERVICE" "$LOCAL_PORT:80" &> /dev/null &
+    local pf_pid=$!
+    echo "$pf_pid" > "$PID_FILE"
+
+    # Wait for port-forward to establish (poll instead of fixed sleep)
+    local max_attempts=50  # 50 * 0.1s = 5 seconds max
+    local attempt=0
+    while [ $attempt -lt $max_attempts ]; do
+        # Check if process died
+        if ! kill -0 "$pf_pid" 2>/dev/null; then
+            echo "Error: Port-forward process died during startup ($CURRENT_REGION)" >&2
+            rm -f "$PID_FILE"
+            exit 1
+        fi
+
+        # Check if port is listening
+        if command -v nc &> /dev/null; then
+            nc -z localhost "$LOCAL_PORT" 2>/dev/null && return 0
+        elif timeout 1 bash -c "</dev/tcp/localhost/$LOCAL_PORT" 2>/dev/null; then
+            return 0
+        fi
+
+        sleep 0.1
+        attempt=$((attempt + 1))
+    done
+
+    # Timed out waiting for port
+    echo "Error: Port-forward timed out after 5 seconds ($CURRENT_REGION)" >&2
+    kill "$pf_pid" 2>/dev/null || true
+    rm -f "$PID_FILE"
+    exit 1
+}
+
+# Reuse existing port-forward or start a new one
+if ! is_port_forward_healthy; then
+    start_port_forward
+fi
+
+# Set Grafana URL to use the port-forward
+export GRAFANA_URL="http://localhost:$LOCAL_PORT"
+
+# Run mcp-grafana (no cleanup trap - let the port-forward persist)
+exec "$MCP_GRAFANA" "$@"


### PR DESCRIPTION
During the first all-hands of the year, I demonstrated using Claude Code with the Grafana MCP server. It makes investigating issues and connecting insights from disparate data sources way better. It's been game changing for me. So I wanted to share my scripts in the main repo so others can benefit.

If there's a better place to put these, let me know!

## Problem

We can't use Grafana's MCP server with our Grafana instances. The reason is that PostHog's Grafana instances are protected by Cognito OAuth at the AWS ALB level. This authentication method doesn't support Bearer token authentication, which the Grafana MCP server requires.

## Changes

Add scripts for connecting AI assistants to PostHog's internal Grafana instances via the Grafana MCP server. These work around ALB Cognito auth by using kubectl port-forwarding with service account tokens.

Scripts included:
- `mcp-grafana-wrapper.sh`: Main wrapper handling port-forward and auth
- `grafana-region`: Switch between US, EU, and dev environments
- `grafana-token`: Manage service account tokens in macOS Keychain

## How did you test this code?

Manually

## Publish to changelog?

No