### PR TITLE
fix(cdp): billable invocation dispatching

### DIFF
--- a/nodejs/src/cdp/cdp-e2e.test.ts
+++ b/nodejs/src/cdp/cdp-e2e.test.ts
@@ -220,7 +220,7 @@ describe.each(['postgres' as const, 'kafka' as const, 'hybrid' as const])('CDP C
                     topic: 'clickhouse_app_metrics2_test',
                     value: {
                         app_source: 'hog_function',
-                        app_source_id: fnFetchNoFilters.id.toString(),
+                        app_source_id: '_event_trigger',
                         count: 1,
                         metric_kind: 'billing',
                         metric_name: 'billable_invocation',

--- a/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -196,64 +196,43 @@ describe.each([
 
                 expect(mockQueueInvocations).toHaveBeenCalledWith(invocations)
 
-                expect(
-                    mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
-                ).toMatchObject(
-                    [
-                        {
-                            key: expect.any(String),
-                            topic: 'clickhouse_app_metrics2_test',
-                            value: {
+                const metrics = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
+
+                // Check triggered metrics (one per destination)
+                const triggeredMetrics = metrics.filter((m: any) => m.value.metric_name === 'triggered')
+                expect(triggeredMetrics).toHaveLength(2)
+                expect(triggeredMetrics).toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({
+                            value: expect.objectContaining({
                                 app_source: 'hog_function',
                                 app_source_id: fnFetchNoFilters.id,
-                                count: 1,
-                                metric_kind: 'other',
                                 metric_name: 'triggered',
-                                team_id: 2,
-                                timestamp: expect.any(String),
-                            },
-                        },
-                        hogType === 'destination' && {
-                            key: expect.any(String),
-                            topic: 'clickhouse_app_metrics2_test',
-                            value: {
-                                app_source: 'hog_function',
-                                app_source_id: fnFetchNoFilters.id,
-                                count: 1,
-                                metric_kind: 'billing',
-                                metric_name: 'billable_invocation',
-                                team_id: 2,
-                                timestamp: expect.any(String),
-                            },
-                        },
-                        {
-                            key: expect.any(String),
-                            topic: 'clickhouse_app_metrics2_test',
-                            value: {
+                            }),
+                        }),
+                        expect.objectContaining({
+                            value: expect.objectContaining({
                                 app_source: 'hog_function',
                                 app_source_id: fnPrinterPageviewFilters.id,
-                                count: 1,
-                                metric_kind: 'other',
                                 metric_name: 'triggered',
-                                team_id: 2,
-                                timestamp: expect.any(String),
-                            },
-                        },
-                        hogType === 'destination' && {
-                            key: expect.any(String),
-                            topic: 'clickhouse_app_metrics2_test',
-                            value: {
-                                app_source: 'hog_function',
-                                app_source_id: fnPrinterPageviewFilters.id,
-                                count: 1,
-                                metric_kind: 'billing',
-                                metric_name: 'billable_invocation',
-                                team_id: 2,
-                                timestamp: expect.any(String),
-                            },
-                        },
-                    ].filter((x) => !!x)
+                            }),
+                        }),
+                    ])
                 )
+
+                // Billing is per-event, not per-destination: 1 event → 2 destinations = 1 billable_invocation
+                if (hogType === 'destination') {
+                    const billingMetrics = metrics.filter((m: any) => m.value.metric_name === 'billable_invocation')
+                    expect(billingMetrics).toHaveLength(1)
+                    expect(billingMetrics[0].value).toMatchObject({
+                        app_source: 'hog_function',
+                        app_source_id: '_event_trigger',
+                        instance_id: globals.event.uuid,
+                        metric_kind: 'billing',
+                        metric_name: 'billable_invocation',
+                        team_id: 2,
+                    })
+                }
             })
 
             it("should filter out functions that don't match the filter", async () => {
@@ -297,6 +276,7 @@ describe.each([
                             timestamp: expect.any(String),
                         },
                     },
+                    // Billing is per-event: 1 event → 1 destination = 1 billable_invocation
                     ...(hogType !== 'destination'
                         ? []
                         : [
@@ -305,7 +285,8 @@ describe.each([
                                   topic: 'clickhouse_app_metrics2_test',
                                   value: {
                                       app_source: 'hog_function',
-                                      app_source_id: fnFetchNoFilters.id,
+                                      app_source_id: '_event_trigger',
+                                      instance_id: globals.event.uuid,
                                       count: 1,
                                       metric_kind: 'billing',
                                       metric_name: 'billable_invocation',
@@ -351,6 +332,58 @@ describe.each([
                     },
                 ])
             })
+
+            if (hogType === 'destination') {
+                it('should bill once per event, not per destination (multiple events)', async () => {
+                    // Create a second event with different UUID
+                    const globals2 = createHogExecutionGlobals({
+                        project: {
+                            id: team.id,
+                        } as any,
+                        event: {
+                            uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+                            event: '$pageview',
+                            properties: {
+                                $current_url: 'https://posthog.com',
+                                $lib_version: '1.0.0',
+                            },
+                        } as any,
+                    })
+
+                    // Process both events - each should trigger both destinations
+                    const { invocations } = await processor.processBatch([globals, globals2])
+
+                    // 2 events × 2 destinations = 4 invocations
+                    expect(invocations).toHaveLength(4)
+
+                    const billingMetrics = mockProducerObserver
+                        .getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
+                        .filter((m: any) => m.value.metric_name === 'billable_invocation')
+
+                    // 2 events = 2 billable_invocations (not 4)
+                    expect(billingMetrics).toHaveLength(2)
+
+                    // Each billing metric should have app_source_id='_event_trigger' and unique event UUID
+                    expect(billingMetrics).toEqual(
+                        expect.arrayContaining([
+                            expect.objectContaining({
+                                value: expect.objectContaining({
+                                    app_source_id: '_event_trigger',
+                                    instance_id: globals.event.uuid,
+                                    metric_name: 'billable_invocation',
+                                }),
+                            }),
+                            expect.objectContaining({
+                                value: expect.objectContaining({
+                                    app_source_id: '_event_trigger',
+                                    instance_id: globals2.event.uuid,
+                                    metric_name: 'billable_invocation',
+                                }),
+                            }),
+                        ])
+                    )
+                })
+            }
         })
 
         describe('quota limiting', () => {

--- a/nodejs/src/cdp/consumers/cdp-events.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-events.consumer.ts
@@ -209,6 +209,9 @@ export class CdpEventsConsumer<THub extends CdpEventsConsumerHub = CdpEventsCons
 
         const triggeredInvocationsMetrics: MinimalAppMetric[] = []
 
+        // Track unique events that have been billed (billing is per-event, not per-destination)
+        const billedEventUuids = new Set<string>()
+
         notMaskedInvocations.forEach((item) => {
             triggeredInvocationsMetrics.push({
                 team_id: item.teamId,
@@ -218,14 +221,20 @@ export class CdpEventsConsumer<THub extends CdpEventsConsumerHub = CdpEventsCons
                 count: 1,
             })
 
+            // Bill once per triggering event, not per destination
             if (item.hogFunction.type === 'destination') {
-                triggeredInvocationsMetrics.push({
-                    team_id: item.teamId,
-                    app_source_id: item.functionId,
-                    metric_kind: 'billing',
-                    metric_name: 'billable_invocation',
-                    count: 1,
-                })
+                const eventUuid = item.state?.globals?.event?.uuid
+                if (eventUuid && !billedEventUuids.has(eventUuid)) {
+                    billedEventUuids.add(eventUuid)
+                    triggeredInvocationsMetrics.push({
+                        team_id: item.teamId,
+                        app_source_id: '_event_trigger',
+                        instance_id: eventUuid,
+                        metric_kind: 'billing',
+                        metric_name: 'billable_invocation',
+                        count: 1,
+                    })
+                }
             }
         })
 


### PR DESCRIPTION
## Problem

c.f. https://posthog.slack.com/archives/C08ERRQT41E/p1768465619916409

Real-time destinations billing was incorrectly counting per-destination instead of per-triggering-event.              
                                                                                                       
  Example of the bug:                                                                                                   
  - Customer has 10 destinations listening to a subscribe event                                                         
  - 185 subscribe events occur                                                                
  - Result: ~1,850 billable invocations charged (185 × 10)                                                              
  - Expected: ~185 billable invocations (one per event)      

Per the pricing RFC, billing should be once per triggering event, regardless of how many destinations fan out from it. @abheek9 

## Changes

Modified billing logic in both event consumers to deduplicate by event UUID:                                          
                                                                                                                        
  - `nodejs/src/cdp/consumers/cdp-events.consumer.ts`                                                        
  - `nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts`
                                                                                                                        
  The billable_invocation metric now uses:                                                                              
  `- app_source_id: '_event_trigger' (since billing is per-event, not per-function)`
  - instance_id: eventUuid (for traceability)       

##   Why instance_id for the event UUID (open for discussion)                                                                             
                                                                                                                        
app_source_id is semantically tied to function/flow IDs throughout the codebase so might be odd using the eventUuid here?              

## How did you test this code?

 - Updated existing tests and added new test cases              
