### PR TITLE
fix(comments/discussions): have email link go to correct page

### DIFF
--- a/frontend/src/scenes/comments/commentsLogic.ts
+++ b/frontend/src/scenes/comments/commentsLogic.ts
@@ -162,7 +162,7 @@ export const commentsLogic = kea<commentsLogicType>([
                         item_context: itemContext,
                         source_comment: values.replyingCommentId ?? undefined,
                         mentions,
-                        slug: discussionsSlug(),
+                        slug: discussionsSlug(props.scope, props.item_id),
                     })
 
                     values.itemContext?.callback?.({ sent: true })
@@ -195,7 +195,7 @@ export const commentsLogic = kea<commentsLogicType>([
                         rich_content,
                         content: textContent,
                         mentions: newMentions,
-                        slug: discussionsSlug(),
+                        slug: discussionsSlug(props.scope, props.item_id),
                     })
                     return [...existingComments.filter((c) => c.id !== editedComment.id), updatedComment]
                 },

--- a/frontend/src/scenes/comments/utils.ts
+++ b/frontend/src/scenes/comments/utils.ts
@@ -3,9 +3,22 @@ import { generateText } from '@tiptap/core'
 import { JSONContent, RichContentNodeType } from 'lib/components/RichContentEditor/types'
 import { DEFAULT_EXTENSIONS } from 'lib/lemon-ui/LemonRichContent/LemonRichContentEditor'
 
-import { OrganizationMemberType } from '~/types'
+import { ActivityScope, OrganizationMemberType } from '~/types'
 
-export const discussionsSlug = (): string => `${window.location.pathname}#panel=discussion`
+export const discussionsSlug = (scope?: string, itemId?: string | null): string => {
+    // Generate proper slug based on scope and item_id when available
+    if (scope && itemId) {
+        if (scope === ActivityScope.REPLAY || scope === 'recording') {
+            return `/replay/${itemId}#panel=discussion`
+        }
+        if (scope === ActivityScope.NOTEBOOK) {
+            return `/notebook/${itemId}#panel=discussion`
+        }
+    }
+
+    // Fallback to current pathname with discussion panel hash
+    return `${window.location.pathname}#panel=discussion`
+}
 
 export const getTextContent = (content: JSONContent | undefined | null, members: OrganizationMemberType[]): string => {
     return content

--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
@@ -131,6 +131,7 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                         time_in_recording: dayjs(values.currentTimestamp).toISOString(),
                         milliseconds_into_recording: values.currentPlayerTime,
                     },
+                    slug: `/replay/${props.recordingId}#panel=discussion`,
                 })
                 playerCommentModel.actions.commentEdited(props.recordingId)
             } finally {
@@ -175,6 +176,7 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                         time_in_recording: dateForTimestamp.toISOString(),
                         milliseconds_into_recording: values.currentPlayerTime,
                     },
+                    slug: `/replay/${props.recordingId}#panel=discussion`,
                 }
 
                 if (commentId) {

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -749,7 +749,17 @@ def send_discussions_mentioned(comment_id: str, mentioned_user_ids: list[int], s
             logger.warning("Skipping discussions mentioned email: no valid recipients after filtering")
             return
 
-        href = f"{settings.SITE_URL}{slug}"
+        # Generate href from comment data if slug not provided
+        if not slug:
+            if comment.scope == "Replay":
+                href = f"{settings.SITE_URL}/replay/{comment.item_id}"
+            elif comment.scope == "Notebook":
+                href = f"{settings.SITE_URL}/notebook/{comment.item_id}"
+            else:
+                # Fallback for other scopes
+                href = settings.SITE_URL
+        else:
+            href = f"{settings.SITE_URL}{slug}"
 
         campaign_key: str = f"discussions_user_mentioned_{comment.id}_updated_at_{comment.created_at.timestamp()}"
         message = EmailMessage(

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -24,6 +24,7 @@ from posthog.tasks.email import (
     send_async_migration_errored_email,
     send_batch_export_run_failure,
     send_canary_email,
+    send_discussions_mentioned,
     send_email_verification,
     send_fatal_plugin_error,
     send_hog_functions_daily_digest,
@@ -1121,3 +1122,136 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
 
         # No email should be sent since recipient doesn't have access
         assert len(mocked_email_messages) == 0
+
+    def test_send_discussions_mentioned_with_slug_generates_correct_href(self, MockEmailMessage: MagicMock) -> None:
+        from posthog.models import Comment
+
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        # Create a mentioned user
+        mentioned_user = User.objects.create_and_join(
+            organization=self.organization, email="mentioned@posthog.com", password=None
+        )
+
+        # Create a replay comment
+        comment = Comment.objects.create(
+            team=self.team,
+            content="Test comment",
+            scope="Replay",
+            item_id="test-replay-id",
+            created_by=self.user,
+        )
+
+        # Call task with explicit slug
+        send_discussions_mentioned(
+            comment_id=str(comment.id),
+            mentioned_user_ids=[mentioned_user.id],
+            slug="/replay/test-replay-id",
+        )
+
+        assert len(mocked_email_messages) == 1
+        assert mocked_email_messages[0].send.call_count == 1
+
+        # Verify the href in template context uses the provided slug
+        actual_href = mocked_email_messages[0].properties["href"]
+        expected_href = "http://localhost:8010/replay/test-replay-id"
+        assert actual_href == expected_href, f"Expected {expected_href}, got {actual_href}"
+
+    def test_send_discussions_mentioned_replay_without_slug_generates_href_from_item_id(
+        self, MockEmailMessage: MagicMock
+    ) -> None:
+        from posthog.models import Comment
+
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        mentioned_user = User.objects.create_and_join(
+            organization=self.organization, email="mentioned2@posthog.com", password=None
+        )
+
+        # Create a replay comment
+        comment = Comment.objects.create(
+            team=self.team,
+            content="Test comment",
+            scope="Replay",
+            item_id="replay-uuid-123",
+            created_by=self.user,
+        )
+
+        # Call task without slug (empty string)
+        send_discussions_mentioned(
+            comment_id=str(comment.id),
+            mentioned_user_ids=[mentioned_user.id],
+            slug="",
+        )
+
+        assert len(mocked_email_messages) == 1
+        assert mocked_email_messages[0].send.call_count == 1
+
+        # Verify the href is auto-generated from scope and item_id
+        assert mocked_email_messages[0].properties["href"] == "http://localhost:8010/replay/replay-uuid-123"
+
+    def test_send_discussions_mentioned_notebook_without_slug_generates_href_from_item_id(
+        self, MockEmailMessage: MagicMock
+    ) -> None:
+        from posthog.models import Comment
+
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        mentioned_user = User.objects.create_and_join(
+            organization=self.organization, email="mentioned3@posthog.com", password=None
+        )
+
+        # Create a notebook comment
+        comment = Comment.objects.create(
+            team=self.team,
+            content="Notebook test comment",
+            scope="Notebook",
+            item_id="notebook-short-id",
+            created_by=self.user,
+        )
+
+        # Call task without slug
+        send_discussions_mentioned(
+            comment_id=str(comment.id),
+            mentioned_user_ids=[mentioned_user.id],
+            slug="",
+        )
+
+        assert len(mocked_email_messages) == 1
+        assert mocked_email_messages[0].send.call_count == 1
+
+        # Verify the href is auto-generated for notebook
+        assert mocked_email_messages[0].properties["href"] == "http://localhost:8010/notebook/notebook-short-id"
+
+    def test_send_discussions_mentioned_unknown_scope_without_slug_falls_back_to_base_url(
+        self, MockEmailMessage: MagicMock
+    ) -> None:
+        from posthog.models import Comment
+
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        mentioned_user = User.objects.create_and_join(
+            organization=self.organization, email="mentioned4@posthog.com", password=None
+        )
+
+        # Create a comment with unknown scope
+        comment = Comment.objects.create(
+            team=self.team,
+            content="Unknown scope comment",
+            scope="UnknownScope",
+            item_id="some-item-id",
+            created_by=self.user,
+        )
+
+        # Call task without slug
+        send_discussions_mentioned(
+            comment_id=str(comment.id),
+            mentioned_user_ids=[mentioned_user.id],
+            slug="",
+        )
+
+        assert len(mocked_email_messages) == 1
+        assert mocked_email_messages[0].send.call_count == 1
+
+        # Verify the href falls back to base URL
+        assert mocked_email_messages[0].properties["href"] == "http://localhost:8010"


### PR DESCRIPTION
## Problem

we're emailing now, but not linking to the correct context, just generic homepage. 
https://posthoghelp.zendesk.com/agent/tickets/43390 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50567)

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

send a slug / defensively also parse a slug on the backend
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
tests, plus local testing: 

![Screenshot 2026-01-21 at 3.09.22 PM.png](https://app.graphite.com/user-attachments/assets/0b7b6497-8983-4cb2-86f7-81041cce70fe.png)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
