### PR TITLE
feat(phai): enforce the number of rows limit on queries

### DIFF
--- a/ee/hogai/context/insight/prompts.py
+++ b/ee/hogai/context/insight/prompts.py
@@ -43,7 +43,7 @@ Here is the insight schema used to retrieve the results above:
 <system_reminder>
 The current date and time is {{{utc_datetime_display}}} UTC, which is {{{project_datetime_display}}} in this project's timezone ({{{project_timezone}}}).
 {{#sql_query}}
-SQL query results are capped at 100 rows. If you need more data, paginate using LIMIT and OFFSET clauses in subsequent queries.
+Your SQL query results are capped at 100 rows. If you need more data, paginate using LIMIT and OFFSET clauses in subsequent queries.
 {{/sql_query}}
 {{#currency}}
 Assume currency values are in {{currency}} and ALWAYS include the proper prefix when displaying values that are likely to be currency values.

--- a/ee/hogai/context/insight/prompts.py
+++ b/ee/hogai/context/insight/prompts.py
@@ -42,6 +42,9 @@ Here is the insight schema used to retrieve the results above:
 {{/insight_schema}}
 <system_reminder>
 The current date and time is {{{utc_datetime_display}}} UTC, which is {{{project_datetime_display}}} in this project's timezone ({{{project_timezone}}}).
+{{#sql_query}}
+SQL query results are capped at 100 rows. If you need more data, paginate using LIMIT and OFFSET clauses in subsequent queries.
+{{/sql_query}}
 {{#currency}}
 Assume currency values are in {{currency}} and ALWAYS include the proper prefix when displaying values that are likely to be currency values.
 {{/currency}}

--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -30,6 +30,7 @@ from posthog.schema import (
     TrendsQuery,
 )
 
+from posthog.hogql.constants import LimitContext
 from posthog.hogql.errors import (
     ExposedHogQLError,
     NotImplementedError as HogQLNotImplementedError,
@@ -291,6 +292,7 @@ class AssistantQueryExecutor:
                 self._team,
                 query.model_dump(mode="json"),
                 execution_mode=execution_mode,
+                limit_context=LimitContext.POSTHOG_AI,
             )
 
             process_elapsed = time.time() - process_start
@@ -553,6 +555,7 @@ async def execute_and_format_query(
         project_timezone=team.timezone_info.tzname(utc_now_datetime),
         currency=currency if is_revenue_analytics_query(query) else None,
         has_truncated_values=has_truncated_values,
+        sql_query=True if isinstance(query, AssistantHogQLQuery | HogQLQuery) else None,
     )
 
     return f"{example_prompt}\n\n{query_result}"

--- a/ee/hogai/tools/execute_sql/prompts.py
+++ b/ee/hogai/tools/execute_sql/prompts.py
@@ -73,6 +73,7 @@ WHERE e.event IN (SELECT event FROM events WHERE ...)
   - Optional org filter → AND (coalesce(variables.org, '') = '' OR p.properties.org = variables.org)
   - Optional browser filter → AND (variables.browser IS NULL OR properties.$browser = variables.browser)
   - Time window should remain enforced for events; add variable guards only if explicitly asked
+- Your SQL query results are capped at 100 rows. The user sees the full results in the UI. If you need to analyze more data, paginate using LIMIT and OFFSET in subsequent queries.
 
 # Expressions guide
 

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -31,6 +31,8 @@ MAX_SELECT_HEATMAPS_LIMIT = 1000000  # 1m datapoints
 MAX_SELECT_COHORT_CALCULATION_LIMIT = 1000000000  # 1b persons
 # Max limit for LLM traces
 MAX_SELECT_TRACES_LIMIT_EXPORT = 10000  # 10k traces
+# Max limit for PostHog AI queries
+MAX_SELECT_POSTHOG_AI_LIMIT = 100  # 100 rows
 # Max amount of memory usage when doing group by before swapping to disk. Only used in certain queries
 MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY = 22 * 1024 * 1024 * 1024
 
@@ -54,6 +56,7 @@ class LimitContext(StrEnum):
     HEATMAPS = "heatmaps"
     SAVED_QUERY = "saved_query"
     RETENTION = "retention"
+    POSTHOG_AI = "posthog_ai"
 
 
 def get_max_limit_for_context(limit_context: LimitContext) -> int:
@@ -72,6 +75,8 @@ def get_max_limit_for_context(limit_context: LimitContext) -> int:
         return MAX_SELECT_RETENTION_LIMIT  # 100k
     elif limit_context == LimitContext.SAVED_QUERY:
         return sys.maxsize  # Max python int
+    elif limit_context == LimitContext.POSTHOG_AI:
+        return MAX_SELECT_POSTHOG_AI_LIMIT  # 100
     else:
         raise ValueError(f"Unexpected LimitContext value: {limit_context}")
 
@@ -80,7 +85,7 @@ def get_default_limit_for_context(limit_context: LimitContext) -> int:
     """Limit used if no limit is provided"""
     if limit_context == LimitContext.EXPORT:
         return CSV_EXPORT_LIMIT
-    elif limit_context in (LimitContext.QUERY, LimitContext.QUERY_ASYNC):
+    elif limit_context in (LimitContext.QUERY, LimitContext.QUERY_ASYNC, LimitContext.POSTHOG_AI):
         return DEFAULT_RETURNED_ROWS  # 100
     elif limit_context == LimitContext.HEATMAPS:
         return MAX_SELECT_HEATMAPS_LIMIT  # 1M


### PR DESCRIPTION
## Problem

PostHog AI has the same limit as for regular queries. It frequently retrieves more data than the context window fits, triggering conversation compaction, which we generally want to avoid.

## Changes

- Added a new limit for PostHog AI queries.
- Added a test for that limit.
- Modified prompts, so the agent knows about the limit.

## How did you test this code?

Unit tests & manual testing
