### PR TITLE
chore: improvements for backfill person properties workflow

### DIFF
--- a/posthog/temporal/messaging/__init__.py
+++ b/posthog/temporal/messaging/__init__.py
@@ -1,6 +1,6 @@
 from posthog.temporal.messaging.backfill_precalculated_person_properties_coordinator_workflow import (
     BackfillPrecalculatedPersonPropertiesCoordinatorWorkflow,
-    get_person_count_activity,
+    sample_uuid_boundaries_activity,
 )
 from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
     BackfillPrecalculatedPersonPropertiesWorkflow,
@@ -22,7 +22,7 @@ WORKFLOWS = [
     RealtimeCohortCalculationCoordinatorWorkflow,
 ]
 ACTIVITIES = [
-    get_person_count_activity,
+    sample_uuid_boundaries_activity,
     get_realtime_cohort_calculation_count_activity,
     backfill_precalculated_person_properties_activity,
     process_realtime_cohort_calculation_activity,

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
@@ -23,7 +23,6 @@ LOGGER = get_logger(__name__)
 
 # Constants for UUID sampling
 PERSON_ID_SAMPLE_RATE = 0.01  # Sample 1% of person IDs to find partition boundaries
-SAMPLE_RATE_MULTIPLIER = 100  # Multiplier to estimate total from sample (inverse of sample rate)
 
 
 class ChildWorkflowConfig(TypedDict):

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
@@ -71,7 +71,7 @@ async def sample_uuid_boundaries_activity(
 ) -> UUIDBoundariesResult:
     """Sample UUID boundaries to partition persons evenly across workers.
 
-    Uses reservoir sampling on 1% of person IDs to find percentile boundaries.
+    Uses random sampling (approximately 1% of person IDs) to find percentile boundaries.
     Returns parallelism-1 boundaries that divide the UUID space into parallelism partitions.
     """
     parallelism = inputs.parallelism

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -18,8 +18,7 @@ class TestFlushKafkaBatch:
             kafka_producer=kafka_producer,
             pending_messages=[],
             team_id=1,
-            cohort_id=123,
-            current_offset=0,
+            persons_processed=0,
             heartbeater=heartbeater,
             logger=logger,
         )
@@ -50,8 +49,7 @@ class TestFlushKafkaBatch:
                 kafka_producer=kafka_producer,
                 pending_messages=mock_results,
                 team_id=1,
-                cohort_id=123,
-                current_offset=1000,
+                persons_processed=1000,
                 heartbeater=heartbeater,
                 logger=logger,
             )
@@ -75,8 +73,7 @@ class TestFlushKafkaBatch:
                 kafka_producer=kafka_producer,
                 pending_messages=[mock_result],
                 team_id=1,
-                cohort_id=123,
-                current_offset=5000,
+                persons_processed=5000,
                 heartbeater=heartbeater,
                 logger=logger,
                 is_final=True,
@@ -104,8 +101,7 @@ class TestFlushKafkaBatch:
                 kafka_producer=kafka_producer,
                 pending_messages=[mock_result],
                 team_id=1,
-                cohort_id=123,
-                current_offset=2000,
+                persons_processed=2000,
                 heartbeater=heartbeater,
                 logger=logger,
                 is_final=False,
@@ -142,8 +138,7 @@ class TestFlushKafkaBatch:
                     kafka_producer=kafka_producer,
                     pending_messages=mock_results,
                     team_id=1,
-                    cohort_id=123,
-                    current_offset=3000,
+                    persons_processed=3000,
                     heartbeater=heartbeater,
                     logger=logger,
                 )
@@ -174,8 +169,7 @@ class TestFlushKafkaBatch:
                     kafka_producer=kafka_producer,
                     pending_messages=mock_results,
                     team_id=1,
-                    cohort_id=123,
-                    current_offset=4000,
+                    persons_processed=4000,
                     heartbeater=heartbeater,
                     logger=logger,
                 )
@@ -185,7 +179,7 @@ class TestFlushKafkaBatch:
 
     @pytest.mark.asyncio
     async def test_heartbeat_details_format(self):
-        """Should format heartbeat details with offset and cohort information."""
+        """Should format heartbeat details with processed persons information."""
         kafka_producer = Mock()
         mock_result = Mock()
         mock_result.get = Mock(return_value=None)
@@ -198,20 +192,18 @@ class TestFlushKafkaBatch:
                 kafka_producer=kafka_producer,
                 pending_messages=[mock_result] * 10000,
                 team_id=1,
-                cohort_id=456,
-                current_offset=50000,
+                persons_processed=50000,
                 heartbeater=heartbeater,
                 logger=logger,
             )
 
         heartbeat_msg = heartbeater.details[0]
         assert "10000 messages" in heartbeat_msg
-        assert "cohort 456" in heartbeat_msg
-        assert "offset 50000" in heartbeat_msg
+        assert "processed 50000 persons" in heartbeat_msg
 
     @pytest.mark.asyncio
     async def test_logger_includes_metadata(self):
-        """Should include team_id, cohort_id, offset, and batch_size in logger metadata."""
+        """Should include team_id, persons_processed, and batch_size in logger metadata."""
         kafka_producer = Mock()
         mock_result = Mock()
         mock_result.get = Mock(return_value=None)
@@ -224,8 +216,7 @@ class TestFlushKafkaBatch:
                 kafka_producer=kafka_producer,
                 pending_messages=[mock_result] * 5000,
                 team_id=42,
-                cohort_id=789,
-                current_offset=25000,
+                persons_processed=25000,
                 heartbeater=heartbeater,
                 logger=logger,
             )
@@ -234,8 +225,7 @@ class TestFlushKafkaBatch:
         logger.info.assert_called_once()
         call_kwargs = logger.info.call_args[1]
         assert call_kwargs["team_id"] == 42
-        assert call_kwargs["cohort_id"] == 789
-        assert call_kwargs["offset"] == 25000
+        assert call_kwargs["persons_processed"] == 25000
         assert call_kwargs["batch_size"] == 5000
 
 
@@ -260,12 +250,12 @@ class TestBatchFlushingBehavior:
 
         with patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.asyncio.to_thread"):
             # Batch 1
-            result1 = await flush_kafka_batch(kafka_producer, mock_results_batch1, 1, 123, 0, heartbeater, logger)
+            result1 = await flush_kafka_batch(kafka_producer, mock_results_batch1, 1, 0, heartbeater, logger)
             # Batch 2
-            result2 = await flush_kafka_batch(kafka_producer, mock_results_batch2, 1, 123, 10000, heartbeater, logger)
+            result2 = await flush_kafka_batch(kafka_producer, mock_results_batch2, 1, 10000, heartbeater, logger)
             # Batch 3 (final)
             result3 = await flush_kafka_batch(
-                kafka_producer, mock_results_batch3, 1, 123, 20000, heartbeater, logger, is_final=True
+                kafka_producer, mock_results_batch3, 1, 20000, heartbeater, logger, is_final=True
             )
 
         assert result1 == 10000


### PR DESCRIPTION
## Problem

The person properties backfill workflow was processing each cohort independently, which caused duplicate work when multiple cohorts shared the same person property filters. This led to redundant evaluations and unnecessary load on the system.

## Changes

- Deduplicate person property filters across all cohorts for a team
- Process all cohorts in a single coordinator workflow instead of one per cohort
- Use UUID sampling to partition persons evenly across parallel workers
- Replace offset/limit pagination with UUID range-based partitioning
- Update workflow to process deduplicated filters team-wide

The sampling approach uses 1% of person IDs (minimum 100, maximum 100k) to find percentile boundaries for even distribution across workers.

## How did you test this code?

- Reviewed code changes for correctness
- Verified workflow inputs and coordinator logic
- Confirmed UUID sampling implementation follows ClickHouse best practices

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no