### PR TITLE
docs(llma): add note about OpenRouter Broadcast alternative

### DIFF
--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -7,6 +7,12 @@ export const OpenRouterInstallation = (): JSX.Element => {
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
     return (
         <Steps>
+            <CalloutBox type="fyi" icon="IconInfo" title="Alternative: OpenRouter Broadcast">
+                <Markdown>
+                    OpenRouter also offers a native [Broadcast feature](https://openrouter.ai/docs/guides/features/broadcast/posthog) that can automatically send LLM analytics data to PostHog without requiring SDK instrumentation. This is a simpler option if you don't need the additional customization that our SDK provides.
+                </Markdown>
+            </CalloutBox>
+
             <Step title="Install the PostHog SDK" badge="required">
                 <Markdown>
                     Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics works


### PR DESCRIPTION
## Problem

Users may not know that OpenRouter has a native Broadcast feature that can send LLM analytics data to PostHog without requiring SDK instrumentation.

## Changes

Added a callout to the OpenRouter installation docs mentioning the Broadcast feature as an alternative option.

## How did you test this code?

Docs change only - verified the markdown link is correct.

## Publish to changelog?

no