### PR TITLE
feat(data-table): Update column configuration API

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -198,6 +198,10 @@ import {
 } from 'products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/types'
 import { SymbolSetOrder } from 'products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/symbol_sets/symbolSetLogic'
 import { LogExplanation } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/types'
+import {
+    ColumnConfigurationApi,
+    PaginatedColumnConfigurationListApi,
+} from 'products/product_analytics/frontend/generated/api.schemas'
 import type {
     SessionGroupSummaryListItemType,
     SessionGroupSummaryType,
@@ -529,6 +533,15 @@ export class ApiRequest {
 
     public insightsCancel(teamId?: TeamType['id']): ApiRequest {
         return this.insights(teamId).addPathComponent('cancel')
+    }
+
+    // # Column Configurations
+    public columnConfigurations(teamId?: TeamType['id']): ApiRequest {
+        return this.environmentsDetail(teamId).addPathComponent('column_configurations')
+    }
+
+    public columnConfigurationDetail(id: string, teamId?: TeamType['id']): ApiRequest {
+        return this.columnConfigurations(teamId).addPathComponent(id)
     }
 
     // # File System
@@ -2589,6 +2602,54 @@ const api = {
                     })
                 )
                 .assembleFullUrl()
+        },
+    },
+
+    columnConfigurations: {
+        async list({
+            teamId = ApiConfig.getCurrentTeamId(),
+            context_key,
+            ...params
+        }: {
+            teamId?: TeamType['id']
+            context_key?: string
+        } = {}): Promise<PaginatedColumnConfigurationListApi> {
+            return new ApiRequest()
+                .columnConfigurations(teamId)
+                .withQueryString(toParams({ context_key, ...params }))
+                .get()
+        },
+
+        async create({
+            teamId = ApiConfig.getCurrentTeamId(),
+            data,
+        }: {
+            teamId?: TeamType['id']
+            data: any
+        }): Promise<ColumnConfigurationApi> {
+            return new ApiRequest().columnConfigurations(teamId).create({ data })
+        },
+
+        async update({
+            teamId = ApiConfig.getCurrentTeamId(),
+            id,
+            data,
+        }: {
+            teamId?: TeamType['id']
+            id: string
+            data: any
+        }): Promise<ColumnConfigurationApi> {
+            return new ApiRequest().columnConfigurationDetail(id, teamId).update({ data })
+        },
+
+        async delete({
+            teamId = ApiConfig.getCurrentTeamId(),
+            id,
+        }: {
+            teamId?: TeamType['id']
+            id: string
+        }): Promise<void> {
+            return new ApiRequest().columnConfigurationDetail(id, teamId).delete()
         },
     },
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2625,7 +2625,7 @@ const api = {
             data,
         }: {
             teamId?: TeamType['id']
-            data: any
+            data: Partial<ColumnConfigurationApi>
         }): Promise<ColumnConfigurationApi> {
             return new ApiRequest().columnConfigurations(teamId).create({ data })
         },
@@ -2637,7 +2637,7 @@ const api = {
         }: {
             teamId?: TeamType['id']
             id: string
-            data: any
+            data: Partial<ColumnConfigurationApi>
         }): Promise<ColumnConfigurationApi> {
             return new ApiRequest().columnConfigurationDetail(id, teamId).update({ data })
         },

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -236,6 +236,7 @@ export const dataTableLogic = kea<dataTableLogicType>([
                         showPersistentColumnConfigurator: query.showPersistentColumnConfigurator ?? false,
                         showSavedQueries: query.showSavedQueries ?? false,
                         showSavedFilters: query.showSavedFilters ?? false,
+                        showTableViews: query.showTableViews ?? false,
                         showHogQLEditor: query.showHogQLEditor ?? showIfFull,
                         allowSorting: query.allowSorting ?? true,
                         showOpenEditorButton:

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10551,6 +10551,10 @@
                     "description": "Show actors query options and back to source",
                     "type": "boolean"
                 },
+                "showTableViews": {
+                    "description": "Show table views feature for this table (requires uniqueKey)",
+                    "type": "boolean"
+                },
                 "showTestAccountFilters": {
                     "description": "Show filter to exclude test accounts",
                     "type": "boolean"
@@ -29290,6 +29294,10 @@
                     "type": "boolean"
                 },
                 "showTable": {
+                    "type": "boolean"
+                },
+                "showTableViews": {
+                    "description": "Show table views feature for this table (requires uniqueKey)",
                     "type": "boolean"
                 },
                 "showTestAccountFilters": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1147,6 +1147,8 @@ interface DataTableNodeViewProps {
     showSavedQueries?: boolean
     /** Show saved filters feature for this table (requires uniqueKey) */
     showSavedFilters?: boolean
+    /** Show table views feature for this table (requires uniqueKey) */
+    showTableViews?: boolean
     /** Can expand row to show raw event data (default: true) */
     expandable?: boolean
     /** Link properties via the URL (default: false) */

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -6015,6 +6015,9 @@ class SavedInsightNode(BaseModel):
         default=None, description="Show actors query options and back to source"
     )
     showTable: bool | None = None
+    showTableViews: bool | None = Field(
+        default=None, description="Show table views feature for this table (requires uniqueKey)"
+    )
     showTestAccountFilters: bool | None = Field(default=None, description="Show filter to exclude test accounts")
     showTimings: bool | None = Field(default=None, description="Show a detailed query timing breakdown")
     suppressSessionAnalysisWarning: bool | None = None
@@ -18278,6 +18281,9 @@ class DataTableNode(BaseModel):
     showSearch: bool | None = Field(default=None, description="Include a free text search field (PersonsNode only)")
     showSourceQueryOptions: bool | None = Field(
         default=None, description="Show actors query options and back to source"
+    )
+    showTableViews: bool | None = Field(
+        default=None, description="Show table views feature for this table (requires uniqueKey)"
     )
     showTestAccountFilters: bool | None = Field(default=None, description="Show filter to exclude test accounts")
     showTimings: bool | None = Field(default=None, description="Show a detailed query timing breakdown")

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -6016,7 +6016,8 @@ class SavedInsightNode(BaseModel):
     )
     showTable: bool | None = None
     showTableViews: bool | None = Field(
-        default=None, description="Show table views feature for this table (requires uniqueKey)"
+        default=None,
+        description="Show table views feature for this table (requires uniqueKey)",
     )
     showTestAccountFilters: bool | None = Field(default=None, description="Show filter to exclude test accounts")
     showTimings: bool | None = Field(default=None, description="Show a detailed query timing breakdown")
@@ -18283,7 +18284,8 @@ class DataTableNode(BaseModel):
         default=None, description="Show actors query options and back to source"
     )
     showTableViews: bool | None = Field(
-        default=None, description="Show table views feature for this table (requires uniqueKey)"
+        default=None,
+        description="Show table views feature for this table (requires uniqueKey)",
     )
     showTestAccountFilters: bool | None = Field(default=None, description="Show filter to exclude test accounts")
     showTimings: bool | None = Field(default=None, description="Show a detailed query timing breakdown")


### PR DESCRIPTION
## Problem

We need to add support for column configurations in the API to enable table views functionality.

## Changes

- Added API endpoints for column configurations:
  - `columnConfigurations` for listing and creating configurations
  - `columnConfigurationDetail` for updating and deleting configurations
- Added corresponding API methods for CRUD operations on column configurations
- Updated schema to include `showTableViews` property for data tables and saved insights
- Added TypeScript interfaces for column configuration API responses

## How did you test this code?

I tested the API endpoints by making requests to create, list, update, and delete column configurations. I verified that the schema changes correctly expose the new `showTableViews` property in the frontend.

## Publish to changelog?

No