### PR TITLE
feat(capture-logs): add jsonl support

### DIFF
--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -56,10 +56,14 @@ pub fn parse_otel_message(json_bytes: &Bytes) -> Result<ExportLogsServiceRequest
     let json_str = std::str::from_utf8(json_bytes)?;
 
     // Check if this is JSONL by looking for multiple complete JSON objects
-    let lines: Vec<&str> = json_str.lines().filter(|line| !line.trim().is_empty()).collect();
-    let is_jsonl = lines.len() > 1 && lines.iter().all(|line| {
-        line.trim().starts_with('{') && line.trim().ends_with('}')
-    });
+    let lines: Vec<&str> = json_str
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+    let is_jsonl = lines.len() > 1
+        && lines
+            .iter()
+            .all(|line| line.trim().starts_with('{') && line.trim().ends_with('}'));
 
     if is_jsonl {
         // Handle JSONL format - parse each line and merge them

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -81,6 +81,10 @@ pub fn parse_otel_message(json_bytes: &Bytes) -> Result<ExportLogsServiceRequest
         merged_request.resource_logs.extend(request.resource_logs);
     }
 
+    if merged_request.resource_logs.is_empty() {
+        return Err(anyhow::anyhow!("No valid log data found in request"));
+    }
+
     Ok(merged_request)
 }
 

--- a/rust/capture-logs/tests/service_test.rs
+++ b/rust/capture-logs/tests/service_test.rs
@@ -6,10 +6,10 @@ use opentelemetry_proto::tonic::common::v1::any_value::Value;
 fn test_parse_single_json_otel_message() {
     let json_data = r#"{"resourceLogs":[{"resource":{"attributes":[]},"scopeLogs":[{"scope":{"name":"test"},"logRecords":[{"timeUnixNano":"1234567890","severityText":"INFO","body":{"stringValue":"test message"}}]}]}]}"#;
     let bytes = Bytes::from(json_data);
-    
+
     let result = parse_otel_message(&bytes);
     assert!(result.is_ok());
-    
+
     let request = result.unwrap();
     assert_eq!(request.resource_logs.len(), 1);
     assert_eq!(request.resource_logs[0].scope_logs.len(), 1);
@@ -39,29 +39,71 @@ fn test_parse_jsonl_otel_message() {
 {"resourceLogs":[{"resource":{"attributes":[]},"scopeLogs":[{"scope":{"name":"test2"},"logRecords":[{"timeUnixNano":"1234567891","severityText":"WARN","body":{"stringValue":"message 2"}}]}]}]}
 {"resourceLogs":[{"resource":{"attributes":[]},"scopeLogs":[{"scope":{"name":"test3"},"logRecords":[{"timeUnixNano":"1234567892","severityText":"ERROR","body":{"stringValue":"message 3"}}]}]}]}"#;
     let bytes = Bytes::from(jsonl_data);
-    
+
     let result = parse_otel_message(&bytes);
     assert!(result.is_ok());
-    
+
     let request = result.unwrap();
     // Should have merged all 3 resource logs
     assert_eq!(request.resource_logs.len(), 3);
-    
+
     // Verify each resource log has the expected content
-    assert_eq!(request.resource_logs[0].scope_logs[0].scope.as_ref().unwrap().name, "test1");
-    assert_eq!(request.resource_logs[1].scope_logs[0].scope.as_ref().unwrap().name, "test2");
-    assert_eq!(request.resource_logs[2].scope_logs[0].scope.as_ref().unwrap().name, "test3");
-    
+    assert_eq!(
+        request.resource_logs[0].scope_logs[0]
+            .scope
+            .as_ref()
+            .unwrap()
+            .name,
+        "test1"
+    );
+    assert_eq!(
+        request.resource_logs[1].scope_logs[0]
+            .scope
+            .as_ref()
+            .unwrap()
+            .name,
+        "test2"
+    );
+    assert_eq!(
+        request.resource_logs[2].scope_logs[0]
+            .scope
+            .as_ref()
+            .unwrap()
+            .name,
+        "test3"
+    );
+
     // Verify log records content
-    match request.resource_logs[0].scope_logs[0].log_records[0].body.as_ref().unwrap().value.as_ref().unwrap() {
+    match request.resource_logs[0].scope_logs[0].log_records[0]
+        .body
+        .as_ref()
+        .unwrap()
+        .value
+        .as_ref()
+        .unwrap()
+    {
         Value::StringValue(s) => assert_eq!(s, "message 1"),
         _ => panic!("Expected string value"),
     }
-    match request.resource_logs[1].scope_logs[0].log_records[0].body.as_ref().unwrap().value.as_ref().unwrap() {
+    match request.resource_logs[1].scope_logs[0].log_records[0]
+        .body
+        .as_ref()
+        .unwrap()
+        .value
+        .as_ref()
+        .unwrap()
+    {
         Value::StringValue(s) => assert_eq!(s, "message 2"),
         _ => panic!("Expected string value"),
     }
-    match request.resource_logs[2].scope_logs[0].log_records[0].body.as_ref().unwrap().value.as_ref().unwrap() {
+    match request.resource_logs[2].scope_logs[0].log_records[0]
+        .body
+        .as_ref()
+        .unwrap()
+        .value
+        .as_ref()
+        .unwrap()
+    {
         Value::StringValue(s) => assert_eq!(s, "message 3"),
         _ => panic!("Expected string value"),
     }
@@ -76,10 +118,10 @@ fn test_parse_jsonl_with_empty_lines() {
 
 "#;
     let bytes = Bytes::from(jsonl_data);
-    
+
     let result = parse_otel_message(&bytes);
     assert!(result.is_ok());
-    
+
     let request = result.unwrap();
     // Should have merged both resource logs, ignoring empty lines
     assert_eq!(request.resource_logs.len(), 2);
@@ -91,7 +133,7 @@ fn test_parse_invalid_jsonl() {
 invalid json line
 {"resourceLogs":[]}"#;
     let bytes = Bytes::from(invalid_jsonl);
-    
+
     let result = parse_otel_message(&bytes);
     assert!(result.is_err());
 }

--- a/rust/capture-logs/tests/service_test.rs
+++ b/rust/capture-logs/tests/service_test.rs
@@ -1,0 +1,97 @@
+use bytes::Bytes;
+use capture_logs::service::parse_otel_message;
+use opentelemetry_proto::tonic::common::v1::any_value::Value;
+
+#[test]
+fn test_parse_single_json_otel_message() {
+    let json_data = r#"{"resourceLogs":[{"resource":{"attributes":[]},"scopeLogs":[{"scope":{"name":"test"},"logRecords":[{"timeUnixNano":"1234567890","severityText":"INFO","body":{"stringValue":"test message"}}]}]}]}"#;
+    let bytes = Bytes::from(json_data);
+    
+    let result = parse_otel_message(&bytes);
+    assert!(result.is_ok());
+    
+    let request = result.unwrap();
+    assert_eq!(request.resource_logs.len(), 1);
+    assert_eq!(request.resource_logs[0].scope_logs.len(), 1);
+    assert_eq!(request.resource_logs[0].scope_logs[0].log_records.len(), 1);
+}
+
+#[test]
+fn test_parse_single_json_otel_message_with_newlines() {
+    let json_data = r#"{"resourceLogs":
+        [{"resource":{"attributes":[]},
+        "scopeLogs":[{"scope":{"name":"test"},"logRecords":[{"timeUnixNano":"1234567890","severityText":"INFO","body":{"stringValue":"test message"}}]}]}]
+    }"#;
+    let bytes = Bytes::from(json_data);
+
+    let result = parse_otel_message(&bytes);
+    assert!(result.is_ok());
+
+    let request = result.unwrap();
+    assert_eq!(request.resource_logs.len(), 1);
+    assert_eq!(request.resource_logs[0].scope_logs.len(), 1);
+    assert_eq!(request.resource_logs[0].scope_logs[0].log_records.len(), 1);
+}
+
+#[test]
+fn test_parse_jsonl_otel_message() {
+    let jsonl_data = r#"{"resourceLogs":[{"resource":{"attributes":[]},"scopeLogs":[{"scope":{"name":"test1"},"logRecords":[{"timeUnixNano":"1234567890","severityText":"INFO","body":{"stringValue":"message 1"}}]}]}]}
+{"resourceLogs":[{"resource":{"attributes":[]},"scopeLogs":[{"scope":{"name":"test2"},"logRecords":[{"timeUnixNano":"1234567891","severityText":"WARN","body":{"stringValue":"message 2"}}]}]}]}
+{"resourceLogs":[{"resource":{"attributes":[]},"scopeLogs":[{"scope":{"name":"test3"},"logRecords":[{"timeUnixNano":"1234567892","severityText":"ERROR","body":{"stringValue":"message 3"}}]}]}]}"#;
+    let bytes = Bytes::from(jsonl_data);
+    
+    let result = parse_otel_message(&bytes);
+    assert!(result.is_ok());
+    
+    let request = result.unwrap();
+    // Should have merged all 3 resource logs
+    assert_eq!(request.resource_logs.len(), 3);
+    
+    // Verify each resource log has the expected content
+    assert_eq!(request.resource_logs[0].scope_logs[0].scope.as_ref().unwrap().name, "test1");
+    assert_eq!(request.resource_logs[1].scope_logs[0].scope.as_ref().unwrap().name, "test2");
+    assert_eq!(request.resource_logs[2].scope_logs[0].scope.as_ref().unwrap().name, "test3");
+    
+    // Verify log records content
+    match request.resource_logs[0].scope_logs[0].log_records[0].body.as_ref().unwrap().value.as_ref().unwrap() {
+        Value::StringValue(s) => assert_eq!(s, "message 1"),
+        _ => panic!("Expected string value"),
+    }
+    match request.resource_logs[1].scope_logs[0].log_records[0].body.as_ref().unwrap().value.as_ref().unwrap() {
+        Value::StringValue(s) => assert_eq!(s, "message 2"),
+        _ => panic!("Expected string value"),
+    }
+    match request.resource_logs[2].scope_logs[0].log_records[0].body.as_ref().unwrap().value.as_ref().unwrap() {
+        Value::StringValue(s) => assert_eq!(s, "message 3"),
+        _ => panic!("Expected string value"),
+    }
+}
+
+#[test]
+fn test_parse_jsonl_with_empty_lines() {
+    let jsonl_data = r#"
+{"resourceLogs":[{"resource":{"attributes":[]},"scopeLogs":[{"scope":{"name":"test1"},"logRecords":[{"timeUnixNano":"1234567890","severityText":"INFO","body":{"stringValue":"message 1"}}]}]}]}
+
+{"resourceLogs":[{"resource":{"attributes":[]},"scopeLogs":[{"scope":{"name":"test2"},"logRecords":[{"timeUnixNano":"1234567891","severityText":"WARN","body":{"stringValue":"message 2"}}]}]}]}
+
+"#;
+    let bytes = Bytes::from(jsonl_data);
+    
+    let result = parse_otel_message(&bytes);
+    assert!(result.is_ok());
+    
+    let request = result.unwrap();
+    // Should have merged both resource logs, ignoring empty lines
+    assert_eq!(request.resource_logs.len(), 2);
+}
+
+#[test]
+fn test_parse_invalid_jsonl() {
+    let invalid_jsonl = r#"{"resourceLogs":[]}
+invalid json line
+{"resourceLogs":[]}"#;
+    let bytes = Bytes::from(invalid_jsonl);
+    
+    let result = parse_otel_message(&bytes);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Problem

some clients (*cough* rory *cough*) are sending jsonl payloads, which we don't currently support. It's pretty simple and useful so lets just support it instead of trying to get the client to merge things into a single json object

## Changes

support jsonl, merge resourceLogs from all json items
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

added unit tests, ran locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
