### PR TITLE
fix(workflows): fix UX defaulting to wrong value for action error handling

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
@@ -222,7 +222,7 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
                                                     { value: 'continue', label: 'Continue to next step' },
                                                     { value: 'abort', label: 'Exit the workflow' },
                                                 ]}
-                                                value={action.on_error || 'continue'}
+                                                value={action.on_error || 'abort'}
                                                 onChange={(value) =>
                                                     setWorkflowAction(action.id, {
                                                         ...action,


### PR DESCRIPTION
## Problem

On the backend we actually default to `abort` when `on_error` is null, so making sure the frontend reflects that

## Changes

change default value

## How did you test this code?

ensured behavior locally