### PR TITLE
fix(surveys): compute person display name server-side using COALESCE

### DIFF
--- a/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
@@ -37,7 +37,7 @@ function toOpenQuestionFormat(responses: ChoiceQuestionResponseData[]): OpenQues
     return responses.map((r) => ({
         distinctId: r.distinctId || '',
         response: r.label,
-        personProperties: r.personProperties,
+        personDisplayName: r.personDisplayName,
         timestamp: r.timestamp,
     }))
 }

--- a/frontend/src/scenes/surveys/components/question-visualizations/VirtualizedResponseList.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/VirtualizedResponseList.tsx
@@ -30,10 +30,8 @@ function ResponseListItem({ response }: { response: OpenQuestionResponseData }):
             <div className="text-sm truncate mb-auto">{responseText}</div>
             <div className="flex items-center justify-between text-xs text-secondary mt-1">
                 <PersonDisplay
-                    person={{
-                        distinct_id: response.distinctId,
-                        properties: response.personProperties || {},
-                    }}
+                    person={{ distinct_id: response.distinctId }}
+                    displayName={response.personDisplayName}
                     withIcon="xs"
                     noEllipsis={false}
                     noLink={!response.distinctId}
@@ -59,10 +57,8 @@ function ResponseListItem({ response }: { response: OpenQuestionResponseData }):
                     <p className="text-sm whitespace-pre-wrap leading-relaxed">{responseText}</p>
                     <div className="flex items-center justify-between text-xs text-secondary mt-3 pt-2 border-t">
                         <PersonDisplay
-                            person={{
-                                distinct_id: response.distinctId,
-                                properties: response.personProperties || {},
-                            }}
+                            person={{ distinct_id: response.distinctId }}
+                            displayName={response.personDisplayName}
                             withIcon
                             noEllipsis={false}
                             noLink={!response.distinctId}

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1841,10 +1841,10 @@ describe('processResultsForSurveyQuestions', () => {
                 },
             ]
             const results = [
-                ['Yes', null, null, null, null, null, null, null, null, 'user1', '2024-01-15T10:00:00Z'], // User 1: picked Yes for question 0
-                ['No', null, null, null, null, null, null, null, null, 'user2', '2024-01-15T10:15:00Z'], // User 2: picked No for question 0
-                ['Yes', null, null, null, null, null, null, null, null, 'user3', '2024-01-15T10:30:00Z'], // User 3: picked Yes for question 0
-                ['Custom answer', null, null, null, null, null, null, null, null, 'user4', '2024-01-15T10:45:00Z'], // User 4: picked custom answer for question 0
+                ['Yes', null, 'user1', '2024-01-15T10:00:00Z'], // User 1: picked Yes for question 0
+                ['No', null, 'user2', '2024-01-15T10:15:00Z'], // User 2: picked No for question 0
+                ['Yes', null, 'user3', '2024-01-15T10:30:00Z'], // User 3: picked Yes for question 0
+                ['Custom answer', null, 'user4', '2024-01-15T10:45:00Z'], // User 4: picked custom answer for question 0
             ]
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -1860,7 +1860,7 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 2,
                 isPredefined: true,
                 distinctId: 'user3',
-                personProperties: undefined,
+                personDisplayName: undefined,
                 timestamp: '2024-01-15T10:30:00Z',
             })
             expect(dataMap.get('No')).toEqual({
@@ -1868,7 +1868,7 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 1,
                 isPredefined: true,
                 distinctId: 'user2',
-                personProperties: undefined,
+                personDisplayName: undefined,
                 timestamp: '2024-01-15T10:15:00Z',
             })
             expect(dataMap.get('Maybe')).toEqual({ label: 'Maybe', value: 0, isPredefined: true })
@@ -1877,7 +1877,7 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 1,
                 isPredefined: false,
                 distinctId: 'user4',
-                personProperties: undefined,
+                personDisplayName: undefined,
                 timestamp: '2024-01-15T10:45:00Z',
             })
         })
@@ -1895,9 +1895,9 @@ describe('processResultsForSurveyQuestions', () => {
             ]
             // For multiple choice questions, the response at questionIndex is an array of selected choices
             const results: SurveyRawResults = [
-                [['A', 'B'], null, null, null, null, null, null, null, null, 'user1', '2024-01-15T10:00:00Z'], // User 1: picked A and B for question 0
-                [['A'], null, null, null, null, null, null, null, null, 'user2', '2024-01-15T10:15:00Z'], // User 2: picked A only for question 0
-                [['C', 'Custom'], null, null, null, null, null, null, null, null, 'user3', '2024-01-15T10:30:00Z'], // User 3: picked C and a custom answer for question 0
+                [['A', 'B'], null, 'user1', '2024-01-15T10:00:00Z'], // User 1: picked A and B for question 0
+                [['A'], null, 'user2', '2024-01-15T10:15:00Z'], // User 2: picked A only for question 0
+                [['C', 'Custom'], null, 'user3', '2024-01-15T10:30:00Z'], // User 3: picked C and a custom answer for question 0
             ]
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -1913,7 +1913,7 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 2,
                 isPredefined: true,
                 distinctId: 'user2',
-                personProperties: undefined,
+                personDisplayName: undefined,
                 timestamp: '2024-01-15T10:15:00Z',
             })
             expect(dataMap.get('B')).toEqual({
@@ -1921,7 +1921,7 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 1,
                 isPredefined: true,
                 distinctId: 'user1',
-                personProperties: undefined,
+                personDisplayName: undefined,
                 timestamp: '2024-01-15T10:00:00Z',
             })
             expect(dataMap.get('C')).toEqual({
@@ -1929,7 +1929,7 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 1,
                 isPredefined: true,
                 distinctId: 'user3',
-                personProperties: undefined,
+                personDisplayName: undefined,
                 timestamp: '2024-01-15T10:30:00Z',
             })
             expect(dataMap.get('Custom')).toEqual({
@@ -1937,7 +1937,7 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 1,
                 isPredefined: false,
                 distinctId: 'user3',
-                personProperties: undefined,
+                personDisplayName: undefined,
                 timestamp: '2024-01-15T10:30:00Z',
             })
         })
@@ -1953,9 +1953,9 @@ describe('processResultsForSurveyQuestions', () => {
                 },
             ]
             const results = [
-                ['Great product!', null, null, null, null, 'John', null, null, null, 'user123', '2024-01-15T10:30:00Z'], // User 1: response, person props (name: John), distinct_id, timestamp
-                ['Could be better', null, null, null, null, null, null, null, null, 'user456', '2024-01-15T11:45:00Z'], // User 2: response, no person props, distinct_id, timestamp
-                ['', null, null, null, null, null, null, null, null, 'user789', '2024-01-15T12:00:00Z'], // User 3: empty response (should be ignored)
+                ['Great product!', 'John', 'user123', '2024-01-15T10:30:00Z'], // User 1: response, person_display_name, distinct_id, timestamp
+                ['Could be better', null, 'user456', '2024-01-15T11:45:00Z'], // User 2: response, no person props, distinct_id, timestamp
+                ['', null, 'user789', '2024-01-15T12:00:00Z'], // User 3: empty response (should be ignored)
             ] as Array<Array<string | string[]>>
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -1968,15 +1968,13 @@ describe('processResultsForSurveyQuestions', () => {
             expect(openData.data[0]).toEqual({
                 distinctId: 'user123',
                 response: 'Great product!',
-                personProperties: {
-                    name: 'John',
-                },
+                personDisplayName: 'John',
                 timestamp: '2024-01-15T10:30:00Z',
             })
             expect(openData.data[1]).toEqual({
                 distinctId: 'user456',
                 response: 'Could be better',
-                personProperties: undefined,
+                personDisplayName: undefined,
                 timestamp: '2024-01-15T11:45:00Z',
             })
         })
@@ -1994,10 +1992,10 @@ describe('processResultsForSurveyQuestions', () => {
             ]
             // Multiple people picking the same choice - should store the LATEST person's data
             const results = [
-                ['Yes', null, null, null, null, 'Alice', null, null, null, 'user1', '2024-01-15T10:00:00Z'], // Alice picks Yes at 10:00
-                ['Yes', null, null, null, null, 'Bob', null, null, null, 'user2', '2024-01-15T11:00:00Z'], // Bob picks Yes at 11:00 (later)
-                ['Yes', null, null, null, null, 'Carol', null, null, null, 'user3', '2024-01-15T12:00:00Z'], // Carol picks Yes at 12:00 (latest)
-                ['No', null, null, null, null, 'Dave', null, null, null, 'user4', '2024-01-15T13:00:00Z'], // Dave picks No
+                ['Yes', 'Alice', 'user1', '2024-01-15T10:00:00Z'], // Alice picks Yes at 10:00
+                ['Yes', 'Bob', 'user2', '2024-01-15T11:00:00Z'], // Bob picks Yes at 11:00 (later)
+                ['Yes', 'Carol', 'user3', '2024-01-15T12:00:00Z'], // Carol picks Yes at 12:00 (latest)
+                ['No', 'Dave', 'user4', '2024-01-15T13:00:00Z'], // Dave picks No
             ]
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -2013,9 +2011,7 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 3,
                 isPredefined: true,
                 distinctId: 'user3',
-                personProperties: {
-                    name: 'Carol',
-                },
+                personDisplayName: 'Carol',
                 timestamp: '2024-01-15T12:00:00Z',
             })
 
@@ -2025,9 +2021,7 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 1,
                 isPredefined: true,
                 distinctId: 'user4',
-                personProperties: {
-                    name: 'Dave',
-                },
+                personDisplayName: 'Dave',
                 timestamp: '2024-01-15T13:00:00Z',
             })
         })
@@ -2043,9 +2037,9 @@ describe('processResultsForSurveyQuestions', () => {
             ]
             // Multiple people picking the same choices - should store the LATEST person's data for each choice
             const results: SurveyRawResults = [
-                [['A', 'B'], null, null, null, null, 'Alice', null, null, null, 'user1', '2024-01-15T10:00:00Z'], // Alice picks A,B at 10:00
-                [['A'], null, null, null, null, 'Bob', null, null, null, 'user2', '2024-01-15T11:00:00Z'], // Bob picks A at 11:00 (later for A)
-                [['B', 'C'], null, null, null, null, 'Carol', null, null, null, 'user3', '2024-01-15T12:00:00Z'], // Carol picks B,C at 12:00 (later for B)
+                [['A', 'B'], 'Alice', 'user1', '2024-01-15T10:00:00Z'], // Alice picks A,B at 10:00
+                [['A'], 'Bob', 'user2', '2024-01-15T11:00:00Z'], // Bob picks A at 11:00 (later for A)
+                [['B', 'C'], 'Carol', 'user3', '2024-01-15T12:00:00Z'], // Carol picks B,C at 12:00 (later for B)
             ]
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -2061,9 +2055,7 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 2, // Alice and Bob both picked A
                 isPredefined: true,
                 distinctId: 'user2',
-                personProperties: {
-                    name: 'Bob',
-                },
+                personDisplayName: 'Bob',
                 timestamp: '2024-01-15T11:00:00Z',
             })
 
@@ -2073,9 +2065,7 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 2, // Alice and Carol both picked B
                 isPredefined: true,
                 distinctId: 'user3',
-                personProperties: {
-                    name: 'Carol',
-                },
+                personDisplayName: 'Carol',
                 timestamp: '2024-01-15T12:00:00Z',
             })
 
@@ -2085,14 +2075,12 @@ describe('processResultsForSurveyQuestions', () => {
                 value: 1,
                 isPredefined: true,
                 distinctId: 'user3',
-                personProperties: {
-                    name: 'Carol',
-                },
+                personDisplayName: 'Carol',
                 timestamp: '2024-01-15T12:00:00Z',
             })
         })
 
-        it('handles invalid person properties gracefully while storing latest data', () => {
+        it('stores latest person display name, handling null values gracefully', () => {
             const questions = [
                 {
                     id: 'single-invalid-props',
@@ -2102,9 +2090,9 @@ describe('processResultsForSurveyQuestions', () => {
                 },
             ]
             const results = [
-                ['Option', 'invalid', null, null, null, null, null, null, null, 'user1', '2024-01-15T10:00:00Z'], // Invalid data
-                ['Option', null, null, null, null, 'Bob', null, null, null, 'user2', '2024-01-15T11:00:00Z'], // Valid name "Bob"
-                ['Option', null, null, null, null, null, null, null, null, 'user3', '2024-01-15T12:00:00Z'], // Empty props (most recent)
+                ['Option', 'invalid', 'user1', '2024-01-15T10:00:00Z'], // Invalid display name (not same as distinct_id)
+                ['Option', 'Bob', 'user2', '2024-01-15T11:00:00Z'], // Valid display name "Bob"
+                ['Option', null, 'user3', '2024-01-15T12:00:00Z'], // Empty props (most recent)
             ]
 
             const processed = processResultsForSurveyQuestions(questions, results)
@@ -2112,13 +2100,13 @@ describe('processResultsForSurveyQuestions', () => {
 
             const dataMap = new Map(singleData.data.map((item) => [item.label, item]))
 
-            // Should have user3's data (latest timestamp) with undefined personProperties (empty string)
+            // Should have user3's data (latest timestamp) with undefined personDisplayName (null value)
             expect(dataMap.get('Option')).toEqual({
                 label: 'Option',
                 value: 3,
                 isPredefined: true,
                 distinctId: 'user3',
-                personProperties: undefined,
+                personDisplayName: undefined,
                 timestamp: '2024-01-15T12:00:00Z',
             })
         })

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -210,27 +210,37 @@ function isQuestionOpenChoice(question: SurveyQuestion, choiceIndex: number): bo
     return !!(choiceIndex === question.choices.length - 1 && question?.hasOpenChoice)
 }
 
+// Builds a COALESCE expression that tries each display name property in order,
+// falling back to distinct_id if none are set. Respects team-level customization.
+function buildPersonDisplayNameExpression(personDisplayNameProperties: string[]): string {
+    const propertyExpressions = personDisplayNameProperties.map((prop) => {
+        // Handle property names with special characters
+        if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(prop)) {
+            return `toString(person.properties.${prop})`
+        }
+        return `toString(person.properties.\`${prop}\`)`
+    })
+    // COALESCE returns the first non-null value; fall back to distinct_id
+    return `coalesce(${[...propertyExpressions, 'toString(events.distinct_id)'].join(', ')})`
+}
+
 // Helper to extract person data from a survey response row
+// Query structure: [...questions, person_display_name, distinct_id, timestamp]
 function extractPersonData(row: SurveyResponseRow): {
     distinctId: string
-    personProperties?: Record<string, any>
+    personDisplayName?: string
     timestamp: string
 } {
-    const distinctId = row.at(-2) as string
     const timestamp = row.at(-1) as string
-    // now, we're querying for all PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES, starting from the third last value, so build our person properties object
-    // from those values. We use them to have a display name for the person
-    const personProperties: Record<string, any> = {}
-    const personDisplayProperties = PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
-    let hasAnyProperties = false
-    for (let i = 0; i < personDisplayProperties.length; i++) {
-        const value = row.at(-3 - i) as string
-        if (value && value !== null && value !== '') {
-            personProperties[personDisplayProperties[i]] = value
-            hasAnyProperties = true
-        }
+    const distinctId = row.at(-2) as string
+    const personDisplayName = row.at(-3) as string | null
+
+    return {
+        distinctId,
+        // Only include display name if it's different from distinct_id (meaning a real name was found)
+        personDisplayName: personDisplayName && personDisplayName !== distinctId ? personDisplayName : undefined,
+        timestamp,
     }
-    return { distinctId, personProperties: hasAnyProperties ? personProperties : undefined, timestamp }
 }
 
 // Helper to count a choice and store person data for latest occurrence
@@ -313,7 +323,7 @@ function processChoiceQuestion(
                 return {
                     ...baseData,
                     distinctId: latestResponsePersonData[label].distinctId,
-                    personProperties: latestResponsePersonData[label].personProperties,
+                    personDisplayName: latestResponsePersonData[label].personDisplayName,
                     timestamp: latestResponsePersonData[label].timestamp,
                 }
             }
@@ -386,8 +396,7 @@ function processRatingQuestion(
 }
 
 function processOpenQuestion(questionIndex: number, results: SurveyRawResults): OpenQuestionProcessedResponses {
-    const data: { distinctId: string; response: string; personProperties?: Record<string, any>; timestamp?: string }[] =
-        []
+    const data: { distinctId: string; response: string; personDisplayName?: string; timestamp?: string }[] = []
     let totalResponses = 0
 
     results?.forEach((row: SurveyResponseRow) => {
@@ -400,7 +409,7 @@ function processOpenQuestion(questionIndex: number, results: SurveyRawResults): 
         const response = {
             distinctId: personData.distinctId,
             response: value,
-            personProperties: personData.personProperties,
+            personDisplayName: personData.personDisplayName,
             timestamp: personData.timestamp,
         }
 
@@ -819,12 +828,18 @@ export const surveyLogic = kea<surveyLogicType>([
                     return `${getSurveyResponse(question, index)} AS q${index}_response`
                 })
 
-                // Also get distinct_id, person properties, and timestamp for open text questions
+                // Build person display name using team settings or defaults
+                const personDisplayNameProps =
+                    teamLogic.values.currentTeam?.person_display_name_properties ||
+                    PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
+                const personDisplayNameExpr = buildPersonDisplayNameExpression(personDisplayNameProps)
+
+                // Query structure: [question_responses..., person_display_name, distinct_id, timestamp]
                 const query = `
                     -- QUERYING ALL SURVEY RESPONSES IN ONE GO
                     SELECT
                         ${questionFields.join(',\n')},
-                        ${PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES.map((property) => `person.properties.${property}`).join(',\n')},
+                        ${personDisplayNameExpr} AS person_display_name,
                         events.distinct_id,
                         events.timestamp
                     FROM events

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3260,14 +3260,16 @@ export interface ChoiceQuestionResponseData {
     isPredefined: boolean
     // For unique responses (value === 1), include person data for display
     distinctId?: string
-    personProperties?: Record<string, any>
+    /** Pre-computed display name from server (email, name, etc.) - avoids brittle client-side property extraction */
+    personDisplayName?: string
     timestamp?: string
 }
 
 export interface OpenQuestionResponseData {
     distinctId: string
     response: string
-    personProperties?: Record<string, any>
+    /** Pre-computed display name from server (email, name, etc.) - avoids brittle client-side property extraction */
+    personDisplayName?: string
     timestamp?: string
 }
 


### PR DESCRIPTION
## Summary

Survey response lists were showing distinct IDs instead of names/emails due to brittle column-position indexing that mapped values to the wrong property keys.

This refactors the approach to compute the display name server-side using COALESCE, eliminating fragile positional indexing.

## Changes

- Add `buildPersonDisplayNameExpression()` that generates a COALESCE expression
- Query returns a single `person_display_name` column instead of 8 separate property columns
- Simplify `extractPersonData()` to extract the pre-computed display name
- Update types: `personProperties?: Record<string, any>` → `personDisplayName?: string`
- Pass `displayName` prop directly to `PersonDisplay` component

## Benefits

- No more fragile positional indexing
- Respects team-level `person_display_name_properties` settings
- Consistent with `asDisplay()` logic used elsewhere
- Reduced data transfer (1 column instead of 8)

## Test plan

- [x] Unit tests pass for `processResultsForSurveyQuestions`
- [x] Manual test: verify survey responses show names/emails instead of IDs