### PR TITLE
chore: add django command for creating a deterministic personal api key locally

### DIFF
--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -124,8 +124,15 @@ core:
               else: migrations:run
             - dev:demo-data
             - dev:sync-flags
+            - dev:api-key
         description: Full reset - wipe volumes, migrate, load demo data, sync flags
         prompt: true
+    dev:api-key:
+        cmd: python manage.py setup_local_api_key
+        description: Creates a personal API key that's always the same,
+            so you don't need to manually create a new one every time you reset the stack.
+        services:
+            - postgresql
 health_checks:
     check:clickhouse:
         bin_script: check_clickhouse_up

--- a/posthog/management/commands/setup_local_api_key.py
+++ b/posthog/management/commands/setup_local_api_key.py
@@ -1,0 +1,69 @@
+# ruff: noqa: T201 allow print statements
+"""
+Creates a deterministic personal API key for local development.
+
+Usage:
+    python manage.py setup_local_api_key
+
+The key value is fixed so it survives database resets.
+
+Safety: Only runs when DEBUG=True and CLOUD_DEPLOYMENT is unset.
+"""
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from posthog.models import User
+from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+from posthog.models.utils import mask_key_value
+
+# Fixed key value for local development - DO NOT use in production
+DEV_API_KEY = "phx_dev_local_test_api_key_1234567890abcdef"
+DEV_USER_EMAIL = "test@posthog.com"
+DEV_KEY_LABEL = "Local Development Key"
+
+
+class Command(BaseCommand):
+    help = "Create a deterministic personal API key for local development"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--email",
+            type=str,
+            default=DEV_USER_EMAIL,
+            help=f"Email of the user to create the key for (default: {DEV_USER_EMAIL})",
+        )
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG:
+            raise CommandError("This command can only run with DEBUG=True")
+        if settings.CLOUD_DEPLOYMENT:
+            raise CommandError("This command cannot run in cloud deployments")
+
+        email = options["email"]
+
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            print(f"User with email '{email}' not found")
+            return
+
+        secure_value = hash_key_value(DEV_API_KEY)
+
+        existing_key = PersonalAPIKey.objects.filter(secure_value=secure_value).first()
+        if existing_key:
+            print(f"API key already exists for user '{existing_key.user.email}'")
+            print(f"Key: {DEV_API_KEY}")
+            return
+
+        PersonalAPIKey.objects.filter(user=user, label=DEV_KEY_LABEL).delete()
+
+        PersonalAPIKey.objects.create(
+            user=user,
+            label=DEV_KEY_LABEL,
+            secure_value=secure_value,
+            mask_value=mask_key_value(DEV_API_KEY),
+        )
+
+        print(f"Created personal API key for '{email}'")
+        print(f"Key: {DEV_API_KEY}")


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

i find myself having to open the UI to create an API key for testing how my stuff works
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- create a new command that only works on a settings.DEBUG and not settings.CLOUD_DEPLOYMENT that creates the same API key every time

## How did you test this code?
- ran it locallyyy
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
nooo!
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
