### PR TITLE
feat(insights): allow goal line color to be changed

### DIFF
--- a/frontend/src/lib/components/GoalLinesList.tsx
+++ b/frontend/src/lib/components/GoalLinesList.tsx
@@ -1,5 +1,7 @@
 import { IconEye, IconTrash } from '@posthog/icons'
+import { LemonColorPicker } from '@posthog/lemon-ui'
 
+import { getSeriesColor, getSeriesColorPalette } from 'lib/colors'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
@@ -19,63 +21,82 @@ interface GoalLinesListProps {
 }
 
 export function GoalLinesList({ goalLines, updateGoalLine, removeGoalLine }: GoalLinesListProps): JSX.Element {
+    const seriesColor = getSeriesColorPalette()
     return (
         <>
-            {goalLines.map(({ label, value = 0, displayLabel = true, position }, goalLineIndex) => (
-                <div className="flex flex-1 gap-1 mb-1 items-center" key={`${goalLineIndex}`}>
-                    <SeriesLetter className="self-center" hasBreakdown={false} seriesIndex={goalLineIndex} />
-                    <LemonInput
-                        placeholder="Label"
-                        className="grow-2"
-                        value={label}
-                        suffix={
-                            <LemonButton
-                                size="small"
-                                noPadding
-                                icon={displayLabel ? <IconEye /> : <IconEyeHidden />}
-                                tooltip={displayLabel ? 'Display label' : 'Hide label'}
-                                onClick={(e) => {
-                                    e.stopPropagation()
-                                    updateGoalLine(goalLineIndex, 'displayLabel', !displayLabel)
-                                }}
-                            />
-                        }
-                        onChange={(value) => updateGoalLine(goalLineIndex, 'label', value)}
-                    />
-                    <LemonInput
-                        type="number"
-                        step="any"
-                        placeholder="Value"
-                        className="grow"
-                        value={value}
-                        onChange={(value) =>
-                            updateGoalLine(
-                                goalLineIndex,
-                                'value',
-                                value !== undefined && !Number.isNaN(value) ? value : 0
-                            )
-                        }
-                    />
-                    <LemonSegmentedButton
-                        value={position ?? 'end'}
-                        onChange={(value) => updateGoalLine(goalLineIndex, 'position', value as 'start' | 'end')}
-                        options={[
-                            { value: 'start', label: 'Start' },
-                            { value: 'end', label: 'End' },
-                        ]}
-                        size="xsmall"
-                        data-attr="goal-line-position-selector"
-                    />
-                    <LemonButton
-                        key="delete"
-                        icon={<IconTrash />}
-                        status="danger"
-                        title="Delete goal line"
-                        noPadding
-                        onClick={() => removeGoalLine(goalLineIndex)}
-                    />
-                </div>
-            ))}
+            {goalLines.map(({ label, value = 0, displayLabel = true, position, borderColor }, goalLineIndex) => {
+                const currentColor = borderColor || getSeriesColor(goalLineIndex)
+                return (
+                    <div className="flex flex-1 gap-1 mb-1 items-center" key={`${goalLineIndex}`}>
+                        <LemonColorPicker
+                            colors={seriesColor}
+                            selectedColor={borderColor || undefined}
+                            onSelectColor={(color) => updateGoalLine(goalLineIndex, 'borderColor', color)}
+                            showCustomColor
+                            customButton={
+                                <div className="cursor-pointer">
+                                    <SeriesLetter
+                                        className="self-center"
+                                        hasBreakdown={false}
+                                        seriesIndex={goalLineIndex}
+                                        seriesColor={currentColor}
+                                    />
+                                </div>
+                            }
+                        />
+                        <LemonInput
+                            placeholder="Label"
+                            className="grow-2"
+                            value={label}
+                            suffix={
+                                <LemonButton
+                                    size="small"
+                                    noPadding
+                                    icon={displayLabel ? <IconEye /> : <IconEyeHidden />}
+                                    tooltip={displayLabel ? 'Display label' : 'Hide label'}
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        updateGoalLine(goalLineIndex, 'displayLabel', !displayLabel)
+                                    }}
+                                />
+                            }
+                            onChange={(value) => updateGoalLine(goalLineIndex, 'label', value)}
+                        />
+                        <LemonInput
+                            type="number"
+                            step="any"
+                            placeholder="Value"
+                            className="grow"
+                            value={value}
+                            onChange={(value) =>
+                                updateGoalLine(
+                                    goalLineIndex,
+                                    'value',
+                                    value !== undefined && !Number.isNaN(value) ? value : 0
+                                )
+                            }
+                        />
+                        <LemonSegmentedButton
+                            value={position ?? 'end'}
+                            onChange={(value) => updateGoalLine(goalLineIndex, 'position', value as 'start' | 'end')}
+                            options={[
+                                { value: 'start', label: 'Start' },
+                                { value: 'end', label: 'End' },
+                            ]}
+                            size="xsmall"
+                            data-attr="goal-line-position-selector"
+                        />
+                        <LemonButton
+                            key="delete"
+                            icon={<IconTrash />}
+                            status="danger"
+                            title="Delete goal line"
+                            noPadding
+                            onClick={() => removeGoalLine(goalLineIndex)}
+                        />
+                    </div>
+                )
+            })}
         </>
     )
 }


### PR DESCRIPTION
## Problem

When creating goal lines in an insight, line color is derived automatically from the goal line index and color palette. The user cannot change the color manually.

Border color is already supported in the backend, so only a proper color selection widget is required.

## Changes

- Wrapped SeriesLetter component with a LemonColorPicker which updates the borderColor property of the corresponding GoalLine.
- To keep design clean, kept SeriesLetter component as-is, only with a `cursor-pointer` class.

## How did you test this code?

Manually. Tested all colors in the LemonColorPicker, and custom colors (hex). Checked if the graph line has the right color, and if changes are persisted.
