### PR TITLE
feat(gateway): add team rate limit multipliers

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -53,15 +53,23 @@ class Settings(BaseSettings):
         try:
             parsed = json.loads(v)
         except json.JSONDecodeError as e:
-            raise ValueError(f"Invalid JSON in team_rate_limit_multipliers: {e}")
-        
+            raise ValueError(f"Invalid JSON in team_rate_limit_multipliers: {e}") from e
+
         if not isinstance(parsed, dict):
             raise ValueError("team_rate_limit_multipliers must be a JSON object")
-        
+
         try:
-            return {int(k): int(val) for k, val in parsed.items()}
+            result = {int(k): int(val) for k, val in parsed.items()}
         except (ValueError, TypeError) as e:
-            raise ValueError(f"team_rate_limit_multipliers keys and values must be integers: {e}")
+            raise ValueError(f"team_rate_limit_multipliers keys and values must be integers: {e}") from e
+
+        for team_id, multiplier in result.items():
+            if multiplier < 1:
+                raise ValueError(
+                    f"team_rate_limit_multipliers values must be >= 1, got {multiplier} for team {team_id}"
+                )
+
+        return result
 
     model_config = {"env_prefix": "LLM_GATEWAY_"}
 

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -50,8 +50,18 @@ class Settings(BaseSettings):
             return {}
         if isinstance(v, dict):
             return v
-        parsed = json.loads(v)
-        return {int(k): int(val) for k, val in parsed.items()}
+        try:
+            parsed = json.loads(v)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON in team_rate_limit_multipliers: {e}")
+        
+        if not isinstance(parsed, dict):
+            raise ValueError("team_rate_limit_multipliers must be a JSON object")
+        
+        try:
+            return {int(k): int(val) for k, val in parsed.items()}
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"team_rate_limit_multipliers keys and values must be integers: {e}")
 
     model_config = {"env_prefix": "LLM_GATEWAY_"}
 

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -1,5 +1,7 @@
+import json
 from functools import lru_cache
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -38,6 +40,18 @@ class Settings(BaseSettings):
     # ~600 bytes per entry (key + AuthenticatedUser + LRU overhead), 10000 entries ≈ 6 MB
     auth_cache_max_size: int = 10000
     auth_cache_ttl: int = 900  # 15 minutes
+
+    team_rate_limit_multipliers: dict[int, int] = {}
+
+    @field_validator("team_rate_limit_multipliers", mode="before")
+    @classmethod
+    def parse_team_multipliers(cls, v: str | dict[int, int] | None) -> dict[int, int]:
+        if v is None or v == "":
+            return {}
+        if isinstance(v, dict):
+            return v
+        parsed = json.loads(v)
+        return {int(k): int(val) for k, val in parsed.items()}
 
     model_config = {"env_prefix": "LLM_GATEWAY_"}
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/model_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/model_throttles.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Literal
 
+import structlog
 from redis.asyncio import Redis
 
 from llm_gateway.rate_limiting.model_cost_service import get_model_limits
 from llm_gateway.rate_limiting.redis_limiter import TokenRateLimiter
-from llm_gateway.rate_limiting.throttles import Throttle, ThrottleContext, ThrottleResult
+from llm_gateway.rate_limiting.throttles import Throttle, ThrottleContext, ThrottleResult, get_team_multiplier
+
+logger = structlog.get_logger(__name__)
 
 LimitKey = Literal["input_tph", "output_tph"]
 
@@ -25,16 +28,35 @@ class TokenThrottle(Throttle):
         self._redis = redis
         self._limiters: dict[str, TokenRateLimiter] = {}
 
-    def _get_limiter(self, model: str) -> TokenRateLimiter:
-        if model not in self._limiters:
+    def _get_limiter_key(self, model: str, team_multiplier: int) -> str:
+        if team_multiplier == 1:
+            return model
+        return f"{model}:tm{team_multiplier}"
+
+    def _get_limiter(self, model: str, team_multiplier: int = 1) -> TokenRateLimiter:
+        limiter_key = self._get_limiter_key(model, team_multiplier)
+        if limiter_key not in self._limiters:
             limits = get_model_limits(model)
-            limit = limits[self.limit_key] * self.limit_multiplier
-            self._limiters[model] = TokenRateLimiter(
+            base_limit = limits[self.limit_key] * self.limit_multiplier
+            limit = base_limit * team_multiplier
+            if team_multiplier > 1:
+                logger.info(
+                    "team_rate_limit_multiplier_applied",
+                    model=model,
+                    throttle_scope=self.scope,
+                    base_limit=base_limit,
+                    team_multiplier=team_multiplier,
+                    effective_limit=limit,
+                )
+            self._limiters[limiter_key] = TokenRateLimiter(
                 redis=self._redis,
                 limit=limit,
                 window_seconds=self.window_seconds,
             )
-        return self._limiters[model]
+        return self._limiters[limiter_key]
+
+    def _get_team_multiplier(self, context: ThrottleContext) -> int:
+        return get_team_multiplier(context.user.team_id)
 
     @abstractmethod
     def _get_cache_key(self, context: ThrottleContext) -> str:
@@ -51,7 +73,8 @@ class TokenThrottle(Throttle):
         if context.model is None or tokens is None:
             return ThrottleResult.allow()
 
-        limiter = self._get_limiter(context.model)
+        team_multiplier = self._get_team_multiplier(context)
+        limiter = self._get_limiter(context.model, team_multiplier)
         key = self._get_cache_key(context)
 
         if await limiter.consume(key, tokens):
@@ -93,7 +116,8 @@ class OutputTokenThrottle(TokenThrottle):
         if context.model is None or tokens is None:
             return ThrottleResult.allow()
 
-        limiter = self._get_limiter(context.model)
+        team_multiplier = self._get_team_multiplier(context)
+        limiter = self._get_limiter(context.model, team_multiplier)
         key = self._get_cache_key(context)
 
         if await limiter.would_allow(key, tokens):
@@ -110,7 +134,8 @@ class OutputTokenThrottle(TokenThrottle):
         if context.model is None:
             return
 
-        limiter = self._get_limiter(context.model)
+        team_multiplier = self._get_team_multiplier(context)
+        limiter = self._get_limiter(context.model, team_multiplier)
         key = self._get_cache_key(context)
         await limiter.consume(key, actual_tokens)
 
@@ -120,14 +145,22 @@ class ProductModelInputTokenThrottle(InputTokenThrottle):
     limit_multiplier = 10
 
     def _get_cache_key(self, context: ThrottleContext) -> str:
-        return f"product:{context.product}:model:{context.model}:input"
+        team_mult = self._get_team_multiplier(context)
+        base = f"product:{context.product}:model:{context.model}:input"
+        if team_mult == 1:
+            return base
+        return f"{base}:tm{team_mult}"
 
 
 class UserModelInputTokenThrottle(InputTokenThrottle):
     scope = "user_model_input_tokens"
 
     def _get_cache_key(self, context: ThrottleContext) -> str:
-        return f"user:{context.user.user_id}:model:{context.model}:input"
+        team_mult = self._get_team_multiplier(context)
+        base = f"user:{context.user.user_id}:model:{context.model}:input"
+        if team_mult == 1:
+            return base
+        return f"{base}:tm{team_mult}"
 
 
 class ProductModelOutputTokenThrottle(OutputTokenThrottle):
@@ -135,11 +168,19 @@ class ProductModelOutputTokenThrottle(OutputTokenThrottle):
     limit_multiplier = 10
 
     def _get_cache_key(self, context: ThrottleContext) -> str:
-        return f"product:{context.product}:model:{context.model}:output"
+        team_mult = self._get_team_multiplier(context)
+        base = f"product:{context.product}:model:{context.model}:output"
+        if team_mult == 1:
+            return base
+        return f"{base}:tm{team_mult}"
 
 
 class UserModelOutputTokenThrottle(OutputTokenThrottle):
     scope = "user_model_output_tokens"
 
     def _get_cache_key(self, context: ThrottleContext) -> str:
-        return f"user:{context.user.user_id}:model:{context.model}:output"
+        team_mult = self._get_team_multiplier(context)
+        base = f"user:{context.user.user_id}:model:{context.model}:output"
+        if team_mult == 1:
+            return base
+        return f"{base}:tm{team_mult}"

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
@@ -4,6 +4,14 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 from llm_gateway.auth.models import AuthenticatedUser
+from llm_gateway.config import get_settings
+
+
+def get_team_multiplier(team_id: int | None) -> int:
+    if team_id is None:
+        return 1
+
+    return get_settings().team_rate_limit_multipliers.get(team_id, 1)
 
 
 @dataclass

--- a/services/llm-gateway/tests/test_throttles.py
+++ b/services/llm-gateway/tests/test_throttles.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from llm_gateway.auth.models import AuthenticatedUser
+from llm_gateway.config import get_settings
 from llm_gateway.rate_limiting.model_throttles import (
     ProductModelInputTokenThrottle,
     UserModelInputTokenThrottle,
@@ -12,6 +13,7 @@ from llm_gateway.rate_limiting.throttles import (
     Throttle,
     ThrottleContext,
     ThrottleResult,
+    get_team_multiplier,
 )
 
 
@@ -179,3 +181,21 @@ class TestThrottleContext:
         assert context.input_tokens == 1000
         assert context.max_output_tokens == 4096
         assert context.request_id == "req-123"
+
+
+class TestGetTeamMultiplier:
+    def test_returns_1_for_none_team_id(self) -> None:
+        assert get_team_multiplier(None) == 1
+
+    def test_returns_1_for_unconfigured_team(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 10}')
+        get_settings.cache_clear()
+        assert get_team_multiplier(99) == 1
+        get_settings.cache_clear()
+
+    def test_returns_configured_multiplier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 10, "5": 5}')
+        get_settings.cache_clear()
+        assert get_team_multiplier(2) == 10
+        assert get_team_multiplier(5) == 5
+        get_settings.cache_clear()


### PR DESCRIPTION
Allow configuring per-team rate limit multipliers via LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS env var (JSON dict of team_id -> multiplier). Teams with a configured multiplier get that factor applied to their token limits.