### PR TITLE
fix(OAuth): prevent button hidden under iOS nav

### DIFF
--- a/frontend/src/scenes/oauth/OAuthAuthorize.tsx
+++ b/frontend/src/scenes/oauth/OAuthAuthorize.tsx
@@ -72,7 +72,10 @@ export const OAuthAuthorize = (): JSX.Element => {
 
     return (
         <div className="min-h-full overflow-y-auto">
-            <div className="max-w-2xl mx-auto py-8 px-4 sm:py-12 sm:px-6">
+            <div
+                className="max-w-2xl mx-auto py-8 px-4 sm:py-12 sm:px-6"
+                style={{ paddingBottom: 'max(2rem, env(safe-area-inset-bottom, 0px))' }}
+            >
                 <div className="text-center mb-4 sm:mb-8">
                     <h2 className="text-xl sm:text-2xl font-semibold">
                         Authorize <strong>{oauthApplication.name}</strong>


### PR DESCRIPTION
## Problem

In the mobile app Accept button on the OAuth page is shown behind iOS navigaion: 
<img width="292.5" height="633" alt="image" src="https://github.com/user-attachments/assets/6fb62b33-91fa-428f-b242-1e6aadffacd0" />

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Publish to changelog?
no