### PR TITLE
fix(ci): add TEST environment variable for HogVM compilation step

### DIFF
--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -116,6 +116,8 @@ jobs:
               run: |
                   python -m common.hogvm.stl.compile
                   git diff --exit-code
+              env:
+                  TEST: 1
 
             - name: Run HogVM Python tests
               run: |
@@ -133,6 +135,8 @@ jobs:
                   bin/turbo --filter=@posthog/hogvm build
                   cd common/hogvm
                   ./test.sh && git diff --exit-code
+              env:
+                  TEST: 1
 
     check-package-version:
         name: Check HogVM TypeScript package version and detect an update


### PR DESCRIPTION
## Problem

Hog CI: SECRET_KEY validation blocks STL bytecode compilation

## Changes

Set TEST=1 in the environment for the STL bytecode check step in CI  to skip the validation check for SECRET_KEY.

## How did you test this code?

Tests

## Publish to changelog?

No