### PR TITLE
fix(events/replay?): switch target user / acting user in billing escalation log

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -85,12 +85,12 @@ def build_billing_token(
         if authorizer_actor != user:
             # We've done a privilege escalation
             report_user_action(
-                user,
+                authorizer_actor,
                 "$billing_privilege_escalation",
                 properties={
-                    "authorizer_actor_id": authorizer_actor.id,
-                    # NOTE(Marce): Hardcoded for now since it's the only place where it can happen
-                    # I have another PR with a better implementation of this.
+                    "target_user_id": user.id,
+                    "target_distinct_id": str(user.distinct_id),
+                    "target_email": user.email,
                     "action": "update_billing",
                 },
             )

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -347,8 +347,10 @@ class TestBuildBillingToken(BaseTest):
         mock_capture.assert_called_once()
         call_kwargs = mock_capture.call_args[1]
         assert call_kwargs["event"] == "$billing_privilege_escalation"
-        assert call_kwargs["distinct_id"] == str(member_user.distinct_id)
-        assert call_kwargs["properties"]["authorizer_actor_id"] == admin_authorizer.id
+        assert call_kwargs["distinct_id"] == str(admin_authorizer.distinct_id)
+        assert call_kwargs["properties"]["target_user_id"] == member_user.id
+        assert call_kwargs["properties"]["target_distinct_id"] == str(member_user.distinct_id)
+        assert call_kwargs["properties"]["target_email"] == member_user.email
         assert call_kwargs["properties"]["action"] == "update_billing"
 
     def test_build_billing_token_raises_when_authorizer_actor_not_in_organization(self):
@@ -398,8 +400,10 @@ class TestBuildBillingToken(BaseTest):
         mock_capture.assert_called_once()
         call_kwargs = mock_capture.call_args[1]
         assert call_kwargs["event"] == "$billing_privilege_escalation"
-        assert call_kwargs["distinct_id"] == str(non_member_user.distinct_id)
-        assert call_kwargs["properties"]["authorizer_actor_id"] == valid_authorizer.id
+        assert call_kwargs["distinct_id"] == str(valid_authorizer.distinct_id)
+        assert call_kwargs["properties"]["target_user_id"] == non_member_user.id
+        assert call_kwargs["properties"]["target_distinct_id"] == str(non_member_user.distinct_id)
+        assert call_kwargs["properties"]["target_email"] == non_member_user.email
 
     @parameterized.expand(
         [
@@ -540,8 +544,10 @@ class TestUpdateBillingOrganizationUsersPrivilegeEscalation(BaseTest):
         mock_capture.assert_called_once()
         capture_kwargs = mock_capture.call_args[1]
         assert capture_kwargs["event"] == "$billing_privilege_escalation"
-        assert capture_kwargs["distinct_id"] == str(member.distinct_id)
-        assert capture_kwargs["properties"]["authorizer_actor_id"] == owner.id
+        assert capture_kwargs["distinct_id"] == str(owner.distinct_id)
+        assert capture_kwargs["properties"]["target_user_id"] == member.id
+        assert capture_kwargs["properties"]["target_distinct_id"] == str(member.distinct_id)
+        assert capture_kwargs["properties"]["target_email"] == member.email
         assert capture_kwargs["properties"]["action"] == "update_billing"
 
     @patch("ee.billing.billing_manager.requests.patch")
@@ -624,7 +630,10 @@ class TestUpdateBillingOrganizationUsersPrivilegeEscalation(BaseTest):
         # Verify that the capture was called with the newer owner as authorizer
         mock_capture.assert_called_once()
         capture_kwargs = mock_capture.call_args[1]
-        assert capture_kwargs["properties"]["authorizer_actor_id"] == newer_owner.id
+        assert capture_kwargs["distinct_id"] == str(newer_owner.distinct_id)
+        assert capture_kwargs["properties"]["target_user_id"] == member.id
+        assert capture_kwargs["properties"]["target_distinct_id"] == str(member.distinct_id)
+        assert capture_kwargs["properties"]["target_email"] == member.email
 
     @patch("ee.billing.billing_manager.requests.patch")
     @patch("posthog.event_usage.posthoganalytics.capture")
@@ -664,8 +673,10 @@ class TestUpdateBillingOrganizationUsersPrivilegeEscalation(BaseTest):
 
         mock_capture.assert_called_once()
         capture_kwargs = mock_capture.call_args[1]
-        assert capture_kwargs["distinct_id"] == str(admin.distinct_id)
-        assert capture_kwargs["properties"]["authorizer_actor_id"] == owner.id
+        assert capture_kwargs["distinct_id"] == str(owner.distinct_id)
+        assert capture_kwargs["properties"]["target_user_id"] == admin.id
+        assert capture_kwargs["properties"]["target_distinct_id"] == str(admin.distinct_id)
+        assert capture_kwargs["properties"]["target_email"] == admin.email
 
     @patch("ee.billing.billing_manager.capture_exception")
     @patch("ee.billing.billing_manager.requests.patch")
@@ -794,4 +805,7 @@ class TestUserUpdateBillingOrganizationUsers(BaseTest):
         mock_capture.assert_called_once()
         capture_kwargs = mock_capture.call_args[1]
         assert capture_kwargs["event"] == "$billing_privilege_escalation"
-        assert capture_kwargs["properties"]["authorizer_actor_id"] == owner.id
+        assert capture_kwargs["distinct_id"] == str(owner.distinct_id)
+        assert capture_kwargs["properties"]["target_user_id"] == member.id
+        assert capture_kwargs["properties"]["target_distinct_id"] == str(member.distinct_id)
+        assert capture_kwargs["properties"]["target_email"] == member.email


### PR DESCRIPTION
## Problem

Annika noticed when filtering for a user that she was getting a Replay result for her own session: https://posthog.slack.com/archives/C03PB072FMJ/p1768477250777659

that led me to find out the` billing_privelege_escalation` is firing with the target user as the acting user and vice versa

This switches that?
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes


<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- fixed tests accordingly
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
