### PR TITLE
feat(phai): experiments and feature flags mode

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,6 +56,7 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
+                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -79,6 +80,7 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
+                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -95,7 +97,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
+                         AND (("pmat_email" ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/ee/hogai/chat_agent/mode_manager.py
+++ b/ee/hogai/chat_agent/mode_manager.py
@@ -15,6 +15,7 @@ from ee.hogai.context import AssistantContextManager
 from ee.hogai.core.agent_modes.factory import AgentModeDefinition
 from ee.hogai.core.agent_modes.mode_manager import AgentModeManager
 from ee.hogai.core.agent_modes.presets.error_tracking import chat_agent_plan_error_tracking_agent, error_tracking_agent
+from ee.hogai.core.agent_modes.presets.flags import chat_agent_plan_flags_agent, flags_agent
 from ee.hogai.core.agent_modes.presets.product_analytics import (
     chat_agent_plan_product_analytics_agent,
     product_analytics_agent,
@@ -27,6 +28,7 @@ from ee.hogai.core.agent_modes.prompt_builder import AgentPromptBuilder
 from ee.hogai.core.agent_modes.toolkit import AgentToolkit, AgentToolkitManager
 from ee.hogai.utils.feature_flags import (
     has_error_tracking_mode_feature_flag,
+    has_flags_mode_feature_flag,
     has_plan_mode_feature_flag,
     has_survey_mode_feature_flag,
 )
@@ -116,6 +118,11 @@ class ChatAgentModeManager(AgentModeManager):
                 registry[AgentMode.ERROR_TRACKING] = error_tracking_agent
         if has_survey_mode_feature_flag(self._team, self._user):
             registry[AgentMode.SURVEY] = survey_agent
+        if has_flags_mode_feature_flag(self._team, self._user):
+            if self._supermode == AgentMode.PLAN:
+                registry[AgentMode.FLAGS] = chat_agent_plan_flags_agent
+            else:
+                registry[AgentMode.FLAGS] = flags_agent
         return registry
 
     @property

--- a/ee/hogai/chat_agent/test/test_mode_manager.py
+++ b/ee/hogai/chat_agent/test/test_mode_manager.py
@@ -164,16 +164,22 @@ class TestAgentToolkit(BaseTest):
 
     @parameterized.expand(
         [
-            # (error_tracking_flag, expected_modes, unexpected_modes)
-            [False, ["product_analytics", "sql", "session_replay"], ["error_tracking"]],
-            [True, ["product_analytics", "sql", "session_replay", "error_tracking"], []],
+            # (error_tracking_flag, flags_flag, expected_modes, unexpected_modes)
+            [False, False, ["product_analytics", "sql", "session_replay"], ["error_tracking", "flags"]],
+            [True, False, ["product_analytics", "sql", "session_replay", "error_tracking"], ["flags"]],
+            [False, True, ["product_analytics", "sql", "session_replay", "flags"], ["error_tracking"]],
+            [True, True, ["product_analytics", "sql", "session_replay", "error_tracking", "flags"], []],
         ]
     )
-    def test_mode_registry_based_on_error_tracking_feature_flag(
-        self, error_tracking_flag, expected_modes, unexpected_modes
+    def test_mode_registry_based_on_feature_flags(
+        self, error_tracking_flag, flags_flag, expected_modes, unexpected_modes
     ):
-        with patch(
-            "ee.hogai.chat_agent.mode_manager.has_error_tracking_mode_feature_flag", return_value=error_tracking_flag
+        with (
+            patch(
+                "ee.hogai.chat_agent.mode_manager.has_error_tracking_mode_feature_flag",
+                return_value=error_tracking_flag,
+            ),
+            patch("ee.hogai.chat_agent.mode_manager.has_flags_mode_feature_flag", return_value=flags_flag),
         ):
             node_path = (NodePath(name=AssistantNodeName.ROOT, message_id="test_id", tool_call_id="test_tool_call_id"),)
             context_manager = AssistantContextManager(

--- a/ee/hogai/context/experiment/__init__.py
+++ b/ee/hogai/context/experiment/__init__.py
@@ -1,0 +1,3 @@
+from .context import ExperimentContext
+
+__all__ = ["ExperimentContext"]

--- a/ee/hogai/context/experiment/context.py
+++ b/ee/hogai/context/experiment/context.py
@@ -1,0 +1,130 @@
+from posthog.models import Experiment, Team
+from posthog.sync import database_sync_to_async
+
+from .prompts import (
+    EXPERIMENT_CONCLUSION_COMMENT_TEMPLATE,
+    EXPERIMENT_CONCLUSION_TEMPLATE,
+    EXPERIMENT_CONTEXT_TEMPLATE,
+    EXPERIMENT_DATES_TEMPLATE,
+    EXPERIMENT_FEATURE_FLAG_VARIANTS_TEMPLATE,
+    EXPERIMENT_NOT_FOUND_TEMPLATE,
+    EXPERIMENT_VARIANTS_TEMPLATE,
+)
+
+
+class ExperimentContext:
+    """
+    Context class for experiments used across the assistant.
+
+    Provides methods to fetch experiment data and format it for AI consumption.
+    """
+
+    def __init__(
+        self,
+        team: Team,
+        experiment_id: int | None = None,
+        feature_flag_key: str | None = None,
+    ):
+        self._team = team
+        self._experiment_id = experiment_id
+        self._feature_flag_key = feature_flag_key
+
+    async def aget_experiment(self) -> Experiment | None:
+        """Fetch the experiment from the database."""
+        try:
+            if self._experiment_id is not None:
+                return await Experiment.objects.select_related("feature_flag").aget(
+                    id=self._experiment_id, team=self._team, deleted=False
+                )
+            elif self._feature_flag_key is not None:
+                return await Experiment.objects.select_related("feature_flag").aget(
+                    feature_flag__key=self._feature_flag_key, team=self._team, deleted=False
+                )
+            return None
+        except Experiment.DoesNotExist:
+            return None
+
+    def get_not_found_message(self) -> str:
+        """Return a formatted not found message."""
+        identifier = (
+            f"id={self._experiment_id}" if self._experiment_id else f"feature_flag_key={self._feature_flag_key}"
+        )
+        return EXPERIMENT_NOT_FOUND_TEMPLATE.format(identifier=identifier)
+
+    def _get_experiment_status(self, experiment: Experiment) -> str:
+        """Determine the experiment status."""
+        if experiment.is_draft:
+            return "Draft"
+        elif not experiment.end_date:
+            return "Running"
+        else:
+            return "Completed"
+
+    @database_sync_to_async
+    def format_experiment(self, experiment: Experiment) -> str:
+        """Format experiment data for AI consumption."""
+        dates_section = ""
+        if experiment.start_date or experiment.end_date:
+            start_date = experiment.start_date.isoformat() if experiment.start_date else "Not started"
+            end_date = experiment.end_date.isoformat() if experiment.end_date else "Ongoing"
+            dates_section = EXPERIMENT_DATES_TEMPLATE.format(
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+        conclusion_section = ""
+        if experiment.conclusion:
+            conclusion_comment_section = ""
+            if experiment.conclusion_comment:
+                conclusion_comment_section = EXPERIMENT_CONCLUSION_COMMENT_TEMPLATE.format(
+                    conclusion_comment=experiment.conclusion_comment
+                )
+            conclusion_section = EXPERIMENT_CONCLUSION_TEMPLATE.format(
+                conclusion=experiment.conclusion,
+                conclusion_comment_section=conclusion_comment_section,
+            )
+
+        variants_section = ""
+        if experiment.variants:
+            variants_list = "\n".join(
+                f"- {key}: {variant.get('name', key)}" for key, variant in experiment.variants.items()
+            )
+            variants_section = EXPERIMENT_VARIANTS_TEMPLATE.format(variants_list=variants_list)
+
+        feature_flag_variants_section = ""
+        if experiment.parameters:
+            params = experiment.parameters
+            if params.get("feature_flag_variants"):
+                variants_list = "\n".join(
+                    f"- {v.get('key', 'unknown')}: {v.get('rollout_percentage', 0)}%"
+                    for v in params["feature_flag_variants"]
+                )
+                feature_flag_variants_section = EXPERIMENT_FEATURE_FLAG_VARIANTS_TEMPLATE.format(
+                    variants_list=variants_list
+                )
+
+        return EXPERIMENT_CONTEXT_TEMPLATE.format(
+            experiment_name=experiment.name,
+            experiment_id=experiment.id,
+            experiment_description=experiment.description or "No description",
+            feature_flag_key=experiment.feature_flag.key,
+            experiment_type=experiment.type or "product",
+            experiment_status=self._get_experiment_status(experiment),
+            dates_section=dates_section,
+            conclusion_section=conclusion_section,
+            variants_section=variants_section,
+            feature_flag_variants_section=feature_flag_variants_section,
+            experiment_created_at=experiment.created_at.isoformat() if experiment.created_at else "Unknown",
+        ).strip()
+
+    async def execute_and_format(self) -> str:
+        """
+        Fetch and format the experiment for AI consumption.
+
+        Returns a formatted string with all experiment context.
+        """
+        experiment = await self.aget_experiment()
+        if experiment is None:
+            return self.get_not_found_message()
+
+        return await self.format_experiment(experiment)

--- a/ee/hogai/context/experiment/prompts.py
+++ b/ee/hogai/context/experiment/prompts.py
@@ -1,0 +1,43 @@
+EXPERIMENT_CONTEXT_TEMPLATE = """
+## Experiment: {experiment_name}
+
+**ID:** {experiment_id}
+**Description:** {experiment_description}
+**Feature Flag Key:** {feature_flag_key}
+**Type:** {experiment_type}
+**Status:** {experiment_status}
+{dates_section}
+{conclusion_section}
+{variants_section}
+{feature_flag_variants_section}
+**Created:** {experiment_created_at}
+""".strip()
+
+EXPERIMENT_DATES_TEMPLATE = """
+**Start Date:** {start_date}
+**End Date:** {end_date}
+""".strip()
+
+EXPERIMENT_CONCLUSION_TEMPLATE = """
+### Conclusion
+**Result:** {conclusion}
+{conclusion_comment_section}
+""".strip()
+
+EXPERIMENT_CONCLUSION_COMMENT_TEMPLATE = """
+**Comment:** {conclusion_comment}
+""".strip()
+
+EXPERIMENT_VARIANTS_TEMPLATE = """
+### Variants
+{variants_list}
+""".strip()
+
+EXPERIMENT_FEATURE_FLAG_VARIANTS_TEMPLATE = """
+### Feature Flag Variants
+{variants_list}
+""".strip()
+
+EXPERIMENT_NOT_FOUND_TEMPLATE = """
+Experiment with {identifier} was not found. Please verify the experiment ID or feature flag key is correct.
+""".strip()

--- a/ee/hogai/context/feature_flag/__init__.py
+++ b/ee/hogai/context/feature_flag/__init__.py
@@ -1,0 +1,3 @@
+from .context import FeatureFlagContext
+
+__all__ = ["FeatureFlagContext"]

--- a/ee/hogai/context/feature_flag/context.py
+++ b/ee/hogai/context/feature_flag/context.py
@@ -1,0 +1,107 @@
+from posthog.models import Team
+from posthog.models.feature_flag import FeatureFlag
+from posthog.sync import database_sync_to_async
+
+from .prompts import (
+    FEATURE_FLAG_CONTEXT_TEMPLATE,
+    FEATURE_FLAG_NOT_FOUND_TEMPLATE,
+    FEATURE_FLAG_RELEASE_CONDITIONS_TEMPLATE,
+    FEATURE_FLAG_ROLLOUT_PERCENTAGE_TEMPLATE,
+    FEATURE_FLAG_VARIANTS_TEMPLATE,
+)
+
+
+class FeatureFlagContext:
+    """
+    Context class for feature flags used across the assistant.
+
+    Provides methods to fetch feature flag data and format it for AI consumption.
+    """
+
+    def __init__(
+        self,
+        team: Team,
+        flag_id: int | None = None,
+        flag_key: str | None = None,
+    ):
+        self._team = team
+        self._flag_id = flag_id
+        self._flag_key = flag_key
+
+    async def aget_feature_flag(self) -> FeatureFlag | None:
+        """Fetch the feature flag from the database."""
+        try:
+            if self._flag_id is not None:
+                return await FeatureFlag.objects.aget(id=self._flag_id, team=self._team, deleted=False)
+            elif self._flag_key is not None:
+                return await FeatureFlag.objects.aget(key=self._flag_key, team=self._team, deleted=False)
+            return None
+        except FeatureFlag.DoesNotExist:
+            return None
+
+    def get_not_found_message(self) -> str:
+        """Return a formatted not found message."""
+        identifier = f"id={self._flag_id}" if self._flag_id else f"key={self._flag_key}"
+        return FEATURE_FLAG_NOT_FOUND_TEMPLATE.format(identifier=identifier)
+
+    @database_sync_to_async
+    def format_feature_flag(self, flag: FeatureFlag) -> str:
+        """Format feature flag data for AI consumption."""
+        rollout_percentage_section = ""
+        if flag.rollout_percentage is not None:
+            rollout_percentage_section = FEATURE_FLAG_ROLLOUT_PERCENTAGE_TEMPLATE.format(
+                rollout_percentage=flag.rollout_percentage
+            )
+
+        variants_section = ""
+        release_conditions_section = ""
+
+        if flag.filters:
+            filters = flag.filters
+
+            if filters.get("multivariate"):
+                variants = filters["multivariate"].get("variants", [])
+                if variants:
+                    variants_list = "\n".join(
+                        f"- {v.get('key', 'unknown')}: {v.get('rollout_percentage', 0)}%" for v in variants
+                    )
+                    variants_section = FEATURE_FLAG_VARIANTS_TEMPLATE.format(variants_list=variants_list)
+
+            groups = filters.get("groups", [])
+            if groups:
+                conditions_list = []
+                for i, group in enumerate(groups):
+                    rollout = group.get("rollout_percentage")
+                    properties = group.get("properties", [])
+                    rollout_str = f"{rollout}%" if rollout is not None else "100%"
+                    conditions_list.append(
+                        f"- Group {i + 1}: {rollout_str} rollout, {len(properties)} property filter(s)"
+                    )
+
+                release_conditions_section = FEATURE_FLAG_RELEASE_CONDITIONS_TEMPLATE.format(
+                    groups_count=len(groups),
+                    conditions_list="\n".join(conditions_list),
+                )
+
+        return FEATURE_FLAG_CONTEXT_TEMPLATE.format(
+            flag_key=flag.key,
+            flag_id=flag.id,
+            flag_name=flag.name or "No description",
+            flag_active=flag.active,
+            flag_created_at=flag.created_at.isoformat() if flag.created_at else "Unknown",
+            rollout_percentage_section=rollout_percentage_section,
+            variants_section=variants_section,
+            release_conditions_section=release_conditions_section,
+        ).strip()
+
+    async def execute_and_format(self) -> str:
+        """
+        Fetch and format the feature flag for AI consumption.
+
+        Returns a formatted string with all feature flag context.
+        """
+        flag = await self.aget_feature_flag()
+        if flag is None:
+            return self.get_not_found_message()
+
+        return await self.format_feature_flag(flag)

--- a/ee/hogai/context/feature_flag/prompts.py
+++ b/ee/hogai/context/feature_flag/prompts.py
@@ -1,0 +1,29 @@
+FEATURE_FLAG_CONTEXT_TEMPLATE = """
+## Feature Flag: {flag_key}
+
+**ID:** {flag_id}
+**Name/Description:** {flag_name}
+**Active:** {flag_active}
+**Created:** {flag_created_at}
+{rollout_percentage_section}
+{variants_section}
+{release_conditions_section}
+""".strip()
+
+FEATURE_FLAG_ROLLOUT_PERCENTAGE_TEMPLATE = """
+**Rollout Percentage:** {rollout_percentage}%
+""".strip()
+
+FEATURE_FLAG_VARIANTS_TEMPLATE = """
+### Variants
+{variants_list}
+""".strip()
+
+FEATURE_FLAG_RELEASE_CONDITIONS_TEMPLATE = """
+### Release Conditions ({groups_count} group(s))
+{conditions_list}
+""".strip()
+
+FEATURE_FLAG_NOT_FOUND_TEMPLATE = """
+Feature flag with {identifier} was not found. Please verify the feature flag ID or key is correct.
+""".strip()

--- a/ee/hogai/core/agent_modes/presets/flags.py
+++ b/ee/hogai/core/agent_modes/presets/flags.py
@@ -88,8 +88,8 @@ flags_agent = AgentModeDefinition(
     toolkit_class=FlagsAgentToolkit,
 )
 
-chat_agent_plan_error_tracking_agent = AgentModeDefinition(
-    mode=AgentMode.ERROR_TRACKING,
+chat_agent_plan_flags_agent = AgentModeDefinition(
+    mode=AgentMode.FLAGS,
     mode_description=MODE_DESCRIPTION,
     toolkit_class=FlagsAgentToolkit,
     node_class=ChatAgentPlanExecutable,

--- a/ee/hogai/core/agent_modes/presets/flags.py
+++ b/ee/hogai/core/agent_modes/presets/flags.py
@@ -1,0 +1,97 @@
+from typing import TYPE_CHECKING
+
+from posthog.schema import AgentMode
+
+from ee.hogai.chat_agent.executables import ChatAgentPlanExecutable, ChatAgentPlanToolsExecutable
+from ee.hogai.core.agent_modes.factory import AgentModeDefinition
+from ee.hogai.core.agent_modes.toolkit import AgentToolkit
+from ee.hogai.tools.todo_write import TodoWriteExample
+
+if TYPE_CHECKING:
+    from ee.hogai.tool import MaxTool
+
+
+POSITIVE_EXAMPLE_CREATE_FLAG = """
+User: Create a feature flag to roll out our new checkout flow to 25% of users
+Assistant: I'll create a feature flag for the new checkout flow with a 25% rollout.
+*Uses create_feature_flag with key: "new-checkout-flow", rollout_percentage: 25*
+""".strip()
+
+POSITIVE_EXAMPLE_CREATE_FLAG_REASONING = """
+The assistant used create_feature_flag because:
+1. The user wants to create a simple rollout flag
+2. The request specifies a percentage (25%) which maps to rollout_percentage
+3. No A/B testing variants are needed, just a gradual rollout
+""".strip()
+
+POSITIVE_EXAMPLE_CREATE_EXPERIMENT = """
+User: I want to run an A/B test on our pricing page
+Assistant: I'll help you set up an A/B test for the pricing page. This requires creating a multivariate feature flag first, then linking it to an experiment.
+*Creates todo list with the following items:*
+1. Create multivariate feature flag with control and test variants
+2. Create experiment linked to the feature flag
+*Uses create_feature_flag with key: "pricing-page-experiment", variants: [control, test]*
+After creating the flag, the assistant uses create_experiment to link it.
+""".strip()
+
+POSITIVE_EXAMPLE_CREATE_EXPERIMENT_REASONING = """
+The assistant used the todo list because:
+1. Creating an experiment requires two steps: first create a multivariate flag, then create the experiment
+2. The create_experiment tool requires an existing feature flag with variants
+3. Breaking this into steps ensures the flag is created before the experiment
+""".strip()
+
+POSITIVE_EXAMPLE_ANALYZE_EXPERIMENT = """
+User: How is our pricing experiment performing?
+Assistant: I'll analyze the results of your pricing experiment.
+*Uses experiment_results_summary to analyze the experiment*
+""".strip()
+
+POSITIVE_EXAMPLE_ANALYZE_EXPERIMENT_REASONING = """
+The assistant used experiment_results_summary because:
+1. The user wants to understand experiment performance
+2. This tool provides statistical analysis and recommendations
+3. It handles both Bayesian and Frequentist analysis automatically
+""".strip()
+
+
+class FlagsAgentToolkit(AgentToolkit):
+    POSITIVE_TODO_EXAMPLES = [
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_CREATE_FLAG,
+            reasoning=POSITIVE_EXAMPLE_CREATE_FLAG_REASONING,
+        ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_CREATE_EXPERIMENT,
+            reasoning=POSITIVE_EXAMPLE_CREATE_EXPERIMENT_REASONING,
+        ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_ANALYZE_EXPERIMENT,
+            reasoning=POSITIVE_EXAMPLE_ANALYZE_EXPERIMENT_REASONING,
+        ),
+    ]
+
+    @property
+    def tools(self) -> list[type["MaxTool"]]:
+        from products.experiments.backend.max_tools import CreateExperimentTool, ExperimentSummaryTool
+        from products.feature_flags.backend.max_tools import CreateFeatureFlagTool
+
+        tools: list[type[MaxTool]] = [CreateFeatureFlagTool, CreateExperimentTool, ExperimentSummaryTool]
+        return tools
+
+
+MODE_DESCRIPTION = "Specialized mode for creating and managing feature flags and experiments. This mode allows you to create feature flags with property-based targeting and rollout percentages, set up A/B test experiments with multivariate flags, and analyze experiment results with statistical summaries."
+
+flags_agent = AgentModeDefinition(
+    mode=AgentMode.FLAGS,
+    mode_description=MODE_DESCRIPTION,
+    toolkit_class=FlagsAgentToolkit,
+)
+
+chat_agent_plan_error_tracking_agent = AgentModeDefinition(
+    mode=AgentMode.ERROR_TRACKING,
+    mode_description=MODE_DESCRIPTION,
+    toolkit_class=FlagsAgentToolkit,
+    node_class=ChatAgentPlanExecutable,
+    tools_node_class=ChatAgentPlanToolsExecutable,
+)

--- a/ee/hogai/core/agent_modes/presets/test/test_flags_preset.py
+++ b/ee/hogai/core/agent_modes/presets/test/test_flags_preset.py
@@ -1,0 +1,27 @@
+from posthog.test.base import BaseTest
+
+from langchain_core.runnables import RunnableConfig
+
+from ee.hogai.context import AssistantContextManager
+
+from ..flags import FlagsAgentToolkit
+
+
+class TestFlagsAgentToolkit(BaseTest):
+    def test_toolkit_includes_all_tools(self):
+        toolkit = FlagsAgentToolkit(
+            team=self.team,
+            user=self.user,
+            context_manager=AssistantContextManager(self.team, self.user, RunnableConfig(configurable={})),
+        )
+
+        tool_classes = toolkit.tools
+        tool_class_names = [tool_class.__name__ for tool_class in tool_classes]
+
+        self.assertIn("CreateFeatureFlagTool", tool_class_names)
+        self.assertIn("CreateExperimentTool", tool_class_names)
+        self.assertIn("ExperimentSummaryTool", tool_class_names)
+
+    def test_toolkit_has_trajectory_examples(self):
+        self.assertIsNotNone(FlagsAgentToolkit.POSITIVE_TODO_EXAMPLES)
+        self.assertGreater(len(FlagsAgentToolkit.POSITIVE_TODO_EXAMPLES), 0)

--- a/ee/hogai/tools/read_data/prompts.py
+++ b/ee/hogai/tools/read_data/prompts.py
@@ -37,6 +37,32 @@ Retrieves and optionally retrieves data for an existing insight by its ID.
 - The user wants to see or discuss a specific saved insight.
 - You need to understand what an existing insight shows.
 
+# Feature flag
+
+Retrieves a feature flag by its numeric ID or key (slug).
+
+## Use this when:
+- You have a feature flag ID or key and want to retrieve its configuration.
+- The user wants to see details about a specific feature flag.
+- You need to understand what conditions and variants a feature flag has.
+
+## Parameters:
+- id: The numeric ID of the feature flag (optional if key is provided)
+- key: The key/slug of the feature flag (optional if id is provided)
+
+# Experiment
+
+Retrieves an experiment by its numeric ID or by its feature flag's key.
+
+## Use this when:
+- You have an experiment ID or its feature flag key and want to retrieve its configuration.
+- The user wants to see details about a specific A/B test experiment.
+- You need to understand the experiment's variants, status, or conclusion.
+
+## Parameters:
+- id: The numeric ID of the experiment (optional if feature_flag_key is provided)
+- feature_flag_key: The key of the experiment's feature flag (optional if id is provided)
+
 {{{billing_prompt}}}
 """.strip()
 

--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -24,6 +24,8 @@ from ee.hogai.chat_agent.sql.mixins import HogQLDatabaseMixin
 from ee.hogai.context.context import AssistantContextManager
 from ee.hogai.context.dashboard.context import DashboardContext, DashboardInsightContext
 from ee.hogai.context.error_tracking import ErrorTrackingIssueContext
+from ee.hogai.context.experiment import ExperimentContext
+from ee.hogai.context.feature_flag import FeatureFlagContext
 from ee.hogai.context.insight.context import InsightContext
 from ee.hogai.context.survey import SurveyContext
 from ee.hogai.tool import MaxTool, ToolMessagesArtifact
@@ -105,6 +107,22 @@ class ReadSurvey(BaseModel):
     survey_id: str = Field(description="The UUID of the survey.")
 
 
+class ReadFeatureFlag(BaseModel):
+    """Retrieves a feature flag by its numeric ID or key (slug)."""
+
+    kind: Literal["feature_flag"] = "feature_flag"
+    id: int | None = Field(default=None, description="The numeric ID of the feature flag.")
+    key: str | None = Field(default=None, description="The key (slug) of the feature flag.")
+
+
+class ReadExperiment(BaseModel):
+    """Retrieves an experiment by its numeric ID or by its feature flag's key."""
+
+    kind: Literal["experiment"] = "experiment"
+    id: int | None = Field(default=None, description="The numeric ID of the experiment.")
+    feature_flag_key: str | None = Field(default=None, description="The key of the experiment's feature flag.")
+
+
 ReadDataQuery = (
     ReadDataWarehouseSchema
     | ReadDataWarehouseTableSchema
@@ -114,6 +132,8 @@ ReadDataQuery = (
     | ReadErrorTrackingIssue
     | ReadArtifact
     | ReadSurvey
+    | ReadFeatureFlag
+    | ReadExperiment
 )
 
 
@@ -165,6 +185,8 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
             ReadErrorTrackingIssue,
             ReadArtifact,
             ReadSurvey,
+            ReadFeatureFlag,
+            ReadExperiment,
         )
         ReadDataKind = Union[tuple(base_kinds + tuple(kinds))]  # type: ignore[valid-type]
 
@@ -220,6 +242,10 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
                 return await self._read_error_tracking_issue(schema.issue_id), None
             case ReadSurvey() as schema:
                 return await self._read_survey(schema.survey_id), None
+            case ReadFeatureFlag() as schema:
+                return await self._read_feature_flag(schema.id, schema.key), None
+            case ReadExperiment() as schema:
+                return await self._read_experiment(schema.id, schema.feature_flag_key), None
 
     async def _read_insight(
         self, artifact_or_insight_id: str, execute: bool
@@ -447,3 +473,35 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
                 return "\n\n".join(lines)
 
         raise MaxToolFatalError(f"Unknown artifact type: {type(content).__name__}")
+
+    async def _read_feature_flag(self, flag_id: int | None, flag_key: str | None) -> str:
+        if flag_id is None and flag_key is None:
+            raise MaxToolRetryableError("You must provide either 'id' or 'key' to read a feature flag.")
+
+        context = FeatureFlagContext(
+            team=self._team,
+            flag_id=flag_id,
+            flag_key=flag_key,
+        )
+
+        flag = await context.aget_feature_flag()
+        if flag is None:
+            raise MaxToolRetryableError(context.get_not_found_message())
+
+        return await context.format_feature_flag(flag)
+
+    async def _read_experiment(self, experiment_id: int | None, feature_flag_key: str | None) -> str:
+        if experiment_id is None and feature_flag_key is None:
+            raise MaxToolRetryableError("You must provide either 'id' or 'feature_flag_key' to read an experiment.")
+
+        context = ExperimentContext(
+            team=self._team,
+            experiment_id=experiment_id,
+            feature_flag_key=feature_flag_key,
+        )
+
+        experiment = await context.aget_experiment()
+        if experiment is None:
+            raise MaxToolRetryableError(context.get_not_found_message())
+
+        return await context.format_experiment(experiment)

--- a/ee/hogai/utils/feature_flags.py
+++ b/ee/hogai/utils/feature_flags.py
@@ -124,3 +124,13 @@ def is_core_memory_disabled(team: Team, user: User) -> bool:
         group_properties={"organization": {"id": str(team.organization_id)}},
         send_feature_flag_events=False,
     )
+
+
+def has_flags_mode_feature_flag(team: Team, user: User) -> bool:
+    return posthoganalytics.feature_enabled(
+        "posthog-ai-flags-mode",
+        str(user.distinct_id),
+        groups={"organization": str(team.organization_id)},
+        group_properties={"organization": {"id": str(team.organization_id)}},
+        send_feature_flag_events=False,
+    )

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -346,6 +346,7 @@ export const FEATURE_FLAGS = {
     POSTHOG_AI_CONVERSATION_FEEDBACK_CONFIG: 'posthog-ai-conversation-feedback-config', // owner: #team-posthog-ai
     POSTHOG_AI_CONVERSATION_FEEDBACK_LLMA_SESSIONS: 'posthog-ai-conversation-feedback-llma-sessions', // owner: #team-posthog-ai
     POSTHOG_AI_QUEUE_MESSAGES_SYSTEM: 'posthog-ai-queue-messages-system', // owner: #team-posthog-ai
+    POSTHOG_AI_FLAGS_MODE: 'posthog-ai-flags-mode', // owner: #team-posthog-ai
     POSTHOG_AI_UPSERT_DASHBOARD: 'phai-upsert-dashboards', // owner: #team-posthog-ai
     RBAC_UI_REDESIGN: 'rbac-ui-redesign', // owner: @reece #team-platform-features
     RECORDINGS_PLAYER_EVENT_PROPERTY_EXPANSION: 'recordings-player-event-property-expansion', // owner: @pauldambra #team-replay

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -361,7 +361,8 @@
                 "plan",
                 "execution",
                 "survey",
-                "research"
+                "research",
+                "flags"
             ],
             "type": "string"
         },

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -448,6 +448,7 @@ export enum AgentMode {
     Execution = 'execution',
     Survey = 'survey',
     Research = 'research',
+    Flags = 'flags',
 }
 
 export enum SlashCommandName {

--- a/frontend/src/scenes/max/components/ModeSelector.tsx
+++ b/frontend/src/scenes/max/components/ModeSelector.tsx
@@ -246,7 +246,7 @@ export function ModeSelector(): JSX.Element | null {
     const webSearchEnabled = useFeatureFlag('PHAI_WEB_SEARCH')
     const errorTrackingModeEnabled = useFeatureFlag('PHAI_ERROR_TRACKING_MODE')
     const surveyModeEnabled = useFeatureFlag('PHAI_SURVEY_MODE')
-    const flagsModeEnabled = useFeatureFlag('PHAI_FLAGS_MODE')
+    const flagsModeEnabled = useFeatureFlag('POSTHOG_AI_FLAGS_MODE')
 
     const currentValue: ModeValue =
         agentMode === AgentMode.Research ? 'deep_research' : agentMode === AgentMode.Plan ? 'plan' : agentMode

--- a/frontend/src/scenes/max/components/ModeSelector.tsx
+++ b/frontend/src/scenes/max/components/ModeSelector.tsx
@@ -147,6 +147,7 @@ interface GetModeOptionsParams {
     errorTrackingModeEnabled: boolean
     surveyModeEnabled: boolean
     hasExistingMessages: boolean
+    flagsModeEnabled: boolean
 }
 
 function getModeOptions({
@@ -156,6 +157,7 @@ function getModeOptions({
     errorTrackingModeEnabled,
     surveyModeEnabled,
     hasExistingMessages,
+    flagsModeEnabled,
 }: GetModeOptionsParams): LemonSelectSection<ModeValue>[] {
     const specialOptions = [
         {
@@ -208,6 +210,9 @@ function getModeOptions({
         if (mode === AgentMode.Survey && !surveyModeEnabled) {
             return false
         }
+        if (mode === AgentMode.Flags && !flagsModeEnabled) {
+            return false
+        }
         return true
     })
 
@@ -241,6 +246,7 @@ export function ModeSelector(): JSX.Element | null {
     const webSearchEnabled = useFeatureFlag('PHAI_WEB_SEARCH')
     const errorTrackingModeEnabled = useFeatureFlag('PHAI_ERROR_TRACKING_MODE')
     const surveyModeEnabled = useFeatureFlag('PHAI_SURVEY_MODE')
+    const flagsModeEnabled = useFeatureFlag('PHAI_FLAGS_MODE')
 
     const currentValue: ModeValue =
         agentMode === AgentMode.Research ? 'deep_research' : agentMode === AgentMode.Plan ? 'plan' : agentMode
@@ -253,6 +259,7 @@ export function ModeSelector(): JSX.Element | null {
                 deepResearchEnabled,
                 webSearchEnabled,
                 errorTrackingModeEnabled,
+                flagsModeEnabled,
                 surveyModeEnabled,
                 hasExistingMessages,
             }),
@@ -263,6 +270,8 @@ export function ModeSelector(): JSX.Element | null {
             errorTrackingModeEnabled,
             surveyModeEnabled,
             hasExistingMessages,
+            flagsModeEnabled,
+            surveyModeEnabled,
         ]
     )
 

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -603,6 +603,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
         product: Scene.Experiment,
         flag: 'experiment-ai-summary',
         icon: iconForType('experiment'),
+        modes: [AgentMode.Flags],
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {
                 return 'Summarized experiment results'
@@ -731,6 +732,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
         description: 'Create a feature flag in seconds',
         product: Scene.FeatureFlags,
         icon: iconForType('feature_flag'),
+        modes: [AgentMode.Flags],
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {
                 return 'Created feature flag'
@@ -743,6 +745,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
         description: 'Create an experiment in seconds',
         product: Scene.Experiments,
         icon: iconForType('experiment'),
+        modes: [AgentMode.Flags],
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {
                 return 'Created experiment'
@@ -990,6 +993,12 @@ export const MODE_DEFINITIONS: Record<
         description: 'Creates and analyzes surveys to collect user feedback.',
         icon: iconForType('survey'),
         scenes: new Set([Scene.Surveys, Scene.Survey]),
+    },
+    [AgentMode.Flags]: {
+        name: 'Feature flags',
+        description: 'Creates and manages feature flags and A/B test experiments.',
+        icon: iconForType('feature_flag'),
+        scenes: new Set([Scene.FeatureFlags, Scene.Experiment, Scene.Experiments]),
     },
 }
 

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -995,10 +995,19 @@ export const MODE_DEFINITIONS: Record<
         scenes: new Set([Scene.Surveys, Scene.Survey]),
     },
     [AgentMode.Flags]: {
-        name: 'Feature flags',
-        description: 'Creates and manages feature flags and A/B test experiments.',
+        name: 'Flags',
+        description: 'Creates and manages feature flags and experiments.',
         icon: iconForType('feature_flag'),
-        scenes: new Set([Scene.FeatureFlags, Scene.Experiment, Scene.Experiments]),
+        scenes: new Set([
+            Scene.FeatureFlags,
+            Scene.FeatureFlag,
+            Scene.EarlyAccessFeature,
+            Scene.EarlyAccessFeatures,
+            Scene.Experiment,
+            Scene.Experiments,
+            Scene.ExperimentsSharedMetric,
+            Scene.ExperimentsSharedMetrics,
+        ]),
     },
 }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -43,6 +43,7 @@ class AgentMode(StrEnum):
     EXECUTION = "execution"
     SURVEY = "survey"
     RESEARCH = "research"
+    FLAGS = "flags"
 
 
 class AggregationAxisFormat(StrEnum):

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -158,6 +158,7 @@ export type MessageApiContextualTools = { [key: string]: unknown }
  * `execution` - execution
  * `survey` - survey
  * `research` - research
+ * `flags` - flags
  */
 export type AgentModeEnumApi = (typeof AgentModeEnumApi)[keyof typeof AgentModeEnumApi]
 
@@ -170,6 +171,7 @@ export const AgentModeEnumApi = {
     execution: 'execution',
     survey: 'survey',
     research: 'research',
+    flags: 'flags',
 } as const
 
 /**


### PR DESCRIPTION
## Problem

We need to add a new agent mode for feature flags and experiments to help users create and manage these features more efficiently through the AI assistant.

**Demo**

<img width="501" height="535" alt="Screenshot 2026-01-22 at 13 14 21" src="https://github.com/user-attachments/assets/bb0a0c47-14bb-480a-9013-3a64709900bc" />


## Changes

- Added a new `FLAGS` agent mode for creating and managing feature flags and experiments
- Created context classes for feature flags and experiments to fetch and format data
- Implemented feature flag-gated access to the new mode
- Added support for reading feature flags and experiments via the `read_data` tool
- Updated UI components to display the new mode and its associated tools
- Added comprehensive tests for the new functionality

## How did you test this code?

- Added unit tests for the new `FlagsAgentToolkit` class
- Added tests for the feature flag and experiment context classes
- Tested the `read_data` tool with feature flag and experiment data
- Updated existing tests to account for the new mode
- Added evaluation tests to ensure proper functionality in the agent

## Publish to changelog?

No