### PR TITLE
fix(llma): evals state bug, beta label, and evals column

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -30,7 +30,7 @@ import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { humanFriendlyDuration, objectsEqual } from 'lib/utils'
+import { objectsEqual } from 'lib/utils'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { EventDetails } from 'scenes/activity/explore/EventDetails'
 import { Dashboard } from 'scenes/dashboard/Dashboard'
@@ -491,7 +491,7 @@ function LLMAnalyticsEvaluationsContent(): JSX.Element {
             ),
         },
         {
-            title: 'Recent',
+            title: 'Runs',
             key: 'recent_stats',
             render: (_, evaluation: EvaluationConfig & { stats?: EvaluationStats }) => {
                 const stats = evaluation.stats
@@ -515,19 +515,6 @@ function LLMAnalyticsEvaluationsContent(): JSX.Element {
                     </div>
                 )
             },
-        },
-        {
-            title: 'Runs',
-            key: 'total_runs',
-            render: (_, evaluation) => (
-                <div className="flex flex-col items-center">
-                    <div className="font-semibold">{evaluation.total_runs}</div>
-                    {evaluation.last_run_at && (
-                        <div className="text-muted text-xs">Last: {humanFriendlyDuration(evaluation.last_run_at)}</div>
-                    )}
-                </div>
-            ),
-            sorter: (a, b) => b.total_runs - a.total_runs,
         },
         {
             title: 'Actions',
@@ -801,8 +788,8 @@ export function LLMAnalyticsScene(): JSX.Element {
             label: (
                 <>
                     Evaluations{' '}
-                    <LemonTag className="ml-1" type="completion">
-                        Alpha
+                    <LemonTag className="ml-1" type="warning">
+                        Beta
                     </LemonTag>
                 </>
             ),

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -21,7 +21,7 @@ export interface LLMEvaluationLogicProps {
 export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
     path(['products', 'llm_analytics', 'evaluations', 'llmEvaluationLogic']),
     props({} as LLMEvaluationLogicProps),
-    key((props) => props.evaluationId || 'new'),
+    key((props) => `${props.evaluationId || 'new'}${props.templateKey ? `-${props.templateKey}` : ''}`),
 
     actions({
         // Evaluation configuration actions


### PR DESCRIPTION
## Changes

This:
- fixes a bug for evals templates where, if selecting one template, and then another, you'd still see the initial template
- switches evals' badge from alpha to beta
- removed a broken and unused column in the evals table

## How did you test this code?

Manually.

## Publish to changelog?

No