### PR TITLE
fix: add breakpoint() to precheck passkey auto-login

### DIFF
--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -197,6 +197,7 @@ export const loginLogic = kea<loginLogicType>([
                 breakpoint()
                 // Dynamic import to avoid circular dependency
                 const { passkeyLogic } = await import('./passkeyLogic')
+                breakpoint()
                 passkeyLogic.actions.beginPasskeyLogin(precheckResponse.webauthn_credentials)
             }
         },

--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -186,7 +186,7 @@ export const loginLogic = kea<loginLogicType>([
             // Reload the page after login to ensure POSTHOG_APP_CONTEXT is set correctly.
             window.location.reload()
         },
-        precheckSuccess: async () => {
+        precheckSuccess: async (_, breakpoint) => {
             const { precheckResponse } = values
             // Auto-trigger passkey prompt if user has passkeys and SSO is not enforced
             if (
@@ -194,6 +194,7 @@ export const loginLogic = kea<loginLogicType>([
                 precheckResponse.webauthn_credentials.length > 0 &&
                 !precheckResponse.sso_enforcement
             ) {
+                breakpoint()
                 // Dynamic import to avoid circular dependency
                 const { passkeyLogic } = await import('./passkeyLogic')
                 passkeyLogic.actions.beginPasskeyLogin(precheckResponse.webauthn_credentials)


### PR DESCRIPTION
## Problem

[error](https://us.posthog.com/project/2/error_tracking/019be03a-0181-7c60-bff3-0300100cd381?fingerprint=c6e7be4e34fa751cbbc39ca7ef6bd6080fd8e07c9fc0ed2f39580bcc91b8a20d1e00ba981c251e5b4ef63d5362d1d117b60daa6284fbc9f92f04d6ddb83d6ec1&timestamp=2026-01-21%2003%3A09%3A23.128000-08%3A00)

The logic is unmounted before the listener runs, which then attempts to import and run another logic's action which has also been unmounted. This PR adds a breakpoint to validate that the logic is not cancelled before performing the import.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add breakpoint call to `precheckSuccess` listener.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
