### PR TITLE
fix(export): Dynamic width for funnel exports

### DIFF
--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -20,6 +20,8 @@ from selenium.webdriver.support.wait import WebDriverWait
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.os_manager import ChromeType
 
+from posthog.schema import NodeKind
+
 from posthog.api.insight_variable import map_stale_to_latest
 from posthog.caching.calculate_results import calculate_for_query_based_insight
 from posthog.exceptions_capture import capture_exception
@@ -43,7 +45,14 @@ def _build_cache_keys_param(insight_cache_keys: Optional[dict[int, str]]) -> str
 
 TMP_DIR = "/tmp"  # NOTE: Externalise this to ENV var
 
-ScreenWidth = Literal[800, 1920, 1400]
+# Newer versions of selenium seem to include the search bar in the height calculation.
+# This is a manually determined offset to ensure the screenshot is the correct height.
+# See https://github.com/SeleniumHQ/selenium/issues/14660.
+HEIGHT_OFFSET = 85
+MAX_WIDTH_PIXELS = 4000  # Max width for wide content like funnels with many steps
+CONTENT_PADDING = 80  # Padding for card borders
+
+ScreenWidth = Literal[800, 1920, 1400, 4000]
 CSSSelector = Literal[".InsightCard", ".ExportedInsight", ".replayer-wrapper", ".heatmap-exporter"]
 
 
@@ -127,7 +136,13 @@ def _export_to_png(
             cache_keys_param = _build_cache_keys_param(insight_cache_keys)
             url_to_render = absolute_uri(f"/exporter?token={access_token}{legend_param}{cache_keys_param}")
             wait_for_css_selector = ".ExportedInsight"
-            screenshot_width = 800
+            query = exported_asset.insight.query or {}
+            source = query.get("source", query)  # This to handle the InsightVizNode wrapper
+            is_funnel = source.get("kind") == NodeKind.FUNNELS_QUERY
+            # Set initial window size large enough for wide content like funnels with many steps
+            # Small funnels will be constrained later.
+            # The higher the number, the more RAM will be required by the Chromium driver.
+            screenshot_width = 4000 if is_funnel else 800
         elif exported_asset.dashboard is not None:
             cache_keys_param = _build_cache_keys_param(insight_cache_keys)
             url_to_render = absolute_uri(f"/exporter?token={access_token}{cache_keys_param}")
@@ -194,12 +209,6 @@ def _export_to_png(
         raise
 
 
-# Newer versions of selenium seem to include the search bar in the height calculation.
-# This is a manually determined offset to ensure the screenshot is the correct height.
-# See https://github.com/SeleniumHQ/selenium/issues/14660.
-HEIGHT_OFFSET = 85
-
-
 def _screenshot_asset(
     image_path: str,
     url_to_render: str,
@@ -208,16 +217,10 @@ def _screenshot_asset(
     screenshot_height: int = 600,
     max_height_pixels: Optional[int] = None,
 ) -> None:
-    MAX_WIDTH_PIXELS = 4000  # Max width for wide content like funnels with many steps
-    CONTENT_PADDING = 80  # Padding for card borders
-
     driver: Optional[webdriver.Chrome] = None
     try:
         driver = get_driver()
-        # Set initial window size large enough for wide content like funnels with many steps
-        # Small funnels will be constrained with max-width later
-        initial_width = max(screenshot_width, MAX_WIDTH_PIXELS)
-        driver.set_window_size(initial_width, screenshot_height)
+        driver.set_window_size(screenshot_width, screenshot_height)
         driver.get(url_to_render)
         posthoganalytics.tag("url_to_render", url_to_render)
 
@@ -257,12 +260,6 @@ def _screenshot_asset(
         # Get the height of the visualization container specifically
         height = driver.execute_script(
             """
-            // Remove CSS constraints that would clip content before measuring
-            const vizElement = document.querySelector('.InsightCard__viz');
-            if (vizElement) {
-                vizElement.style.maxHeight = 'none';
-            }
-
             const element = document.querySelector('.InsightCard__viz') ||
                           document.querySelector('.ExportedInsight__content') ||
                           document.querySelector('.replayer-wrapper') ||
@@ -287,20 +284,38 @@ def _screenshot_asset(
         # Calculate width for replay players and non-funnel tables
         # Funnels are handled separately with fit-content measurement below
         width = driver.execute_script(
-            """
+            f"""
+            // Check for replay player first
             const replayElement = document.querySelector('.replayer-wrapper');
-            if (replayElement) {
+            if (replayElement) {{
                 return replayElement.offsetWidth;
-            }
+            }}
 
-            // For non-funnel tables, use scrollWidth
             const funnelElement = document.querySelector('.FunnelBarVertical');
-            if (!funnelElement) {
-                const tableElement = document.querySelector('table');
-                if (tableElement) {
-                    return Math.max(tableElement.scrollWidth, tableElement.offsetWidth);
-                }
-            }
+            if (funnelElement) {{
+                // Force funnel to shrink to content size
+                funnelElement.style.width = 'fit-content';
+                funnelElement.style.maxWidth = 'fit-content';
+
+                const table = funnelElement.querySelector('table');
+                if (table) {{
+                    table.style.width = 'fit-content';
+                    table.style.maxWidth = 'fit-content';
+                }}
+
+                // Force a reflow
+                void funnelElement.offsetWidth;
+
+                // Now measure the actual content width
+                return funnelElement.offsetWidth + {CONTENT_PADDING};
+            }}
+
+            // Fall back to table width for insights
+            const tableElement = document.querySelector('table');
+            if (tableElement) {{
+                return tableElement.offsetWidth * 1.5;
+            }}
+
             return null;
         """
         )
@@ -313,48 +328,11 @@ def _screenshot_asset(
                     capped_width=MAX_WIDTH_PIXELS,
                     url=url_to_render,
                 )
-            width = max(int(screenshot_width), min(MAX_WIDTH_PIXELS, calculated_width))
+            width = min(MAX_WIDTH_PIXELS, calculated_width)
         else:
             width = screenshot_width
 
-        # For funnels, constrain to fit-content and measure actual width needed
-        actual_content_width = driver.execute_script(
-            """
-            const funnelElement = document.querySelector('.FunnelBarVertical');
-            if (funnelElement) {
-                // Force funnel to shrink to content size
-                funnelElement.style.width = 'fit-content';
-                funnelElement.style.maxWidth = 'fit-content';
-
-                const table = funnelElement.querySelector('table');
-                if (table) {
-                    table.style.width = 'fit-content';
-                    table.style.maxWidth = 'fit-content';
-                }
-
-                // Force a reflow
-                void funnelElement.offsetWidth;
-
-                // Now measure the actual content width
-                return funnelElement.offsetWidth;
-            }
-            return null;
-            """
-        )
-
-        # If we got actual content width from funnel measurement, use it
-        if actual_content_width and isinstance(actual_content_width, (int, float)):
-            width = int(actual_content_width) + CONTENT_PADDING
-            if width > MAX_WIDTH_PIXELS:
-                logger.warning(
-                    "screenshot_width_capped",
-                    original_width=width,
-                    capped_width=MAX_WIDTH_PIXELS,
-                    url=url_to_render,
-                )
-                width = MAX_WIDTH_PIXELS
-
-        # Set window size with the final dimensions
+        # Set window size with the calculated dimensions
         driver.set_window_size(width, height + HEIGHT_OFFSET)
 
         # Allow a moment for any dynamic resizing

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -328,7 +328,7 @@ def _screenshot_asset(
                     capped_width=MAX_WIDTH_PIXELS,
                     url=url_to_render,
                 )
-            width = min(MAX_WIDTH_PIXELS, calculated_width)
+            width = min(MAX_WIDTH_PIXELS, int(calculated_width))
         else:
             width = screenshot_width
 

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -319,7 +319,7 @@ def _screenshot_asset(
             return null;
         """
         )
-        if isinstance(width, int):
+        if isinstance(width, (int, float)):
             calculated_width = width or screenshot_width
             if calculated_width > MAX_WIDTH_PIXELS:
                 logger.warning(


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

A [customer reported](https://posthog.slack.com/archives/C09ALCCKESZ/p1768980271399249) that during "wide funnel" exports they were unable to see the entire funnel (and had to rely upon either taking a screenshot themselves or piecing together the different parts) as it was cut off due to the screenshot having a scrollbar. 

This PR addresses that by modifying the resizing logic in our `image_exporter` service. 

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- For funnels we now effectively:
	- Start at our newly defined maximum width (4000px) 
	- Load the browser and open the funnel insight
	- Dynamically figure out the width that the funnel would require  
	- Adjust the screenshot width to this
- Other insight types have been left as is.
- Emit a `warning<screenshot_width_capped>` log whenever we exceed the maximum width (similar to what we're doing for the height).  

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

✅ **Tried it locally with renders of different insights**

_Before:_

<img width="2250" height="1018" alt="export-pageview-pageview-pageview-user-conversion-rate (13)" src="https://github.com/user-attachments/assets/985d3317-d499-4a5c-8f43-78fb7faa4746" />
<img width="1600" height="1018" alt="export-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-user-conversion-rate (40)" src="https://github.com/user-attachments/assets/a1651880-032b-4ff8-a478-ce87a320372d" />
<img width="1600" height="1018" alt="export-multi-resource-insight (8)" src="https://github.com/user-attachments/assets/97155258-482b-4ad8-9aa0-c261e7292dbb" />


_After:_

<img width="1600" height="1018" alt="export-multi-resource-insight (7)" src="https://github.com/user-attachments/assets/8a5441db-c631-4b7b-8740-71dfaa514673" />
<img width="1606" height="1018" alt="export-pageview-pageview-pageview-user-conversion-rate (12)" src="https://github.com/user-attachments/assets/c9965508-5e40-4733-880d-845478dacb01" />
<img width="7006" height="1018" alt="export-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-user-conversion-rate (39)" src="https://github.com/user-attachments/assets/3dce8001-8d35-4c3a-afcc-218065fa2e60" />

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->


**Please note:** Even though we have increased the width, there still is a limit after which the funnels get cut-off (18 1/3th or so):

<img width="8000" height="1018" alt="export-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-pageview-user-con" src="https://github.com/user-attachments/assets/f2dcedb0-095d-427a-b1a9-0b00584d78e1" />

This was deemed acceptable as these very wide funnels should be relatively rare. If this becomes a problem in the future we can increase the width (as long we keep an eye on the memory usage).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

Yes, wider funnels (4+ steps) are now better visualised in `png` exports

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
