### PR TITLE
fix(data-modeling): async context bug for clickhouse modifiers

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -728,7 +728,7 @@ async def get_query_row_count(query: str, team: Team, logger: FilteringBoundLogg
     settings = HogQLGlobalSettings()
     settings.max_execution_time = HOGQL_INCREASED_MAX_EXECUTION_TIME
 
-    modifiers = create_default_modifiers_for_team(team)
+    modifiers = await database_sync_to_async(create_default_modifiers_for_team)(team)
     context = HogQLContext(
         team=team,
         team_id=team.id,
@@ -776,7 +776,7 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
     settings = HogQLGlobalSettings()
     settings.max_execution_time = HOGQL_INCREASED_MAX_EXECUTION_TIME
 
-    modifiers = create_default_modifiers_for_team(team)
+    modifiers = await database_sync_to_async(create_default_modifiers_for_team)(team)
     context = HogQLContext(
         team=team,
         team_id=team.id,


### PR DESCRIPTION
## Problem

create_default_modifiers_for_team raises a sync only operation error when the organization is lazy loaded from an async context.

## Changes

Wrap calls to that function in database sync to async (i think prefetching organization would also work)

## How did you test this code?

Added unit test that repro's the issue and verifies the fix.

## Publish to changelog?
no