### PR TITLE
chore: change consumer groups used for US deployment

### DIFF
--- a/posthog/clickhouse/kafka_engine.py
+++ b/posthog/clickhouse/kafka_engine.py
@@ -3,6 +3,23 @@ from typing import Literal
 
 from django.conf import settings
 
+# Consumer group names for Kafka tables.
+# US deployment uses named groups after the cluster reshard, other deployments use legacy group names.
+# Once we make all envs match, we can remove the _US check
+_US = settings.CLOUD_DEPLOYMENT == "US"
+CONSUMER_GROUP_EVENTS_JSON = "clickhouse_events_json" if _US else "group1"
+CONSUMER_GROUP_APP_METRICS = "clickhouse_app_metrics" if _US else "group1"
+CONSUMER_GROUP_APP_METRICS2 = "clickhouse_app_metrics2" if _US else "group1"
+CONSUMER_GROUP_INGESTION_WARNINGS = "clickhouse_ingestion_warnings" if _US else "group1"
+CONSUMER_GROUP_SESSION_REPLAY_EVENTS = "clickhouse_session_replay_events" if _US else "group1"
+CONSUMER_GROUP_LOG_ENTRIES = "clickhouse_log_entries_v3" if _US else "clickhouse_log_entries"
+CONSUMER_GROUP_DOCUMENT_EMBEDDINGS = "clickhouse_document_embeddings2" if _US else "clickhouse_document_embeddings"
+CONSUMER_GROUP_HEATMAPS = "clickhouse_heatmaps" if _US else "group1"
+CONSUMER_GROUP_PRECALCULATED_EVENTS = "clickhouse_precalculated_events2" if _US else "clickhouse_precalculated_events"
+CONSUMER_GROUP_PRECALCULATED_PERSON_PROPERTIES = (
+    "clickhouse_precalculated_person_properties2" if _US else "clickhouse_precalculated_person_properties"
+)
+
 STORAGE_POLICY = lambda: "SETTINGS storage_policy = 'hot_to_cold'" if settings.CLICKHOUSE_ENABLE_STORAGE_POLICY else ""
 
 KAFKA_ENGINE = "Kafka('{kafka_host}', '{topic}', '{group}', '{serialization}')"

--- a/posthog/clickhouse/kafka_engine.py
+++ b/posthog/clickhouse/kafka_engine.py
@@ -15,7 +15,7 @@ CONSUMER_GROUP_SESSION_REPLAY_EVENTS = "clickhouse_session_replay_events" if _US
 CONSUMER_GROUP_LOG_ENTRIES = "clickhouse_log_entries_v3" if _US else "clickhouse_log_entries"
 CONSUMER_GROUP_DOCUMENT_EMBEDDINGS = "clickhouse_document_embeddings2" if _US else "clickhouse_document_embeddings"
 CONSUMER_GROUP_HEATMAPS = "clickhouse_heatmaps" if _US else "group1"
-CONSUMER_GROUP_PRECALCULATED_EVENTS = "clickhouse_precalculated_events2" if _US else "clickhouse_precalculated_events"
+CONSUMER_GROUP_PRECALCULATED_EVENTS = "clickhouse_precalculated_events2" if _US else "clickhouse_prefiltered_events"
 CONSUMER_GROUP_PRECALCULATED_PERSON_PROPERTIES = (
     "clickhouse_precalculated_person_properties2" if _US else "clickhouse_precalculated_person_properties"
 )

--- a/posthog/clickhouse/log_entries.py
+++ b/posthog/clickhouse/log_entries.py
@@ -1,5 +1,5 @@
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
-from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS, kafka_engine, ttl_period
+from posthog.clickhouse.kafka_engine import CONSUMER_GROUP_LOG_ENTRIES, KAFKA_COLUMNS, kafka_engine, ttl_period
 from posthog.clickhouse.table_engines import Distributed, ReplacingMergeTree, ReplicationScheme
 from posthog.kafka_client.topics import KAFKA_LOG_ENTRIES
 from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
@@ -143,7 +143,7 @@ def KAFKA_LOG_ENTRIES_V3_TABLE_SQL():
     ).format(
         table_name=f"kafka_{LOG_ENTRIES_TABLE}_v3",
         on_cluster_clause=ON_CLUSTER_CLAUSE(False),
-        engine=kafka_engine(topic=KAFKA_LOG_ENTRIES, group="clickhouse_log_entries"),
+        engine=kafka_engine(topic=KAFKA_LOG_ENTRIES, group=CONSUMER_GROUP_LOG_ENTRIES),
         extra_fields="",
     )
 

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -586,7 +586,7 @@
       condition String,
       uuid UUID,
       source String
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_prefiltered_events', kafka_group_name = 'clickhouse_precalculated_events', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_prefiltered_events', kafka_group_name = 'clickhouse_prefiltered_events', kafka_format = 'JSONEachRow')
   SETTINGS kafka_max_block_size = 1000000, kafka_poll_max_batch_size = 100000, kafka_poll_timeout_ms = 1000, kafka_flush_interval_ms = 7500, kafka_skip_broken_messages = 100, kafka_num_consumers = 1
   
   '''
@@ -1996,7 +1996,7 @@
       condition String,
       uuid UUID,
       source String
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_prefiltered_events', kafka_group_name = 'clickhouse_precalculated_events', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_prefiltered_events', kafka_group_name = 'clickhouse_prefiltered_events', kafka_format = 'JSONEachRow')
   SETTINGS kafka_max_block_size = 1000000, kafka_poll_max_batch_size = 100000, kafka_poll_timeout_ms = 1000, kafka_flush_interval_ms = 7500, kafka_skip_broken_messages = 100, kafka_num_consumers = 1
   
   '''

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -586,7 +586,7 @@
       condition String,
       uuid UUID,
       source String
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_prefiltered_events', kafka_group_name = 'clickhouse_prefiltered_events', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_prefiltered_events', kafka_group_name = 'clickhouse_precalculated_events', kafka_format = 'JSONEachRow')
   SETTINGS kafka_max_block_size = 1000000, kafka_poll_max_batch_size = 100000, kafka_poll_timeout_ms = 1000, kafka_flush_interval_ms = 7500, kafka_skip_broken_messages = 100, kafka_num_consumers = 1
   
   '''
@@ -1996,7 +1996,7 @@
       condition String,
       uuid UUID,
       source String
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_prefiltered_events', kafka_group_name = 'clickhouse_prefiltered_events', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_prefiltered_events', kafka_group_name = 'clickhouse_precalculated_events', kafka_format = 'JSONEachRow')
   SETTINGS kafka_max_block_size = 1000000, kafka_poll_max_batch_size = 100000, kafka_poll_timeout_ms = 1000, kafka_flush_interval_ms = 7500, kafka_skip_broken_messages = 100, kafka_num_consumers = 1
   
   '''

--- a/posthog/heatmaps/sql.py
+++ b/posthog/heatmaps/sql.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
-from posthog.clickhouse.kafka_engine import kafka_engine, ttl_period
+from posthog.clickhouse.kafka_engine import CONSUMER_GROUP_HEATMAPS, kafka_engine, ttl_period
 from posthog.clickhouse.table_engines import Distributed, MergeTreeEngine, ReplicationScheme
 from posthog.kafka_client.topics import KAFKA_CLICKHOUSE_HEATMAP_EVENTS
 
@@ -98,7 +98,7 @@ HEATMAPS_TABLE_SQL = lambda on_cluster=True: (
 
 KAFKA_HEATMAPS_TABLE_SQL = lambda: KAFKA_HEATMAPS_TABLE_BASE_SQL.format(
     table_name="kafka_heatmaps",
-    engine=kafka_engine(topic=KAFKA_CLICKHOUSE_HEATMAP_EVENTS),
+    engine=kafka_engine(topic=KAFKA_CLICKHOUSE_HEATMAP_EVENTS, group=CONSUMER_GROUP_HEATMAPS),
 )
 
 HEATMAPS_TABLE_MV_SQL = (

--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -1,5 +1,5 @@
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
-from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS_WITH_PARTITION, kafka_engine
+from posthog.clickhouse.kafka_engine import CONSUMER_GROUP_APP_METRICS, KAFKA_COLUMNS_WITH_PARTITION, kafka_engine
 from posthog.clickhouse.table_engines import AggregatingMergeTree, Distributed, ReplicationScheme
 from posthog.kafka_client.topics import KAFKA_APP_METRICS
 
@@ -89,7 +89,7 @@ CREATE TABLE IF NOT EXISTS {KAFKA_APP_METRICS_TABLE}
     error_type String,
     error_details String CODEC(ZSTD(3))
 )
-ENGINE={kafka_engine(topic=KAFKA_APP_METRICS)}
+ENGINE={kafka_engine(topic=KAFKA_APP_METRICS, group=CONSUMER_GROUP_APP_METRICS)}
 """
 )
 

--- a/posthog/models/app_metrics2/sql.py
+++ b/posthog/models/app_metrics2/sql.py
@@ -1,4 +1,9 @@
-from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS_WITH_PARTITION, kafka_engine, ttl_period
+from posthog.clickhouse.kafka_engine import (
+    CONSUMER_GROUP_APP_METRICS2,
+    KAFKA_COLUMNS_WITH_PARTITION,
+    kafka_engine,
+    ttl_period,
+)
 from posthog.clickhouse.table_engines import AggregatingMergeTree, Distributed, ReplicationScheme
 from posthog.kafka_client.topics import KAFKA_APP_METRICS2
 
@@ -91,7 +96,7 @@ CREATE TABLE IF NOT EXISTS {KAFKA_APP_METRICS2_TABLE}
     metric_name String,
     count Int64
 )
-ENGINE={kafka_engine(topic=KAFKA_APP_METRICS2)}
+ENGINE={kafka_engine(topic=KAFKA_APP_METRICS2, group=CONSUMER_GROUP_APP_METRICS2)}
 """
 )
 

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -4,6 +4,7 @@ from posthog.clickhouse.base_sql import COPY_ROWS_BETWEEN_TEAMS_BASE_SQL
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
 from posthog.clickhouse.indexes import index_by_kafka_timestamp
 from posthog.clickhouse.kafka_engine import (
+    CONSUMER_GROUP_EVENTS_JSON,
     KAFKA_COLUMNS,
     KAFKA_COLUMNS_WITH_PARTITION,
     KAFKA_TIMESTAMP_MS_COLUMN,
@@ -241,7 +242,7 @@ def KAFKA_EVENTS_TABLE_JSON_SQL():
     ).format(
         table_name="kafka_events_json",
         on_cluster_clause=ON_CLUSTER_CLAUSE(),
-        engine=kafka_engine(topic=KAFKA_EVENTS_JSON),
+        engine=kafka_engine(topic=KAFKA_EVENTS_JSON, group=CONSUMER_GROUP_EVENTS_JSON),
         extra_fields="",
         dynamically_materialized_columns=EVENTS_TABLE_DYNAMICALLY_MATERIALIZED_COLUMNS(),
         materialized_columns="",

--- a/posthog/models/ingestion_warnings/sql.py
+++ b/posthog/models/ingestion_warnings/sql.py
@@ -1,6 +1,10 @@
 from django.conf import settings
 
-from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS_WITH_PARTITION, kafka_engine
+from posthog.clickhouse.kafka_engine import (
+    CONSUMER_GROUP_INGESTION_WARNINGS,
+    KAFKA_COLUMNS_WITH_PARTITION,
+    kafka_engine,
+)
 from posthog.clickhouse.table_engines import Distributed, MergeTreeEngine, ReplicationScheme
 from posthog.kafka_client.topics import KAFKA_INGESTION_WARNINGS
 
@@ -42,7 +46,7 @@ ORDER BY (team_id, toHour(timestamp), type, source, timestamp)
 def KAFKA_INGESTION_WARNINGS_TABLE_SQL():
     return INGESTION_WARNINGS_TABLE_BASE_SQL().format(
         table_name="kafka_ingestion_warnings",
-        engine=kafka_engine(topic=KAFKA_INGESTION_WARNINGS),
+        engine=kafka_engine(topic=KAFKA_INGESTION_WARNINGS, group=CONSUMER_GROUP_INGESTION_WARNINGS),
         materialized_columns="",
         extra_fields="",
     )

--- a/posthog/models/precalculated_events/sql.py
+++ b/posthog/models/precalculated_events/sql.py
@@ -1,4 +1,4 @@
-from posthog.clickhouse.kafka_engine import kafka_engine
+from posthog.clickhouse.kafka_engine import CONSUMER_GROUP_PRECALCULATED_EVENTS, kafka_engine
 from posthog.clickhouse.table_engines import Distributed, ReplacingMergeTree, ReplicationScheme
 from posthog.settings import CLICKHOUSE_CLUSTER
 
@@ -97,7 +97,7 @@ CREATE TABLE IF NOT EXISTS {table_name}
 SETTINGS kafka_max_block_size = 1000000, kafka_poll_max_batch_size = 100000, kafka_poll_timeout_ms = 1000, kafka_flush_interval_ms = 7500, kafka_skip_broken_messages = 100, kafka_num_consumers = 1
 """.format(
         table_name=PRECALCULATED_EVENTS_KAFKA_TABLE,
-        engine=kafka_engine(topic="clickhouse_prefiltered_events", group="clickhouse_prefiltered_events"),
+        engine=kafka_engine(topic="clickhouse_prefiltered_events", group=CONSUMER_GROUP_PRECALCULATED_EVENTS),
     )
 
 

--- a/posthog/models/precalculated_person_properties/sql.py
+++ b/posthog/models/precalculated_person_properties/sql.py
@@ -1,4 +1,4 @@
-from posthog.clickhouse.kafka_engine import kafka_engine
+from posthog.clickhouse.kafka_engine import CONSUMER_GROUP_PRECALCULATED_PERSON_PROPERTIES, kafka_engine
 from posthog.clickhouse.table_engines import Distributed, ReplacingMergeTree, ReplicationScheme
 from posthog.settings import CLICKHOUSE_CLUSTER
 
@@ -124,7 +124,7 @@ SETTINGS kafka_max_block_size = 1000000, kafka_poll_max_batch_size = 100000, kaf
 """.format(
         table_name=PRECALCULATED_PERSON_PROPERTIES_KAFKA_TABLE,
         engine=kafka_engine(
-            topic="clickhouse_precalculated_person_properties", group="clickhouse_precalculated_person_properties"
+            topic="clickhouse_precalculated_person_properties", group=CONSUMER_GROUP_PRECALCULATED_PERSON_PROPERTIES
         ),
     )
 

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
-from posthog.clickhouse.kafka_engine import kafka_engine
+from posthog.clickhouse.kafka_engine import CONSUMER_GROUP_SESSION_REPLAY_EVENTS, kafka_engine
 from posthog.clickhouse.table_engines import AggregatingMergeTree, Distributed, ReplicationScheme
 from posthog.kafka_client.topics import KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS
 
@@ -126,7 +126,7 @@ def KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=True):
     return KAFKA_SESSION_REPLAY_EVENTS_TABLE_BASE_SQL.format(
         table_name="kafka_session_replay_events",
         on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
-        engine=kafka_engine(topic=KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS),
+        engine=kafka_engine(topic=KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS, group=CONSUMER_GROUP_SESSION_REPLAY_EVENTS),
     )
 
 

--- a/products/error_tracking/backend/embedding.py
+++ b/products/error_tracking/backend/embedding.py
@@ -1,7 +1,11 @@
 from django.conf import settings
 
 from posthog.clickhouse.indexes import index_by_kafka_timestamp
-from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS_WITH_PARTITION, kafka_engine
+from posthog.clickhouse.kafka_engine import (
+    CONSUMER_GROUP_DOCUMENT_EMBEDDINGS,
+    KAFKA_COLUMNS_WITH_PARTITION,
+    kafka_engine,
+)
 from posthog.clickhouse.table_engines import Distributed, ReplacingMergeTree, ReplicationScheme
 from posthog.kafka_client.topics import KAFKA_DOCUMENT_EMBEDDINGS_TOPIC
 
@@ -97,7 +101,7 @@ def DOCUMENT_EMBEDDINGS_WRITABLE_TABLE_SQL():
 def KAFKA_DOCUMENT_EMBEDDINGS_TABLE_SQL():
     return DOCUMENT_EMBEDDINGS_TABLE_BASE_SQL.format(
         table_name=KAFKA_DOCUMENT_EMBEDDINGS,
-        engine=kafka_engine(KAFKA_DOCUMENT_EMBEDDINGS_TOPIC, group="clickhouse_document_embeddings"),
+        engine=kafka_engine(KAFKA_DOCUMENT_EMBEDDINGS_TOPIC, group=CONSUMER_GROUP_DOCUMENT_EMBEDDINGS),
         content_default="",
         metadata_default="",
         extra_fields="",


### PR DESCRIPTION
## Problem

During the reshard we had to keep 2 ingestion pipelines for sharded tables, leading to us having 2 different consumer groups for them.

Now, we need to keep the new groups.

## Changes

For US deployment, use the consumer groups after the reshard to avoid changing them if we recreate the kafka tables through a migration.

## How did you test this code?

Unit tests