### PR TITLE
test(logs): clamp date_to on zoomDateRange and add tests

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/zoom-utils.test.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/zoom-utils.test.ts
@@ -1,0 +1,93 @@
+import { zoomDateRange } from './zoom-utils'
+
+describe('zoomDateRange', () => {
+    beforeEach(() => {
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date('2024-01-15T12:00:00.000Z'))
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    describe('relative date ranges', () => {
+        it('multiplies relative date_from when date_to is not set', () => {
+            const result = zoomDateRange({ date_from: '-1h', date_to: null }, 2)
+            expect(result).toEqual({ date_from: '-2h', date_to: null })
+        })
+
+        it('handles different relative units', () => {
+            expect(zoomDateRange({ date_from: '-30m', date_to: null }, 2)).toEqual({
+                date_from: '-60m',
+                date_to: null,
+            })
+            expect(zoomDateRange({ date_from: '-7d', date_to: null }, 2)).toEqual({
+                date_from: '-14d',
+                date_to: null,
+            })
+        })
+    })
+
+    describe('absolute date ranges', () => {
+        it('expands range symmetrically from center', () => {
+            const result = zoomDateRange(
+                {
+                    date_from: '2024-01-15T10:00:00.000Z',
+                    date_to: '2024-01-15T11:00:00.000Z',
+                },
+                2
+            )
+            // Original range: 10:00 - 11:00 (60 mins), center at 10:30
+            // New range should be 60 mins on each side of center = 9:30 - 11:30
+            // But 11:30 is before now (12:00), so no clamping needed
+            expect(result.date_from).toContain('2024-01-15T09:30:00')
+            expect(result.date_to).toContain('2024-01-15T11:30:00')
+        })
+
+        it('clamps date_to to now when expansion would exceed current time', () => {
+            const result = zoomDateRange(
+                {
+                    date_from: '2024-01-15T11:00:00.000Z',
+                    date_to: '2024-01-15T12:00:00.000Z',
+                },
+                2
+            )
+            // Original range: 11:00 - 12:00 (60 mins), center at 11:30
+            // Expanded would be 10:30 - 12:30, but 12:30 is after now (12:00)
+            // So date_to should be clamped to 12:00
+            expect(result.date_from).toContain('2024-01-15T10:30:00')
+            expect(result.date_to).toContain('2024-01-15T12:00:00')
+        })
+
+        it('handles zooming in (multiplier < 1)', () => {
+            const result = zoomDateRange(
+                {
+                    date_from: '2024-01-15T10:00:00.000Z',
+                    date_to: '2024-01-15T12:00:00.000Z',
+                },
+                0.5
+            )
+            // Original range: 10:00 - 12:00 (120 mins), center at 11:00
+            // New range should be 30 mins on each side = 10:30 - 11:30
+            expect(result.date_from).toContain('2024-01-15T10:30:00')
+            expect(result.date_to).toContain('2024-01-15T11:30:00')
+        })
+    })
+
+    describe('edge cases', () => {
+        it('handles missing date_from by defaulting to 1 hour ago', () => {
+            const result = zoomDateRange({ date_from: null, date_to: null }, 2)
+            // Default range: 11:00 - 12:00 (1h ago to now), center at 11:30
+            // Expanded: 10:30 - 12:30, but clamped to 12:00
+            expect(result.date_from).toContain('2024-01-15T10:30:00')
+            expect(result.date_to).toContain('2024-01-15T12:00:00')
+        })
+
+        it('handles invalid date strings gracefully', () => {
+            const result = zoomDateRange({ date_from: 'invalid', date_to: null }, 2)
+            // Falls back to default range (1h ago to now), same as above
+            expect(result.date_from).toContain('2024-01-15T10:30:00')
+            expect(result.date_to).toContain('2024-01-15T12:00:00')
+        })
+    })
+})

--- a/products/logs/frontend/components/LogsViewer/Filters/zoom-utils.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/zoom-utils.ts
@@ -21,6 +21,7 @@ export const zoomDateRange = (
     dateRange: { date_from?: string | null; date_to?: string | null },
     multiplier: number
 ): { date_from?: string | null; date_to?: string | null } => {
+    const now = dayjs()
     // If only date_from is set and is relative we can do a nicer zoom function
     if (dateRange.date_from && !dateRange.date_to) {
         const newDateFrom = zoomDateRelative(dateRange.date_from, multiplier)
@@ -33,9 +34,9 @@ export const zoomDateRange = (
     }
 
     const start = dateRange.date_from
-        ? (dateStringToDayJs(dateRange.date_from) ?? dayjs().subtract(1, 'hour'))
-        : dayjs().subtract(1, 'hour')
-    const end = dateRange.date_to ? (dateStringToDayJs(dateRange.date_to) ?? dayjs()) : dayjs()
+        ? (dateStringToDayJs(dateRange.date_from) ?? now.subtract(1, 'hour'))
+        : now.subtract(1, 'hour')
+    const end = dateRange.date_to ? (dateStringToDayJs(dateRange.date_to) ?? now) : now
 
     const diffMins = end.diff(start, 'minutes')
     const centerDate = start.add(diffMins * 0.5, 'minutes')
@@ -45,6 +46,6 @@ export const zoomDateRange = (
 
     return {
         date_from: newStart.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
-        date_to: newEnd.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+        date_to: (newEnd.isAfter(now) ? now : newEnd).format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
     }
 }


### PR DESCRIPTION
## Problem

Zoom functionality currently zooms into the future.

## Changes

- Added proper clamping of date ranges to ensure that zoomed date ranges never extend beyond the current time
- Added tests

## How did you test this code?

- Added unit tests