### PR TITLE
fix: posthog-js not displaying latest version

### DIFF
--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.test.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.test.ts
@@ -3,31 +3,27 @@ import { expectLogic } from 'kea-test-utils'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
-import { PosthogJSDeprecation, versionCheckerLogic } from './versionCheckerLogic'
+import { versionCheckerLogic } from './versionCheckerLogic'
 
-const useMockedVersions = (
-    githubVersions: { version: string }[],
-    usedVersions: { version: string; timestamp: string }[],
-    deprecateBeforeVersion: string
+const useMockedSdkDoctor = (
+    latestVersion: string,
+    usedVersions: { version: string; count: number; releaseDate?: string }[]
 ): void => {
     useMocks({
         get: {
-            'https://api.github.com/repos/posthog/posthog-js/tags': () => [
-                200,
-                githubVersions.map((x) => ({ name: x.version })),
-            ],
-            'https://raw.githubusercontent.com/PostHog/posthog-js/main/deprecation.json': () => [
+            'api/sdk_doctor/': () => [
                 200,
                 {
-                    deprecateBeforeVersion,
-                } as PosthogJSDeprecation,
-            ],
-        },
-        post: {
-            '/api/environments/:team_id/query': () => [
-                200,
-                {
-                    results: usedVersions.map((x) => [x.version, x.timestamp]),
+                    web: {
+                        latest_version: latestVersion,
+                        usage: usedVersions.map((v) => ({
+                            lib_version: v.version,
+                            count: v.count,
+                            is_latest: v.version === latestVersion,
+                            max_timestamp: '2023-01-01T12:00:00Z',
+                            release_date: v.releaseDate ?? '2023-01-01T00:00:00Z',
+                        })),
+                    },
                 },
             ],
         },
@@ -35,91 +31,57 @@ const useMockedVersions = (
 }
 
 describe('versionCheckerLogic', () => {
-    // jest.setTimeout(1000)
     let logic: ReturnType<typeof versionCheckerLogic.build>
 
     beforeEach(() => {
-        useMockedVersions([{ version: '1.0.0' }], [{ version: '1.0.0', timestamp: '2023-01-01T12:00:00Z' }], '1.0.0')
+        useMockedSdkDoctor('1.0.0', [{ version: '1.0.0', count: 100 }])
         initKeaTests()
         localStorage.clear()
-        logic = versionCheckerLogic()
+        logic = versionCheckerLogic({ teamId: 1 })
     })
 
     afterEach(() => {
         logic.unmount()
     })
 
-    it('should load and check versions', async () => {
+    it('should not show warning when on latest version', async () => {
         logic.mount()
-        await expectLogic(logic)
-            .toFinishAllListeners()
-            .toMatchValues({
-                availableVersions: {
-                    sdkVersions: [{ major: 1, minor: 0, patch: 0 }],
-                    deprecation: { deprecateBeforeVersion: '1.0.0' },
-                },
-                usedVersions: [
-                    {
-                        version: { major: 1, minor: 0, patch: 0 },
-                        timestamp: '2023-01-01T12:00:00Z',
-                    },
-                ],
-                lastCheckTimestamp: expect.any(Number),
-                versionWarning: null,
-            })
+        await expectLogic(logic).toFinishAllListeners().toMatchValues({
+            versionWarning: null,
+        })
     })
 
     it.each([
-        { versionCount: 1, expectation: null },
+        { latestVersion: '1.0.50', usedVersion: '1.0.0', expectation: null }, // Only 50 patches behind, no warning
         {
-            versionCount: 11,
-            expectation: null,
-        },
-        {
-            versionCount: 51,
-            expectation: {
-                latestUsedVersion: '1.0.0',
-                latestAvailableVersion: '1.0.50',
-                numVersionsBehind: 50,
-                level: 'error',
-            },
-        },
-        {
-            minorUsedVersion: 40,
-            versionCount: 1,
+            latestVersion: '1.40.0',
+            usedVersion: '1.0.0',
             expectation: {
                 latestUsedVersion: '1.0.0',
                 latestAvailableVersion: '1.40.0',
-                numVersionsBehind: 40,
-                level: 'warning',
+                level: 'error',
             },
         },
         {
-            majorUsedVersion: 2,
-            versionCount: 1,
+            latestVersion: '1.50.0',
+            usedVersion: '1.0.0',
+            expectation: {
+                latestUsedVersion: '1.0.0',
+                latestAvailableVersion: '1.50.0',
+                level: 'error',
+            },
+        },
+        {
+            latestVersion: '2.0.0',
+            usedVersion: '1.0.0',
             expectation: {
                 latestUsedVersion: '1.0.0',
                 latestAvailableVersion: '2.0.0',
-                numVersionsBehind: 1,
-                level: 'info',
+                level: 'error',
             },
         },
     ])('return a version warning if diff is great enough', async (options) => {
-        // TODO: How do we clear the persisted value?
-        const versionsList = Array.from({ length: options.versionCount }, (_, i) => ({
-            version: `${options.majorUsedVersion || 1}.${options.minorUsedVersion || 0}.${i}`,
-        })).reverse()
-
-        useMockedVersions(
-            versionsList,
-            [
-                {
-                    version: '1.0.0',
-                    timestamp: '2023-01-01T12:00:00Z',
-                },
-            ],
-            '1.0.0'
-        )
+        useMockedSdkDoctor(options.latestVersion, [{ version: options.usedVersion, count: 100 }])
 
         logic.mount()
 
@@ -130,62 +92,30 @@ describe('versionCheckerLogic', () => {
     it.each([
         {
             usedVersions: [
-                { version: '1.9.0', timestamp: '2023-01-01T12:00:00Z' },
-                { version: '1.83.1', timestamp: '2023-01-01T10:00:00Z' },
+                { version: '1.9.0', count: 50 },
+                { version: '1.83.1', count: 50 },
             ],
-            expectation: null,
+            latestVersion: '1.84.0',
+            expectation: null, // Highest used is 1.83.1, only 1 minor behind
         },
         {
             usedVersions: [
-                { version: '1.80.0', timestamp: '2023-01-01T12:00:00Z' },
-                { version: '1.83.1', timestamp: '2023-01-01T10:00:00Z' },
-                { version: '1.20.1', timestamp: '2023-01-01T10:00:00Z' },
-                { version: '1.0.890', timestamp: '2023-01-01T10:00:00Z' },
-                { version: '0.89.5', timestamp: '2023-01-01T10:00:00Z' },
-                { version: '0.0.5', timestamp: '2023-01-01T10:00:00Z' },
-                { version: '1.84.0', timestamp: '2023-01-01T08:00:00Z' },
+                { version: '1.40.0', count: 50 },
+                { version: '1.42.0', count: 50 },
             ],
-            expectation: null,
-        },
-        {
-            usedVersions: [
-                { version: '1.40.0', timestamp: '2023-01-01T12:00:00Z' },
-                { version: '1.41.1-beta', timestamp: '2023-01-01T10:00:00Z' },
-                { version: '1.42.0', timestamp: '2023-01-01T08:00:00Z' },
-                { version: '1.42.0-delta', timestamp: '2023-01-01T08:00:00Z' },
-            ],
+            latestVersion: '1.84.0',
             expectation: {
                 latestUsedVersion: '1.42.0',
-                numVersionsBehind: 42,
                 latestAvailableVersion: '1.84.0',
-                level: 'warning',
+                level: 'error',
             },
         },
-    ])('when having multiple versions used, should match with the latest one', async (options) => {
-        useMockedVersions([{ version: '1.84.0' }], options.usedVersions, '1.0.0')
+    ])('when having multiple versions used, should match with the highest one', async (options) => {
+        useMockedSdkDoctor(options.latestVersion, options.usedVersions)
 
         logic.mount()
 
         await expectLogic(logic).toFinishAllListeners()
         expectLogic(logic).toMatchValues({ versionWarning: options.expectation })
-    })
-
-    it('should show an error if the current version is below the deprecation version', async () => {
-        useMockedVersions(
-            [{ version: '1.0.1' }, { version: '1.0.0' }],
-            [{ version: '1.0.0', timestamp: '2023-01-01T12:00:00Z' }],
-            '1.0.1'
-        )
-
-        logic.mount()
-
-        await expectLogic(logic).toFinishAllListeners()
-        expectLogic(logic).toMatchValues({
-            versionWarning: {
-                latestUsedVersion: '1.0.0',
-                latestAvailableVersion: '1.0.1',
-                level: 'error',
-            },
-        })
     })
 })

--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
@@ -1,49 +1,16 @@
-import { actions, afterMount, kea, key, listeners, path, props, reducers, sharedListeners } from 'kea'
-import { loaders } from 'kea-loaders'
+import { afterMount, connect, kea, key, path, props, selectors } from 'kea'
 
-import api from 'lib/api'
-import { isNotNil } from 'lib/utils'
 import {
-    SemanticVersion,
-    diffVersions,
-    highestVersion,
-    isEqualVersion,
-    parseVersion,
-    tryParseVersion,
-    versionToString,
-} from 'lib/utils/semver'
-import { sceneLogic } from 'scenes/sceneLogic'
-
-import { hogql } from '~/queries/utils'
+    AugmentedTeamSdkVersionsInfo,
+    sidePanelSdkDoctorLogic,
+} from '~/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic'
 
 import type { versionCheckerLogicType } from './versionCheckerLogicType'
-
-// If you would like to deprecate all posthog-js versions older than a specific version
-// (i.e. after fixing an important bug) please edit
-// https://github.com/PostHog/posthog-js/blob/main/deprecation.json
-
-const CHECK_INTERVAL_MS = 1000 * 60 * 60 * 6 // 6 hour
-
-export type SDKVersion = {
-    version: SemanticVersion
-    timestamp?: string
-}
 
 export type SDKVersionWarning = {
     latestUsedVersion: string
     latestAvailableVersion: string
-    numVersionsBehind?: number
     level: 'warning' | 'info' | 'error'
-}
-
-export interface PosthogJSDeprecation {
-    deprecateBeforeVersion?: string
-    deprecateOlderThanDays?: number
-}
-
-export interface AvailableVersions {
-    sdkVersions?: SemanticVersion[]
-    deprecation?: PosthogJSDeprecation
 }
 
 export interface VersionCheckerLogicProps {
@@ -54,180 +21,51 @@ export const versionCheckerLogic = kea<versionCheckerLogicType>([
     props({ teamId: null } as VersionCheckerLogicProps),
     key(({ teamId }) => teamId || 'no-team-id'),
     path((key) => ['components', 'VersionChecker', 'versionCheckerLogic', key]),
-    actions({
-        setVersionWarning: (versionWarning: SDKVersionWarning | null) => ({ versionWarning }),
-        setSdkVersions: (sdkVersions: SDKVersion[]) => ({ sdkVersions }),
+
+    connect({
+        values: [sidePanelSdkDoctorLogic, ['augmentedData', 'rawDataLoading']],
+        actions: [sidePanelSdkDoctorLogic, ['loadRawData']],
     }),
-    loaders(({ values }) => ({
-        availableVersions: [
-            {} as AvailableVersions,
-            {
-                loadAvailableVersions: async (): Promise<AvailableVersions> => {
-                    // Make both requests simultaneously and don't return until both have finished, to avoid a flash
-                    // of partial results in the UI.
-                    const availableVersionsPromise: Promise<SemanticVersion[]> = fetch(
-                        'https://api.github.com/repos/posthog/posthog-js/tags'
-                    )
-                        .then((r) => r.json())
-                        .then((r) => r.map((x: any) => tryParseVersion(x.name)).filter(isNotNil))
-                    const deprecationPromise: Promise<PosthogJSDeprecation> = fetch(
-                        'https://raw.githubusercontent.com/PostHog/posthog-js/main/deprecation.json'
-                    ).then((r) => r.json())
-                    const settled = await Promise.allSettled([availableVersionsPromise, deprecationPromise])
-                    const availableVersions = settled[0].status === 'fulfilled' ? settled[0].value : []
-                    const deprecation = settled[1].status === 'fulfilled' ? settled[1].value : {}
-                    // if one or more of the requests failed, merge in the previous value if we have one
-                    return {
-                        ...values.availableVersions,
-                        sdkVersions: availableVersions,
-                        deprecation: deprecation,
-                    }
-                },
-            },
-        ],
-        usedVersions: [
-            null as SDKVersion[] | null,
-            {
-                loadUsedVersions: async () => {
-                    const query = hogql`
-                        SELECT properties.$lib_version AS lib_version, max(timestamp) AS latest_timestamp, count(lib_version) as count
-                        FROM events
-                        WHERE timestamp >= now() - INTERVAL 1 DAY
-                        AND timestamp <= now()
-                        AND properties.$lib = 'web'
-                        GROUP BY lib_version
-                        ORDER BY latest_timestamp DESC
-                        limit 10`
 
-                    const currentScene = sceneLogic.findMounted()?.values.activeSceneId ?? 'VersionChecker'
-                    const res = await api.queryHogQL(
-                        query,
-                        { scene: currentScene, productKey: 'platform_and_support' },
-                        { refresh: 'force_blocking' }
-                    )
-
-                    return (
-                        res.results
-                            ?.map((x) => {
-                                const version = tryParseVersion(x[0])
-                                if (!version) {
-                                    return null
-                                }
-                                return {
-                                    version,
-                                    timestamp: x[1],
-                                }
-                            })
-                            .filter(isNotNil) ?? null
-                    )
-                },
-            },
-        ],
-    })),
-
-    reducers({
-        lastCheckTimestamp: [
-            0,
-            { persist: true },
-            {
-                loadUsedVersionsSuccess: () => Date.now(),
-            },
-        ],
+    selectors({
         versionWarning: [
-            null as SDKVersionWarning | null,
-            // bumping cache key due to an incorrect tag being cached on 2024-02-12
-            { persist: true, prefix: '2024-02-12' },
-            {
-                setVersionWarning: (_, { versionWarning }) => versionWarning,
+            (s) => [s.augmentedData, s.rawDataLoading],
+            (augmentedData: AugmentedTeamSdkVersionsInfo, loading: boolean): SDKVersionWarning | null => {
+                if (loading || !augmentedData?.web) {
+                    return null
+                }
+
+                const webSdk = augmentedData.web
+                if (!webSdk.needsUpdating) {
+                    return null
+                }
+
+                const latestRelease = webSdk.allReleases[0]
+                if (!latestRelease) {
+                    return null
+                }
+
+                // Map SDK doctor's isOutdated/isOld to our warning levels
+                let level: 'warning' | 'info' | 'error' = 'warning'
+                if (webSdk.isOutdated) {
+                    level = 'error'
+                } else if (webSdk.isOld) {
+                    level = 'warning'
+                }
+
+                return {
+                    latestUsedVersion: latestRelease.version,
+                    latestAvailableVersion: latestRelease.latestVersion,
+                    level,
+                }
             },
         ],
     }),
-
-    sharedListeners(({ values, actions }) => ({
-        checkForVersionWarning: () => {
-            if (!values.usedVersions?.length) {
-                return
-            }
-            const { deprecation, sdkVersions } = values.availableVersions
-
-            // We want the highest semantic version to be the latest used one, rather than
-            // the one with the latest timestamp, because secondary installations can spew old versions
-            const latestUsedVersion = highestVersion(values.usedVersions.map((v) => v.version))
-
-            // the latest version published on github
-            const latestAvailableVersion = sdkVersions?.[0]
-
-            // the version where, anything before this deprecated (i.e. this version is allowed, before it is not)
-            const deprecateBeforeVersion = deprecation?.deprecateBeforeVersion
-                ? parseVersion(deprecation.deprecateBeforeVersion)
-                : null
-
-            let warning: SDKVersionWarning | null = null
-
-            if (deprecateBeforeVersion) {
-                const diff = diffVersions(deprecateBeforeVersion, latestUsedVersion)
-                // if they are behind the deprecatedBeforeVersion by any amount, show an error
-                if (diff && diff.diff > 0) {
-                    warning = {
-                        latestUsedVersion: versionToString(latestUsedVersion),
-                        latestAvailableVersion: versionToString(latestAvailableVersion || deprecateBeforeVersion),
-                        level: 'error',
-                    }
-                }
-            }
-
-            if (!warning && sdkVersions && latestAvailableVersion) {
-                const diff = diffVersions(latestAvailableVersion, latestUsedVersion)
-
-                if (diff && diff.diff > 0) {
-                    // there's a difference between the latest used version and the latest available version
-
-                    let numVersionsBehind = sdkVersions.findIndex((v) => isEqualVersion(v, latestUsedVersion))
-                    if (numVersionsBehind === -1) {
-                        // if we couldn't find the versions, use the length of the list as a fallback
-                        numVersionsBehind = sdkVersions.length - 1
-                    }
-                    if (numVersionsBehind < diff.diff) {
-                        // we might have deleted versions, but if the actual diff is X then we must be at least X versions behind
-                        numVersionsBehind = diff.diff
-                    }
-
-                    let level: 'warning' | 'info' | 'error' | undefined
-                    if (diff.kind === 'major') {
-                        level = 'info' // it is desirable to be on the latest major version, but not critical
-                    } else if (diff.kind === 'minor') {
-                        level = numVersionsBehind >= 40 ? 'warning' : undefined
-                    }
-
-                    if (level === undefined && numVersionsBehind >= 50) {
-                        level = 'error'
-                    }
-
-                    // we check if there is a "latest user version string" to avoid returning odd data in unexpected cases
-                    if (level && !!versionToString(latestUsedVersion).trim().length) {
-                        warning = {
-                            latestUsedVersion: versionToString(latestUsedVersion),
-                            latestAvailableVersion: versionToString(latestAvailableVersion),
-                            level,
-                            numVersionsBehind,
-                        }
-                    }
-                }
-            }
-
-            actions.setVersionWarning(warning)
-        },
-    })),
-
-    listeners(({ sharedListeners }) => ({
-        loadAvailableVersionsSuccess: sharedListeners.checkForVersionWarning,
-        loadUsedVersionsSuccess: sharedListeners.checkForVersionWarning,
-    })),
 
     afterMount(({ actions, values }) => {
-        if (values.lastCheckTimestamp < Date.now() - CHECK_INTERVAL_MS) {
-            actions.loadAvailableVersions()
-            actions.loadUsedVersions()
+        // Trigger SDK Doctor to load data if not already loaded
+        if (!values.augmentedData?.web && !values.rawDataLoading) {
+            actions.loadRawData()
         }
     }),
 ])


### PR DESCRIPTION
## Problem
Problem
The version checker banner was showing incorrect `latestAvailableVersion` values (e.g., 1.257.2 instead of the actual latest 1.328.0).
The posthog-js repository transitioned to a monorepo structure recently, which changed how releases are tagged:
Old format: Git tags like v1.257.2
New format: GitHub releases with names like posthog-js@1.328.0
The version checker was fetching from the GitHub /tags API endpoint, which only returns the old-style v1.x.x tags. The new monorepo-style releases (posthog-js@1.328.0) are created as GitHub releases, not traditional git tags.

Also, the tryParseVersion function expected version strings starting with an optional v followed by digits (e.g., v1.2.3 or 1.2.3), so even if the new tags were returned, they would be filtered out because posthog-js@1.328.0 doesn't match the expected pattern.

## Changes
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Changed the API endpoint from /tags to reuse versioning check from `sidePanelSdkDoctorLogic` instead

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
