### PR TITLE
fix: switch from logs_gb_in_period to logs_mb_in_period in usage reports

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -2515,17 +2515,17 @@ class TestHogFunctionUsageReports(ClickhouseDestroyTablesMixin, TestCase, Clickh
         # Test org-level logs metrics (sum of both teams)
         assert org_1_report["logs_bytes_in_period"] == 4_000_000_000  # 1.5B + 2.5B
         assert org_1_report["logs_records_in_period"] == 3000  # 1000 + 2000
-        assert org_1_report["logs_gb_in_period"] == 4.0  # 1.5 + 2.5
+        assert org_1_report["logs_mb_in_period"] == 4000  # 1500 + 2500
 
         # Test team 1 logs metrics
         assert org_1_report["teams"]["3"]["logs_bytes_in_period"] == 1_500_000_000
         assert org_1_report["teams"]["3"]["logs_records_in_period"] == 1000
-        assert org_1_report["teams"]["3"]["logs_gb_in_period"] == 1.5
+        assert org_1_report["teams"]["3"]["logs_mb_in_period"] == 1500
 
         # Test team 2 logs metrics
         assert org_1_report["teams"]["4"]["logs_bytes_in_period"] == 2_500_000_000
         assert org_1_report["teams"]["4"]["logs_records_in_period"] == 2000
-        assert org_1_report["teams"]["4"]["logs_gb_in_period"] == 2.5
+        assert org_1_report["teams"]["4"]["logs_mb_in_period"] == 2500
 
 
 @freeze_time("2022-01-10T10:00:00Z")

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -224,7 +224,7 @@ class UsageReportCounters:
     # Logs
     logs_bytes_in_period: int
     logs_records_in_period: int
-    logs_gb_in_period: float
+    logs_mb_in_period: int
 
 
 # Instance metadata to be included in overall report
@@ -2065,8 +2065,7 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         ),
         logs_bytes_in_period=all_data["teams_with_logs_bytes_in_period"].get(team.id, 0),
         logs_records_in_period=all_data["teams_with_logs_records_in_period"].get(team.id, 0),
-        # decimal GB (not GiB) to match pricing; billing uses logs_bytes_in_period for precision
-        logs_gb_in_period=round(all_data["teams_with_logs_bytes_in_period"].get(team.id, 0) / 1_000_000_000, 3),
+        logs_mb_in_period=int(all_data["teams_with_logs_bytes_in_period"].get(team.id, 0) // 1_000_000),
     )
 
 


### PR DESCRIPTION
## Changes

- When i initially suggested reporting usage and billing on the same metric, I didn't consider sufficiently the importance of GB being a float (with 3 digit precision)
- Billing has an implied assumption of all usage metrics being ints (Stripe also requires usage to be ints)
- While usage reports already had some usage metrics as floats, those metrics were not used for billing any products
- I initially thought I'd refactor billing to handle both ints and floats but decided to take a step back and consider alternatives: https://github.com/PostHog/billing/pull/1745
- Based on this, we were all aligned that we should stick to ints and rather support an optional config to display usage in a more readable format, where needed
    - Caveat: For now it won't be possible to customize/convert it on Stripe invoices - those will still show whatever billing is based on
- For logs specifically, we're therefore going with MB (int, floored) instead of GB - since we were going to use GB with 3 digit precision, it's effectively the same

Agreed with logs team here: https://posthog.slack.com/archives/C0A7XRQUVE3/p1768837232268249

## How did you test this code?

Updated tests