### PR TITLE
Fix publishing to use OIDC provenance

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -84,3 +84,6 @@ jobs:
 
             - name: Publish the package in the npm registry
               run: cd services/mcp/typescript && pnpm publish --access public
+              env:
+                  NPM_CONFIG_PROVENANCE: true
+                  NODE_AUTH_TOKEN: ''

--- a/services/mcp/typescript/package.json
+++ b/services/mcp/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/agent-toolkit",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "description": "PostHog tools for AI agents",
     "main": "dist/index.js",
     "module": "dist/index.mjs",


### PR DESCRIPTION
`map-publish.yml` is broken; this should fix it?

Context: https://github.com/PostHog/posthog/actions/runs/21047566279/job/60525833853