### PR TITLE
feat(livestream): Add session stats to the events messages

### DIFF
--- a/livestream/events/filter_easyjson.go
+++ b/livestream/events/filter_easyjson.go
@@ -61,16 +61,28 @@ func easyjson4d398eaaDecodeGithubComPosthogPosthogLivestreamEvents(in *jlexer.Le
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					v1 := in.Interface()
+					var v1 interface{}
 					if m, ok := v1.(easyjson.Unmarshaler); ok {
 						m.UnmarshalEasyJSON(in)
 					} else if m, ok := v1.(json.Unmarshaler); ok {
 						_ = m.UnmarshalJSON(in.Raw())
+					} else {
+						v1 = in.Interface()
 					}
 					(out.Properties)[key] = v1
 					in.WantComma()
 				}
 				in.Delim('}')
+			}
+		case "stats":
+			if in.IsNull() {
+				in.Skip()
+				out.Stats = nil
+			} else {
+				if out.Stats == nil {
+					out.Stats = new(EventStats)
+				}
+				easyjson4d398eaaDecodeGithubComPosthogPosthogLivestreamEvents1(in, out.Stats)
 			}
 		default:
 			in.SkipRecursive()
@@ -144,6 +156,11 @@ func easyjson4d398eaaEncodeGithubComPosthogPosthogLivestreamEvents(out *jwriter.
 			out.RawByte('}')
 		}
 	}
+	if in.Stats != nil {
+		const prefix string = ",\"stats\":"
+		out.RawString(prefix)
+		easyjson4d398eaaEncodeGithubComPosthogPosthogLivestreamEvents1(out, *in.Stats)
+	}
 	out.RawByte('}')
 }
 
@@ -170,7 +187,56 @@ func (v *ResponsePostHogEvent) UnmarshalJSON(data []byte) error {
 func (v *ResponsePostHogEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson4d398eaaDecodeGithubComPosthogPosthogLivestreamEvents(l, v)
 }
-func easyjson4d398eaaDecodeGithubComPosthogPosthogLivestreamEvents1(in *jlexer.Lexer, out *ResponseGeoEvent) {
+func easyjson4d398eaaDecodeGithubComPosthogPosthogLivestreamEvents1(in *jlexer.Lexer, out *EventStats) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "users_on_product":
+			out.UsersOnProduct = int(in.Int())
+		case "active_recordings":
+			out.ActiveRecordings = int(in.Int())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson4d398eaaEncodeGithubComPosthogPosthogLivestreamEvents1(out *jwriter.Writer, in EventStats) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"users_on_product\":"
+		out.RawString(prefix[1:])
+		out.Int(int(in.UsersOnProduct))
+	}
+	{
+		const prefix string = ",\"active_recordings\":"
+		out.RawString(prefix)
+		out.Int(int(in.ActiveRecordings))
+	}
+	out.RawByte('}')
+}
+func easyjson4d398eaaDecodeGithubComPosthogPosthogLivestreamEvents2(in *jlexer.Lexer, out *ResponseGeoEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -205,7 +271,7 @@ func easyjson4d398eaaDecodeGithubComPosthogPosthogLivestreamEvents1(in *jlexer.L
 		in.Consumed()
 	}
 }
-func easyjson4d398eaaEncodeGithubComPosthogPosthogLivestreamEvents1(out *jwriter.Writer, in ResponseGeoEvent) {
+func easyjson4d398eaaEncodeGithubComPosthogPosthogLivestreamEvents2(out *jwriter.Writer, in ResponseGeoEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -230,23 +296,23 @@ func easyjson4d398eaaEncodeGithubComPosthogPosthogLivestreamEvents1(out *jwriter
 // MarshalJSON supports json.Marshaler interface
 func (v ResponseGeoEvent) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson4d398eaaEncodeGithubComPosthogPosthogLivestreamEvents1(&w, v)
+	easyjson4d398eaaEncodeGithubComPosthogPosthogLivestreamEvents2(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ResponseGeoEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson4d398eaaEncodeGithubComPosthogPosthogLivestreamEvents1(w, v)
+	easyjson4d398eaaEncodeGithubComPosthogPosthogLivestreamEvents2(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *ResponseGeoEvent) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson4d398eaaDecodeGithubComPosthogPosthogLivestreamEvents1(&r, v)
+	easyjson4d398eaaDecodeGithubComPosthogPosthogLivestreamEvents2(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ResponseGeoEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson4d398eaaDecodeGithubComPosthogPosthogLivestreamEvents1(l, v)
+	easyjson4d398eaaDecodeGithubComPosthogPosthogLivestreamEvents2(l, v)
 }

--- a/livestream/events/stats_provider.go
+++ b/livestream/events/stats_provider.go
@@ -1,0 +1,30 @@
+package events
+
+type StatsProvider interface {
+	GetUsersOnProduct(token string) int
+	GetActiveRecordings(token string) int
+}
+
+type statsProvider struct {
+	stats        *Stats
+	sessionStats *SessionStats
+}
+
+func NewStatsProvider(stats *Stats, sessionStats *SessionStats) StatsProvider {
+	return &statsProvider{
+		stats:        stats,
+		sessionStats: sessionStats,
+	}
+}
+
+func (s *statsProvider) GetUsersOnProduct(token string) int {
+	store := s.stats.GetExistingStoreForToken(token)
+	if store == nil {
+		return 0
+	}
+	return store.Len()
+}
+
+func (s *statsProvider) GetActiveRecordings(token string) int {
+	return s.sessionStats.CountForToken(token)
+}

--- a/livestream/events/stats_provider_test.go
+++ b/livestream/events/stats_provider_test.go
@@ -1,0 +1,119 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatsProvider_GetUsersOnProduct(t *testing.T) {
+	t.Run("returns 0 for unknown token", func(t *testing.T) {
+		stats := NewStatsKeeper()
+		sessionStats := NewSessionStatsKeeper(0, 0)
+		provider := NewStatsProvider(stats, sessionStats)
+
+		assert.Equal(t, 0, provider.GetUsersOnProduct("unknown-token"))
+	})
+
+	t.Run("returns 0 for empty token", func(t *testing.T) {
+		stats := NewStatsKeeper()
+		sessionStats := NewSessionStatsKeeper(0, 0)
+		provider := NewStatsProvider(stats, sessionStats)
+
+		assert.Equal(t, 0, provider.GetUsersOnProduct(""))
+	})
+
+	t.Run("returns correct count for token with users", func(t *testing.T) {
+		stats := NewStatsKeeper()
+		sessionStats := NewSessionStatsKeeper(0, 0)
+		provider := NewStatsProvider(stats, sessionStats)
+
+		stats.GetStoreForToken("team-a").Add("user1", NoSpaceType{})
+		stats.GetStoreForToken("team-a").Add("user2", NoSpaceType{})
+		stats.GetStoreForToken("team-a").Add("user3", NoSpaceType{})
+
+		assert.Equal(t, 3, provider.GetUsersOnProduct("team-a"))
+	})
+
+	t.Run("tokens are isolated from each other", func(t *testing.T) {
+		stats := NewStatsKeeper()
+		sessionStats := NewSessionStatsKeeper(0, 0)
+		provider := NewStatsProvider(stats, sessionStats)
+
+		stats.GetStoreForToken("team-a").Add("user1", NoSpaceType{})
+		stats.GetStoreForToken("team-a").Add("user2", NoSpaceType{})
+		stats.GetStoreForToken("team-b").Add("user3", NoSpaceType{})
+
+		assert.Equal(t, 2, provider.GetUsersOnProduct("team-a"))
+		assert.Equal(t, 1, provider.GetUsersOnProduct("team-b"))
+		assert.Equal(t, 0, provider.GetUsersOnProduct("team-c"))
+	})
+
+	t.Run("same user counted once per token", func(t *testing.T) {
+		stats := NewStatsKeeper()
+		sessionStats := NewSessionStatsKeeper(0, 0)
+		provider := NewStatsProvider(stats, sessionStats)
+
+		stats.GetStoreForToken("team-a").Add("user1", NoSpaceType{})
+		stats.GetStoreForToken("team-a").Add("user1", NoSpaceType{})
+		stats.GetStoreForToken("team-a").Add("user1", NoSpaceType{})
+
+		assert.Equal(t, 1, provider.GetUsersOnProduct("team-a"))
+	})
+}
+
+func TestStatsProvider_GetActiveRecordings(t *testing.T) {
+	t.Run("returns 0 for unknown token", func(t *testing.T) {
+		stats := NewStatsKeeper()
+		sessionStats := NewSessionStatsKeeper(0, 0)
+		provider := NewStatsProvider(stats, sessionStats)
+
+		assert.Equal(t, 0, provider.GetActiveRecordings("unknown-token"))
+	})
+
+	t.Run("returns 0 for empty token", func(t *testing.T) {
+		stats := NewStatsKeeper()
+		sessionStats := NewSessionStatsKeeper(0, 0)
+		provider := NewStatsProvider(stats, sessionStats)
+
+		assert.Equal(t, 0, provider.GetActiveRecordings(""))
+	})
+
+	t.Run("returns correct count for token with recordings", func(t *testing.T) {
+		stats := NewStatsKeeper()
+		sessionStats := NewSessionStatsKeeper(0, 0)
+		provider := NewStatsProvider(stats, sessionStats)
+
+		sessionStats.Add("team-a", "session1")
+		sessionStats.Add("team-a", "session2")
+		sessionStats.Add("team-a", "session3")
+
+		assert.Equal(t, 3, provider.GetActiveRecordings("team-a"))
+	})
+
+	t.Run("tokens are isolated from each other", func(t *testing.T) {
+		stats := NewStatsKeeper()
+		sessionStats := NewSessionStatsKeeper(0, 0)
+		provider := NewStatsProvider(stats, sessionStats)
+
+		sessionStats.Add("team-a", "session1")
+		sessionStats.Add("team-a", "session2")
+		sessionStats.Add("team-b", "session3")
+
+		assert.Equal(t, 2, provider.GetActiveRecordings("team-a"))
+		assert.Equal(t, 1, provider.GetActiveRecordings("team-b"))
+		assert.Equal(t, 0, provider.GetActiveRecordings("team-c"))
+	})
+
+	t.Run("same session counted once per token", func(t *testing.T) {
+		stats := NewStatsKeeper()
+		sessionStats := NewSessionStatsKeeper(0, 0)
+		provider := NewStatsProvider(stats, sessionStats)
+
+		sessionStats.Add("team-a", "session1")
+		sessionStats.Add("team-a", "session1")
+		sessionStats.Add("team-a", "session1")
+
+		assert.Equal(t, 1, provider.GetActiveRecordings("team-a"))
+	})
+}

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -107,7 +107,8 @@ func main() {
 		}
 	}()
 
-	filter := events.NewFilter(subChan, unSubChan, phEventChan)
+	statsProvider := events.NewStatsProvider(stats, sessionStats)
+	filter := events.NewFilter(subChan, unSubChan, phEventChan, statsProvider)
 	go filter.Run()
 
 	// Echo instance


### PR DESCRIPTION
## Problem
The Web Analytics live dashboard needs to poll `/stats` constantly to get session statistics. This results in the current online count not actually being a live metric.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Clients can now pass an optional `includeStats` flag with their request. If present, the Livestream service will append a new `stats` field in the response containing the `users_on_product` and `active_recordings` statistics. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Added new tests and confirmed locally. 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
