### PR TITLE
fix(data-warehouse): Expose sync_lookback_days for meta ads

### DIFF
--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -210,6 +210,7 @@ class ExternalDataSourceSerializers(UserAccessControlSerializerMixin, serializer
             "linkedin_ads_integration_id",
             # meta ads
             "meta_ads_integration_id",
+            "sync_lookback_days",
             # reddit ads
             "reddit_integration_id",
             # salesforce


### PR DESCRIPTION
## Problem
- https://posthoghelp.zendesk.com/agent/tickets/47054 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49722)
- When editing a source, we're not sending the meta ads look back period from the source job inputs back to the browser

## Changes
Add it to the allow list 
