### PR TITLE
fix(vercel): return finalized: true on delete installation

### DIFF
--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -399,14 +399,12 @@ class VercelIntegration:
         logger.info("Starting Vercel installation deletion", installation_id=installation_id, integration="vercel")
         installation = VercelIntegration._get_installation(installation_id)
         installation.delete()
-        is_dev = settings.DEBUG
         logger.info(
             "Successfully deleted Vercel installation",
             installation_id=installation_id,
-            finalized=is_dev,
             integration="vercel",
         )
-        return {"finalized": is_dev}  # Immediately finalize in dev mode for testing purposes
+        return {"finalized": True}
 
     @staticmethod
     def get_product_plans(product_slug: str) -> dict[str, Any]:

--- a/ee/vercel/test/test_integration.py
+++ b/ee/vercel/test/test_integration.py
@@ -161,18 +161,10 @@ class TestVercelIntegration(TestCase):
     def test_update_installation_not_found(self):
         VercelIntegration.update_installation(self.NONEXISTENT_INSTALLATION_ID, "pro200")
 
-    @patch("django.conf.settings.DEBUG", True)
-    def test_delete_installation_dev_mode(self):
+    def test_delete_installation(self):
         result = VercelIntegration.delete_installation(self.installation_id)
 
         assert result["finalized"]
-        assert not OrganizationIntegration.objects.filter(integration_id=self.installation_id).exists()
-
-    @patch("django.conf.settings.DEBUG", False)
-    def test_delete_installation_prod_mode(self):
-        result = VercelIntegration.delete_installation(self.installation_id)
-
-        assert not result["finalized"]
         assert not OrganizationIntegration.objects.filter(integration_id=self.installation_id).exists()
 
     def test_delete_installation_not_found(self):


### PR DESCRIPTION
## Problem

Users deleting their Vercel integration get stuck in "pending deletion" state instead of the integration being fully removed. This happens because we only return `finalized: true` in dev mode.

## Changes

- Changed `delete_installation` to always return `finalized: true` instead of only when `DEBUG=True`
- Simplified tests by consolidating the dev/prod mode tests into one

## How did you test this code?

- Ran unit tests for the delete installation functionality
- `pytest ee/vercel/test/test_integration.py::TestVercelIntegration::test_delete_installation -v` ✅
- `pytest ee/api/vercel/test/test_vercel_installation.py -v` ✅

## Publish to changelog?

No