### PR TITLE
fix(ci): fix node ci

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -259,6 +259,9 @@ jobs:
                   # Run Rust migrations for test databases
                   cd nodejs && pnpm run setup:test:rust
 
+                  # Set up ClickHouse test database and schema
+                  cd .. && TEST=1 SECRET_KEY='abcdef' python manage.py setup_test_environment --only-clickhouse
+
             - name: Set up databases (slow path - run migrations)
               if: github.event_name != 'pull_request' || steps.check_migrations.outputs.has_migrations == 'true'
               env:

--- a/posthog/management/commands/setup_test_environment.py
+++ b/posthog/management/commands/setup_test_environment.py
@@ -32,16 +32,20 @@ class Command(BaseCommand):
         parser.add_argument(
             "--only-postgres", action="store_true", help="Only set up the Postgres database", default=False
         )
+        parser.add_argument(
+            "--only-clickhouse", action="store_true", help="Only set up the ClickHouse database", default=False
+        )
 
     def handle(self, *args, **options):
         if not TEST:
             raise ValueError("TEST environment variable needs to be set for this command to function")
 
-        disable_migrations()
+        if not options["only_clickhouse"]:
+            disable_migrations()
 
-        test_runner = TestRunner(interactive=False)
-        test_runner.setup_databases()
-        test_runner.setup_test_environment()
+            test_runner = TestRunner(interactive=False)
+            test_runner.setup_databases()
+            test_runner.setup_test_environment()
 
         if options["only_postgres"]:
             print("Only setting up Postgres database")  # noqa: T201


### PR DESCRIPTION
 ### Description:                                                                                                  
                                                                                                                
The CI fast path introduced in #45648 skips setup_test_environment.py and only restores Postgres schema + runsRust migrations. This causes all Node.js tests to fail with Database posthog_test does not exist because     
ClickHouse setup was never run.                                                                               
                                                                                                                
  Changes:                                                                                                      
  - Add --only-clickhouse flag to setup_test_environment.py to set up ClickHouse without re-running Postgres    
  setup                                                                                                         
  - Call it in the CI fast path after Rust migrations                                                           
                                                              