### PR TITLE
fix(logs): fix the attribute breakdown not recomputing row heights

### DIFF
--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -417,6 +417,9 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         togglePrettifyLog: ({ logId }) => {
             actions.recomputeRowHeights([logId])
         },
+        toggleAttributeBreakdown: ({ logId }) => {
+            actions.recomputeRowHeights([logId])
+        },
         moveCursorDown: ({ shiftSelect }) => {
             const { logs, cursor } = values
             if (logs.length === 0) {


### PR DESCRIPTION
## Problem

Expanding attribute breakdowns in the log viewer was causing a horrible overlay issue.

## Changes

Ensures toggleAttributeBreakdown triggers recomputation of rowHeights

## How did you test this code?

Local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no
