### PR TITLE
feat(replay): make max exports per month configurable

### DIFF
--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -119,14 +119,31 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 created_at__gte=start_of_month,
             ).count()
 
-            if (
-                not self.context["request"].user.is_staff
-                and existing_full_video_exports_count >= FULL_VIDEO_EXPORTS_LIMIT_PER_TEAM
-            ):
+            # Get team-specific limit from extra_settings, fallback to default
+            team_limit = FULL_VIDEO_EXPORTS_LIMIT_PER_TEAM
+            get_team = self.context.get("get_team")
+            if get_team is not None:
+                team = get_team()
+                if team is not None and team.extra_settings and "full_video_exports_limit" in team.extra_settings:
+                    limit_value = team.extra_settings["full_video_exports_limit"]
+                    try:
+                        team_limit = int(limit_value)
+                        if team_limit <= 0:
+                            raise ValueError("Limit must be positive")
+                    except (ValueError, TypeError):
+                        logger.warning(
+                            "invalid_full_video_exports_limit",
+                            team_id=team.id,
+                            limit_value=limit_value,
+                            limit_value_type=type(limit_value).__name__,
+                        )
+                        team_limit = FULL_VIDEO_EXPORTS_LIMIT_PER_TEAM
+
+            if not self.context["request"].user.is_staff and existing_full_video_exports_count >= team_limit:
                 raise ValidationError(
                     {
                         "export_limit_exceeded": [
-                            f"Your team has reached the limit of {FULL_VIDEO_EXPORTS_LIMIT_PER_TEAM} full video exports this month."
+                            f"Your team has reached the limit of {team_limit} full video exports this month."
                         ]
                     }
                 )

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -861,6 +861,58 @@ class TestExports(APIBaseTest):
             )
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    @patch("posthog.api.exports.async_to_sync")
+    @patch("posthog.api.exports.async_connect")
+    def test_video_export_team_specific_limit(self, mock_async_connect, mock_async_to_sync) -> None:
+        """Test that teams can have custom export limits via extra_settings"""
+        # Set a custom limit of 3 for this team
+        self.team.extra_settings = {"full_video_exports_limit": 3}
+        self.team.save()
+
+        # Create 2 video exports (should succeed)
+        for i in range(2):
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/exports",
+                {
+                    "export_format": "video/mp4",
+                    "export_context": {
+                        "mode": "video",
+                        "session_recording_id": f"session_{i}",
+                    },
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # The 3rd export should succeed (at the custom limit)
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/exports",
+            {
+                "export_format": "video/mp4",
+                "export_context": {
+                    "mode": "video",
+                    "session_recording_id": "session_3",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # The 4th export should fail with the custom limit in error message
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/exports",
+            {
+                "export_format": "video/mp4",
+                "export_context": {
+                    "mode": "video",
+                    "session_recording_id": "session_4",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error_data = response.json()
+        self.assertEqual(error_data["type"], "validation_error")
+        self.assertEqual(error_data["attr"], "export_limit_exceeded")
+        self.assertIn("reached the limit of 3 full video exports this month", error_data["detail"])
+
     @patch("posthog.tasks.exports.image_exporter.export_image")
     def test_synchronous_export_records_failure_on_query_error(self, mock_export_direct) -> None:
         """Test that synchronous exports record failure info when a QueryError occurs."""


### PR DESCRIPTION
## Problem

We want to temporarily increase max exports per month for a specific team. This makes it configurable via Django Admin "extra_settings" 

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

check extra_settings field, if not, fallback to default MAX_EXPORTS
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
added a test
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
