### PR TITLE
fix(sql-insights): initialize axis settings from query props

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -403,7 +403,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             },
         ],
         selectedXAxis: [
-            null as string | null,
+            (props.query.chartSettings?.xAxis?.column ?? null) as string | null,
             {
                 _setQuery: (_, { node }) => node.chartSettings?.xAxis?.column ?? null,
                 clearAxis: () => null,
@@ -411,7 +411,10 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             },
         ],
         selectedYAxis: [
-            null as (SelectedYAxis | null)[] | null,
+            (props.query.chartSettings?.yAxis?.map((axis) => ({
+                name: axis.column,
+                settings: axis.settings ?? DefaultAxisSettings(),
+            })) ?? null) as (SelectedYAxis | null)[] | null,
             {
                 _setQuery: (state, { node }) => {
                     if (node.chartSettings?.yAxis) {


### PR DESCRIPTION
Previously, selectedXAxis and selectedYAxis in dataVisualizationLogic were initialized as null, causing charts to not render correctly when the query already contained axis settings (e.g., when loading a saved SQL insight).

Now these reducers initialize from props.query.chartSettings, ensuring the chart renders correctly on mount.

Also fixes test isolation issues in seriesBreakdownLogic tests that were exposed by this change.

## Problem

When loading a saved SQL insight that has axis settings (xAxis/yAxis) configured in `chartSettings`, the chart would not render correctly. This is because `selectedXAxis` and `selectedYAxis` in `dataVisualizationLogic` were initialized as `null`, ignoring any existing settings in the query props.

## Changes

- Initialize `selectedXAxis` from `props.query.chartSettings?.xAxis?.column` instead of `null`
- Initialize `selectedYAxis` from `props.query.chartSettings?.yAxis` instead of `null`
- Add tests for the new initialization behavior
- Fix test isolation issues in `seriesBreakdownLogic.test.ts` that were exposed by this change (tests were relying on stale props between test runs)

## How did you test this code?

1. Verified the fix manually by loading a saved SQL insight with pre-configured axis settings - chart now renders correctly on mount
2. Added unit tests that verify `selectedXAxis` and `selectedYAxis` initialize from props when present
3. Added unit test that verifies they initialize as `null` when not present in props
4. All 9 tests in `seriesBreakdownLogic.test.ts` pass

## Publish to changelog?

no