### PR TITLE
fix(capture-logs): fix handling of empty log bodies in otel

### DIFF
--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -22,12 +22,19 @@ use tracing::{debug, error, instrument};
 // due to a bug in the otel proto rust library we need to patch the json to support (valid) empty Values
 // see https://github.com/open-telemetry/opentelemetry-rust/issues/1253
 // FIXME: remove once upstream has fixed the issue, OR we should fork upstream and fix the issue ourselves
-fn patch_otel_json(v: &mut Value) {
+pub fn patch_otel_json(v: &mut Value) {
     match v {
         Value::Object(map) => {
             // In OTel, AnyValue is usually a field named "value"
             // If we find "value": {}, change it to "value": null
             if let Some(inner) = map.get_mut("value") {
+                if inner.is_object() && inner.as_object().map(|obj| obj.is_empty()).unwrap_or(false)
+                {
+                    *inner = Value::Null;
+                }
+            }
+            // Handle empty body objects - body should be an AnyValue or null
+            if let Some(inner) = map.get_mut("body") {
                 if inner.is_object() && inner.as_object().map(|obj| obj.is_empty()).unwrap_or(false)
                 {
                     *inner = Value::Null;

--- a/rust/capture-logs/tests/service_test.rs
+++ b/rust/capture-logs/tests/service_test.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
-use capture_logs::service::parse_otel_message;
+use capture_logs::service::{parse_otel_message, patch_otel_json};
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
+use serde_json::json;
 
 #[test]
 fn test_parse_single_json_otel_message() {
@@ -136,4 +137,269 @@ invalid json line
 
     let result = parse_otel_message(&bytes);
     assert!(result.is_err());
+}
+
+#[test]
+fn test_parse_otel_message_with_empty_body() {
+    let json_data = r#"{"resourceLogs":[{"resource":{"attributes":[]},"scopeLogs":[{"scope":{"name":"test"},"logRecords":[{"timeUnixNano":"1234567890","severityText":"INFO","body":{}}]}]}]}"#;
+    let bytes = Bytes::from(json_data);
+
+    let result = parse_otel_message(&bytes);
+    assert!(result.is_ok());
+
+    let request = result.unwrap();
+    assert_eq!(request.resource_logs.len(), 1);
+    assert_eq!(request.resource_logs[0].scope_logs.len(), 1);
+    assert_eq!(request.resource_logs[0].scope_logs[0].log_records.len(), 1);
+
+    // Body should be None after patching empty object to null
+    assert!(request.resource_logs[0].scope_logs[0].log_records[0]
+        .body
+        .is_none());
+}
+
+#[test]
+fn test_parse_otel_message_with_empty_value_in_attributes() {
+    let json_data = r#"{"resourceLogs":[{"resource":{"attributes":[{"key":"test_key","value":{}}]},"scopeLogs":[{"scope":{"name":"test"},"logRecords":[{"timeUnixNano":"1234567890","severityText":"INFO","body":{"stringValue":"test message"},"attributes":[{"key":"attr_key","value":{}}]}]}]}]}"#;
+    let bytes = Bytes::from(json_data);
+
+    let result = parse_otel_message(&bytes);
+    assert!(result.is_ok());
+
+    let request = result.unwrap();
+    assert_eq!(request.resource_logs.len(), 1);
+    assert_eq!(request.resource_logs[0].scope_logs.len(), 1);
+    assert_eq!(request.resource_logs[0].scope_logs[0].log_records.len(), 1);
+
+    // Resource attribute with empty value should be None after patching
+    assert_eq!(
+        request.resource_logs[0]
+            .resource
+            .as_ref()
+            .unwrap()
+            .attributes
+            .len(),
+        1
+    );
+    assert!(request.resource_logs[0]
+        .resource
+        .as_ref()
+        .unwrap()
+        .attributes[0]
+        .value
+        .is_none());
+
+    // Log record attribute with empty value should be None after patching
+    assert_eq!(
+        request.resource_logs[0].scope_logs[0].log_records[0]
+            .attributes
+            .len(),
+        1
+    );
+    assert!(
+        request.resource_logs[0].scope_logs[0].log_records[0].attributes[0]
+            .value
+            .is_none()
+    );
+}
+
+#[test]
+fn test_parse_otel_message_with_mixed_empty_and_valid_values() {
+    let json_data = r#"{"resourceLogs":[{"resource":{"attributes":[{"key":"valid_key","value":{"stringValue":"valid_value"}},{"key":"empty_key","value":{}}]},"scopeLogs":[{"scope":{"name":"test"},"logRecords":[{"timeUnixNano":"1234567890","severityText":"INFO","body":{},"attributes":[{"key":"valid_attr","value":{"intValue":42}},{"key":"empty_attr","value":{}}]}]}]}]}"#;
+    let bytes = Bytes::from(json_data);
+
+    let result = parse_otel_message(&bytes);
+    assert!(result.is_ok());
+
+    let request = result.unwrap();
+    let resource = request.resource_logs[0].resource.as_ref().unwrap();
+    let log_record = &request.resource_logs[0].scope_logs[0].log_records[0];
+
+    // Resource attributes: valid one should have value, empty one should be None
+    assert_eq!(resource.attributes.len(), 2);
+    match resource.attributes[0]
+        .value
+        .as_ref()
+        .unwrap()
+        .value
+        .as_ref()
+        .unwrap()
+    {
+        Value::StringValue(s) => assert_eq!(s, "valid_value"),
+        _ => panic!("Expected string value"),
+    }
+    assert!(resource.attributes[1].value.is_none());
+
+    // Body should be None after patching
+    assert!(log_record.body.is_none());
+
+    // Log record attributes: valid one should have value, empty one should be None
+    assert_eq!(log_record.attributes.len(), 2);
+    match log_record.attributes[0]
+        .value
+        .as_ref()
+        .unwrap()
+        .value
+        .as_ref()
+        .unwrap()
+    {
+        Value::IntValue(i) => assert_eq!(*i, 42),
+        _ => panic!("Expected int value"),
+    }
+    assert!(log_record.attributes[1].value.is_none());
+}
+
+#[test]
+fn test_parse_otel_message_with_nested_empty_values() {
+    // Test that empty values in nested structures are also patched
+    let json_data = r#"{"resourceLogs":[{"resource":{"attributes":[]},"scopeLogs":[{"scope":{"name":"test"},"logRecords":[{"timeUnixNano":"1234567890","severityText":"INFO","body":{"kvlistValue":{"values":[{"key":"nested_key","value":{}}]}},"attributes":[{"key":"nested_attr","value":{"kvlistValue":{"values":[{"key":"inner_key","value":{}}]}}}]}]}]}]}"#;
+    let bytes = Bytes::from(json_data);
+
+    let result = parse_otel_message(&bytes);
+    assert!(result.is_ok());
+
+    let request = result.unwrap();
+    assert_eq!(request.resource_logs.len(), 1);
+    assert_eq!(request.resource_logs[0].scope_logs.len(), 1);
+    assert_eq!(request.resource_logs[0].scope_logs[0].log_records.len(), 1);
+
+    // The parsing should succeed even with nested empty values that get patched to null
+    let log_record = &request.resource_logs[0].scope_logs[0].log_records[0];
+    assert!(log_record.body.is_some());
+    assert_eq!(log_record.attributes.len(), 1);
+}
+
+#[test]
+fn test_patch_otel_json_empty_value() {
+    let mut json = json!({
+        "key": "test",
+        "value": {}
+    });
+
+    patch_otel_json(&mut json);
+
+    assert_eq!(json["key"], "test");
+    assert!(json["value"].is_null());
+}
+
+#[test]
+fn test_patch_otel_json_empty_body() {
+    let mut json = json!({
+        "timeUnixNano": "1234567890",
+        "body": {}
+    });
+
+    patch_otel_json(&mut json);
+
+    assert_eq!(json["timeUnixNano"], "1234567890");
+    assert!(json["body"].is_null());
+}
+
+#[test]
+fn test_patch_otel_json_non_empty_values() {
+    let mut json = json!({
+        "value": {
+            "stringValue": "test"
+        },
+        "body": {
+            "intValue": 42
+        }
+    });
+
+    patch_otel_json(&mut json);
+
+    // Non-empty values should remain unchanged
+    assert_eq!(json["value"]["stringValue"], "test");
+    assert_eq!(json["body"]["intValue"], 42);
+}
+
+#[test]
+fn test_patch_otel_json_nested_empty_values() {
+    let mut json = json!({
+        "resourceLogs": [{
+            "resource": {
+                "attributes": [{
+                    "key": "test_key",
+                    "value": {}
+                }]
+            },
+            "scopeLogs": [{
+                "logRecords": [{
+                    "body": {},
+                    "attributes": [{
+                        "key": "attr_key",
+                        "value": {}
+                    }]
+                }]
+            }]
+        }]
+    });
+
+    patch_otel_json(&mut json);
+
+    // All empty values and bodies should be patched to null
+    assert!(json["resourceLogs"][0]["resource"]["attributes"][0]["value"].is_null());
+    assert!(json["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]["body"].is_null());
+    assert!(
+        json["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]["attributes"][0]["value"]
+            .is_null()
+    );
+}
+
+#[test]
+fn test_patch_otel_json_array_with_empty_values() {
+    let mut json = json!([
+        {
+            "value": {}
+        },
+        {
+            "body": {}
+        },
+        {
+            "value": {
+                "stringValue": "valid"
+            }
+        }
+    ]);
+
+    patch_otel_json(&mut json);
+
+    // Empty objects should be patched to null
+    assert!(json[0]["value"].is_null());
+    assert!(json[1]["body"].is_null());
+    // Valid values should remain unchanged
+    assert_eq!(json[2]["value"]["stringValue"], "valid");
+}
+
+#[test]
+fn test_patch_otel_json_mixed_empty_and_non_empty() {
+    let mut json = json!({
+        "logRecord": {
+            "body": {},
+            "attributes": [
+                {
+                    "key": "empty_attr",
+                    "value": {}
+                },
+                {
+                    "key": "valid_attr",
+                    "value": {
+                        "stringValue": "test_value"
+                    }
+                }
+            ]
+        }
+    });
+
+    patch_otel_json(&mut json);
+
+    // Empty body should be null
+    assert!(json["logRecord"]["body"].is_null());
+    // Empty attribute value should be null
+    assert!(json["logRecord"]["attributes"][0]["value"].is_null());
+    // Valid attribute value should remain unchanged
+    assert_eq!(
+        json["logRecord"]["attributes"][1]["value"]["stringValue"],
+        "test_value"
+    );
 }


### PR DESCRIPTION
## Problem
Otel clients can send `body: {}` instead of what the rust deserialization expects which is `body:null`. We had this same problem with values which is fixed now, add body to the fix
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
fix deserialization to handle `body: {}`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
🤖 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
