### PR TITLE
feat(session-summaries): add duration_ms to session summary tracking

### DIFF
--- a/ee/api/session_summaries.py
+++ b/ee/api/session_summaries.py
@@ -1,5 +1,6 @@
 import os
 import asyncio
+import time
 from datetime import datetime
 from typing import Any, cast
 
@@ -168,6 +169,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             video_validation_enabled=video_validation_enabled,
         )
         # Summarize provided sessions
+        start_time = time.time()
         try:
             summary = async_to_sync(self._get_summary_from_progress_stream)(
                 session_ids=session_ids,
@@ -178,6 +180,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 video_validation_enabled=video_validation_enabled,
                 extra_summary_context=extra_summary_context,
             )
+            duration_ms = int((time.time() - start_time) * 1000)
             capture_session_summary_generated(
                 user=user,
                 team=self.team,
@@ -188,9 +191,11 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 session_ids=session_ids,
                 video_validation_enabled=video_validation_enabled,
                 success=True,
+                duration_ms=duration_ms,
             )
             return Response(summary.model_dump(exclude_none=True, mode="json"), status=status.HTTP_200_OK)
         except Exception as err:
+            duration_ms = int((time.time() - start_time) * 1000)
             logger.exception(
                 f"Failed to generate session group summary for sessions {logging_session_ids(session_ids)} from team {self.team.id} by user {user.id}: {err}",
                 team_id=self.team.id,
@@ -207,6 +212,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 session_ids=session_ids,
                 video_validation_enabled=video_validation_enabled,
                 success=False,
+                duration_ms=duration_ms,
                 error_type=type(err).__name__,
                 error_message=str(err),
             )
@@ -293,6 +299,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             video_validation_enabled=video_validation_enabled,
         )
         # Summarize provided sessions individually
+        start_time = time.time()
         try:
             summaries = async_to_sync(self._get_individual_summaries)(
                 session_ids=session_ids,
@@ -301,6 +308,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 video_validation_enabled=video_validation_enabled,
                 extra_summary_context=extra_summary_context,
             )
+            duration_ms = int((time.time() - start_time) * 1000)
             capture_session_summary_generated(
                 user=user,
                 team=self.team,
@@ -311,9 +319,11 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 session_ids=session_ids,
                 video_validation_enabled=video_validation_enabled,
                 success=True,
+                duration_ms=duration_ms,
             )
             return Response(summaries, status=status.HTTP_200_OK)
         except Exception as err:
+            duration_ms = int((time.time() - start_time) * 1000)
             logger.exception(
                 f"Failed to generate individual session summaries for sessions {logging_session_ids(session_ids)} from team {self.team.id} by user {user.id}: {err}",
                 team_id=self.team.id,
@@ -330,6 +340,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 session_ids=session_ids,
                 video_validation_enabled=video_validation_enabled,
                 success=False,
+                duration_ms=duration_ms,
                 error_type=type(err).__name__,
                 error_message=str(err),
             )

--- a/ee/api/session_summaries.py
+++ b/ee/api/session_summaries.py
@@ -180,7 +180,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 video_validation_enabled=video_validation_enabled,
                 extra_summary_context=extra_summary_context,
             )
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration = time.time() - start_time
             capture_session_summary_generated(
                 user=user,
                 team=self.team,
@@ -191,11 +191,11 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 session_ids=session_ids,
                 video_validation_enabled=video_validation_enabled,
                 success=True,
-                duration_ms=duration_ms,
+                duration=duration,
             )
             return Response(summary.model_dump(exclude_none=True, mode="json"), status=status.HTTP_200_OK)
         except Exception as err:
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration = time.time() - start_time
             logger.exception(
                 f"Failed to generate session group summary for sessions {logging_session_ids(session_ids)} from team {self.team.id} by user {user.id}: {err}",
                 team_id=self.team.id,
@@ -212,7 +212,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 session_ids=session_ids,
                 video_validation_enabled=video_validation_enabled,
                 success=False,
-                duration_ms=duration_ms,
+                duration=duration,
                 error_type=type(err).__name__,
                 error_message=str(err),
             )
@@ -308,7 +308,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 video_validation_enabled=video_validation_enabled,
                 extra_summary_context=extra_summary_context,
             )
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration = time.time() - start_time
             capture_session_summary_generated(
                 user=user,
                 team=self.team,
@@ -319,11 +319,11 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 session_ids=session_ids,
                 video_validation_enabled=video_validation_enabled,
                 success=True,
-                duration_ms=duration_ms,
+                duration=duration,
             )
             return Response(summaries, status=status.HTTP_200_OK)
         except Exception as err:
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration = time.time() - start_time
             logger.exception(
                 f"Failed to generate individual session summaries for sessions {logging_session_ids(session_ids)} from team {self.team.id} by user {user.id}: {err}",
                 team_id=self.team.id,
@@ -340,7 +340,7 @@ class SessionSummariesViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 session_ids=session_ids,
                 video_validation_enabled=video_validation_enabled,
                 success=False,
-                duration_ms=duration_ms,
+                duration=duration,
                 error_type=type(err).__name__,
                 error_message=str(err),
             )

--- a/ee/api/test/test_session_summaries.py
+++ b/ee/api/test/test_session_summaries.py
@@ -147,10 +147,10 @@ class TestSessionSummariesAPI(APIBaseTest):
         self.assertEqual(generated_kwargs["session_ids"], ["session1", "session2"])
         self.assertTrue(generated_kwargs["success"])
         self.assertIsNone(generated_kwargs.get("error_type"))
-        # Verify duration_ms is tracked
-        self.assertIsNotNone(generated_kwargs.get("duration_ms"))
-        self.assertIsInstance(generated_kwargs["duration_ms"], int)
-        self.assertGreaterEqual(generated_kwargs["duration_ms"], 0)
+        # Verify duration is tracked
+        self.assertIsNotNone(generated_kwargs.get("duration"))
+        self.assertIsInstance(generated_kwargs["duration"], float)
+        self.assertGreaterEqual(generated_kwargs["duration"], 0)
         # Tracking IDs should match
         self.assertEqual(started_kwargs["tracking_id"], generated_kwargs["tracking_id"])
 
@@ -290,13 +290,13 @@ class TestSessionSummariesAPI(APIBaseTest):
         error: dict[str, Any] = response.json()  # type: ignore[attr-defined]
         self.assertIn("Failed to generate session summaries", str(error))
 
-        # Verify duration_ms is tracked even on failure
+        # Verify duration is tracked even on failure
         mock_capture_generated.assert_called_once()
         generated_kwargs = mock_capture_generated.call_args[1]
         self.assertFalse(generated_kwargs["success"])
-        self.assertIsNotNone(generated_kwargs.get("duration_ms"))
-        self.assertIsInstance(generated_kwargs["duration_ms"], int)
-        self.assertGreaterEqual(generated_kwargs["duration_ms"], 0)
+        self.assertIsNotNone(generated_kwargs.get("duration"))
+        self.assertIsInstance(generated_kwargs["duration"], float)
+        self.assertGreaterEqual(generated_kwargs["duration"], 0)
 
     def test_wrong_http_method(self) -> None:
         """Test that only POST is allowed"""

--- a/ee/hogai/session_summaries/tracking.py
+++ b/ee/hogai/session_summaries/tracking.py
@@ -52,7 +52,7 @@ def capture_session_summary_generated(
     session_ids: list[str],
     video_validation_enabled: bool | None,
     success: bool | None,
-    duration_ms: int | None = None,
+    duration: float | None = None,
     error_type: str | None = None,
     error_message: str | None = None,
 ) -> None:
@@ -69,8 +69,8 @@ def capture_session_summary_generated(
         "video_validation_enabled": video_validation_enabled,
         "success": success,
     }
-    if duration_ms is not None:
-        properties["duration_ms"] = duration_ms
+    if duration is not None:
+        properties["duration"] = duration
     if error_type is not None:
         properties["error_type"] = error_type
     if error_message is not None:

--- a/ee/hogai/session_summaries/tracking.py
+++ b/ee/hogai/session_summaries/tracking.py
@@ -52,6 +52,7 @@ def capture_session_summary_generated(
     session_ids: list[str],
     video_validation_enabled: bool | None,
     success: bool | None,
+    duration_ms: int | None = None,
     error_type: str | None = None,
     error_message: str | None = None,
 ) -> None:
@@ -68,6 +69,8 @@ def capture_session_summary_generated(
         "video_validation_enabled": video_validation_enabled,
         "success": success,
     }
+    if duration_ms is not None:
+        properties["duration_ms"] = duration_ms
     if error_type is not None:
         properties["error_type"] = error_type
     if error_message is not None:

--- a/ee/hogai/tools/replay/summarize_sessions.py
+++ b/ee/hogai/tools/replay/summarize_sessions.py
@@ -194,7 +194,7 @@ class SummarizeSessionsTool(MaxTool):
                 content, artifact = summaries_content, None
         except Exception as err:
             # The session summarization failed
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration = time.time() - start_time
             capture_session_summary_generated(
                 user=self._user,
                 team=self._team,
@@ -205,13 +205,13 @@ class SummarizeSessionsTool(MaxTool):
                 session_ids=session_ids,
                 video_validation_enabled=video_validation_enabled,
                 success=False,
-                duration_ms=duration_ms,
+                duration=duration,
                 error_type=type(err).__name__,
                 error_message=str(err),
             )
             raise
         # The session successfully summarized
-        duration_ms = int((time.time() - start_time) * 1000)
+        duration = time.time() - start_time
         capture_session_summary_generated(
             user=self._user,
             team=self._team,
@@ -222,7 +222,7 @@ class SummarizeSessionsTool(MaxTool):
             session_ids=session_ids,
             video_validation_enabled=video_validation_enabled,
             success=True,
-            duration_ms=duration_ms,
+            duration=duration,
         )
         return content, artifact
 

--- a/ee/hogai/tools/replay/summarize_sessions.py
+++ b/ee/hogai/tools/replay/summarize_sessions.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from textwrap import dedent
 from typing import Any, Literal
 from uuid import uuid4
@@ -154,6 +155,7 @@ class SummarizeSessionsTool(MaxTool):
             session_ids=session_ids,
             video_validation_enabled=video_validation_enabled,
         )
+        start_time = time.time()
         try:
             # Summarize the sessions
             summaries_content, session_group_summary_id = await self._summarize_sessions(
@@ -192,6 +194,7 @@ class SummarizeSessionsTool(MaxTool):
                 content, artifact = summaries_content, None
         except Exception as err:
             # The session summarization failed
+            duration_ms = int((time.time() - start_time) * 1000)
             capture_session_summary_generated(
                 user=self._user,
                 team=self._team,
@@ -202,11 +205,13 @@ class SummarizeSessionsTool(MaxTool):
                 session_ids=session_ids,
                 video_validation_enabled=video_validation_enabled,
                 success=False,
+                duration_ms=duration_ms,
                 error_type=type(err).__name__,
                 error_message=str(err),
             )
             raise
         # The session successfully summarized
+        duration_ms = int((time.time() - start_time) * 1000)
         capture_session_summary_generated(
             user=self._user,
             team=self._team,
@@ -217,6 +222,7 @@ class SummarizeSessionsTool(MaxTool):
             session_ids=session_ids,
             video_validation_enabled=video_validation_enabled,
             success=True,
+            duration_ms=duration_ms,
         )
         return content, artifact
 


### PR DESCRIPTION
Figured I'd give claude a whirl for something small

Track the duration of session summary generation in milliseconds by:
- Adding duration_ms parameter to capture_session_summary_generated function
- Measuring execution time for both successful and failed summarizations
- Including duration_ms in event properties for PostHog analytics
- Adding test assertions to verify duration tracking