### PR TITLE
chore(cohorts): change logger.warn to logger.info for cohort calculation events

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -289,7 +289,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
     def calculate_people_ch(self, pending_version: int, *, initiating_user_id: Optional[int] = None):
         from posthog.models.cohort.util import recalculate_cohortpeople
 
-        logger.warn(
+        logger.info(
             "cohort_calculation_started",
             id=self.pk,
             current_version=self.version,
@@ -336,7 +336,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         )
         self.refresh_from_db()
 
-        logger.warn(
+        logger.info(
             "cohort_calculation_completed",
             id=self.pk,
             version=pending_version,


### PR DESCRIPTION
Changes logger.warn to logger.info for cohort calculation start/complete events since
   these are informational, not warnings.