### PR TITLE
feat(llma): add LLM analytics workflows to temporal management commands

### DIFF
--- a/posthog/management/commands/execute_temporal_workflow.py
+++ b/posthog/management/commands/execute_temporal_workflow.py
@@ -18,6 +18,7 @@ from posthog.temporal.dlq_replay import WORKFLOWS as DLQ_REPLAY_WORKFLOWS
 from posthog.temporal.enforce_max_replay_retention import WORKFLOWS as ENFORCE_MAX_REPLAY_RETENTION_WORKFLOWS
 from posthog.temporal.export_recording import WORKFLOWS as EXPORT_RECORDING_WORKFLOWS
 from posthog.temporal.import_recording import WORKFLOWS as IMPORT_RECORDING_WORKFLOWS
+from posthog.temporal.llm_analytics import WORKFLOWS as LLM_ANALYTICS_WORKFLOWS
 from posthog.temporal.proxy_service import WORKFLOWS as PROXY_SERVICE_WORKFLOWS
 from posthog.temporal.quota_limiting import WORKFLOWS as QUOTA_LIMITING_WORKFLOWS
 from posthog.temporal.salesforce_enrichment import WORKFLOWS as SALESFORCE_ENRICHMENT_WORKFLOWS
@@ -137,6 +138,7 @@ class Command(BaseCommand):
             + USAGE_REPORTS_WORKFLOWS
             + QUOTA_LIMITING_WORKFLOWS
             + AI_WORKFLOWS
+            + LLM_ANALYTICS_WORKFLOWS
             + SALESFORCE_ENRICHMENT_WORKFLOWS
             + TEST_WORKFLOWS
             + DELETE_RECORDING_WORKFLOWS

--- a/posthog/management/commands/start_temporal_workflow.py
+++ b/posthog/management/commands/start_temporal_workflow.py
@@ -16,6 +16,7 @@ from posthog.temporal.dlq_replay import WORKFLOWS as DLQ_REPLAY_WORKFLOWS
 from posthog.temporal.enforce_max_replay_retention import WORKFLOWS as ENFORCE_MAX_REPLAY_RETENTION_WORKFLOWS
 from posthog.temporal.export_recording import WORKFLOWS as EXPORT_RECORDING_WORKFLOWS
 from posthog.temporal.import_recording import WORKFLOWS as IMPORT_RECORDING_WORKFLOWS
+from posthog.temporal.llm_analytics import WORKFLOWS as LLM_ANALYTICS_WORKFLOWS
 from posthog.temporal.proxy_service import WORKFLOWS as PROXY_SERVICE_WORKFLOWS
 from posthog.temporal.quota_limiting import WORKFLOWS as QUOTA_LIMITING_WORKFLOWS
 from posthog.temporal.salesforce_enrichment import WORKFLOWS as SALESFORCE_ENRICHMENT_WORKFLOWS
@@ -136,6 +137,7 @@ class Command(BaseCommand):
             + USAGE_REPORTS_WORKFLOWS
             + QUOTA_LIMITING_WORKFLOWS
             + AI_WORKFLOWS
+            + LLM_ANALYTICS_WORKFLOWS
             + SALESFORCE_ENRICHMENT_WORKFLOWS
             + SYNC_PERSON_DISTINCT_IDS_WORKFLOWS
             + TEST_WORKFLOWS

--- a/posthog/temporal/llm_analytics/__init__.py
+++ b/posthog/temporal/llm_analytics/__init__.py
@@ -25,7 +25,7 @@ WORKFLOWS = [
     RunEvaluationWorkflow,
     BatchTraceSummarizationWorkflow,
     BatchTraceSummarizationCoordinatorWorkflow,
-    DailyTraceClusteringWorkflow,
+    # DailyTraceClusteringWorkflow is a child workflow and should not be invoked directly via management commands
     TraceClusteringCoordinatorWorkflow,
 ]
 


### PR DESCRIPTION
## Problem

LLM analytics workflows (trace clustering, trace summarization) cannot be manually triggered via Django management commands.

## Changes

Adds `LLM_ANALYTICS_WORKFLOWS` import to both `start_temporal_workflow` and `execute_temporal_workflow` management commands.

## How did you test this code?

Tested locally by running the command.

## Publish to changelog?

No