### PR TITLE
chore: bundle sie doesn't need to compare chunk files

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -137,8 +137,10 @@ jobs:
                   compression: 'none'
                   # Check all JS bundles in the dist folder
                   pattern: 'frontend/dist/*.js'
-                  # Exclude source maps
-                  exclude: 'frontend/dist/*.js.map'
+                  # Exclude source maps and chunk files (chunk hashes change every build)
+                  exclude: |
+                      frontend/dist/*.js.map
+                      frontend/dist/chunk-*.js
                   # Only show large changes
                   minimum-change-threshold: 1000
 


### PR DESCRIPTION
we don't need tocompare bundle size of chunks across builds because they change and aren;t comparable