### PR TITLE
feat: add webhook to get events from github prs

### DIFF
--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -145,6 +145,11 @@ CONSTANCE_CONFIG = {
         "Used to validate Slack events for example when unfurling links",
         str,
     ),
+    "GITHUB_WEBHOOK_SECRET": (
+        get_from_env("GITHUB_WEBHOOK_SECRET", default=""),
+        "Used to validate GitHub webhook events (HMAC-SHA256 signature verification)",
+        str,
+    ),
     "PARALLEL_DASHBOARD_ITEM_CACHE": (
         get_from_env("PARALLEL_DASHBOARD_ITEM_CACHE", default=5),
         "user to determine how many insight cache updates to run at a time",
@@ -213,6 +218,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "SLACK_APP_CLIENT_ID",
     "SLACK_APP_CLIENT_SECRET",
     "SLACK_APP_SIGNING_SECRET",
+    "GITHUB_WEBHOOK_SECRET",
     "PARALLEL_DASHBOARD_ITEM_CACHE",
     "ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS",
     "RATE_LIMIT_ENABLED",
@@ -228,4 +234,5 @@ SECRET_SETTINGS = [
     "EMAIL_HOST_PASSWORD",
     "SLACK_APP_CLIENT_SECRET",
     "SLACK_APP_SIGNING_SECRET",
+    "GITHUB_WEBHOOK_SECRET",
 ]

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -49,6 +49,7 @@ from posthog.temporal.codec_server import decode_payloads
 from products.early_access_features.backend.api import early_access_features
 from products.product_tours.backend.api import product_tours
 from products.slack_app.backend.api import slack_event_handler
+from products.tasks.backend.webhooks import github_pr_webhook
 
 from .utils import opt_slash_path, render_template
 from .views import (
@@ -250,6 +251,8 @@ urlpatterns = [
     path("uploaded_media/<str:image_uuid>", uploaded_media.download),
     opt_slash_path("slack/interactivity-callback", slack_interactivity_callback),
     opt_slash_path("slack/event-callback", slack_event_handler),
+    # GitHub webhooks for task lifecycle events
+    opt_slash_path("webhooks/github/pr", github_pr_webhook),
     # Message preferences
     path("messaging-preferences/<str:token>/", preferences_page, name="message_preferences"),
     opt_slash_path("messaging-preferences/update", update_preferences, name="message_preferences_update"),

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -1,0 +1,239 @@
+import hmac
+import json
+import hashlib
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from rest_framework.test import APIClient
+
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+from posthog.models.user import User
+
+from products.tasks.backend.models import Task, TaskRun
+
+
+def generate_github_signature(payload: bytes, secret: str) -> str:
+    """Generate a GitHub-style HMAC-SHA256 signature."""
+    return (
+        "sha256="
+        + hmac.new(
+            secret.encode("utf-8"),
+            payload,
+            hashlib.sha256,
+        ).hexdigest()
+    )
+
+
+class TestGitHubPRWebhook(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.webhook_secret = "test-webhook-secret"
+
+        # Create test organization, team, and user
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create(email="test@example.com", distinct_id="user-123")
+
+        # Create a task and task run with a PR URL
+        self.task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Test Task",
+            description="Test description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            repository="posthog/posthog",
+        )
+        self.task_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/posthog/posthog/pull/123"},
+        )
+
+    def _make_webhook_request(self, payload: dict, event_type: str = "pull_request"):
+        """Helper to make a webhook request with proper signature."""
+        payload_bytes = json.dumps(payload).encode("utf-8")
+        signature = generate_github_signature(payload_bytes, self.webhook_secret)
+
+        return self.client.post(
+            "/webhooks/github/pr/",
+            data=payload_bytes,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE_256=signature,
+            HTTP_X_GITHUB_EVENT=event_type,
+        )
+
+    @patch("products.tasks.backend.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.webhooks.posthoganalytics.capture")
+    def test_pr_merged_webhook(self, mock_capture, mock_get_secret):
+        """Test that a PR merged webhook creates a log entry and analytics event."""
+        mock_get_secret.return_value = self.webhook_secret
+
+        payload = {
+            "action": "closed",
+            "pull_request": {
+                "html_url": "https://github.com/posthog/posthog/pull/123",
+                "merged": True,
+            },
+        }
+
+        response = self._make_webhook_request(payload)
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify analytics was called
+        mock_capture.assert_called_once()
+        call_kwargs = mock_capture.call_args[1]
+        self.assertEqual(call_kwargs["event"], "pr_merged")
+        self.assertEqual(call_kwargs["properties"]["pr_url"], "https://github.com/posthog/posthog/pull/123")
+        self.assertEqual(call_kwargs["properties"]["task_id"], str(self.task.id))
+        self.assertEqual(call_kwargs["properties"]["run_id"], str(self.task_run.id))
+
+    @patch("products.tasks.backend.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.webhooks.posthoganalytics.capture")
+    def test_pr_closed_without_merge_webhook(self, mock_capture, mock_get_secret):
+        """Test that a PR closed (not merged) webhook creates correct events."""
+        mock_get_secret.return_value = self.webhook_secret
+
+        payload = {
+            "action": "closed",
+            "pull_request": {
+                "html_url": "https://github.com/posthog/posthog/pull/123",
+                "merged": False,
+            },
+        }
+
+        response = self._make_webhook_request(payload)
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify analytics was called with pr_closed event
+        mock_capture.assert_called_once()
+        call_kwargs = mock_capture.call_args[1]
+        self.assertEqual(call_kwargs["event"], "pr_closed")
+
+    @patch("products.tasks.backend.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.webhooks.posthoganalytics.capture")
+    def test_pr_opened_webhook(self, mock_capture, mock_get_secret):
+        """Test that a PR opened webhook creates correct events."""
+        mock_get_secret.return_value = self.webhook_secret
+
+        payload = {
+            "action": "opened",
+            "pull_request": {
+                "html_url": "https://github.com/posthog/posthog/pull/123",
+                "merged": False,
+            },
+        }
+
+        response = self._make_webhook_request(payload)
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify analytics was called with pr_created event
+        mock_capture.assert_called_once()
+        call_kwargs = mock_capture.call_args[1]
+        self.assertEqual(call_kwargs["event"], "pr_created")
+
+    @patch("products.tasks.backend.webhooks.get_github_webhook_secret")
+    def test_invalid_signature_rejected(self, mock_get_secret):
+        """Test that requests with invalid signatures are rejected."""
+        mock_get_secret.return_value = self.webhook_secret
+
+        payload = {"action": "closed", "pull_request": {"html_url": "https://github.com/org/repo/pull/1"}}
+        payload_bytes = json.dumps(payload).encode("utf-8")
+
+        response = self.client.post(
+            "/webhooks/github/pr/",
+            data=payload_bytes,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE_256="sha256=invalid",
+            HTTP_X_GITHUB_EVENT="pull_request",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    @patch("products.tasks.backend.webhooks.get_github_webhook_secret")
+    def test_missing_signature_rejected(self, mock_get_secret):
+        """Test that requests without signatures are rejected."""
+        mock_get_secret.return_value = self.webhook_secret
+
+        payload = {"action": "closed", "pull_request": {"html_url": "https://github.com/org/repo/pull/1"}}
+
+        response = self.client.post(
+            "/webhooks/github/pr/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="pull_request",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    @patch("products.tasks.backend.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.webhooks.posthoganalytics.capture")
+    def test_unknown_pr_url_returns_200(self, mock_capture, mock_get_secret):
+        """Test that webhooks for unknown PR URLs return 200 but don't emit events."""
+        mock_get_secret.return_value = self.webhook_secret
+
+        payload = {
+            "action": "closed",
+            "pull_request": {
+                "html_url": "https://github.com/unknown/repo/pull/999",
+                "merged": True,
+            },
+        }
+
+        response = self._make_webhook_request(payload)
+
+        self.assertEqual(response.status_code, 200)
+        mock_capture.assert_not_called()
+
+    @patch("products.tasks.backend.webhooks.get_github_webhook_secret")
+    def test_non_pr_event_ignored(self, mock_get_secret):
+        """Test that non-pull_request events are acknowledged but ignored."""
+        mock_get_secret.return_value = self.webhook_secret
+
+        payload = {"action": "created", "issue": {"html_url": "https://github.com/org/repo/issues/1"}}
+
+        response = self._make_webhook_request(payload, event_type="issues")
+
+        self.assertEqual(response.status_code, 200)
+
+    @patch("products.tasks.backend.webhooks.get_github_webhook_secret")
+    def test_ignored_pr_actions(self, mock_get_secret):
+        """Test that PR actions other than opened/closed are acknowledged but ignored."""
+        mock_get_secret.return_value = self.webhook_secret
+
+        for action in ["edited", "reopened", "synchronize", "labeled"]:
+            payload = {
+                "action": action,
+                "pull_request": {
+                    "html_url": "https://github.com/posthog/posthog/pull/123",
+                    "merged": False,
+                },
+            }
+
+            response = self._make_webhook_request(payload)
+            self.assertEqual(response.status_code, 200, f"Failed for action: {action}")
+
+    def test_webhook_secret_not_configured(self):
+        """Test that webhook returns 500 if secret is not configured."""
+        with patch("products.tasks.backend.webhooks.get_github_webhook_secret", return_value=None):
+            payload = {"action": "closed", "pull_request": {"html_url": "https://github.com/org/repo/pull/1"}}
+
+            response = self.client.post(
+                "/webhooks/github/pr/",
+                data=json.dumps(payload),
+                content_type="application/json",
+                HTTP_X_GITHUB_EVENT="pull_request",
+            )
+
+            self.assertEqual(response.status_code, 500)
+
+    def test_method_not_allowed(self):
+        """Test that non-POST methods are rejected."""
+        response = self.client.get("/webhooks/github/pr/")
+        self.assertEqual(response.status_code, 405)

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -1,0 +1,164 @@
+import hmac
+import json
+import hashlib
+
+from django.http import HttpRequest, HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+
+import structlog
+import posthoganalytics
+
+from posthog.models.instance_setting import get_instance_setting
+
+from products.tasks.backend.models import TaskRun
+
+logger = structlog.get_logger(__name__)
+
+
+def verify_github_signature(payload: bytes, signature: str | None, secret: str) -> bool:
+    """
+    Verify the GitHub webhook signature using HMAC-SHA256.
+
+    GitHub sends a signature in the X-Hub-Signature-256 header in the format:
+    sha256=<hex_digest>
+    """
+    if not signature or not signature.startswith("sha256="):
+        return False
+
+    expected_signature = (
+        "sha256="
+        + hmac.new(
+            secret.encode("utf-8"),
+            payload,
+            hashlib.sha256,
+        ).hexdigest()
+    )
+
+    return hmac.compare_digest(expected_signature, signature)
+
+
+def get_github_webhook_secret() -> str | None:
+    """Get the GitHub webhook secret from instance settings."""
+    secret = get_instance_setting("GITHUB_WEBHOOK_SECRET")
+    return secret if secret else None
+
+
+@csrf_exempt
+def github_pr_webhook(request: HttpRequest) -> HttpResponse:
+    """
+    Handle GitHub pull_request webhook events.
+
+    This endpoint:
+    1. Validates the HMAC-SHA256 signature from GitHub
+    2. Parses pull_request events (opened, closed, merged)
+    3. Finds TaskRun by matching pr_url in output field
+    4. Emits console log events and analytics
+
+    Expected events:
+    - pull_request.opened → log "PR created"
+    - pull_request.closed with merged=true → log "PR merged"
+    - pull_request.closed with merged=false → log "PR closed"
+    """
+    if request.method != "POST":
+        return HttpResponse(status=405)
+
+    webhook_secret = get_github_webhook_secret()
+    if not webhook_secret:
+        logger.error(
+            "github_pr_webhook_no_secret",
+            message="GITHUB_WEBHOOK_SECRET not configured",
+        )
+        return HttpResponse("Webhook not configured", status=500)
+
+    signature = request.headers.get("X-Hub-Signature-256")
+    if not verify_github_signature(request.body, signature, webhook_secret):
+        logger.warning(
+            "github_pr_webhook_invalid_signature",
+            has_signature=bool(signature),
+        )
+        return HttpResponse("Invalid signature", status=403)
+
+    try:
+        payload = json.loads(request.body)
+    except json.JSONDecodeError:
+        return HttpResponse("Invalid JSON", status=400)
+
+    event_type = request.headers.get("X-GitHub-Event")
+    if event_type != "pull_request":
+        # Not a PR event, acknowledge but don't process, shouldnt happen becuase of github app permissions
+        return HttpResponse(status=200)
+
+    action = payload.get("action")
+    pull_request = payload.get("pull_request", {})
+    pr_url = pull_request.get("html_url")
+    merged = pull_request.get("merged", False)
+
+    if not pr_url:
+        logger.warning("github_pr_webhook_no_pr_url", action=action)
+        return HttpResponse(status=200)
+
+    if action == "opened":
+        event_action = "created"
+        analytics_event = "pr_created"
+    elif action == "closed":
+        if merged:
+            event_action = "merged"
+            analytics_event = "pr_merged"
+        else:
+            event_action = "closed"
+            analytics_event = "pr_closed"
+    else:
+        # Other actions (reopened, edited, etc.) - acknowledge but don't process
+        logger.debug("github_pr_webhook_ignored_action", action=action, pr_url=pr_url)
+        return HttpResponse(status=200)
+
+    # Find TaskRun by pr_url in output field
+    task_run = TaskRun.objects.filter(output__pr_url=pr_url).select_related("task", "task__created_by").first()
+
+    if not task_run:
+        logger.debug(
+            "github_pr_webhook_no_task_run",
+            action=action,
+            pr_url=pr_url,
+            message="No TaskRun found with this PR URL",
+        )
+        return HttpResponse(status=200)
+
+    # Emit messgae to the task run
+    task_run.emit_console_event("info", f"PR {event_action}: {pr_url}")
+
+    logger.info(
+        "github_pr_webhook_processed",
+        action=action,
+        event_action=event_action,
+        pr_url=pr_url,
+        task_id=str(task_run.task_id),
+        run_id=str(task_run.id),
+    )
+
+    # Emit PostHog analytics event
+    try:
+        # should probably not use a distinct id and send an anon id with person processing off in fail case...
+        distinct_id = (
+            str(task_run.task.created_by.distinct_id) if task_run.task.created_by else f"team_{task_run.team_id}"
+        )
+
+        posthoganalytics.capture(
+            distinct_id=distinct_id,
+            event=analytics_event,
+            properties={
+                "task_id": str(task_run.task_id),
+                "run_id": str(task_run.id),
+                "pr_url": pr_url,
+                "repository": task_run.task.repository,
+                "team_id": task_run.team_id,
+            },
+        )
+    except Exception as e:
+        logger.warning(
+            "github_pr_webhook_analytics_failed",
+            error=str(e),
+            analytics_event=analytics_event,
+        )
+
+    return HttpResponse(status=200)


### PR DESCRIPTION
## Problem

We need to track GitHub PR lifecycle events (created, closed, merged) for tasks that generate PRs. This will help us understand how many task-generated PRs are actually merged and provide better visibility into the task lifecycle.

## Changes

- Added a GitHub webhook endpoint to handle PR lifecycle events
- Implemented signature verification using HMAC-SHA256 to validate webhook requests
- Added a new `GITHUB_WEBHOOK_SECRET` setting to store the webhook secret
- Created event tracking for PR created, closed, and merged events
- Added comprehensive tests for the webhook handler

## How did you test this code?

- Added unit tests covering all webhook scenarios:
  - PR opened, closed, and merged events
  - Invalid signatures and missing headers
  - Unknown PR URLs
  - Non-PR events
  - Various edge cases
- Manually tested with GitHub webhook payloads using a local development environment
- Verified analytics events are properly captured