### PR TITLE
feat: remap flutter types

### DIFF
--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -73,6 +73,8 @@ pub const POSTHOG_SDK_EXCEPTION_RESOLVED: &str = "cymbal_posthog_sdk_exception_r
 pub const SUSPICIOUS_FRAMES_DETECTED: &str = "cymbal_suspicious_frames_detected";
 pub const LEGACY_JS_FRAME_RESOLVED: &str = "cymbal_legacy_js_frame_resolved";
 pub const JAVA_EXCEPTION_REMAP_FAILED: &str = "cymbal_java_exception_remap_failed";
+pub const DART_EXCEPTION_REMAP_FAILED: &str = "cymbal_dart_exception_remap_failed";
+pub const DART_EXCEPTION_REMAP_SUCCESS: &str = "cymbal_dart_exception_remap_success";
 
 // Spike detection metrics
 pub const SPIKE_DETECTION_TIME: &str = "cymbal_spike_detection_time";

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -73,8 +73,6 @@ pub const POSTHOG_SDK_EXCEPTION_RESOLVED: &str = "cymbal_posthog_sdk_exception_r
 pub const SUSPICIOUS_FRAMES_DETECTED: &str = "cymbal_suspicious_frames_detected";
 pub const LEGACY_JS_FRAME_RESOLVED: &str = "cymbal_legacy_js_frame_resolved";
 pub const JAVA_EXCEPTION_REMAP_FAILED: &str = "cymbal_java_exception_remap_failed";
-pub const DART_EXCEPTION_REMAP_FAILED: &str = "cymbal_dart_exception_remap_failed";
-pub const DART_EXCEPTION_REMAP_SUCCESS: &str = "cymbal_dart_exception_remap_success";
 
 // Spike detection metrics
 pub const SPIKE_DETECTION_TIME: &str = "cymbal_spike_detection_time";

--- a/rust/cymbal/src/pipeline/exception/stack_processing.rs
+++ b/rust/cymbal/src/pipeline/exception/stack_processing.rs
@@ -234,7 +234,6 @@ async fn remap_dart_minified_exception_type(
     team_id: i32,
     catalog: &Catalog,
 ) -> Option<String> {
-    // Find a JS frame with a chunk_id to use for looking up the sourcemap
     let chunk_id = frames.iter().find_map(|frame| match frame {
         RawFrame::JavaScriptWeb(js_frame) => js_frame.chunk_id.clone(),
         RawFrame::JavaScriptNode(node_frame) => node_frame.chunk_id.clone(),
@@ -242,14 +241,12 @@ async fn remap_dart_minified_exception_type(
         _ => None,
     })?;
 
-    // Look up the sourcemap using the chunk_id (it may already be cached from frame resolution)
     let sourcemap = catalog
         .smp
         .lookup(team_id, OrChunkId::ChunkId(chunk_id))
         .await
         .ok()?;
 
-    // Get the dart2js minified names from the sourcemap
     let minified_names = sourcemap.get_dart_minified_names()?;
 
     if minified_names.is_empty() {

--- a/rust/cymbal/src/pipeline/exception/stack_processing.rs
+++ b/rust/cymbal/src/pipeline/exception/stack_processing.rs
@@ -10,8 +10,7 @@ use crate::{
     frames::RawFrame,
     langs::java::RawJavaFrame,
     metric_consts::{
-        DART_EXCEPTION_REMAP_FAILED, DART_EXCEPTION_REMAP_SUCCESS, FINGERPRINT_BATCH_TIME,
-        FRAME_BATCH_TIME, FRAME_RESOLUTION, JAVA_EXCEPTION_REMAP_FAILED,
+        FINGERPRINT_BATCH_TIME, FRAME_BATCH_TIME, FRAME_RESOLUTION, JAVA_EXCEPTION_REMAP_FAILED,
     },
     symbol_store::{chunk_id::OrChunkId, dart_minified_names::lookup_minified_type, Catalog},
     types::{FingerprintedErrProps, RawErrProps, Stacktrace},
@@ -249,23 +248,7 @@ async fn remap_dart_minified_exception_type(
 
     let minified_names = sourcemap.get_dart_minified_names()?;
 
-    if minified_names.is_empty() {
-        metrics::counter!(DART_EXCEPTION_REMAP_FAILED, "reason" => "no_minified_names")
-            .increment(1);
-        return None;
-    }
-
-    match lookup_minified_type(minified_names, exception_type) {
-        Some(original) => {
-            metrics::counter!(DART_EXCEPTION_REMAP_SUCCESS).increment(1);
-            Some(original)
-        }
-        None => {
-            metrics::counter!(DART_EXCEPTION_REMAP_FAILED, "reason" => "type_not_found")
-                .increment(1);
-            None
-        }
-    }
+    lookup_minified_type(minified_names, exception_type)
 }
 
 #[cfg(test)]

--- a/rust/cymbal/src/symbol_store/dart_minified_names.rs
+++ b/rust/cymbal/src/symbol_store/dart_minified_names.rs
@@ -2,14 +2,11 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-/// Parses the dart2js minified_names extension from a sourcemap JSON.
-/// Returns a map from minified name -> original name for global (class/type) names.
 pub fn parse_dart_minified_names(sourcemap_json: &str) -> Option<HashMap<String, String>> {
     let parsed: Dart2JsSourceMap = serde_json::from_str(sourcemap_json).ok()?;
     let ext = parsed.x_org_dartlang_dart2js?;
     let minified_names = ext.minified_names?;
 
-    // Parse the CSV format: "minified1,index1,minified2,index2,..."
     let global_str = minified_names.global?;
     let parts: Vec<&str> = global_str.split(',').collect();
 
@@ -31,7 +28,6 @@ pub fn parse_dart_minified_names(sourcemap_json: &str) -> Option<HashMap<String,
     }
 }
 
-/// Looks up a minified type name (e.g., "BA" from "minified:BA") and returns the original name.
 pub fn lookup_minified_type(
     minified_names: &HashMap<String, String>,
     minified_type: &str,

--- a/rust/cymbal/src/symbol_store/dart_minified_names.rs
+++ b/rust/cymbal/src/symbol_store/dart_minified_names.rs
@@ -1,0 +1,113 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+/// Parses the dart2js minified_names extension from a sourcemap JSON.
+/// Returns a map from minified name -> original name for global (class/type) names.
+pub fn parse_dart_minified_names(sourcemap_json: &str) -> Option<HashMap<String, String>> {
+    let parsed: Dart2JsSourceMap = serde_json::from_str(sourcemap_json).ok()?;
+    let ext = parsed.x_org_dartlang_dart2js?;
+    let minified_names = ext.minified_names?;
+
+    // Parse the CSV format: "minified1,index1,minified2,index2,..."
+    let global_str = minified_names.global?;
+    let parts: Vec<&str> = global_str.split(',').collect();
+
+    let mut result = HashMap::new();
+    for chunk in parts.chunks(2) {
+        if let [minified, index_str] = chunk {
+            if let Ok(index) = index_str.parse::<usize>() {
+                if let Some(original) = parsed.names.get(index) {
+                    result.insert(minified.to_string(), original.clone());
+                }
+            }
+        }
+    }
+
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+/// Looks up a minified type name (e.g., "BA" from "minified:BA") and returns the original name.
+pub fn lookup_minified_type(
+    minified_names: &HashMap<String, String>,
+    minified_type: &str,
+) -> Option<String> {
+    let minified_id = minified_type.strip_prefix("minified:")?;
+    minified_names.get(minified_id).cloned()
+}
+
+#[derive(Deserialize)]
+struct Dart2JsSourceMap {
+    #[serde(default)]
+    names: Vec<String>,
+    #[serde(rename = "x_org_dartlang_dart2js")]
+    x_org_dartlang_dart2js: Option<Dart2JsExtension>,
+}
+
+#[derive(Deserialize)]
+struct Dart2JsExtension {
+    minified_names: Option<MinifiedNames>,
+}
+
+#[derive(Deserialize)]
+struct MinifiedNames {
+    global: Option<String>,
+    #[allow(dead_code)]
+    instance: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_dart_minified_names() {
+        let sourcemap = r#"{
+            "version": 3,
+            "names": ["ClassA", "methodFoo", "UnsupportedError", "MyException"],
+            "x_org_dartlang_dart2js": {
+                "minified_names": {
+                    "global": "A,0,BA,2,BE,3",
+                    "instance": "a,1"
+                }
+            }
+        }"#;
+
+        let result = parse_dart_minified_names(sourcemap).unwrap();
+        assert_eq!(result.get("A"), Some(&"ClassA".to_string()));
+        assert_eq!(result.get("BA"), Some(&"UnsupportedError".to_string()));
+        assert_eq!(result.get("BE"), Some(&"MyException".to_string()));
+    }
+
+    #[test]
+    fn test_lookup_minified_type() {
+        let mut names = HashMap::new();
+        names.insert("BA".to_string(), "UnsupportedError".to_string());
+        names.insert("BE".to_string(), "MyException".to_string());
+
+        assert_eq!(
+            lookup_minified_type(&names, "minified:BA"),
+            Some("UnsupportedError".to_string())
+        );
+        assert_eq!(
+            lookup_minified_type(&names, "minified:BE"),
+            Some("MyException".to_string())
+        );
+        assert_eq!(lookup_minified_type(&names, "minified:XX"), None);
+        assert_eq!(lookup_minified_type(&names, "NotMinified"), None);
+    }
+
+    #[test]
+    fn test_parse_missing_extension() {
+        let sourcemap = r#"{
+            "version": 3,
+            "names": ["ClassA"]
+        }"#;
+
+        assert!(parse_dart_minified_names(sourcemap).is_none());
+    }
+}

--- a/rust/cymbal/src/symbol_store/mod.rs
+++ b/rust/cymbal/src/symbol_store/mod.rs
@@ -18,6 +18,7 @@ use crate::{
 pub mod caching;
 pub mod chunk_id;
 pub mod concurrency;
+pub mod dart_minified_names;
 pub mod hermesmap;
 pub mod proguard;
 pub mod saving;


### PR DESCRIPTION
remap flutter exception types

https://posthog.slack.com/archives/C07AA937K9A/p1768415443965209

Tested it locally. Types are correctly remapped 
<img width="825" height="166" alt="image" src="https://github.com/user-attachments/assets/0169a26d-699d-46a8-9cca-504df02d2f32" />
