### PR TITLE
fix: use correct command line option to set region in wizard

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/components/SetupWizardBanner.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/components/SetupWizardBanner.tsx
@@ -24,7 +24,7 @@ const SetupWizardBanner = ({
     }
 
     const region = preflight?.region || Region.US
-    const wizardCommand = `npx -y @posthog/wizard@latest${region === Region.EU ? ` --eu` : ''}`
+    const wizardCommand = `npx -y @posthog/wizard@latest${region === Region.EU ? ` --region eu` : ''}`
 
     return (
         <>


### PR DESCRIPTION
## Problem
Incorrect command line option provided in setup instructions
<img width="1261" height="399" alt="Screenshot 2026-01-21 at 12 57 52 AM" src="https://github.com/user-attachments/assets/9508d4cc-db4a-4008-9973-bcf56cf2b6b7" />


## Changes

fix the command line option

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
