### PR TITLE
feat(llma): add team IDs to trace summarization and clustering allowlists

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -74,7 +74,12 @@ LLMA_TRACE_PRODUCT = "llm-analytics"
 ALLOWED_TEAM_IDS: list[int] = [
     1,  # Local development
     2,  # Internal PostHog project
-    112495,  # Dogfooding project
+    # Dogfooding projects
+    112495,
+    148051,
+    140227,
+    237906,
+    294356,
 ]
 
 # Cluster labeling agent configuration

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -54,7 +54,12 @@ EVENT_NAME_TRACE_SUMMARY = "$ai_trace_summary"
 ALLOWED_TEAM_IDS: list[int] = [
     1,  # Local development
     2,  # Internal PostHog project
-    112495,  # Dogfooding project
+    # Dogfooding projects
+    112495,
+    148051,
+    140227,
+    237906,
+    294356,
 ]
 
 # Temporal configuration


### PR DESCRIPTION
## Problem

Additional teams need access to the LLM analytics trace summarization and clustering workflows for dogfooding.

## Changes

Added team IDs 148051, 140227, 237906, and 294356 to the ALLOWED_TEAM_IDS lists in:
- `posthog/temporal/llm_analytics/trace_clustering/constants.py`
- `posthog/temporal/llm_analytics/trace_summarization/constants.py`

## How did you test this code?

Configuration change only - no functional code modified.

## Publish to changelog?

No