### PR TITLE
fix(insights): disable sampling for funnel insights

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/SamplingFilter.tsx
@@ -17,7 +17,7 @@ interface SamplingFilterProps {
 }
 
 export function SamplingFilter({ insightProps, infoTooltipContent }: SamplingFilterProps): JSX.Element {
-    const { hasDataWarehouseSeries, insightType } = useValues(insightVizDataLogic(insightProps))
+    const { hasDataWarehouseSeries, insightType, isFunnels } = useValues(insightVizDataLogic(insightProps))
     const { samplingPercentage, isSamplingAvailable } = useValues(samplingFilterLogic(insightProps))
     const { setSamplingPercentage } = useActions(samplingFilterLogic(insightProps))
 
@@ -58,9 +58,7 @@ export function SamplingFilter({ insightProps, infoTooltipContent }: SamplingFil
                             options={AVAILABLE_SAMPLING_PERCENTAGES.map((percentage) => ({
                                 value: percentage,
                                 label: `${percentage}%`,
-                                disabledReason: isSamplingAvailable
-                                    ? 'Sampling percentage cannot be changed for funnels'
-                                    : undefined,
+                                disabledReason: isFunnels ? 'Sampling is not supported for funnels' : undefined,
                             }))}
                             value={samplingPercentage}
                             onChange={(newValue) => {

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -73,9 +73,13 @@ export function InsightEmptyState({
     )
 }
 
-function SamplingLink({ insightProps }: { insightProps: InsightLogicProps }): JSX.Element {
+function SamplingLink({ insightProps }: { insightProps: InsightLogicProps }): JSX.Element | null {
     const { setSamplingPercentage } = useActions(samplingFilterLogic(insightProps))
     const { suggestedSamplingPercentage } = useValues(samplingFilterLogic(insightProps))
+
+    if (suggestedSamplingPercentage === null) {
+        return null
+    }
 
     return (
         <Tooltip

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -186,6 +186,27 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         isWebStatsTable: [(s) => [s.querySource], (q) => isWebStatsTableQuery(q)],
         isWebOverview: [(s) => [s.querySource], (q) => isWebOverviewQuery(q)],
         isWebAnalytics: [(s) => [s.querySource], (q) => isWebAnalyticsInsightQuery(q)],
+        insightType: [
+            (s) => [s.isTrends, s.isFunnels, s.isRetention, s.isPaths, s.isStickiness, s.isLifecycle],
+            (isTrends, isFunnels, isRetention, isPaths, isStickiness, isLifecycle) => {
+                switch (true) {
+                    case isTrends:
+                        return 'Trends'
+                    case isFunnels:
+                        return 'Funnels'
+                    case isRetention:
+                        return 'Retention'
+                    case isPaths:
+                        return 'Paths'
+                    case isStickiness:
+                        return 'Stickiness'
+                    case isLifecycle:
+                        return 'Lifecycle'
+                    default:
+                        return 'Unknown'
+                }
+            },
+        ],
         isTrendsLike: [(s) => [s.querySource], (q) => isTrendsQuery(q) || isLifecycleQuery(q) || isStickinessQuery(q)], // this is for filtering out world map
         supportsDisplay: [(s) => [s.querySource], (q) => isTrendsQuery(q) || isStickinessQuery(q)],
         supportsCompare: [


### PR DESCRIPTION
Sampling has known issues with funnels, so disable it for new funnel insights. Existing funnels with sampling enabled can still turn it off but cannot re-enable it or change the percentage. Sends a specific event when a user disables sampling on a funnel insight.

https://github.com/user-attachments/assets/9c09bc65-39a9-4530-94ed-f5f14a475bd9

