### PR TITLE
chore: we don't care about the hash when comparing bundle

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -141,6 +141,8 @@ jobs:
                   exclude: 'frontend/dist/*.js.map'
                   # Only show large changes
                   minimum-change-threshold: 1000
+                  order-by: 'Size:desc'
+                  strip-hash: "-[A-Za-z0-9]{8}\\.js$"
 
             - name: Check toolbar for CSP eval violations
               run: pnpm --filter=@posthog/frontend check-toolbar-csp-eval


### PR DESCRIPTION
every PR shows a 50MB bundle improvement
but really we're swapping uniquely hashed files

let's strip the hash when comparing

[CleanShot 2026-01-20 at 16.33.37.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/c3672a26-6680-4113-8373-f79177b6cda0.mp4" />](https://app.graphite.com/user-attachments/video/c3672a26-6680-4113-8373-f79177b6cda0.mp4)
