### PR TITLE
feat(logs): add tracking for logs settings changes

### DIFF
--- a/products/logs/frontend/components/LogsViewer/logsViewerSettingsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerSettingsLogic.ts
@@ -1,4 +1,5 @@
-import { actions, kea, path, reducers } from 'kea'
+import { actions, kea, listeners, path, reducers } from 'kea'
+import posthog from 'posthog-js'
 
 import type { logsViewerSettingsLogicType } from './logsViewerSettingsLogicType'
 
@@ -40,5 +41,17 @@ export const logsViewerSettingsLogic = kea<logsViewerSettingsLogicType>([
                 setPrettifyJson: (_, { prettifyJson }) => prettifyJson,
             },
         ],
+    })),
+
+    listeners(() => ({
+        setTimezone: ({ timezone }) => {
+            posthog.capture('logs setting changed', { setting: 'timezone', value: timezone })
+        },
+        setWrapBody: ({ wrapBody }) => {
+            posthog.capture('logs setting changed', { setting: 'wrap_body', value: wrapBody })
+        },
+        setPrettifyJson: ({ prettifyJson }) => {
+            posthog.capture('logs setting changed', { setting: 'prettify_json', value: prettifyJson })
+        },
     })),
 ])

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -901,7 +901,8 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             }
             actions.syncUrlAndRunQuery()
         },
-        setOrderBy: () => {
+        setOrderBy: ({ orderBy }) => {
+            posthog.capture('logs setting changed', { setting: 'order_by', value: orderBy })
             actions.syncUrlAndRunQuery()
         },
         setLogsPageSize: () => {


### PR DESCRIPTION
## Problem

I want to start compressing some of these lesser-used settings into sub-menus to reduce UI clutter. We need to track user interactions to support this work.

## Changes

Added event tracking for logs settings changes:
- timezone settings
- wrap body setting
- prettify JSON setting
- order by setting

All events are captured with a consistent event name "logs setting changed" and include the specific setting name and value.

## How did you test this code?

Manually tested by changing each setting in the logs viewer and verifying that the appropriate PostHog events were captured with the correct properties.

## Publish to changelog?

No