### PR TITLE
fix(error-tracking): show error tracking in sidebar when errors exist

### DIFF
--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -109,8 +109,8 @@ class ProductIntent(UUIDTModel, RootTeamMixin):
         return Experiment.objects.filter(team=self.team, start_date__isnull=False).exists()
 
     def has_activated_error_tracking(self) -> bool:
-        # the team has resolved any issues
-        return ErrorTrackingIssue.objects.filter(team=self.team, status=ErrorTrackingIssue.Status.RESOLVED).exists()
+        # the team has any error tracking issues
+        return ErrorTrackingIssue.objects.filter(team=self.team).exists()
 
     def has_activated_surveys(self) -> bool:
         return Survey.objects.filter(team__project_id=self.team.project_id, start_date__isnull=False).exists()


### PR DESCRIPTION
## Problem

When users send errors to PostHog, the error tracking product doesn't appear in their sidebar until they've resolved at least one issue. This creates a confusing experience where users have data but can't easily find it.

The activation criteria (`has_activated_error_tracking`) was checking for `status=RESOLVED`, but this is inconsistent with other products like experiments and surveys which just check for existence (a launched experiment/survey).

## Changes

- Changed `has_activated_error_tracking()` to check for the existence of any `ErrorTrackingIssue` rather than requiring resolved issues
- Added tests for `has_activated_error_tracking` (there were none previously)

This aligns the error tracking activation pattern with experiments and surveys - all now check for "has the team used this product at all" rather than "has the team completed a full workflow".

## How did you test this code?

- [x] Added unit tests covering all status types (active, resolved, archived) and the no-issues case
- [x] All tests pass locally: `pytest posthog/models/test/test_product_intent.py::TestProductIntent::test_has_activated_error_tracking* -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)