### PR TITLE
feat(sdk-doctor): alert when outdated version captures ≥10% of events

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
@@ -175,7 +175,10 @@ export const sidePanelSdkDoctorLogic = kea<sidePanelSdkDoctorLogicType>([
                         const totalEvents = releasesInfo.reduce((sum, r) => sum + r.count, 0)
 
                         // Check if any outdated version handles significant traffic (≥10% of events)
+                        // Skip for mobile SDKs - users don't auto-update apps, so outdated versions are expected
+                        const isMobileSdk = DEVICE_CONTEXT_CONFIG.mobileSDKs.includes(sdkType as SdkType)
                         const hasSignificantOutdatedTraffic =
+                            !isMobileSdk &&
                             totalEvents > 0 &&
                             releasesInfo.some(
                                 (r) => r.isOutdated && r.count / totalEvents >= SIGNIFICANT_TRAFFIC_THRESHOLD

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
@@ -155,6 +155,10 @@ export const sidePanelSdkDoctorLogic = kea<sidePanelSdkDoctorLogicType>([
                     return {}
                 }
 
+                // Threshold for considering an outdated version's traffic "significant"
+                // If an outdated version handles ≥10% of events, flag the SDK as needing attention
+                const SIGNIFICANT_TRAFFIC_THRESHOLD = 0.1
+
                 return Object.fromEntries(
                     Object.entries(rawData).map(([sdkType, teamSdkUsage]) => {
                         const isSingleVersion = teamSdkUsage.usage.length === 1
@@ -167,12 +171,26 @@ export const sidePanelSdkDoctorLogic = kea<sidePanelSdkDoctorLogicType>([
                             )
                         )
 
+                        // Calculate total events across all versions of this SDK
+                        const totalEvents = releasesInfo.reduce((sum, r) => sum + r.count, 0)
+
+                        // Check if any outdated version handles significant traffic (≥10% of events)
+                        const hasSignificantOutdatedTraffic =
+                            totalEvents > 0 &&
+                            releasesInfo.some(
+                                (r) => r.isOutdated && r.count / totalEvents >= SIGNIFICANT_TRAFFIC_THRESHOLD
+                            )
+
+                        // SDK is outdated if most recent version is outdated OR any outdated version has significant traffic
+                        // Safe: backend only includes SDKs with at least one usage entry
+                        const isOutdated = releasesInfo[0]!.isOutdated || hasSignificantOutdatedTraffic
+
                         return [
                             sdkType,
                             {
-                                isOutdated: releasesInfo[0]!.isOutdated,
+                                isOutdated,
                                 isOld: releasesInfo[0]!.isOld,
-                                needsUpdating: releasesInfo[0]!.needsUpdating,
+                                needsUpdating: isOutdated || releasesInfo[0]!.isOld,
                                 currentVersion: teamSdkUsage.latest_version,
                                 allReleases: releasesInfo,
                             },

--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.test.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.test.ts
@@ -109,7 +109,12 @@ describe('versionCheckerLogic', () => {
                 { version: '1.83.1', count: 50 },
             ],
             latestVersion: '1.84.0',
-            expectation: null, // Highest used is 1.83.1, only 1 minor behind
+            // 1.9.0 is outdated and has 50% of traffic (≥10% threshold), so warning is expected
+            expectation: {
+                latestUsedVersion: '1.83.1',
+                latestAvailableVersion: '1.84.0',
+                level: 'error',
+            },
         },
         {
             usedVersions: [


### PR DESCRIPTION
## Problem                                                                                                                          
Customers can have multiple SDK versions capturing events simultaneously. When an outdated SDK version loads first, its init config takes precedence (the web SDK ignores subsequent init attempts, and their configs). This means a customer could have significant traffic flowing through an outdated SDK while SDK Doctor shows "All caught up!" because they *also* have a current version.

Example: A customer had version 1.174.2 capturing 594,703 events while their current version (1.333.0) only captured a few hundred. SDK Doctor wasn't flagging this because it only checked if the most recent version was outdated. 

<img width="898" height="1832" alt="CleanShot 2026-01-21 at 09 11 09@2x" src="https://github.com/user-attachments/assets/4ef45a85-0979-456a-bc1b-91bc7549b9ab" />

(Screenshot from organization ID 01920d62-f565-0000-91b8-2246dcef77c8: FirstPromoter, project ID 33931: Prod App)

## Changes

SDK Doctor now flags an SDK as needing attention when any `outdated` version handles ≥10% of total events over the last 7 days, even if the user also has current/recent versions capturing events as well:
- Added traffic threshold check in `augmentedData` selector
- Calculates total events across all versions of each SDK
- Flags `isOutdated` at SDK level if any outdated version exceeds 10% of traffic
- Mobile SDKs are exempted from this new check.

P.S. I'll make the little tweaks you suggested in our previous PR in a subsequent PR. I wanted to keep this one clean and focused on this change.
## How did you test this code?

Manual testing with a script on my local:                  
  1. Sent 166 events with current version of web SDK
  2. Sent 38 events with outdated version
  3. Verified SDK Doctor correctly shows "Time for an update!" only when outdated version exceeds 10%                                                                              
  4. Verified no alert when outdated version is below 10% threshold  


## Publish to changelog?
no
