### PR TITLE
refactor(logs): replace logsLogic with logsSceneLogic across components

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -13,11 +13,11 @@ import { LogsFilterBar } from 'products/logs/frontend/components/LogsViewer/Filt
 import { LogsSetupPrompt } from 'products/logs/frontend/components/SetupPrompt/SetupPrompt'
 import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPrompt/logsIngestionLogic'
 
-import { logsLogic } from './logsLogic'
+import { logsSceneLogic } from './logsSceneLogic'
 
 export const scene: SceneExport = {
     component: LogsScene,
-    logic: logsLogic,
+    logic: logsSceneLogic,
     settingSectionId: 'environment-logs',
 }
 
@@ -42,10 +42,10 @@ const LogsSceneContent = (): JSX.Element => {
         orderBy,
         sparklineData,
         sparklineBreakdownBy,
-    } = useValues(logsLogic)
+    } = useValues(logsSceneLogic)
     const { teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
     const { runQuery, fetchNextLogsPage, setOrderBy, addFilter, setDateRange, setSparklineBreakdownBy } =
-        useActions(logsLogic)
+        useActions(logsSceneLogic)
 
     return (
         <>

--- a/products/logs/frontend/attributeBreakdownLogic.tsx
+++ b/products/logs/frontend/attributeBreakdownLogic.tsx
@@ -3,7 +3,7 @@ import { connect, kea, key, path, props, selectors } from 'kea'
 import { PropertyFilterType } from '~/types'
 
 import type { attributeBreakdownLogicType } from './attributeBreakdownLogicType'
-import { logsLogic } from './logsLogic'
+import { logsSceneLogic } from './logsSceneLogic'
 
 export interface AttributeBreakdownLogicProps {
     attribute: string
@@ -17,7 +17,7 @@ export const attributeBreakdownLogic = kea<attributeBreakdownLogicType>([
     path((key) => ['products', 'logs', 'frontend', 'logsAttributeBreakdownsLogic', key]),
 
     connect((props: AttributeBreakdownLogicProps) => ({
-        values: [logsLogic({ tabId: props.tabId }), ['logs']],
+        values: [logsSceneLogic({ tabId: props.tabId }), ['logs']],
     })),
 
     selectors(({ props }) => ({

--- a/products/logs/frontend/components/LogsViewer/Filters/AttributesFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/AttributesFilter.tsx
@@ -5,11 +5,11 @@ import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
 
-import { logsLogic } from '../../../logsLogic'
+import { logsSceneLogic } from '../../../logsSceneLogic'
 
 export const AttributesFilter = (): JSX.Element => {
-    const { filterGroup } = useValues(logsLogic)
-    const { setFilterGroup } = useActions(logsLogic)
+    const { filterGroup } = useValues(logsSceneLogic)
+    const { setFilterGroup } = useActions(logsSceneLogic)
 
     const rootKey = 'logs'
 
@@ -30,7 +30,7 @@ export const AttributesFilter = (): JSX.Element => {
 }
 
 const NestedFilterGroup = (): JSX.Element => {
-    const { openFilterOnInsert } = useValues(logsLogic)
+    const { openFilterOnInsert } = useValues(logsSceneLogic)
     const { filterGroup } = useValues(universalFiltersLogic)
     const { replaceGroupValue, removeGroupValue } = useActions(universalFiltersLogic)
 

--- a/products/logs/frontend/components/LogsViewer/Filters/DateRangeFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/DateRangeFilter.tsx
@@ -7,7 +7,7 @@ import { DATE_TIME_FORMAT, formatDateRange } from 'lib/utils'
 
 import { DateMappingOption } from '~/types'
 
-import { logsLogic } from '../../../logsLogic'
+import { logsSceneLogic } from '../../../logsSceneLogic'
 
 const dateMapping: DateMappingOption[] = [
     { key: CUSTOM_OPTION_KEY, values: [] },
@@ -54,8 +54,8 @@ const dateMapping: DateMappingOption[] = [
 ]
 
 export const DateRangeFilter = (): JSX.Element => {
-    const { dateRange } = useValues(logsLogic)
-    const { setDateRange } = useActions(logsLogic)
+    const { dateRange } = useValues(logsSceneLogic)
+    const { setDateRange } = useActions(logsSceneLogic)
 
     return (
         <DateFilter

--- a/products/logs/frontend/components/LogsViewer/Filters/FilterGroup.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/FilterGroup.tsx
@@ -21,7 +21,7 @@ import {
     UniversalFiltersGroup,
 } from '~/types'
 
-import { logsLogic } from '../../../logsLogic'
+import { logsSceneLogic } from '../../../logsSceneLogic'
 
 export const taxonomicFilterLogicKey = 'logs'
 export const taxonomicGroupTypes = [
@@ -31,8 +31,8 @@ export const taxonomicGroupTypes = [
 ]
 
 export const LogsFilterGroup = (): JSX.Element => {
-    const { filterGroup, tabId, utcDateRange, serviceNames, filterGroup: logsFilterGroup } = useValues(logsLogic)
-    const { setFilterGroup } = useActions(logsLogic)
+    const { filterGroup, tabId, utcDateRange, serviceNames, filterGroup: logsFilterGroup } = useValues(logsSceneLogic)
+    const { setFilterGroup } = useActions(logsSceneLogic)
 
     const endpointFilters = {
         dateRange: { ...utcDateRange, date_to: utcDateRange.date_to ?? dayjs().toISOString() },
@@ -57,7 +57,7 @@ export const LogsFilterGroup = (): JSX.Element => {
 
 const UniversalSearch = (): JSX.Element => {
     const [visible, setVisible] = useState<boolean>(false)
-    const { utcDateRange, serviceNames, filterGroup: logsFilterGroup } = useValues(logsLogic)
+    const { utcDateRange, serviceNames, filterGroup: logsFilterGroup } = useValues(logsSceneLogic)
     const { addGroupFilter, setGroupValues } = useActions(universalFiltersLogic)
     const { filterGroup } = useValues(universalFiltersLogic)
 

--- a/products/logs/frontend/components/LogsViewer/Filters/FilterHistoryDropdown.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/FilterHistoryDropdown.tsx
@@ -8,7 +8,7 @@ import { capitalizeFirstLetter } from 'lib/utils'
 
 import { AnyPropertyFilter } from '~/types'
 
-import { logsLogic } from '../../../logsLogic'
+import { logsSceneLogic } from '../../../logsSceneLogic'
 import { LogsFiltersHistoryEntry } from '../../../types'
 
 const formatDateRange = (dateRange: LogsFiltersHistoryEntry['filters']['dateRange']): string => {
@@ -102,8 +102,8 @@ const HistoryEntryButton = ({
 }
 
 export const FilterHistoryDropdown = (): JSX.Element | null => {
-    const { filterHistory, hasFilterHistory } = useValues(logsLogic)
-    const { restoreFiltersFromHistory, clearFilterHistory } = useActions(logsLogic)
+    const { filterHistory, hasFilterHistory } = useValues(logsSceneLogic)
+    const { restoreFiltersFromHistory, clearFilterHistory } = useActions(logsSceneLogic)
 
     if (!hasFilterHistory) {
         return null

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar.tsx
@@ -9,7 +9,7 @@ import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconPauseCircle, IconPlayCircle } from 'lib/lemon-ui/icons'
 import { Scene } from 'scenes/sceneTypes'
 
-import { logsLogic } from 'products/logs/frontend/logsLogic'
+import { logsSceneLogic } from '../../../logsSceneLogic'
 
 import { DateRangeFilter } from './DateRangeFilter'
 import { LogsFilterGroup } from './FilterGroup'
@@ -20,8 +20,8 @@ import { SeverityLevelsFilter } from './SeverityLevelsFilter'
 
 export const LogsFilterBar = (): JSX.Element => {
     const newLogsDateRangePicker = useFeatureFlag('NEW_LOGS_DATE_RANGE_PICKER')
-    const { logsLoading, liveTailRunning, liveTailDisabledReason, dateRange } = useValues(logsLogic)
-    const { runQuery, zoomDateRange, setLiveTailRunning, setDateRange } = useActions(logsLogic)
+    const { logsLoading, liveTailRunning, liveTailDisabledReason, dateRange } = useValues(logsSceneLogic)
+    const { runQuery, zoomDateRange, setLiveTailRunning, setDateRange } = useActions(logsSceneLogic)
 
     return (
         <div className="flex flex-col gap-y-1.5">

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar.tsx
@@ -10,7 +10,6 @@ import { IconPauseCircle, IconPlayCircle } from 'lib/lemon-ui/icons'
 import { Scene } from 'scenes/sceneTypes'
 
 import { logsSceneLogic } from '../../../logsSceneLogic'
-
 import { DateRangeFilter } from './DateRangeFilter'
 import { LogsFilterGroup } from './FilterGroup'
 import { FilterHistoryDropdown } from './FilterHistoryDropdown'

--- a/products/logs/frontend/components/LogsViewer/Filters/SearchTermFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SearchTermFilter.tsx
@@ -2,11 +2,11 @@ import { useActions, useValues } from 'kea'
 
 import { LemonInput } from '@posthog/lemon-ui'
 
-import { logsLogic } from '../../../logsLogic'
+import { logsSceneLogic } from '../../../logsSceneLogic'
 
 export const SearchTermFilter = (): JSX.Element => {
-    const { searchTerm } = useValues(logsLogic)
-    const { setSearchTerm } = useActions(logsLogic)
+    const { searchTerm } = useValues(logsSceneLogic)
+    const { setSearchTerm } = useActions(logsSceneLogic)
 
     return (
         <LemonInput

--- a/products/logs/frontend/components/LogsViewer/Filters/ServiceFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/ServiceFilter.tsx
@@ -6,12 +6,12 @@ import { projectLogic } from 'scenes/projectLogic'
 
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
-import { logsLogic } from '../../../logsLogic'
+import { logsSceneLogic } from '../../../logsSceneLogic'
 
 export const ServiceFilter = (): JSX.Element => {
-    const { serviceNames, dateRange } = useValues(logsLogic)
+    const { serviceNames, dateRange } = useValues(logsSceneLogic)
     const { currentProjectId } = useValues(projectLogic)
-    const { setServiceNames } = useActions(logsLogic)
+    const { setServiceNames } = useActions(logsSceneLogic)
 
     const endpoint = combineUrl(`api/environments/${currentProjectId}/logs/values`, {
         key: 'service.name',

--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
@@ -7,7 +7,7 @@ import { capitalizeFirstLetter } from 'lib/utils'
 
 import { LogMessage } from '~/queries/schema/schema-general'
 
-import { logsLogic } from '../../../logsLogic'
+import { logsSceneLogic } from '../../../logsSceneLogic'
 
 const options: Record<LogMessage['severity_text'], string> = {
     trace: 'Trace',
@@ -21,8 +21,8 @@ const options: Record<LogMessage['severity_text'], string> = {
 const ALL_LOG_LEVELS = Object.values(options) as LogMessage['severity_text'][]
 
 export const SeverityLevelsFilter = (): JSX.Element => {
-    const { severityLevels } = useValues(logsLogic)
-    const { setSeverityLevels } = useActions(logsLogic)
+    const { severityLevels } = useValues(logsSceneLogic)
+    const { setSeverityLevels } = useActions(logsSceneLogic)
 
     const onClick = (level: LogMessage['severity_text']): void => {
         const levels = [...severityLevels]

--- a/products/logs/frontend/logsSceneLogic.test.ts
+++ b/products/logs/frontend/logsSceneLogic.test.ts
@@ -34,7 +34,7 @@ const createMockLog = (uuid: string): LogMessage => ({
     event_name: 'log',
 })
 
-describe('logsLogic', () => {
+describe('logsSceneLogic', () => {
     let logic: ReturnType<typeof logsSceneLogic.build>
 
     beforeEach(async () => {

--- a/products/logs/frontend/logsSceneLogic.test.ts
+++ b/products/logs/frontend/logsSceneLogic.test.ts
@@ -8,7 +8,7 @@ import { LogMessage } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { FilterLogicalOperator } from '~/types'
 
-import { logsLogic } from './logsLogic'
+import { logsSceneLogic } from './logsSceneLogic'
 import { LogsFilters } from './types'
 
 jest.mock('@posthog/lemon-ui', () => ({
@@ -35,7 +35,7 @@ const createMockLog = (uuid: string): LogMessage => ({
 })
 
 describe('logsLogic', () => {
-    let logic: ReturnType<typeof logsLogic.build>
+    let logic: ReturnType<typeof logsSceneLogic.build>
 
     beforeEach(async () => {
         useMocks({
@@ -45,7 +45,7 @@ describe('logsLogic', () => {
             },
         })
         initKeaTests()
-        logic = logsLogic({ tabId: 'test-tab' })
+        logic = logsSceneLogic({ tabId: 'test-tab' })
         logic.mount()
 
         await expectLogic(logic).toFinishAllListeners()

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -72,7 +72,7 @@ export interface LogsLogicProps {
     tabId: string
 }
 
-export const logsSceneLogic = kea<logsLogicType>([
+export const logsSceneLogic = kea<logsSceneLogicType>([
     props({} as LogsLogicProps),
     path(['products', 'logs', 'frontend', 'logsSceneLogic']),
     tabAwareScene(),

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -72,7 +72,7 @@ export interface LogsLogicProps {
     tabId: string
 }
 
-export const logsLogic = kea<logsLogicType>([
+export const logsSceneLogic = kea<logsLogicType>([
     props({} as LogsLogicProps),
     path(['products', 'logs', 'frontend', 'logsLogic']),
     tabAwareScene(),

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -74,7 +74,7 @@ export interface LogsLogicProps {
 
 export const logsSceneLogic = kea<logsLogicType>([
     props({} as LogsLogicProps),
-    path(['products', 'logs', 'frontend', 'logsLogic']),
+    path(['products', 'logs', 'frontend', 'logsSceneLogic']),
     tabAwareScene(),
     connect(() => ({
         actions: [teamLogic, ['addProductIntent']],

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -39,7 +39,7 @@ import {
 } from '~/types'
 
 import { zoomDateRange } from './components/LogsViewer/Filters/zoom-utils'
-import type { logsLogicType } from './logsLogicType'
+import type { logsSceneLogicType } from './logsSceneLogicType'
 import { LogsFilters, LogsFiltersHistoryEntry, LogsOrderBy, ParsedLogMessage } from './types'
 
 const DEFAULT_DATE_RANGE = { date_from: '-1h', date_to: null }


### PR DESCRIPTION
## Problem

Product convention uses '<product>SceneLogic` as the naming convention for scene logic, which defines a logical barrier between component and scene logic. Currently our scene logic is tightly coupled to lots of logs components.

## Changes

Renamed `logsLogic` to `logsSceneLogic` to better reflect its role as a scene logic, improving code clarity and maintainability.

This is the first step on a path to reduce the responsibility of the logs scene logic.

## How did you test this code?

Local dev

## Publish to changelog?

No