### PR TITLE
fix: duplicated dashboard tiles should insert close to the original

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -31,7 +31,7 @@ import { clearDOMTextSelection, getJSHeapMemory, shouldCancelQuery, toParams, uu
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { BREAKPOINTS } from 'scenes/dashboard/dashboardUtils'
-import { calculateLayouts } from 'scenes/dashboard/tileLayouts'
+import { calculateDuplicateLayout, calculateLayouts } from 'scenes/dashboard/tileLayouts'
 import { dataThemeLogic } from 'scenes/dataThemeLogic'
 import { MaxContextInput, createMaxContextHelpers } from 'scenes/max/maxTypes'
 import { Scene } from 'scenes/sceneTypes'
@@ -433,10 +433,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             newTile.text = { body: newTile.text.body } as TextModel
                         }
 
+                        const { duplicateLayouts, tilesToUpdate } = calculateDuplicateLayout(values.layouts, tile.id)
+
                         const dashboard: DashboardType<InsightModel> = await api.update(
                             `api/environments/${values.currentTeamId}/dashboards/${props.id}`,
                             {
-                                duplicate_tiles: [newTile],
+                                duplicate_tiles: [{ ...newTile, layouts: duplicateLayouts }],
+                                tiles: tilesToUpdate.length > 0 ? tilesToUpdate : undefined,
                             }
                         )
                         return getQueryBasedDashboard(dashboard)

--- a/frontend/src/scenes/dashboard/tileLayouts.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.ts
@@ -34,6 +34,7 @@ export function calculateDuplicateLayout(
     const { x, y, w, h } = originalSmLayout
     const columnCount = BREAKPOINT_COLUMN_COUNTS.sm
 
+    // for the xs layout, we can always place the tile just below the original
     const xsLayoutForDuplicate = originalXsLayout
         ? {
               x: originalXsLayout.x,
@@ -43,6 +44,7 @@ export function calculateDuplicateLayout(
           }
         : undefined
 
+    // place the tile on the right if there's space
     if (canPlaceToRight(currentLayouts?.sm || [], tileId, x, y, w, h, columnCount)) {
         result.duplicateLayouts = {
             sm: { x: x + w, y, w, h },
@@ -51,16 +53,20 @@ export function calculateDuplicateLayout(
         return result
     }
 
+    // otherwise, place it below
     const insertY = y + h
     result.duplicateLayouts = {
         sm: { x, y: insertY, w, h },
         xs: xsLayoutForDuplicate,
     }
 
+    // shift down any tiles that would overlap with the new placement
     for (const smLayout of currentLayouts?.sm || []) {
+        // ignore the duplicated tile and tiles above the insertion point
         if (String(smLayout.i) === String(tileId) || smLayout.y < insertY) {
             continue
         }
+
         const xsLayout = currentLayouts?.xs?.find((l) => l.i === smLayout.i)
         const xsInsertY = originalXsLayout ? originalXsLayout.y + originalXsLayout.h : undefined
         result.tilesToUpdate.push({

--- a/frontend/src/scenes/dashboard/tileLayouts.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.ts
@@ -62,14 +62,17 @@ export function calculateDuplicateLayout(
             continue
         }
         const xsLayout = currentLayouts?.xs?.find((l) => l.i === smLayout.i)
-        const xsInsertY = originalXsLayout ? originalXsLayout.y + originalXsLayout.h : 0
+        const xsInsertY = originalXsLayout ? originalXsLayout.y + originalXsLayout.h : undefined
         result.tilesToUpdate.push({
             id: parseInt(smLayout.i),
             layouts: {
                 sm: { x: smLayout.x, y: smLayout.y + h, w: smLayout.w, h: smLayout.h },
                 xs:
-                    xsLayout && xsLayout.y >= xsInsertY
-                        ? { x: xsLayout.x, y: xsLayout.y + (originalXsLayout?.h || h), w: xsLayout.w, h: xsLayout.h }
+                    xsLayout && xsInsertY !== undefined && xsLayout.y >= xsInsertY
+                        ? { x: xsLayout.x, y: xsLayout.y + originalXsLayout!.h, w: xsLayout.w, h: xsLayout.h }
+                        : xsLayout
+                        ? { x: xsLayout.x, y: xsLayout.y, w: xsLayout.w, h: xsLayout.h }
+                        : undefined,
                         : xsLayout
                           ? { x: xsLayout.x, y: xsLayout.y, w: xsLayout.w, h: xsLayout.h }
                           : undefined,

--- a/frontend/src/scenes/dashboard/tileLayouts.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.ts
@@ -6,6 +6,104 @@ import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { isFunnelsQuery, isPathsQuery, isRetentionQuery, isTrendsQuery } from '~/queries/utils'
 import { ChartDisplayType, DashboardLayoutSize, DashboardTile, QueryBasedInsightModel } from '~/types'
 
+export interface TileLayout {
+    x: number
+    y: number
+    w: number
+    h: number
+}
+
+export interface DuplicateLayoutResult {
+    duplicateLayouts: { sm?: TileLayout; xs?: TileLayout }
+    tilesToUpdate: Array<{ id: number; layouts: { sm?: TileLayout; xs?: TileLayout } }>
+}
+
+export function calculateDuplicateLayout(
+    currentLayouts: Partial<Record<DashboardLayoutSize, Layout[]>> | null,
+    tileId: number
+): DuplicateLayoutResult {
+    const result: DuplicateLayoutResult = { duplicateLayouts: {}, tilesToUpdate: [] }
+
+    const originalSmLayout = currentLayouts?.sm?.find((l) => String(l.i) === String(tileId))
+    const originalXsLayout = currentLayouts?.xs?.find((l) => String(l.i) === String(tileId))
+
+    if (!originalSmLayout) {
+        return result
+    }
+
+    const { x, y, w, h } = originalSmLayout
+    const columnCount = BREAKPOINT_COLUMN_COUNTS.sm
+
+    const xsLayoutForDuplicate = originalXsLayout
+        ? {
+              x: originalXsLayout.x,
+              y: originalXsLayout.y + originalXsLayout.h,
+              w: originalXsLayout.w,
+              h: originalXsLayout.h,
+          }
+        : undefined
+
+    if (canPlaceToRight(currentLayouts?.sm || [], tileId, x, y, w, h, columnCount)) {
+        result.duplicateLayouts = {
+            sm: { x: x + w, y, w, h },
+            xs: xsLayoutForDuplicate,
+        }
+        return result
+    }
+
+    const insertY = y + h
+    result.duplicateLayouts = {
+        sm: { x, y: insertY, w, h },
+        xs: xsLayoutForDuplicate,
+    }
+
+    for (const smLayout of currentLayouts?.sm || []) {
+        if (String(smLayout.i) === String(tileId) || smLayout.y < insertY) {
+            continue
+        }
+        const xsLayout = currentLayouts?.xs?.find((l) => l.i === smLayout.i)
+        const xsInsertY = originalXsLayout ? originalXsLayout.y + originalXsLayout.h : 0
+        result.tilesToUpdate.push({
+            id: parseInt(smLayout.i),
+            layouts: {
+                sm: { x: smLayout.x, y: smLayout.y + h, w: smLayout.w, h: smLayout.h },
+                xs:
+                    xsLayout && xsLayout.y >= xsInsertY
+                        ? { x: xsLayout.x, y: xsLayout.y + (originalXsLayout?.h || h), w: xsLayout.w, h: xsLayout.h }
+                        : xsLayout
+                          ? { x: xsLayout.x, y: xsLayout.y, w: xsLayout.w, h: xsLayout.h }
+                          : undefined,
+            },
+        })
+    }
+
+    return result
+}
+
+function canPlaceToRight(
+    layouts: Layout[],
+    excludeTileId: number,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    columnCount: number
+): boolean {
+    const rightX = x + w
+    if (rightX + w > columnCount) {
+        return false
+    }
+
+    return !layouts.some((l) => {
+        if (String(l.i) === String(excludeTileId)) {
+            return false
+        }
+        const overlapsX = l.x < rightX + w && l.x + l.w > rightX
+        const overlapsY = l.y < y + h && l.y + l.h > y
+        return overlapsX && overlapsY
+    })
+}
+
 export const sortTilesByLayout = (
     tiles: Array<DashboardTile<QueryBasedInsightModel>>,
     col: DashboardLayoutSize

--- a/frontend/src/scenes/dashboard/tileLayouts.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.ts
@@ -71,9 +71,6 @@ export function calculateDuplicateLayout(
                     xsLayout && xsInsertY !== undefined && xsLayout.y >= xsInsertY
                         ? { x: xsLayout.x, y: xsLayout.y + originalXsLayout!.h, w: xsLayout.w, h: xsLayout.h }
                         : xsLayout
-                        ? { x: xsLayout.x, y: xsLayout.y, w: xsLayout.w, h: xsLayout.h }
-                        : undefined,
-                        : xsLayout
                           ? { x: xsLayout.x, y: xsLayout.y, w: xsLayout.w, h: xsLayout.h }
                           : undefined,
             },

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -472,7 +472,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
         duplicate_tiles = initial_data.pop("duplicate_tiles", [])
         for tile_data in duplicate_tiles:
             existing_tile = DashboardTile.objects.get(dashboard=instance, id=tile_data["id"])
-            existing_tile.layouts = {}
+            existing_tile.layouts = tile_data.get("layouts", {})
             self._deep_duplicate_tiles(instance, existing_tile)
 
         if "request" in self.context:


### PR DESCRIPTION
when you duplicate a tile on a long dashboard you think it has failed because it pops the duplicate at the very bottom

instead now

 * the front end calculates a layout that places the tile to the right or below depending on space
 * sends that in the duplicate API call

(my machine was running too much so the app was running slowly while recording this gif 😅 )

![CleanShot 2026-01-22 at 08 18 15](https://github.com/user-attachments/assets/6f51931a-49a7-4db0-888d-b39f2b670745)
