### PR TITLE
fix(mcp): add EU subdomain routing for Claude Code OAuth

### DIFF
--- a/services/mcp/typescript/src/integrations/mcp/index.ts
+++ b/services/mcp/typescript/src/integrations/mcp/index.ts
@@ -59,7 +59,8 @@ function getPublicUrl(request: Request): URL {
 // allowing us to redirect to the correct EU OAuth server.
 function getRegionFromHostname(request: Request): CloudRegion | undefined {
     const publicUrl = getPublicUrl(request)
-    if (publicUrl.hostname === 'mcp-eu.posthog.com') {
+    // DNS hostnames are case-insensitive, so normalize to lowercase
+    if (publicUrl.hostname.toLowerCase() === 'mcp-eu.posthog.com') {
         return 'eu'
     }
     return undefined


### PR DESCRIPTION
## Problem

EU users connecting to the PostHog MCP server via Claude Code are incorrectly redirected to the US OAuth login page, even when using `?region=eu`. This is because Claude Code has a bug where it ignores the `authorization_servers` field from OAuth protected resource metadata and instead fetches `/.well-known/oauth-authorization-server` directly from the MCP server hostname.

See: https://github.com/anthropics/claude-code/issues/2267

## Changes

- Add hostname detection for `mcp-eu.posthog.com` subdomain
- Add `/.well-known/oauth-authorization-server` endpoint that redirects to the correct region's OAuth server (RFC 8414)
- Use hostname-based region OR query param (`?region=eu`) as fallback
- Backward compatible with existing `?region=eu` query param

## How it works

1. EU users connect to `https://mcp-eu.posthog.com/mcp`
2. MCP server detects the EU hostname
3. Claude Code fetches `/.well-known/oauth-authorization-server` from `mcp-eu.posthog.com`
4. Server redirects to `https://eu.posthog.com/.well-known/oauth-authorization-server`
5. User authenticates via EU OAuth

## How did you test this code?

- Unit tests pass (135 tests)
- Local testing with `.dev.vars` disabled confirms correct redirects:
  - `?region=eu` → redirects to `https://eu.posthog.com/.well-known/oauth-authorization-server`
  - Default → redirects to `https://us.posthog.com/.well-known/oauth-authorization-server`
- Subdomain `mcp-eu.posthog.com` already added to Cloudflare

## Related

- Wizard PR to use subdomain: (coming next)
- Claude Code bug: https://github.com/anthropics/claude-code/issues/2267

🤖 Generated with [Claude Code](https://claude.com/claude-code)