### PR TITLE
fix(workflows): fix react over-caching of workflow property filters UX

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
@@ -10,7 +10,7 @@ import { FilterType } from '~/types'
 import { HogFlowAction } from '../types'
 
 export type HogFlowFiltersProps = {
-    actionId?: HogFlowAction['id']
+    filtersKey: string
     filters: HogFlowAction['filters']
     setFilters: (filters: HogFlowAction['filters']) => void
     typeKey?: string
@@ -64,14 +64,14 @@ export function HogFlowEventFilters({ filters, setFilters, typeKey, buttonCopy }
     )
 }
 
-export function HogFlowPropertyFilters({ actionId, filters, setFilters }: HogFlowFiltersProps): JSX.Element {
+export function HogFlowPropertyFilters({ filtersKey, filters, setFilters }: HogFlowFiltersProps): JSX.Element {
     return (
         <PropertyFilters
             propertyFilters={filters?.properties}
             onChange={(properties: FilterType['properties']): void => {
                 setFilters({ ...filters, properties: properties ?? [] } as HogFlowAction['filters'])
             }}
-            pageKey={`HogFlowPropertyFilters.${actionId}`}
+            pageKey={`HogFlowPropertyFilters.${filtersKey}`}
             taxonomicGroupTypes={[
                 TaxonomicFilterGroupType.WorkflowVariables,
                 TaxonomicFilterGroupType.EventProperties,

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
@@ -192,7 +192,7 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
                                                 will skip this step and continue to the next one.
                                             </p>
                                             <HogFlowPropertyFilters
-                                                actionId={action.id}
+                                                filtersKey={`action-skip-conditions-${action.id}`}
                                                 filters={action.filters ?? {}}
                                                 setFilters={(filters) =>
                                                     setWorkflowAction(action.id, { ...action, filters })

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -102,7 +102,7 @@ export function StepConditionalBranchConfiguration({
                     </div>
 
                     <HogFlowPropertyFilters
-                        actionId={`${action.id}.${index}`}
+                        filtersKey={`condition-branch-condition-${action.id}-${index}`}
                         filters={condition.filters ?? {}}
                         setFilters={(filters) =>
                             setConditions(

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -252,6 +252,7 @@ function StepTriggerConfigurationEvents({
                     setFilters={(filters) =>
                         setWorkflowActionConfig(action.id, { type: 'event', filters: filters ?? {} })
                     }
+                    filtersKey={`workflow-trigger-${action.id}`}
                     typeKey="workflow-trigger"
                     buttonCopy="Add trigger event"
                 />

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
@@ -30,7 +30,7 @@ export function StepWaitUntilConditionConfiguration({
         <>
             <StepSchemaErrors />
 
-            <div>
+            <div className="flex flex-col gap-1">
                 <LemonLabel>Wait time</LemonLabel>
                 <HogFlowDuration
                     value={max_wait_duration}
@@ -40,7 +40,7 @@ export function StepWaitUntilConditionConfiguration({
                 />
             </div>
 
-            <div>
+            <div className="flex flex-col gap-1">
                 <LemonLabel>Conditions to wait for</LemonLabel>
                 <LemonInput
                     value={localConditionName || ''}
@@ -49,7 +49,7 @@ export function StepWaitUntilConditionConfiguration({
                     size="small"
                 />
                 <HogFlowPropertyFilters
-                    actionId={action.id}
+                    filtersKey={`wait-until-condition-${action.id}`}
                     filters={condition.filters ?? {}}
                     setFilters={(filters) =>
                         partialSetWorkflowActionConfig(action.id, { condition: { ...condition, filters } })


### PR DESCRIPTION
## Problem

Context: https://posthog.slack.com/archives/C06GG249PR6/p1768511563991439

The `pageKey` prop being the same for conditional action's conditions and the overall skip-action conditions was causing a glitchy link between the two components.

## Changes

- Make sure the react key is unique between these two mounted components
- Fix some awkward spacing on the wait until condition config UX

## How did you test this code?

Verified conditional actions working as expected when editing the skip conditions:

<img width="628" height="423" alt="Screenshot 2026-01-15 at 5 31 37 PM" src="https://github.com/user-attachments/assets/203a5ed3-ab37-4f61-b94c-a45c25df236f" />

<img width="623" height="531" alt="Screenshot 2026-01-15 at 5 34 20 PM" src="https://github.com/user-attachments/assets/674fbae9-083b-438b-8d8e-ea6094cffe57" />

