### PR TITLE
fix(bq-batch-export): Enable support for Parquet list type

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -680,8 +680,12 @@ class BigQueryClient:
         """Load a file into BigQuery table."""
         schema = tuple(field.to_destination_field() for field in table.fields)
         if format == "Parquet":
+            opts = bigquery.format_options.ParquetOptions()
+            opts.enable_list_inference = True
+
             job_config = bigquery.LoadJobConfig(
                 source_format="PARQUET",
+                parquet_options=opts,
                 schema=schema,
             )
         elif format == "JSONLines":

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -350,7 +350,13 @@ def test_properties(request, session_id):
         return {**{"$session_id": session_id}, **request.param}
     except AttributeError:
         pass
-    return {"$browser": "Chrome", "$os": "Mac OS X", "prop": "value", "$session_id": session_id}
+    return {
+        "$browser": "Chrome",
+        "$os": "Mac OS X",
+        "prop": "value",
+        "$session_id": session_id,
+        "$current_url": "posthog.com",
+    }
 
 
 @pytest.fixture

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/utils.py
@@ -1,5 +1,4 @@
 import os
-import ast
 import json
 import asyncio
 import datetime as dt
@@ -126,20 +125,30 @@ async def assert_clickhouse_records_in_redshift(
                     event[column] = json.loads(event[column])
 
             for column in array_super_columns:
-                # Arrays stored in SUPER are dumped like Python sets: '{"value", "value1"}'
-                # But we expect these to come as lists from ClickHouse.
-                # So, since they are read as strings, we first `json.loads` them and
-                # then pass the resulting string to `literal_eval`, which will produce
-                # either a dict or a set (depending if it's empty or not). Either way
-                # we can cast them to list.
+                # Arrays stored in SUPER are dumped almost like the string
+                # representation of as Python sets, but without quotes for the values:
+                # '"{value,value1}"'. We expect these to be Python lists rather than
+                # whatever garbage that is, as reading from ClickHouse returns Python
+                #  lists. So, we load up the string as JSON, and compare against '"{}"'
+                # to determine if it is empty. If it is, we can just set the value to
+                # empty list. Otherwise, we strip the '"{}"', and iterate through the
+                # values adding them to a new list.
                 if column in event and event.get(column, None) is not None:
-                    load_result = json.loads(event[column])
-
-                    if not isinstance(load_result, list):
-                        value = ast.literal_eval(load_result)
-                        event[column] = list(value)
+                    loaded = json.loads(event[column])
+                    if isinstance(loaded, list):
+                        # In COPY tests, it is already a list. I have no clue why.
+                        # TODO: investigate.
+                        event[column] = loaded
+                    elif loaded == "{}":
+                        event[column] = []
                     else:
-                        event[column] = load_result
+                        # ruff complains that using `strip` is misleading, but the
+                        # alternative would mean calling two functions, and the example
+                        # in their docs (removing only a file suffix) is not what I'm
+                        # doing here. So, I respectfully disagree.
+                        stripped = loaded.strip("{}")  # noqa: B005
+                        values = list(stripped.split(","))
+                        event[column] = values
 
             if extra_fields:
                 for column in extra_fields:

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
@@ -334,7 +334,7 @@ async def test_insert_into_snowflake_activity_merges_sessions_data_in_follow_up_
     # Snowflake client doesn't evaluate arrays to python lists.
     # The presence of new lines is an indicator that 'urls' is of the correct type as
     # that's how snowflake displays arrays.
-    assert rows[0][2] == '[\n  "http://localhost.org"\n]'
+    assert rows[0][2] == '[\n  "http://localhost.org",\n  "posthog.com"\n]'
 
 
 async def test_insert_into_snowflake_activity_removes_internal_stage_files(


### PR DESCRIPTION
## Problem

BigQuery silently ignores Parquet list types when loading them in the sessions model, setting the value as `NULL`. Even worse, our tests do not cover that as we do not set the `current_url` property.

After adding said property our tests fail due to `urls` being empty.

Thanks to https://github.com/googleapis/python-bigquery/issues/19, I got the idea of trying with the `enable_list_inference` setting for parquet loading, which for some stupid reason is disabled by default. Enabling this makes the tests work.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Set `bigquery.format_options.ParquetOptions.enable_list_inference = True`.
Pass it to the BigQuery load job

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Updated tests, ran them.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
