### PR TITLE
feat: Relay GitHub secret scanning alerts to EU

### DIFF
--- a/posthog/api/test/test_github.py
+++ b/posthog/api/test/test_github.py
@@ -578,6 +578,16 @@ class TestRelayToEu(TestCase):
 
         self.assertIsNone(result)
 
+    @override_settings(GITHUB_SECRET_ALERT_RELAY_URL="https://eu.posthog.com/api/github/secret_alert/")
+    @patch("posthog.api.github.get_instance_region")
+    def test_returns_none_when_in_eu_region(self, mock_get_region):
+        """Prevent infinite loop if relay URL accidentally configured in EU."""
+        mock_get_region.return_value = "EU"
+
+        result = relay_to_eu('{"test": "data"}', "kid", "sig")
+
+        self.assertIsNone(result)
+
 
 class TestSecretAlertRelayIntegration(APIBaseTest):
     @patch("posthog.api.github.verify_github_signature")

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -47,6 +47,9 @@ if E2E_TESTING:
 IS_COLLECT_STATIC = len(sys.argv) > 1 and sys.argv[1] == "collectstatic"
 SERVER_GATEWAY_INTERFACE = get_from_env("SERVER_GATEWAY_INTERFACE", "WSGI", type_cast=str)
 
+# GitHub secret alert relay URL - set in US deployment to forward alerts to EU
+GITHUB_SECRET_ALERT_RELAY_URL: str | None = get_from_env("GITHUB_SECRET_ALERT_RELAY_URL", optional=True)
+
 # Bulk deletion operations can be disabled during database migrations
 DISABLE_BULK_DELETES: bool = get_from_env("DISABLE_BULK_DELETES", False, type_cast=str_to_bool)
 

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -52,6 +52,7 @@
     'posthog.tasks.feature_flags.update_team_flags_cache',
     'posthog.tasks.feature_flags.update_team_service_flags_cache',
     'posthog.tasks.heatmap_screenshot.generate_heatmap_screenshot',
+    'posthog.tasks.hog_flows.refresh_affected_hog_flows',
     'posthog.tasks.hog_functions.refresh_affected_hog_functions',
     'posthog.tasks.hog_functions.sync_hog_function_templates_task',
     'posthog.tasks.hypercache_verification.verify_and_fix_flags_cache_task',

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -52,7 +52,6 @@
     'posthog.tasks.feature_flags.update_team_flags_cache',
     'posthog.tasks.feature_flags.update_team_service_flags_cache',
     'posthog.tasks.heatmap_screenshot.generate_heatmap_screenshot',
-    'posthog.tasks.hog_flows.refresh_affected_hog_flows',
     'posthog.tasks.hog_functions.refresh_affected_hog_functions',
     'posthog.tasks.hog_functions.sync_hog_function_templates_task',
     'posthog.tasks.hypercache_verification.verify_and_fix_flags_cache_task',


### PR DESCRIPTION
## Problem

GitHub doesn't support sending alerts to multiple APIs, so we currently only revoke keys issued from US PostHog. This leave our EU users without this awesome protection.

## Changes

When at least one key is not found, we relay the request to our EU deployment. This relay logic is synchronous so that we can provide GitHub with accurate statistics. These requests don't contain any PII.

## How did you test this code?

Bunch o' tests
