### PR TITLE
fix: Fix clichouse delete mutation propagation

### DIFF
--- a/posthog/temporal/cleanup_property_definitions/activities.py
+++ b/posthog/temporal/cleanup_property_definitions/activities.py
@@ -1,5 +1,7 @@
 from uuid import uuid4
 
+from django.conf import settings
+
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
@@ -66,9 +68,11 @@ async def delete_property_definitions_from_clickhouse(
     delete_query_id = str(uuid4())
     logger.info(f"Executing lightweight delete with query_id: {delete_query_id}")
 
-    # Use lightweight_deletes_sync=0 to avoid waiting for all replicas to be online.
-    # The delete is applied immediately on the current replica and propagates asynchronously.
-    async with get_client(lightweight_deletes_sync=0) as client:
+    # In production, use lightweight_deletes_sync=0 to avoid waiting for all replicas.
+    # In tests, use lightweight_deletes_sync=2 to ensure deletes are visible immediately.
+    lightweight_deletes_sync = 2 if settings.TEST else 0
+
+    async with get_client(lightweight_deletes_sync=lightweight_deletes_sync) as client:
         await client.execute_query(
             delete_query,
             query_parameters={

--- a/posthog/temporal/cleanup_property_definitions/activities.py
+++ b/posthog/temporal/cleanup_property_definitions/activities.py
@@ -66,7 +66,9 @@ async def delete_property_definitions_from_clickhouse(
     delete_query_id = str(uuid4())
     logger.info(f"Executing lightweight delete with query_id: {delete_query_id}")
 
-    async with get_client() as client:
+    # Use lightweight_deletes_sync=0 to avoid waiting for all replicas to be online.
+    # The delete is applied immediately on the current replica and propagates asynchronously.
+    async with get_client(lightweight_deletes_sync=0) as client:
         await client.execute_query(
             delete_query,
             query_parameters={


### PR DESCRIPTION
## Problem

While testing the property definitions job in dev, i ran into the following error while cleaning up Clickhouse entries:
```
{
      "message": "Code: 341. DB::Exception: Mutation is not finished because some replicas are inactive right now: b-1. Mutation will be done asynchronously. (UNFINISHED) (version 25.8.11.66 (official build))\n",
}
```

This was due to an inactive replica.  Other parts of the code use  `lightweight_deletes_sync=0` so this job should also use it

## Changes

- Use `lightweight_deletes_sync=0` in prop defs deletion job

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
