### PR TITLE
revert: fix(product-analytics): Properly unmount liveEventsLogic when navigating away

### DIFF
--- a/frontend/src/scenes/activity/live/liveEventsTableSceneLogic.ts
+++ b/frontend/src/scenes/activity/live/liveEventsTableSceneLogic.ts
@@ -1,4 +1,4 @@
-import { kea, path, props, selectors } from 'kea'
+import { connect, kea, path, props, selectors } from 'kea'
 
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { Scene } from 'scenes/sceneTypes'
@@ -6,9 +6,11 @@ import { sceneConfigurations } from 'scenes/scenes'
 
 import { Breadcrumb } from '~/types'
 
+import { liveEventsLogic } from './liveEventsLogic'
 import type { liveEventsTableSceneLogicType } from './liveEventsTableSceneLogicType'
 
 export interface LiveEventsTableSceneProps {
+    showLiveStreamErrorToast?: boolean
     tabId?: string
 }
 
@@ -16,6 +18,10 @@ export const liveEventsTableSceneLogic = kea<liveEventsTableSceneLogicType>([
     path(['scenes', 'activity', 'live-events', 'liveEventsTableSceneLogic']),
     tabAwareScene(),
     props({} as LiveEventsTableSceneProps),
+    connect(() => ({
+        values: [liveEventsLogic, ['events', 'filters', 'streamPaused']],
+        actions: [liveEventsLogic, ['pauseStream', 'resumeStream', 'setFilters', 'clearEvents']],
+    })),
     selectors(() => ({
         breadcrumbs: [
             () => [],


### PR DESCRIPTION
This reverts commit 108b17a4eeb226133cc9c11536ddd6b44718e8b6. Pull Request: https://github.com/PostHog/posthog/pull/45047.

This change is causing issues in the Livestream client. Reverting while I investigate.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
