### PR TITLE
chore(product-analytics): Filter out unneeded properties in Live Activity tab

### DIFF
--- a/frontend/src/scenes/activity/live/liveEventsLogic.tsx
+++ b/frontend/src/scenes/activity/live/liveEventsLogic.tsx
@@ -124,6 +124,7 @@ export const liveEventsLogic = kea<liveEventsLogicType>([
             if (eventType) {
                 url.searchParams.append('eventType', eventType)
             }
+            url.searchParams.append('columns', '$current_url,$screen_name')
 
             cache.batch = []
             cache.eventSourceController = new AbortController()


### PR DESCRIPTION
## Problem
The Livestream service had no way to filter out properties until recently. With that change, the Live Activity tab is now able to significantly reduce SSE download size for clients with a large number of properties on their events or who have a high event volume.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Filter for `$current_url` and `$current_url`.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
