### PR TITLE
feat(logs): remove logviewer messagecell popover and simplify attributecell popover

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogsViewerCellPopover.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerCellPopover.tsx
@@ -5,7 +5,6 @@ import { LemonButton, LemonDropdown } from '@posthog/lemon-ui'
 
 import { IconTableChart } from 'lib/lemon-ui/icons'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
-import { cn } from 'lib/utils/css-classes'
 
 import { PropertyOperator } from '~/types'
 
@@ -27,7 +26,6 @@ export function LogsViewerCellPopover({
     children,
 }: LogsViewerCellPopoverProps): JSX.Element {
     const displayValue = value != null ? String(value) : '-'
-    const isLongValue = displayValue.length > 50
 
     return (
         <LemonDropdown
@@ -36,52 +34,39 @@ export function LogsViewerCellPopover({
             trigger="hover"
             closeOnClickInside={false}
             overlay={
-                <div className="p-2 max-w-md">
-                    <div className="flex items-center justify-between gap-2 mb-1">
-                        <span className="font-semibold text-xs text-muted truncate" title={attributeKey}>
-                            {attributeKey}
-                        </span>
-                        <div className="flex items-center gap-1 shrink-0">
-                            <LemonButton
-                                size="xsmall"
-                                icon={<IconCopy />}
-                                tooltip="Copy value"
-                                onClick={() => copyToClipboard(displayValue, 'attribute value')}
-                            />
-                            {onAddFilter && (
-                                <>
-                                    <LemonButton
-                                        size="xsmall"
-                                        icon={<IconPlusSquare />}
-                                        tooltip="Add as filter"
-                                        onClick={() => onAddFilter(attributeKey, displayValue)}
-                                    />
-                                    <LemonButton
-                                        size="xsmall"
-                                        icon={<IconMinusSquare />}
-                                        tooltip="Exclude as filter"
-                                        onClick={() => onAddFilter(attributeKey, displayValue, PropertyOperator.IsNot)}
-                                    />
-                                </>
-                            )}
-                            {onToggleColumn && (
+                <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-1 shrink-0">
+                        <LemonButton
+                            size="xsmall"
+                            icon={<IconCopy />}
+                            tooltip="Copy value"
+                            onClick={() => copyToClipboard(displayValue, 'attribute value')}
+                        />
+                        {onAddFilter && (
+                            <>
                                 <LemonButton
                                     size="xsmall"
-                                    icon={<IconTableChart />}
-                                    tooltip={isColumn ? 'Remove from columns' : 'Add as column'}
-                                    active={isColumn}
-                                    onClick={() => onToggleColumn(attributeKey)}
+                                    icon={<IconPlusSquare />}
+                                    tooltip="Add as filter"
+                                    onClick={() => onAddFilter(attributeKey, displayValue)}
                                 />
-                            )}
-                        </div>
-                    </div>
-                    <div
-                        className={cn(
-                            'font-mono text-xs bg-bg-3000 rounded p-2',
-                            isLongValue && 'max-h-48 overflow-y-auto'
+                                <LemonButton
+                                    size="xsmall"
+                                    icon={<IconMinusSquare />}
+                                    tooltip="Exclude as filter"
+                                    onClick={() => onAddFilter(attributeKey, displayValue, PropertyOperator.IsNot)}
+                                />
+                            </>
                         )}
-                    >
-                        <span className="whitespace-pre-wrap break-all">{displayValue}</span>
+                        {onToggleColumn && (
+                            <LemonButton
+                                size="xsmall"
+                                icon={<IconTableChart />}
+                                tooltip={isColumn ? 'Remove from columns' : 'Add as column'}
+                                active={isColumn}
+                                onClick={() => onToggleColumn(attributeKey)}
+                            />
+                        )}
                     </div>
                 </div>
             }

--- a/products/logs/frontend/components/VirtualizedLogsList/cells/MessageCell.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/cells/MessageCell.tsx
@@ -1,10 +1,9 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 
 import { cn } from 'lib/utils/css-classes'
 
 import { JsonType } from '~/types'
 
-import { LogsViewerCellPopover } from 'products/logs/frontend/components/LogsViewer/LogsViewerCellPopover'
 import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
 import { LOG_ROW_FAB_WIDTH } from 'products/logs/frontend/components/VirtualizedLogsList/layoutUtils'
 import { useCellScrollRef } from 'products/logs/frontend/components/VirtualizedLogsList/useCellScroll'
@@ -19,47 +18,41 @@ export interface MessageCellProps {
 
 export function MessageCell({ message, wrapBody, prettifyJson, parsedBody, style }: MessageCellProps): JSX.Element {
     const { tabId } = useValues(logsViewerLogic)
-    const { addFilter } = useActions(logsViewerLogic)
     const { scrollRef, handleScroll } = useCellScrollRef({ tabId, cellKey: 'message', enabled: !wrapBody })
 
     const displayValue = prettifyJson && parsedBody ? JSON.stringify(parsedBody, null, 2) : message
 
     return (
-        <LogsViewerCellPopover attributeKey="body" value={displayValue} onAddFilter={addFilter}>
-            <div style={style} className="relative flex items-start self-stretch">
-                <div
-                    ref={wrapBody ? undefined : scrollRef}
-                    onScroll={wrapBody ? undefined : handleScroll}
-                    className={cn(
-                        'flex-1 self-stretch',
-                        wrapBody ? 'overflow-hidden' : 'overflow-x-auto hide-scrollbar'
+        <div style={style} className="relative flex items-start self-stretch">
+            <div
+                ref={wrapBody ? undefined : scrollRef}
+                onScroll={wrapBody ? undefined : handleScroll}
+                className={cn('flex-1 self-stretch', wrapBody ? 'overflow-hidden' : 'overflow-x-auto hide-scrollbar')}
+            >
+                <div className={cn('flex items-center min-h-full', wrapBody ? 'py-1.5' : 'w-max')}>
+                    {prettifyJson && parsedBody ? (
+                        <pre
+                            className={cn(
+                                'font-mono text-xs inline-block mb-0',
+                                wrapBody ? 'whitespace-pre-wrap break-all' : 'whitespace-nowrap'
+                            )}
+                            style={{ paddingRight: wrapBody ? 16 : LOG_ROW_FAB_WIDTH }}
+                        >
+                            {displayValue}
+                        </pre>
+                    ) : (
+                        <span
+                            className={cn(
+                                'font-mono text-xs',
+                                wrapBody ? 'whitespace-pre-wrap break-all' : 'whitespace-nowrap'
+                            )}
+                            style={{ paddingRight: wrapBody ? 16 : LOG_ROW_FAB_WIDTH }}
+                        >
+                            {displayValue}
+                        </span>
                     )}
-                >
-                    <div className={cn('flex items-center min-h-full', wrapBody ? 'py-1.5' : 'w-max')}>
-                        {prettifyJson && parsedBody ? (
-                            <pre
-                                className={cn(
-                                    'font-mono text-xs inline-block mb-0',
-                                    wrapBody ? 'whitespace-pre-wrap break-all' : 'whitespace-nowrap'
-                                )}
-                                style={{ paddingRight: wrapBody ? 16 : LOG_ROW_FAB_WIDTH }}
-                            >
-                                {displayValue}
-                            </pre>
-                        ) : (
-                            <span
-                                className={cn(
-                                    'font-mono text-xs',
-                                    wrapBody ? 'whitespace-pre-wrap break-all' : 'whitespace-nowrap'
-                                )}
-                                style={{ paddingRight: wrapBody ? 16 : LOG_ROW_FAB_WIDTH }}
-                            >
-                                {displayValue}
-                            </span>
-                        )}
-                    </div>
                 </div>
             </div>
-        </LogsViewerCellPopover>
+        </div>
     )
 }


### PR DESCRIPTION
## Problem

The current logs viewer cell popover noisy, janky and cluttered, making it difficult for users to quickly interact with log data.

## Changes

- Simplified the logs viewer cell popover UI
- Removed the popover from the message cell

![image.png](https://app.graphite.com/user-attachments/assets/e4f65601-bc09-4638-be02-3a49c7bfc98a.png)

## How did you test this code?

Manually tested the logs viewer interface to ensure:
- The cell popover still appears correctly on hover
- All action buttons (copy, add filter, exclude filter, toggle column) work as expected
- The message cell displays correctly without the popover wrapper
- Log content remains properly formatted and scrollable

## Publish to changelog?

No