### PR TITLE
chore(data-table): Adjust count text size and add vertical divider when query timing is shown

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -761,9 +761,11 @@ export function DataTable({
         ) : null,
     ].filter((x) => !!x)
 
+    const shouldShowCount = showCount && sourceFeatures.has(QueryFeature.showCount)
     const secondRowLeft = [
         showReload ? <Reload key="reload" /> : null,
         showCount && sourceFeatures.has(QueryFeature.showCount) ? <DataTableCount key="count" /> : null,
+        shouldShowCount && showElapsedTime ? <LemonDivider vertical={true} key="divider" /> : null,
         showElapsedTime ? <ElapsedTime key="elapsed-time" showTimings={showTimings} /> : null,
     ].filter((x) => !!x)
 

--- a/frontend/src/queries/nodes/DataTable/DataTableCount.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableCount.tsx
@@ -26,7 +26,7 @@ export function DataTableCount(): JSX.Element | null {
         ? `${pluralize(displayFilteredCount, entityType.singular, entityType.plural)} matched out of ${totalCount.toLocaleString()}`
         : `Total count: ${pluralize(totalCount, entityType.singular, entityType.plural)}`
 
-    return <span className="text-xs">{text}</span>
+    return <span className="text-small">{text}</span>
 }
 
 function getEntityType(query: any): { singular: string; plural: string } {


### PR DESCRIPTION
## Problem

The data table UI has inconsistent styling and lacks a visual separator between the count and elapsed time elements.

## Changes

- Added a vertical divider between the count and elapsed time elements in the data table
- Updated the styling of the count text from `text-xs` to `text-small`

### Before

![image.png](https://app.graphite.com/user-attachments/assets/3d40bb3f-97c0-4aa2-b333-4927c3345120.png)

### Now without timing

![image.png](https://app.graphite.com/user-attachments/assets/4e344664-2d0d-44de-9222-bcf942e2fc32.png)

### Now with timing

![image.png](https://app.graphite.com/user-attachments/assets/ab23742a-f354-4b17-ade9-05d37a9ed001.png)

## How did you test this code?

I manually tested the UI changes by viewing data tables with both count and elapsed time displayed, verifying that the divider appears correctly and the text styling is consistent.

## Publish to changelog?

No