### PR TITLE
fix(workflows): fix email template duplication bug

### DIFF
--- a/products/workflows/frontend/TemplateLibrary/messageTemplateLogic.test.ts
+++ b/products/workflows/frontend/TemplateLibrary/messageTemplateLogic.test.ts
@@ -1,0 +1,91 @@
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { NEW_TEMPLATE } from './constants'
+import { messageTemplateLogic } from './messageTemplateLogic'
+
+describe('messageTemplateLogic', () => {
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:team/messaging_templates': { count: 0, results: [] },
+                '/api/environments/:team/messaging_templates/:id': NEW_TEMPLATE,
+            },
+            post: {
+                '/api/environments/:team/messaging_templates': (req) => {
+                    const body = req.body as Record<string, unknown>
+                    return {
+                        ...body,
+                        id: 'created-template-id',
+                        created_at: '2024-01-01T00:00:00Z',
+                        updated_at: '2024-01-01T00:00:00Z',
+                    }
+                },
+            },
+        })
+        initKeaTests()
+    })
+
+    describe('state reset on navigation to new template', () => {
+        it('should reset form state when navigating to new template URL', async () => {
+            const logic = messageTemplateLogic({ id: 'new' })
+            logic.mount()
+
+            // Modify the form values
+            logic.actions.setTemplateValue('name', 'Modified Name')
+            logic.actions.setTemplateValue('description', 'Modified Description')
+
+            await expectLogic(logic).toMatchValues({
+                template: expect.objectContaining({
+                    name: 'Modified Name',
+                    description: 'Modified Description',
+                }),
+            })
+
+            // Navigate to the new template URL (simulates going to list and back to new)
+            router.actions.push('/workflows/library/templates/new')
+
+            await expectLogic(logic).toMatchValues({
+                template: expect.objectContaining({
+                    id: 'new',
+                    name: '',
+                    description: '',
+                }),
+            })
+        })
+
+        it('should reset template id to "new" after creating a template and navigating back', async () => {
+            const logic = messageTemplateLogic({ id: 'new' })
+            logic.mount()
+
+            // Simulate what happens after saveTemplateSuccess - the template now has a real ID
+            logic.actions.setTemplateValue('name', 'Created Template')
+            logic.actions.resetTemplate({
+                ...NEW_TEMPLATE,
+                id: 'created-template-id',
+                name: 'Created Template',
+            })
+
+            await expectLogic(logic).toMatchValues({
+                template: expect.objectContaining({
+                    id: 'created-template-id',
+                    name: 'Created Template',
+                }),
+            })
+
+            // Navigate to new template URL
+            router.actions.push('/workflows/library/templates/new')
+
+            // Should reset to NEW_TEMPLATE defaults, including id: 'new'
+            await expectLogic(logic).toMatchValues({
+                template: expect.objectContaining({
+                    id: 'new',
+                    name: '',
+                }),
+            })
+        })
+    })
+})

--- a/products/workflows/frontend/TemplateLibrary/messageTemplateLogic.ts
+++ b/products/workflows/frontend/TemplateLibrary/messageTemplateLogic.ts
@@ -1,7 +1,7 @@
 import { actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
-import { router } from 'kea-router'
+import { router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
@@ -193,4 +193,14 @@ export const messageTemplateLogic = kea<messageTemplateLogicType>([
             actions.resetTemplate(NEW_TEMPLATE)
         }
     }),
+    urlToAction(({ actions, props }) => ({
+        [urls.workflowsLibraryTemplateNew()]: () => {
+            // Reset state when navigating to the new template page to avoid stale data
+            // from previously created templates persisting in the form
+            if (props.id === 'new') {
+                actions.resetTemplate({ ...NEW_TEMPLATE })
+                actions.setOriginalTemplate({ ...NEW_TEMPLATE })
+            }
+        },
+    })),
 ])


### PR DESCRIPTION
### Problem

closes https://posthoghelp.zendesk.com/agent/tickets/47270 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50233)

The new template page cached form state aggressively because the Kea logic  was keyed by id='new' and afterMount only runs on first mount. This caused:                                          
  - Form fields persisting when navigating away and back                                                                
  - Creating a second template would overwrite the first (since template.id retained the saved ID)                      
                                                                                                                        
### Fix

- Added urlToAction listener that resets form state to defaults whenever navigating to the new template URL. 

### Tested

![2026-01-19 14 08 10](https://github.com/user-attachments/assets/d9963dcc-618b-4856-af89-bde0a0aeb9df)

- local dev
- added tests


