### PR TITLE
chore(llma): use GPT-4.1 mini for temporal trace summarization

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -4,15 +4,15 @@ from datetime import timedelta
 
 from temporalio.common import RetryPolicy
 
-from products.llm_analytics.backend.summarization.models import GeminiModel, SummarizationMode, SummarizationProvider
+from products.llm_analytics.backend.summarization.models import OpenAIModel, SummarizationMode, SummarizationProvider
 
 # Window processing configuration
 DEFAULT_MAX_TRACES_PER_WINDOW = 10  # Max traces to process per window (conservative for worst-case 30s/trace)
 DEFAULT_BATCH_SIZE = 3  # Number of traces to process in parallel (reduced to avoid rate limits)
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)
-DEFAULT_PROVIDER = SummarizationProvider.GEMINI
-DEFAULT_MODEL = GeminiModel.GEMINI_3_FLASH_PREVIEW
+DEFAULT_PROVIDER = SummarizationProvider.OPENAI
+DEFAULT_MODEL = OpenAIModel.GPT_4_1_MINI
 
 # Max text representation length by provider (in characters)
 # Gemini models have ~1M token context. At typical 2.5:1 char/token ratio,
@@ -37,7 +37,7 @@ WORKFLOW_EXECUTION_TIMEOUT_MINUTES = 120  # Max time for single team workflow (i
 # Retry policies
 SAMPLE_RETRY_POLICY = RetryPolicy(maximum_attempts=3)
 # Summarize retries with exponential backoff for rate limit handling (429s)
-# Gemini rate limits reset per minute, so 15s initial with 2x backoff handles most cases
+# 15s initial with 2x backoff handles most rate limit scenarios
 SUMMARIZE_RETRY_POLICY = RetryPolicy(
     maximum_attempts=4,
     initial_interval=timedelta(seconds=15),


### PR DESCRIPTION
## Problem

The temporal trace summarization workflow uses Gemini 3 Flash Preview while the frontend uses GPT-4.1 mini. This inconsistency makes debugging harder and may produce different summary quality.

Switching back to gpt-4.1 for consistency for now.

## Changes

Switch temporal workflow default from Gemini 3 Flash Preview to OpenAI GPT-4.1 mini to match frontend defaults.

## How did you test this code?

Ran existing tests: `pytest posthog/temporal/llm_analytics/trace_summarization/tests/` - all 12 tests pass.

## Publish to changelog?

No