### PR TITLE
fix: editing event definitions in popover

### DIFF
--- a/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
@@ -132,12 +132,14 @@ function DefinitionView({ group }: { group: TaxonomicFilterGroup }): JSX.Element
     const { selectedItemMeta, dataWarehousePopoverFields } = useValues(taxonomicFilterLogic)
     const { selectItem } = useActions(taxonomicFilterLogic)
 
-    // Use effect here to make definition view stateful. TaxonomicFilterLogic won't mount within definitionPopoverLogic
+    // Pre-populate field mappings from the insight filter.
+    // Only apply to data warehouse - for events/properties, selectedItemMeta.id is the
+    // event name which would incorrectly overwrite the event definition's UUID.
     useEffect(() => {
-        if (selectedItemMeta && definition.name == selectedItemMeta.id) {
+        if (isDataWarehouse && selectedItemMeta && definition.name == selectedItemMeta.id) {
             setLocalDefinition(selectedItemMeta)
         }
-    }, [definition]) // oxlint-disable-line react-hooks/exhaustive-deps
+    }, [definition, isDataWarehouse]) // eslint-disable-line react-hooks/exhaustive-deps
 
     const hasSentAsLabel = useMemo(() => {
         const _definition = definition as PropertyDefinition

--- a/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
@@ -136,7 +136,7 @@ function DefinitionView({ group }: { group: TaxonomicFilterGroup }): JSX.Element
     // Only apply to data warehouse - for events/properties, selectedItemMeta.id is the
     // event name which would incorrectly overwrite the event definition's UUID.
     useEffect(() => {
-        if (isDataWarehouse && selectedItemMeta && definition.name == selectedItemMeta.id) {
+        if (isDataWarehouse && selectedItemMeta && definition.name === selectedItemMeta.id) {
             setLocalDefinition(selectedItemMeta)
         }
     }, [definition, isDataWarehouse]) // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Problem

When using the Definition Popover with data warehouse fields, the component was incorrectly applying metadata from all taxonomic filter groups, which could overwrite event definition UUIDs with event names.

Bug only affected events without enterprise rows (most events after removing gates for INGESTION_TAXONOMY)

![Screenshot 2026-01-20 at 18.57.19.png](https://app.graphite.com/user-attachments/assets/e9e44374-6de3-41e9-8693-adea7bc7ce87.png)

## Changes

Only apply selectedItemMeta to data warehouse types. 

> Other definition types (events, properties, actions, cohorts) don't use insight filter metadata - only data warehouse needs it for field mappings. This was causing event names to overwrite UUIDs on save.

## How did you test this code?

New insight -> Search any event without `ee_enterpriseeventdefinition` row -> Click "Edit" and change smth -> Save

## Publish to changelog?

No