### PR TITLE
chore(llma): bump labeling agent to GPT-5.2

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -77,7 +77,7 @@ ALLOWED_TEAM_IDS: list[int] = [
 ]
 
 # Cluster labeling agent configuration
-LABELING_AGENT_MODEL = "gpt-5.1"  # OpenAI GPT-5.1 for reasoning
+LABELING_AGENT_MODEL = "gpt-5.2"  # OpenAI GPT-5.2 for reasoning
 LABELING_AGENT_MAX_ITERATIONS = 50  # Max agent iterations before forced finalization
 LABELING_AGENT_RECURSION_LIMIT = 150  # LangGraph recursion limit (> 2 * max_iterations)
 LABELING_AGENT_TIMEOUT = 600.0  # 10 minutes for full agent run


### PR DESCRIPTION
## Problem

The cluster labeling agent uses GPT-5.1 for reasoning. GPT-5.2 offers improved quality at a modest cost increase.

## Changes

Bump labeling agent model from GPT-5.1 to GPT-5.2.

## How did you test this code?

Ran existing tests: `pytest posthog/temporal/llm_analytics/trace_clustering/tests/` - all 92 tests pass.

## Publish to changelog?

No