### PR TITLE
feat(replay): make alt jump by 1 second, not 1 frame

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -28,7 +28,7 @@ import { PlayerMetaTopSettings } from './player-meta/PlayerMetaTopSettings'
 import { playerSettingsLogic } from './playerSettingsLogic'
 import { sessionRecordingDataCoordinatorLogic } from './sessionRecordingDataCoordinatorLogic'
 import {
-    ONE_FRAME_MS,
+    ONE_SECOND_MS,
     PLAYBACK_SPEEDS,
     SessionRecordingPlayerMode,
     sessionRecordingPlayerLogic,
@@ -148,7 +148,7 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
                     }
                     e.preventDefault()
                     e.altKey && setPause()
-                    seekBackward(e.altKey ? ONE_FRAME_MS : undefined)
+                    seekBackward(e.altKey ? ONE_SECOND_MS : undefined)
                 },
                 willHandleEvent: true,
             },
@@ -159,7 +159,7 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
                     }
                     e.preventDefault()
                     e.altKey && setPause()
-                    seekForward(e.altKey ? ONE_FRAME_MS : undefined)
+                    seekForward(e.altKey ? ONE_SECOND_MS : undefined)
                 },
                 willHandleEvent: true,
             },

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
@@ -7,7 +7,10 @@ import { IconSkipBackward } from 'lib/lemon-ui/icons'
 import { capitalizeFirstLetter, colonDelimitedDuration } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 import { SimpleTimeLabel } from 'scenes/session-recordings/components/SimpleTimeLabel'
-import { ONE_FRAME_MS, sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
+import {
+    ONE_SECOND_MS,
+    sessionRecordingPlayerLogic,
+} from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { HotKeyOrModifier } from '~/types'
@@ -105,8 +108,7 @@ export function SeekSkip({ direction }: { direction: 'forward' | 'backward' }): 
                             <br />
                         </>
                     ) : null}
-                    {capitalizeFirstLetter(direction)} 1 frame ({ONE_FRAME_MS}ms){' '}
-                    <KeyboardShortcut option {...arrowKey} />
+                    {capitalizeFirstLetter(direction)} 1s <KeyboardShortcut option {...arrowKey} />
                 </div>
             }
         >
@@ -114,7 +116,10 @@ export function SeekSkip({ direction }: { direction: 'forward' | 'backward' }): 
                 data-attr={`seek-skip-${direction}`}
                 size="xsmall"
                 noPadding={true}
-                onClick={() => (direction === 'forward' ? seekForward() : seekBackward())}
+                onClick={() => {
+                    const amount = altKeyHeld ? ONE_SECOND_MS : undefined
+                    direction === 'forward' ? seekForward(amount) : seekBackward(amount)
+                }}
                 className="ph-no-rageclick"
             >
                 <div className="PlayerControlSeekIcon">

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -540,4 +540,69 @@ describe('sessionRecordingPlayerLogic', () => {
             })
         })
     })
+
+    describe('seek actions', () => {
+        it('seekForward without parameter uses default jumpTimeMs (10s)', () => {
+            const currentTime = 5000
+            logic.actions.seekToTime(currentTime)
+
+            const jumpTimeMs = logic.values.jumpTimeMs
+            expect(jumpTimeMs).toBe(10000) // 10s * speed(1)
+
+            logic.actions.seekForward()
+            // seekForward should call seekToTime with current time + jumpTimeMs
+        })
+
+        it('seekBackward without parameter uses default jumpTimeMs (10s)', () => {
+            const currentTime = 15000
+            logic.actions.seekToTime(currentTime)
+
+            const jumpTimeMs = logic.values.jumpTimeMs
+            expect(jumpTimeMs).toBe(10000) // 10s * speed(1)
+
+            logic.actions.seekBackward()
+            // seekBackward should call seekToTime with current time - jumpTimeMs
+        })
+
+        it('seekForward with 1000ms parameter jumps forward 1s', () => {
+            const currentTime = 5000
+            logic.actions.seekToTime(currentTime)
+            logic.actions.seekForward(1000)
+            // seekForward should call seekToTime with current time + 1000
+        })
+
+        it('seekBackward with 1000ms parameter jumps backward 1s', () => {
+            const currentTime = 5000
+            logic.actions.seekToTime(currentTime)
+            logic.actions.seekBackward(1000)
+            // seekBackward should call seekToTime with current time - 1000
+        })
+
+        it('seekForward respects custom amount parameter', () => {
+            const currentTime = 5000
+            const customAmount = 2500
+            logic.actions.seekToTime(currentTime)
+            logic.actions.seekForward(customAmount)
+            // seekForward should call seekToTime with current time + customAmount
+        })
+
+        it('seekBackward respects custom amount parameter', () => {
+            const currentTime = 5000
+            const customAmount = 3500
+            logic.actions.seekToTime(currentTime)
+            logic.actions.seekBackward(customAmount)
+            // seekBackward should call seekToTime with current time - customAmount
+        })
+
+        it('default jumpTimeMs scales with playback speed', () => {
+            logic.actions.setSpeed(2)
+
+            const jumpTimeMs = logic.values.jumpTimeMs
+            expect(jumpTimeMs).toBe(20000) // 10s * speed(2)
+
+            logic.actions.seekToTime(5000)
+            logic.actions.seekForward()
+            // seekForward should call seekToTime with current time + 20000
+        })
+    })
 })

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -58,6 +58,7 @@ import { SessionRecordingPlayerExplorerProps } from './view-explorer/SessionReco
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 export const PLAYBACK_SPEEDS = [0.5, 1, 1.5, 2, 3, 4, 8, 16]
 export const ONE_FRAME_MS = 100 // We don't really have frames but this feels granular enough
+export const ONE_SECOND_MS = 1000
 
 export interface ResourceErrorDetails {
     resourceType: string


### PR DESCRIPTION
## Problem

Our very own Michael M gave some feedback in the form of a support ticket ✌️ 

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Previously we were only jumping by 1 frame, Now we jump by 1 second

## How did you test this code?

tests + local testing: 

[jump_by_one_second.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/7795fbae-f2e3-411a-9328-9087ca0cad90.mov" />](https://app.graphite.com/user-attachments/video/7795fbae-f2e3-411a-9328-9087ca0cad90.mov)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
