### PR TITLE
feat(insights): Add failure_type to exported asset insights incl. alerts

### DIFF
--- a/terraform/providers_root.tf.tpl
+++ b/terraform/providers_root.tf.tpl
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     posthog = {
       source  = "PostHog/posthog"
-      version = "0.0.1-beta.1"
+      version = "1.0.2"
     }
   }
 }

--- a/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/alerts.tf
+++ b/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/alerts.tf
@@ -63,11 +63,6 @@ locals {
       })
     }
   ]...)
-
-  # Reference for hog_functions - all alerts get Slack notifications
-  alerts_with_slack_notifications = {
-    for key, alert in posthog_alert.export_alert : key => alert
-  }
 }
 
 resource "posthog_alert" "export_alert" {
@@ -87,7 +82,7 @@ resource "posthog_alert" "export_alert" {
 }
 
 resource "posthog_hog_function" "slack_alert_notification" {
-  for_each = local.alerts_with_slack_notifications
+  for_each = posthog_alert.export_alert
 
   name        = "Post to Slack on insight alert firing"
   description = "Post to a Slack channel when this insight alert fires"

--- a/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/alerts.tf
+++ b/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/alerts.tf
@@ -2,8 +2,8 @@
 # PostHog Alerts Configuration
 # =============================================================================
 #
-# This file demonstrates how to configure PostHog alerts with Slack notifications
-# using the PostHog Terraform provider.
+# This file configures PostHog alerts with Slack notifications using for_each
+# to avoid duplication across regions and alert types.
 #
 # Prerequisites:
 #   - Set required variables (see variables.tf)
@@ -13,132 +13,146 @@
 #   https://registry.terraform.io/providers/PostHog/posthog/latest/docs/resources/alert
 # =============================================================================
 
-# Terraform configuration for PostHog alert
-# Compatible with posthog provider v1.0
-# Source alert ID: 019a972a-2df1-0000-4b6a-8f54b42bbbb3
-import {
-  to = posthog_alert.decrease_in_success_rate_for_exports
-  id = "019a972a-2df1-0000-4b6a-8f54b42bbbb3"
+locals {
+  regions = {
+    us = posthog_insight.export_successes_and_failures["us"]
+    eu = posthog_insight.export_successes_and_failures["eu"]
+  }
+
+  # Alert configurations (shared across regions)
+  alert_configs = {
+    decrease_in_success_rate = {
+      name            = "Decrease in success rate for exports"
+      threshold_lower = 0.99
+      threshold_upper = null
+      series_index    = 0
+    }
+    timeout_spike = {
+      name            = "Timeout spike"
+      threshold_lower = null
+      threshold_upper = 0.03
+      series_index    = 5
+    }
+    system_error_spike = {
+      name            = "System error spike"
+      threshold_lower = null
+      threshold_upper = 0.03
+      series_index    = 4
+    }
+    user_error_spike = {
+      name            = "User error spike"
+      threshold_lower = null
+      threshold_upper = 0.03
+      series_index    = 3
+    }
+    unknown_alert_spike = {
+      name            = "Unknown alert spike"
+      threshold_lower = null
+      threshold_upper = 0.01
+      series_index    = 6
+    }
+  }
+
+  # Flatten: creates keys like "decrease_in_success_rate_us", "decrease_in_success_rate_eu"
+  alerts = merge([
+    for region_key, insight in local.regions : {
+      for alert_key, config in local.alert_configs :
+      "${alert_key}_${region_key}" => merge(config, {
+        region  = region_key
+        insight = insight
+      })
+    }
+  ]...)
+
+  # Reference for hog_functions - all alerts get Slack notifications
+  alerts_with_slack_notifications = {
+    for key, alert in posthog_alert.export_alert : key => alert
+  }
 }
 
-resource "posthog_alert" "decrease_in_success_rate_for_exports" {
-  name = "Decrease in success rate for exports"
-  enabled = true
-  calculation_interval = "hourly"
-  condition_type = "absolute_value"
-  threshold_type = "absolute"
-  threshold_lower = 0.97
-  series_index = 0
+resource "posthog_alert" "export_alert" {
+  for_each = local.alerts
+
+  name                   = "${each.value.name} (${upper(each.value.region)})"
+  enabled                = true
+  calculation_interval   = "daily"
+  condition_type         = "absolute_value"
+  threshold_type         = "absolute"
+  threshold_lower        = each.value.threshold_lower
+  threshold_upper        = each.value.threshold_upper
+  series_index           = each.value.series_index
   check_ongoing_interval = false
-  insight = posthog_insight.export_successes_and_failures_us.id
-  subscribed_users = var.analytics_platform_alert_subscribed_user_ids
+  insight                = each.value.insight.id
+  subscribed_users       = var.analytics_platform_alert_subscribed_user_ids
 }
 
-# Terraform configuration for PostHog hog_function
-# Compatible with posthog provider v1.0
-# Source hog_function ID: 019a972e-cb45-0000-fbfe-a9c0e26b6547
-import {
-  to = posthog_hog_function.post_to_slack_on_insight_alert_firing
-  id = "019a972e-cb45-0000-fbfe-a9c0e26b6547"
-}
+resource "posthog_hog_function" "slack_alert_notification" {
+  for_each = local.alerts_with_slack_notifications
 
-resource "posthog_hog_function" "post_to_slack_on_insight_alert_firing" {
-  name = "Post to Slack on insight alert firing"
+  name        = "Post to Slack on insight alert firing"
   description = "Post to a Slack channel when this insight alert fires"
-  type = "internal_destination"
-  enabled = true
-  hog = "let res := fetch('https://slack.com/api/chat.postMessage', {\n  'body': {\n    'channel': inputs.channel,\n    'icon_emoji': inputs.icon_emoji,\n    'username': inputs.username,\n    'blocks': inputs.blocks,\n    'text': inputs.text\n  },\n  'method': 'POST',\n  'headers': {\n    'Authorization': f'Bearer {inputs.slack_workspace.access_token}',\n    'Content-Type': 'application/json'\n  }\n});\n\nif (res.status != 200 or res.body.ok == false) {\n  throw Error(f'Failed to post message to Slack: {res.status}: {res.body}');\n}"
+  type        = "internal_destination"
+  enabled     = true
+  hog         = "let res := fetch('https://slack.com/api/chat.postMessage', {\n  'body': {\n    'channel': inputs.channel,\n    'icon_emoji': inputs.icon_emoji,\n    'username': inputs.username,\n    'blocks': inputs.blocks,\n    'text': inputs.text\n  },\n  'method': 'POST',\n  'headers': {\n    'Authorization': f'Bearer {inputs.slack_workspace.access_token}',\n    'Content-Type': 'application/json'\n  }\n});\n\nif (res.status != 200 or res.body.ok == false) {\n  throw Error(f'Failed to post message to Slack: {res.status}: {res.body}');\n}"
+
   inputs_json = jsonencode({
-    "text": {
-      "value": "Alert triggered: {event.properties.insight_name}",
-      "templating": "hog"
-    },
-    "blocks": {
-      "value": [
+    "text" = {
+      "value"      = "Alert triggered: {event.properties.insight_name}"
+      "templating" = "hog"
+    }
+    "blocks" = {
+      "value" = [
         {
-          "text": {
-            "text": "Alert '{event.properties.alert_name}' firing for insight '{event.properties.insight_name}'",
-            "type": "plain_text"
-          },
-          "type": "header"
+          "text" = {
+            "text" = "Alert '{event.properties.alert_name}' firing for insight '{event.properties.insight_name}'"
+            "type" = "plain_text"
+          }
+          "type" = "header"
         },
         {
-          "text": {
-            "text": "{event.properties.breaches}",
-            "type": "plain_text"
-          },
-          "type": "section"
+          "text" = { "text" = "{event.properties.breaches}", "type" = "plain_text" }
+          "type" = "section"
         },
         {
-          "type": "context",
-          "elements": [
+          "type"     = "context"
+          "elements" = [{ "text" = "Project: <{project.url}|{project.name}>", "type" = "mrkdwn" }]
+        },
+        { "type" = "divider" },
+        {
+          "type" = "actions"
+          "elements" = [
             {
-              "text": "Project: <{project.url}|{project.name}>",
-              "type": "mrkdwn"
-            }
-          ]
-        },
-        {
-          "type": "divider"
-        },
-        {
-          "type": "actions",
-          "elements": [
-            {
-              "url": "{project.url}/insights/{event.properties.insight_id}",
-              "text": {
-                "text": "View Insight",
-                "type": "plain_text"
-              },
-              "type": "button"
+              "url"  = "{project.url}/insights/{event.properties.insight_id}"
+              "text" = { "text" = "View Insight", "type" = "plain_text" }
+              "type" = "button"
             },
             {
-              "url": "{project.url}/insights/{event.properties.insight_id}/alerts?alert_id={event.properties.alert_id}",
-              "text": {
-                "text": "View Alert",
-                "type": "plain_text"
-              },
-              "type": "button"
+              "url"  = "{project.url}/insights/{event.properties.insight_id}/alerts?alert_id={event.properties.alert_id}"
+              "text" = { "text" = "View Alert", "type" = "plain_text" }
+              "type" = "button"
             }
           ]
         }
-      ],
-      "templating": "hog"
-    },
-    "channel": {
-      "value": var.analytics_platform_slack_channel_id,
-      "templating": "hog"
-    },
-    "username": {
-      "value": "Export-monitor",
-      "templating": "hog"
-    },
-    "icon_emoji": {
-      "value": ":hogzilla:",
-      "templating": "hog"
-    },
-    "slack_workspace": {
-      "value": var.analytics_platform_slack_workspace_id,
-      "templating": "hog"
+      ]
+      "templating" = "hog"
     }
+    "channel"         = { "value" = var.analytics_platform_slack_channel_id, "templating" = "hog" }
+    "username"        = { "value" = "Export-monitor", "templating" = "hog" }
+    "icon_emoji"      = { "value" = ":hogzilla:", "templating" = "hog" }
+    "slack_workspace" = { "value" = var.analytics_platform_slack_workspace_id, "templating" = "hog" }
   })
+
   filters_json = jsonencode({
-    "source": "events",
-    "events": [
-      {
-        "id": "$insight_alert_firing",
-        "type": "events"
-      }
-    ],
-    "properties": [
-      {
-        "key": "alert_id",
-        "type": "event",
-        "value": posthog_alert.decrease_in_success_rate_for_exports.id,
-        "operator": "exact"
-      }
-    ]
+    "source" = "events"
+    "events" = [{ "id" = "$insight_alert_firing", "type" = "events" }]
+    "properties" = [{
+      "key"      = "alert_id"
+      "type"     = "event"
+      "value"    = each.value.id
+      "operator" = "exact"
+    }]
   })
+
   template_id = "template-slack"
-  icon_url = "/static/services/slack.png"
+  icon_url    = "/static/services/slack.png"
 }

--- a/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/moved.tf
+++ b/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/moved.tf
@@ -1,0 +1,9 @@
+moved {
+  from = posthog_insight.export_successes_and_failures_us
+  to   = posthog_insight.export_successes_and_failures["us"]
+}
+
+moved {
+  from = posthog_insight.export_successes_and_failures_eu
+  to   = posthog_insight.export_successes_and_failures["eu"]
+}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

This PR migrates our existing "exported asset failure" insights ([us](https://us.posthog.com/project/2/insights/pgGH5Tf3), [eu](https://us.posthog.com/project/2/insights/o5s3JBdC)) to Terraform. This is done so that these updated insights are also managed through VCS to avoid it accidentally being reset when the TF plan would be re-applied. 

In order to do this, I've made use of the existing "manage with terraform" functionality, in order to get the actual data / results, afterwards I've done some optimisations (using `for_each` and `local` variables) in order to increase the DRY-ness of the code. This as `hog_functions` need to be wired 1-1 to alerts, otherwise we can't access them in the Alert Modal (due to how the fetching logic works currently). The added benefit here is that this also makes managing both insights through code easier as it acts as a single source of truth (compared to updating 2 insights).

Oh and finally, this PR introduces a `moved.tf`, this is solely there for a single TF run, once the run has completed, I can remove it again. This is needed in order to link the "for_each" generated resources correctly to the existing state.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

1. Update the "exported asset failure" insights to display the "failure types"
2. Enhance the generated TF to improve DRY-ness of the code.

In order to simplify the code / plan, I've removed all alerts / hog functions on the existing insight in order to simplify the TF moved code (if it isn't there we don't need it to move it either). Thus all alerts and hog functions will be created again. 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

✅ The Terragrunt speculative plan looks sensible ([link](https://github.com/PostHog/posthog/actions/runs/21170903781/job/60887295391?pr=45425))

<img width="1324" height="328" alt="CleanShot 2026-01-20 at 13 15 17@2x" src="https://github.com/user-attachments/assets/89aa8002-e439-4556-b37b-ba14d756ea19" />


<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

N/A internal dashboard update

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
