### PR TITLE
feat(logs): implement polling for log availability in NoLogsPrompt

### DIFF
--- a/products/logs/frontend/components/SetupPrompt/SetupPrompt.tsx
+++ b/products/logs/frontend/components/SetupPrompt/SetupPrompt.tsx
@@ -5,11 +5,14 @@ import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { ListHog } from 'lib/components/hedgehogs'
+import { useInterval } from 'lib/hooks/useInterval'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 
 import { logsIngestionLogic } from './logsIngestionLogic'
+
+const POLLING_INTERVAL_MS = 5000
 
 export const LogsSetupPrompt = ({
     children,
@@ -42,6 +45,14 @@ export const LogsSetupPrompt = ({
 
 const NoLogsPrompt = ({ className }: { className?: string }): JSX.Element | null => {
     const { addProductIntent } = useActions(teamLogic)
+    const { hasLogs } = useValues(logsIngestionLogic)
+    const { loadTeamHasLogs } = useActions(logsIngestionLogic)
+
+    useInterval(() => {
+        if (!hasLogs) {
+            loadTeamHasLogs()
+        }
+    }, POLLING_INTERVAL_MS)
 
     return (
         <ProductIntroduction
@@ -54,20 +65,29 @@ const NoLogsPrompt = ({ className }: { className?: string }): JSX.Element | null
             className={className}
             customHog={ListHog}
             actionElementOverride={
-                <LemonButton
-                    type="primary"
-                    targetBlank
-                    sideIcon={<IconExternal className="w-5 h-5" />}
-                    to="https://posthog.com/docs/logs/"
-                    onClick={() => {
-                        addProductIntent({
-                            product_type: ProductKey.LOGS,
-                            intent_context: ProductIntentContext.LOGS_DOCS_VIEWED,
-                        })
-                    }}
-                >
-                    Configure your logging client
-                </LemonButton>
+                <div className="flex flex-col items-start gap-4">
+                    <LemonButton
+                        type="primary"
+                        targetBlank
+                        sideIcon={<IconExternal className="w-5 h-5" />}
+                        to="https://posthog.com/docs/logs/"
+                        onClick={() => {
+                            addProductIntent({
+                                product_type: ProductKey.LOGS,
+                                intent_context: ProductIntentContext.LOGS_DOCS_VIEWED,
+                            })
+                        }}
+                    >
+                        Configure your logging client
+                    </LemonButton>
+                    <div className="flex items-center gap-2 px-3 py-1.5 border border-accent rounded">
+                        <div className="relative flex items-center justify-center">
+                            <div className="absolute w-3 h-3 border-2 border-accent rounded-full animate-ping" />
+                            <div className="w-2 h-2 bg-accent rounded-full" />
+                        </div>
+                        <span className="text-sm">Watching for logs</span>
+                    </div>
+                </div>
             }
         />
     )


### PR DESCRIPTION
## Problem

When users set up logs in PostHog, there's currently no visual indication that the system is actively checking for incoming logs. This creates uncertainty for users who have configured their logging client but don't see immediate results.

## Changes

Added a polling mechanism that periodically checks if logs have been received, along with a visual indicator that shows the system is actively watching for logs

![image.png](https://app.graphite.com/user-attachments/assets/bc4f9434-bc88-40c2-9442-5ee1070a485e.png)

## How did you test this code?

Tested the component in both states (with and without logs) to ensure the polling mechanism works correctly. Verified that the polling stops once logs are detected, and that the visual indicator displays properly.

## Publish to changelog?

No