### PR TITLE
feat(logs): allow logsdetail modal to close when clicked outside

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
@@ -80,8 +80,8 @@ export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element
             isOpen={isLogDetailsOpen}
             onClose={closeLogDetails}
             simple
-            overlayClassName="backdrop-blur-none bg-transparent flex items-stretch justify-end pr-16 py-4 pointer-events-none h-screen"
-            className="m-0! max-w-3xl w-[50vw] pointer-events-auto min-h-full"
+            overlayClassName="backdrop-blur-none bg-transparent flex items-stretch justify-end pr-16 py-4 h-screen"
+            className="m-0! max-w-3xl w-[50vw] min-h-full"
             hideCloseButton
         >
             <div className="flex flex-col h-full">


### PR DESCRIPTION
## Problem

Clicking outside the logs detail modal does not close it, this is unexpected behaviour.

## Changes

Removed the pointer-events-none class from the overlay and pointer-events-auto from the modal in the LogDetailsModal component 

## How did you test this code?

Local dev

## Publish to changelog?

No