### PR TITLE
chore(web-analytics): consider query interval for date range calculation

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -19247,7 +19247,7 @@
                 },
                 "interval": {
                     "$ref": "#/definitions/IntervalType",
-                    "description": "For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
                 },
                 "kind": {
                     "const": "MarketingAnalyticsAggregatedQuery",
@@ -19550,7 +19550,7 @@
                 },
                 "interval": {
                     "$ref": "#/definitions/IntervalType",
-                    "description": "For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
                 },
                 "kind": {
                     "const": "MarketingAnalyticsTableQuery",
@@ -21499,7 +21499,7 @@
                 },
                 "interval": {
                     "$ref": "#/definitions/IntervalType",
-                    "description": "For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
                 },
                 "kind": {
                     "const": "NonIntegratedConversionsTableQuery",
@@ -32887,7 +32887,7 @@
                 },
                 "interval": {
                     "$ref": "#/definitions/IntervalType",
-                    "description": "For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
                 },
                 "kind": {
                     "const": "WebExternalClicksTableQuery",
@@ -33039,7 +33039,7 @@
                 },
                 "interval": {
                     "$ref": "#/definitions/IntervalType",
-                    "description": "For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
                 },
                 "kind": {
                     "const": "WebGoalsQuery",
@@ -33216,7 +33216,7 @@
                 },
                 "interval": {
                     "$ref": "#/definitions/IntervalType",
-                    "description": "For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
                 },
                 "kind": {
                     "const": "WebOverviewQuery",
@@ -33356,7 +33356,7 @@
                 },
                 "interval": {
                     "$ref": "#/definitions/IntervalType",
-                    "description": "For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
                 },
                 "kind": {
                     "const": "WebPageURLSearchQuery",
@@ -33540,7 +33540,7 @@
                 },
                 "interval": {
                     "$ref": "#/definitions/IntervalType",
-                    "description": "For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
                 },
                 "kind": {
                     "const": "WebStatsTableQuery",
@@ -33733,7 +33733,7 @@
                 },
                 "interval": {
                     "$ref": "#/definitions/IntervalType",
-                    "description": "For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
                 },
                 "kind": {
                     "const": "WebTrendsQuery",
@@ -33960,7 +33960,7 @@
                 },
                 "interval": {
                     "$ref": "#/definitions/IntervalType",
-                    "description": "For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
                 },
                 "kind": {
                     "const": "WebVitalsPathBreakdownQuery",
@@ -34146,7 +34146,7 @@
                 },
                 "interval": {
                     "$ref": "#/definitions/IntervalType",
-                    "description": "For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+                    "description": "Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
                 },
                 "kind": {
                     "const": "WebVitalsQuery",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2055,7 +2055,7 @@ interface WebAnalyticsQueryBase<R extends Record<string, any>> extends DataNode<
     filterTestAccounts?: boolean
     /** @deprecated ignored, always treated as disabled */
     includeRevenue?: boolean
-    /** For Product Analytics UI compatibility only - not used in Web Analytics query execution */
+    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
     interval?: IntervalType
     /** Groups aggregation - not used in Web Analytics but required for type compatibility */
     aggregation_group_type_index?: integer | null

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -1156,6 +1156,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             kind: NodeKind.WebOverviewQuery,
                             properties: webAnalyticsFilters,
                             dateRange,
+                            interval,
                             sampling,
                             compareFilter,
                             filterTestAccounts,

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -74,7 +74,7 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
             date_range=self.query.dateRange,
             team=self.team,
             timezone_info=self._timezone_info,
-            interval=None,
+            interval=self.query.interval,
             now=datetime.now(self._timezone_info),
         )
 
@@ -85,7 +85,7 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
                 return QueryCompareToDateRange(
                     date_range=self.query.dateRange,
                     team=self.team,
-                    interval=None,
+                    interval=self.query.interval,
                     now=datetime.now(self._timezone_info),
                     timezone_info=self._timezone_info,
                     compare_to=self.query.compareFilter.compare_to,
@@ -94,7 +94,7 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
                 return QueryPreviousPeriodDateRange(
                     date_range=self.query.dateRange,
                     team=self.team,
-                    interval=None,
+                    interval=self.query.interval,
                     now=datetime.now(self._timezone_info),
                     timezone_info=self._timezone_info,
                 )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -13113,7 +13113,7 @@ class WebExternalClicksTableQuery(BaseModel):
     includeRevenue: bool | None = None
     interval: IntervalType | None = Field(
         default=None,
-        description="For Product Analytics UI compatibility only - not used in Web Analytics query execution",
+        description="Interval for date range calculation (affects date_to rounding for hour vs day ranges)",
     )
     kind: Literal["WebExternalClicksTableQuery"] = "WebExternalClicksTableQuery"
     limit: int | None = None
@@ -13150,7 +13150,7 @@ class WebGoalsQuery(BaseModel):
     includeRevenue: bool | None = None
     interval: IntervalType | None = Field(
         default=None,
-        description="For Product Analytics UI compatibility only - not used in Web Analytics query execution",
+        description="Interval for date range calculation (affects date_to rounding for hour vs day ranges)",
     )
     kind: Literal["WebGoalsQuery"] = "WebGoalsQuery"
     limit: int | None = None
@@ -13186,7 +13186,7 @@ class WebOverviewQuery(BaseModel):
     includeRevenue: bool | None = None
     interval: IntervalType | None = Field(
         default=None,
-        description="For Product Analytics UI compatibility only - not used in Web Analytics query execution",
+        description="Interval for date range calculation (affects date_to rounding for hour vs day ranges)",
     )
     kind: Literal["WebOverviewQuery"] = "WebOverviewQuery"
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
@@ -13221,7 +13221,7 @@ class WebPageURLSearchQuery(BaseModel):
     includeRevenue: bool | None = None
     interval: IntervalType | None = Field(
         default=None,
-        description="For Product Analytics UI compatibility only - not used in Web Analytics query execution",
+        description="Interval for date range calculation (affects date_to rounding for hour vs day ranges)",
     )
     kind: Literal["WebPageURLSearchQuery"] = "WebPageURLSearchQuery"
     limit: int | None = None
@@ -13263,7 +13263,7 @@ class WebStatsTableQuery(BaseModel):
     includeScrollDepth: bool | None = None
     interval: IntervalType | None = Field(
         default=None,
-        description="For Product Analytics UI compatibility only - not used in Web Analytics query execution",
+        description="Interval for date range calculation (affects date_to rounding for hour vs day ranges)",
     )
     kind: Literal["WebStatsTableQuery"] = "WebStatsTableQuery"
     limit: int | None = None
@@ -14331,7 +14331,7 @@ class MarketingAnalyticsAggregatedQuery(BaseModel):
     integrationFilter: IntegrationFilter | None = Field(default=None, description="Filter by integration IDs")
     interval: IntervalType | None = Field(
         default=None,
-        description="For Product Analytics UI compatibility only - not used in Web Analytics query execution",
+        description="Interval for date range calculation (affects date_to rounding for hour vs day ranges)",
     )
     kind: Literal["MarketingAnalyticsAggregatedQuery"] = "MarketingAnalyticsAggregatedQuery"
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
@@ -14372,7 +14372,7 @@ class MarketingAnalyticsTableQuery(BaseModel):
     integrationFilter: IntegrationFilter | None = Field(default=None, description="Filter by integration type")
     interval: IntervalType | None = Field(
         default=None,
-        description="For Product Analytics UI compatibility only - not used in Web Analytics query execution",
+        description="Interval for date range calculation (affects date_to rounding for hour vs day ranges)",
     )
     kind: Literal["MarketingAnalyticsTableQuery"] = "MarketingAnalyticsTableQuery"
     limit: int | None = Field(default=None, description="Number of rows to return")
@@ -14475,7 +14475,7 @@ class NonIntegratedConversionsTableQuery(BaseModel):
     includeRevenue: bool | None = None
     interval: IntervalType | None = Field(
         default=None,
-        description="For Product Analytics UI compatibility only - not used in Web Analytics query execution",
+        description="Interval for date range calculation (affects date_to rounding for hour vs day ranges)",
     )
     kind: Literal["NonIntegratedConversionsTableQuery"] = "NonIntegratedConversionsTableQuery"
     limit: int | None = Field(default=None, description="Number of rows to return")
@@ -14821,7 +14821,7 @@ class WebTrendsQuery(BaseModel):
     filterTestAccounts: bool | None = None
     includeRevenue: bool | None = None
     interval: IntervalType = Field(
-        ..., description="For Product Analytics UI compatibility only - not used in Web Analytics query execution"
+        ..., description="Interval for date range calculation (affects date_to rounding for hour vs day ranges)"
     )
     kind: Literal["WebTrendsQuery"] = "WebTrendsQuery"
     limit: int | None = None
@@ -14859,7 +14859,7 @@ class WebVitalsPathBreakdownQuery(BaseModel):
     includeRevenue: bool | None = None
     interval: IntervalType | None = Field(
         default=None,
-        description="For Product Analytics UI compatibility only - not used in Web Analytics query execution",
+        description="Interval for date range calculation (affects date_to rounding for hour vs day ranges)",
     )
     kind: Literal["WebVitalsPathBreakdownQuery"] = "WebVitalsPathBreakdownQuery"
     metric: WebVitalsMetric
@@ -16651,7 +16651,7 @@ class WebVitalsQuery(BaseModel):
     includeRevenue: bool | None = None
     interval: IntervalType | None = Field(
         default=None,
-        description="For Product Analytics UI compatibility only - not used in Web Analytics query execution",
+        description="Interval for date range calculation (affects date_to rounding for hour vs day ranges)",
     )
     kind: Literal["WebVitalsQuery"] = "WebVitalsQuery"
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")


### PR DESCRIPTION
## Problem

When selecting "Last 24 hours" with "Compare to Previous Period" in web analytics, the overview fetched ~40 hours of data instead of 24 hours showing a different value than the trends query runner. Althought the extra data is in the future, we should try to keep the query as close as possible, as this could be extra problematic for timezones further away from UTC.

## Root Cause

The `interval` field existed on `WebOverviewQuery` but wasn't being passed from frontend or used in backend. With `interval=None` defaulting to `DAY`, `date_to` extended to 23:59:59 (end of day) instead of the correct hourly boundary.

## Solution

- Frontend: Pass `interval` to `WebOverviewQuery`
- Backend: Use `self.query.interval` in `query_date_range` and `query_compare_to_date_range`

## How did you test this code

- [x] Added parameterized test for interval handling
- [x] All 31 web overview tests pass
- [ ] Manual: Verify "Last 24 hours" with comparison shows correct 24-hour windows