### PR TITLE
chore(data-warehouse): Use the correct source

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/cdp_producer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/cdp_producer.py
@@ -87,13 +87,13 @@ class CDPProducer:
         dot_notated_table_name = get_data_warehouse_table_name(schema.source, raw_table_name)
 
         self.logger.debug(f"Checking if table {dot_notated_table_name} is used in any HogQL functions")
-        self.logger.debug(f"Using table_name = {dot_notated_table_name}, source = data-warehouse")
+        self.logger.debug(f"Using table_name = {dot_notated_table_name}, source = data-warehouse-table")
 
         return (
             HogFunction.objects.filter(
                 team_id=self.team_id,
                 enabled=True,
-                filters__source="data-warehouse",
+                filters__source="data-warehouse-table",
                 filters__data_warehouse__contains=[{"table_name": dot_notated_table_name}],
             )
             .exclude(deleted=True)

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_cdp_producer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_cdp_producer.py
@@ -37,7 +37,7 @@ def test_should_produce_table_with_matching_hog_function(team):
     HogFunction.objects.create(
         team=team,
         enabled=True,
-        filters={"source": "data-warehouse", "data_warehouse": [{"table_name": "postgres.table_1"}]},
+        filters={"source": "data-warehouse-table", "data_warehouse": [{"table_name": "postgres.table_1"}]},
     )
 
     producer = CDPProducer(team_id=team.id, schema_id=str(schema.id), job_id="", logger=mock.MagicMock())
@@ -53,7 +53,7 @@ def test_should_not_produce_table_with_disabled_matching_hog_function(team):
     HogFunction.objects.create(
         team=team,
         enabled=False,
-        filters={"source": "data-warehouse", "data_warehouse": [{"table_name": "postgres.table_1"}]},
+        filters={"source": "data-warehouse-table", "data_warehouse": [{"table_name": "postgres.table_1"}]},
     )
 
     producer = CDPProducer(team_id=team.id, schema_id=str(schema.id), job_id="", logger=mock.MagicMock())
@@ -70,7 +70,7 @@ def test_should_not_produce_table_with_deleted_matching_hog_function(team):
         team=team,
         enabled=True,
         deleted=True,
-        filters={"source": "data-warehouse", "data_warehouse": [{"table_name": "postgres.table_1"}]},
+        filters={"source": "data-warehouse-table", "data_warehouse": [{"table_name": "postgres.table_1"}]},
     )
 
     producer = CDPProducer(team_id=team.id, schema_id=str(schema.id), job_id="", logger=mock.MagicMock())
@@ -86,7 +86,7 @@ def test_should_produce_table_with_new_style_table_name(team):
     HogFunction.objects.create(
         team=team,
         enabled=True,
-        filters={"source": "data-warehouse", "data_warehouse": [{"table_name": "postgres.table_1"}]},
+        filters={"source": "data-warehouse-table", "data_warehouse": [{"table_name": "postgres.table_1"}]},
     )
 
     producer = CDPProducer(team_id=team.id, schema_id=str(schema.id), job_id="", logger=mock.MagicMock())
@@ -102,7 +102,7 @@ def test_should_produce_table_with_source_prefix(team):
     HogFunction.objects.create(
         team=team,
         enabled=True,
-        filters={"source": "data-warehouse", "data_warehouse": [{"table_name": "postgres.eu.table_1"}]},
+        filters={"source": "data-warehouse-table", "data_warehouse": [{"table_name": "postgres.eu.table_1"}]},
     )
 
     producer = CDPProducer(team_id=team.id, schema_id=str(schema.id), job_id="", logger=mock.MagicMock())
@@ -118,7 +118,7 @@ def test_should_produce_table_with_leading_underscore_source_prefix(team):
     HogFunction.objects.create(
         team=team,
         enabled=True,
-        filters={"source": "data-warehouse", "data_warehouse": [{"table_name": "postgres.eu.table_1"}]},
+        filters={"source": "data-warehouse-table", "data_warehouse": [{"table_name": "postgres.eu.table_1"}]},
     )
 
     producer = CDPProducer(team_id=team.id, schema_id=str(schema.id), job_id="", logger=mock.MagicMock())

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -2959,7 +2959,7 @@ async def test_cdp_producer_push_to_s3(team, stripe_customer, mock_stripe_client
     await sync_to_async(HogFunction.objects.create)(
         team=team,
         enabled=True,
-        filters={"source": "data-warehouse", "data_warehouse": [{"table_name": "stripe.customer"}]},
+        filters={"source": "data-warehouse-table", "data_warehouse": [{"table_name": "stripe.customer"}]},
     )
 
     with mock.patch(
@@ -3011,7 +3011,7 @@ async def test_cdp_producer_push_to_kafka(team, stripe_customer, mock_stripe_cli
     await sync_to_async(HogFunction.objects.create)(
         team=team,
         enabled=True,
-        filters={"source": "data-warehouse", "data_warehouse": [{"table_name": "stripe.customer"}]},
+        filters={"source": "data-warehouse-table", "data_warehouse": [{"table_name": "stripe.customer"}]},
     )
 
     with (


### PR DESCRIPTION
## Problem
- The CDP source name for warehouse tables changed, but it wasn't updated on the python side

## Changes
- Update the source name
