### PR TITLE
chore(llma): remove Beta tag from Errors tab

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -722,14 +722,7 @@ export function LLMAnalyticsScene(): JSX.Element {
     ) {
         tabs.push({
             key: 'errors',
-            label: (
-                <>
-                    Errors{' '}
-                    <LemonTag className="ml-1" type="warning">
-                        Beta
-                    </LemonTag>
-                </>
-            ),
+            label: 'Errors',
             content: (
                 <LLMAnalyticsSetupPrompt>
                     <LLMAnalyticsErrors />


### PR DESCRIPTION
## Problem

The Errors tab in LLM Analytics is ready to graduate to GA. The Beta tag in the UI should be removed.

Part of #44323

## Changes

Removes the Beta `<LemonTag>` from the Errors tab label.

**Before:** `Errors Beta`
**After:** `Errors`

## How did you test this code?

Visual inspection. The feature flag remains at 100% rollout as a safety net.

## Publish to changelog?

yes - LLM Analytics errors tab is now generally available.