### PR TITLE
chore(ci): use dynamic repository owner in sync-clickhouse-versions workflow

### DIFF
--- a/.github/workflows/sync-clickhouse-versions.yml
+++ b/.github/workflows/sync-clickhouse-versions.yml
@@ -23,6 +23,8 @@ jobs:
               with:
                   app-id: ${{ secrets.GH_APP_POSTHOG_CLOUD_INFRA_WORKFLOW_TRIGGER_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_CLOUD_INFRA_WORKFLOW_TRIGGER_PRIVATE_KEY }}
+                  owner: ${{ github.repository_owner }}
+                  repositories: posthog-cloud-infra
 
             - name: Get app token for PR creation
               id: app-token

--- a/.github/workflows/sync-clickhouse-versions.yml
+++ b/.github/workflows/sync-clickhouse-versions.yml
@@ -32,6 +32,8 @@ jobs:
               with:
                   app-id: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_PRIVATE_KEY }}
+                  owner: ${{ github.repository_owner }}
+                  repositories: posthog
 
             - uses: actions/checkout@v6
               with:

--- a/.github/workflows/sync-clickhouse-versions.yml
+++ b/.github/workflows/sync-clickhouse-versions.yml
@@ -32,8 +32,6 @@ jobs:
               with:
                   app-id: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_PRIVATE_KEY }}
-                  owner: ${{ github.repository_owner }}
-                  repositories: posthog
 
             - uses: actions/checkout@v6
               with:


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

After merging: https://github.com/PostHog/posthog/pull/45000 I wanted to run the "sync ClickHouse setting" job manually to ensure that it works as expected, however in doing so I noticed that the run failed: https://github.com/PostHog/posthog/actions/runs/21211560076/job/61021167434.

Looking at [the documentation of the action](https://github.com/actions/create-github-app-token) and the error message:

> Inputs 'owner' and 'repositories' are not set. Creating token for this repository (PostHog/posthog).

it looks like the `owner` and `repositories` fields need to be filled if you're trying to create a token for a different repo. This PR fixes that.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Configure the `owner` and `repositories` for the `posthog-cloud-infra` repo so that the script can access the token.

It's not needed to be added for the step below as:

> If owner and repositories are empty, access will be scoped to only the current repository.

which is exactly what we want there.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

This is difficult to test, so I will re-run the sync job after merging this.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

N/A - Internal CI job fix.

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
