### PR TITLE
feat: Show the skip 10s icon on video when user skips the time

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.scss
@@ -6,3 +6,55 @@
         }
     }
 }
+
+.SeekIndicator {
+    animation:
+        SeekIndicator__FadeIn 0.1s ease-out forwards,
+        SeekIndicator__FadeOut 0.2s ease-in 0.3s forwards;
+
+    .SeekIndicator__bubble {
+        animation: SeekIndicator__Pop 0.15s ease-out forwards;
+    }
+
+    .SeekIndicator__icon {
+        font-size: 2.5rem;
+
+        &--forward {
+            transform: scaleX(-1);
+        }
+    }
+}
+
+@keyframes SeekIndicator__FadeIn {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes SeekIndicator__FadeOut {
+    from {
+        opacity: 1;
+    }
+
+    to {
+        opacity: 0;
+    }
+}
+
+@keyframes SeekIndicator__Pop {
+    0% {
+        transform: scale(0.8);
+    }
+
+    50% {
+        transform: scale(1.1);
+    }
+
+    100% {
+        transform: scale(1);
+    }
+}

--- a/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
@@ -32,6 +32,7 @@ const SeekIndicator = (): JSX.Element | null => {
                 'SeekIndicator absolute inset-0 z-20 flex items-center pointer-events-none',
                 isForward ? 'justify-end pr-[15%]' : 'justify-start pl-[15%]'
             )}
+            key="seek-indicator"
         >
             <div className="SeekIndicator__bubble flex flex-col items-center justify-center rounded-full bg-black/60 w-20 h-20">
                 <IconSkipBackward

--- a/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
@@ -1,7 +1,6 @@
 import './PlayerFrameOverlay.scss'
 
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
 
 import { IconEmoji, IconPlay, IconRewindPlay, IconWarning } from '@posthog/icons'
 
@@ -20,32 +19,12 @@ import { SessionRecordingPlayerMode } from './sessionRecordingPlayerLogic'
 
 const SeekIndicator = (): JSX.Element | null => {
     const { seekIndicator } = useValues(sessionRecordingPlayerLogic)
-    const { hideSeekIndicator } = useActions(sessionRecordingPlayerLogic)
-    const [visible, setVisible] = useState(false)
-    const [currentIndicator, setCurrentIndicator] = useState<{
-        direction: 'forward' | 'backward'
-        seconds: number
-    } | null>(null)
 
-    useEffect(() => {
-        if (seekIndicator) {
-            setCurrentIndicator(seekIndicator)
-            setVisible(true)
-
-            const timer = setTimeout(() => {
-                setVisible(false)
-                hideSeekIndicator()
-            }, 500)
-
-            return () => clearTimeout(timer)
-        }
-    }, [seekIndicator, hideSeekIndicator])
-
-    if (!currentIndicator || !visible) {
+    if (!seekIndicator) {
         return null
     }
 
-    const isForward = currentIndicator.direction === 'forward'
+    const isForward = seekIndicator.direction === 'forward'
 
     return (
         <div
@@ -60,7 +39,7 @@ const SeekIndicator = (): JSX.Element | null => {
                         'SeekIndicator__icon--forward': isForward,
                     })}
                 />
-                <span className="text-white text-sm font-semibold">{currentIndicator.seconds}s</span>
+                <span className="text-white text-sm font-semibold">{seekIndicator.seconds}s</span>
             </div>
         </div>
     )

--- a/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
@@ -32,7 +32,7 @@ const SeekIndicator = (): JSX.Element | null => {
                 'SeekIndicator absolute inset-0 z-20 flex items-center pointer-events-none',
                 isForward ? 'justify-end pr-[15%]' : 'justify-start pl-[15%]'
             )}
-            key="seek-indicator"
+            key={`seek-indicator-${isForward ? 'forward' : 'backward'}-${Date.now()}`}
         >
             <div className="SeekIndicator__bubble flex flex-col items-center justify-center rounded-full bg-black/60 w-20 h-20">
                 <IconSkipBackward

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -408,6 +408,8 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         seekForward: (amount?: number) => ({ amount }),
         seekBackward: (amount?: number) => ({ amount }),
         seekToStart: true,
+        showSeekIndicator: (direction: 'forward' | 'backward', seconds: number) => ({ direction, seconds }),
+        hideSeekIndicator: true,
         resolvePlayerState: true,
         updateAnimation: true,
         stopAnimation: true,
@@ -507,6 +509,13 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 setQuickEmojiIsOpen: (_, { quickEmojiIsOpen }) => quickEmojiIsOpen,
                 setShowingClipParams: (state, { showingClipParams }) => (showingClipParams ? false : state),
                 setIsCommenting: (state, { isCommenting }) => (isCommenting ? false : state),
+            },
+        ],
+        seekIndicator: [
+            null as { direction: 'forward' | 'backward'; seconds: number } | null,
+            {
+                showSeekIndicator: (_, { direction, seconds }) => ({ direction, seconds }),
+                hideSeekIndicator: () => null,
             },
         ],
         maskingWindow: [
@@ -1507,9 +1516,11 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         },
         seekForward: ({ amount = values.jumpTimeMs }) => {
             actions.seekToTime((values.currentPlayerTime || 0) + amount)
+            actions.showSeekIndicator('forward', Math.round(amount / 1000))
         },
         seekBackward: ({ amount = values.jumpTimeMs }) => {
             actions.seekToTime((values.currentPlayerTime || 0) - amount)
+            actions.showSeekIndicator('backward', Math.round(amount / 1000))
         },
 
         seekToTime: ({ timeInMilliseconds }) => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1543,7 +1543,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     segments.findIndex((s) => s.startTimestamp === segment.startTimestamp && s.kind === segment.kind)
 
                 const seekToPrevActivityEnd = (segment: RecordingSegment): void => {
-                    const prevActivity = findPrevActivitySegment(findSegmentIndex(segment) + 1)
+                    const prevActivity = findPrevActivitySegment(findSegmentIndex(segment))
                     if (prevActivity) {
                         targetTime = Math.max(0, prevActivity.endTimestamp - startTimestamp - amount)
                     }
@@ -1569,10 +1569,11 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             if (cache.seekIndicatorTimer) {
                 clearTimeout(cache.seekIndicatorTimer)
             }
+            // Wait for CSS animation to complete (100ms fade-in + 300ms visible + 200ms fade-out)
             cache.seekIndicatorTimer = setTimeout(() => {
                 actions.hideSeekIndicator()
                 cache.seekIndicatorTimer = null
-            }, 500)
+            }, 600)
         },
 
         seekToTime: ({ timeInMilliseconds }) => {

--- a/services/mcp/typescript/src/resources/index.ts
+++ b/services/mcp/typescript/src/resources/index.ts
@@ -111,7 +111,6 @@ async function registerSkillResources(server: McpServer, context: Context): Prom
             }
 
             const installCommand = generateInstallCommand(skill.id, skill.downloadUrl)
-            console.log(`Registering skill: ${skill.id}`)
 
             server.registerResource(
                 skill.name,
@@ -137,7 +136,6 @@ async function registerSkillResources(server: McpServer, context: Context): Prom
             )
         }
 
-        console.log(`Registered ${manifest.skills.length} skills (returning install commands)`)
     } catch (error) {
         // Skills are optional - log error but don't fail startup
         console.error('Failed to register skill resources:', error)

--- a/services/mcp/typescript/src/resources/index.ts
+++ b/services/mcp/typescript/src/resources/index.ts
@@ -111,6 +111,7 @@ async function registerSkillResources(server: McpServer, context: Context): Prom
             }
 
             const installCommand = generateInstallCommand(skill.id, skill.downloadUrl)
+            console.log(`Registering skill: ${skill.id}`)
 
             server.registerResource(
                 skill.name,
@@ -136,6 +137,7 @@ async function registerSkillResources(server: McpServer, context: Context): Prom
             )
         }
 
+        console.log(`Registered ${manifest.skills.length} skills (returning install commands)`)
     } catch (error) {
         // Skills are optional - log error but don't fail startup
         console.error('Failed to register skill resources:', error)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Small nice-to-have UI since right now the skipping 10 seconds happen silently

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="1294" height="1233" alt="Screenshot 2026-01-21 at 09 50 28" src="https://github.com/user-attachments/assets/2d0e5def-8072-4bf8-bc39-d7f291a16236" />
<img width="1294" height="1233" alt="Screenshot 2026-01-21 at 09 49 33" src="https://github.com/user-attachments/assets/0b96f71d-6687-404b-8e9e-136d3401f2eb" />

Added handling of inactivity rewind:
If currently in a gap > 3s: go to end of previous activity - 10s
If normal rewind would land in a gap > 3s: go to end of previous activity - 10s
Otherwise: normal rewind (go back 10s)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
