### PR TITLE
fix(hogli): add global cargo registry cleanup to doctor:disk and nuke

### DIFF
--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -610,7 +610,10 @@ utilities:
             - name: python venvs
               cmd: rm -rf .venv .flox/cache/venv && uv sync --active
             - name: rust builds
-              cmd: cd rust && cargo clean && find . -name 'index.node' -type f -delete
+              cmd: |
+                  cd rust && cargo clean
+                  find . -name 'index.node' -type f -delete
+                  rm -rf ~/.cargo/registry/cache ~/.cargo/registry/index ~/.cargo/.package-cache
             - dev:reset
         description: Wipe everything and rebuild (node_modules, Python, Rust, then dev:reset)
         prompt: true


### PR DESCRIPTION
**Problem:** Rustc version mismatch errors can occur when stale global cargo caches reference an old rustc version. Neither `doctor:disk --area rust` nor `nuke` touched the global `~/.cargo/registry/` directories.

**Changes:**
- `_cleanup_rust()` now removes global registry cache/index and the `.package-cache` lock file
- `nuke` rust step includes global cargo registry cleanup
- Estimation notes that global registry will also be cleaned

**Test plan:**
- Run `hogli doctor:disk --area rust --dry-run` and verify it mentions global cache cleanup
- Run cleanup and verify global cargo registry is removed