### PR TITLE
fix(flags): Update language in multi-variant served value explainer

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -1396,17 +1396,28 @@ function FeatureFlagRollout({
                                 </span>
                             ) : (
                                 <>
-                                    {capitalizeFirstLetter(aggregationTargetName)} will be served{' '}
-                                    {multivariateEnabled ? (
-                                        <>
-                                            <strong>a variant key</strong> according to the below distribution
-                                        </>
-                                    ) : (
-                                        <strong>
-                                            <code>true</code>
-                                        </strong>
-                                    )}{' '}
-                                    <span>if they match one or more release condition groups.</span>
+                                    <div>
+                                        {capitalizeFirstLetter(aggregationTargetName)} will be served{' '}
+                                        {multivariateEnabled ? (
+                                            <>
+                                                <strong>a variant key</strong> according to the below distribution
+                                            </>
+                                        ) : (
+                                            <strong>
+                                                <code>true</code>
+                                            </strong>
+                                        )}{' '}
+                                        if they match one or more release condition groups.
+                                    </div>
+                                    {multivariateEnabled && (
+                                        <div>
+                                            {capitalizeFirstLetter(aggregationTargetName)} will be served{' '}
+                                            <strong>
+                                                <code>false</code>
+                                            </strong>{' '}
+                                            otherwise.
+                                        </div>
+                                    )}
                                 </>
                             )}
                         </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -1408,16 +1408,17 @@ function FeatureFlagRollout({
                                             </strong>
                                         )}{' '}
                                         if they match one or more release condition groups.
+                                        {multivariateEnabled && (
+                                            <>
+                                                {' '}
+                                                Otherwise, the feature flag will evaluate to{' '}
+                                                <strong>
+                                                    <code>false</code>
+                                                </strong>
+                                                .
+                                            </>
+                                        )}
                                     </div>
-                                    {multivariateEnabled && (
-                                        <div>
-                                            {capitalizeFirstLetter(aggregationTargetName)} will be served{' '}
-                                            <strong>
-                                                <code>false</code>
-                                            </strong>{' '}
-                                            otherwise.
-                                        </div>
-                                    )}
                                 </>
                             )}
                         </div>


### PR DESCRIPTION
## Problem

Adds some clarifying text to multi-variant flags indicating that they can return `false` if no release conditions are met.

Closes #41549
Original PR: https://github.com/PostHog/posthog/pull/41903

## Changes

<img width="1162" height="133" alt="image" src="https://github.com/user-attachments/assets/c0ffaae6-d960-4c73-aaaa-a8943d34151c" />
