### PR TITLE
fix(logs): fix value search no filtering correctly

### DIFF
--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -277,7 +277,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
 
     @action(detail=False, methods=["GET"], required_scopes=["logs:read"])
     def values(self, request: Request, *args, **kwargs) -> Response:
-        search = request.GET.get("search", "")
+        search = request.GET.get("value", "")
         limit = request.GET.get("limit", 100)
         offset = request.GET.get("offset", 0)
         attributeKey = request.GET.get("key", "")

--- a/products/logs/backend/log_values_query_runner.py
+++ b/products/logs/backend/log_values_query_runner.py
@@ -55,6 +55,7 @@ class LogValuesQueryRunner(AnalyticsQueryRunner[LogValuesQueryResponse], LogsQue
                 AND time_bucket <= {date_to_start_of_interval} + {one_interval_period}
                 AND attribute_type = {attributeType}
                 AND attribute_key = {attributeKey}
+                AND attribute_value ILIKE {search}
                 AND {where}
                 GROUP BY team_id, attribute_value
                 ORDER BY sum(attribute_count) desc, attribute_value asc


### PR DESCRIPTION
## Problem

we weren't correctly filtering on the backend of attribute filter searches

## Changes

pass the `value` param from the frontend to the api call and clickhouse query
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
locally, unit tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
