### PR TITLE
feat(approvals): make the policy snapshots human readable

### DIFF
--- a/frontend/src/scenes/approvals/ApprovalDetail.tsx
+++ b/frontend/src/scenes/approvals/ApprovalDetail.tsx
@@ -368,13 +368,21 @@ interface PolicySnapshot {
 }
 
 function PolicyConfigurationDisplay({ policySnapshot }: { policySnapshot?: PolicySnapshot }): JSX.Element {
-    const { members } = useValues(membersLogic)
-    const { roles } = useValues(rolesLogic)
+    const { members, membersLoading } = useValues(membersLogic)
+    const { roles, rolesLoading } = useValues(rolesLogic)
 
     if (!policySnapshot) {
         return (
             <div className="bg-bg-light p-4 rounded border">
                 <span className="text-secondary">No policy configuration available</span>
+            </div>
+        )
+    }
+
+    if (membersLoading || rolesLoading) {
+        return (
+            <div className="bg-bg-light p-4 rounded border">
+                <LemonSkeleton className="h-32" />
             </div>
         )
     }

--- a/frontend/src/scenes/approvals/ApprovalDetail.tsx
+++ b/frontend/src/scenes/approvals/ApprovalDetail.tsx
@@ -1,6 +1,6 @@
 import useSize from '@react-hook/size'
 import { useActions, useValues } from 'kea'
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { LemonTag, lemonToast } from '@posthog/lemon-ui'
 
@@ -13,7 +13,9 @@ import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { Link } from 'lib/lemon-ui/Link'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { getApprovalActionLabel, getApprovalResourceName, getApprovalResourceUrl } from 'scenes/approvals/utils'
+import { membersLogic } from 'scenes/organization/membersLogic'
 import { SceneExport } from 'scenes/sceneTypes'
+import { rolesLogic } from 'scenes/settings/organization/Permissions/Roles/rolesLogic'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
@@ -37,9 +39,16 @@ function ApprovalDetail({ id }: ApprovalLogicProps): JSX.Element {
     const { approveChangeRequest, rejectChangeRequest, cancelChangeRequest, setProposedChangesTab } = useActions(
         approvalLogic({ id })
     )
+    const { loadAllMembers } = useActions(membersLogic)
+    const { loadRoles } = useActions(rolesLogic)
 
     const containerRef = useRef<HTMLDivElement>(null)
     const [width] = useSize(containerRef)
+
+    useEffect(() => {
+        loadAllMembers()
+        loadRoles()
+    }, [loadAllMembers, loadRoles])
 
     if (changeRequestMissing) {
         return <NotFound object="change request" />
@@ -250,11 +259,7 @@ function ApprovalDetail({ id }: ApprovalLogicProps): JSX.Element {
 
                 <section>
                     <h3 className="font-semibold mb-2">Policy Configuration</h3>
-                    <div className="bg-bg-light p-4 rounded border">
-                        <pre className="text-sm overflow-x-auto">
-                            {JSON.stringify(changeRequest.policy_snapshot, null, 2)}
-                        </pre>
-                    </div>
+                    <PolicyConfigurationDisplay policySnapshot={changeRequest.policy_snapshot} />
                 </section>
             </div>
         </SceneContent>
@@ -347,4 +352,130 @@ function StatusTag({ state }: { state: ChangeRequestState }): JSX.Element {
             {state}
         </LemonTag>
     )
+}
+
+interface PolicySnapshot {
+    quorum?: number
+    users?: number[]
+    roles?: string[]
+    allow_self_approve?: boolean
+    conditions?: {
+        type?: string
+        field?: string
+        operator?: string
+        value?: number
+    }
+}
+
+function PolicyConfigurationDisplay({ policySnapshot }: { policySnapshot?: PolicySnapshot }): JSX.Element {
+    const { members } = useValues(membersLogic)
+    const { roles } = useValues(rolesLogic)
+
+    if (!policySnapshot) {
+        return (
+            <div className="bg-bg-light p-4 rounded border">
+                <span className="text-secondary">No policy configuration available</span>
+            </div>
+        )
+    }
+
+    const userIds = policySnapshot.users || []
+    const roleIds = policySnapshot.roles || []
+    const conditions = policySnapshot.conditions
+
+    const usersById = new Map(members?.map((m) => [m.user.id, m.user]) || [])
+    const rolesById = new Map(roles?.map((r) => [r.id, r]) || [])
+
+    return (
+        <div className="bg-bg-light p-4 rounded border space-y-4">
+            {/* Approvers (users) */}
+            <div>
+                <div className="text-secondary text-sm mb-2">Approvers</div>
+                {userIds.length === 0 ? (
+                    <span className="text-muted">No approvers configured</span>
+                ) : (
+                    <div className="flex flex-wrap gap-3">
+                        {userIds.map((id) => {
+                            const user = usersById.get(id)
+                            return user ? (
+                                <div key={id} className="flex items-center gap-2">
+                                    <ProfilePicture user={user} size="sm" />
+                                    <span className="text-sm">{user.first_name || user.email}</span>
+                                </div>
+                            ) : (
+                                <div key={id} className="flex items-center gap-2 text-muted">
+                                    <ProfilePicture size="sm" />
+                                    <span className="text-sm italic">Deleted user ID {id}</span>
+                                </div>
+                            )
+                        })}
+                    </div>
+                )}
+            </div>
+
+            {/* Approver roles */}
+            <div>
+                <div className="text-secondary text-sm mb-2">Approver roles</div>
+                {roleIds.length === 0 ? (
+                    <span className="text-muted">No approver roles configured</span>
+                ) : (
+                    <div className="flex flex-wrap gap-2">
+                        {roleIds.map((id) => {
+                            const role = rolesById.get(id)
+                            return role ? (
+                                <LemonTag key={id} type="highlight">
+                                    {role.name}
+                                </LemonTag>
+                            ) : (
+                                <LemonTag key={id} type="muted">
+                                    Deleted role ID {id}
+                                </LemonTag>
+                            )
+                        })}
+                    </div>
+                )}
+            </div>
+
+            {/* Condition */}
+            {conditions && Object.keys(conditions).length > 0 && (
+                <div>
+                    <div className="text-secondary text-sm mb-1">Condition</div>
+                    <div>{formatConditionText(conditions)}</div>
+                </div>
+            )}
+
+            {/* Approvals required */}
+            <div>
+                <div className="text-secondary text-sm mb-1">Approvals required</div>
+                <div>{policySnapshot.quorum || 1}</div>
+            </div>
+
+            {/* Self-approval */}
+            <div>
+                <div className="text-secondary text-sm mb-1">Self-approval</div>
+                <div>{policySnapshot.allow_self_approve ? 'Allowed' : 'Not allowed'}</div>
+            </div>
+        </div>
+    )
+}
+
+function formatConditionText(conditions: NonNullable<PolicySnapshot['conditions']>): string {
+    const field = conditions.field?.replace(/_/g, ' ') || 'field'
+
+    switch (conditions.type) {
+        case 'any_change':
+            return `Require approval for any change to ${field}`
+        case 'before_after':
+            if (conditions.operator && conditions.value !== undefined) {
+                return `Require approval when ${field} ${conditions.operator} ${conditions.value}%`
+            }
+            return `Require approval based on ${field} threshold`
+        case 'change_amount':
+            if (conditions.operator && conditions.value !== undefined) {
+                return `Require approval when ${field} changes by ${conditions.operator} ${conditions.value}%`
+            }
+            return `Require approval based on ${field} change amount`
+        default:
+            return 'Custom condition'
+    }
 }

--- a/frontend/src/scenes/approvals/ApprovalDetail.tsx
+++ b/frontend/src/scenes/approvals/ApprovalDetail.tsx
@@ -1,6 +1,6 @@
 import useSize from '@react-hook/size'
 import { useActions, useValues } from 'kea'
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 
 import { LemonTag, lemonToast } from '@posthog/lemon-ui'
 
@@ -39,16 +39,9 @@ function ApprovalDetail({ id }: ApprovalLogicProps): JSX.Element {
     const { approveChangeRequest, rejectChangeRequest, cancelChangeRequest, setProposedChangesTab } = useActions(
         approvalLogic({ id })
     )
-    const { loadAllMembers } = useActions(membersLogic)
-    const { loadRoles } = useActions(rolesLogic)
 
     const containerRef = useRef<HTMLDivElement>(null)
     const [width] = useSize(containerRef)
-
-    useEffect(() => {
-        loadAllMembers()
-        loadRoles()
-    }, [loadAllMembers, loadRoles])
 
     if (changeRequestMissing) {
         return <NotFound object="change request" />

--- a/frontend/src/scenes/approvals/approvalLogic.tsx
+++ b/frontend/src/scenes/approvals/approvalLogic.tsx
@@ -6,7 +6,9 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { getApprovalActionLabel } from 'scenes/approvals/utils'
+import { membersLogic } from 'scenes/organization/membersLogic'
 import { Scene } from 'scenes/sceneTypes'
+import { rolesLogic } from 'scenes/settings/organization/Permissions/Roles/rolesLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -26,6 +28,7 @@ export const approvalLogic = kea<approvalLogicType>([
     key(({ id }) => id),
     connect({
         values: [teamLogic, ['currentTeamId']],
+        actions: [membersLogic, ['loadAllMembers'], rolesLogic, ['loadRoles']],
     }),
     actions({
         loadChangeRequest: true,
@@ -137,5 +140,7 @@ export const approvalLogic = kea<approvalLogicType>([
     })),
     afterMount(({ actions }) => {
         actions.loadChangeRequest()
+        actions.loadAllMembers()
+        actions.loadRoles()
     }),
 ])

--- a/posthog/approvals/decorators.py
+++ b/posthog/approvals/decorators.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 from posthog.approvals.actions.registry import get_action
 from posthog.approvals.exceptions import ApprovalRequired
 from posthog.approvals.models import ChangeRequest, ChangeRequestState
+from posthog.approvals.notifications import send_approval_requested_notification
 from posthog.approvals.policies import PolicyDecision, PolicyEngine
 from posthog.approvals.serializers import ChangeRequestSerializer
 from posthog.event_usage import report_user_action
@@ -148,6 +149,8 @@ def _create_change_request(
             "resource_type": action_class.resource_type,
         },
     )
+
+    send_approval_requested_notification(change_request)
 
     return change_request
 

--- a/posthog/approvals/services.py
+++ b/posthog/approvals/services.py
@@ -14,7 +14,7 @@ from posthog.approvals.exceptions import (
     ReasonRequiredError,
 )
 from posthog.approvals.models import Approval, ApprovalDecision, ChangeRequest, ChangeRequestState
-from posthog.approvals.notifications import send_approval_decision_notification
+from posthog.approvals.notifications import send_approval_applied_notification, send_approval_decision_notification
 from posthog.event_usage import report_user_action
 from posthog.models import User
 
@@ -114,6 +114,8 @@ def apply_change_request(change_request: ChangeRequest) -> Any:
                     "change_request_id": str(change_request.id),
                 },
             )
+
+        send_approval_applied_notification(change_request)
 
         return result
 

--- a/posthog/approvals/tests/test_notifications.py
+++ b/posthog/approvals/tests/test_notifications.py
@@ -1,0 +1,394 @@
+from datetime import timedelta
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+from posthog.approvals.models import Approval, ApprovalDecision, ApprovalPolicy, ChangeRequest, ChangeRequestState
+from posthog.approvals.notifications import (
+    _build_change_request_url,
+    _send_approval_email,
+    send_approval_applied_notification,
+    send_approval_decision_notification,
+    send_approval_expired_notification,
+    send_approval_requested_notification,
+)
+from posthog.email import CUSTOMER_IO_TEMPLATE_ID_MAP
+from posthog.models.instance_setting import override_instance_config
+
+
+class TestApprovalNotifications(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user.first_name = "Test"
+        self.user.save()
+
+        self.approver = self._create_user("approver@posthog.com", first_name="Approver")
+        self.approver2 = self._create_user("approver2@posthog.com", first_name="Approver2")
+
+        self.policy = ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=self.team,
+            action_key="feature_flags.update_rollout_percentage",
+            approver_config={"users": [self.approver.id, self.approver2.id], "quorum": 1},
+            enabled=True,
+            expires_after=timedelta(days=14),
+        )
+
+        self.change_request = ChangeRequest.objects.create(
+            action_key="feature_flags.update_rollout_percentage",
+            action_version=1,
+            team=self.team,
+            organization=self.organization,
+            resource_type="FeatureFlag",
+            resource_id="123",
+            intent={"rollout_percentage": 50},
+            intent_display={"description": "Update rollout to 50%"},
+            policy_snapshot={"quorum": 1},
+            created_by=self.user,
+            state=ChangeRequestState.PENDING,
+            expires_at=timezone.now() + timedelta(days=14),
+        )
+
+
+class TestCustomerIOTemplateIDs(TestApprovalNotifications):
+    def test_all_approval_templates_have_customer_io_ids(self):
+        expected_templates = [
+            "approval_requested",
+            "approval_approved",
+            "approval_rejected",
+            "approval_expired",
+            "approval_applied",
+        ]
+
+        for template in expected_templates:
+            self.assertIn(template, CUSTOMER_IO_TEMPLATE_ID_MAP)
+            self.assertIsNotNone(CUSTOMER_IO_TEMPLATE_ID_MAP[template])
+
+
+class TestBuildChangeRequestUrl(TestApprovalNotifications):
+    def test_builds_correct_url(self):
+        with self.settings(SITE_URL="https://app.posthog.com"):
+            url = _build_change_request_url(self.change_request)
+            expected = f"https://app.posthog.com/project/{self.team.project_id}/approvals/{self.change_request.id}"
+            self.assertEqual(url, expected)
+
+    def test_strips_trailing_slash_from_site_url(self):
+        with self.settings(SITE_URL="https://app.posthog.com/"):
+            url = _build_change_request_url(self.change_request)
+            expected = f"https://app.posthog.com/project/{self.team.project_id}/approvals/{self.change_request.id}"
+            self.assertEqual(url, expected)
+
+
+class TestSendApprovalEmail(TestApprovalNotifications):
+    @patch("posthog.approvals.notifications.EmailMessage")
+    @patch("posthog.approvals.notifications.is_email_available")
+    def test_sends_email_when_available(self, mock_is_email_available, mock_email_message):
+        mock_is_email_available.return_value = True
+        mock_message_instance = MagicMock()
+        mock_email_message.return_value = mock_message_instance
+
+        with override_instance_config("EMAIL_HOST", "localhost"):
+            _send_approval_email(
+                recipient=self.approver,
+                template_name="approval_requested",
+                subject="Test User needs your sign-off",
+                change_request=self.change_request,
+                extra_context={"requester_name": "Test User"},
+            )
+
+        mock_email_message.assert_called_once()
+        call_kwargs = mock_email_message.call_args[1]
+        self.assertEqual(call_kwargs["template_name"], "approval_requested")
+        self.assertEqual(call_kwargs["subject"], "Test User needs your sign-off")
+        self.assertTrue(call_kwargs["use_http"])
+        mock_message_instance.add_user_recipient.assert_called_once_with(self.approver)
+        mock_message_instance.send.assert_called_once_with(send_async=True)
+
+    @patch("posthog.approvals.notifications.is_email_available")
+    def test_skips_when_email_not_available(self, mock_is_email_available):
+        mock_is_email_available.return_value = False
+
+        _send_approval_email(
+            recipient=self.approver,
+            template_name="approval_requested",
+            subject="Test",
+            change_request=self.change_request,
+        )
+
+    def test_subjects_are_privacy_conscious(self):
+        subjects = [
+            "Test User needs your sign-off",
+            "Test User approved your change",
+            "Your change request was declined",
+            "Your change request timed out",
+            "Your change is live! 🎉",
+        ]
+        for subject in subjects:
+            self.assertNotIn("feature flag", subject.lower())
+            self.assertNotIn("rollout", subject.lower())
+
+
+class TestSendApprovalRequestedNotification(TestApprovalNotifications):
+    @patch("posthog.approvals.notifications._send_approval_email")
+    def test_sends_to_all_approvers(self, mock_send_email):
+        send_approval_requested_notification(self.change_request)
+
+        self.assertEqual(mock_send_email.call_count, 2)
+
+        call_args_list = [call[1] for call in mock_send_email.call_args_list]
+        recipients = [args["recipient"] for args in call_args_list]
+        self.assertIn(self.approver, recipients)
+        self.assertIn(self.approver2, recipients)
+
+    @patch("posthog.approvals.notifications._send_approval_email")
+    def test_skips_when_no_policy(self, mock_send_email):
+        self.policy.delete()
+
+        send_approval_requested_notification(self.change_request)
+
+        mock_send_email.assert_not_called()
+
+    @patch("posthog.approvals.notifications._send_approval_email")
+    def test_uses_correct_template(self, mock_send_email):
+        send_approval_requested_notification(self.change_request)
+
+        call_kwargs = mock_send_email.call_args_list[0][1]
+        self.assertEqual(call_kwargs["template_name"], "approval_requested")
+        self.assertIn("needs your sign-off", call_kwargs["subject"])
+
+    @patch("posthog.approvals.notifications._send_approval_email")
+    def test_continues_on_individual_email_failure(self, mock_send_email):
+        mock_send_email.side_effect = [Exception("Email failed"), None]
+
+        send_approval_requested_notification(self.change_request)
+
+        self.assertEqual(mock_send_email.call_count, 2)
+
+
+class TestSendApprovalDecisionNotification(TestApprovalNotifications):
+    @patch("posthog.approvals.notifications._send_approval_email")
+    def test_sends_approval_notification(self, mock_send_email):
+        approval = Approval.objects.create(
+            change_request=self.change_request,
+            created_by=self.approver,
+            decision=ApprovalDecision.APPROVED,
+            reason="Looks good",
+        )
+
+        send_approval_decision_notification(self.change_request, approval)
+
+        mock_send_email.assert_called_once()
+        call_kwargs = mock_send_email.call_args[1]
+        self.assertEqual(call_kwargs["recipient"], self.user)
+        self.assertEqual(call_kwargs["template_name"], "approval_approved")
+        self.assertIn("approved your change", call_kwargs["subject"])
+
+    @patch("posthog.approvals.notifications._send_approval_email")
+    def test_sends_rejection_notification(self, mock_send_email):
+        approval = Approval.objects.create(
+            change_request=self.change_request,
+            created_by=self.approver,
+            decision=ApprovalDecision.REJECTED,
+            reason="Not safe",
+        )
+
+        send_approval_decision_notification(self.change_request, approval)
+
+        mock_send_email.assert_called_once()
+        call_kwargs = mock_send_email.call_args[1]
+        self.assertEqual(call_kwargs["template_name"], "approval_rejected")
+        self.assertEqual(call_kwargs["subject"], "Your change request was declined")
+
+    @patch("posthog.approvals.notifications._send_approval_email")
+    def test_skips_when_no_requester(self, mock_send_email):
+        self.change_request.created_by = None
+        self.change_request.save()
+
+        approval = Approval.objects.create(
+            change_request=self.change_request,
+            created_by=self.approver,
+            decision=ApprovalDecision.APPROVED,
+        )
+
+        send_approval_decision_notification(self.change_request, approval)
+
+        mock_send_email.assert_not_called()
+
+
+class TestSendApprovalExpiredNotification(TestApprovalNotifications):
+    @patch("posthog.approvals.notifications._send_approval_email")
+    def test_sends_expired_notification(self, mock_send_email):
+        send_approval_expired_notification(self.change_request)
+
+        mock_send_email.assert_called_once()
+        call_kwargs = mock_send_email.call_args[1]
+        self.assertEqual(call_kwargs["recipient"], self.user)
+        self.assertEqual(call_kwargs["template_name"], "approval_expired")
+        self.assertEqual(call_kwargs["subject"], "Your change request timed out")
+
+    @patch("posthog.approvals.notifications._send_approval_email")
+    def test_skips_when_no_requester(self, mock_send_email):
+        self.change_request.created_by = None
+        self.change_request.save()
+
+        send_approval_expired_notification(self.change_request)
+
+        mock_send_email.assert_not_called()
+
+
+class TestSendApprovalAppliedNotification(TestApprovalNotifications):
+    @patch("posthog.approvals.notifications._send_approval_email")
+    def test_sends_applied_notification(self, mock_send_email):
+        send_approval_applied_notification(self.change_request)
+
+        mock_send_email.assert_called_once()
+        call_kwargs = mock_send_email.call_args[1]
+        self.assertEqual(call_kwargs["recipient"], self.user)
+        self.assertEqual(call_kwargs["template_name"], "approval_applied")
+        self.assertEqual(call_kwargs["subject"], "Your change is live! 🎉")
+
+    @patch("posthog.approvals.notifications._send_approval_email")
+    def test_skips_when_no_requester(self, mock_send_email):
+        self.change_request.created_by = None
+        self.change_request.save()
+
+        send_approval_applied_notification(self.change_request)
+
+        mock_send_email.assert_not_called()
+
+
+class TestEmailTemplateRendering(TestApprovalNotifications):
+    @patch("posthog.approvals.notifications.is_email_available")
+    def test_approval_requested_template_renders(self, mock_is_email_available):
+        mock_is_email_available.return_value = True
+
+        with override_instance_config("EMAIL_HOST", "localhost"), self.settings(SITE_URL="https://app.posthog.com"):
+            from posthog.email import EmailMessage
+
+            message = EmailMessage(
+                campaign_key="test_approval_requested",
+                template_name="approval_requested",
+                subject="Test User needs your sign-off",
+                template_context={
+                    "change_request_url": "https://app.posthog.com/project/1/approvals/123",
+                    "team_name": "Test Team",
+                    "requester_name": "Test User",
+                },
+            )
+
+            self.assertIn("needs your sign-off", message.html_body)
+            self.assertIn("Test Team", message.html_body)
+
+    @patch("posthog.approvals.notifications.is_email_available")
+    def test_approval_approved_template_renders(self, mock_is_email_available):
+        mock_is_email_available.return_value = True
+
+        with override_instance_config("EMAIL_HOST", "localhost"), self.settings(SITE_URL="https://app.posthog.com"):
+            from posthog.email import EmailMessage
+
+            message = EmailMessage(
+                campaign_key="test_approval_approved",
+                template_name="approval_approved",
+                subject="Admin User approved your change",
+                template_context={
+                    "change_request_url": "https://app.posthog.com/project/1/approvals/123",
+                    "team_name": "Test Team",
+                    "approver_name": "Admin User",
+                },
+            )
+
+            self.assertIn("approved your change", message.html_body)
+            self.assertIn("Test Team", message.html_body)
+
+    @patch("posthog.approvals.notifications.is_email_available")
+    def test_approval_rejected_template_renders(self, mock_is_email_available):
+        mock_is_email_available.return_value = True
+
+        with override_instance_config("EMAIL_HOST", "localhost"), self.settings(SITE_URL="https://app.posthog.com"):
+            from posthog.email import EmailMessage
+
+            message = EmailMessage(
+                campaign_key="test_approval_rejected",
+                template_name="approval_rejected",
+                subject="Your change request was declined",
+                template_context={
+                    "change_request_url": "https://app.posthog.com/project/1/approvals/123",
+                    "team_name": "Test Team",
+                    "approver_name": "Admin User",
+                },
+            )
+
+            self.assertIn("wasn't approved", message.html_body)
+            self.assertIn("Test Team", message.html_body)
+
+    @patch("posthog.approvals.notifications.is_email_available")
+    def test_approval_expired_template_renders(self, mock_is_email_available):
+        mock_is_email_available.return_value = True
+
+        with override_instance_config("EMAIL_HOST", "localhost"), self.settings(SITE_URL="https://app.posthog.com"):
+            from posthog.email import EmailMessage
+
+            message = EmailMessage(
+                campaign_key="test_approval_expired",
+                template_name="approval_expired",
+                subject="Your change request timed out",
+                template_context={
+                    "change_request_url": "https://app.posthog.com/project/1/approvals/123",
+                    "team_name": "Test Team",
+                },
+            )
+
+            self.assertIn("expired", message.html_body)
+            self.assertIn("Test Team", message.html_body)
+
+    @patch("posthog.approvals.notifications.is_email_available")
+    def test_approval_applied_template_renders(self, mock_is_email_available):
+        mock_is_email_available.return_value = True
+
+        with override_instance_config("EMAIL_HOST", "localhost"), self.settings(SITE_URL="https://app.posthog.com"):
+            from posthog.email import EmailMessage
+
+            message = EmailMessage(
+                campaign_key="test_approval_applied",
+                template_name="approval_applied",
+                subject="Your change is live! 🎉",
+                template_context={
+                    "change_request_url": "https://app.posthog.com/project/1/approvals/123",
+                    "team_name": "Test Team",
+                },
+            )
+
+            self.assertIn("is live", message.html_body)
+            self.assertIn("Test Team", message.html_body)
+
+    @patch("posthog.approvals.notifications.is_email_available")
+    def test_templates_contain_cta_button(self, mock_is_email_available):
+        mock_is_email_available.return_value = True
+        templates_with_cta = {
+            "approval_requested": "Review changes",
+            "approval_approved": "View details",
+            "approval_rejected": "See feedback",
+            "approval_expired": "View expired request",
+            "approval_applied": "View details",
+        }
+
+        with override_instance_config("EMAIL_HOST", "localhost"), self.settings(SITE_URL="https://app.posthog.com"):
+            from posthog.email import EmailMessage
+
+            for template_name, expected_cta in templates_with_cta.items():
+                message = EmailMessage(
+                    campaign_key=f"test_{template_name}",
+                    template_name=template_name,
+                    subject="Test Subject",
+                    template_context={
+                        "change_request_url": "https://app.posthog.com/project/1/approvals/123",
+                        "team_name": "Test Team",
+                        "requester_name": "Test User",
+                        "approver_name": "Admin User",
+                    },
+                )
+                self.assertIn(
+                    expected_cta, message.html_body, f"Template {template_name} should have CTA button '{expected_cta}'"
+                )

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -106,6 +106,11 @@ CUSTOMER_IO_TEMPLATE_ID_MAP = {
     "passkey_added": "51",
     "passkey_removed": "52",
     "new_conversation_ticket": "53",
+    "approval_requested": "54",
+    "approval_approved": "55",
+    "approval_rejected": "56",
+    "approval_expired": "57",
+    "approval_applied": "58",
 }
 
 

--- a/posthog/templates/email/approval_applied.html
+++ b/posthog/templates/email/approval_applied.html
@@ -1,0 +1,16 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block heading %}Your change is live! 🎉{% endblock %}
+{% block section %}
+<p>
+    Your change in <b>{{ team_name }}</b> has been approved and applied. Ship it!
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{{ change_request_url }}">View details</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{{ change_request_url }}">{{ change_request_url }}</a>
+    </p>
+</div>
+{% endblock %}

--- a/posthog/templates/email/approval_approved.html
+++ b/posthog/templates/email/approval_approved.html
@@ -1,0 +1,16 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block heading %}{{ approver_name }} approved your change{% endblock %}
+{% block section %}
+<p>
+    Nice! Your change in <b>{{ team_name }}</b> got the green light from <b>{{ approver_name }}</b>. Once all required approvals are in, it'll be applied automatically.
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{{ change_request_url }}">View details</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{{ change_request_url }}">{{ change_request_url }}</a>
+    </p>
+</div>
+{% endblock %}

--- a/posthog/templates/email/approval_expired.html
+++ b/posthog/templates/email/approval_expired.html
@@ -1,0 +1,16 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block heading %}Your change request timed out{% endblock %}
+{% block section %}
+<p>
+    Your change in <b>{{ team_name }}</b> expired before getting all the approvals it needed. No worries though – you can submit a new one whenever you're ready.
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{{ change_request_url }}">View expired request</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{{ change_request_url }}">{{ change_request_url }}</a>
+    </p>
+</div>
+{% endblock %}

--- a/posthog/templates/email/approval_rejected.html
+++ b/posthog/templates/email/approval_rejected.html
@@ -1,0 +1,16 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block heading %}Your change request was declined{% endblock %}
+{% block section %}
+<p>
+    Your change request in <b>{{ team_name }}</b> wasn't approved this time. Check the feedback and feel free to submit a new request if needed.
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{{ change_request_url }}">See feedback</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{{ change_request_url }}">{{ change_request_url }}</a>
+    </p>
+</div>
+{% endblock %}

--- a/posthog/templates/email/approval_requested.html
+++ b/posthog/templates/email/approval_requested.html
@@ -1,0 +1,16 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block heading %}{{ requester_name }} needs your sign-off{% endblock %}
+{% block section %}
+<p>
+    <b>{{ requester_name }}</b> wants to make a change in <b>{{ team_name }}</b> and needs your approval before it goes live.
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{{ change_request_url }}">Review changes</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{{ change_request_url }}">{{ change_request_url }}</a>
+    </p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Problem

- The policy snapshot seen on the change request detail page is rendered as plain JSON. Make it human readable.

## Changes

Before:
<img width="494" height="350" alt="image" src="https://github.com/user-attachments/assets/478c9316-88de-4c48-86ca-e5f375631d0a" />

After:
<img width="494" height="350" alt="image" src="https://github.com/user-attachments/assets/05400d9f-04a0-4523-a81a-9ede5c5d1ca1" />