### PR TITLE
chore(livestream): Remove logging for Livestream unsub race condition

### DIFF
--- a/livestream/events/filter.go
+++ b/livestream/events/filter.go
@@ -148,7 +148,7 @@ func (c *Filter) Run() {
 					if responseEvent == nil {
 						responseEvent = convertToResponsePostHogEvent(event, sub.TeamId)
 					}
-T
+
 					select {
 					case sub.EventChan <- *responseEvent:
 					default:

--- a/livestream/events/filter.go
+++ b/livestream/events/filter.go
@@ -115,7 +115,6 @@ func (c *Filter) Run() {
 
 			for _, sub := range c.subs {
 				if sub.ShouldClose.Load() {
-					log.Println("User has unsubscribed, but not been removed from the slice of subs")
 					continue
 				}
 
@@ -149,7 +148,7 @@ func (c *Filter) Run() {
 					if responseEvent == nil {
 						responseEvent = convertToResponsePostHogEvent(event, sub.TeamId)
 					}
-
+T
 					select {
 					case sub.EventChan <- *responseEvent:
 					default:


### PR DESCRIPTION
## Problem
There's an expected race condition in the livestream service where a user can unsubscribe from the events channel, but before their subscription is removed from the slice, the service receives a message intended for them. We handle this correctly by checking ShouldClose and skipping the send, but we were also logging a warning each time this happened.

 After [#45047](https://github.com/PostHog/posthog/pull/45047) was merged to properly unsubscribe users from SSE streams when leaving the live activity page, significantly more clients started unsubscribing correctly. This caused the race condition to trigger more frequently, resulting in a high volume of warning logs in production.

<img width="1414" height="246" alt="image" src="https://github.com/user-attachments/assets/e0617901-46a6-42a8-9bea-c6097926b893" />

During this time, we could see the unsub queue metric was at 0%:
<img width="680" height="307" alt="image" src="https://github.com/user-attachments/assets/6b60d087-0f72-40b8-9582-c488c35afeae" />

This log is unnecessary as we can use the unsub queue metric should show us if we're not removing subscriptions quickly enough. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Remove logging.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
