### PR TITLE
fix(rust): attempt to fix workspace build issues by rolling fwd

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -216,6 +216,8 @@ jobs:
             - name: Run cargo test
               env:
                   RUST_BACKTRACE: 1
+                  # Use system OpenSSL instead of vendored to avoid assembly build issue (2026-01-13)
+                  OPENSSL_NO_VENDOR: 1
                   # Set up dual database environment for feature-flags service
                   PERSONS_READ_DATABASE_URL: ${{ matrix.package == 'feature-flags' && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}
                   PERSONS_WRITE_DATABASE_URL: ${{ matrix.package == 'feature-flags' && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -13,9 +13,6 @@ on:
 jobs:
     build:
         name: build ${{ matrix.image }}
-        concurrency:
-            group: rust-docker-build-${{ github.ref }}
-            cancel-in-progress: false
         strategy:
             matrix:
                 include:

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
+            - 'eli.r/rust-build-pin-openssl-src'
 
 jobs:
     build:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5478,9 +5478,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.1+3.5.1"
+version = "300.4.2+3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
 dependencies = [
  "cc",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -90,6 +90,9 @@ opentelemetry-otlp = "0.15.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["trace", "rt-tokio"] }
 public-suffix = "0.1.2"
 rand = "0.8.5"
+# ssl-vendored statically links OpenSSL for production stability (no runtime libssl dependency)
+# NOTE: openssl-src is pinned to 300.4.2+3.4.1 in Cargo.lock to avoid ARM64 assembly issues in 3.5.x
+# To update: cargo update -p openssl-src --precise <version>
 rdkafka = { version = "0.37.0", features = ["tracing", "ssl-vendored"] }
 reqwest = { version = "0.12.3", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Problem
The changes to the Rust CI build Action to set no-vendor flag for openssl is causing build failures.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
