### PR TITLE
fix(experiments): handle orphaned shared metrics in removal

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1274,8 +1274,19 @@ export const experimentLogic = kea<experimentLogicType>([
                     id: sharedMetric.saved_metric,
                     metadata: sharedMetric.metadata,
                 }))
+
+            // Also remove orphaned shared metrics that were incorrectly stored in the metrics arrays
+            const cleanedMetrics = (values.experiment.metrics || []).filter(
+                (m) => !('isSharedMetric' in m && m.isSharedMetric && m.sharedMetricId === sharedMetricId)
+            )
+            const cleanedMetricsSecondary = (values.experiment.metrics_secondary || []).filter(
+                (m) => !('isSharedMetric' in m && m.isSharedMetric && m.sharedMetricId === sharedMetricId)
+            )
+
             await api.update(`api/projects/${values.currentProjectId}/experiments/${values.experimentId}`, {
                 saved_metrics_ids: sharedMetricsIds,
+                metrics: cleanedMetrics,
+                metrics_secondary: cleanedMetricsSecondary,
             })
 
             actions.loadExperiment()


### PR DESCRIPTION
## Problem

Users cannot remove certain shared metrics from experiments. Clicking "Remove from experiment" does nothing, no API request is sent and the metric remains.

### Root cause

Shared metrics can become "orphaned" when they are incorrectly stored in the `experiment.metrics` JSON array instead of the proper `experiment.saved_metrics` M2M relationship.

**How this happens:**
1. When shared metrics are displayed in the UI, they are "enriched" with `isSharedMetric: true` and `sharedMetricId` fields for rendering purposes
2. At some point (likely through an old code path), these enriched objects were saved directly to the `metrics` JSON field
3. This creates an orphan: a shared metric embedded in `metrics` instead of linked via `saved_metrics`

**Example of corrupted state:**
```json
{
  "metrics": [
    {
      "name": "Some metric (stale name)",
      "uuid": "...",
      "isSharedMetric": true,      // <- Should never be persisted
      "sharedMetricId": 46275,     // <- Should never be persisted
      "kind": "ExperimentMetric"
    }
  ],
  "saved_metrics": []  // Empty! The shared metric should be here instead
}
```

**Why removal fails:**
The `removeSharedMetricFromExperiment` action only looks in `saved_metrics`:
```typescript
const sharedMetricsIds = values.experiment.saved_metrics
    .filter((sm) => sm.saved_metric !== sharedMetricId)
    // ...
```

Since the orphaned metric is in `metrics` (not `saved_metrics`), the filter finds nothing to remove, and the PATCH sends the same data back.

### Symptoms
- Remove button does nothing (no network request)
- Metric name is stale (doesn't update when shared metric is renamed)
- Metric shows different name in experiment vs. in the shared metrics modal

## Solution

Modify `removeSharedMetricFromExperiment` to also clean orphaned shared metrics from the `metrics` and `metrics_secondary` arrays:

```typescript
// Also remove orphaned shared metrics from metrics arrays
const cleanedMetrics = (values.experiment.metrics || []).filter(
    (m) => !('isSharedMetric' in m && m.isSharedMetric && m.sharedMetricId === sharedMetricId)
)
```

This is a targeted fix that:
- Only affects removal of shared metrics (not regular metrics)
- Only removes metrics that have `isSharedMetric: true` AND match the `sharedMetricId`
- Preserves all other metrics in the array
- Cannot accidentally delete the actual shared metric (only removes the association)

## How did you test this code?

1. **Unit tests**: Added tests for removing orphaned shared metrics from both `metrics` and `metrics_secondary` arrays
2. **Local reproduction**:
   - Created corrupted state in local DB (orphaned shared metric in `metrics` array with `isSharedMetric: true`)
   - Added the orphan's UUID to `primary_metrics_ordered_uuids` so it renders in UI
   - Verified the metric appears with stale name
   - Clicked remove - verified PATCH includes cleaned `metrics` array
   - Verified metric is removed from experiment


## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
