### PR TITLE
feat(replay): change how we filter for visited_page

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -702,7 +702,7 @@ describe('sessionRecordingsPlaylistLogic', () => {
     })
 
     describe('convertUniversalFiltersToRecordingsQuery', () => {
-        it('expands the visited_page filter to a pageview with $current_url property', () => {
+        it('passes the visited_page filter as a recording property', () => {
             const result = convertUniversalFiltersToRecordingsQuery({
                 ...DEFAULT_RECORDING_FILTERS,
                 filter_group: {
@@ -730,21 +730,7 @@ describe('sessionRecordingsPlaylistLogic', () => {
                 console_log_filters: [],
                 date_from: '-3d',
                 date_to: null,
-                events: [
-                    {
-                        id: '$pageview',
-                        name: '$pageview',
-                        properties: [
-                            {
-                                key: '$current_url',
-                                operator: 'exact',
-                                type: 'event',
-                                value: ['https://example-url.com'],
-                            },
-                        ],
-                        type: 'events',
-                    },
-                ],
+                events: [],
                 filter_test_accounts: false,
                 having_predicates: [
                     {
@@ -758,7 +744,14 @@ describe('sessionRecordingsPlaylistLogic', () => {
                 operand: 'AND',
                 order: 'console_error_count',
                 order_direction: 'DESC',
-                properties: [],
+                properties: [
+                    {
+                        key: 'visited_page',
+                        operator: 'exact',
+                        type: 'recording',
+                        value: ['https://example-url.com'],
+                    },
+                ],
             })
         })
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -35,7 +35,6 @@ import {
     VALID_RECORDING_ORDERS,
 } from '~/queries/schema/schema-general'
 import {
-    EntityTypes,
     FilterLogicalOperator,
     FilterType,
     LegacyRecordingFilters,
@@ -280,19 +279,9 @@ export function convertUniversalFiltersToRecordingsQuery(universalFilters: Recor
         } else if (isAnyPropertyfilter(f)) {
             if (isRecordingPropertyFilter(f)) {
                 if (f.key === 'visited_page') {
-                    events.push({
-                        id: '$pageview',
-                        name: '$pageview',
-                        type: EntityTypes.EVENTS,
-                        properties: [
-                            {
-                                type: PropertyFilterType.Event,
-                                key: '$current_url',
-                                value: f.value,
-                                operator: f.operator,
-                            },
-                        ],
-                    })
+                    // Pass visited_page as a recording property to use all_urls array in backend
+                    // This filters by URLs that actually appear in the recording, not just events during the session
+                    properties.push(f)
                 } else if (f.key === 'snapshot_source' && f.value) {
                     having_predicates.push(f)
                 } else if (f.key === 'comment_text') {


### PR DESCRIPTION
## Problem

We got feedback on a ticket: https://posthoghelp.zendesk.com/agent/tickets/46912 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49978)

that pointed out that its a bad experience when the event occurs outside of the scope of the recording in the session (during "load" for example)

For this filter rely on `all_urls` property under the hood to ensure its visited in the scope of the recording
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- map `visited_page` filter to check `all_urls `
- do some special array handling for is set/is not set operators

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
