### PR TITLE
chore(gateway): lower model limit

### DIFF
--- a/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_service.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_service.py
@@ -10,7 +10,7 @@ from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
 
 logger = structlog.get_logger(__name__)
 
-TARGET_LIMIT_COST_PER_HOUR: Final[float] = 60.0
+TARGET_LIMIT_COST_PER_HOUR: Final[float] = 20.0
 CACHE_TTL_SECONDS: Final[int] = 300
 
 


### PR DESCRIPTION
this was temporarily high for the wizard, we can lower it now.