### PR TITLE
feat: add social auth connections to user page in admin

### DIFF
--- a/posthog/admin/admins/user_admin.py
+++ b/posthog/admin/admins/user_admin.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberInline
 from posthog.admin.inlines.personal_api_key_inline import PersonalAPIKeyInline
 from posthog.admin.inlines.totp_device_inline import TOTPDeviceInline
+from posthog.admin.inlines.user_social_auth_inline import UserSocialAuthInline
 from posthog.api.authentication import password_reset_token_generator
 from posthog.api.email_verification import EmailVerifier
 from posthog.models import User
@@ -48,7 +49,7 @@ class UserAdmin(DjangoUserAdmin):
     change_password_form = None  # This view is not exposed in our subclass of UserChangeForm
     change_form_template = "admin/posthog/user/change_form.html"
 
-    inlines = [OrganizationMemberInline, PersonalAPIKeyInline, TOTPDeviceInline]
+    inlines = [OrganizationMemberInline, PersonalAPIKeyInline, TOTPDeviceInline, UserSocialAuthInline]
     fieldsets = (
         (
             None,

--- a/posthog/admin/inlines/user_social_auth_inline.py
+++ b/posthog/admin/inlines/user_social_auth_inline.py
@@ -1,0 +1,28 @@
+from django.contrib import admin
+
+from social_django.models import UserSocialAuth
+
+
+class UserSocialAuthInline(admin.TabularInline):
+    """
+    Inline table for UserSocialAuth records on the User admin page.
+    Allows viewing and deleting social auth connections.
+    """
+
+    model = UserSocialAuth
+    extra = 0
+    fields = ("provider", "uid", "extra_data", "created", "modified")
+    readonly_fields = ("provider", "uid", "extra_data", "created", "modified")
+    can_delete = True
+    show_change_link = False
+    verbose_name = "Social auth connection"
+    verbose_name_plural = "Social auth connections"
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        return True


### PR DESCRIPTION
## Problem

Ticket: https://posthoghelp.zendesk.com/agent/tickets/47226 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49525)

User signed up with Google OAuth using work email, then changed their PostHog email to personal to create a separate work account. 

When they tried to accept an invite for the work email with Google SSO (already linked to another account), they got an error: **"This invite is intended for another email address."**

## Changes

The simplest fix is to delete the social auth record - then the customer can register again with their work Google account and log into the personal account with their personal Google account (a new social auth record gets created on next login).

So...
Added social auth connections to user page in Django admin

<img width="1407" height="224" alt="Screenshot 2026-01-19 at 14 33 02" src="https://github.com/user-attachments/assets/bbe4ff4c-7ed4-4e61-9300-2bb4a98c83df" />


Why add to admin:
- Safer then manually deliting through django shell
- Also useful for debugging SAML assertions

## How did you test this code?
Manually logged in through Google, went to user page in admin, tried deleting social auth record