### PR TITLE
chore(flags): Add metric to track hash key override query results

### DIFF
--- a/docs/internal/feature-flags/experience-continuity.md
+++ b/docs/internal/feature-flags/experience-continuity.md
@@ -364,8 +364,9 @@ Ensure `$anon_distinct_id` is a **top-level field**, not nested in `person_prope
 ### Logs to Check
 
 - `/flags` endpoint logs for `anon_distinct_id` processing
-- Canonical log field: `hash_key_override_skipped` (optimization active)
+- Canonical log field: `hash_key_override_status` (values: `None`, `"skipped"`, `"error"`, `"empty"`, `"found"`)
 - Metric: `flags_experience_continuity_optimized_total`
+- Metric: `flags_hash_key_query_result_total` (labels: `result="empty"` or `result="has_overrides"`)
 
 ## See also
 

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -30,7 +30,8 @@ use crate::{
     metrics::consts::{
         FLAG_COHORT_PROCESSING_TIME, FLAG_COHORT_QUERY_TIME, FLAG_DATABASE_ERROR_COUNTER,
         FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME, FLAG_GROUP_QUERY_TIME,
-        FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME, FLAG_PERSON_QUERY_TIME,
+        FLAG_HASH_KEY_QUERY_RESULT, FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME,
+        FLAG_PERSON_QUERY_TIME,
     },
     properties::{
         property_matching::match_property,
@@ -732,6 +733,18 @@ async fn try_get_feature_flag_hash_key_overrides(
     for (feature_flag_key, hash_key, _) in sorted_overrides {
         feature_flag_hash_key_overrides.insert(feature_flag_key, hash_key);
     }
+
+    // Track whether query returned overrides to understand cache optimization potential
+    let result_label = if feature_flag_hash_key_overrides.is_empty() {
+        "empty"
+    } else {
+        "has_overrides"
+    };
+    common_metrics::inc(
+        FLAG_HASH_KEY_QUERY_RESULT,
+        &[("result".to_string(), result_label.to_string())],
+        1,
+    );
 
     Ok(feature_flag_hash_key_overrides)
 }

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -121,12 +121,14 @@ pub struct FlagsCanonicalLogLine {
     /// These errors (like missing dependencies or cycles) set errors_while_computing_flags=true
     /// in the response but don't increment flags_errored.
     pub dependency_graph_errors: usize,
-    pub hash_key_override_attempted: bool,
-    pub hash_key_override_succeeded: bool,
-    /// True when experience continuity lookup was skipped due to optimization.
-    /// This is set when flags have experience continuity enabled but don't need
-    /// a hash key lookup (100% rollout with no multivariate variants).
-    pub hash_key_override_skipped: bool,
+    /// Status of hash key override lookup for experience continuity.
+    /// Values:
+    /// - None: no flags require experience continuity
+    /// - "skipped": optimization applied (100% rollout, no variants needing lookup)
+    /// - "error": query failed
+    /// - "empty": query succeeded, no overrides found
+    /// - "found": query succeeded, overrides returned
+    pub hash_key_override_status: Option<&'static str>,
 
     // Rate limiting
     pub rate_limited: bool,
@@ -172,9 +174,7 @@ impl Default for FlagsCanonicalLogLine {
             cohorts_evaluated: 0,
             flags_errored: 0,
             dependency_graph_errors: 0,
-            hash_key_override_attempted: false,
-            hash_key_override_succeeded: false,
-            hash_key_override_skipped: false,
+            hash_key_override_status: None,
             rate_limited: false,
             team_cache_source: None,
             http_status: 200,
@@ -230,9 +230,7 @@ impl FlagsCanonicalLogLine {
             cohorts_evaluated = self.cohorts_evaluated,
             flags_errored = self.flags_errored,
             dependency_graph_errors = self.dependency_graph_errors,
-            hash_key_override_attempted = self.hash_key_override_attempted,
-            hash_key_override_succeeded = self.hash_key_override_succeeded,
-            hash_key_override_skipped = self.hash_key_override_skipped,
+            hash_key_override_status = self.hash_key_override_status,
             rate_limited = self.rate_limited,
             team_cache_source = self.team_cache_source,
             error_code = self.error_code,
@@ -291,9 +289,7 @@ mod tests {
         assert_eq!(log.cohorts_evaluated, 0);
         assert_eq!(log.flags_errored, 0);
         assert_eq!(log.dependency_graph_errors, 0);
-        assert!(!log.hash_key_override_attempted);
-        assert!(!log.hash_key_override_succeeded);
-        assert!(!log.hash_key_override_skipped);
+        assert!(log.hash_key_override_status.is_none());
         assert!(!log.rate_limited);
         assert!(log.team_cache_source.is_none());
         assert_eq!(log.http_status, 200);
@@ -327,8 +323,7 @@ mod tests {
         log.property_cache_misses = 2;
         log.cohorts_evaluated = 4;
         log.flags_errored = 1;
-        log.hash_key_override_attempted = true;
-        log.hash_key_override_succeeded = true;
+        log.hash_key_override_status = Some("found");
         log.rate_limited = false;
         log.team_cache_source = Some("redis");
         log.http_status = 200;
@@ -377,16 +372,14 @@ mod tests {
             with_canonical_log(|l| {
                 l.db_property_fetches = 3;
                 l.cohorts_evaluated = 5;
-                l.hash_key_override_attempted = true;
-                l.hash_key_override_succeeded = true;
+                l.hash_key_override_status = Some("found");
             });
         })
         .await;
 
         assert_eq!(final_log.db_property_fetches, 3);
         assert_eq!(final_log.cohorts_evaluated, 5);
-        assert!(final_log.hash_key_override_attempted);
-        assert!(final_log.hash_key_override_succeeded);
+        assert_eq!(final_log.hash_key_override_status, Some("found"));
     }
 
     #[tokio::test]

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -57,6 +57,11 @@ pub const FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER: &str =
 pub const FLAG_EXPERIENCE_CONTINUITY_OPTIMIZED: &str =
     "flags_experience_continuity_optimized_total";
 
+// Hash key override query result metric
+// Tracks the result of hash key override queries to understand cache optimization potential
+// Labels: result="empty" (no overrides found) | result="has_overrides" (overrides exist)
+pub const FLAG_HASH_KEY_QUERY_RESULT: &str = "flags_hash_key_query_result_total";
+
 // Flag definitions rate limiting
 pub const FLAG_DEFINITIONS_RATE_LIMITED_COUNTER: &str = "flags_flag_definitions_rate_limited_total";
 pub const FLAG_DEFINITIONS_REQUESTS_COUNTER: &str = "flags_flag_definitions_requests_total";


### PR DESCRIPTION
## Problem

We need observability into hash key override (experience continuity) lookups to evaluate optimization strategies like Bloom filters. The existing canonical log fields (`hash_key_override_attempted`, `hash_key_override_succeeded`, `hash_key_override_skipped`) didn't distinguish between queries that returned empty results vs queries that found overrides.

Understanding what percentage of lookups return empty results is critical for deciding if a Bloom filter (which excels at negative lookups) is worth implementing.

## Changes

1. **Added Prometheus metric** `flags_hash_key_query_result_total` with label `result="empty"` or `result="has_overrides"` to track query outcomes

2. **Consolidated canonical log fields** from three booleans into one status field:
   - `hash_key_override_status: Option<&'static str>` with values:
     - `None` - no flags require experience continuity
     - `"skipped"` - optimization applied (100% rollout, no variants)
     - `"error"` - query failed
     - `"empty"` - query succeeded, no overrides found
     - `"found"` - query succeeded, overrides returned

## How did you test this code?

- All existing unit tests pass
- `cargo clippy --all-targets --all-features -- -D warnings` passes
- `cargo fmt` applied
- `cargo shear` shows no unused dependencies

## Publish to changelog?

no
