### PR TITLE
fix(product tours): add product_tours to /flags config response

### DIFF
--- a/posthog/storage/team_metadata_cache.py
+++ b/posthog/storage/team_metadata_cache.py
@@ -103,6 +103,7 @@ TEAM_METADATA_FIELDS = [
     "cookieless_server_hash_mode",
     "survey_config",
     "surveys_opt_in",
+    "product_tours_opt_in",
     "capture_console_log_opt_in",
     "capture_performance_opt_in",
     "capture_dead_clicks",

--- a/rust/feature-flags/src/api/types.rs
+++ b/rust/feature-flags/src/api/types.rs
@@ -157,6 +157,10 @@ pub struct ConfigResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub surveys: Option<Value>,
 
+    /// Whether product tours are enabled
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub product_tours: Option<Value>,
+
     /// Logs product options
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logs: Option<LogsConfig>,

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -255,6 +255,9 @@ fn apply_core_config_fields(response: &mut FlagsResponse, config: &Config, team:
     };
 
     response.config.surveys = Some(serde_json::json!(team.surveys_opt_in.unwrap_or(false)));
+    response.config.product_tours = Some(serde_json::json!(team
+        .product_tours_opt_in
+        .unwrap_or(false)));
     response.config.heatmaps = Some(team.heatmaps_opt_in.unwrap_or(false));
     response.config.default_identified_only = Some(true);
     response.config.flags_persistence_default =
@@ -311,6 +314,7 @@ mod tests {
             session_recording_opt_in: false,
             inject_web_apps: None,
             surveys_opt_in: None,
+            product_tours_opt_in: None,
             heatmaps_opt_in: None,
             conversations_enabled: None,
             conversations_settings: None,
@@ -595,6 +599,32 @@ mod tests {
     }
 
     #[test]
+    fn test_product_tours_enabled() {
+        let mut response = create_base_response();
+        let config = Config::default_test_config();
+        let mut team = create_base_team();
+
+        team.product_tours_opt_in = Some(true);
+
+        apply_core_config_fields(&mut response, &config, &team);
+
+        assert_eq!(response.config.product_tours, Some(json!(true)));
+    }
+
+    #[test]
+    fn test_product_tours_disabled() {
+        let mut response = create_base_response();
+        let config = Config::default_test_config();
+        let mut team = create_base_team();
+
+        team.product_tours_opt_in = Some(false);
+
+        apply_core_config_fields(&mut response, &config, &team);
+
+        assert_eq!(response.config.product_tours, Some(json!(false)));
+    }
+
+    #[test]
     fn test_heatmaps_enabled() {
         let mut response = create_base_response();
         let config = Config::default_test_config();
@@ -710,6 +740,7 @@ mod tests {
 
         // Test that defaults are applied correctly
         assert_eq!(response.config.surveys, Some(json!(false)));
+        assert_eq!(response.config.product_tours, Some(json!(false)));
         assert_eq!(response.config.heatmaps, Some(false));
         assert_eq!(response.config.flags_persistence_default, Some(false));
         assert_eq!(response.config.autocapture_exceptions, Some(json!(false)));

--- a/rust/feature-flags/src/team/team_models.rs
+++ b/rust/feature-flags/src/team/team_models.rs
@@ -20,6 +20,7 @@ pub struct Team {
     pub session_recording_opt_in: bool, // Not nullable in schema, so needs to be handled in deserialization
     pub inject_web_apps: Option<bool>,
     pub surveys_opt_in: Option<bool>,
+    pub product_tours_opt_in: Option<bool>,
     pub heatmaps_opt_in: Option<bool>,
     pub conversations_enabled: Option<bool>,
     pub conversations_settings: Option<Json<serde_json::Value>>,

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -22,6 +22,7 @@ const TEAM_COLUMNS: &str = "
     session_recording_opt_in,
     inject_web_apps,
     surveys_opt_in,
+    product_tours_opt_in,
     heatmaps_opt_in,
     conversations_enabled,
     conversations_settings,


### PR DESCRIPTION
## Problem

product tours are not in the /flags config response, so they cannot be used without `__preview_remote_config`

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds product tours to /flags config response, based on `product_tours_opt_in` flag, which is set automatically when users create tours -- will prob migrate that to an explicit opt-in at some point

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

unit tests

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no