### PR TITLE
chore(dagster): add billing location to workspace and slack alerts

### DIFF
--- a/.dagster_home/workspace.yaml
+++ b/.dagster_home/workspace.yaml
@@ -13,6 +13,7 @@ load_from:
 
     # These dags are loaded in local dev
     - python_module: posthog.dags.locations.analytics_platform
+    - python_module: posthog.dags.locations.billing
     - python_module: posthog.dags.locations.experiments
     - python_module: posthog.dags.locations.growth
     - python_module: posthog.dags.locations.ingestion

--- a/posthog/dags/common/common.py
+++ b/posthog/dags/common/common.py
@@ -10,6 +10,7 @@ from posthog.clickhouse.query_tagging import DagsterTags
 
 class JobOwners(str, Enum):
     TEAM_ANALYTICS_PLATFORM = "team-analytics-platform"
+    TEAM_BILLING = "team-billing"
     TEAM_CLICKHOUSE = "team-clickhouse"
     TEAM_DATA_STACK = "team-data-stack"
     TEAM_ERROR_TRACKING = "team-error-tracking"

--- a/posthog/dags/slack_alerts.py
+++ b/posthog/dags/slack_alerts.py
@@ -10,6 +10,7 @@ from posthog.dags.common import JobOwners
 
 notification_channel_per_team = {
     JobOwners.TEAM_ANALYTICS_PLATFORM.value: "#alerts-analytics-platform",
+    JobOwners.TEAM_BILLING.value: "#alerts-billing",
     JobOwners.TEAM_CLICKHOUSE.value: "#alerts-clickhouse",
     JobOwners.TEAM_DATA_STACK.value: "#alerts-data-warehouse",
     JobOwners.TEAM_ERROR_TRACKING.value: "#alerts-error-tracking",


### PR DESCRIPTION
## Problem

We need to add support for Billing team alerts and DAGs in our Dagster setup.

## Changes

- Added `posthog.dags.locations.billing` to the Dagster workspace configuration
- Added Billing team to the Slack notification channels with alerts going to `#alerts-billing`

## How did you test this code?

Verified that the Dagster workspace loads correctly with the new billing module and confirmed that the Slack notification channel mapping works as expected.

## Publish to changelog?

No