### PR TITLE
chore(llma): remove beta badge from Sessions tab

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -747,14 +747,7 @@ export function LLMAnalyticsScene(): JSX.Element {
     ) {
         tabs.push({
             key: 'sessions',
-            label: (
-                <>
-                    Sessions{' '}
-                    <LemonTag className="ml-1" type="warning">
-                        Beta
-                    </LemonTag>
-                </>
-            ),
+            label: 'Sessions',
             content: (
                 <LLMAnalyticsSetupPrompt>
                     <LLMAnalyticsSessionsScene />


### PR DESCRIPTION
## Problem

The LLM Analytics Sessions tab is ready for GA but still displays a beta badge.

Closes #45438

## Changes

Remove the beta badge from the Sessions tab label in the LLM Analytics UI.

Feature flag gating is intentionally kept in place as a safety valve.

## How did you test this code?

- TypeScript check passes (no new errors introduced)
- Visual verification that Sessions tab no longer shows beta badge

## Publish to changelog?

yes - LLM Analytics Sessions tab is now generally available.