### PR TITLE
fix: reload stale error tracking query

### DIFF
--- a/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
+++ b/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, kea, listeners, path } from 'kea'
+import { actions, kea, listeners, path, reducers } from 'kea'
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
@@ -34,6 +34,19 @@ export const issueActionsLogic = kea<issueActionsLogicType>([
 
         mutationSuccess: (mutationName: string) => ({ mutationName }),
         mutationFailure: (mutationName: string, error: unknown) => ({ mutationName, error }),
+        clearNeedsReload: true,
+    }),
+
+    reducers({
+        needsReload: [
+            false,
+            {
+                mutationSuccess: () => {
+                    return true
+                },
+                clearNeedsReload: () => false,
+            },
+        ],
     }),
 
     listeners(({ actions }) => {

--- a/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
+++ b/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
@@ -41,9 +41,7 @@ export const issueActionsLogic = kea<issueActionsLogicType>([
         needsReload: [
             false,
             {
-                mutationSuccess: () => {
-                    return true
-                },
+                mutationSuccess: () => true,
                 clearNeedsReload: () => false,
             },
         ],

--- a/products/error_tracking/frontend/logics/issuesDataNodeLogic.tsx
+++ b/products/error_tracking/frontend/logics/issuesDataNodeLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, kea, listeners, path, props, selectors } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, props, selectors } from 'kea'
 
 import { DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { ErrorTrackingIssue } from '~/queries/schema/schema-general'
@@ -19,7 +19,7 @@ export const issuesDataNodeLogic = kea<issuesDataNodeLogicType>([
     connect(({ key, query }: IssuesDataNodeLogicProps) => {
         const nodeLogic = dataNodeLogic({ key, query, refresh: 'blocking' })
         return {
-            values: [nodeLogic, ['response', 'responseLoading']],
+            values: [nodeLogic, ['response', 'responseLoading'], issueActionsLogic, ['needsReload']],
             actions: [
                 nodeLogic,
                 ['setResponse', 'loadData', 'cancelQuery'],
@@ -34,6 +34,7 @@ export const issuesDataNodeLogic = kea<issuesDataNodeLogicType>([
                     'updateIssueStatus',
                     'mutationSuccess',
                     'mutationFailure',
+                    'clearNeedsReload',
                 ],
             ],
         }
@@ -156,4 +157,12 @@ export const issuesDataNodeLogic = kea<issuesDataNodeLogicType>([
         mutationSuccess: () => actions.reloadData(),
         mutationFailure: () => actions.reloadData(),
     })),
+
+    afterMount(({ values, actions }) => {
+        // Check immediately on mount if we need to reload
+        if (values.needsReload) {
+            actions.clearNeedsReload()
+            actions.reloadData()
+        }
+    }),
 ])

--- a/products/error_tracking/frontend/logics/issuesDataNodeLogic.tsx
+++ b/products/error_tracking/frontend/logics/issuesDataNodeLogic.tsx
@@ -52,7 +52,7 @@ export const issuesDataNodeLogic = kea<issuesDataNodeLogicType>([
     }),
 
     listeners(({ values, actions }) => ({
-        reloadData: async () => {
+        reloadData: () => {
             actions.loadData('force_blocking')
         },
         // optimistically update local results
@@ -159,7 +159,6 @@ export const issuesDataNodeLogic = kea<issuesDataNodeLogicType>([
     })),
 
     afterMount(({ values, actions }) => {
-        // Check immediately on mount if we need to reload
         if (values.needsReload) {
             actions.clearNeedsReload()
             actions.reloadData()

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
@@ -128,7 +128,10 @@ export function IssuesList(): JSX.Element {
     const context = useIssueQueryContext()
 
     return (
-        <BindLogic logic={issuesDataNodeLogic} props={{ key: insightVizDataNodeKey(insightProps) }}>
+        <BindLogic
+            logic={issuesDataNodeLogic}
+            props={{ key: insightVizDataNodeKey(insightProps), query: query.source }}
+        >
             <SceneStickyBar showBorderBottom={false}>
                 <ListOptions />
                 {orderBy === 'revenue' && (


### PR DESCRIPTION
When people change something in the error tracking issue like title, description, status, assignee and then go back to the list, it does not refresh automatically and data is stale.

Made it so that whenever you mutate data, list query will reload itself when you go back to the list