### PR TITLE
Ai tool execution tracking

### DIFF
--- a/ee/hogai/core/agent_modes/executables.py
+++ b/ee/hogai/core/agent_modes/executables.py
@@ -389,6 +389,19 @@ class AgentToolsExecutable(BaseAgentLoopExecutable):
                 raise ValueError(
                     f"Tool '{tool_call.name}' returned {type(result).__name__}, expected LangchainToolMessage"
                 )
+
+            # Track successful tool execution
+            user_distinct_id = self._get_user_distinct_id(config)
+            if user_distinct_id:
+                posthoganalytics.capture(
+                    distinct_id=user_distinct_id,
+                    event="ai tool executed",
+                    properties={
+                        **self._get_debug_props(config),
+                        "tool_name": tool_call.name,
+                    },
+                    groups=groups(None, self._team),
+                )
         except MaxToolError as e:
             logger.exception(
                 "maxtool_error", extra={"tool": tool_call.name, "error": str(e), "retry_strategy": e.retry_strategy}


### PR DESCRIPTION
## Problem

To gain better observability into the usage of AI agent tools, we need to track successful tool executions. This helps understand which tools are being used effectively within the AI agents.

## Changes

- Added PostHog event tracking for successful tool executions within `AgentToolsExecutable`.
- The event `"ai tool executed"` is captured, including the `tool_name` and relevant debug properties.
- The event is sent with `organization` and `project` groups for better context.
- Added a new unit test `test_successful_tool_execution_emits_analytics_event` to verify the event capture and its properties.

## How did you test this code?

- Added a new unit test `test_successful_tool_execution_emits_analytics_event` in `ee/hogai/core/agent_modes/test/test_executables.py` to specifically cover this functionality.
- Ran all existing tests in `ee/hogai/core/agent_modes/test/test_executables.py` to ensure no regressions. All tests passed.

## Publish to changelog?

no

---
<a href="https://cursor.com/background-agent?bcId=bc-c42da9fb-e6aa-4c07-987b-57046dfba0b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c42da9fb-e6aa-4c07-987b-57046dfba0b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

