### PR TITLE
chore: Remove moved tf file as the plan has been applied now

### DIFF
--- a/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/moved.tf
+++ b/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/moved.tf
@@ -1,9 +1,0 @@
-moved {
-  from = posthog_insight.export_successes_and_failures_us
-  to   = posthog_insight.export_successes_and_failures["us"]
-}
-
-moved {
-  from = posthog_insight.export_successes_and_failures_eu
-  to   = posthog_insight.export_successes_and_failures["eu"]
-}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

After merging and applying: https://github.com/PostHog/posthog/pull/45425 we can now clean up the `moved.tf` file as it was solely there due to the `for_each` migration to improve the DRY-ness of our TF setup. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Deleted the no longer needed `moved.tf` file, this is a no-op and just general cleanup

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

✅ CI is passing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

N/A

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
