### PR TITLE
fix(replay): fix bottom-dock layout for single tab replay

### DIFF
--- a/frontend/src/scenes/session-recordings/detail/SessionRecordingScene.scss
+++ b/frontend/src/scenes/session-recordings/detail/SessionRecordingScene.scss
@@ -1,4 +1,22 @@
 .SessionRecordingScene {
+    .SessionRecordingPlayerWrapper {
+        height: calc(100vh - 6rem);
+        min-height: 25rem;
+
+        // When vertically stacked, ensure proper flex behavior
+        &.SessionRecordingPlayerWrapper--stacked-vertically {
+            display: flex;
+            flex-direction: column;
+
+            .SessionRecordingPlayer {
+                flex: 1;
+                height: auto; // Override any fixed height
+                min-height: 0; // Allow flex child to shrink below content size
+            }
+        }
+    }
+
+    // Keep original behavior for non-stacked layout
     .SessionRecordingPlayer {
         height: calc(100vh - 6rem);
         min-height: 25rem;


### PR DESCRIPTION
## Problem

Weird layout/white screen when using bottom dock in single-video tab player!!

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- fix ui
- add a story file to prevent next time
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

story file +
### before:

![Screenshot 2026-01-16 at 9.18.40 AM.png](https://app.graphite.com/user-attachments/assets/6bb55943-3572-4365-a5b6-bd6812886a20.png)
### after
![Screenshot 2026-01-16 at 9.17.44 AM.png](https://app.graphite.com/user-attachments/assets/4c7b50c7-93d6-4c92-a72d-925e03226b51.png)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
