### PR TITLE
feat(kafka-deduplicator): defensive cleanup of S3 checkpoint local import directory

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/downloader.rs
@@ -22,7 +22,7 @@ pub trait CheckpointDownloader: Send + Sync + std::fmt::Debug {
 
     /// Given a list of fully-qualified remote file keys, download all
     /// files in parallel from remote storage and into the given local
-    /// directory path, creating that base directory if it doesn't exist
+    /// directory path. Caller is responsible for creating the directory.
     async fn download_files(&self, remote_keys: &[String], local_base_path: &Path) -> Result<()>;
 
     /// Check if the downloader is available and configured for use

--- a/rust/kafka-deduplicator/src/checkpoint/import.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/import.rs
@@ -63,6 +63,35 @@ impl CheckpointImporter {
             let local_path_tag = local_attempt_path.to_string_lossy().to_string();
             let attempt_tag = attempt.get_attempt_path();
 
+            // Defensive cleanup: remove any existing directory from a previous failed attempt.
+            // Since the path is deterministic (based on checkpoint timestamp), a crash loop
+            // could leave corrupted partial downloads that would break the retry.
+            if local_attempt_path.exists() {
+                info!(
+                    checkpoint = attempt_tag,
+                    local_attempt_path = local_path_tag,
+                    "Removing existing directory before checkpoint import (likely from previous failed attempt)"
+                );
+                tokio::fs::remove_dir_all(&local_attempt_path)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Failed to remove existing directory before import: {}",
+                            local_path_tag
+                        )
+                    })?;
+            }
+
+            // Create the directory for this import attempt
+            tokio::fs::create_dir_all(&local_attempt_path)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to create local directory for import: {}",
+                        local_path_tag
+                    )
+                })?;
+
             match self
                 .fetch_checkpoint_files(&attempt, &local_attempt_path)
                 .await
@@ -185,5 +214,136 @@ impl CheckpointImporter {
 
     pub async fn is_available(&self) -> bool {
         self.downloader.is_available().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use chrono::{TimeZone, Utc};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    /// Mock downloader for testing checkpoint import behavior
+    #[derive(Debug)]
+    struct MockDownloader {
+        metadata: CheckpointMetadata,
+        download_count: Arc<AtomicUsize>,
+    }
+
+    impl MockDownloader {
+        fn new(metadata: CheckpointMetadata) -> Self {
+            Self {
+                metadata,
+                download_count: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CheckpointDownloader for MockDownloader {
+        async fn list_recent_checkpoints(
+            &self,
+            _topic: &str,
+            _partition_number: i32,
+        ) -> Result<Vec<String>> {
+            Ok(vec![self.metadata.get_metadata_filepath()])
+        }
+
+        async fn download_file(&self, _remote_key: &str) -> Result<Vec<u8>> {
+            let json = self.metadata.to_json()?;
+            Ok(json.into_bytes())
+        }
+
+        async fn download_and_store_file(
+            &self,
+            _remote_key: &str,
+            local_filepath: &Path,
+        ) -> Result<()> {
+            tokio::fs::write(local_filepath, b"mock file content").await?;
+            Ok(())
+        }
+
+        async fn download_files(
+            &self,
+            remote_keys: &[String],
+            local_base_path: &Path,
+        ) -> Result<()> {
+            self.download_count.fetch_add(1, Ordering::SeqCst);
+            for key in remote_keys {
+                let filename = key.rsplit('/').next().unwrap_or(key);
+                let local_path = local_base_path.join(filename);
+                self.download_and_store_file(key, &local_path).await?;
+            }
+            Ok(())
+        }
+
+        async fn is_available(&self) -> bool {
+            true
+        }
+    }
+
+    #[tokio::test]
+    async fn test_import_cleans_up_existing_directory_from_crashed_attempt() {
+        let tmp_dir = TempDir::new().unwrap();
+        let store_base_path = tmp_dir.path().to_path_buf();
+
+        let topic = "test-topic";
+        let partition = 0;
+        // Use a fixed timestamp so we know exactly what path will be used
+        let attempt_timestamp = Utc.with_ymd_and_hms(2025, 6, 15, 12, 0, 0).unwrap();
+
+        let mut metadata = CheckpointMetadata::new(
+            topic.to_string(),
+            partition,
+            attempt_timestamp,
+            12345,
+            100,
+            50,
+        );
+        metadata.track_file(
+            "checkpoints/test-topic/0/2025-06-15T12-00-00Z/000001.sst".to_string(),
+            "checksum1".to_string(),
+        );
+
+        // Calculate the exact path that import will use
+        let expected_import_path = metadata.get_store_path(&store_base_path);
+
+        // Simulate a crashed previous attempt: create the directory with a "corrupted" file
+        std::fs::create_dir_all(&expected_import_path).unwrap();
+        let corrupted_file = expected_import_path.join("CORRUPTED_FROM_CRASH");
+        std::fs::write(&corrupted_file, b"this simulates leftover corrupted data").unwrap();
+        assert!(
+            corrupted_file.exists(),
+            "Corrupted file should exist before import"
+        );
+
+        // Create importer with mock downloader
+        let downloader = MockDownloader::new(metadata);
+        let importer = CheckpointImporter::new(Box::new(downloader), store_base_path, 3);
+
+        // Run import - should succeed after cleaning up the corrupted directory
+        let result = importer
+            .import_checkpoint_for_topic_partition(topic, partition)
+            .await;
+
+        assert!(result.is_ok(), "Import should succeed: {:?}", result.err());
+        let import_path = result.unwrap();
+        assert_eq!(import_path, expected_import_path);
+
+        // Verify the corrupted file is gone (directory was pre-deleted and recreated)
+        assert!(
+            !corrupted_file.exists(),
+            "Corrupted file should have been removed by defensive pre-deletion"
+        );
+
+        // Verify the imported file exists
+        let imported_file = import_path.join("000001.sst");
+        assert!(
+            imported_file.exists(),
+            "Imported SST file should exist after successful import"
+        );
     }
 }

--- a/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
@@ -140,12 +140,6 @@ impl CheckpointDownloader for S3Downloader {
 
     async fn download_files(&self, remote_keys: &[String], local_base_path: &Path) -> Result<()> {
         let start_time = Instant::now();
-        tokio::fs::create_dir_all(local_base_path)
-            .await
-            .with_context(|| {
-                format!("Failed to create local base directory: {local_base_path:?}")
-            })?;
-
         let mut download_futures = Vec::with_capacity(remote_keys.len());
         for remote_key in remote_keys {
             let remote_filename = remote_key


### PR DESCRIPTION
## Problem
If a previous import attempt of the same checkpoint has failed on a given pod, and that pod is reassigned the same checkpoint, we don't want the new import attempt to fail
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Defensively delete inbound checkpoint import local path prior to recreate and file import steps
* Small refactor to extract prechecks into importer module
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
