### PR TITLE
feat(ci): Skip SQL snapshot update when no-snapshot-update label on PR

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -149,6 +149,9 @@ jobs:
                   if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
                     echo "mode=check" >> $GITHUB_OUTPUT
                     echo "Fork detected - running in CHECK mode (no commits allowed)"
+                  elif [ "${{ contains(github.event.pull_request.labels.*.name, 'no-snapshot-update') }}" == "true" ]; then
+                    echo "mode=check" >> $GITHUB_OUTPUT
+                    echo "::notice::🔍 Running in CHECK mode - 'no-snapshot-update' label detected"
                   else
                     AUTHOR="${{ github.actor }}"
                     echo "Workflow triggered by: $AUTHOR"


### PR DESCRIPTION
## Problem

snapshot update causing lot of changes to be automatically added to PR.
It makes the reviewing HogQL PRs way harder.

## Changes

Only run the checks

## How did you test this code?

Created this PR in no-snapshot-update mode
