### PR TITLE
fix: normalize SCIM active field to boolean

### DIFF
--- a/ee/api/scim/test/test_scim_utils.py
+++ b/ee/api/scim/test/test_scim_utils.py
@@ -197,6 +197,6 @@ class TestNormalizeScimOperations:
         assert normalize_scim_operations(input_ops) == expected_ops
 
     def test_does_not_mutate_original_operations(self):
-        original = [{"op": "replace", "value": {"active": "True"}}]
+        original: list[dict] = [{"op": "replace", "value": {"active": "True"}}]
         normalize_scim_operations(original)
         assert original[0]["value"]["active"] == "True"

--- a/ee/api/scim/test/test_scim_utils.py
+++ b/ee/api/scim/test/test_scim_utils.py
@@ -1,6 +1,13 @@
 from parameterized import parameterized
 
-from ee.api.scim.utils import mask_email, mask_pii_value, mask_scim_filter, mask_scim_payload, mask_string
+from ee.api.scim.utils import (
+    mask_email,
+    mask_pii_value,
+    mask_scim_filter,
+    mask_scim_payload,
+    mask_string,
+    normalize_scim_operations,
+)
 
 
 class TestMaskString:
@@ -134,3 +141,62 @@ class TestMaskScimFilter:
     )
     def test_mask_scim_filter(self, input_value, expected):
         assert mask_scim_filter(input_value) == expected
+
+
+class TestNormalizeScimOperations:
+    @parameterized.expand(
+        [
+            # String "True"/"False" to boolean when path is "active"
+            (
+                [{"op": "replace", "path": "active", "value": "True"}],
+                [{"op": "replace", "path": "active", "value": True}],
+            ),
+            (
+                [{"op": "replace", "path": "active", "value": "true"}],
+                [{"op": "replace", "path": "active", "value": True}],
+            ),
+            (
+                [{"op": "replace", "path": "active", "value": "FALSE"}],
+                [{"op": "replace", "path": "active", "value": False}],
+            ),
+            (
+                [{"op": "replace", "path": "active", "value": "false"}],
+                [{"op": "replace", "path": "active", "value": False}],
+            ),
+            ([{"op": "add", "path": "active", "value": "True"}], [{"op": "add", "path": "active", "value": True}]),
+            # String in nested value dict
+            ([{"op": "replace", "value": {"active": "True"}}], [{"op": "replace", "value": {"active": True}}]),
+            (
+                [{"op": "replace", "value": {"active": "false", "name": "Test"}}],
+                [{"op": "replace", "value": {"active": False, "name": "Test"}}],
+            ),
+            # Boolean values pass through unchanged
+            (
+                [{"op": "replace", "path": "active", "value": True}],
+                [{"op": "replace", "path": "active", "value": True}],
+            ),
+            (
+                [{"op": "replace", "path": "active", "value": False}],
+                [{"op": "replace", "path": "active", "value": False}],
+            ),
+            ([{"op": "replace", "value": {"active": True}}], [{"op": "replace", "value": {"active": True}}]),
+            # Non-active operations pass through unchanged
+            (
+                [{"op": "replace", "path": "userName", "value": "test@example.com"}],
+                [{"op": "replace", "path": "userName", "value": "test@example.com"}],
+            ),
+            (
+                [{"op": "replace", "path": "name.givenName", "value": "John"}],
+                [{"op": "replace", "path": "name.givenName", "value": "John"}],
+            ),
+            # Empty operations list
+            ([], []),
+        ]
+    )
+    def test_normalize_scim_operations(self, input_ops, expected_ops):
+        assert normalize_scim_operations(input_ops) == expected_ops
+
+    def test_does_not_mutate_original_operations(self):
+        original = [{"op": "replace", "value": {"active": "True"}}]
+        normalize_scim_operations(original)
+        assert original[0]["value"]["active"] == "True"

--- a/ee/api/scim/utils.py
+++ b/ee/api/scim/utils.py
@@ -133,3 +133,24 @@ def detect_identity_provider(request: Request) -> SCIMProvisionedUser.IdentityPr
         return SCIMProvisionedUser.IdentityProvider.ONELOGIN
 
     return SCIMProvisionedUser.IdentityProvider.OTHER
+
+
+def normalize_scim_operations(operations: list[dict]) -> list[dict]:
+    """
+    Normalize SCIM PATCH operations to handle string booleans for 'active' field
+    """
+    normalized = []
+    for op in operations:
+        op = op.copy()
+        path = op.get("path")
+        value = op.get("value")
+
+        if path == "active" and isinstance(value, str):
+            op["value"] = value.lower() == "true"
+        elif isinstance(value, dict) and "active" in value and isinstance(value["active"], str):
+            value = value.copy()
+            value["active"] = value["active"].lower() == "true"
+            op["value"] = value
+
+        normalized.append(op)
+    return normalized

--- a/ee/api/scim/views.py
+++ b/ee/api/scim/views.py
@@ -23,7 +23,7 @@ from posthog.models.organization_domain import OrganizationDomain
 from ee.api.scim.auth import SCIMBearerTokenAuthentication
 from ee.api.scim.group import PostHogSCIMGroup
 from ee.api.scim.user import PostHogSCIMUser, SCIMUserConflict
-from ee.api.scim.utils import detect_identity_provider, mask_scim_filter, mask_scim_payload
+from ee.api.scim.utils import detect_identity_provider, mask_scim_filter, mask_scim_payload, normalize_scim_operations
 from ee.models.rbac.role import Role
 from ee.models.scim_provisioned_user import SCIMProvisionedUser
 
@@ -258,6 +258,7 @@ class SCIMUserDetailView(SCIMBaseView):
         scim_user = self.get_object(user_id)
         try:
             operations = request.data.get("Operations", [])
+            operations = normalize_scim_operations(operations)
             scim_user.handle_operations(operations)
             return Response(scim_user.to_dict())
         except Exception as e:


### PR DESCRIPTION
## Problem
django-scim2 expects the `active` field to be a boolean, but some IdPs (e.g., Entra ID) send it as a string, causing validation errors.

Error: https://us.posthog.com/project/2/error_tracking/019bd568-4cb2-7400-8225-b41ff7d39630?fingerprint=490b803725245ce49ecd7f050656c26b29cf195c2bcaed7db63af56b6a003af56a315151c398e75671057a7b5666bb7aa0aa397fecb6351e747a22b84bdd4eb3&timestamp=2026-01-19T00%3A38%3A47.042000-08%3A00

## Changes
Added `normalize_scim_operations()` to convert string boolean values to proper booleans in PATCH operations before passing them to django-scim2's validation.

## How did you test the code?
Tests