### PR TITLE
fix(ph-ai): removed dead code ph-ai usage report

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -603,11 +603,6 @@ def update_all_orgs_billing_quotas(
     api_queries_usage = get_teams_with_api_queries_metrics(period_start, period_end)
     _, exception_metrics = get_teams_with_exceptions_captured_in_period(period_start, period_end)
 
-    # Check if AI billing usage report is enabled
-    is_ai_billing_enabled = posthoganalytics.feature_enabled(
-        "posthog-ai-billing-usage-report", "internal_billing_events"
-    )
-
     # Clickhouse is good at counting things so we count across all teams rather than doing it one by one
     all_data = {
         "teams_with_event_count_in_period": convert_team_usage_rows_to_dict(
@@ -641,10 +636,8 @@ def update_all_orgs_billing_quotas(
         "teams_with_ai_event_count_in_period": convert_team_usage_rows_to_dict(
             get_teams_with_ai_event_count_in_period(period_start, period_end)
         ),
-        "teams_with_ai_credits_used_in_period": (
-            convert_team_usage_rows_to_dict(get_teams_with_ai_credits_used_in_period(period_start, period_end))
-            if is_ai_billing_enabled
-            else {}
+        "teams_with_ai_credits_used_in_period": convert_team_usage_rows_to_dict(
+            get_teams_with_ai_credits_used_in_period(period_start, period_end)
         ),
         "teams_with_workflow_emails_sent_in_period": convert_team_usage_rows_to_dict(
             get_teams_with_workflow_emails_sent_in_period(period_start, period_end)
@@ -685,7 +678,7 @@ def update_all_orgs_billing_quotas(
             api_queries_read_bytes=all_data["teams_with_api_queries_read_bytes"].get(team.id, 0),
             survey_responses=all_data["teams_with_survey_responses_count_in_period"].get(team.id, 0),
             llm_events=all_data["teams_with_ai_event_count_in_period"].get(team.id, 0),
-            ai_credits=all_data["teams_with_ai_credits_used_in_period"].get(team.id, 0) if is_ai_billing_enabled else 0,
+            ai_credits=all_data["teams_with_ai_credits_used_in_period"].get(team.id, 0),
             cdp_trigger_events=all_data["teams_with_cdp_trigger_events_metrics"].get(team.id, 0),
             rows_exported=all_data["teams_with_rows_exported_in_period"].get(team.id, 0),
             workflow_emails=all_data["teams_with_workflow_emails_sent_in_period"].get(team.id, 0),

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -15,7 +15,6 @@ from django.db.models import Count, F, Q, Sum
 
 import requests
 import structlog
-import posthoganalytics
 from cachetools import cached
 from celery import shared_task
 from dateutil import parser
@@ -1724,11 +1723,6 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         period_start, period_end
     )
 
-    # Check if AI billing usage report is enabled
-    is_ai_billing_enabled = posthoganalytics.feature_enabled(
-        "posthog-ai-billing-usage-report", "internal_billing_events"
-    )
-
     return {
         "teams_with_event_count_in_period": get_teams_with_billable_event_count_in_period(
             period_start, period_end, count_distinct=True
@@ -1940,9 +1934,7 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
             period_start, period_end
         ),
         "teams_with_ai_event_count_in_period": get_teams_with_ai_event_count_in_period(period_start, period_end),
-        "teams_with_ai_credits_used_in_period": (
-            get_teams_with_ai_credits_used_in_period(period_start, period_end) if is_ai_billing_enabled else []
-        ),
+        "teams_with_ai_credits_used_in_period": get_teams_with_ai_credits_used_in_period(period_start, period_end),
         "teams_with_active_hog_destinations_in_period": get_teams_with_active_hog_destinations_in_period(),
         "teams_with_active_hog_transformations_in_period": get_teams_with_active_hog_transformations_in_period(),
         "teams_with_workflow_emails_sent_in_period": get_teams_with_workflow_emails_sent_in_period(

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1069,7 +1069,16 @@ def get_teams_with_ai_credits_used_in_period(
     Using the field from properties to filter events instead.
     """
     region = get_instance_region()
-    assert region is not None, "Region must be set in production infrastructure"
+
+    if region is None:
+        # In production, we want to fail fast if region is not set
+        # In non-production environments (e.g., tests), we can return gracefully
+        from posthog.settings import TEST
+
+        if not TEST:
+            assert region is not None, "Region must be set in production infrastructure"
+        return []
+
     team_to_query = CLOUD_REGION_TO_TEAM_ID[region]
 
     with tags_context(product=Product.MAX_AI, usage_report="ai_credits", kind="usage_report"):


### PR DESCRIPTION
## Problem

ph-ai usage_report stopped being executed on after Jan. 14th 2026 due to the flag being removed from the DB but the code references were kept there, evaluating it always as falsy.

<img width="1945" height="758" alt="CleanShot 2026-01-21 at 12  27 47" src="https://github.com/user-attachments/assets/3ac9e325-3987-4c00-b75d-5691adc70dd2" />

[slack thread](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1768997555378759)

## Changes

* removed dead code

