### PR TITLE
chore: calculate JS and CSS dist file size without map files

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -149,12 +149,18 @@ jobs:
             - name: Check toolbar for CSP eval violations
               run: pnpm --filter=@posthog/frontend check-toolbar-csp-eval
 
-            - name: Calculate dist folder size
-              id: dist-size
+            - name: Calculate JS and CSS bundle sizes
+              id: bundle-sizes
               run: |
-                  size_bytes=$(du -sb frontend/dist | cut -f1)
-                  echo "size_bytes=${size_bytes}" >> $GITHUB_OUTPUT
-                  echo "Frontend dist folder size: ${size_bytes} bytes ($(numfmt --to=iec-i --suffix=B ${size_bytes}))"
+                  # Calculate total size of JS files (excluding .map files)
+                  size_js_bytes=$(find frontend/dist -name '*.js' ! -name '*.js.map' -type f -exec stat --printf='%s\n' {} + | awk '{sum+=$1} END {print sum+0}')
+                  echo "size_js_bytes=${size_js_bytes}" >> $GITHUB_OUTPUT
+                  echo "JS bundle size: ${size_js_bytes} bytes ($(numfmt --to=iec-i --suffix=B ${size_js_bytes}))"
+
+                  # Calculate total size of CSS files (excluding .map files)
+                  size_css_bytes=$(find frontend/dist -name '*.css' ! -name '*.css.map' -type f -exec stat --printf='%s\n' {} + | awk '{sum+=$1} END {print sum+0}')
+                  echo "size_css_bytes=${size_css_bytes}" >> $GITHUB_OUTPUT
+                  echo "CSS bundle size: ${size_css_bytes} bytes ($(numfmt --to=iec-i --suffix=B ${size_css_bytes}))"
 
             - name: Capture bundle size to PostHog
               if: |
@@ -166,7 +172,8 @@ jobs:
                   event: 'posthog-ci-frontend-bundle-size'
                   properties: |
                       {
-                        "size_bytes": ${{ steps.dist-size.outputs.size_bytes }},
+                        "size_js_bytes": ${{ steps.bundle-sizes.outputs.size_js_bytes }},
+                        "size_css_bytes": ${{ steps.bundle-sizes.outputs.size_css_bytes }},
                         "branch": ${{ toJSON(github.head_ref || github.ref_name) }},
                         "sha": ${{ toJSON(github.sha) }},
                         "pr_number": ${{ github.event.pull_request.number || 'null' }},


### PR DESCRIPTION
Replace the total dist folder size tracking with separate size_js_bytes and size_css_bytes properties. This excludes source map files and gives more granular insight into bundle composition.

follow-up to https://github.com/PostHog/posthog/pull/45476

the dist folder is 700MB

we don't want to count all of its contents

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
