### PR TITLE
Ai tool execution tracking

### DIFF
--- a/ee/hogai/core/agent_modes/executables.py
+++ b/ee/hogai/core/agent_modes/executables.py
@@ -389,6 +389,19 @@ class AgentToolsExecutable(BaseAgentLoopExecutable):
                 raise ValueError(
                     f"Tool '{tool_call.name}' returned {type(result).__name__}, expected LangchainToolMessage"
                 )
+
+            # Track successful tool execution
+            user_distinct_id = self._get_user_distinct_id(config)
+            if user_distinct_id:
+                posthoganalytics.capture(
+                    distinct_id=user_distinct_id,
+                    event="ai tool executed",
+                    properties={
+                        **self._get_debug_props(config),
+                        "tool_name": tool_call.name,
+                    },
+                    groups=groups(None, self._team),
+                )
         except MaxToolError as e:
             logger.exception(
                 "maxtool_error", extra={"tool": tool_call.name, "error": str(e), "retry_strategy": e.retry_strategy}


### PR DESCRIPTION
## Problem

This change addresses the need to track successful executions of AI tools within the Hog AI agent. By capturing an event for each successful tool execution, we gain valuable insights into which tools are being utilized effectively and contribute to better understanding agent performance and usage patterns.

## Changes

A `posthoganalytics.capture` call has been added to `ee/hogai/core/agent_modes/executables.py`. This call is made after a tool successfully returns a result. It captures an `"ai tool executed"` event with the following properties:
- `tool_name`: The name of the tool that was executed.
- Existing debug properties from the configuration.
- Team-level groups for analytics.

## How did you test this code?

The change was verified for correct placement and linting issues. Manual testing would involve running an AI agent that executes tools and confirming the "ai tool executed" event appears in PostHog.

## Publish to changelog?

no

---
<a href="https://cursor.com/background-agent?bcId=bc-069021e3-bc05-48e9-b731-bd9eedff5564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-069021e3-bc05-48e9-b731-bd9eedff5564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

