### PR TITLE
chore(web-analytics): use consistent timezone for compare date range

### DIFF
--- a/posthog/hogql_queries/web_analytics/test/test_web_overview.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview.py
@@ -931,3 +931,27 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert tz_date_range.date_from().tzinfo.key == "America/Los_Angeles"
         # UTC should be used when convertToProjectTimezone=False
         assert utc_date_range.date_from().tzinfo.key == "UTC"
+
+    def test_compare_to_date_range_respects_convertToProjectTimezone(self):
+        self.team.timezone = "Asia/Tokyo"
+        self.team.save()
+
+        query = WebOverviewQuery(
+            dateRange=DateRange(date_from="-24h"),
+            properties=[],
+            compareFilter=CompareFilter(compare=True),
+        )
+
+        # Test with UTC modifier - both main and compare date ranges should use UTC
+        modifiers_utc = HogQLQueryModifiers(convertToProjectTimezone=False)
+        runner_utc = WebOverviewQueryRunner(team=self.team, query=query, modifiers=modifiers_utc)
+
+        assert runner_utc.query_date_range._timezone_info == ZoneInfo("UTC")
+        assert runner_utc.query_compare_to_date_range._timezone_info == ZoneInfo("UTC")
+
+        # Test with team timezone - both should use team timezone
+        modifiers_tz = HogQLQueryModifiers(convertToProjectTimezone=True)
+        runner_tz = WebOverviewQueryRunner(team=self.team, query=query, modifiers=modifiers_tz)
+
+        assert runner_tz.query_date_range._timezone_info == ZoneInfo("Asia/Tokyo")
+        assert runner_tz.query_compare_to_date_range._timezone_info == ZoneInfo("Asia/Tokyo")

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -61,20 +61,21 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
         return user_access_control.assert_access_level_for_resource("web_analytics", "viewer")
 
     @cached_property
-    def query_date_range(self):
+    def _timezone_info(self) -> ZoneInfo:
         # Respect the convertToProjectTimezone modifier for date range calculation
         # When convertToProjectTimezone=False, use UTC for both date boundaries AND column conversion
-        timezone_info = (
-            ZoneInfo("UTC")
-            if self.modifiers and not self.modifiers.convertToProjectTimezone
-            else self.team.timezone_info
-        )
+        if self.modifiers and not self.modifiers.convertToProjectTimezone:
+            return ZoneInfo("UTC")
+        return self.team.timezone_info
+
+    @cached_property
+    def query_date_range(self):
         return QueryDateRange(
             date_range=self.query.dateRange,
             team=self.team,
-            timezone_info=timezone_info,
+            timezone_info=self._timezone_info,
             interval=None,
-            now=datetime.now(timezone_info),
+            now=datetime.now(self._timezone_info),
         )
 
     @cached_property
@@ -85,7 +86,8 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
                     date_range=self.query.dateRange,
                     team=self.team,
                     interval=None,
-                    now=datetime.now(),
+                    now=datetime.now(self._timezone_info),
+                    timezone_info=self._timezone_info,
                     compare_to=self.query.compareFilter.compare_to,
                 )
             elif self.query.compareFilter.compare:
@@ -93,7 +95,8 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
                     date_range=self.query.dateRange,
                     team=self.team,
                     interval=None,
-                    now=datetime.now(),
+                    now=datetime.now(self._timezone_info),
+                    timezone_info=self._timezone_info,
                 )
 
         return None


### PR DESCRIPTION
## Problem

Users in non-UTC time zones, without the new query engine, and specific timezone overlaps are seeing incorrect "compare with previous period" percentages in web analytics. 

The comparison date range was using datetime.now() without timezone awareness, causing misaligned date boundaries between the current and previous periods.

More context here: https://posthoghelp.zendesk.com/agent/tickets/46992 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50671)

## Changes

- Extract _timezone_info cached property in WebAnalyticsQueryRunner to ensure consistent timezone handling
- Pass timezone_info parameter to QueryCompareToDateRange and QueryPreviousPeriodDateRange constructors
- Use timezone-aware datetime.now(timezone_info) for comparison date ranges

## How did you test this code?

Checking snapshots and underlying data along with unit tests. 

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No.