### PR TITLE
chore(llma): standardize temporal child workflow ID prefixes

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -22,6 +22,7 @@ WORKFLOW_EXECUTION_TIMEOUT = timedelta(minutes=30)
 WORKFLOW_NAME = "llma-trace-clustering"
 COORDINATOR_WORKFLOW_NAME = "llma-trace-clustering-coordinator"
 COORDINATOR_SCHEDULE_ID = "llma-trace-clustering-coordinator-schedule"
+CHILD_WORKFLOW_ID_PREFIX = "llma-trace-clustering-team"
 
 # Activity timeouts (per activity type)
 COMPUTE_ACTIVITY_TIMEOUT = timedelta(seconds=120)  # Fetch + k-means + distances

--- a/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
@@ -18,7 +18,11 @@ from temporalio.workflow import ChildWorkflowHandle
 
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.llm_analytics.trace_clustering import constants
-from posthog.temporal.llm_analytics.trace_clustering.constants import ALLOWED_TEAM_IDS, COORDINATOR_WORKFLOW_NAME
+from posthog.temporal.llm_analytics.trace_clustering.constants import (
+    ALLOWED_TEAM_IDS,
+    CHILD_WORKFLOW_ID_PREFIX,
+    COORDINATOR_WORKFLOW_NAME,
+)
 from posthog.temporal.llm_analytics.trace_clustering.models import ClusteringResult, ClusteringWorkflowInputs
 from posthog.temporal.llm_analytics.trace_clustering.workflow import DailyTraceClusteringWorkflow
 
@@ -115,7 +119,7 @@ class TraceClusteringCoordinatorWorkflow(PostHogWorkflow):
                         min_k=inputs.min_k,
                         max_k=inputs.max_k,
                     ),
-                    id=f"trace-clustering-team-{team_id}-{temporalio.workflow.now().isoformat()}",
+                    id=f"{CHILD_WORKFLOW_ID_PREFIX}-{team_id}-{temporalio.workflow.now().isoformat()}",
                     execution_timeout=constants.WORKFLOW_EXECUTION_TIMEOUT,
                     retry_policy=constants.COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY,
                     parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -61,3 +61,4 @@ ALLOWED_TEAM_IDS: list[int] = [
 WORKFLOW_NAME = "llma-trace-summarization"
 COORDINATOR_WORKFLOW_NAME = "llma-trace-summarization-coordinator"
 COORDINATOR_SCHEDULE_ID = "llma-trace-summarization-coordinator-schedule"
+CHILD_WORKFLOW_ID_PREFIX = "llma-trace-summarization-team"

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -19,6 +19,7 @@ from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.llm_analytics.trace_summarization import constants
 from posthog.temporal.llm_analytics.trace_summarization.constants import (
     ALLOWED_TEAM_IDS,
+    CHILD_WORKFLOW_ID_PREFIX,
     COORDINATOR_WORKFLOW_NAME,
     DEFAULT_BATCH_SIZE,
     DEFAULT_MAX_TRACES_PER_WINDOW,
@@ -125,7 +126,7 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
                         provider=inputs.provider,
                         model=inputs.model,
                     ),
-                    id=f"batch-summarization-team-{team_id}-{temporalio.workflow.now().isoformat()}",
+                    id=f"{CHILD_WORKFLOW_ID_PREFIX}-{team_id}-{temporalio.workflow.now().isoformat()}",
                     execution_timeout=timedelta(minutes=WORKFLOW_EXECUTION_TIMEOUT_MINUTES),
                     retry_policy=constants.COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY,
                 )


### PR DESCRIPTION
## Problem

LLM analytics temporal child workflow IDs used inconsistent prefixes (`batch-summarization-team-` and `trace-clustering-team-`), making it harder to filter and observe workflows in Temporal.

## Changes

- Add `CHILD_WORKFLOW_ID_PREFIX` constants to both `trace_summarization` and `trace_clustering` modules
- Update coordinators to use the constants
- Standardize on `llma-trace-summarization-team-` and `llma-trace-clustering-team-` prefixes

## How did you test this code?

Constants only change - verified imports and string formatting are correct.

## Publish to changelog?

No