### PR TITLE
fix: does front end bundle need more oomph

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -109,7 +109,7 @@ jobs:
         name: Frontend bundle size
         needs: [changes]
         if: needs.changes.outputs.frontend == 'true' && github.event_name != 'merge_group'
-        runs-on: depot-ubuntu-24.04
+        runs-on: depot-ubuntu-24.04-4
         steps:
             - uses: actions/checkout@v6
             - name: Install pnpm


### PR DESCRIPTION
Increase runner from depot-ubuntu-24.04 (2 cores) to depot-ubuntu-24.04-4 (4 cores) to address runner connectivity issues.

