### PR TITLE
feat: email notifications on new ticket

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -604,6 +604,7 @@ export interface ConversationsSettings {
     widget_color?: string
     widget_public_token?: string | null
     widget_domains?: string[] | null
+    notification_recipients?: number[] | null
 }
 
 export interface LogsSettings {

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -105,6 +105,7 @@ CUSTOMER_IO_TEMPLATE_ID_MAP = {
     "oauth_token_exposed": "50",
     "passkey_added": "51",
     "passkey_removed": "52",
+    "new_conversation_ticket": "53",
 }
 
 

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -1179,12 +1179,13 @@ def send_new_ticket_notification(ticket_id: str, team_id: int, first_message_con
 
     campaign_key = f"new_conversation_ticket_{ticket.id}"
     message = EmailMessage(
+        use_http=True,
         campaign_key=campaign_key,
         subject=f"[Ticket #{ticket.ticket_number}] New support ticket in {team.name}",
         template_name="new_conversation_ticket",
         template_context={
-            "team": team,
-            "ticket": ticket,
+            "team_name": team.name,
+            "ticket_number": ticket.ticket_number,
             "customer_name": customer_name,
             "customer_email": customer_email,
             "first_message": first_message_content[:500] if first_message_content else "",

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -37,6 +37,7 @@ from posthog.models.utils import UUIDT
 from posthog.ph_client import get_client
 from posthog.user_permissions import UserPermissions
 
+from products.conversations.backend.models import Ticket
 from products.error_tracking.backend.models import ErrorTrackingIssueAssignment
 
 logger = structlog.get_logger(__name__)
@@ -1129,3 +1130,70 @@ def send_oauth_token_exposed(user_id: int, token_type: str, mask_value: str, mor
     )
     message.add_user_recipient(user)
     message.send()
+
+
+@shared_task(**EMAIL_TASK_KWARGS)
+def send_new_ticket_notification(ticket_id: str, team_id: int, first_message_content: str) -> None:
+    if not is_email_available(with_absolute_urls=True):
+        logger.warning("Skipping new ticket notification: email service not available")
+        return
+
+    try:
+        team = Team.objects.get(pk=team_id)
+        ticket = Ticket.objects.get(id=ticket_id, team=team)
+    except (Team.DoesNotExist, Ticket.DoesNotExist):
+        logger.warning(f"Skipping new ticket notification: ticket or team not found (ticket_id={ticket_id})")
+        return
+
+    # Get notification recipients from team settings
+    conversations_settings = team.conversations_settings or {}
+    recipient_ids = conversations_settings.get("notification_recipients", [])
+
+    if not recipient_ids:
+        return
+
+    # Get users who should receive notifications and have access to the project
+    memberships = OrganizationMembership.objects.prefetch_related("user", "organization").filter(
+        organization_id=team.organization_id,
+        user_id__in=recipient_ids,
+    )
+
+    memberships_to_email = []
+    for membership in memberships:
+        team_permissions = UserPermissions(membership.user).team(team)
+        if (
+            team_permissions.effective_membership_level_for_parent_membership(membership.organization, membership)
+            is not None
+        ):
+            memberships_to_email.append(membership)
+
+    if not memberships_to_email:
+        return
+
+    # Extract customer info from anonymous_traits
+    traits = ticket.anonymous_traits or {}
+    customer_name = traits.get("name")
+    customer_email = traits.get("email")
+
+    ticket_url = f"{settings.SITE_URL}/project/{team.pk}/conversations/tickets/{ticket.id}"
+
+    campaign_key = f"new_conversation_ticket_{ticket.id}"
+    message = EmailMessage(
+        campaign_key=campaign_key,
+        subject=f"[Ticket #{ticket.ticket_number}] New support ticket in {team.name}",
+        template_name="new_conversation_ticket",
+        template_context={
+            "team": team,
+            "ticket": ticket,
+            "customer_name": customer_name,
+            "customer_email": customer_email,
+            "first_message": first_message_content[:500] if first_message_content else "",
+            "ticket_url": ticket_url,
+        },
+    )
+
+    for membership in memberships_to_email:
+        message.add_user_recipient(membership.user)
+
+    message.send()
+    logger.info(f"Sent new ticket notification for ticket {ticket.id} to {len(memberships_to_email)} recipients")

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -37,6 +37,7 @@
     'posthog.tasks.email.send_hog_functions_digest_email',
     'posthog.tasks.email.send_invite',
     'posthog.tasks.email.send_member_join',
+    'posthog.tasks.email.send_new_ticket_notification',
     'posthog.tasks.email.send_oauth_token_exposed',
     'posthog.tasks.email.send_passkey_added_email',
     'posthog.tasks.email.send_passkey_removed_email',

--- a/posthog/templates/email/new_conversation_ticket.html
+++ b/posthog/templates/email/new_conversation_ticket.html
@@ -1,0 +1,39 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block heading %}New support ticket received{% endblock %}
+{% block section %}
+<!-- prettier-ignore -->
+<p>
+    A new support ticket has been created in project <b>{{ team.name }}</b>.
+</p>
+<p>
+    <b>Ticket #{{ ticket.ticket_number }}</b>
+</p>
+{% if customer_name %}
+<p>
+    <b>From:</b> {{ customer_name }}{% if customer_email %} ({{ customer_email }}){% endif %}
+</p>
+{% endif %}
+<p>
+    <b>Message:</b><br />
+    {{ first_message }}
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{{ ticket_url }}">View ticket</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{{ ticket_url }}">{{ ticket_url }}</a>
+    </p>
+</div>
+{% endblock %}
+
+{% block footer %}
+Need help?
+<a href="https://posthog.com/questions?{{ utm_tags }}"
+    target="_blank"><b>Visit support</b></a>
+or
+<a href="https://posthog.com/docs?{{ utm_tags }}"
+    target="_blank"><b>Read our documentation</b></a>.
+
+{% endblock %}

--- a/posthog/templates/email/new_conversation_ticket.html
+++ b/posthog/templates/email/new_conversation_ticket.html
@@ -3,10 +3,10 @@
 {% block section %}
 <!-- prettier-ignore -->
 <p>
-    A new support ticket has been created in project <b>{{ team.name }}</b>.
+    A new support ticket has been created in project <b>{{ team_name }}</b>.
 </p>
 <p>
-    <b>Ticket #{{ ticket.ticket_number }}</b>
+    <b>Ticket #{{ ticket_number }}</b>
 </p>
 {% if customer_name %}
 <p>

--- a/products/conversations/frontend/scenes/settings/SupportSettingsScene.tsx
+++ b/products/conversations/frontend/scenes/settings/SupportSettingsScene.tsx
@@ -3,6 +3,7 @@ import { useActions, useValues } from 'kea'
 import { IconPencil, IconPlus, IconTrash } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonColorPicker, LemonInput, LemonSwitch } from '@posthog/lemon-ui'
 
+import { MemberSelectMultiple } from 'lib/components/MemberSelectMultiple'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
@@ -119,6 +120,7 @@ export function SupportSettingsScene(): JSX.Element {
         setWidgetEnabledLoading,
         setGreetingInputValue,
         saveGreetingText,
+        setNotificationRecipients,
     } = useActions(supportSettingsLogic)
     const {
         isAddingDomain,
@@ -126,6 +128,7 @@ export function SupportSettingsScene(): JSX.Element {
         conversationsEnabledLoading,
         widgetEnabledLoading,
         greetingInputValue,
+        notificationRecipients,
     } = useValues(supportSettingsLogic)
 
     return (
@@ -165,6 +168,16 @@ export function SupportSettingsScene(): JSX.Element {
             <div>
                 {currentTeam?.conversations_enabled && (
                     <>
+                        <div className="mb-8 mt-2 max-w-[800px]">
+                            <h3>Email notifications</h3>
+                            <p>Team members who will receive email notifications when new tickets are created.</p>
+                            <MemberSelectMultiple
+                                idKey="id"
+                                value={notificationRecipients}
+                                onChange={setNotificationRecipients}
+                            />
+                        </div>
+
                         <div>
                             <h3>In-app widget</h3>
                             <p>Turn on the in-app support widget to start receiving messages from your users</p>
@@ -190,7 +203,7 @@ export function SupportSettingsScene(): JSX.Element {
                         </div>
 
                         {currentTeam?.conversations_settings?.widget_enabled && (
-                            <div className="mt-4 flex flex-col gap-y-2 border rounded py-2 px-4 mb-2 max-w-[800px]">
+                            <div className="mt-8 flex flex-col gap-y-2 border rounded py-2 px-4 mb-2 max-w-[800px]">
                                 <h3>Widget settings</h3>
                                 <div className="flex items-center gap-4 py-2">
                                     <label className="w-40 shrink-0">Button color</label>

--- a/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
+++ b/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
@@ -4,6 +4,8 @@ import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { UserBasicType } from '~/types'
+
 import type { supportSettingsLogicType } from './supportSettingsLogicType'
 
 export const supportSettingsLogic = kea<supportSettingsLogicType>([
@@ -26,6 +28,8 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         cancelDomainEdit: true,
         setGreetingInputValue: (value: string | null) => ({ value }),
         saveGreetingText: true,
+        // Notification recipients
+        setNotificationRecipients: (users: UserBasicType[]) => ({ users }),
     }),
     reducers({
         conversationsEnabledLoading: [
@@ -81,6 +85,10 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             (s) => [s.currentTeam],
             (currentTeam): string[] => currentTeam?.conversations_settings?.widget_domains || [],
         ],
+        notificationRecipients: [
+            (s) => [s.currentTeam],
+            (currentTeam): number[] => currentTeam?.conversations_settings?.notification_recipients || [],
+        ],
     }),
     listeners(({ values, actions }) => ({
         generateNewToken: async () => {
@@ -129,6 +137,14 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                 conversations_settings: {
                     ...values.currentTeam?.conversations_settings,
                     widget_greeting_text: values.greetingInputValue,
+                },
+            })
+        },
+        setNotificationRecipients: ({ users }) => {
+            actions.updateCurrentTeam({
+                conversations_settings: {
+                    ...values.currentTeam?.conversations_settings,
+                    notification_recipients: users.map((u) => u.id),
                 },
             })
         },


### PR DESCRIPTION
## Problem

When a new ticket created we should send emails. 

## Changes

Add email notifications to settings
Send email when new ticket is created

<img width="615" height="194" alt="Screenshot 2026-01-21 at 13 43 12" src="https://github.com/user-attachments/assets/531943c3-e331-48f4-a48c-f4830eac6b80" />
