### PR TITLE
chore(llma): remove Sessions tab feature flag gating

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -280,7 +280,6 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_SESSION_SUMMARIZATION: 'llm-analytics-session-summarization', // owner: #team-llm-analytics
     LLM_ANALYTICS_CLUSTERS_TAB: 'llm-analytics-clusters-tab', // owner: #team-llm-analytics
     LLM_ANALYTICS_CLUSTERING_ADMIN: 'llm-analytics-clustering-admin', // owner: #team-llm-analytics
-    LLM_ANALYTICS_SESSIONS_VIEW: 'llm-analytics-sessions-view', // owner: #team-llm-analytics
     LLM_ANALYTICS_SUMMARIZATION: 'llm-analytics-summarization', // owner: #team-llm-analytics
     LLM_ANALYTICS_TEXT_VIEW: 'llm-analytics-text-view', // owner: #team-llm-analytics
     LLM_ANALYTICS_TRANSLATION: 'llm-analytics-translation', // owner: #team-llm-analytics

--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -733,30 +733,17 @@ export function LLMAnalyticsScene(): JSX.Element {
         })
     }
 
-    // TODO: Once we remove FF, should add to the shortcuts list at the top of the component
-    if (
-        featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SESSIONS_VIEW] ||
-        featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
-    ) {
-        tabs.push({
-            key: 'sessions',
-            label: (
-                <>
-                    Sessions{' '}
-                    <LemonTag className="ml-1" type="warning">
-                        Beta
-                    </LemonTag>
-                </>
-            ),
-            content: (
-                <LLMAnalyticsSetupPrompt>
-                    <LLMAnalyticsSessionsScene />
-                </LLMAnalyticsSetupPrompt>
-            ),
-            link: combineUrl(urls.llmAnalyticsSessions(), searchParams).url,
-            'data-attr': 'sessions-tab',
-        })
-    }
+    tabs.push({
+        key: 'sessions',
+        label: 'Sessions',
+        content: (
+            <LLMAnalyticsSetupPrompt>
+                <LLMAnalyticsSessionsScene />
+            </LLMAnalyticsSetupPrompt>
+        ),
+        link: combineUrl(urls.llmAnalyticsSessions(), searchParams).url,
+        'data-attr': 'sessions-tab',
+    })
 
     // TODO: Once we are out of beta, should add to the shortcuts list at the top of the component
     tabs.push({

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -215,27 +215,8 @@ function TraceMetadata({
     markupUsd?: number
     showBillingInfo?: boolean
 }): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-
     const getSessionUrl = (sessionId: string): string => {
-        if (
-            featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SESSIONS_VIEW] ||
-            featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
-        ) {
-            return urls.llmAnalyticsSession(sessionId, { timestamp: getSessionStartTimestamp(trace.createdAt) })
-        }
-        // Fallback to filtering traces by session when feature flag is off
-        const filter = [
-            {
-                key: '$ai_session_id',
-                value: [sessionId],
-                operator: 'exact',
-                type: 'event',
-            },
-        ]
-        const params = new URLSearchParams()
-        params.set('filters', JSON.stringify(filter))
-        return `${urls.llmAnalyticsTraces()}?${params.toString()}`
+        return urls.llmAnalyticsSession(sessionId, { timestamp: getSessionStartTimestamp(trace.createdAt) })
     }
 
     return (
@@ -246,14 +227,7 @@ function TraceMetadata({
                 </Chip>
             )}
             {trace.aiSessionId && (
-                <Chip
-                    title={
-                        featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SESSIONS_VIEW] ||
-                        featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
-                            ? 'AI Session ID - Click to view session details'
-                            : 'AI Session ID - Click to filter traces by this session'
-                    }
-                >
+                <Chip title="AI Session ID - Click to view session details">
                     <Link to={getSessionUrl(trace.aiSessionId)} subtle>
                         <span className="font-mono">{trace.aiSessionId.slice(0, 8)}...</span>
                     </Link>


### PR DESCRIPTION
## Problem

Sessions tab feature flag gating is no longer needed now that the feature is GA.

Closes #45438

## Changes

- Remove feature flag checks for `LLM_ANALYTICS_SESSIONS_VIEW` from `LLMAnalyticsScene.tsx`
- Simplify session URL logic in `LLMAnalyticsTraceScene.tsx` (always link to session detail page)
- Remove `LLM_ANALYTICS_SESSIONS_VIEW` constant from `constants.tsx`

## How did you test this code?

- Pre-commit hooks pass
- Sessions tab renders without feature flag

## Publish to changelog?

No - this is cleanup, user-facing change was in #45441