### PR TITLE
fix(surveys): remove frame-ancesotrs from hosted survey

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -2140,6 +2140,8 @@ def public_survey_page(request, survey_id: str):
 
     if survey.enable_iframe_embedding:
         response.xframe_options_exempt = True
+        # Override infrastructure-level CSP to allow embedding from any origin
+        response["Content-Security-Policy"] = "frame-ancestors *"
     else:
         response["X-Frame-Options"] = "DENY"
 

--- a/posthog/api/test/test_external_surveys.py
+++ b/posthog/api/test/test_external_surveys.py
@@ -145,6 +145,8 @@ class TestExternalSurveys(APIBaseTest):
 
         # X-Frame-Options should not be present when iframe embedding is enabled
         assert "X-Frame-Options" not in response
+        # CSP should allow framing from any origin
+        assert response["Content-Security-Policy"] == "frame-ancestors *"
         assert "Cache-Control" in response
         assert "Vary" in response
 


### PR DESCRIPTION
## Problem
we want to enable hosted surveys to be embedded in iframes. the current frame-ancestors config blocks this

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
overriding frame-ancestors here

also doing it in argocd config https://github.com/PostHog/charts/pull/7955 because i'm not sure this won't just get overridden

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no