### PR TITLE
chore: Allow `UserProductList` deletion

### DIFF
--- a/posthog/admin/admins/user_product_list_admin.py
+++ b/posthog/admin/admins/user_product_list_admin.py
@@ -52,6 +52,3 @@ class UserProductListAdmin(admin.ModelAdmin):
 
     def has_change_permission(self, request, obj=None):
         return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False


### PR DESCRIPTION
## Problem

Admins are unable to delete users or organizations via the Django admin because the associated `UserProductList` objects cannot be cascade-deleted. This is due to the `UserProductListAdmin` explicitly blocking delete permissions.

## Changes

Removed the `has_delete_permission` method from `UserProductListAdmin` in `posthog/admin/admins/user_product_list_admin.py`. By default, Django admin allows delete permissions, enabling the cascade deletion of `UserProductList` entries when a user or organization is deleted.

## How did you test this code?

Ran existing Django admin tests to ensure no regressions. Manually verified that deleting a user with an associated `UserProductList` now works correctly in the admin.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C043VJ93L3B/p1769015374518679?thread_ts=1769015374.518679&cid=C043VJ93L3B)

<a href="https://cursor.com/background-agent?bcId=bc-a5aff208-9f39-4b46-86c4-5a1fcc1e0914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5aff208-9f39-4b46-86c4-5a1fcc1e0914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

