### PR TITLE
fix(llm_analytics): round total cost to whole dollars

### DIFF
--- a/products/llm_analytics/backend/dashboard_templates.py
+++ b/products/llm_analytics/backend/dashboard_templates.py
@@ -85,7 +85,7 @@ def get_llm_analytics_default_template() -> DashboardTemplate:
                         ],
                         "trendsFilter": {
                             "aggregationAxisPrefix": "$",
-                            "decimalPlaces": 4,
+                            "decimalPlaces": 0,
                             "display": "BoldNumber",
                         },
                         "dateRange": {


### PR DESCRIPTION
The "Total cost (USD)" insight was displaying 4 decimal places (e.g.,
$30,270.4302), making it hard to read. Changed to 0 decimal places for
cleaner display.