### PR TITLE
fix(early-access): add columns to ActorsQuery for person display

### DIFF
--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -42,6 +42,7 @@ import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { Query } from '~/queries/Query/Query'
+import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { Node, NodeKind, ProductIntentContext, ProductKey, QuerySchema } from '~/queries/schema/schema-general'
 import {
     CyclotronJobFiltersType,
@@ -670,6 +671,7 @@ function PersonsTableByFilter({ recordingsFilters, properties }: PersonsTableByF
         source: {
             kind: NodeKind.ActorsQuery,
             fixedProperties: properties,
+            select: defaultDataTableColumns(NodeKind.ActorsQuery),
         },
         full: true,
         propertiesViaUrl: false,


### PR DESCRIPTION
Add select columns to ActorsQuery in PersonsTableByFilter to ensure persons display properly with default person columns (display name, id, created_at).

## Problem

When viewing the list of opted-in or opted-out users for an early access feature, the persons table was not displaying any was broken for persons. 


## Changes

- Added `select: defaultDataTableColumns(NodeKind.ActorsQuery)` to the `ActorsQuery` in `PersonsTableByFilter` component
- Added import for `defaultDataTableColumns` from `~/queries/nodes/DataTable/utils`

This ensures the persons table displays with the default person columns: person display name, id, and created_at timestamp.
Before: 
<img width="334" height="531" alt="image" src="https://github.com/user-attachments/assets/82103841-78d9-4045-9468-5e90e6337989" />


After:
<img width="1239" height="300" alt="image" src="https://github.com/user-attachments/assets/9e0b8230-0f0e-43fd-8d03-3f677eee3532" />

I dropped the delete button to avoid confusion because it actually deletes the person 😓 


## How did you test this code?

1. Created an early access feature and linked it to a feature flag
2. Opted in a test user by setting the `$feature_enrollment/{flag_key}` person property to `"true"`
3. Navigated to the early access feature detail page
4. Verified that the "Opted-In Users" tab now displays persons with columns (display name, id, created_at)
5. Verified that the "Opted-Out Users" tab also displays persons correctly


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

Do not publish to changelog.
