### PR TITLE
feat(endpoints): add version-specific fields to EndpointVersion model

### DIFF
--- a/products/endpoints/backend/migrations/0009_endpointversion_version_fields.py
+++ b/products/endpoints/backend/migrations/0009_endpointversion_version_fields.py
@@ -1,0 +1,49 @@
+import django.db.models.deletion
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False  # Required for AddIndexConcurrently
+
+    dependencies = [
+        ("data_warehouse", "0014_mat_view_credential_deletion"),
+        ("endpoints", "0008_endpoint_last_executed_at"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="endpointversion",
+            name="cache_age_seconds",
+            field=models.IntegerField(
+                blank=True, help_text="Cache age in seconds. If null, uses default interval-based caching.", null=True
+            ),
+        ),
+        migrations.AddField(
+            model_name="endpointversion",
+            name="description",
+            field=models.TextField(blank=True, default="", help_text="Optional description for this endpoint version"),
+        ),
+        migrations.AddField(
+            model_name="endpointversion",
+            name="is_materialized",
+            field=models.BooleanField(default=False, help_text="Whether this version's query results are materialized"),
+        ),
+        migrations.AddField(
+            model_name="endpointversion",
+            name="saved_query",
+            field=models.ForeignKey(
+                blank=True,
+                db_index=False,  # We'll add the index concurrently below
+                help_text="The underlying materialized view for this version",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="endpoint_versions",
+                to="data_warehouse.datawarehousesavedquery",
+            ),
+        ),
+        AddIndexConcurrently(
+            model_name="endpointversion",
+            index=models.Index(fields=["saved_query"], name="endpointvers_saved_q_0dc3_idx"),
+        ),
+    ]

--- a/products/endpoints/backend/migrations/max_migration.txt
+++ b/products/endpoints/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0008_endpoint_last_executed_at
+0009_endpointversion_version_fields


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

we're misusing Endpoint + EndpointVersion django models. 

## Changes

This is the first PR in a stack that will make the django models sensible and allow easier version management: Endpoint holds the high-level Endpoint data, while EndpointVersion holds the query, and other configurations that can be specific to the version.

So:

- add the fields to the EndpointVersion model

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

nothing to test here really, just new fields. but ran the migration locally

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->