### PR TITLE
fix(cohorts): prevent backfill timeouts with batched kafka flushing

### DIFF
--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -3,7 +3,7 @@ import time
 import asyncio
 import datetime as dt
 import dataclasses
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import temporalio.activity
 import temporalio.workflow
@@ -18,6 +18,9 @@ from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger
 
 from common.hogvm.python.execute import execute_bytecode
+
+if TYPE_CHECKING:
+    from posthog.kafka_client.client import _KafkaProducer
 
 LOGGER = get_logger(__name__)
 
@@ -42,6 +45,68 @@ def parse_person_properties(properties_raw: Any, person_id: str) -> dict[str, An
             return {}
     else:
         return properties_raw if isinstance(properties_raw, dict) else {}
+
+
+async def flush_kafka_batch(
+    kafka_producer: "_KafkaProducer",
+    pending_messages: list,
+    team_id: int,
+    cohort_id: int,
+    current_offset: int,
+    heartbeater,
+    logger,
+    is_final: bool = False,
+) -> int:
+    """Flush a batch of Kafka messages and check for failures.
+
+    Returns the number of messages flushed.
+    """
+    if not pending_messages:
+        return 0
+
+    batch_size = len(pending_messages)
+    batch_type = "final " if is_final else ""
+    heartbeater.details = (
+        f"Flushing {batch_type}{batch_size} messages for cohort {cohort_id} at offset {current_offset}",
+    )
+    logger.info(
+        f"Flushing {batch_type}batch of {batch_size} messages for cohort {cohort_id}",
+        team_id=team_id,
+        cohort_id=cohort_id,
+        offset=current_offset,
+        batch_size=batch_size,
+    )
+
+    await asyncio.to_thread(kafka_producer.flush)
+
+    # Check for failures in this batch
+    failed_count = 0
+    for send_result in pending_messages:
+        try:
+            send_result.get(timeout=0)  # Non-blocking check
+        except Exception as e:
+            logger.warning(
+                f"Kafka send result failure for cohort {cohort_id}: {e}",
+                team_id=team_id,
+                cohort_id=cohort_id,
+                offset=current_offset,
+                error=str(e),
+                exception_type=type(e).__name__,
+            )
+            failed_count += 1
+
+    if failed_count > 0:
+        logger.error(
+            f"Failed to send {failed_count}/{batch_size} Kafka messages for cohort {cohort_id}",
+            team_id=team_id,
+            cohort_id=cohort_id,
+            offset=current_offset,
+            failed_count=failed_count,
+            batch_size=batch_size,
+        )
+        raise Exception(f"Failed to send {failed_count}/{batch_size} Kafka messages for cohort {cohort_id}")
+
+    return batch_size
 
 
 def get_person_properties_backfill_success_metric():
@@ -116,6 +181,9 @@ async def backfill_precalculated_person_properties_activity(
         current_offset = inputs.offset
         total_processed = 0
         total_events_produced = 0
+        total_flushed = 0
+        FLUSH_BATCH_SIZE = 10_000  # Flush every 10k messages to allow heartbeats
+        pending_kafka_messages = []
 
         while True:
             # Check if we've hit the limit
@@ -171,7 +239,6 @@ async def backfill_precalculated_person_properties_activity(
             }
 
             batch_count = 0
-            events_to_produce = []
 
             with tags_context(
                 team_id=inputs.team_id,
@@ -223,7 +290,39 @@ async def backfill_precalculated_person_properties_activity(
                                     "matches": matches,
                                     "source": f"cohort_backfill_{inputs.cohort_id}",
                                 }
-                                events_to_produce.append(event)
+
+                                # Produce to Kafka without blocking - collect send results for later flushing
+                                try:
+                                    send_result = kafka_producer.produce(
+                                        topic=KAFKA_CDP_CLICKHOUSE_PRECALCULATED_PERSON_PROPERTIES,
+                                        key=event["distinct_id"],
+                                        data=event,
+                                    )
+                                    pending_kafka_messages.append(send_result)
+                                    total_events_produced += 1
+
+                                    # Flush in batches to allow heartbeats
+                                    if len(pending_kafka_messages) >= FLUSH_BATCH_SIZE:
+                                        flushed = await flush_kafka_batch(
+                                            kafka_producer,
+                                            pending_kafka_messages,
+                                            inputs.team_id,
+                                            inputs.cohort_id,
+                                            current_offset,
+                                            heartbeater,
+                                            logger,
+                                        )
+                                        total_flushed += flushed
+                                        pending_kafka_messages.clear()
+
+                                except Exception as e:
+                                    logger.warning(
+                                        f"Failed to produce Kafka message for distinct_id {event['distinct_id']}: {e}",
+                                        distinct_id=event["distinct_id"],
+                                        person_id=person_id,
+                                        error=str(e),
+                                    )
+                                    # Continue processing even if Kafka produce fails
 
             # No more persons, we're done
             if batch_count == 0:
@@ -231,30 +330,32 @@ async def backfill_precalculated_person_properties_activity(
 
             logger.info(f"Streamed {batch_count} persons at offset {current_offset}")
 
-            # Produce events to Kafka in batches
-            if events_to_produce:
-                heartbeater.details = (f"Publishing {len(events_to_produce)} events to Kafka",)
-
-                for event in events_to_produce:
-                    await asyncio.to_thread(
-                        kafka_producer.produce,
-                        topic=KAFKA_CDP_CLICKHOUSE_PRECALCULATED_PERSON_PROPERTIES,
-                        key=event["distinct_id"],
-                        data=event,
-                    )
-
-                total_events_produced += len(events_to_produce)
-                logger.info(f"Produced {len(events_to_produce)} events for batch at offset {current_offset}")
-
             total_processed += batch_count
             current_offset += batch_count
 
             # Update heartbeat
-            heartbeater.details = (f"Processed {total_processed} persons, produced {total_events_produced} events",)
+            heartbeater.details = (
+                f"Processed {total_processed} persons, produced {total_events_produced} events, flushed {total_flushed}",
+            )
 
             # If we got fewer persons than batch_size, we're done
             if batch_count < current_batch_size:
                 break
+
+        # Flush any remaining messages
+        if pending_kafka_messages:
+            flushed = await flush_kafka_batch(
+                kafka_producer,
+                pending_kafka_messages,
+                inputs.team_id,
+                inputs.cohort_id,
+                current_offset,
+                heartbeater,
+                logger,
+                is_final=True,
+            )
+            total_flushed += flushed
+            pending_kafka_messages.clear()
 
         end_time = time.time()
         duration_seconds = end_time - start_time
@@ -263,9 +364,10 @@ async def backfill_precalculated_person_properties_activity(
 
         logger.info(
             f"Completed person properties precalculation: processed {total_processed} persons, "
-            f"produced {total_events_produced} events in {duration_seconds:.1f} seconds",
+            f"produced {total_events_produced} events, flushed {total_flushed} in {duration_seconds:.1f} seconds",
             persons_processed=total_processed,
             events_produced=total_events_produced,
+            events_flushed=total_flushed,
             duration_seconds=duration_seconds,
         )
 
@@ -293,7 +395,7 @@ class BackfillPrecalculatedPersonPropertiesWorkflow(PostHogWorkflow):
         await temporalio.workflow.execute_activity(
             backfill_precalculated_person_properties_activity,
             inputs,
-            start_to_close_timeout=dt.timedelta(hours=2),  # Long timeout for large batches
+            start_to_close_timeout=dt.timedelta(hours=12),  # Long timeout for large batches
             heartbeat_timeout=dt.timedelta(minutes=5),
             retry_policy=temporalio.common.RetryPolicy(
                 maximum_attempts=3,

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -1,0 +1,283 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import flush_kafka_batch
+
+
+class TestFlushKafkaBatch:
+    """Tests for the flush_kafka_batch helper function."""
+
+    @pytest.mark.asyncio
+    async def test_empty_messages_returns_zero(self):
+        """When pending_messages is empty, should return 0 without flushing."""
+        kafka_producer = Mock()
+        heartbeater = Mock()
+        logger = Mock()
+
+        result = await flush_kafka_batch(
+            kafka_producer=kafka_producer,
+            pending_messages=[],
+            team_id=1,
+            cohort_id=123,
+            current_offset=0,
+            heartbeater=heartbeater,
+            logger=logger,
+        )
+
+        assert result == 0
+        kafka_producer.flush.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_successful_batch_flush(self):
+        """Should flush messages and return batch size on success."""
+        kafka_producer = Mock()
+        kafka_producer.flush = Mock()
+
+        # Mock successful send results
+        mock_results = [Mock() for _ in range(100)]
+        for mock_result in mock_results:
+            mock_result.get = Mock(return_value=None)
+
+        heartbeater = Mock()
+        logger = Mock()
+
+        with patch(
+            "posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.asyncio.to_thread"
+        ) as mock_thread:
+            mock_thread.return_value = None
+
+            result = await flush_kafka_batch(
+                kafka_producer=kafka_producer,
+                pending_messages=mock_results,
+                team_id=1,
+                cohort_id=123,
+                current_offset=1000,
+                heartbeater=heartbeater,
+                logger=logger,
+            )
+
+        assert result == 100
+        mock_thread.assert_called_once_with(kafka_producer.flush)
+        logger.info.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_final_batch_includes_final_in_messages(self):
+        """When is_final=True, should include 'final' in heartbeat and log messages."""
+        kafka_producer = Mock()
+        mock_result = Mock()
+        mock_result.get = Mock(return_value=None)
+
+        heartbeater = Mock()
+        logger = Mock()
+
+        with patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.asyncio.to_thread"):
+            await flush_kafka_batch(
+                kafka_producer=kafka_producer,
+                pending_messages=[mock_result],
+                team_id=1,
+                cohort_id=123,
+                current_offset=5000,
+                heartbeater=heartbeater,
+                logger=logger,
+                is_final=True,
+            )
+
+        # Check heartbeat details includes "final"
+        assert heartbeater.details[0].startswith("Flushing final ")
+
+        # Check logger includes "final"
+        log_call_args = logger.info.call_args[0][0]
+        assert "final" in log_call_args.lower()
+
+    @pytest.mark.asyncio
+    async def test_non_final_batch_excludes_final_from_messages(self):
+        """When is_final=False, should not include 'final' in messages."""
+        kafka_producer = Mock()
+        mock_result = Mock()
+        mock_result.get = Mock(return_value=None)
+
+        heartbeater = Mock()
+        logger = Mock()
+
+        with patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.asyncio.to_thread"):
+            await flush_kafka_batch(
+                kafka_producer=kafka_producer,
+                pending_messages=[mock_result],
+                team_id=1,
+                cohort_id=123,
+                current_offset=2000,
+                heartbeater=heartbeater,
+                logger=logger,
+                is_final=False,
+            )
+
+        # Check heartbeat details does not include "final"
+        heartbeat_msg = heartbeater.details[0]
+        assert "final" not in heartbeat_msg.lower()
+
+        # Check logger does not include "final"
+        log_call_args = logger.info.call_args[0][0]
+        assert "final" not in log_call_args.lower()
+
+    @pytest.mark.asyncio
+    async def test_batch_flush_with_partial_failures(self):
+        """Should raise exception when some messages fail to send."""
+        kafka_producer = Mock()
+
+        # Create mix of successful and failed results
+        successful_result = Mock()
+        successful_result.get = Mock(return_value=None)
+
+        failed_result = Mock()
+        failed_result.get = Mock(side_effect=Exception("Send failed"))
+
+        mock_results = [successful_result, failed_result, successful_result]
+
+        heartbeater = Mock()
+        logger = Mock()
+
+        with patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.asyncio.to_thread"):
+            with pytest.raises(Exception, match="Failed to send 1/3 Kafka messages"):
+                await flush_kafka_batch(
+                    kafka_producer=kafka_producer,
+                    pending_messages=mock_results,
+                    team_id=1,
+                    cohort_id=123,
+                    current_offset=3000,
+                    heartbeater=heartbeater,
+                    logger=logger,
+                )
+
+        # Should log warnings for failed messages
+        assert logger.warning.call_count == 1
+        # Should log error summary
+        assert logger.error.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_batch_flush_with_all_failures(self):
+        """Should raise exception when all messages fail to send."""
+        kafka_producer = Mock()
+
+        # All results fail
+        mock_results = []
+        for _ in range(5):
+            failed_result = Mock()
+            failed_result.get = Mock(side_effect=Exception("Send failed"))
+            mock_results.append(failed_result)
+
+        heartbeater = Mock()
+        logger = Mock()
+
+        with patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.asyncio.to_thread"):
+            with pytest.raises(Exception, match="Failed to send 5/5 Kafka messages"):
+                await flush_kafka_batch(
+                    kafka_producer=kafka_producer,
+                    pending_messages=mock_results,
+                    team_id=1,
+                    cohort_id=123,
+                    current_offset=4000,
+                    heartbeater=heartbeater,
+                    logger=logger,
+                )
+
+        assert logger.warning.call_count == 5
+        assert logger.error.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_details_format(self):
+        """Should format heartbeat details with offset and cohort information."""
+        kafka_producer = Mock()
+        mock_result = Mock()
+        mock_result.get = Mock(return_value=None)
+
+        heartbeater = Mock()
+        logger = Mock()
+
+        with patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.asyncio.to_thread"):
+            await flush_kafka_batch(
+                kafka_producer=kafka_producer,
+                pending_messages=[mock_result] * 10000,
+                team_id=1,
+                cohort_id=456,
+                current_offset=50000,
+                heartbeater=heartbeater,
+                logger=logger,
+            )
+
+        heartbeat_msg = heartbeater.details[0]
+        assert "10000 messages" in heartbeat_msg
+        assert "cohort 456" in heartbeat_msg
+        assert "offset 50000" in heartbeat_msg
+
+    @pytest.mark.asyncio
+    async def test_logger_includes_metadata(self):
+        """Should include team_id, cohort_id, offset, and batch_size in logger metadata."""
+        kafka_producer = Mock()
+        mock_result = Mock()
+        mock_result.get = Mock(return_value=None)
+
+        heartbeater = Mock()
+        logger = Mock()
+
+        with patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.asyncio.to_thread"):
+            await flush_kafka_batch(
+                kafka_producer=kafka_producer,
+                pending_messages=[mock_result] * 5000,
+                team_id=42,
+                cohort_id=789,
+                current_offset=25000,
+                heartbeater=heartbeater,
+                logger=logger,
+            )
+
+        # Check logger.info was called with metadata
+        logger.info.assert_called_once()
+        call_kwargs = logger.info.call_args[1]
+        assert call_kwargs["team_id"] == 42
+        assert call_kwargs["cohort_id"] == 789
+        assert call_kwargs["offset"] == 25000
+        assert call_kwargs["batch_size"] == 5000
+
+
+class TestBatchFlushingBehavior:
+    """Tests for batch flushing logic and integration."""
+
+    def test_flush_batch_size_constant_is_10k(self):
+        """Verify the FLUSH_BATCH_SIZE constant is set to 10,000."""
+        import inspect
+
+        import posthog.temporal.messaging.backfill_precalculated_person_properties_workflow as module
+
+        source = inspect.getsource(module.backfill_precalculated_person_properties_activity)
+        assert "FLUSH_BATCH_SIZE = 10_000" in source
+
+    @pytest.mark.asyncio
+    async def test_multiple_batches_handled_correctly(self):
+        """Should handle multiple batch flushes correctly."""
+        kafka_producer = Mock()
+
+        # Simulate 3 batches: 10k, 10k, 5k
+        heartbeater = Mock()
+        logger = Mock()
+
+        mock_results_batch1 = [Mock() for _ in range(10000)]
+        mock_results_batch2 = [Mock() for _ in range(10000)]
+        mock_results_batch3 = [Mock() for _ in range(5000)]
+
+        for result in mock_results_batch1 + mock_results_batch2 + mock_results_batch3:
+            result.get = Mock(return_value=None)
+
+        with patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.asyncio.to_thread"):
+            # Batch 1
+            result1 = await flush_kafka_batch(kafka_producer, mock_results_batch1, 1, 123, 0, heartbeater, logger)
+            # Batch 2
+            result2 = await flush_kafka_batch(kafka_producer, mock_results_batch2, 1, 123, 10000, heartbeater, logger)
+            # Batch 3 (final)
+            result3 = await flush_kafka_batch(
+                kafka_producer, mock_results_batch3, 1, 123, 20000, heartbeater, logger, is_final=True
+            )
+
+        assert result1 == 10000
+        assert result2 == 10000
+        assert result3 == 5000
+        assert result1 + result2 + result3 == 25000

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -242,15 +242,6 @@ class TestFlushKafkaBatch:
 class TestBatchFlushingBehavior:
     """Tests for batch flushing logic and integration."""
 
-    def test_flush_batch_size_constant_is_10k(self):
-        """Verify the FLUSH_BATCH_SIZE constant is set to 10,000."""
-        import inspect
-
-        import posthog.temporal.messaging.backfill_precalculated_person_properties_workflow as module
-
-        source = inspect.getsource(module.backfill_precalculated_person_properties_activity)
-        assert "FLUSH_BATCH_SIZE = 10_000" in source
-
     @pytest.mark.asyncio
     async def test_multiple_batches_handled_correctly(self):
         """Should handle multiple batch flushes correctly."""


### PR DESCRIPTION
## Problem

The precalculated person properties backfill workflow was timing out for team 2. 
Activities processing too many persons exceeded the 2-hour timeout, causing backfills to fail after reaching maximum retry attempts.

## Changes

- Increased activity timeout from 2 hours to 12 hours
- Implemented batched Kafka flushing (flush every 10K messages instead of accumulating all)
- Added flush_kafka_batch() function following the pattern from realtime cohort workflow
- Enhanced heartbeat updates during Kafka operations for better observability

## How did you test this code?

- Verified implementation follows the same pattern as realtime_cohort_calculation_workflow.py
- Code review completed (see CODE_REVIEW.md)
- Ready for testing on staging with a large team backfill

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No