### PR TITLE
feat(customers): Add attribution data to power users table

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
@@ -67,6 +67,8 @@ export function renderColumnMeta<T extends DataVisualizationNode | DataTableNode
         title = 'Event'
     } else if (key === 'person') {
         title = 'Person'
+    } else if (trimQuotes(key).endsWith('$virt_initial_channel_type')) {
+        title = 'Channel type'
     } else if (trimQuotes(key).endsWith('$virt_mrr')) {
         title = 'MRR'
     } else if (trimQuotes(key).endsWith('$virt_revenue')) {

--- a/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
@@ -72,7 +72,13 @@ function PowerUsersTable(): JSX.Element {
         source: {
             kind: NodeKind.ActorsQuery,
             select: isB2c
-                ? ['person_display_name -- Person', 'event_count', ...revenueFields, 'last_seen']
+                ? [
+                      'person_display_name -- Person',
+                      'event_count',
+                      ...revenueFields,
+                      '$virt_initial_channel_type',
+                      'last_seen',
+                  ]
                 : ['group', 'event_count', ...revenueFields, 'last_seen'],
             source: {
                 kind: NodeKind.InsightActorsQuery,


### PR DESCRIPTION
## Problem

Let's add channel type data to power users table

## Changes

- Added support for displaying `$virt_initial_channel_type` properties with the user-friendly title "Channel type" in data tables
- Added the channel type column to the Power Users table for B2C customers in the Active Users Insights component

## How did you test this code?

Verified that the channel type column appears correctly in the Power Users table for B2C customers with the proper "Channel type" header instead of the raw property name.

## Publish to changelog?

Yes