### PR TITLE
chore(ci): track frontend bundle size in PostHog

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -165,13 +165,13 @@ jobs:
                   posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
                   event: 'posthog-ci-frontend-bundle-size'
                   properties: |
-                    {
-                      "size_bytes": ${{ steps.dist-size.outputs.size_bytes }},
-                      "branch": ${{ toJSON(github.head_ref || github.ref_name) }},
-                      "sha": ${{ toJSON(github.sha) }},
-                      "pr_number": ${{ github.event.pull_request.number || 'null' }},
-                      "event_type": ${{ toJSON(github.event_name) }}
-                    }
+                      {
+                        "size_bytes": ${{ steps.dist-size.outputs.size_bytes }},
+                        "branch": ${{ toJSON(github.head_ref || github.ref_name) }},
+                        "sha": ${{ toJSON(github.sha) }},
+                        "pr_number": ${{ github.event.pull_request.number || 'null' }},
+                        "event_type": ${{ toJSON(github.event_name) }}
+                      }
 
     frontend-typescript-checks:
         name: Frontend typechecking

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -164,7 +164,7 @@ jobs:
               with:
                   posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
                   event: 'posthog-ci-frontend-bundle-size'
-                  properties: '{"size_bytes": ${{ steps.dist-size.outputs.size_bytes }}, "branch": "${{ github.head_ref || github.ref_name }}", "sha": "${{ github.sha }}", "pr_number": "${{ github.event.pull_request.number || ''}}", "event_type": "${{ github.event_name }}"}'
+                  properties: '{"size_bytes": ${{ steps.dist-size.outputs.size_bytes }}, "branch": "${{ github.head_ref || github.ref_name }}", "sha": "${{ github.sha }}", "pr_number": ${{ github.event.pull_request.number || 'null' }}, "event_type": "${{ github.event_name }}"}'
 
     frontend-typescript-checks:
         name: Frontend typechecking

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -164,7 +164,14 @@ jobs:
               with:
                   posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
                   event: 'posthog-ci-frontend-bundle-size'
-                  properties: '{"size_bytes": ${{ steps.dist-size.outputs.size_bytes }}, "branch": "${{ github.head_ref || github.ref_name }}", "sha": "${{ github.sha }}", "pr_number": ${{ github.event.pull_request.number || 'null' }}, "event_type": "${{ github.event_name }}"}'
+                  properties: |
+                    {
+                      "size_bytes": ${{ steps.dist-size.outputs.size_bytes }},
+                      "branch": ${{ toJSON(github.head_ref || github.ref_name) }},
+                      "sha": ${{ toJSON(github.sha) }},
+                      "pr_number": ${{ github.event.pull_request.number || 'null' }},
+                      "event_type": ${{ toJSON(github.event_name) }}
+                    }
 
     frontend-typescript-checks:
         name: Frontend typechecking

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -149,6 +149,23 @@ jobs:
             - name: Check toolbar for CSP eval violations
               run: pnpm --filter=@posthog/frontend check-toolbar-csp-eval
 
+            - name: Calculate dist folder size
+              id: dist-size
+              run: |
+                  size_bytes=$(du -sb frontend/dist | cut -f1)
+                  echo "size_bytes=${size_bytes}" >> $GITHUB_OUTPUT
+                  echo "Frontend dist folder size: ${size_bytes} bytes ($(numfmt --to=iec-i --suffix=B ${size_bytes}))"
+
+            - name: Capture bundle size to PostHog
+              if: |
+                  (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog') ||
+                  (github.event_name != 'pull_request' && github.repository == 'PostHog/posthog')
+              uses: PostHog/posthog-github-action@8c42e50f2c52e002eabb9bee3f69b152ee8fc1dd # v1.0.1
+              with:
+                  posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
+                  event: 'posthog-ci-frontend-bundle-size'
+                  properties: '{"size_bytes": ${{ steps.dist-size.outputs.size_bytes }}, "branch": "${{ github.head_ref || github.ref_name }}", "sha": "${{ github.sha }}", "pr_number": "${{ github.event.pull_request.number || ''}}", "event_type": "${{ github.event_name }}"}'
+
     frontend-typescript-checks:
         name: Frontend typechecking
         needs: [changes]


### PR DESCRIPTION
Add tracking of the frontend dist folder size in bytes as a PostHog event after each build. This allows tracking bundle size trends over time via insights.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
