### PR TITLE
chore(customers): Add groups introduction to customer analytics dashboard

### DIFF
--- a/frontend/src/lib/introductions/groupsAccessLogic.ts
+++ b/frontend/src/lib/introductions/groupsAccessLogic.ts
@@ -52,5 +52,12 @@ export const groupsAccessLogic = kea<groupsAccessLogicType>([
             (s) => [s.groupsAccessStatus],
             (groupsAccessStatus) => groupsAccessStatus === GroupsAccessStatus.HasAccess,
         ],
+        shouldShowGroupsIntroduction: [
+            (s) => [s.groupsAccessStatus],
+            (groupsAccessStatus) =>
+                [GroupsAccessStatus.HasAccess, GroupsAccessStatus.HasGroupTypes, GroupsAccessStatus.NoAccess].includes(
+                    groupsAccessStatus
+                ),
+        ],
     }),
 ])

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -4,7 +4,7 @@ import { router } from 'kea-router'
 import { IconPeople } from '@posthog/icons'
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-import { GroupsAccessStatus, groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
+import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
@@ -46,7 +46,7 @@ export function GroupsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
     const { saveGroupViewModalOpen, groupViewName } = useValues(groupViewLogic)
     const { setSaveGroupViewModalOpen, setGroupViewName, saveGroupView } = useActions(groupViewLogic)
 
-    const { groupsAccessStatus } = useValues(groupsAccessLogic)
+    const { shouldShowGroupsIntroduction } = useValues(groupsAccessLogic)
     const { aggregationLabel } = useValues(groupsModel)
     const hasCustomerAnalyticsEnabled = useFeatureFlag('CUSTOMER_ANALYTICS')
 
@@ -54,11 +54,7 @@ export function GroupsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
         throw new Error('groupTypeIndex is undefined')
     }
 
-    if (
-        groupsAccessStatus == GroupsAccessStatus.HasAccess ||
-        groupsAccessStatus == GroupsAccessStatus.HasGroupTypes ||
-        groupsAccessStatus == GroupsAccessStatus.NoAccess
-    ) {
+    if (shouldShowGroupsIntroduction) {
         return (
             <SceneContent>
                 <PersonsManagementSceneTabs tabKey={`groups-${groupTypeIndex}`} />

--- a/products/customer_analytics/frontend/CustomerAnalyticsFilters.tsx
+++ b/products/customer_analytics/frontend/CustomerAnalyticsFilters.tsx
@@ -8,6 +8,7 @@ import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { CUSTOM_OPTION_KEY } from 'lib/components/DateFilter/types'
 import { FilterBar } from 'lib/components/FilterBar'
 import { dayjs } from 'lib/dayjs'
+import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { formatDateRange } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { Scene } from 'scenes/sceneTypes'
@@ -81,7 +82,6 @@ export function CustomerAnalyticsFilters(): JSX.Element {
     const {
         businessType,
         dateFilter: { dateTo, dateFrom },
-        groupsEnabled,
         groupOptions,
         selectedGroupType,
     } = useValues(customerAnalyticsSceneLogic)
@@ -90,8 +90,7 @@ export function CustomerAnalyticsFilters(): JSX.Element {
     const { reportCustomerAnalyticsDashboardBusinessModeChanged, reportCustomerAnalyticsDashboardDateFilterApplied } =
         useActions(eventUsageLogic)
     const { addProductIntent } = useActions(teamLogic)
-    // TODO: Add CTA for cross sell
-    const b2bDisabledReason = groupsEnabled ? '' : 'Group analytics add-on is not enabled'
+    const { shouldShowGroupsIntroduction } = useValues(groupsAccessLogic)
 
     return (
         <FilterBar
@@ -119,7 +118,6 @@ export function CustomerAnalyticsFilters(): JSX.Element {
                                 label: 'B2B',
                                 value: 'b2b',
                                 'data-attr': 'customer-analytics-b2b',
-                                disabledReason: b2bDisabledReason,
                             },
                         ]}
                         value={businessType}
@@ -132,7 +130,7 @@ export function CustomerAnalyticsFilters(): JSX.Element {
                             })
                         }}
                     />
-                    {businessType === 'b2b' && (
+                    {businessType === 'b2b' && !shouldShowGroupsIntroduction && (
                         <LemonSelect
                             size="small"
                             data-attr="customer-analytics-group-type"

--- a/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
+++ b/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
@@ -1,4 +1,4 @@
-import { BindLogic, useActions } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 
 import { IconGear } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
@@ -6,7 +6,9 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { GroupsIntroduction } from 'scenes/groups/GroupsIntroduction'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
 import { teamLogic } from 'scenes/teamLogic'
@@ -35,6 +37,8 @@ export function CustomerAnalyticsScene({ tabId }: { tabId?: string }): JSX.Eleme
     const { addProductIntent } = useActions(teamLogic)
     const { reportCustomerAnalyticsDashboardConfigurationButtonClicked, reportCustomerAnalyticsViewed } =
         useActions(eventUsageLogic)
+    const { businessType } = useValues(customerAnalyticsSceneLogic)
+    const { shouldShowGroupsIntroduction } = useValues(groupsAccessLogic)
 
     if (!tabId) {
         throw new Error('CustomerAnalyticsScene was rendered with no tabId')
@@ -43,6 +47,17 @@ export function CustomerAnalyticsScene({ tabId }: { tabId?: string }): JSX.Eleme
     useOnMountEffect(() => {
         reportCustomerAnalyticsViewed()
     })
+
+    const content =
+        businessType === 'b2b' && shouldShowGroupsIntroduction ? (
+            <GroupsIntroduction />
+        ) : (
+            <>
+                <ActiveUsersInsights />
+                <SignupInsights />
+                <SessionInsights />
+            </>
+        )
 
     return (
         <BindLogic logic={dataNodeCollectionLogic} props={{ key: CUSTOMER_ANALYTICS_DATA_COLLECTION_NODE_ID }}>
@@ -83,11 +98,7 @@ export function CustomerAnalyticsScene({ tabId }: { tabId?: string }): JSX.Eleme
                 />
                 <FeedbackBanner feedbackButtonId="dashboard" />
                 <CustomerAnalyticsFilters />
-                <div className="space-y-2">
-                    <ActiveUsersInsights />
-                    <SignupInsights />
-                    <SessionInsights />
-                </div>
+                <div className="space-y-2">{content}</div>
             </SceneContent>
         </BindLogic>
     )


### PR DESCRIPTION
## Problem

When using the Customer Analytics feature in B2B mode, users should be directed to the Groups Introduction page if they don't have groups properly configured, similar to how the Groups scene works.

## Changes

- Added a new selector `shouldShowGroupsIntroduction` in `groupsAccessLogic` to centralize the logic for determining when to show the groups introduction
- Updated the Groups scene to use this new selector instead of directly checking group access status
- Modified the Customer Analytics scene to show the Groups Introduction when in B2B mode and groups need to be configured
- Removed the disabled state for the B2B option in Customer Analytics filters

<img width="1258" height="788" alt="image" src="https://github.com/user-attachments/assets/6fa96124-d1c6-4db9-82ce-bd8b50b71197" />

## How did you test this code?

Tested the Customer Analytics scene in both B2C and B2B modes with various group configuration states to ensure the Groups Introduction appears correctly when needed. Verified that the existing Groups scene functionality continues to work as expected with the refactored logic.