### PR TITLE
fix: remove deprecated authenticate_secondarily

### DIFF
--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -51,7 +51,7 @@ from posthog.auth import (
     PersonalAPIKeyAuthentication,
     SessionAuthentication,
     TemporaryTokenAuthentication,
-    authenticate_secondarily,
+    session_auth_required,
 )
 from posthog.constants import PERMITTED_FORUM_DOMAINS
 from posthog.email import is_email_available
@@ -772,7 +772,7 @@ class UserViewSet(
         return Response({"success": True})
 
 
-@authenticate_secondarily
+@session_auth_required
 def get_toolbar_preloaded_flags(request):
     """Retrieve cached feature flags for toolbar"""
     toolbar_flags_key = request.GET.get("key")
@@ -800,7 +800,7 @@ def get_toolbar_preloaded_flags(request):
     return JsonResponse({"featureFlags": feature_flags})
 
 
-@authenticate_secondarily
+@session_auth_required
 @require_http_methods(["POST"])
 def prepare_toolbar_preloaded_flags(request):
     """
@@ -851,7 +851,7 @@ def prepare_toolbar_preloaded_flags(request):
         return JsonResponse({"error": "Invalid request"}, status=400)
 
 
-@authenticate_secondarily
+@session_auth_required
 def redirect_to_site(request):
     REDIRECT_TO_SITE_COUNTER.inc()
     team = request.user.team
@@ -903,7 +903,7 @@ def redirect_to_site(request):
         return redirect("{}#__posthog={}".format(app_url, state))
 
 
-@authenticate_secondarily
+@session_auth_required
 def redirect_to_website(request):
     team = request.user.team
     app_url = request.GET.get("appUrl") or (team.app_urls and team.app_urls[0])
@@ -966,7 +966,7 @@ def redirect_to_website(request):
 
 
 @require_http_methods(["POST"])
-@authenticate_secondarily
+@session_auth_required
 def test_slack_webhook(request):
     """Test webhook."""
     try:

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -575,23 +575,20 @@ class WidgetAuthentication(authentication.BaseAuthentication):
         return (None, team)
 
 
-def authenticate_secondarily(endpoint):
+def session_auth_required(endpoint):
     """
-    DEPRECATED: Used for supporting legacy endpoints not on DRF.
-    Authentication for function views.
+    DEPRECATED: Require session authentication for function-based views.
+
+    Returns 401 if user is not authenticated via session.
     """
 
     @functools.wraps(endpoint)
     def wrapper(request: HttpRequest):
         if not request.user.is_authenticated:
-            try:
-                auth_result = PersonalAPIKeyAuthentication().authenticate(request)
-                if isinstance(auth_result, tuple) and auth_result[0].__class__.__name__ == "User":
-                    request.user = auth_result[0]
-                else:
-                    raise AuthenticationFailed("Authentication credentials were not provided.")
-            except AuthenticationFailed as e:
-                return JsonResponse({"detail": e.detail}, status=401)
+            return JsonResponse(
+                {"detail": "Authentication credentials were not provided."},
+                status=401,
+            )
         return endpoint(request)
 
     return wrapper


### PR DESCRIPTION
## Problem
`@authenticate_secondarily` is a legacy decorator that adds Personal API Key fallback auth to plain Django function views. It was originally added for Zapier integration (https://github.com/PostHog/posthog/pull/1281), but these specific endpoints (`redirect_to_site`, `redirect_to_website`, `test_slack_webhook`, `prepare_toolbar_preloaded_flags`, `get_toolbar_preloaded_flags`)  are used only in Toolbar/Settings and only need session auth. 

## Changes
- Added a new `@session_auth_required` decorator
- Replaced `authenticate_secondarily` with `@session_auth_required`

## How did you test this code?
Tests