### PR TITLE
feat(llma): add tooltip to evaluation reasoning column

### DIFF
--- a/products/llm_analytics/frontend/components/GenerationEvalRunsTable.tsx
+++ b/products/llm_analytics/frontend/components/GenerationEvalRunsTable.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useValues } from 'kea'
 
 import { IconCheck, IconMinus, IconWarning, IconX } from '@posthog/icons'
-import { LemonTable, LemonTag, Link } from '@posthog/lemon-ui'
+import { LemonTable, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
@@ -84,9 +84,11 @@ function GenerationEvalRunsTableContent(): JSX.Element {
             title: 'Reasoning',
             key: 'reasoning',
             render: (_, run) => (
-                <div className="max-w-md">
-                    <div className="text-sm text-default line-clamp-2">{run.reasoning}</div>
-                </div>
+                <Tooltip title={run.reasoning}>
+                    <div className="max-w-md cursor-default">
+                        <div className="text-sm text-default line-clamp-2">{run.reasoning}</div>
+                    </div>
+                </Tooltip>
             ),
         },
     ]

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconCheck, IconMinus, IconRefresh, IconWarning, IconX } from '@posthog/icons'
-import { LemonButton, LemonTable, LemonTag, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonTable, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
@@ -85,9 +85,11 @@ export function EvaluationRunsTable(): JSX.Element {
             title: 'Reasoning',
             key: 'reasoning',
             render: (_, run) => (
-                <div className="max-w-md">
-                    <div className="text-sm text-default line-clamp-2">{run.reasoning}</div>
-                </div>
+                <Tooltip title={run.reasoning}>
+                    <div className="max-w-md cursor-default">
+                        <div className="text-sm text-default line-clamp-2">{run.reasoning}</div>
+                    </div>
+                </Tooltip>
             ),
         },
         {


### PR DESCRIPTION
## Problem

Reasoning text in LLM evaluation tables is truncated with `line-clamp-2`, making it difficult to read full explanations from the LLM judge.

## Changes

Added hover tooltip to the reasoning column in both evaluation tables so users can see the complete text on hover.

<img width="1295" height="554" alt="image" src="https://github.com/user-attachments/assets/89ecc8fe-4164-45e6-9944-8b429e661293" />


## How did you test this code?

Manual testing - hover over truncated reasoning text to see full content in tooltip.

## Publish to changelog?

no