### PR TITLE
fix(experiments): handle session properties in experiment metrics

### DIFF
--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_session_properties.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_session_properties.ambr
@@ -1,0 +1,73 @@
+# serializer version: 1
+# name: TestExperimentSessionPropertyMetrics.test_session_duration_not_multiplied_across_events
+  '''
+  SELECT entity_metrics.variant AS variant,
+         count(entity_metrics.entity_id) AS num_users,
+         sum(entity_metrics.value) AS total_sum,
+         sum(power(entity_metrics.value, 2)) AS total_sum_of_squares
+  FROM
+    (SELECT metric_events.entity_id AS entity_id,
+            metric_events.variant AS variant,
+            sum(coalesce(accurateCastOrNull(metric_events.value, 'Float64'), 0)) AS value
+     FROM
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               accurateCastOrNull(coalesce(metric_events_by_session.session_value, 0), 'Float64') AS value,
+               metric_events_by_session.session_id AS session_id
+        FROM
+          (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+                  if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+                  min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+                  max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+                  argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+                  argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+           GROUP BY entity_id) AS exposures
+        INNER JOIN
+          (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+                  events.`$session_id` AS session_id,
+                  any(events__session.`$session_duration`) AS session_value,
+                  min(toTimeZone(events.timestamp, 'UTC')) AS first_event_timestamp
+           FROM events
+           LEFT JOIN
+             (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                     raw_sessions.session_id_v7 AS session_id_v7
+              FROM raw_sessions
+              WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0)), toIntervalDay(3))))
+              GROUP BY raw_sessions.session_id_v7,
+                       raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, '$pageview')), isNotNull(events.`$session_id`), notEquals(events.`$session_id`, ''))
+           GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
+                    events.`$session_id`) AS metric_events_by_session ON and(equals(exposures.entity_id, metric_events_by_session.entity_id), greaterOrEquals(metric_events_by_session.first_event_timestamp, exposures.first_exposure_time))) AS metric_events
+     GROUP BY metric_events.entity_id,
+              metric_events.variant) AS entity_metrics
+  GROUP BY entity_metrics.variant
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=600,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=39728447488,
+                     allow_experimental_analyzer=1,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
@@ -1,0 +1,182 @@
+"""
+Tests for session property aggregation in experiment metrics.
+
+These tests verify that session properties (like $session_duration) are correctly
+aggregated in experiments, avoiding the multiplication bug where each event in a
+session contributes the full session value instead of deduplicating per session.
+"""
+
+from typing import cast
+
+from freezegun import freeze_time
+from posthog.test.base import _create_event, _create_person, flush_persons_and_events
+
+from django.test import override_settings
+
+from posthog.schema import (
+    EventsNode,
+    ExperimentMeanMetric,
+    ExperimentMetricMathType,
+    ExperimentQuery,
+    ExperimentQueryResponse,
+)
+
+from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
+from posthog.hogql_queries.experiments.test.experiment_query_runner.base import ExperimentQueryRunnerBaseTest
+from posthog.models.utils import uuid7
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestExperimentSessionPropertyMetrics(ExperimentQueryRunnerBaseTest):
+    """Tests for session property aggregation in experiments."""
+
+    @freeze_time("2024-01-01T12:00:00Z")
+    def test_session_duration_not_multiplied_across_events(self):
+        """
+        Critical test: Verify session duration is NOT multiplied by event count.
+
+        Setup:
+        - Control user: 1 session of 60 seconds with 3 pageviews
+        - Test user: 1 session of 120 seconds with 2 pageviews
+
+        Expected (correct):
+        - Control sum: 60 (one session contributes 60s once)
+        - Test sum: 120 (one session contributes 120s once)
+
+        Bug behavior (what currently happens):
+        - Control sum: 180 (60s * 3 pageviews = each event contributes full duration)
+        - Test sum: 240 (120s * 2 pageviews)
+
+        This test should FAIL initially, proving the bug exists.
+        """
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        ff_property = f"$feature/{feature_flag.key}"
+
+        # Create session IDs
+        control_session_id = str(uuid7("2024-01-02"))
+        test_session_id = str(uuid7("2024-01-02"))
+
+        # Control user: 1 session with 3 pageviews
+        # Session duration = 60s (from first pageview to last pageview)
+        # Exposure is in a DIFFERENT session to isolate the metric session
+        _create_person(distinct_ids=["control_user"], team_id=self.team.pk)
+
+        # Exposure event (in its own session, before the metric session)
+        _create_event(
+            team=self.team,
+            event="$feature_flag_called",
+            distinct_id="control_user",
+            timestamp="2024-01-02T11:00:00Z",  # 1 hour before metric events
+            properties={
+                "$feature_flag_response": "control",
+                ff_property: "control",
+                "$feature_flag": feature_flag.key,
+                "$session_id": f"{control_session_id}_exposure",  # Different session
+            },
+        )
+
+        # 3 pageviews in the metric session, spanning 60 seconds
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="control_user",
+            timestamp="2024-01-02T12:00:00Z",  # Session start
+            properties={ff_property: "control", "$session_id": control_session_id},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="control_user",
+            timestamp="2024-01-02T12:00:30Z",  # T+30s
+            properties={ff_property: "control", "$session_id": control_session_id},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="control_user",
+            timestamp="2024-01-02T12:01:00Z",  # T+60s (session duration = 60s)
+            properties={ff_property: "control", "$session_id": control_session_id},
+        )
+
+        # Test user: 1 session with 2 pageviews
+        # Session duration = 120s (from first pageview to last pageview)
+        _create_person(distinct_ids=["test_user"], team_id=self.team.pk)
+
+        # Exposure event (in its own session, before the metric session)
+        _create_event(
+            team=self.team,
+            event="$feature_flag_called",
+            distinct_id="test_user",
+            timestamp="2024-01-02T11:00:00Z",  # 1 hour before metric events
+            properties={
+                "$feature_flag_response": "test",
+                ff_property: "test",
+                "$feature_flag": feature_flag.key,
+                "$session_id": f"{test_session_id}_exposure",  # Different session
+            },
+        )
+
+        # 2 pageviews in the metric session, spanning 120 seconds
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="test_user",
+            timestamp="2024-01-02T12:00:00Z",  # Session start
+            properties={ff_property: "test", "$session_id": test_session_id},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="test_user",
+            timestamp="2024-01-02T12:02:00Z",  # T+120s (session duration = 120s)
+            properties={ff_property: "test", "$session_id": test_session_id},
+        )
+
+        flush_persons_and_events()
+
+        # Create metric using session property
+        metric = ExperimentMeanMetric(
+            source=EventsNode(
+                event="$pageview",
+                math=ExperimentMetricMathType.SUM,
+                math_property="$session_duration",
+                math_property_type="session_properties",
+            ),
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.baseline is not None
+        assert result.variant_results is not None
+        self.assertEqual(len(result.variant_results), 1)
+
+        control_variant = result.baseline
+        test_variant = result.variant_results[0]
+
+        # These assertions represent the CORRECT behavior
+        # Control: 1 session * 60 seconds = 60
+        # Test: 1 session * 120 seconds = 120
+        #
+        # If the bug exists, we'd see:
+        # Control: 3 events * 60 seconds = 180 (WRONG)
+        # Test: 2 events * 120 seconds = 240 (WRONG)
+        self.assertEqual(control_variant.sum, 60, "Control session duration should be 60s (not multiplied by 3 events)")
+        self.assertEqual(test_variant.sum, 120, "Test session duration should be 120s (not multiplied by 2 events)")
+
+        # Each variant has 1 user
+        self.assertEqual(control_variant.number_of_samples, 1)
+        self.assertEqual(test_variant.number_of_samples, 1)

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
@@ -1,7 +1,7 @@
 from typing import cast
 
 from freezegun import freeze_time
-from posthog.test.base import _create_event, _create_person, flush_persons_and_events
+from posthog.test.base import _create_event, _create_person, flush_persons_and_events, snapshot_clickhouse_queries
 
 from django.test import override_settings
 
@@ -20,6 +20,7 @@ from posthog.models.utils import uuid7
 
 @override_settings(IN_UNIT_TESTING=True)
 class TestExperimentSessionPropertyMetrics(ExperimentQueryRunnerBaseTest):
+    @snapshot_clickhouse_queries
     @freeze_time("2024-01-01T12:00:00Z")
     def test_session_duration_not_multiplied_across_events(self):
         feature_flag = self.create_feature_flag()

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
@@ -1,11 +1,3 @@
-"""
-Tests for session property aggregation in experiment metrics.
-
-These tests verify that session properties (like $session_duration) are correctly
-aggregated in experiments, avoiding the multiplication bug where each event in a
-session contributes the full session value instead of deduplicating per session.
-"""
-
 from typing import cast
 
 from freezegun import freeze_time
@@ -28,27 +20,8 @@ from posthog.models.utils import uuid7
 
 @override_settings(IN_UNIT_TESTING=True)
 class TestExperimentSessionPropertyMetrics(ExperimentQueryRunnerBaseTest):
-    """Tests for session property aggregation in experiments."""
-
     @freeze_time("2024-01-01T12:00:00Z")
     def test_session_duration_not_multiplied_across_events(self):
-        """
-        Critical test: Verify session duration is NOT multiplied by event count.
-
-        Setup:
-        - Control user: 1 session of 60 seconds with 3 pageviews
-        - Test user: 1 session of 120 seconds with 2 pageviews
-
-        Expected (correct):
-        - Control sum: 60 (one session contributes 60s once)
-        - Test sum: 120 (one session contributes 120s once)
-
-        Bug behavior (what currently happens):
-        - Control sum: 180 (60s * 3 pageviews = each event contributes full duration)
-        - Test sum: 240 (120s * 2 pageviews)
-
-        This test should FAIL initially, proving the bug exists.
-        """
         feature_flag = self.create_feature_flag()
         experiment = self.create_experiment(feature_flag=feature_flag)
         experiment.stats_config = {"method": "frequentist"}

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
@@ -135,21 +135,12 @@ class TestExperimentSessionPropertyMetrics(ExperimentQueryRunnerBaseTest):
 
         assert result.baseline is not None
         assert result.variant_results is not None
-        self.assertEqual(len(result.variant_results), 1)
+        assert len(result.variant_results) == 1
 
         control_variant = result.baseline
         test_variant = result.variant_results[0]
 
-        # These assertions represent the CORRECT behavior
-        # Control: 1 session * 60 seconds = 60
-        # Test: 1 session * 120 seconds = 120
-        #
-        # If the bug exists, we'd see:
-        # Control: 3 events * 60 seconds = 180 (WRONG)
-        # Test: 2 events * 120 seconds = 240 (WRONG)
-        self.assertEqual(control_variant.sum, 60, "Control session duration should be 60s (not multiplied by 3 events)")
-        self.assertEqual(test_variant.sum, 120, "Test session duration should be 120s (not multiplied by 2 events)")
-
-        # Each variant has 1 user
-        self.assertEqual(control_variant.number_of_samples, 1)
-        self.assertEqual(test_variant.number_of_samples, 1)
+        assert control_variant.sum == 60
+        assert test_variant.sum == 120
+        assert control_variant.number_of_samples == 1
+        assert test_variant.number_of_samples == 1


### PR DESCRIPTION
## Problem

When using session properties like `$session_duration` in experiment metrics, the value was being multiplied by the number of events in the session. For example, a 60-second session with 3 pageviews would report 180 seconds instead of 60.

## Changes

- Fixes session property aggregation (e.g., `$session_duration`) in experiment metrics
- Prevents multiplication bug where each event in a session contributed the full session value
- Adds backwards compatibility for `$session_duration` without explicit `math_property_type`


Uses a 3-layer CTE pattern (matching the approach in Trends):
1. **Deduplicate within sessions**: GROUP BY `$session_id` to get one value per session
2. **Join with exposures**: Filter by temporal ordering
3. **Aggregate per entity**: Sum/avg across sessions

## How did you test this code?

- [x] `test_session_duration_not_multiplied_across_events` - verifies deduplication
- [x] `test_multiple_sessions_per_user_sums_correctly` - verifies multi-session aggregation
- [x] `test_session_duration_backwards_compat_without_property_type` - verifies backwards compat
- [x] All existing experiment tests pass

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
