### PR TITLE
feat: switch evals to dedicated queue

### DIFF
--- a/products/llm_analytics/backend/api/evaluation_runs.py
+++ b/products/llm_analytics/backend/api/evaluation_runs.py
@@ -123,7 +123,7 @@ class EvaluationRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                     "run-evaluation",
                     inputs,
                     id=workflow_id,
-                    task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
+                    task_queue=settings.LLMA_EVALS_TASK_QUEUE,
                     id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
                     retry_policy=RetryPolicy(maximum_attempts=3),
                 )

--- a/products/llm_analytics/backend/api/test/test_evaluation_runs.py
+++ b/products/llm_analytics/backend/api/test/test_evaluation_runs.py
@@ -75,7 +75,7 @@ class TestEvaluationRunViewSet(APIBaseTest):
         call_args = mock_client.start_workflow.call_args
 
         assert call_args[0][0] == "run-evaluation"  # workflow name
-        assert call_args[1]["task_queue"] == settings.GENERAL_PURPOSE_TASK_QUEUE
+        assert call_args[1]["task_queue"] == settings.LLMA_EVALS_TASK_QUEUE
 
         # Verify the workflow inputs contain event data
         workflow_inputs = call_args[0][1]


### PR DESCRIPTION
## Problem

Switches evals to their own dedicated queue, which is already set up and healthy ([us](https://argocd-internal.internal.posthog.dev/applications/argocd/temporal-worker-llm-analytics-evals-prod-us), [eu](https://argocd-internal.internal.posthog.dev/applications/argocd/temporal-worker-llm-analytics-evals-prod-eu)).

## Publish to changelog?

No