### PR TITLE
feat: Support revoking OAuth access/refresh tokens via GitHub

### DIFF
--- a/posthog/api/github.py
+++ b/posthog/api/github.py
@@ -21,10 +21,15 @@ from rest_framework.views import APIView
 
 from posthog.api.personal_api_key import PersonalAPIKeySerializer
 from posthog.models import Team
+from posthog.models.oauth import find_oauth_access_token, find_oauth_refresh_token, revoke_oauth_session
 from posthog.models.personal_api_key import find_personal_api_key
 from posthog.models.utils import mask_key_value
 from posthog.redis import get_client
-from posthog.tasks.email import send_personal_api_key_exposed, send_project_secret_api_key_exposed
+from posthog.tasks.email import (
+    send_oauth_token_exposed,
+    send_personal_api_key_exposed,
+    send_project_secret_api_key_exposed,
+)
 from posthog.utils import get_instance_region
 
 logger = structlog.get_logger(__name__)
@@ -44,6 +49,8 @@ PROJECT_SECRET_API_KEY_LEAKED_COUNTER = Counter(
 # GitHub sends swapped type names - these constants clarify the mismatch
 GITHUB_TYPE_FOR_PERSONAL_API_KEY = "posthog_feature_flags_secure_api_key"
 GITHUB_TYPE_FOR_PROJECT_SECRET = "posthog_personal_api_key"
+GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN = "posthog_oauth_access_token"
+GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN = "posthog_oauth_refresh_token"
 
 
 class SignatureVerificationError(Exception):
@@ -140,7 +147,14 @@ def verify_github_signature(payload: str, kid: str, sig: str) -> None:
 
 class SecretAlertSerializer(serializers.Serializer):
     token = serializers.CharField()
-    type = serializers.ChoiceField(choices=[GITHUB_TYPE_FOR_PERSONAL_API_KEY, GITHUB_TYPE_FOR_PROJECT_SECRET])
+    type = serializers.ChoiceField(
+        choices=[
+            GITHUB_TYPE_FOR_PERSONAL_API_KEY,
+            GITHUB_TYPE_FOR_PROJECT_SECRET,
+            GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN,
+            GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN,
+        ]
+    )
     url = serializers.CharField(allow_blank=True)
     source: Any = serializers.CharField()
 
@@ -284,6 +298,56 @@ class SecretAlert(APIView):
                         **token_debug,
                     }
                 )
+
+            elif item["type"] == GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN:
+                access_token = find_oauth_access_token(token)
+                local_found = access_token is not None
+
+                pending_events.append(
+                    {
+                        "type": "oauth_access_token",
+                        "source": item["source"],
+                        "url": item["url"],
+                        "found": local_found,
+                        "token_hash": token_sha256,
+                        **token_debug,
+                    }
+                )
+
+                if access_token is not None:
+                    result["label"] = "true_positive"
+                    more_info = f"This token was detected by GitHub at {item['url']}."
+
+                    user = access_token.user
+                    revoke_oauth_session(access_token=access_token)
+
+                    if user:
+                        send_oauth_token_exposed(user.id, "access", mask_key_value(token), more_info)
+
+            elif item["type"] == GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN:
+                refresh_token = find_oauth_refresh_token(token)
+                local_found = refresh_token is not None
+
+                pending_events.append(
+                    {
+                        "type": "oauth_refresh_token",
+                        "source": item["source"],
+                        "url": item["url"],
+                        "found": local_found,
+                        "token_hash": token_sha256,
+                        **token_debug,
+                    }
+                )
+
+                if refresh_token is not None:
+                    result["label"] = "true_positive"
+                    more_info = f"This token was detected by GitHub at {item['url']}."
+
+                    user = refresh_token.user
+                    revoke_oauth_session(refresh_token=refresh_token)
+
+                    if user:
+                        send_oauth_token_exposed(user.id, "refresh", mask_key_value(token), more_info)
 
             else:
                 raise ValidationError(detail="Unexpected alert type")

--- a/posthog/api/test/test_github.py
+++ b/posthog/api/test/test_github.py
@@ -1,15 +1,19 @@
 import json
+from datetime import timedelta
 from hashlib import sha256
 
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
+from django.utils import timezone
 
 from rest_framework import status
 
 from posthog import redis
 from posthog.api.github import (
+    GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN,
+    GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN,
     GITHUB_TYPE_FOR_PERSONAL_API_KEY,
     GITHUB_TYPE_FOR_PROJECT_SECRET,
     SignatureVerificationError,
@@ -17,6 +21,7 @@ from posthog.api.github import (
     verify_github_signature,
 )
 from posthog.models import PersonalAPIKey
+from posthog.models.oauth import OAuthAccessToken, OAuthApplication, OAuthGrant, OAuthRefreshToken
 from posthog.models.personal_api_key import hash_key_value
 from posthog.models.utils import generate_random_token_personal, mask_key_value
 
@@ -857,3 +862,465 @@ class TestSecretAlertRegionTracking(APIBaseTest):
         props = alert_calls[0][1]["properties"]
         self.assertNotIn("key_found_region", props)
         self.assertFalse(props["found"])
+
+
+class TestOAuthTokenSecretAlert(APIBaseTest):
+    def _create_oauth_app(self):
+        from django.conf import settings
+
+        from posthog.models.test.test_oauth import generate_rsa_key
+
+        with self.settings(
+            OAUTH2_PROVIDER={
+                **settings.OAUTH2_PROVIDER,
+                "OIDC_RSA_PRIVATE_KEY": generate_rsa_key(),
+            }
+        ):
+            return OAuthApplication.objects.create(
+                name="Test OAuth App",
+                client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+                authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+                redirect_uris="https://example.com/callback",
+                algorithm="RS256",
+                skip_authorization=False,
+                organization=self.organization,
+                user=self.user,
+            )
+
+    @patch("posthog.api.github.verify_github_signature")
+    @patch("posthog.api.github.send_oauth_token_exposed")
+    def test_oauth_access_token_found_and_revoked(self, mock_send_email, mock_verify):
+        mock_verify.return_value = None
+
+        oauth_app = self._create_oauth_app()
+        token = "pha_test_access_token_github_alert_123"
+        access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token=token,
+            expires=timezone.now() + timedelta(hours=1),
+            scope="openid profile",
+        )
+        access_token_id = access_token.id
+
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": token,
+                        "type": GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN,
+                        "url": "https://github.com/test/repo/blob/main/secrets.txt",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["label"], "true_positive")
+        self.assertEqual(data[0]["token_type"], GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN)
+
+        self.assertFalse(OAuthAccessToken.objects.filter(id=access_token_id).exists())
+
+        mock_send_email.assert_called_once()
+        call_args = mock_send_email.call_args
+        self.assertEqual(call_args[0][0], self.user.id)
+        self.assertEqual(call_args[0][1], "access")
+
+    @patch("posthog.api.github.verify_github_signature")
+    @patch("posthog.api.github.send_oauth_token_exposed")
+    def test_oauth_refresh_token_found_and_revoked(self, mock_send_email, mock_verify):
+        mock_verify.return_value = None
+
+        oauth_app = self._create_oauth_app()
+        token = "phr_test_refresh_token_github_alert_123"
+        refresh_token = OAuthRefreshToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token=token,
+        )
+
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": token,
+                        "type": GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN,
+                        "url": "https://github.com/test/repo/blob/main/secrets.txt",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["label"], "true_positive")
+        self.assertEqual(data[0]["token_type"], GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN)
+
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(refresh_token.revoked)
+
+        mock_send_email.assert_called_once()
+        call_args = mock_send_email.call_args
+        self.assertEqual(call_args[0][0], self.user.id)
+        self.assertEqual(call_args[0][1], "refresh")
+
+    @patch("posthog.api.github.verify_github_signature")
+    def test_unknown_oauth_access_token_returns_false_positive(self, mock_verify):
+        mock_verify.return_value = None
+
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": "pha_nonexistent_access_token_12345678901234567890",
+                        "type": GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN,
+                        "url": "https://github.com/test/repo/blob/main/config.py",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["label"], "false_positive")
+
+    @patch("posthog.api.github.verify_github_signature")
+    def test_unknown_oauth_refresh_token_returns_false_positive(self, mock_verify):
+        mock_verify.return_value = None
+
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": "phr_nonexistent_refresh_token_12345678901234567890",
+                        "type": GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN,
+                        "url": "https://github.com/test/repo/blob/main/config.py",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["label"], "false_positive")
+
+    @patch("posthog.api.github.verify_github_signature")
+    @patch("posthog.api.github.send_oauth_token_exposed")
+    def test_oauth_access_token_revocation_also_revokes_related_artifacts(self, mock_send_email, mock_verify):
+        mock_verify.return_value = None
+
+        oauth_app = self._create_oauth_app()
+
+        refresh_token = OAuthRefreshToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="phr_related_refresh_token_123",
+        )
+
+        access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="pha_test_access_with_refresh_123",
+            expires=timezone.now() + timedelta(hours=1),
+            scope="openid profile",
+            source_refresh_token=refresh_token,
+        )
+        access_token_id = access_token.id
+
+        grant = OAuthGrant.objects.create(
+            user=self.user,
+            application=oauth_app,
+            code="test_grant_code",
+            expires=timezone.now() + timedelta(minutes=5),
+            redirect_uri="https://example.com/callback",
+            scope="openid profile",
+            code_challenge="test_challenge",
+            code_challenge_method=OAuthGrant.CODE_CHALLENGE_S256,
+        )
+        grant_id = grant.id
+
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": "pha_test_access_with_refresh_123",
+                        "type": GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN,
+                        "url": "https://github.com/test/repo/blob/main/secrets.txt",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data[0]["label"], "true_positive")
+
+        self.assertFalse(OAuthAccessToken.objects.filter(id=access_token_id).exists())
+
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(refresh_token.revoked)
+
+        self.assertFalse(OAuthGrant.objects.filter(id=grant_id).exists())
+
+    @patch("posthog.api.github.verify_github_signature")
+    @patch("posthog.api.github.send_oauth_token_exposed")
+    def test_oauth_refresh_token_revocation_also_revokes_related_artifacts(self, mock_send_email, mock_verify):
+        mock_verify.return_value = None
+
+        oauth_app = self._create_oauth_app()
+
+        refresh_token = OAuthRefreshToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="phr_leaked_refresh_token_456",
+        )
+
+        access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="pha_related_access_token_456",
+            expires=timezone.now() + timedelta(hours=1),
+            scope="openid profile",
+            source_refresh_token=refresh_token,
+        )
+        access_token_id = access_token.id
+
+        grant = OAuthGrant.objects.create(
+            user=self.user,
+            application=oauth_app,
+            code="test_grant_code_refresh",
+            expires=timezone.now() + timedelta(minutes=5),
+            redirect_uri="https://example.com/callback",
+            scope="openid profile",
+            code_challenge="test_challenge",
+            code_challenge_method=OAuthGrant.CODE_CHALLENGE_S256,
+        )
+        grant_id = grant.id
+
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": "phr_leaked_refresh_token_456",
+                        "type": GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN,
+                        "url": "https://github.com/test/repo/blob/main/secrets.txt",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data[0]["label"], "true_positive")
+
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(refresh_token.revoked)
+
+        self.assertFalse(OAuthAccessToken.objects.filter(id=access_token_id).exists())
+
+        self.assertFalse(OAuthGrant.objects.filter(id=grant_id).exists())
+
+    @patch("posthog.api.github.verify_github_signature")
+    def test_revoked_oauth_refresh_token_returns_false_positive(self, mock_verify):
+        mock_verify.return_value = None
+
+        oauth_app = self._create_oauth_app()
+        token = "phr_already_revoked_token_123"
+        OAuthRefreshToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token=token,
+            revoked=timezone.now(),
+        )
+
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": token,
+                        "type": GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN,
+                        "url": "https://github.com/test/repo/blob/main/secrets.txt",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["label"], "false_positive")
+
+    @patch("posthog.api.github.verify_github_signature")
+    @patch("posthog.api.github.send_oauth_token_exposed")
+    def test_initial_access_token_revokes_paired_refresh_token(self, mock_send_email, mock_verify):
+        """Initial access token (no source_refresh_token) should still revoke paired refresh token."""
+        mock_verify.return_value = None
+
+        oauth_app = self._create_oauth_app()
+
+        # Create access token WITHOUT source_refresh_token (initial token from authorization flow)
+        access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="pha_initial_access_token_no_source",
+            expires=timezone.now() + timedelta(hours=1),
+            scope="openid profile",
+            source_refresh_token=None,  # Initial token has no source_refresh_token
+        )
+        access_token_id = access_token.id
+
+        # Create refresh token for same user+app (no source_refresh_token link)
+        refresh_token = OAuthRefreshToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="phr_paired_refresh_no_link",
+            access_token=access_token,
+        )
+
+        # Create grant for same user+app
+        grant = OAuthGrant.objects.create(
+            user=self.user,
+            application=oauth_app,
+            code="test_grant_code_initial",
+            expires=timezone.now() + timedelta(minutes=5),
+            redirect_uri="https://example.com/callback",
+            scope="openid profile",
+            code_challenge="test_challenge",
+            code_challenge_method=OAuthGrant.CODE_CHALLENGE_S256,
+        )
+        grant_id = grant.id
+
+        # Leak the access token
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": "pha_initial_access_token_no_source",
+                        "type": GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN,
+                        "url": "https://github.com/test/repo/blob/main/secrets.txt",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data[0]["label"], "true_positive")
+
+        # Access token should be deleted
+        self.assertFalse(OAuthAccessToken.objects.filter(id=access_token_id).exists())
+
+        # Refresh token should be revoked
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(refresh_token.revoked)
+
+        # Grant should be deleted
+        self.assertFalse(OAuthGrant.objects.filter(id=grant_id).exists())
+
+    @patch("posthog.api.github.verify_github_signature")
+    @patch("posthog.api.github.send_oauth_token_exposed")
+    def test_initial_refresh_token_revokes_paired_access_token(self, mock_send_email, mock_verify):
+        """Initial refresh token should still revoke paired access token."""
+        mock_verify.return_value = None
+
+        oauth_app = self._create_oauth_app()
+
+        # Create access token WITHOUT source_refresh_token (initial token)
+        access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="pha_initial_access_for_refresh_leak",
+            expires=timezone.now() + timedelta(hours=1),
+            scope="openid profile",
+            source_refresh_token=None,
+        )
+        access_token_id = access_token.id
+
+        # Create refresh token for same user+app
+        refresh_token = OAuthRefreshToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="phr_initial_refresh_to_leak",
+            access_token=access_token,
+        )
+
+        # Create grant for same user+app
+        grant = OAuthGrant.objects.create(
+            user=self.user,
+            application=oauth_app,
+            code="test_grant_code_refresh_leak",
+            expires=timezone.now() + timedelta(minutes=5),
+            redirect_uri="https://example.com/callback",
+            scope="openid profile",
+            code_challenge="test_challenge",
+            code_challenge_method=OAuthGrant.CODE_CHALLENGE_S256,
+        )
+        grant_id = grant.id
+
+        # Leak the refresh token
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": "phr_initial_refresh_to_leak",
+                        "type": GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN,
+                        "url": "https://github.com/test/repo/blob/main/secrets.txt",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data[0]["label"], "true_positive")
+
+        # Access token should be deleted
+        self.assertFalse(OAuthAccessToken.objects.filter(id=access_token_id).exists())
+
+        # Refresh token should be revoked
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(refresh_token.revoked)
+
+        # Grant should be deleted
+        self.assertFalse(OAuthGrant.objects.filter(id=grant_id).exists())

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -102,6 +102,7 @@ CUSTOMER_IO_TEMPLATE_ID_MAP = {
     "personal_api_key_exposed": "45",
     "email_mfa_link": "48",
     "project_secret_api_key_exposed": "49",
+    "oauth_token_exposed": "50",
     "passkey_added": "51",
     "passkey_removed": "52",
 }

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -225,3 +225,57 @@ class OAuthGrant(AbstractGrant):
 
     scoped_teams: ArrayField = ArrayField(models.IntegerField(), null=True, blank=True)
     scoped_organizations: ArrayField = ArrayField(models.CharField(max_length=100), null=True, blank=True)
+
+
+def find_oauth_access_token(token: str) -> OAuthAccessToken | None:
+    """Find an OAuth access token by its value using the token_checksum index."""
+    from hashlib import sha256
+
+    checksum = sha256(token.encode()).hexdigest()
+    try:
+        return OAuthAccessToken.objects.select_related("user", "application", "source_refresh_token").get(
+            token_checksum=checksum
+        )
+    except OAuthAccessToken.DoesNotExist:
+        return None
+
+
+def find_oauth_refresh_token(token: str) -> OAuthRefreshToken | None:
+    """Find an active OAuth refresh token by its value."""
+    try:
+        return OAuthRefreshToken.objects.select_related("user", "application", "access_token").get(
+            token=token, revoked__isnull=True
+        )
+    except OAuthRefreshToken.DoesNotExist:
+        return None
+
+
+def revoke_oauth_session(
+    access_token: OAuthAccessToken | None = None, refresh_token: OAuthRefreshToken | None = None
+) -> None:
+    """Revoke all OAuth artifacts related to a session (access token, refresh token, and grant)."""
+    from django.utils import timezone
+
+    now = timezone.now()
+
+    # Get user and application from whichever token we have
+    if access_token:
+        user = access_token.user
+        application = access_token.application
+    elif refresh_token:
+        user = refresh_token.user
+        application = refresh_token.application
+    else:
+        return
+
+    if not user or not application:
+        raise ValueError("Cannot revoke OAuth session: token has no user or application")
+
+    # Delete all access tokens for this user+application
+    OAuthAccessToken.objects.filter(user=user, application=application).delete()
+
+    # Revoke all refresh tokens for this user+application
+    OAuthRefreshToken.objects.filter(user=user, application=application, revoked__isnull=True).update(revoked=now)
+
+    # Delete all grants for this user+application
+    OAuthGrant.objects.filter(user=user, application=application).delete()

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -37,6 +37,7 @@
     'posthog.tasks.email.send_hog_functions_digest_email',
     'posthog.tasks.email.send_invite',
     'posthog.tasks.email.send_member_join',
+    'posthog.tasks.email.send_oauth_token_exposed',
     'posthog.tasks.email.send_passkey_added_email',
     'posthog.tasks.email.send_passkey_removed_email',
     'posthog.tasks.email.send_password_changed_email',

--- a/posthog/templates/api_key_search/values.html
+++ b/posthog/templates/api_key_search/values.html
@@ -110,6 +110,84 @@
                         </tr>
                     </tbody>
                 </table>
+                {% elif oauth_access_token_object %}
+                <table id="results_list">
+                    <thead>
+                        <tr>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Type" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "User" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Application" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Expires" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Scope" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Created" %}</span></div>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><a href="/admin/posthog/oauthaccesstoken/{{ oauth_access_token_object.id }}/change/">OAuth Access Token</a></td>
+                            <td><a href="/admin/posthog/user/{{ oauth_access_token_object.user.id }}/change/">{{ oauth_access_token_object.user.email }}</a></td>
+                            <td>
+                                {% if oauth_access_token_object.application %}
+                                <a href="/admin/posthog/oauthapplication/{{ oauth_access_token_object.application.id }}/change/">{{ oauth_access_token_object.application.name }}</a>
+                                {% else %}
+                                -
+                                {% endif %}
+                            </td>
+                            <td>{{ oauth_access_token_object.expires }}</td>
+                            <td>{{ oauth_access_token_object.scope }}</td>
+                            <td>{{ oauth_access_token_object.created }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+                {% elif oauth_refresh_token_object %}
+                <table id="results_list">
+                    <thead>
+                        <tr>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Type" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "User" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Application" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Revoked" %}</span></div>
+                            </th>
+                            <th scope="col">
+                                <div class="text"><span>{% trans "Created" %}</span></div>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><a href="/admin/posthog/oauthrefreshtoken/{{ oauth_refresh_token_object.id }}/change/">OAuth Refresh Token</a></td>
+                            <td><a href="/admin/posthog/user/{{ oauth_refresh_token_object.user.id }}/change/">{{ oauth_refresh_token_object.user.email }}</a></td>
+                            <td>
+                                {% if oauth_refresh_token_object.application %}
+                                <a href="/admin/posthog/oauthapplication/{{ oauth_refresh_token_object.application.id }}/change/">{{ oauth_refresh_token_object.application.name }}</a>
+                                {% else %}
+                                -
+                                {% endif %}
+                            </td>
+                            <td>{{ oauth_refresh_token_object.revoked|yesno:"Yes,No" }}</td>
+                            <td>{{ oauth_refresh_token_object.created }}</td>
+                        </tr>
+                    </tbody>
+                </table>
                 {% elif query != "" %}
                 <span>No results found</span>
                 {% endif %}

--- a/posthog/templates/api_key_search/values.html
+++ b/posthog/templates/api_key_search/values.html
@@ -137,7 +137,13 @@
                     <tbody>
                         <tr>
                             <td><a href="/admin/posthog/oauthaccesstoken/{{ oauth_access_token_object.id }}/change/">OAuth Access Token</a></td>
-                            <td><a href="/admin/posthog/user/{{ oauth_access_token_object.user.id }}/change/">{{ oauth_access_token_object.user.email }}</a></td>
+                            <td>
+                                {% if oauth_access_token_object.user %}
+                                <a href="/admin/posthog/user/{{ oauth_access_token_object.user.id }}/change/">{{ oauth_access_token_object.user.email }}</a>
+                                {% else %}
+                                -
+                                {% endif %}
+                            </td>
                             <td>
                                 {% if oauth_access_token_object.application %}
                                 <a href="/admin/posthog/oauthapplication/{{ oauth_access_token_object.application.id }}/change/">{{ oauth_access_token_object.application.name }}</a>
@@ -175,7 +181,13 @@
                     <tbody>
                         <tr>
                             <td><a href="/admin/posthog/oauthrefreshtoken/{{ oauth_refresh_token_object.id }}/change/">OAuth Refresh Token</a></td>
-                            <td><a href="/admin/posthog/user/{{ oauth_refresh_token_object.user.id }}/change/">{{ oauth_refresh_token_object.user.email }}</a></td>
+                            <td>
+                                {% if oauth_refresh_token_object.user %}
+                                <a href="/admin/posthog/user/{{ oauth_refresh_token_object.user.id }}/change/">{{ oauth_refresh_token_object.user.email }}</a>
+                                {% else %}
+                                -
+                                {% endif %}
+                            </td>
                             <td>
                                 {% if oauth_refresh_token_object.application %}
                                 <a href="/admin/posthog/oauthapplication/{{ oauth_refresh_token_object.application.id }}/change/">{{ oauth_refresh_token_object.application.name }}</a>

--- a/posthog/templates/email/oauth_token_exposed.html
+++ b/posthog/templates/email/oauth_token_exposed.html
@@ -1,0 +1,12 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block heading %}{{ token_type }} has been revoked{% endblock %}
+{% block section %}
+<p>
+    Your {{ token_type }} with value <strong>{{ mask_value }}</strong> was publicly exposed.
+    {% if more_info %}{{ more_info }}{% endif %}
+</p>
+<p>
+    To protect your account, this token and all related tokens for this application have been revoked.
+    Any application using these tokens will need to be reauthorized.
+</p>
+{% endblock %} {% block preheader %}{{preheader}}{% endblock %}

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -37,6 +37,7 @@ from posthog.models.message_preferences import (
     MessageRecipientPreference,
     PreferenceStatus,
 )
+from posthog.models.oauth import find_oauth_access_token, find_oauth_refresh_token
 from posthog.models.personal_api_key import find_personal_api_key
 from posthog.plugins.plugin_server_api import validate_messaging_preferences_token
 from posthog.redis import get_client
@@ -434,6 +435,14 @@ def api_key_search_view(request: HttpRequest):
         except Team.DoesNotExist:
             pass
 
+    oauth_access_token_object = None
+    if query is not None and query.startswith("pha_"):
+        oauth_access_token_object = find_oauth_access_token(query)
+
+    oauth_refresh_token_object = None
+    if query is not None and query.startswith("phr_"):
+        oauth_refresh_token_object = find_oauth_refresh_token(query)
+
     context = {
         **admin_site.each_context(request),
         **{
@@ -443,6 +452,8 @@ def api_key_search_view(request: HttpRequest):
             "personal_api_key_hash_mode": personal_api_key_hash_mode,
             "team_object": team_object,
             "team_object_key_type": team_object_key_type,
+            "oauth_access_token_object": oauth_access_token_object,
+            "oauth_refresh_token_object": oauth_refresh_token_object,
         },
     }
 


### PR DESCRIPTION
This extends our GitHub Secrets Scanning integration to include OAuth access tokens and refresh tokens. If either is leaked, both tokens are revoked to protect the user's account and data. There are extensive tests for this functionality. Also manually tested the customer.io email.

After merge:
- [ ] Merge docs update https://github.com/PostHog/posthog.com/pull/14433