### PR TITLE
feat(billing): add all Harmonic tags to Salesforce Accounts

### DIFF
--- a/ee/billing/salesforce_enrichment/constants.py
+++ b/ee/billing/salesforce_enrichment/constants.py
@@ -1,6 +1,7 @@
 REDIS_TTL_SECONDS: int = 12 * 60 * 60  # 12h
 SALESFORCE_ACCOUNTS_CACHE_KEY: str = "salesforce-enrichment:global:all_accounts"
 HARMONIC_BASE_URL: str = "https://api.harmonic.ai"
+YC_INVESTOR_NAME: str = "y combinator"
 HARMONIC_DEFAULT_MAX_CONCURRENT_REQUESTS: int = 5  # rate limit: 10/s
 HARMONIC_REQUEST_TIMEOUT_SECONDS: int = 30
 HARMONIC_BATCH_SIZE: int = 100
@@ -38,6 +39,14 @@ mutation($identifiers: CompanyEnrichmentIdentifiersInput!) {
                 lastFundingType
                 lastFundingTotal
                 fundingStage
+                investors {
+                    ... on Company {
+                        name
+                    }
+                    ... on Person {
+                        fullName
+                    }
+                }
             }
             tractionMetrics {
                 webTraffic {

--- a/ee/billing/test/fixtures/harmonic_api_response.json
+++ b/ee/billing/test/fixtures/harmonic_api_response.json
@@ -26,7 +26,13 @@
             "lastFundingAt": "2025-02-25T00:00:00Z",
             "lastFundingType": "POST_IPO_DEBT",
             "lastFundingTotal": 500000000,
-            "fundingStage": "EXITED"
+            "fundingStage": "EXITED",
+            "investors": [
+                {"name": "Formus Capital"},
+                {"name": "Peak XV Partners"},
+                {"name": "GV"},
+                {"fullName": "Julia Dewahl"}
+            ]
         },
         "tractionMetrics": {
             "webTraffic": {


### PR DESCRIPTION
## Problem
Follow up from: https://github.com/PostHog/posthog/pull/44630#pullrequestreview-3657562010

We want to store all tags from Harmonic in SFDC. We'll use SFDC Junction objects for this to create relationships between the tags and Accounts

## Changes

- Added `_normalize_text_value()` function to standardize text values for consistent storage
- Implemented `_prepare_harmonic_tags()` to process and deduplicate tags from Harmonic API
- Enhanced YC company detection with better comments and handling of edge cases
- Added comprehensive test coverage for all new functionality

## How did you test this code?

- Added extensive unit tests for all new functions:
  - Tests for `_normalize_text_value()` with various input formats
  - Tests for `_prepare_harmonic_tags()` covering deduplication, normalization, and edge cases
  - Added test for YC detection when investors key is missing
- Verified that existing functionality remains unchanged

## Publish to changelog?

No