### PR TITLE
chore(batch-exports): Bump BigQuery `start_query_timeout` to 15 mins

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -395,7 +395,7 @@ class BigQueryClient:
             return table
 
     async def execute_query(
-        self, query: str, start_query_timeout: float | int = 10 * 60, poll_interval: float | int = 0.5
+        self, query: str, start_query_timeout: float | int = 15 * 60, poll_interval: float | int = 0.5
     ) -> RowIterator | _EmptyRowIterator:
         """Execute a query and wait for it to complete.
 


### PR DESCRIPTION
## Problem

We timeout BigQuery queries that take longer than 10 mins to start running, which may be too short in some circumstances.

## Changes

Bump it to 15 mins for now.

## How did you test this code?

I didn't but it should be very low risk.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No
