### PR TITLE
feat(analytics-platform): Support the force_data_skipping_indices clickhouse setting

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -17214,7 +17214,7 @@
                     "type": "boolean"
                 },
                 "forceClickhouseDataSkippingIndexes": {
-                    "description": "If these are provided, the query will fail if these skip indexes are not used *",
+                    "description": "If these are provided, the query will fail if these skip indexes are not used",
                     "items": {
                         "type": "string"
                     },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -17213,6 +17213,13 @@
                 "debug": {
                     "type": "boolean"
                 },
+                "forceClickhouseDataSkippingIndexes": {
+                    "description": "If these are provided, the query will fail if these skip indexes are not used *",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "formatCsvAllowDoubleQuotes": {
                     "type": "boolean"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -412,7 +412,7 @@ export interface HogQLQueryModifiers {
     usePreaggregatedTableTransforms?: boolean
     usePreaggregatedIntermediateResults?: boolean
     optimizeProjections?: boolean
-    /** If these are provided, the query will fail if these skip indexes are not used **/
+    /** If these are provided, the query will fail if these skip indexes are not used */
     forceClickhouseDataSkippingIndexes?: string[]
 }
 

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -412,6 +412,8 @@ export interface HogQLQueryModifiers {
     usePreaggregatedTableTransforms?: boolean
     usePreaggregatedIntermediateResults?: boolean
     optimizeProjections?: boolean
+    /** If these are provided, the query will fail if these skip indexes are not used **/
+    forceClickhouseDataSkippingIndexes?: string[]
 }
 
 export interface DataWarehouseEventsModifier {

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -107,6 +107,7 @@ class HogQLQuerySettings(BaseModel):
     date_time_output_format: Optional[str] = None
     date_time_input_format: Optional[str] = None
     join_algorithm: Optional[str] = None
+    force_data_skipping_indices: Optional[list[str]] = None
 
 
 # Settings applied on top of all HogQL queries.

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -1357,8 +1357,8 @@ class HogQLPrinter(Visitor[str]):
             elif isinstance(value, int) or isinstance(value, float):
                 pairs.append(f"{key}={value}")
             elif isinstance(value, list):
-                if not all(isinstance(item, str) for item in value):
-                    raise QueryError(f"List {key} can only contain strings")
+                if not all(isinstance(item, str) and item for item in value):
+                    raise QueryError(f"List setting {key} can only contain non-empty strings")
                 formatted_items = ", ".join(self._print_hogql_identifier_or_index(item) for item in value)
                 pairs.append(f"{key}={self._print_escaped_string(formatted_items)}")
             elif isinstance(value, str):

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -1350,16 +1350,21 @@ class HogQLPrinter(Visitor[str]):
         for key, value in settings:
             if value is None:
                 continue
-            if not isinstance(value, int | float | str):
-                raise QueryError(f"Setting {key} must be a string, int, or float")
             if not re.match(r"^[a-zA-Z0-9_]+$", key):
                 raise QueryError(f"Setting {key} is not supported")
             if isinstance(value, bool):
                 pairs.append(f"{key}={1 if value else 0}")
             elif isinstance(value, int) or isinstance(value, float):
                 pairs.append(f"{key}={value}")
-            else:
+            elif isinstance(value, list):
+                if not all(isinstance(item, str) for item in value):
+                    raise QueryError(f"List {key} can only contain strings")
+                formatted_items = ", ".join(self._print_hogql_identifier_or_index(item) for item in value)
+                pairs.append(f"{key}={self._print_escaped_string(formatted_items)}")
+            elif isinstance(value, str):
                 pairs.append(f"{key}={self._print_escaped_string(value)}")
+            else:
+                raise QueryError(f"Setting {key} has unsupported type {type(value).__name__}")
         if len(pairs) > 0:
             return f"SETTINGS {', '.join(pairs)}"
         return None

--- a/posthog/hogql/printer/test/__snapshots__/test_printer.ambr
+++ b/posthog/hogql/printer/test/__snapshots__/test_printer.ambr
@@ -1,4 +1,42 @@
 # serializer version: 1
+# name: TestMaterializedColumnOptimization.test_force_data_skipping_indices_fails_when_index_cannot_be_used
+  '''
+  SELECT events.distinct_id AS distinct_id
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(concat(ifNull(toString(nullIf(nullIf(events.mat_test_prop, ''), 'null')), ''), ''), 'foo'))
+  LIMIT 100 SETTINGS force_data_skipping_indices='bloom_filter_mat_test_prop',
+                     readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestMaterializedColumnOptimization.test_force_data_skipping_indices_works_with_simple_equality
+  '''
+  SELECT events.distinct_id AS distinct_id
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(events.mat_test_prop, 'foo'))
+  LIMIT 100 SETTINGS force_data_skipping_indices='bloom_filter_mat_test_prop',
+                     readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
 # name: TestMaterializedColumnOptimization.test_ilike_and_not_ilike_optimization_gives_correct_results_0_no_mat_col
   '''
   SELECT events.distinct_id AS distinct_id

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -204,6 +204,8 @@ class HogQLQueryExecutor:
 
         if self.query_modifiers.formatCsvAllowDoubleQuotes is not None:
             settings.format_csv_allow_double_quotes = self.query_modifiers.formatCsvAllowDoubleQuotes
+        if self.query_modifiers.forceClickhouseDataSkippingIndexes:
+            settings.force_data_skipping_indices = self.query_modifiers.forceClickhouseDataSkippingIndexes
 
         try:
             self.clickhouse_context = dataclasses.replace(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5026,7 +5026,7 @@ class HogQLQueryModifiers(BaseModel):
     dataWarehouseEventsModifiers: list[DataWarehouseEventsModifier] | None = None
     debug: bool | None = None
     forceClickhouseDataSkippingIndexes: list[str] | None = Field(
-        default=None, description="If these are provided, the query will fail if these skip indexes are not used *"
+        default=None, description="If these are provided, the query will fail if these skip indexes are not used"
     )
     formatCsvAllowDoubleQuotes: bool | None = None
     inCohortVia: InCohortVia | None = None

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5025,6 +5025,9 @@ class HogQLQueryModifiers(BaseModel):
     customChannelTypeRules: list[CustomChannelRule] | None = None
     dataWarehouseEventsModifiers: list[DataWarehouseEventsModifier] | None = None
     debug: bool | None = None
+    forceClickhouseDataSkippingIndexes: list[str] | None = Field(
+        default=None, description="If these are provided, the query will fail if these skip indexes are not used *"
+    )
     formatCsvAllowDoubleQuotes: bool | None = None
     inCohortVia: InCohortVia | None = None
     materializationMode: MaterializationMode | None = None

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -1020,7 +1020,7 @@ def materialized(
             if create_ngram_lower_index:
                 indexes_to_drop.append(get_ngram_lower_index_name(column.name))
             for index_name in indexes_to_drop:
-                sync_execute(f"ALTER TABLE {data_table} DROP INDEX {index_name} SETTINGS mutations_sync = 2")
+                sync_execute(f"ALTER TABLE {data_table} DROP INDEX IF EXISTS {index_name} SETTINGS mutations_sync = 2")
         cleanup_materialized_columns()
 
 


### PR DESCRIPTION
## Problem

We want to write tests to assert that an index was used (see https://github.com/PostHog/posthog/pull/45177 for a WIP example). We can either do this by grabbing the CH query after the fact and running `EXPLAIN` on it, or, for some query runners, it's easier to use the `force_data_skipping_indices` `SETTING`

## Changes

This PR adds support for `force_data_skipping_indices`, which can be passed in as a `HogQLQueryModifier` and added as a `SETTING` to the clickhouse query

## How did you test this code?
See the linked PR for where this is used in a test (https://github.com/PostHog/posthog/pull/45177)

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
