### PR TITLE
feat(logs): introduce better UX for when no logs are found

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -44,7 +44,7 @@ const LogsSceneContent = (): JSX.Element => {
         sparklineBreakdownBy,
     } = useValues(logsSceneLogic)
     const { teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
-    const { runQuery, fetchNextLogsPage, setOrderBy, addFilter, setDateRange, setSparklineBreakdownBy } =
+    const { runQuery, fetchNextLogsPage, setOrderBy, addFilter, setDateRange, setSparklineBreakdownBy, zoomDateRange } =
         useActions(logsSceneLogic)
 
     return (
@@ -98,6 +98,7 @@ const LogsSceneContent = (): JSX.Element => {
                     onDateRangeChange={setDateRange}
                     sparklineBreakdownBy={sparklineBreakdownBy}
                     onSparklineBreakdownByChange={setSparklineBreakdownBy}
+                    onExpandTimeRange={() => zoomDateRange(2)}
                 />
             </div>
         </>

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -38,6 +38,7 @@ export interface LogsViewerProps {
     onDateRangeChange: (dateRange: DateRange) => void
     sparklineBreakdownBy: LogsSparklineBreakdownBy
     onSparklineBreakdownByChange: (breakdownBy: LogsSparklineBreakdownBy) => void
+    onExpandTimeRange?: () => void
 }
 
 export function LogsViewer({
@@ -56,6 +57,7 @@ export function LogsViewer({
     onDateRangeChange,
     sparklineBreakdownBy,
     onSparklineBreakdownByChange,
+    onExpandTimeRange,
 }: LogsViewerProps): JSX.Element {
     return (
         <BindLogic logic={logDetailsModalLogic} props={{ tabId }}>
@@ -73,6 +75,7 @@ export function LogsViewer({
                     onDateRangeChange={onDateRangeChange}
                     sparklineBreakdownBy={sparklineBreakdownBy}
                     onSparklineBreakdownByChange={onSparklineBreakdownByChange}
+                    onExpandTimeRange={onExpandTimeRange}
                 />
             </BindLogic>
         </BindLogic>
@@ -92,6 +95,7 @@ interface LogsViewerContentProps {
     onDateRangeChange: (dateRange: DateRange) => void
     sparklineBreakdownBy: LogsSparklineBreakdownBy
     onSparklineBreakdownByChange: (breakdownBy: LogsSparklineBreakdownBy) => void
+    onExpandTimeRange?: () => void
 }
 
 function LogsViewerContent({
@@ -107,6 +111,7 @@ function LogsViewerContent({
     onDateRangeChange,
     sparklineBreakdownBy,
     onSparklineBreakdownByChange,
+    onExpandTimeRange,
 }: LogsViewerContentProps): JSX.Element {
     const {
         tabId,
@@ -334,6 +339,7 @@ function LogsViewerContent({
                 showPinnedWithOpacity
                 hasMoreLogsToLoad={hasMoreLogsToLoad}
                 onLoadMore={onLoadMore}
+                onExpandTimeRange={onExpandTimeRange}
             />
 
             <LogDetailsModal timezone={timezone} />

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -6,7 +6,10 @@ import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
 import { CellMeasurer, CellMeasurerCache } from 'react-virtualized/dist/es/CellMeasurer'
 import { List, ListRowProps } from 'react-virtualized/dist/es/List'
 
+import { LemonButton, Link } from '@posthog/lemon-ui'
+
 import { TZLabelProps } from 'lib/components/TZLabel'
+import { DetectiveHog } from 'lib/components/hedgehogs'
 
 import { logDetailsModalLogic } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic'
 import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
@@ -32,6 +35,7 @@ interface VirtualizedLogsListProps {
     disableInfiniteScroll?: boolean
     hasMoreLogsToLoad?: boolean
     onLoadMore?: () => void
+    onExpandTimeRange?: () => void
 }
 
 export function VirtualizedLogsList({
@@ -46,6 +50,7 @@ export function VirtualizedLogsList({
     disableInfiniteScroll = false,
     hasMoreLogsToLoad = false,
     onLoadMore,
+    onExpandTimeRange,
 }: VirtualizedLogsListProps): JSX.Element {
     const {
         tabId,
@@ -242,7 +247,25 @@ export function VirtualizedLogsList({
     )
 
     if (dataSource.length === 0 && !loading) {
-        return <div className="p-4 text-muted text-center">No logs to display</div>
+        return (
+            <div className="flex flex-col items-center gap-3 p-8 text-center h-full min-h-40">
+                <DetectiveHog className="w-32 h-32" />
+                <div>
+                    <h4 className="font-semibold m-0">No logs found</h4>
+                    <p className="text-muted text-sm mt-1 mb-0 max-w-80">
+                        Try adjusting your filters, expanding the time range, or checking that your app is sending logs.
+                    </p>
+                    <Link to="https://posthog.com/docs/logs/" target="_blank">
+                        View documentation
+                    </Link>
+                </div>
+                {onExpandTimeRange && (
+                    <LemonButton type="secondary" size="small" onClick={onExpandTimeRange}>
+                        Expand time range
+                    </LemonButton>
+                )}
+            </div>
+        )
     }
 
     // Fixed height mode for pinned logs


### PR DESCRIPTION
## Problem

When no logs are found, the current UI simply displays a generic "No logs to display" message without providing users with helpful context or actions. This creates a poor user experience for those trying to troubleshoot missing logs.

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/5fdcd460-5601-4b52-9f6e-543e18d6aa83.png)

- Enhanced the empty state UI for logs with a more informative message, documentation link, and visual elements
- Added an "Expand time range" button to help users quickly adjust their search parameters
- Implemented a `zoomDateRange` action to allow users to expand the time range when no logs are found

## How did you test this code?

Tested the empty state UI by:
- Filtering logs with criteria that return no results
- Verifying the new empty state appears with all elements (detective hedgehog, message, documentation link, and expand button)
- Testing the "Expand time range" button functionality to ensure it correctly doubles the date range
- Confirming the UI properly handles the transition from empty state to displaying logs when results are found

## Publish to changelog?

No