### PR TITLE
chore(background-jobs): enable hot reload for temporal worker by default

### DIFF
--- a/bin/mprocs-with-logging.yaml
+++ b/bin/mprocs-with-logging.yaml
@@ -24,10 +24,10 @@ procs:
             bin/check_temporal_up && \
             bin/check_video_deps && \
             bin/check_ducklake_up && \
-            if [ -n "$TEMPORAL_WATCH" ]; then \
-                nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue" 2>&1 | tee /tmp/posthog-temporal-worker.log; \
-            else \
+            if [ -n "$TEMPORAL_SKIP_HOT_RELOAD" ]; then \
                 python manage.py start_temporal_worker --task-queue development-task-queue 2>&1 | tee /tmp/posthog-temporal-worker.log; \
+            else \
+                nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue" 2>&1 | tee /tmp/posthog-temporal-worker.log; \
             fi
 
     dagster:

--- a/bin/mprocs-with-logging.yaml
+++ b/bin/mprocs-with-logging.yaml
@@ -24,7 +24,7 @@ procs:
             bin/check_temporal_up && \
             bin/check_video_deps && \
             bin/check_ducklake_up && \
-            if [ -n "$TEMPORAL_SKIP_HOT_RELOAD" ]; then \
+            if [ -n "$TEMPORAL_DISABLE_HOT_RELOAD" ]; then \
                 python manage.py start_temporal_worker --task-queue development-task-queue 2>&1 | tee /tmp/posthog-temporal-worker.log; \
             else \
                 nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue" 2>&1 | tee /tmp/posthog-temporal-worker.log; \

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -23,10 +23,10 @@ procs:
             bin/check_kafka_clickhouse_up && \
             bin/check_temporal_up && \
             bin/check_ducklake_up && \
-            if [ -n "$TEMPORAL_WATCH" ]; then \
-                nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue"; \
-            else \
+            if [ -n "$TEMPORAL_SKIP_HOT_RELOAD" ]; then \
                 python manage.py start_temporal_worker --task-queue development-task-queue; \
+            else \
+                nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue"; \
             fi
 
     dagster:

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -23,7 +23,7 @@ procs:
             bin/check_kafka_clickhouse_up && \
             bin/check_temporal_up && \
             bin/check_ducklake_up && \
-            if [ -n "$TEMPORAL_SKIP_HOT_RELOAD" ]; then \
+            if [ -n "$TEMPORAL_DISABLE_HOT_RELOAD" ]; then \
                 python manage.py start_temporal_worker --task-queue development-task-queue; \
             else \
                 nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue"; \

--- a/posthog/temporal/README.md
+++ b/posthog/temporal/README.md
@@ -475,7 +475,7 @@ There are examples on how to achieve this throughout the codebase: Batch exports
 
 The development stack includes: A Temporal service to act as a local orchestrator, a Temporal UI, and, if you are using `mprocs`, multiple Temporal workers that are started automatically, one per task queue. These workers includes a worker listening on the shared `general-purpose-task-queue`, which can be used for development. If you have deployed a new set of workers, add it to `bin/mprocs.yaml` so that a worker can start automatically for folks doing local development.
 
-By default, Temporal workers automatically hot reload when Python files change (similar to backend and celery workers). If you need to disable hot reloading, set `TEMPORAL_SKIP_HOT_RELOAD=1`.
+By default, Temporal workers automatically hot reload when Python files change (similar to backend and celery workers). If you need to disable hot reloading, set `TEMPORAL_DISABLE_HOT_RELOAD=1`.
 
 Some products or features may require additional configuration, for example: Data warehouse workflows require additional credentials that must be present in the environment (`#team-data-warehouse` can assist with this reached out for help). Check other documentation based on the product you are trying to develop locally for.
 

--- a/posthog/temporal/README.md
+++ b/posthog/temporal/README.md
@@ -475,6 +475,8 @@ There are examples on how to achieve this throughout the codebase: Batch exports
 
 The development stack includes: A Temporal service to act as a local orchestrator, a Temporal UI, and, if you are using `mprocs`, multiple Temporal workers that are started automatically, one per task queue. These workers includes a worker listening on the shared `general-purpose-task-queue`, which can be used for development. If you have deployed a new set of workers, add it to `bin/mprocs.yaml` so that a worker can start automatically for folks doing local development.
 
+By default, Temporal workers automatically hot reload when Python files change (similar to backend and celery workers). If you need to disable hot reloading, set `TEMPORAL_SKIP_HOT_RELOAD=1`.
+
 Some products or features may require additional configuration, for example: Data warehouse workflows require additional credentials that must be present in the environment (`#team-data-warehouse` can assist with this reached out for help). Check other documentation based on the product you are trying to develop locally for.
 
 As you run workflows, you will be able to see the logs in the worker's logs, and you can go to the Temporal UI at http://localhost:8081 to check on the workflow status.


### PR DESCRIPTION
## Problem

The Temporal worker service by default requires manually setting `TEMPORAL_WATCH=1` to enable hot reloading during development, while other services (e.g. backend `bin/start-backend` and celery woker `bin/start-celery`) have it enabled by default. This inconsistency is misleading for developers, as it takes some time to figure out that code changes are not automatically applied (this is what happened to me).

This PR proposes enabling hot reload by default, while still allowing disabling it if hot reloading is not desired.

There is one conversation in https://github.com/PostHog/posthog/pull/40812#pullrequestreview-3411531450 around that topic, mentioning the use case of batch exports for not having hot reloading. But I think people working in that domain have it easier to remember to turn hot reloading off, while it is more convenient and consistent to be enabled by default for everybody else. If there are further reasons not to enable it by default, this PR invites documenting those.

## Changes

- Changed Temporal worker hot reloading from opt-in (`TEMPORAL_WATCH`) to opt-out (`TEMPORAL_DISABLE_HOT_RELOAD`)
- Updated both `bin/mprocs.yaml` and `bin/mprocs-with-logging.yaml` to enable hot reloading by default
- Updated documentation in `posthog/temporal/README.md` to reflect the new default behavior

## How did you test this code?

Manually:
- Starting with `op run --env-file=.env.local -- bin/start` did autoreload debug changes in `products/experiments/backend/max_tools.py` 
- Starting with `TEMPORAL_DISABLE_HOT_RELOAD=1 op run --env-file=.env.local -- bin/start` did not, but only after restarting the temporal service

## Publish to changelog?

No