### PR TITLE
fix(platform): change edit mode back to just 'e' as the keybind

### DIFF
--- a/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
+++ b/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
@@ -142,7 +142,7 @@ export const appShortcutLogic = kea<appShortcutLogicType>([
                 return
             }
 
-            // Handle sequence shortcuts and single-key shortcuts (no modifier keys, not in editable elements)
+            // Handle sequence shortcuts (no modifier keys, not in editable elements)
             if (isEditableElement(event.target) || event.altKey) {
                 return
             }
@@ -151,6 +151,10 @@ export const appShortcutLogic = kea<appShortcutLogicType>([
             const key = event.key.toLowerCase()
 
             // Check for single-key shortcuts first (immediate trigger, no sequence)
+            // Since single key shortcuts trigger eagerly, sequence shortcuts need to
+            // check for collisions before being implemented. We could also make this
+            // "lazy" but that would result in a noticeable lag in app for single key
+            // shortcuts. My preference is the eager way
             const singleKeyMatch = values.registeredAppShortcuts.find((shortcut) =>
                 shortcut.keybind.some((keybind) => isSingleKeyKeybind(keybind) && keybind[0] === key)
             )

--- a/frontend/src/lib/components/AppShortcuts/shortcuts.ts
+++ b/frontend/src/lib/components/AppShortcuts/shortcuts.ts
@@ -10,7 +10,7 @@ export const keyBinds: Record<string, string[]> = {
     toggleShortcutMenuFallback: ['command', 'shift', 'k'],
     search: ['command', 'k'],
     new: [...baseModifier, 'n'],
-    edit: [...baseModifier, 'e'],
+    edit: ['e'],
     save: [...baseModifier, 's'],
     dashboardAddTextTile: [...baseModifier, 'a'],
     filter: [...baseModifier, 'f'],


### PR DESCRIPTION
## Problem

customer reported 'e' was changed to 'cmd+option+e' for edit mode for layouts. this changes it back. 

## Changes

make 'e' the keybind for edit mode again (MEKEMA if you like red hats)

## How did you test this code?

https://github.com/user-attachments/assets/7a75b688-2eb1-41ed-8a2a-62e392842a38

ran locally.

> NOTE: there is a feature flag `ai-first` which causes an error toast to show for the max conversation history failing to load when toggling edit mode OFF. this feature flag is currently only rolled out to @adamleithp and @rafaeelaudibert just noting here for context

## Publish to changelog?

no