### PR TITLE
feat(insights): support AS aliases for breakdown display names

### DIFF
--- a/frontend/src/queries/nodes/DataTable/utils.test.ts
+++ b/frontend/src/queries/nodes/DataTable/utils.test.ts
@@ -1,6 +1,8 @@
 import {
     defaultDataTableEventColumns,
     defaultDataTablePersonColumns,
+    extractAsAlias,
+    extractDisplayLabel,
     extractExpressionComment,
     getColumnsForQuery,
     removeExpressionComment,
@@ -12,6 +14,46 @@ describe('DataTable utils', () => {
         expect(extractExpressionComment('')).toBe('')
         expect(extractExpressionComment('asd -- bla')).toBe('bla')
         expect(extractExpressionComment('asd -- asd --   bla  ')).toBe('bla')
+    })
+
+    it.each([
+        // Basic AS alias (case insensitive)
+        ['properties.$browser AS Browser', 'Browser'],
+        ['properties.$browser as browser', 'browser'],
+        ['properties.$browser As Mixed', 'Mixed'],
+        // Backtick aliases with spaces
+        ['properties.$city AS `City Name`', 'City Name'],
+        ['toUpper(x) as `My Display Name`', 'My Display Name'],
+        // Complex expressions
+        ["coalesce(properties.$city, 'Unknown') AS City", 'City'],
+        ['arrayJoin(properties.$active_feature_flags) AS flag', 'flag'],
+        // AS inside string literal should still match final AS
+        ["replaceAll(x, ' as ', '_') AS cleaned", 'cleaned'],
+        // Nested AS - takes outermost/last
+        ['if(x as y, 1, 0) AS result', 'result'],
+        // Unicode aliases
+        ['x AS città', 'città'],
+        // No alias - returns null
+        ['properties.$browser', null],
+        ['coalesce(a, b)', null],
+        // Malformed - returns null
+        ['x AS', null],
+        ['x AS ', null],
+    ])('extractAsAlias(%s) = %s', (input, expected) => {
+        expect(extractAsAlias(input)).toBe(expected)
+    })
+
+    it.each([
+        // AS alias takes priority
+        ['properties.$browser AS Browser', 'Browser'],
+        // Falls back to comment syntax
+        ['asd -- bla', 'bla'],
+        // AS alias when no comment
+        ['x AS foo', 'foo'],
+        // No alias or comment - returns original
+        ['properties.$browser', 'properties.$browser'],
+    ])('extractDisplayLabel(%s) = %s', (input, expected) => {
+        expect(extractDisplayLabel(input)).toBe(expected)
     })
 
     it('removeExpressionComment', () => {

--- a/frontend/src/queries/nodes/DataTable/utils.test.ts
+++ b/frontend/src/queries/nodes/DataTable/utils.test.ts
@@ -50,6 +50,8 @@ describe('DataTable utils', () => {
         ['asd -- bla', 'bla'],
         // AS alias when no comment
         ['x AS foo', 'foo'],
+        // AS alias takes priority over comment when both present
+        ['x AS foo -- bar', 'foo'],
         // No alias or comment - returns original
         ['properties.$browser', 'properties.$browser'],
     ])('extractDisplayLabel(%s) = %s', (input, expected) => {

--- a/frontend/src/queries/nodes/DataTable/utils.ts
+++ b/frontend/src/queries/nodes/DataTable/utils.ts
@@ -86,13 +86,9 @@ export function extractDisplayLabel(query: string): string {
     if (!query || typeof query !== 'string') {
         return query
     }
-    // Try AS alias first (standard SQL)
-    const alias = extractAsAlias(query)
-    if (alias) {
-        return alias
-    }
-    // Fall back to comment syntax (PostHog-specific)
-    return extractExpressionComment(query)
+    // Parse `expr AS column` first, fallback to `expr -- column`
+    return extractAsAlias(query) ?? extractExpressionComment(query)
+    
 }
 
 export function removeExpressionComment(query: string): string {

--- a/frontend/src/queries/nodes/DataTable/utils.ts
+++ b/frontend/src/queries/nodes/DataTable/utils.ts
@@ -88,7 +88,6 @@ export function extractDisplayLabel(query: string): string {
     }
     // Parse `expr AS column` first, fallback to `expr -- column`
     return extractAsAlias(query) ?? extractExpressionComment(query)
-    
 }
 
 export function removeExpressionComment(query: string): string {

--- a/frontend/src/queries/nodes/DataTable/utils.ts
+++ b/frontend/src/queries/nodes/DataTable/utils.ts
@@ -62,6 +62,39 @@ export function extractExpressionComment(query: string): string {
     return query
 }
 
+/** Extract AS alias from SQL expression (e.g., "expr AS foo" -> "foo") */
+export function extractAsAlias(query: string): string | null {
+    if (!query || typeof query !== 'string') {
+        return null
+    }
+    const trimmed = query.trim()
+    if (!trimmed) {
+        return null
+    }
+
+    // Match: whitespace + AS (case-insensitive) + whitespace + (backticked or word alias) at end
+    const asMatch = trimmed.match(/\s+[Aa][Ss]\s+(`[^`]+`|[\w\u0080-\uFFFF]+)\s*$/)
+    if (asMatch) {
+        const alias = asMatch[1]
+        return alias.startsWith('`') && alias.endsWith('`') ? alias.slice(1, -1) : alias
+    }
+    return null
+}
+
+/** Get display label for an expression, trying AS alias first, then comment syntax */
+export function extractDisplayLabel(query: string): string {
+    if (!query || typeof query !== 'string') {
+        return query
+    }
+    // Try AS alias first (standard SQL)
+    const alias = extractAsAlias(query)
+    if (alias) {
+        return alias
+    }
+    // Fall back to comment syntax (PostHog-specific)
+    return extractExpressionComment(query)
+}
+
 export function removeExpressionComment(query: string): string {
     if (query.includes('--')) {
         return query.split('--').slice(0, -1).join('--').trim()

--- a/frontend/src/queries/nodes/DataTable/utils.ts
+++ b/frontend/src/queries/nodes/DataTable/utils.ts
@@ -72,8 +72,8 @@ export function extractAsAlias(query: string): string | null {
         return null
     }
 
-    // Match: whitespace + AS (case-insensitive) + whitespace + (backticked or word alias) at end
-    const asMatch = trimmed.match(/\s+[Aa][Ss]\s+(`[^`]+`|[\w\u0080-\uFFFF]+)\s*$/)
+    // Match: whitespace + AS (case-insensitive) + whitespace + (backticked or word alias), optionally followed by comment
+    const asMatch = trimmed.match(/\s+[Aa][Ss]\s+(`[^`]+`|[\w\u0080-\uFFFF]+)(\s*--.*)?$/)
     if (asMatch) {
         const alias = asMatch[1]
         return alias.startsWith('`') && alias.endsWith('`') ? alias.slice(1, -1) : alias

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -16,7 +16,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { groupsModel } from '~/models/groupsModel'
-import { extractExpressionComment } from '~/queries/nodes/DataTable/utils'
+import { extractDisplayLabel } from '~/queries/nodes/DataTable/utils'
 import { BreakdownType, GroupTypeIndex } from '~/types'
 
 import { BreakdownTagMenu } from './BreakdownTagMenu'
@@ -138,7 +138,7 @@ export function BreakdownTag({
             propertyName = group.name_singular || group.group_type
         }
     } else {
-        propertyName = extractExpressionComment(propertyName as string)
+        propertyName = extractDisplayLabel(propertyName as string)
     }
 
     const clickable = onClick !== undefined

--- a/frontend/src/scenes/insights/summarizeInsight.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.ts
@@ -16,7 +16,7 @@ import { cohortsModel } from '~/models/cohortsModel'
 import { cohortsModelType } from '~/models/cohortsModelType'
 import { groupsModel } from '~/models/groupsModel'
 import { groupsModelType } from '~/models/groupsModelType'
-import { extractExpressionComment } from '~/queries/nodes/DataTable/utils'
+import { extractDisplayLabel } from '~/queries/nodes/DataTable/utils'
 import {
     Breakdown,
     BreakdownFilter,
@@ -59,8 +59,8 @@ function summarizeSingularBreakdown(
         breakdownType &&
         breakdownType in PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE
             ? getCoreFilterDefinition(breakdown, PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE[breakdownType])
-                  ?.label || extractExpressionComment(breakdown)
-            : extractExpressionComment(breakdown as string)
+                  ?.label || extractDisplayLabel(breakdown)
+            : extractDisplayLabel(breakdown as string)
     return `${noun}'s ${propertyLabel}`
 }
 
@@ -264,7 +264,7 @@ function summarizeQuery(query: Node): string {
 
         if (selected.length > 0) {
             return `${selected
-                .map(extractExpressionComment)
+                .map(extractDisplayLabel)
                 .filter((c) => !query.hiddenColumns?.includes(c))
                 .join(', ')}${source ? ` from ${source}` : ''}`
         }

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -15,7 +15,7 @@ import { IndexedTrendResult } from 'scenes/trends/types'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { extractExpressionComment } from '~/queries/nodes/DataTable/utils'
+import { extractDisplayLabel } from '~/queries/nodes/DataTable/utils'
 import { isValidBreakdown } from '~/queries/utils'
 import { ChartDisplayType, TrendsFilterType } from '~/types'
 
@@ -232,7 +232,7 @@ export function InsightsTable({
                         isPinned={isColumnPinned(columnKey)}
                         onTogglePin={() => toggleColumnPin(columnKey)}
                     >
-                        {extractExpressionComment(breakdown.property?.toString())}
+                        {extractDisplayLabel(breakdown.property?.toString())}
                     </MultipleBreakdownColumnTitle>
                 ),
                 render: (_, item) => {


### PR DESCRIPTION
SQL expression breakdowns with `as` aliases

<img width="1334" height="782" alt="CleanShot 2026-01-15 at 19 33 58@2x" src="https://github.com/user-attachments/assets/3b072f45-ea1d-4062-a2d0-075690cbbd02" />


Now extract the alias as the column label

<img width="834" height="394" alt="CleanShot 2026-01-15 at 19 35 51@2x" src="https://github.com/user-attachments/assets/2e5e20e3-1680-41b9-8845-d58b947ee76c" />


Supports `expr as foo` | `expr AS foo` | `expr as `bar``

This fits the mental model SQL users already have. Context: https://posthog.slack.com/archives/C0862M4NJHG/p1765845963245089

Note that we do support this too with `expr -- Comment` where the comment becomes the breakdown label, but that's not immediately obvious to a SQL user.

Weighed changing the name of the method but it's used in 9 places, so keeping the comment extraction as priority to respect original behavior. Changing the name of this method would make it drift from the existing `removeExpressionComment` which is not used for display but for SQL execution, so I didn't need to modify that for a purely display feature.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
