### PR TITLE
feat(logs): link distinct id attribute to person profile

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogAttributes.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogAttributes.tsx
@@ -6,11 +6,13 @@ import { LemonButton, LemonTable } from '@posthog/lemon-ui'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { IconTableChart } from 'lib/lemon-ui/icons'
 import { cn } from 'lib/utils/css-classes'
+import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { AttributeBreakdowns } from 'products/logs/frontend/AttributeBreakdowns'
 import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
+import { isDistinctIdKey } from 'products/logs/frontend/utils'
 
 export interface LogAttributesProps {
     attributes: Record<string, string>
@@ -115,18 +117,26 @@ export function LogAttributes({ attributes, type, logUuid, title }: LogAttribute
                         title: 'Value',
                         key: 'value',
                         dataIndex: 'value',
-                        render: (_, record) => (
-                            <CopyToClipboardInline
-                                explicitValue={record.value}
-                                description="attribute value"
-                                iconSize="xsmall"
-                                iconPosition="start"
-                                selectable
-                                className="gap-1 font-mono text-xs"
-                            >
-                                {record.value}
-                            </CopyToClipboardInline>
-                        ),
+                        render: (_, record) => {
+                            return (
+                                <CopyToClipboardInline
+                                    explicitValue={record.value}
+                                    description="attribute value"
+                                    iconSize="xsmall"
+                                    iconPosition="start"
+                                    selectable
+                                    className="gap-1 font-mono text-xs"
+                                >
+                                    {isDistinctIdKey(record.key) ? (
+                                        <span onClick={(e) => e.stopPropagation()}>
+                                            <PersonDisplay person={{ distinct_id: record.value }} noEllipsis inline />
+                                        </span>
+                                    ) : (
+                                        <span>{record.value}</span>
+                                    )}
+                                </CopyToClipboardInline>
+                            )
+                        },
                     },
                 ]}
                 dataSource={rows}

--- a/products/logs/frontend/components/VirtualizedLogsList/cells/AttributeCell.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/cells/AttributeCell.tsx
@@ -1,10 +1,13 @@
 import { useActions, useValues } from 'kea'
 import { memo } from 'react'
 
+import { PersonDisplay } from 'scenes/persons/PersonDisplay'
+
 import { LogsViewerCellPopover } from 'products/logs/frontend/components/LogsViewer/LogsViewerCellPopover'
 import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
 import { LogRowScrollButtons } from 'products/logs/frontend/components/VirtualizedLogsList/LogRowScrollButtons'
 import { useCellScroll } from 'products/logs/frontend/components/VirtualizedLogsList/useCellScroll'
+import { isDistinctIdKey } from 'products/logs/frontend/utils'
 
 export interface AttributeCellProps {
     attributeKey: string
@@ -35,9 +38,15 @@ export const AttributeCell = memo(function AttributeCell({
         >
             <div style={{ width, flexShrink: 0 }} className="relative flex items-center self-stretch group/attr pr-1">
                 <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-x-auto hide-scrollbar">
-                    <span className="font-mono text-xs text-muted whitespace-nowrap pr-24" title={value}>
-                        {value}
-                    </span>
+                    {isDistinctIdKey(attributeKey) ? (
+                        <span className="font-mono text-xs whitespace-nowrap pr-24" title={value}>
+                            <PersonDisplay person={{ distinct_id: value }} noEllipsis inline />
+                        </span>
+                    ) : (
+                        <span className="font-mono text-xs text-muted whitespace-nowrap pr-24" title={value}>
+                            {value}
+                        </span>
+                    )}
                 </div>
                 <LogRowScrollButtons
                     onStartScrolling={startScrolling}

--- a/products/logs/frontend/utils.tsx
+++ b/products/logs/frontend/utils.tsx
@@ -1,0 +1,5 @@
+const DISTINCT_ID_KEYS = ['distinct.id', 'distinct_id', 'distinctId', 'distinctID']
+
+export function isDistinctIdKey(key: string): boolean {
+    return DISTINCT_ID_KEYS.includes(key)
+}


### PR DESCRIPTION
## Problem

we now capture browser logs, which include the user's distinct ID, but to find the person you have to manually search in events. Link directly to the person profile

## Changes

wrap the attribute value in PersonDisplay

## How did you test this code?

locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
