### PR TITLE
fix(llma): Test with Jest thinking it's in prod

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -246,8 +246,7 @@ jobs:
                   SHARD_INDEX: ${{ matrix.shard }}
                   SHARD_COUNT: 3
                   LOG_LEVEL: info
-                  TEST: 1
-              run: bin/turbo run test --filter=@posthog/nodejs
+              run: TEST=1 bin/turbo run test --filter=@posthog/nodejs
 
             - name: Output logs on failure
               if: failure()

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -246,6 +246,7 @@ jobs:
                   SHARD_INDEX: ${{ matrix.shard }}
                   SHARD_COUNT: 3
                   LOG_LEVEL: info
+                  TEST: 1
               run: bin/turbo run test --filter=@posthog/nodejs
 
             - name: Output logs on failure

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -145,6 +145,7 @@ jobs:
             CLICKHOUSE_HOST: 'localhost'
             CLICKHOUSE_DATABASE: 'posthog_test'
             KAFKA_HOSTS: 'kafka:9092'
+            TEST: '1'
 
         steps:
             - name: Code check out
@@ -246,7 +247,7 @@ jobs:
                   SHARD_INDEX: ${{ matrix.shard }}
                   SHARD_COUNT: 3
                   LOG_LEVEL: info
-              run: TEST=1 bin/turbo run test --filter=@posthog/nodejs
+              run: bin/turbo run test --filter=@posthog/nodejs
 
             - name: Output logs on failure
               if: failure()


### PR DESCRIPTION
The Test with Jest step thinks it's in production:
```
FAIL src/cdp/templates/_sources/webhook/incoming_webhook.template.test.ts (15.163 s)
  ● incoming webhook template › should invoke the function

    Command failed: cd /home/runner/work/posthog/posthog && ./bin/hoge /tmp/hog-019be23b-7f80-0000-be2d-6eea9fbf4cff.hog /tmp/hog-019be23b-7f80-0000-be2d-6eea9fbf4cff.hoge
    {'event': '\nYou are using the default SECRET_KEY in a production environment!\nFor the safety of your instance, you must generate and set a unique key.\n', 'timestamp': '2026-01-21T20:25:11.714857Z', 'logger': 'posthog.settings.access', 'level': 'critical', 'pid': 39163, 'tid': 139794049506176}
```