### PR TITLE
fix(ci): add sccache logging and stats to Rust Docker builds

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -24,7 +24,9 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    cargo chef cook --release --recipe-path recipe.json --bin $BIN
+    SCCACHE_NO_DAEMON=1 SCCACHE_START_SERVER=1 sccache 2>&1 & \
+    cargo chef cook --release --recipe-path recipe.json --bin $BIN && \
+    sccache --show-stats
 
 COPY . .
 RUN --mount=type=secret,id=SCCACHE_WEBDAV_ENDPOINT,required=false \
@@ -33,13 +35,12 @@ RUN --mount=type=secret,id=SCCACHE_WEBDAV_ENDPOINT,required=false \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     if [ -f "/run/secrets/SCCACHE_WEBDAV_ENDPOINT" ] && [ -f "/run/secrets/SCCACHE_WEBDAV_TOKEN" ]; then \
-    SCCACHE_WEBDAV_ENDPOINT=$(cat /run/secrets/SCCACHE_WEBDAV_ENDPOINT) \
-    SCCACHE_WEBDAV_TOKEN=$(cat /run/secrets/SCCACHE_WEBDAV_TOKEN) \
-    cargo build --release --bin $BIN; \
-    else \
-    cargo build --release --bin $BIN; \
-    fi
-
+        export SCCACHE_WEBDAV_ENDPOINT=$(cat /run/secrets/SCCACHE_WEBDAV_ENDPOINT); \
+        export SCCACHE_WEBDAV_TOKEN=$(cat /run/secrets/SCCACHE_WEBDAV_TOKEN); \
+    fi && \
+    SCCACHE_NO_DAEMON=1 SCCACHE_START_SERVER=1 sccache 2>&1 & \
+    cargo build --release --bin $BIN && \
+    sccache --show-stats
 
 FROM debian:bookworm-slim AS runtime
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.91-bookworm AS base
 # Note - sccache pinned due to problem with depot builds. See https://posthog.slack.com/archives/C0457KENW2E/p1768558484810999?thread_ts=1768497407.301109&cid=C0457KENW2E
 RUN cargo install --locked cargo-chef sccache@0.12.0
-ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
+ENV RUSTC_WRAPPER=sccache SCCACHE_LOG=debug SCCACHE_DIR=/sccache
 
 FROM base AS planner
 WORKDIR /app


### PR DESCRIPTION
## Problem

Our Rust Docker builds fail randomly with exit code 101, but succeed on retry. This suggests cache contention or transient sccache issues. We need visibility into what's happening with sccache to diagnose the root cause.

## Changes

- Adds sccache server startup and `sccache --show-stats` output after each build step to reveal cache hit/miss rates and errors
- Fixes secrets handling in final build step

## How did you test this code?

- [ ] Trigger a build and verify sccache stats appear in the logs
- [ ] Monitor subsequent builds for failure patterns and correlate with stats output

## Publish to changelog?

no
