### PR TITLE
feat(logs): add orderby functionality to log row header and always show column menu ellipsis

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -29,7 +29,7 @@ export interface LogsViewerProps {
     totalLogsCount?: number
     hasMoreLogsToLoad?: boolean
     orderBy: LogsOrderBy
-    onChangeOrderBy: (orderBy: LogsOrderBy) => void
+    onChangeOrderBy: (orderBy: LogsOrderBy, source: 'header' | 'toolbar') => void
     onRefresh?: () => void
     onLoadMore?: () => void
     onAddFilter?: (key: string, value: string, operator?: PropertyOperator, type?: PropertyFilterType) => void
@@ -87,7 +87,7 @@ interface LogsViewerContentProps {
     totalLogsCount?: number
     hasMoreLogsToLoad?: boolean
     orderBy: LogsOrderBy
-    onChangeOrderBy: (orderBy: LogsOrderBy) => void
+    onChangeOrderBy: (orderBy: LogsOrderBy, source: 'header' | 'toolbar') => void
     onRefresh?: () => void
     onLoadMore?: () => void
     sparklineData: LogsSparklineData
@@ -315,7 +315,11 @@ function LogsViewerContent({
                 onBreakdownByChange={onSparklineBreakdownByChange}
             />
             <SceneDivider />
-            <LogsViewerToolbar totalLogsCount={totalLogsCount} orderBy={orderBy} onChangeOrderBy={onChangeOrderBy} />
+            <LogsViewerToolbar
+                totalLogsCount={totalLogsCount}
+                orderBy={orderBy}
+                onChangeOrderBy={(newOrderBy) => onChangeOrderBy(newOrderBy, 'toolbar')}
+            />
             <LogsSelectionToolbar />
             {pinnedLogsArray.length > 0 && (
                 <VirtualizedLogsList
@@ -327,6 +331,8 @@ function LogsViewerContent({
                     fixedHeight={250}
                     disableInfiniteScroll
                     disableCursor
+                    orderBy={orderBy}
+                    onChangeOrderBy={(newOrderBy) => onChangeOrderBy(newOrderBy, 'header')}
                 />
             )}
 
@@ -340,6 +346,8 @@ function LogsViewerContent({
                 hasMoreLogsToLoad={hasMoreLogsToLoad}
                 onLoadMore={onLoadMore}
                 onExpandTimeRange={onExpandTimeRange}
+                orderBy={orderBy}
+                onChangeOrderBy={(newOrderBy) => onChangeOrderBy(newOrderBy, 'header')}
             />
 
             <LogDetailsModal timezone={timezone} />

--- a/products/logs/frontend/components/VirtualizedLogsList/LogRowHeader.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRowHeader.tsx
@@ -2,6 +2,7 @@ import { IconArrowLeft, IconArrowRight, IconEllipsis, IconTrash } from '@posthog
 import { LemonButton, LemonCheckbox, LemonMenu } from '@posthog/lemon-ui'
 
 import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
+import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 
 import {
     CHECKBOX_WIDTH,
@@ -15,6 +16,7 @@ import {
     getFixedColumnsWidth,
     getMessageStyle,
 } from 'products/logs/frontend/components/VirtualizedLogsList/layoutUtils'
+import { LogsOrderBy } from 'products/logs/frontend/types'
 
 export interface LogRowHeaderProps {
     rowWidth: number
@@ -28,6 +30,9 @@ export interface LogRowHeaderProps {
     totalCount?: number
     onSelectAll?: () => void
     onClearSelection?: () => void
+    // Sorting
+    orderBy?: LogsOrderBy
+    onChangeOrderBy?: (orderBy: LogsOrderBy) => void
 }
 
 export function LogRowHeader({
@@ -41,6 +46,8 @@ export function LogRowHeader({
     totalCount = 0,
     onSelectAll,
     onClearSelection,
+    orderBy,
+    onChangeOrderBy,
 }: LogRowHeaderProps): JSX.Element {
     const flexWidth =
         rowWidth -
@@ -69,8 +76,21 @@ export function LogRowHeader({
             </div>
 
             {/* Timestamp */}
-            <div className="flex items-center pr-3" style={{ width: TIMESTAMP_WIDTH, flexShrink: 0 }}>
+            <div
+                className="flex items-center justify-between pr-3 gap-1 h-full border-r"
+                style={{ width: TIMESTAMP_WIDTH, flexShrink: 0 }}
+            >
                 Timestamp
+                <LemonButton
+                    size="xsmall"
+                    className="h-full"
+                    icon={orderBy === 'latest' ? <IconArrowDown /> : <IconArrowUp />}
+                    tooltip={orderBy === 'latest' ? 'Showing latest first' : 'Showing earliest first'}
+                    onClick={() => {
+                        const newOrderBy = orderBy === 'latest' ? 'earliest' : 'latest'
+                        onChangeOrderBy?.(newOrderBy)
+                    }}
+                />
             </div>
 
             {/* Attribute columns */}
@@ -127,7 +147,7 @@ export function LogRowHeader({
                                         size="xsmall"
                                         noPadding
                                         icon={<IconEllipsis className="text-muted" />}
-                                        className="opacity-0 group-hover/header:opacity-100 shrink-0"
+                                        className="shrink-0"
                                     />
                                 </LemonMenu>
                             )}

--- a/products/logs/frontend/components/VirtualizedLogsList/LogRowHeader.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRowHeader.tsx
@@ -85,11 +85,16 @@ export function LogRowHeader({
                     size="xsmall"
                     className="h-full"
                     icon={orderBy === 'latest' ? <IconArrowDown /> : <IconArrowUp />}
-                    tooltip={orderBy === 'latest' ? 'Showing latest first' : 'Showing earliest first'}
+                    tooltip={
+                        orderBy === 'latest'
+                            ? 'Showing latest first. Click to show earliest first (reloads).'
+                            : 'Showing earliest first. Click to show latest first (reloads).'
+                    }
                     onClick={() => {
                         const newOrderBy = orderBy === 'latest' ? 'earliest' : 'latest'
                         onChangeOrderBy?.(newOrderBy)
                     }}
+                    disabled={!orderBy || !onChangeOrderBy}
                 />
             </div>
 

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -21,7 +21,7 @@ import {
     getMinRowWidth,
 } from 'products/logs/frontend/components/VirtualizedLogsList/layoutUtils'
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
-import { ParsedLogMessage } from 'products/logs/frontend/types'
+import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
 
 interface VirtualizedLogsListProps {
     dataSource: ParsedLogMessage[]
@@ -36,6 +36,8 @@ interface VirtualizedLogsListProps {
     hasMoreLogsToLoad?: boolean
     onLoadMore?: () => void
     onExpandTimeRange?: () => void
+    orderBy?: LogsOrderBy
+    onChangeOrderBy?: (orderBy: LogsOrderBy) => void
 }
 
 export function VirtualizedLogsList({
@@ -51,6 +53,8 @@ export function VirtualizedLogsList({
     hasMoreLogsToLoad = false,
     onLoadMore,
     onExpandTimeRange,
+    orderBy,
+    onChangeOrderBy,
 }: VirtualizedLogsListProps): JSX.Element {
     const {
         tabId,
@@ -292,6 +296,8 @@ export function VirtualizedLogsList({
                                     totalCount={dataSource.length}
                                     onSelectAll={() => selectAll(dataSource)}
                                     onClearSelection={clearSelection}
+                                    orderBy={orderBy}
+                                    onChangeOrderBy={onChangeOrderBy}
                                 />
                                 <List
                                     ref={listRef}
@@ -342,6 +348,8 @@ export function VirtualizedLogsList({
                                 totalCount={dataSource.length}
                                 onSelectAll={() => selectAll(dataSource)}
                                 onClearSelection={clearSelection}
+                                orderBy={orderBy}
+                                onChangeOrderBy={onChangeOrderBy}
                             />
                             <List
                                 ref={listRef}

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -239,7 +239,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             liveTailAbortController,
         }),
         setDateRange: (dateRange: DateRange) => ({ dateRange }),
-        setOrderBy: (orderBy: LogsOrderBy) => ({ orderBy }),
+        setOrderBy: (orderBy: LogsOrderBy, source: 'header' | 'toolbar' = 'toolbar') => ({ orderBy, source }),
         setSearchTerm: (searchTerm: LogsQuery['searchTerm']) => ({ searchTerm }),
         setSeverityLevels: (severityLevels: LogsQuery['severityLevels']) => ({ severityLevels }),
         setServiceNames: (serviceNames: LogsQuery['serviceNames']) => ({ serviceNames }),
@@ -901,8 +901,8 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             }
             actions.syncUrlAndRunQuery()
         },
-        setOrderBy: ({ orderBy }) => {
-            posthog.capture('logs setting changed', { setting: 'order_by', value: orderBy })
+        setOrderBy: ({ orderBy, source }) => {
+            posthog.capture('logs setting changed', { setting: 'order_by', value: orderBy, source })
             actions.syncUrlAndRunQuery()
         },
         setLogsPageSize: () => {


### PR DESCRIPTION
## Problem

We currently have an earliest/latest option in the toolbar, I'm in the process of cleaning this up & I want to see if the earliest/latest functionality works just as well for users directly on the timestamp column header.

## Changes  
![image.png](https://app.graphite.com/user-attachments/assets/f185c0f5-198c-45c9-923c-247a343de09e.png)

- Added a source parameter to `onChangeOrderBy` to track whether sorting changes come from the header or toolbar
- Added a sort direction button in the timestamp column header
- Passed orderBy and onChangeOrderBy props to VirtualizedLogsList components
- Instrumented analytics to track the source of sort order changes

## How did you test this code?

Tested by:

- Changing sort order using both the new header button and existing toolbar controls
- Verifying that analytics events include the correct source parameter
- Ensuring the sort direction indicator displays correctly in both ascending and descending modes

## Publish to changelog?

No