### PR TITLE
feat(workflows): allow soft-deletion and restoring workflows

### DIFF
--- a/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
@@ -17,15 +17,8 @@ import { WorkflowSceneLogicProps } from './workflowSceneLogic'
 export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.Element => {
     const logic = workflowLogic(props)
     const { workflow, workflowChanged, isWorkflowSubmitting, workflowLoading, workflowHasErrors } = useValues(logic)
-    const {
-        saveWorkflowPartial,
-        submitWorkflow,
-        discardChanges,
-        setWorkflowValue,
-        duplicate,
-        archiveWorkflow,
-        restoreWorkflow,
-    } = useActions(logic)
+    const { saveWorkflowPartial, submitWorkflow, discardChanges, setWorkflowValue, duplicate, archiveWorkflow } =
+        useActions(logic)
     const { searchParams } = useValues(router)
     const editTemplateId = searchParams.editTemplateId as string | undefined
     const templateId = searchParams.templateId as string | undefined
@@ -105,15 +98,11 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
                                             </LemonButton>
                                             <LemonDivider />
                                             <LemonButton
-                                                status={workflow.status === 'archived' ? 'default' : 'danger'}
+                                                status="danger"
                                                 fullWidth
-                                                onClick={
-                                                    workflow.status === 'archived'
-                                                        ? () => restoreWorkflow(workflow)
-                                                        : () => archiveWorkflow(workflow)
-                                                }
+                                                onClick={() => archiveWorkflow(workflow)}
                                             >
-                                                {workflow.status === 'archived' ? 'Restore' : 'Archive'}
+                                                Archive
                                             </LemonButton>
                                         </>
                                     }

--- a/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
@@ -17,8 +17,15 @@ import { WorkflowSceneLogicProps } from './workflowSceneLogic'
 export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.Element => {
     const logic = workflowLogic(props)
     const { workflow, workflowChanged, isWorkflowSubmitting, workflowLoading, workflowHasErrors } = useValues(logic)
-    const { saveWorkflowPartial, submitWorkflow, discardChanges, setWorkflowValue, duplicate, deleteWorkflow } =
-        useActions(logic)
+    const {
+        saveWorkflowPartial,
+        submitWorkflow,
+        discardChanges,
+        setWorkflowValue,
+        duplicate,
+        archiveWorkflow,
+        restoreWorkflow,
+    } = useActions(logic)
     const { searchParams } = useValues(router)
     const editTemplateId = searchParams.editTemplateId as string | undefined
     const templateId = searchParams.templateId as string | undefined
@@ -97,8 +104,16 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
                                                 Save as template
                                             </LemonButton>
                                             <LemonDivider />
-                                            <LemonButton status="danger" fullWidth onClick={() => deleteWorkflow()}>
-                                                Delete
+                                            <LemonButton
+                                                status={workflow.status === 'archived' ? 'default' : 'danger'}
+                                                fullWidth
+                                                onClick={
+                                                    workflow.status === 'archived'
+                                                        ? () => restoreWorkflow(workflow)
+                                                        : () => archiveWorkflow(workflow)
+                                                }
+                                            >
+                                                {workflow.status === 'archived' ? 'Restore' : 'Archive'}
                                             </LemonButton>
                                         </>
                                     }

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -322,16 +322,14 @@ export function WorkflowsTable(): JSX.Element {
                             header: 'Archived workflows',
                             key: 'archived_workflows',
                             className: 'p-1',
-                            content:
-                                    <LemonTable
-                                ) : (
-                                    <LemonTable
-                                        dataSource={archivedWorkflows}
-                                        loading={workflowsLoading}
-                                        columns={columns}
-                                        defaultSorting={{ columnKey: 'updatedAt', order: 1 }}
-                                    />
-                                ),
+                            content: (
+                                <LemonTable
+                                    dataSource={archivedWorkflows}
+                                    loading={workflowsLoading}
+                                    columns={columns}
+                                    defaultSorting={{ columnKey: 'updatedAt', order: 1 }}
+                                />
+                            ),
                         },
                     ]}
                 />

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -323,8 +323,7 @@ export function WorkflowsTable(): JSX.Element {
                             key: 'archived_workflows',
                             className: 'p-1',
                             content:
-                                archivedWorkflows.length === 0 ? (
-                                    <div className="p-4 text-muted">No archived workflows.</div>
+                                    <LemonTable
                                 ) : (
                                     <LemonTable
                                         dataSource={archivedWorkflows}

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -1,7 +1,7 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { LemonCollapse, LemonDivider, LemonInput, LemonSelect, LemonTag, Link } from '@posthog/lemon-ui'
+import { LemonCollapse, LemonDivider, LemonInput, LemonSelect, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { AppMetricsSparkline } from 'lib/components/AppMetrics/AppMetricsSparkline'
 import { MemberSelect } from 'lib/components/MemberSelect'
@@ -90,6 +90,7 @@ export function WorkflowsTable(): JSX.Element {
         duplicateWorkflow,
         archiveWorkflow,
         restoreWorkflow,
+        deleteWorkflow,
         setSearchTerm,
         setCreatedBy,
         setStatus,
@@ -102,7 +103,11 @@ export function WorkflowsTable(): JSX.Element {
             key: 'name',
             sorter: (a, b) => (a.name || '').localeCompare(b.name || ''),
             render: (_, item) => {
-                return (
+                return item.status === 'archived' ? (
+                    <Tooltip title="Restore this workflow to make changes">
+                        <span className="font-semibold text-sm text-muted">{item.name}</span>
+                    </Tooltip>
+                ) : (
                     <LemonTableLink
                         to={urls.workflow(item.id, 'workflow')}
                         title={item.name}
@@ -199,19 +204,21 @@ export function WorkflowsTable(): JSX.Element {
                     <More
                         overlay={
                             <>
-                                <LemonButton
-                                    data-attr="workflow-edit"
-                                    fullWidth
-                                    status={workflow.status === 'draft' ? 'default' : 'danger'}
-                                    onClick={() => toggleWorkflowStatus(workflow)}
-                                    tooltip={
-                                        workflow.status === 'draft'
-                                            ? 'Enables the workflow to start sending messages'
-                                            : 'Disables the workflow from sending any new messages. In-progress workflows will end immediately.'
-                                    }
-                                >
-                                    {workflow.status === 'draft' ? 'Enable' : 'Disable'}
-                                </LemonButton>
+                                {workflow.status !== 'archived' && (
+                                    <LemonButton
+                                        data-attr="workflow-edit"
+                                        fullWidth
+                                        status={workflow.status === 'draft' ? 'default' : 'danger'}
+                                        onClick={() => toggleWorkflowStatus(workflow)}
+                                        tooltip={
+                                            workflow.status === 'draft'
+                                                ? 'Enables the workflow to start sending messages'
+                                                : 'Disables the workflow from sending any new messages. In-progress workflows will end immediately.'
+                                        }
+                                    >
+                                        {workflow.status === 'draft' ? 'Enable' : 'Disable'}
+                                    </LemonButton>
+                                )}
                                 <LemonButton
                                     data-attr="workflow-duplicate"
                                     fullWidth
@@ -232,6 +239,16 @@ export function WorkflowsTable(): JSX.Element {
                                 >
                                     {workflow.status === 'archived' ? 'Restore' : 'Archive'}
                                 </LemonButton>
+                                {workflow.status === 'archived' && (
+                                    <LemonButton
+                                        data-attr="workflow-delete"
+                                        fullWidth
+                                        status="danger"
+                                        onClick={() => deleteWorkflow(workflow)}
+                                    >
+                                        Delete
+                                    </LemonButton>
+                                )}
                             </>
                         }
                     />

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -17,13 +17,13 @@ import { projectLogic } from 'scenes/projectLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { deleteFromTree } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { HogFunctionTemplateType } from '~/types'
 
 import { HogFlowActionSchema, isFunctionAction, isTriggerFunction } from './hogflows/steps/types'
 import { type HogFlow, type HogFlowAction, HogFlowActionValidationResult, type HogFlowEdge } from './hogflows/types'
 import type { workflowLogicType } from './workflowLogicType'
 import { workflowSceneLogic } from './workflowSceneLogic'
+import { workflowsLogic } from './workflowsLogic'
 
 export interface WorkflowLogicProps {
     id?: string
@@ -116,6 +116,7 @@ export const workflowLogic = kea<workflowLogicType>([
     key((props) => props.id || 'new'),
     connect(() => ({
         values: [userLogic, ['user'], projectLogic, ['currentProjectId']],
+        actions: [workflowsLogic, ['archiveWorkflow', 'restoreWorkflow']],
     })),
     actions({
         partialSetWorkflowActionConfig: (actionId: string, config: Partial<HogFlowAction['config']>) => ({
@@ -138,7 +139,6 @@ export const workflowLogic = kea<workflowLogicType>([
         }),
         discardChanges: true,
         duplicate: true,
-        deleteWorkflow: true,
     }),
     loaders(({ props, values }) => ({
         originalWorkflow: [
@@ -481,38 +481,6 @@ export const workflowLogic = kea<workflowLogicType>([
             const createdWorkflow = await api.hogFlows.createHogFlow(newWorkflow)
             lemonToast.success('Workflow duplicated')
             router.actions.push(urls.workflow(createdWorkflow.id, 'workflow'))
-        },
-        deleteWorkflow: async () => {
-            const workflow = values.originalWorkflow
-            if (!workflow) {
-                return
-            }
-            LemonDialog.open({
-                title: 'Delete workflow?',
-                description: `Are you sure you want to delete "${workflow.name}"? This action cannot be undone.${
-                    workflow.status === 'active' ? ' In-progress workflows will end immediately.' : ''
-                }`,
-                primaryButton: {
-                    children: 'Delete',
-                    type: 'primary',
-                    status: 'danger',
-                    onClick: async () => {
-                        try {
-                            await api.hogFlows.deleteHogFlow(workflow.id)
-                            lemonToast.success(`Workflow "${workflow.name}" deleted`)
-                            router.actions.push(urls.workflows())
-                            deleteFromTree('hog_flow/', workflow.id)
-                        } catch (error: any) {
-                            lemonToast.error(
-                                `Failed to delete workflow: ${error.detail || error.message || 'Unknown error'}`
-                            )
-                        }
-                    },
-                },
-                secondaryButton: {
-                    children: 'Cancel',
-                },
-            })
         },
         triggerManualWorkflow: async ({ variables }) => {
             if (!values.workflow.id || values.workflow.id === 'new') {

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -116,7 +116,7 @@ export const workflowLogic = kea<workflowLogicType>([
     key((props) => props.id || 'new'),
     connect(() => ({
         values: [userLogic, ['user'], projectLogic, ['currentProjectId']],
-        actions: [workflowsLogic, ['archiveWorkflow', 'restoreWorkflow']],
+        actions: [workflowsLogic, ['archiveWorkflow']],
     })),
     actions({
         partialSetWorkflowActionConfig: (actionId: string, config: Partial<HogFlowAction['config']>) => ({

--- a/products/workflows/frontend/Workflows/workflowsLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowsLogic.ts
@@ -89,7 +89,6 @@ export const workflowsLogic = kea<workflowsLogicType>([
                                     })
                                     lemonToast.success(`Workflow "${workflow.name}" archived`)
                                     router.actions.push(urls.workflows())
-                                    deleteFromTree('hog_flow/', workflow.id)
                                     actions.loadWorkflows()
                                 } catch (error: any) {
                                     lemonToast.error(
@@ -123,6 +122,7 @@ export const workflowsLogic = kea<workflowsLogicType>([
                                 try {
                                     await api.hogFlows.deleteHogFlow(workflow.id)
                                     lemonToast.success(`Workflow "${workflow.name}" deleted`)
+                                    deleteFromTree('hog_flow/', workflow.id)
                                     actions.loadWorkflows()
                                 } catch (error: any) {
                                     lemonToast.error(

--- a/products/workflows/frontend/Workflows/workflowsLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowsLogic.ts
@@ -102,6 +102,8 @@ export const workflowsLogic = kea<workflowsLogicType>([
                             children: 'Cancel',
                         },
                     })
+                    // Return unchanged workflows since dialog handles the update
+                    return values.workflows
                 },
                 restoreWorkflow: async ({ workflow }) => {
                     const updatedWorkflow = await api.hogFlows.updateHogFlow(workflow.id, {

--- a/products/workflows/frontend/Workflows/workflowsLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowsLogic.ts
@@ -106,11 +106,18 @@ export const workflowsLogic = kea<workflowsLogicType>([
                     return values.workflows
                 },
                 restoreWorkflow: async ({ workflow }) => {
-                    const updatedWorkflow = await api.hogFlows.updateHogFlow(workflow.id, {
-                        status: 'draft',
-                    })
-                    lemonToast.success(`Workflow "${workflow.name}" restored to draft status`)
-                    return values.workflows.map((c) => (c.id === updatedWorkflow.id ? updatedWorkflow : c))
+                    try {
+                        const updatedWorkflow = await api.hogFlows.updateHogFlow(workflow.id, {
+                            status: 'draft',
+                        })
+                        lemonToast.success(`Workflow "${workflow.name}" restored to draft status`)
+                        return values.workflows.map((c) => (c.id === updatedWorkflow.id ? updatedWorkflow : c))
+                    } catch (error: any) {
+                        lemonToast.error(
+                            `Failed to restore workflow: ${error?.detail || error?.message || 'Unknown error'}`
+                        )
+                        return values.workflows
+                    }
                 },
                 deleteWorkflow: async ({ workflow }) => {
                     LemonDialog.open({

--- a/products/workflows/frontend/Workflows/workflowsLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowsLogic.ts
@@ -29,6 +29,7 @@ export const workflowsLogic = kea<workflowsLogicType>([
         duplicateWorkflow: (workflow: HogFlow) => ({ workflow }),
         archiveWorkflow: (workflow: HogFlow) => ({ workflow }),
         restoreWorkflow: (workflow: HogFlow) => ({ workflow }),
+        deleteWorkflow: (workflow: HogFlow) => ({ workflow }),
         loadWorkflows: () => ({}),
         setFilters: (filters: Partial<WorkflowsFilters>) => ({ filters }),
         setSearchTerm: (search: string) => ({ search }),
@@ -70,6 +71,7 @@ export const workflowsLogic = kea<workflowsLogicType>([
                 },
                 archiveWorkflow: async ({ workflow }) => {
                     LemonDialog.open({
+                        width: 500,
                         title: 'Archive workflow?',
                         description: `Are you sure you want to archive "${workflow.name}"?${
                             workflow.status === 'active'
@@ -107,6 +109,32 @@ export const workflowsLogic = kea<workflowsLogicType>([
                     })
                     lemonToast.success(`Workflow "${workflow.name}" restored to draft status`)
                     return values.workflows.map((c) => (c.id === updatedWorkflow.id ? updatedWorkflow : c))
+                },
+                deleteWorkflow: async ({ workflow }) => {
+                    LemonDialog.open({
+                        width: 500,
+                        title: 'Delete workflow?',
+                        description: `Are you sure you want to permanently delete "${workflow.name}"? This action cannot be undone.`,
+                        primaryButton: {
+                            children: 'Delete',
+                            type: 'primary',
+                            status: 'danger',
+                            onClick: async () => {
+                                try {
+                                    await api.hogFlows.deleteHogFlow(workflow.id)
+                                    lemonToast.success(`Workflow "${workflow.name}" deleted`)
+                                    actions.loadWorkflows()
+                                } catch (error: any) {
+                                    lemonToast.error(
+                                        `Failed to delete workflow: ${error.detail || error.message || 'Unknown error'}`
+                                    )
+                                }
+                            },
+                        },
+                        secondaryButton: {
+                            children: 'Cancel',
+                        },
+                    })
                 },
             },
         ],

--- a/products/workflows/frontend/Workflows/workflowsLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowsLogic.ts
@@ -137,6 +137,7 @@ export const workflowsLogic = kea<workflowsLogicType>([
                             children: 'Cancel',
                         },
                     })
+                    return values.workflows
                 },
             },
         ],


### PR DESCRIPTION
## Problem

Currently users can only hard-delete workflows, which will inevitably lead to tedious support tickets / frustration if a user expected this to not be permanent. Plus we already have the 'archived' status, and just aren't using it yet

## Changes

https://github.com/user-attachments/assets/7c3151e4-5676-4eab-9beb-930b83cadc61


## How did you test this code?

See video above. This will also be included in playwright test flows coming soon