### PR TITLE
fix(appmetrics logs): use proper timezone + sorting for time boundary queries

### DIFF
--- a/frontend/src/scenes/hog-functions/logs/logsViewerLogic.test.ts
+++ b/frontend/src/scenes/hog-functions/logs/logsViewerLogic.test.ts
@@ -1,0 +1,41 @@
+import { dayjs } from 'lib/dayjs'
+
+import { toAbsoluteClickhouseTimestamp } from './logsViewerLogic'
+
+describe('logsViewerLogic', () => {
+    describe('toAbsoluteClickhouseTimestamp', () => {
+        it.each([
+            {
+                description: 'converts UTC timestamp correctly',
+                input: dayjs.tz('2024-01-15 10:30:45.123', 'UTC'),
+                expected: '2024-01-15 10:30:45.123',
+            },
+            {
+                description: 'converts US/Pacific timestamp to UTC',
+                input: dayjs.tz('2024-01-15 02:30:45.123', 'US/Pacific'),
+                expected: '2024-01-15 10:30:45.123',
+            },
+            {
+                description: 'converts Europe/Berlin timestamp to UTC',
+                input: dayjs.tz('2024-01-15 11:30:45.123', 'Europe/Berlin'),
+                expected: '2024-01-15 10:30:45.123',
+            },
+            {
+                description: 'converts Asia/Tokyo timestamp to UTC',
+                input: dayjs.tz('2024-01-15 19:30:45.123', 'Asia/Tokyo'),
+                expected: '2024-01-15 10:30:45.123',
+            },
+        ])('$description', ({ input, expected }) => {
+            expect(toAbsoluteClickhouseTimestamp(input)).toBe(expected)
+        })
+
+        it('formats timestamp without ISO format', () => {
+            const timestamp = dayjs.tz('2024-06-20 14:00:00.000', 'UTC')
+            const result = toAbsoluteClickhouseTimestamp(timestamp)
+
+            expect(result).not.toContain('T')
+            expect(result).not.toContain('Z')
+            expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/)
+        })
+    })
+})

--- a/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
+++ b/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
@@ -79,7 +79,7 @@ const toKey = (log: LogEntry): string => {
 
 const toAbsoluteClickhouseTimestamp = (timestamp: Dayjs): string => {
     // TRICKY: CH query is timezone aware so we dont send iso
-    return timestamp.format('YYYY-MM-DD HH:mm:ss.SSS')
+    return timestamp.tz('UTC').format('YYYY-MM-DD HH:mm:ss.SSS')
 }
 
 const buildBoundaryFilters = (request: LogEntryParams): string => {
@@ -342,7 +342,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
                     if (!results.length) {
                         actions.markLogsEnd()
                     }
-                    return groupLogs([...results, ...values.groupedLogs.flatMap((group) => group.entries)])
+                    return groupLogs([...values.groupedLogs.flatMap((group) => group.entries), ...results])
                 },
 
                 addLogGroups: ({ logGroups }) => {

--- a/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
+++ b/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
@@ -77,8 +77,9 @@ const toKey = (log: LogEntry): string => {
     return `${log.instanceId}-${log.level}-${log.timestamp.toISOString()}`
 }
 
-const toAbsoluteClickhouseTimestamp = (timestamp: Dayjs): string => {
-    // TRICKY: CH query is timezone aware so we dont send iso
+export const toAbsoluteClickhouseTimestamp = (timestamp: Dayjs): string => {
+    // TRICKY: CH query is timezone aware so we dont send iso, and we need to convert to UTC
+    // See https://github.com/PostHog/posthog/pull/45651
     return timestamp.tz('UTC').format('YYYY-MM-DD HH:mm:ss.SSS')
 }
 


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/47606 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50589)

This is a tricky bug, here's the network requests that show what's going on:
<img width="1352" height="735" alt="Screenshot 2026-01-21 at 6 36 30 PM" src="https://github.com/user-attachments/assets/cfba2600-04c8-40b9-9c5d-46802b63708c" />


## Changes

- Convert timestamp to UTC before formatting in logs queries
- Add older logs to end of array so the groups are sorted in an expected way

## How did you test this code?

Verified correct filter values locally