### PR TITLE
fix(ph-ai): interrupted or cancelled ET crash conversation view

### DIFF
--- a/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
+++ b/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
@@ -160,9 +160,22 @@ export function ErrorTrackingFiltersWidget({
     filters,
 }: {
     toolCallId: string
-    filters: MaxErrorTrackingSearchResponse
+    filters: MaxErrorTrackingSearchResponse | null | undefined
 }): JSX.Element {
     const logicProps: MaxErrorTrackingWidgetLogicProps = { toolCallId, filters }
+
+    if (!filters) {
+        return (
+            <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
+                <div className="py-2">
+                    <EmptyMessage
+                        title="Error tracking data unavailable"
+                        description="The error tracking search could not be completed"
+                    />
+                </div>
+            </MessageTemplate>
+        )
+    }
 
     return (
         <BindLogic logic={maxErrorTrackingWidgetLogic} props={logicProps}>

--- a/frontend/src/scenes/max/messages/maxErrorTrackingWidgetLogic.ts
+++ b/frontend/src/scenes/max/messages/maxErrorTrackingWidgetLogic.ts
@@ -12,7 +12,7 @@ import type { maxErrorTrackingWidgetLogicType } from './maxErrorTrackingWidgetLo
 
 export interface MaxErrorTrackingWidgetLogicProps {
     toolCallId: string
-    filters: MaxErrorTrackingSearchResponse
+    filters: MaxErrorTrackingSearchResponse | null | undefined
 }
 
 export const maxErrorTrackingWidgetLogic = kea<maxErrorTrackingWidgetLogicType>([
@@ -26,20 +26,20 @@ export const maxErrorTrackingWidgetLogic = kea<maxErrorTrackingWidgetLogicType>(
 
     reducers(({ props }) => ({
         issues: [
-            (props.filters.issues ?? []) as MaxErrorTrackingIssuePreview[],
+            (props.filters?.issues ?? []) as MaxErrorTrackingIssuePreview[],
             {
                 loadMoreIssuesSuccess: (state, { moreIssuesResponse }) =>
                     moreIssuesResponse ? [...state, ...moreIssuesResponse.issues] : state,
             },
         ],
         hasMore: [
-            props.filters.has_more ?? false,
+            props.filters?.has_more ?? false,
             {
                 loadMoreIssuesSuccess: (_, { moreIssuesResponse }) => moreIssuesResponse?.hasMore ?? false,
             },
         ],
         nextCursor: [
-            (props.filters.next_cursor ?? null) as string | null,
+            (props.filters?.next_cursor ?? null) as string | null,
             {
                 loadMoreIssuesSuccess: (_, { moreIssuesResponse }) => moreIssuesResponse?.nextCursor ?? null,
             },
@@ -52,6 +52,9 @@ export const maxErrorTrackingWidgetLogic = kea<maxErrorTrackingWidgetLogicType>(
             {
                 loadMoreIssues: async () => {
                     const filters = props.filters
+                    if (!filters) {
+                        return null
+                    }
                     const currentOffset = values.nextCursor ? parseInt(values.nextCursor, 10) : values.issues.length
                     const limit = filters.limit ?? 50
 


### PR DESCRIPTION
## Problem

When a PostHog AI chat conversation contains a `search_error_tracking_issues tool call` that was interrupted or cancelled mid-flight, visiting that conversation would be broken with:
```
TypeError: Cannot read properties of null (reading 'issues')
```

This was due to the fact that `ui_payload` for the tool call can be `null` when the CH query was cancelled before completing  fully.
In the bug-reported conversation, there was a  CH query that was cancelled, leaving the conversation with an incomplete tool response.

**Before**:
<img width="1133" height="603" alt="CleanShot 2026-01-16 at 10  09 59" src="https://github.com/user-attachments/assets/60886f30-3808-4c52-bad1-a860e0ac6d36" />

**After**:

https://github.com/user-attachments/assets/66913fe3-b90a-401b-a28f-d15e801f27ac



## Changes

* handled potentially null `props.filters`
* early return to prevent querying when filters is null
* fallback UI with display message

## How did you test this code?

- [x] unit tests
- [x] e2e tests
