### PR TITLE
chore(cdp): deprecate Mailchimp destination

### DIFF
--- a/posthog/cdp/templates/mailchimp/template_mailchimp.py
+++ b/posthog/cdp/templates/mailchimp/template_mailchimp.py
@@ -1,7 +1,7 @@
 from posthog.cdp.templates.hog_function_template import HogFunctionTemplateDC
 
 template: HogFunctionTemplateDC = HogFunctionTemplateDC(
-    status="beta",
+    status="deprecated",
     free=False,
     type="destination",
     id="template-mailchimp",


### PR DESCRIPTION
Deprecate the Mailchimp destination due to ongoing complications with Mailchimp/Akamai that have been causing support workload and reputation issues with no resolution from the provider side.

This prevents new Mailchimp destinations from being created while existing ones continue to function.