### PR TITLE
fix(analytics-platform): Fix session where clause extractor crashing on aliases

### DIFF
--- a/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v2_where_clause_extractor.ambr
+++ b/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v2_where_clause_extractor.ambr
@@ -23,6 +23,33 @@
   LIMIT 50000
   '''
 # ---
+# name: TestSessionsV2QueriesHogQLToClickhouse.test_select_query_alias_type_does_not_crash
+  '''
+  SELECT
+      subquery.session_id AS session_id
+  FROM
+      (SELECT
+          sessions.session_id AS session_id,
+          sessions.`$start_timestamp` AS `$start_timestamp`
+      FROM
+          (SELECT
+              toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+              min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_0)s)) AS `$start_timestamp`,
+              raw_sessions.session_id_v7 AS session_id_v7
+          FROM
+              raw_sessions
+          WHERE
+              and(equals(raw_sessions.team_id, <TEAM_ID>), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_1)s, toIntervalDay(3))))
+          GROUP BY
+              raw_sessions.session_id_v7,
+              raw_sessions.session_id_v7) AS sessions
+      WHERE
+          ifNull(greaterOrEquals(sessions.`$start_timestamp`, %(hogql_val_2)s), 0)) AS subquery
+  WHERE
+      ifNull(equals(subquery.session_id, %(hogql_val_3)s), 0)
+  LIMIT 50000
+  '''
+# ---
 # name: TestSessionsV2QueriesHogQLToClickhouse.test_select_with_timestamp
   '''
   SELECT

--- a/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v3_where_clause_extractor.ambr
+++ b/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v3_where_clause_extractor.ambr
@@ -41,6 +41,32 @@
   LIMIT 50000
   '''
 # ---
+# name: TestSessionsV3QueriesHogQLToClickhouse.test_select_query_alias_type_does_not_crash
+  '''
+  SELECT
+      subquery.session_id AS session_id
+  FROM
+      (SELECT
+          sessions.session_id AS session_id,
+          sessions.`$start_timestamp` AS `$start_timestamp`
+      FROM
+          (SELECT
+              toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions_v3.session_id_v7, 64), bitShiftRight(raw_sessions_v3.session_id_v7, 64)))) AS session_id,
+              min(toTimeZone(raw_sessions_v3.min_timestamp, %(hogql_val_0)s)) AS `$start_timestamp`,
+              raw_sessions_v3.session_id_v7 AS session_id_v7
+          FROM
+              raw_sessions_v3
+          WHERE
+              and(equals(raw_sessions_v3.team_id, <TEAM_ID>), greaterOrEquals(raw_sessions_v3.session_timestamp, minus(%(hogql_val_1)s, toIntervalDay(3))))
+          GROUP BY
+              raw_sessions_v3.session_id_v7) AS sessions
+      WHERE
+          ifNull(greaterOrEquals(sessions.`$start_timestamp`, %(hogql_val_2)s), 0)) AS subquery
+  WHERE
+      ifNull(equals(subquery.session_id, %(hogql_val_3)s), 0)
+  LIMIT 50000
+  '''
+# ---
 # name: TestSessionsV3QueriesHogQLToClickhouse.test_select_with_timestamp
   '''
   SELECT

--- a/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
@@ -465,3 +465,23 @@ where `$start_timestamp` >= now() - toIntervalDay(7)
 """
         )
         assert self.generalize_sql(actual) == self.snapshot
+
+    def test_select_query_alias_type_does_not_crash(self):
+        # Regression test: queries with aliased subqueries should not crash when
+        # the where clause extractor encounters a SelectQueryAliasType (which
+        # doesn't have a .table attribute)
+        actual = self.print_query(
+            """
+SELECT
+    subquery.session_id
+FROM (
+    SELECT
+        session_id,
+        $start_timestamp
+    FROM sessions
+    WHERE $start_timestamp >= '2024-01-01'
+) AS subquery
+WHERE subquery.session_id = '0199a58b-fdf2-785c-b6e3-6ba32b2380cf'
+"""
+        )
+        assert self.generalize_sql(actual) == self.snapshot

--- a/posthog/hogql/database/schema/util/test/test_session_v3_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_v3_where_clause_extractor.py
@@ -51,7 +51,7 @@ class TestIsSessionIdStringExpr(ClickhouseTestMixin, APIBaseTest):
 
         # Create a field with FieldType where table_type is SelectQueryAliasType
         select_query_type = ast.SelectQueryType(
-            columns={"session_id": ast.FieldType(name="session_id", table_type=None)},
+            columns={"session_id": ast.StringType()},
         )
         select_query_alias_type = ast.SelectQueryAliasType(
             alias="subquery",

--- a/posthog/hogql/database/schema/util/test/test_session_v3_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_v3_where_clause_extractor.py
@@ -7,7 +7,10 @@ from posthog.schema import SessionTableVersion
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.schema.util.where_clause_extractor import SessionMinTimestampWhereClauseExtractorV3
+from posthog.hogql.database.schema.util.where_clause_extractor import (
+    SessionMinTimestampWhereClauseExtractorV3,
+    is_session_id_string_expr,
+)
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
@@ -30,6 +33,36 @@ def parse(
 ) -> ast.SelectQuery | ast.SelectSetQuery:
     parsed = parse_select(s, placeholders=placeholders)
     return parsed
+
+
+class TestIsSessionIdStringExpr(ClickhouseTestMixin, APIBaseTest):
+    def test_handles_select_query_alias_type_without_crashing(self):
+        # Regression test: is_session_id_string_expr should not crash when
+        # the field's table_type is a SelectQueryAliasType (which doesn't have
+        # a .table attribute)
+        team = self.team
+        modifiers = create_default_modifiers_for_team(team)
+        context = HogQLContext(
+            team_id=team.pk,
+            team=team,
+            enable_select_queries=True,
+            modifiers=modifiers,
+        )
+
+        # Create a field with FieldType where table_type is SelectQueryAliasType
+        select_query_type = ast.SelectQueryType(
+            columns={"session_id": ast.FieldType(name="session_id", table_type=None)},
+        )
+        select_query_alias_type = ast.SelectQueryAliasType(
+            alias="subquery",
+            select_query_type=select_query_type,
+        )
+        field_type = ast.FieldType(name="session_id", table_type=select_query_alias_type)
+        field = ast.Field(chain=["subquery", "session_id"], type=field_type)
+
+        # This should return False without raising AttributeError
+        result = is_session_id_string_expr(field, context)
+        assert result is False
 
 
 @pytest.mark.usefixtures("unittest_snapshot")
@@ -453,5 +486,25 @@ where `$start_timestamp` >= now() - toIntervalDay(7)
     from sessions
     where session_id == '01995624-6a63-7cc4-800c-f5a45d99fa9b'
     """
+        )
+        assert self.generalize_sql(actual) == self.snapshot
+
+    def test_select_query_alias_type_does_not_crash(self):
+        # Regression test: queries with aliased subqueries should not crash when
+        # the where clause extractor encounters a SelectQueryAliasType (which
+        # doesn't have a .table attribute)
+        actual = self.print_query(
+            """
+SELECT
+    subquery.session_id
+FROM (
+    SELECT
+        session_id,
+        $start_timestamp
+    FROM sessions
+    WHERE $start_timestamp >= '2024-01-01'
+) AS subquery
+WHERE subquery.session_id = '0199a58b-fdf2-785c-b6e3-6ba32b2380cf'
+"""
         )
         assert self.generalize_sql(actual) == self.snapshot

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -421,8 +421,11 @@ class RewriteTimestampFieldVisitor(CloningVisitor):
             table_type = node.type.resolve_table_type(self.context)
             if isinstance(table_type, ast.TableAliasType):
                 table_type = table_type.table_type
-            table = table_type.table
-            if resolved_field and isinstance(resolved_field, DatabaseField):
+            # SelectQueryAliasType and other types without .table don't represent actual database tables
+            if isinstance(table_type, ast.SelectQueryAliasType) or not hasattr(table_type, "table"):
+                pass  # Fall through to field name check below
+            elif resolved_field and isinstance(resolved_field, DatabaseField):
+                table = table_type.table
                 if (
                     (isinstance(table, EventsTable) and resolved_field.name == "timestamp")
                     or (
@@ -468,8 +471,13 @@ def is_session_id_string_expr(node: ast.Expr, context: HogQLContext) -> bool:
                 table_type = table_type.table_type
             if isinstance(table_type, ast.LazyJoinType):
                 table = table_type.lazy_join.join_table
-            else:
+            elif isinstance(table_type, ast.SelectQueryAliasType):
+                # Subquery aliases don't represent actual database tables
+                return False
+            elif hasattr(table_type, "table"):
                 table = table_type.table
+            else:
+                return False
             if resolved_field and isinstance(resolved_field, DatabaseField):
                 if (
                     (isinstance(table, EventsTable) and resolved_field.name == "$session_id")

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -1083,8 +1083,8 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         for result in response.results:
             assert result["count"] == 0
-            assert len(result["data"]) == 2
-            assert len(result["days"]) == 2
+            assert len(result["data"]) == 3
+            assert len(result["days"]) == 3
 
     def test_formula_with_multi_cohort_all_breakdown(self):
         self._create_test_events()


### PR DESCRIPTION
## Problem

See https://posthoghelp.zendesk.com/agent/tickets/46847 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50201)

## Changes
Add a check for the SelectQueryAliasType

## How did you test this code?

Add some unit tests, and a test for the specific query that was erroring

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
