### PR TITLE
fix: Notebooks template link overflow

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/NotebookShareModal.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookShareModal.tsx
@@ -67,7 +67,7 @@ export function NotebookShareModal({ shortId }: NotebookShareModalProps): JSX.El
                             onClick={() => void copyToClipboard(notebookUrl, 'notebook link')}
                             title={notebookUrl}
                         >
-                            <span className="truncate">{notebookUrl}</span>
+                            <span className="truncate overflow-hidden block min-w-0">{notebookUrl}</span>
                         </LemonButton>
 
                         <LemonDivider className="my-4" />
@@ -91,7 +91,7 @@ export function NotebookShareModal({ shortId }: NotebookShareModalProps): JSX.El
                     onClick={() => void copyToClipboard(canvasUrl, 'canvas link')}
                     title={canvasUrl}
                 >
-                    <span className="truncate">{canvasUrl}</span>
+                    <span className="truncate overflow-hidden block min-w-0">{canvasUrl}</span>
                 </LemonButton>
 
                 <LemonDivider className="my-4" />


### PR DESCRIPTION
## Problem

The "Template Link" field in the Notebooks Share modal was overflowing, causing UI issues when the link was too long.

Before:
<img width="1032" height="649" alt="image" src="https://github.com/user-attachments/assets/df33f308-3ced-4668-a602-0842c5a5bb3e" />


After:
<img width="1032" height="649" alt="image" src="https://github.com/user-attachments/assets/e8a4396d-e131-4add-9566-b5753f61cca9" />


## Changes

Added `overflow-hidden block min-w-0` classes to the `span` elements containing the URLs within the "Template Link" and "Internal Link" buttons in `NotebookShareModal.tsx`. These classes ensure proper truncation and overflow handling for long URLs.

Also included unrelated linter fixes found during development.

## How did you test this code?

Manually verified that long links in the Notebooks Share modal no longer overflow.
Ran `prettier` to ensure code formatting.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C08UM214Z50/p1768841072272739?thread_ts=1768841072.272739&cid=C08UM214Z50)

<a href="https://cursor.com/background-agent?bcId=bc-b70fe978-c773-473d-ad6f-30cc3d22ca83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b70fe978-c773-473d-ad6f-30cc3d22ca83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

