### PR TITLE
chore(sdk-doctor): address PR feedback from #42916

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSdkDoctor.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSdkDoctor.tsx
@@ -5,7 +5,6 @@ import { IconInfo, IconStethoscope } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonTable, LemonTableColumns, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
-import { dayjs } from 'lib/dayjs'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { IconWithBadge } from 'lib/lemon-ui/icons'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils'
@@ -110,8 +109,8 @@ const COLUMNS: LemonTableColumns<AugmentedTeamSdkVersionsInfoRelease> = [
                         <Tooltip
                             placement="right"
                             title={
-                                record.releaseDate
-                                    ? `Released ${dayjs(record.releaseDate).fromNow()}. Upgrade recommended.`
+                                record.releasedAgo
+                                    ? `Released ${record.releasedAgo}. Upgrade recommended.`
                                     : 'Upgrade recommended'
                             }
                         >
@@ -119,7 +118,7 @@ const COLUMNS: LemonTableColumns<AugmentedTeamSdkVersionsInfoRelease> = [
                                 Outdated
                             </LemonTag>
                         </Tooltip>
-                    ) : record.latestVersion && record.version === record.latestVersion ? (
+                    ) : record.isCurrentOrNewer ? (
                         <Tooltip
                             placement="right"
                             title={
@@ -138,9 +137,9 @@ const COLUMNS: LemonTableColumns<AugmentedTeamSdkVersionsInfoRelease> = [
                         <Tooltip
                             placement="right"
                             title={
-                                record.releaseDate ? (
+                                record.releasedAgo ? (
                                     <>
-                                        Released {dayjs(record.releaseDate).fromNow()}.
+                                        Released {record.releasedAgo}.
                                         <br />
                                         Upgrading is a good idea, but it's not urgent yet.
                                     </>
@@ -149,11 +148,7 @@ const COLUMNS: LemonTableColumns<AugmentedTeamSdkVersionsInfoRelease> = [
                                 )
                             }
                         >
-                            <LemonTag
-                                type="warning"
-                                className="shrink-0 cursor-help"
-                                style={{ color: 'var(--warning-dark)', borderColor: 'var(--warning-dark)' }}
-                            >
+                            <LemonTag type="warning" className="shrink-0 cursor-help">
                                 Recent
                             </LemonTag>
                         </Tooltip>
@@ -333,7 +328,7 @@ function SdkSection({ sdkType }: { sdkType: SdkType }): JSX.Element {
                     <Tooltip
                         title={
                             <>
-                                Version number cached daily near midnight UTC.
+                                Version number cached once a day.
                                 <br />
                                 Click 'Releases ↗' to check for any since.
                             </>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
@@ -4,6 +4,7 @@ import { loaders } from 'kea-loaders'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
 import { SemanticVersion, diffVersions, parseVersion, versionToString } from 'lib/utils/semver'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
@@ -63,10 +64,12 @@ export type AugmentedTeamSdkVersionsInfoRelease = {
     count: number
     latestVersion: string
     releaseDate: string | undefined
+    releasedAgo: string | undefined
     daysSinceRelease: number | undefined
     isOutdated: boolean
     isOld: boolean
     needsUpdating: boolean
+    isCurrentOrNewer: boolean
 }
 
 /**
@@ -311,6 +314,12 @@ function computeAugmentedInfoRelease(
         // Check if versions differ
         const diff = diffVersions(latestVersion, currentVersion)
 
+        // Check if current version is equal to or newer than cached latest
+        // This handles the case where events show a newer version than what's cached from GitHub
+        // diff === null means versions are equal; positive diff from (current, latest) means current is ahead
+        const currentAheadOfLatest = diffVersions(currentVersion, latestVersion)
+        const isCurrentOrNewer = diff === null || (currentAheadOfLatest !== null && currentAheadOfLatest.diff > 0)
+
         // Count number of versions behind by estimating based on semantic version difference
         let releasesBehind = 0
         if (diff) {
@@ -396,7 +405,9 @@ function computeAugmentedInfoRelease(
             isOutdated,
             isOld, // Returned separately for "Old" badge in UI
             needsUpdating: isOutdated || isOld,
+            isCurrentOrNewer,
             releaseDate: usageEntry.release_date,
+            releasedAgo: usageEntry.release_date ? dayjs(usageEntry.release_date).fromNow() : undefined,
             daysSinceRelease,
             latestVersion: versionToString(latestVersion),
         }
@@ -410,7 +421,9 @@ function computeAugmentedInfoRelease(
             isOutdated: false,
             isOld: false,
             needsUpdating: false,
+            isCurrentOrNewer: false,
             releaseDate: undefined,
+            releasedAgo: undefined,
             daysSinceRelease: undefined,
             latestVersion: versionToString(latestVersion),
         }

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
@@ -316,9 +316,8 @@ function computeAugmentedInfoRelease(
 
         // Check if current version is equal to or newer than cached latest
         // This handles the case where events show a newer version than what's cached from GitHub
-        // diff === null means versions are equal; positive diff from (current, latest) means current is ahead
-        const currentAheadOfLatest = diffVersions(currentVersion, latestVersion)
-        const isCurrentOrNewer = diff === null || (currentAheadOfLatest !== null && currentAheadOfLatest.diff > 0)
+        // diff === null means versions are equal; diff.diff <= 0 means current >= latest
+        const isCurrentOrNewer = diff === null || diff.diff <= 0
 
         // Count number of versions behind by estimating based on semantic version difference
         let releasesBehind = 0

--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.test.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.test.ts
@@ -131,4 +131,14 @@ describe('versionCheckerLogic', () => {
         await expectLogic(logic).toFinishAllListeners()
         expectLogic(logic).toMatchValues({ versionWarning: options.expectation })
     })
+
+    it('should show Current badge when used version is newer than latest cached from GitHub', async () => {
+        // Simulate stale cache: GitHub says latest is 1.300.0 but user has 1.333.0
+        setupTest('1.300.0', [{ version: '1.333.0', count: 100 }])
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        const augmented = logic.values.augmentedData
+        expect(augmented?.web?.allReleases[0]?.isCurrentOrNewer).toBe(true)
+    })
 })


### PR DESCRIPTION
## Problem
Fixing nits from #42916 (already merged)

Issues:
1. `dayjs().fromNow()` was being called in render, re-parsing dates on every rerender 
2. Tooltip text "cached daily near midnight UTC" was misleading (process takes ~14 hours)
3. Custom inline styles on LemonTag instead of using design system
  
## Changes
- **Performance**: Move `dayjs` calculations to kea logic via new `releasedAgo` field
- **Tooltip**: Simplify to "Version number cached once a day"
- **Styling**: Remove custom inline styles, use standard `type="warning"` on LemonTag                                                                                      


And new (not from #42916):
When GitHub cache was stale, versions newer than cached showed "Recent" instead of "Current"

- **Badge logic**: Add `isCurrentOrNewer` field - shows "Current" when event version ≥ cached latest 
- **Testing**: Add test case for `isCurrentOrNewer` in `versionCheckerLogic.test.ts`
  
## How did you test this code?
- On my local with test events 
- For the badge logic change, did manual testing with temporary code to simulate stale GitHub cache (set cached latest to 1.300.0, verified newer versions showed "Current" badge) 
  - Added automated test: "should show Current badge when used version is newer than latest cached from GitHub"

## Publish to changelog?
No
