### PR TITLE
feat(customers): Show group count in groups list

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.test.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.test.ts
@@ -469,6 +469,8 @@ describe('dataNodeLogic', () => {
             cachedResults: { result: [1, 2, 3] },
         })
         logic.mount()
+
+        // Query to fetch the count will still be called
         expect(performQuery).toHaveBeenCalledTimes(0)
 
         await expectLogic(logic).toMatchValues({ response: { result: [1, 2, 3] } })

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -1182,6 +1182,10 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         filteredCountQuery: () => {
             actions.loadFilteredCount()
         },
+        queryId: () => {
+            actions.loadTotalCount()
+            actions.loadFilteredCount()
+        },
     })),
     afterMount(({ actions, props, cache }) => {
         cache.localResults = {}

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -15,6 +15,7 @@ import {
 } from 'kea'
 import { lazyLoaders, loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
+import posthog from 'posthog-js'
 
 import api, { ApiMethodOptions } from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -681,7 +682,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                         // Extract count from first row, first column
                         return response?.results?.[0]?.[0] || 0
                     } catch (error) {
-                        console.error('Failed to load total count:', error)
+                        posthog.captureException(error, { action: 'load total count in dataNodeLogic' })
                         return null
                     }
                 },
@@ -701,7 +702,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                         // Extract count from first row, first column
                         return response?.results?.[0]?.[0] || 0
                     } catch (error) {
-                        console.error('Failed to load filtered count:', error)
+                        posthog.captureException(error, { action: 'load filtered count in dataNodeLogic' })
                         return null
                     }
                 },
@@ -1180,10 +1181,6 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
             }
         },
         filteredCountQuery: () => {
-            actions.loadFilteredCount()
-        },
-        queryId: () => {
-            actions.loadTotalCount()
             actions.loadFilteredCount()
         },
     })),

--- a/frontend/src/queries/nodes/DataTable/queryFeatures.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.ts
@@ -111,6 +111,7 @@ export function getQueryFeatures(query: Node): Set<QueryFeature> {
         features.add(QueryFeature.resultIsArrayOfArrays)
         features.add(QueryFeature.columnConfigurator)
         features.add(QueryFeature.linkDataButton)
+        features.add(QueryFeature.showCount)
     }
 
     if (

--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -115,7 +115,7 @@ export function GroupsScene({ tabId }: { tabId?: string } = {}): JSX.Element {
             <Query
                 uniqueKey={`groups-query-${tabId}`}
                 attachTo={groupsSceneLogic({ tabId })}
-                query={{ ...query, hiddenColumns }}
+                query={{ ...query, hiddenColumns, showCount: true }}
                 setQuery={setQuery}
                 context={{
                     refresh: 'blocking',

--- a/posthog/hogql_queries/groups/groups_query_runner.py
+++ b/posthog/hogql_queries/groups/groups_query_runner.py
@@ -3,7 +3,7 @@ from posthog.schema import CachedGroupsQueryResponse, GroupsQuery, GroupsQueryRe
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.parser import parse_expr, parse_order_expr
-from posthog.hogql.property import property_to_expr
+from posthog.hogql.property import has_aggregation, property_to_expr
 
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
@@ -19,16 +19,26 @@ class GroupsQueryRunner(AnalyticsQueryRunner[GroupsQueryResponse]):
         if self.query.group_type_index is None:
             raise ValueError("group_type_index is required")
 
-        # IMPORTANT: group_name and key MUST always be the first two columns
-        # The frontend (crm/utils.tsx) depends on this ordering, specifically
-        # hardcoding that 'key' is at index 1 in the results array.
-        # See test_column_ordering_consistency for regression tests.
-        self.columns = [
-            "group_name",
-            "key",
-        ]
+        # Detect if this is a count/aggregation query
+        self.is_aggregation_query = False
         if self.query.select:
-            self.columns.extend([col for col in self.query.select if col not in self.columns])
+            self.is_aggregation_query = any(has_aggregation(parse_expr(col)) for col in self.query.select)
+
+        # Handle column logic differently for aggregation queries
+        if self.is_aggregation_query:
+            # For aggregation queries, use select as-is (e.g., ['count(*)'])
+            self.columns = self.query.select or []
+        else:
+            # IMPORTANT: group_name and key MUST always be the first two columns
+            # The frontend (crm/utils.tsx) depends on this ordering, specifically
+            # hardcoding that 'key' is at index 1 in the results array.
+            # See test_column_ordering_consistency for regression tests.
+            self.columns = [
+                "group_name",
+                "key",
+            ]
+            if self.query.select:
+                self.columns.extend([col for col in self.query.select if col not in self.columns])
 
         self.paginator = HogQLHasMorePaginator.from_limit_context(
             limit_context=self.limit_context, limit=self.query.limit, offset=self.query.offset
@@ -48,8 +58,7 @@ class GroupsQueryRunner(AnalyticsQueryRunner[GroupsQueryResponse]):
         if self.query.properties:
             where_exprs.append(property_to_expr(self.query.properties, self.team, scope="group"))
 
-        order_by: list[ast.OrderExpr] = []
-        similarity_order = None
+        # Search logic for both aggregation and regular queries
         if self.query.search is not None and self.query.search != "":
             where_exprs.append(
                 ast.Or(
@@ -67,41 +76,64 @@ class GroupsQueryRunner(AnalyticsQueryRunner[GroupsQueryResponse]):
                     ]
                 )
             )
-            similarity_order = self._get_similarity_order_for_search()
 
         where = ast.And(exprs=list(where_exprs)) if where_exprs else None
 
-        order_by_exprs = self.query.orderBy if self.query.orderBy else ["created_at DESC"]
-        has_user_ordering = self.query.orderBy is not None and len(self.query.orderBy) > 0
+        # Handle aggregation vs regular queries differently
+        if self.is_aggregation_query:
+            # For aggregation queries: simple select, no complex column logic
+            select_exprs = [parse_expr(col) for col in self.columns]
 
-        # Add user-specified ordering first
-        for col in order_by_exprs:
-            # group_name isn't actually a field
-            if col.startswith("group_name"):
-                order_by.append(
-                    ast.OrderExpr(
-                        expr=ast.Call(
-                            name="coalesce", args=[ast.Field(chain=["properties", "name"]), ast.Field(chain=["key"])]
-                        ),
-                        order="DESC" if "DESC" in col else "ASC",
+            # No ordering for count queries (or simple default)
+            order_by = []
+
+            # Use simplified groups table reference for aggregations
+            return ast.SelectQuery(
+                select=select_exprs,
+                select_from=ast.JoinExpr(table=ast.Field(chain=["groups"])),
+                where=where,
+                order_by=order_by,
+            )
+        else:
+            # Existing complex query logic for regular group listings
+            order_by: list[ast.OrderExpr] = []
+            similarity_order = None
+
+            if self.query.search is not None and self.query.search != "":
+                similarity_order = self._get_similarity_order_for_search()
+
+            order_by_exprs = self.query.orderBy if self.query.orderBy else ["created_at DESC"]
+            has_user_ordering = self.query.orderBy is not None and len(self.query.orderBy) > 0
+
+            # Add user-specified ordering first
+            for col in order_by_exprs:
+                # group_name isn't actually a field
+                if col.startswith("group_name"):
+                    order_by.append(
+                        ast.OrderExpr(
+                            expr=ast.Call(
+                                name="coalesce",
+                                args=[ast.Field(chain=["properties", "name"]), ast.Field(chain=["key"])],
+                            ),
+                            order="DESC" if "DESC" in col else "ASC",
+                        )
                     )
-                )
-            else:
-                order_by.append(parse_order_expr(col, timings=self.timings))
+                else:
+                    order_by.append(parse_order_expr(col, timings=self.timings))
 
-        if similarity_order is not None:
-            # Add similarity ordering after user ordering (but not after default created_at DESC)
-            order_by.append(similarity_order) if has_user_ordering else order_by.insert(0, similarity_order)
+            if similarity_order is not None:
+                # Add similarity ordering after user ordering (but not after default created_at DESC)
+                order_by.append(similarity_order) if has_user_ordering else order_by.insert(0, similarity_order)
 
-        return ast.SelectQuery(
-            select=[
-                ast.Call(name="coalesce", args=[ast.Field(chain=["properties", "name"]), ast.Field(chain=["key"])]),
-                *[parse_expr(col) for col in self.columns[1:]],
-            ],
-            select_from=ast.JoinExpr(table=ast.Field(chain=["groups"])),
-            where=where,
-            order_by=order_by,
-        )
+            return ast.SelectQuery(
+                select=[
+                    ast.Call(name="coalesce", args=[ast.Field(chain=["properties", "name"]), ast.Field(chain=["key"])]),
+                    *[parse_expr(col) for col in self.columns[1:]],
+                ],
+                select_from=ast.JoinExpr(table=ast.Field(chain=["groups"])),
+                where=where,
+                order_by=order_by,
+            )
 
     def _calculate(self) -> GroupsQueryResponse:
         response = self.paginator.execute_hogql_query(

--- a/posthog/hogql_queries/groups/groups_query_runner.py
+++ b/posthog/hogql_queries/groups/groups_query_runner.py
@@ -79,15 +79,11 @@ class GroupsQueryRunner(AnalyticsQueryRunner[GroupsQueryResponse]):
 
         where = ast.And(exprs=list(where_exprs)) if where_exprs else None
 
-        # Handle aggregation vs regular queries differently
+        order_by: list[ast.OrderExpr] = []
+
         if self.is_aggregation_query:
-            # For aggregation queries: simple select, no complex column logic
             select_exprs = [parse_expr(col) for col in self.columns]
 
-            # No ordering for count queries (or simple default)
-            order_by = []
-
-            # Use simplified groups table reference for aggregations
             return ast.SelectQuery(
                 select=select_exprs,
                 select_from=ast.JoinExpr(table=ast.Field(chain=["groups"])),
@@ -95,8 +91,6 @@ class GroupsQueryRunner(AnalyticsQueryRunner[GroupsQueryResponse]):
                 order_by=order_by,
             )
         else:
-            # Existing complex query logic for regular group listings
-            order_by: list[ast.OrderExpr] = []
             similarity_order = None
 
             if self.query.search is not None and self.query.search != "":


### PR DESCRIPTION
## Problem

Same as https://github.com/PostHog/posthog/pull/45289 but for groups. Had to change GroupsQueryRunner as it was a bit too hardcoded and did not support aggregations.

## Changes

- Added support for count queries in the Groups query runner by detecting aggregation queries
- Modified the query runner to handle both regular group listing queries and aggregation queries
- Added tests for count queries with various filters and search parameters
- Added the `showCount` feature to the Groups page UI
- Updated the dataNodeLogic to reload counts when the queryId changes

### No filters

![image.png](https://app.graphite.com/user-attachments/assets/1d29fcf8-8b88-4cf6-8e23-e3bbc70adb99.png)

### With filters

![image.png](https://app.graphite.com/user-attachments/assets/957490ce-c965-48e2-9488-76b281a318f7.png)

### Independent state by group type

![image.png](https://app.graphite.com/user-attachments/assets/ccdb2d78-5368-457d-821e-45ee0a196f69.png)

## How did you test this code?

- Added unit tests for the count functionality:
  - Test for total count of groups
  - Test for filtered count based on property filters
  - Test for filtered count based on search terms
- Manually verified that the count displays correctly in the Groups UI with various filters applied
- Switching groups reset the count. State is not shared between groups and persons lists