### PR TITLE
chore: Call out setting to truncate strings in limit exceeded error

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -133,10 +133,12 @@ class StringLimitExceededError(Exception):
         else:
             msg = f"A column "
 
-        msg += f"in '{schema}.{table}' exceeds Redshift's string limit and cannot be exported"
+        msg += (
+            f"in '{schema}.{table}' exceeds Redshift's string limit and cannot be exported."
+            " The 'json_parse_truncate_strings' setting can be enabled in Redshift to"
+            " automatically truncate strings to the maximum limit."
+        )
 
-        if column in {"properties", "set", "set_once", "person_properties"}:
-            msg += ". Consider switching this column to 'SUPER' type which can support longer documents compared to 'VARCHAR'"
         super().__init__(msg)
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
@@ -730,4 +730,4 @@ async def test_copy_into_redshift_activity_handles_data_over_string_limit(
 
     assert result.error is not None
     assert result.error.type == "StringLimitExceededError"
-    assert "Consider switching this column to 'SUPER' type" in result.error.message
+    assert "'json_parse_truncate_strings' setting can be enabled" in result.error.message


### PR DESCRIPTION
## Problem

Redshift has a strict limit for strings. The only real fix for this is truncating the strings, which can be achieved by enabling a setting in Redshift. I don't think mentioning that the column could be migrated to 'SUPER' type is an option as that would require creating a new batch export. We don't have a good way to achieve this at the moment.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Based on that, update the error message.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
