### PR TITLE
feat(surveys): support LLM analytics action for survey results

### DIFF
--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -63,15 +63,16 @@ export function eventRowActionsContent(event: EventType): JSX.Element {
                     Visit issue
                 </LemonButton>
             ) : null}
-            {event.event === '$ai_trace' && '$ai_trace_id' in event.properties ? (
+            {(event.event === '$ai_trace' || event.event === SurveyEventName.SENT) &&
+            '$ai_trace_id' in event.properties ? (
                 <LemonButton
                     fullWidth
                     sideIcon={<IconAI />}
                     data-attr="events-table-trace-link"
-                    to={urls.llmAnalyticsTrace(event.properties.$ai_trace_id, {
-                        event: event.id,
-                        exception_ts: event.timestamp,
-                    })}
+                    to={urls.llmAnalyticsTrace(
+                        event.properties.$ai_trace_id,
+                        event.event === '$ai_trace' ? { event: event.id, exception_ts: event.timestamp } : {}
+                    )}
                 >
                     View LLM Trace
                 </LemonButton>


### PR DESCRIPTION
## Problem

we're working on integrating surveys a bit better with LLM analytics (like a thumbs up/down for a generation)

part of that is a recommendation to pass `$ai_trace_id` with survey results

context: https://github.com/PostHog/posthog/pull/44858

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

enables 'view llm trace' action for `survey sent` events that contain an `$ai_trace_id`

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no