### PR TITLE
fix: reverse thread messages and add col-reverse

### DIFF
--- a/frontend/src/layout/panel-layout/AiFirstNavBar.tsx
+++ b/frontend/src/layout/panel-layout/AiFirstNavBar.tsx
@@ -7,6 +7,8 @@ import { IconChevronRight, IconPlusSmall, IconSidebarClose, IconSidebarOpen } fr
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { AccountMenu } from 'lib/components/Account/AccountMenu'
+import { OrganizationMenu } from 'lib/components/Account/OrganizationMenu'
+import { ProjectMenu } from 'lib/components/Account/ProjectMenu'
 import { RenderKeybind } from 'lib/components/AppShortcuts/AppShortcutMenu'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
@@ -22,15 +24,13 @@ import { sceneLogic } from 'scenes/sceneLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
+import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { AppsMenu } from '~/layout/panel-layout/ai-first/AppsMenu'
 import { ConversationsMenu } from '~/layout/panel-layout/ai-first/ConversationsMenu'
 import { RecentConversationsList } from '~/layout/panel-layout/ai-first/RecentConversationsList'
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { ConfigurePinnedTabsModal } from '~/layout/scenes/ConfigurePinnedTabsModal'
 
-import { OrganizationMenu } from '../../lib/components/Account/OrganizationMenu'
-import { ProjectMenu } from '../../lib/components/Account/ProjectMenu'
-import { navigation3000Logic } from '../navigation-3000/navigationLogic'
 import { DataMenu } from './ai-first/DataMenu'
 
 const navBarStyles = cva({

--- a/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
+++ b/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
@@ -127,6 +127,7 @@ function ChatArea({ threadVisible, conversationId, conversation, onStartNewConve
                         </div>
                     )}
                     <Thread className="p-3" />
+                    <div className="flex-grow" />
                 </>
             )}
 

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -1168,6 +1168,16 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     ? conversation?.type !== ConversationType.DeepResearch
                     : true,
         ],
+
+        isAiUx: [(s) => [s.featureFlags], (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.AI_UX]],
+
+        threadGroupedForDisplay: [
+            (s) => [s.threadGrouped, s.isAiUx],
+            (threadGrouped, isAiUx): ThreadMessage[] => {
+                // Reverse the thread for AI-UX mode so it works with flex-direction: column-reverse
+                return isAiUx ? [...threadGrouped].reverse() : threadGrouped
+            },
+        ],
     }),
 
     afterMount((logic) => {


### PR DESCRIPTION
## Problem
This is opinionated, but i like messages stuck to bottom of screen so i can see new info coming as it comes

## Changes (behind flag `ai-ux-improvements`)
* new selector `threadGroupedForDisplay` for thread messages, if flag, reverse order of thread 
* in `Thread.tsx`, if flag, add `flex-col-reverse grow-0`

## How did you test this code?
New chats still animate like before
When new messages start reach max-height of container, the area sticks to the bottom

## Publish to changelog?
No