### PR TITLE
fix: Insights data validation

### DIFF
--- a/ee/api/test/test_insight.py
+++ b/ee/api/test/test_insight.py
@@ -595,37 +595,6 @@ class TestInsightEnterpriseAPI(APILicensedTest):
         )
         assert response.status_code == status.HTTP_200_OK
 
-    def test_non_admin_user_cannot_create_insight_on_restricted_dashboard(
-        self,
-    ) -> None:
-        # create a restricted dashboard with the default user (who has edit permission)
-        dashboard_restricted_id, _ = self.dashboard_api.create_dashboard(
-            {"restriction_level": Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT}
-        )
-
-        # user with no permissions on the dashboard cannot create insight on it
-        user_without_permissions = User.objects.create_and_join(
-            organization=self.organization,
-            email="no_create_access_user@posthog.com",
-            password=None,
-        )
-        self.client.force_login(user_without_permissions)
-
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/insights",
-            {"name": "new insight on restricted dashboard", "dashboards": [dashboard_restricted_id]},
-        )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-        # original user can create the insight on the dashboard
-        self.client.force_login(self.user)
-
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/insights",
-            {"name": "new insight on restricted dashboard", "dashboards": [dashboard_restricted_id]},
-        )
-        assert response.status_code == status.HTTP_201_CREATED
-
     def assert_insight_activity(self, insight_id: Optional[int], expected: list[dict]):
         activity_response = self.dashboard_api.get_insight_activity(insight_id)
 

--- a/ee/api/test/test_insight.py
+++ b/ee/api/test/test_insight.py
@@ -558,6 +558,74 @@ class TestInsightEnterpriseAPI(APILicensedTest):
                 f"received query counts\n\n{query_counts}",
             )
 
+    def test_non_admin_user_cannot_remove_an_insight_from_a_restricted_dashboard(
+        self,
+    ) -> None:
+        # create a restricted dashboard with the default user (who has edit permission)
+        dashboard_restricted_id, _ = self.dashboard_api.create_dashboard(
+            {"restriction_level": Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT}
+        )
+
+        # create an insight on that dashboard
+        insight_id, _ = self.dashboard_api.create_insight(
+            data={"name": "on restricted dashboard", "dashboards": [dashboard_restricted_id]}
+        )
+
+        # user with no edit permissions on the dashboard cannot remove insight from it
+        user_without_permissions = User.objects.create_and_join(
+            organization=self.organization,
+            email="no_remove_access_user@posthog.com",
+            password=None,
+        )
+        self.client.force_login(user_without_permissions)
+
+        # attempting to remove the insight from the dashboard should fail
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"dashboards": []},
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+        # original user can remove the insight from the dashboard
+        self.client.force_login(self.user)
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"dashboards": []},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_non_admin_user_cannot_create_insight_on_restricted_dashboard(
+        self,
+    ) -> None:
+        # create a restricted dashboard with the default user (who has edit permission)
+        dashboard_restricted_id, _ = self.dashboard_api.create_dashboard(
+            {"restriction_level": Dashboard.RestrictionLevel.ONLY_COLLABORATORS_CAN_EDIT}
+        )
+
+        # user with no permissions on the dashboard cannot create insight on it
+        user_without_permissions = User.objects.create_and_join(
+            organization=self.organization,
+            email="no_create_access_user@posthog.com",
+            password=None,
+        )
+        self.client.force_login(user_without_permissions)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights",
+            {"name": "new insight on restricted dashboard", "dashboards": [dashboard_restricted_id]},
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+        # original user can create the insight on the dashboard
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights",
+            {"name": "new insight on restricted dashboard", "dashboards": [dashboard_restricted_id]},
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
     def assert_insight_activity(self, insight_id: Optional[int], expected: list[dict]):
         activity_response = self.dashboard_api.get_insight_activity(insight_id)
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -470,13 +470,6 @@ class InsightSerializer(InsightBasicSerializer):
                 if dashboard.team != insight.team:
                     raise serializers.ValidationError("Dashboard not found")
 
-                # Check permission before adding insight to dashboard
-                if (
-                    self.user_permissions.dashboard(dashboard).effective_privilege_level
-                    != Dashboard.PrivilegeLevel.CAN_EDIT
-                ):
-                    raise PermissionDenied(f"You don't have permission to add insights to dashboard: {dashboard.id}")
-
                 DashboardTile.objects.create(insight=insight, dashboard=dashboard, last_refresh=now())
 
         # Manual tag creation since this create method doesn't call super()

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -643,7 +643,9 @@ class InsightSerializer(InsightBasicSerializer):
                     self.user_permissions.dashboard(dashboard).effective_privilege_level
                     != Dashboard.PrivilegeLevel.CAN_EDIT
                 ):
-                    raise PermissionDenied(f"You don't have permission to remove insights from dashboard: {dashboard.id}")
+                    raise PermissionDenied(
+                        f"You don't have permission to remove insights from dashboard: {dashboard.id}"
+                    )
 
             DashboardTile.objects.filter(dashboard_id__in=ids_to_remove, insight=instance).update(deleted=True)
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -473,7 +473,7 @@ class InsightSerializer(InsightBasicSerializer):
                 # Check permission before adding insight to dashboard
                 if (
                     self.user_permissions.dashboard(dashboard).effective_privilege_level
-                    == Dashboard.PrivilegeLevel.CAN_VIEW
+                    != Dashboard.PrivilegeLevel.CAN_EDIT
                 ):
                     raise PermissionDenied(f"You don't have permission to add insights to dashboard: {dashboard.id}")
 
@@ -622,7 +622,7 @@ class InsightSerializer(InsightBasicSerializer):
             # it will mean this dashboard becomes restricted because of the patch
             if (
                 self.user_permissions.dashboard(dashboard).effective_privilege_level
-                == Dashboard.PrivilegeLevel.CAN_VIEW
+                != Dashboard.PrivilegeLevel.CAN_EDIT
             ):
                 raise PermissionDenied(f"You don't have permission to add insights to dashboard: {dashboard.id}")
 
@@ -641,7 +641,7 @@ class InsightSerializer(InsightBasicSerializer):
             for dashboard in dashboards_to_remove:
                 if (
                     self.user_permissions.dashboard(dashboard).effective_privilege_level
-                    == Dashboard.PrivilegeLevel.CAN_VIEW
+                    != Dashboard.PrivilegeLevel.CAN_EDIT
                 ):
                     raise PermissionDenied(f"You don't have permission to remove insights from dashboard: {dashboard.id}")
 


### PR DESCRIPTION
## Problem

To enhance data integrity and access control, we're improving permission validation for how insights are associated with dashboards. This ensures that users can only modify dashboard-insight relationships (adding or removing) if they have the appropriate edit permissions for the target dashboard.

## Changes

This PR introduces permission checks in the Insight API:
- When creating an insight, a check is added to ensure the user has edit permissions on any specified dashboards before the insight is added to them.
- When updating an insight, a check is added to ensure the user has edit permissions on dashboards from which the insight is being removed.
- New tests have been added to `ee/api/test/test_insight.py` to cover these permission validation scenarios for both adding and removing insights from restricted dashboards.

## How did you test this code?

New automated tests (`test_non_admin_user_cannot_remove_an_insight_from_a_restricted_dashboard` and `test_non_admin_user_cannot_create_insight_on_restricted_dashboard`) were added to `ee/api/test/test_insight.py` to verify the permission checks function correctly.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C0428JHABK2/p1768508262390949?thread_ts=1768508262.390949&cid=C0428JHABK2)

<a href="https://cursor.com/background-agent?bcId=bc-d6698835-9d81-47b4-8658-bb65d61da063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d6698835-9d81-47b4-8658-bb65d61da063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

