### PR TITLE
feat(workflows): Allow linking to workflow templates like we can for dashboard templates

### DIFF
--- a/frontend/src/scenes/dashboard/newDashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/newDashboardLogic.ts
@@ -270,12 +270,12 @@ export const newDashboardLogic = kea<newDashboardLogicType>([
     })),
     actionToUrl({
         hideNewDashboardModal: () => {
-            const hashParams = router.values.hashParams
+            const hashParams = { ...router.values.hashParams }
             delete hashParams['newDashboard']
             return [router.values.location.pathname, router.values.searchParams, hashParams]
         },
         showNewDashboardModal: () => {
-            const hashParams = router.values.hashParams
+            const hashParams = { ...router.values.hashParams }
             hashParams['newDashboard'] = 'modal'
             return [router.values.location.pathname, router.values.searchParams, hashParams]
         },

--- a/products/workflows/frontend/Workflows/newWorkflowLogic.test.ts
+++ b/products/workflows/frontend/Workflows/newWorkflowLogic.test.ts
@@ -1,0 +1,73 @@
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { newWorkflowLogic } from './newWorkflowLogic'
+
+describe('newWorkflowLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    describe('urlToAction', () => {
+        it('opens modal when navigating to /workflows with #newWorkflow hash param', async () => {
+            const logic = newWorkflowLogic()
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                router.actions.push('/workflows', {}, { newWorkflow: 'modal' })
+            })
+                .toDispatchActions(['showNewWorkflowModal'])
+                .toMatchValues({
+                    newWorkflowModalVisible: true,
+                })
+        })
+
+        it('opens modal when navigating to /workflows/:tab with #newWorkflow hash param', async () => {
+            const logic = newWorkflowLogic()
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                router.actions.push('/workflows/library', {}, { newWorkflow: 'modal' })
+            })
+                .toDispatchActions(['showNewWorkflowModal'])
+                .toMatchValues({
+                    newWorkflowModalVisible: true,
+                })
+        })
+
+        it('does not open modal when hash param is missing', async () => {
+            const logic = newWorkflowLogic()
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                router.actions.push('/workflows', {}, {})
+            }).toNotHaveDispatchedActions(['showNewWorkflowModal'])
+
+            expect(logic.values.newWorkflowModalVisible).toBe(false)
+        })
+    })
+
+    describe('actionToUrl', () => {
+        it('adds newWorkflow hash param when showing modal', () => {
+            const logic = newWorkflowLogic()
+            logic.mount()
+
+            router.actions.push('/workflows', {}, {})
+            logic.actions.showNewWorkflowModal()
+
+            expect(router.values.hashParams).toHaveProperty('newWorkflow', 'modal')
+        })
+
+        it('removes newWorkflow hash param when hiding modal', () => {
+            const logic = newWorkflowLogic()
+            logic.mount()
+
+            router.actions.push('/workflows', {}, { newWorkflow: 'modal' })
+            logic.actions.hideNewWorkflowModal()
+
+            expect(router.values.hashParams).not.toHaveProperty('newWorkflow')
+        })
+    })
+})

--- a/products/workflows/frontend/Workflows/newWorkflowLogic.ts
+++ b/products/workflows/frontend/Workflows/newWorkflowLogic.ts
@@ -1,5 +1,5 @@
 import { actions, kea, listeners, path, reducers } from 'kea'
-import { router } from 'kea-router'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { urls } from 'scenes/urls'
 
@@ -33,4 +33,28 @@ export const newWorkflowLogic = kea<newWorkflowLogicType>([
             router.actions.push(urls.workflowNew())
         },
     })),
+    urlToAction(({ actions }) => ({
+        '/workflows': (_, _searchParams, hashParams) => {
+            if ('newWorkflow' in hashParams) {
+                actions.showNewWorkflowModal()
+            }
+        },
+        '/workflows/:tab': (_, _searchParams, hashParams) => {
+            if ('newWorkflow' in hashParams) {
+                actions.showNewWorkflowModal()
+            }
+        },
+    })),
+    actionToUrl({
+        hideNewWorkflowModal: () => {
+            const hashParams = router.values.hashParams
+            delete hashParams['newWorkflow']
+            return [router.values.location.pathname, router.values.searchParams, hashParams]
+        },
+        showNewWorkflowModal: () => {
+            const hashParams = router.values.hashParams
+            hashParams['newWorkflow'] = 'modal'
+            return [router.values.location.pathname, router.values.searchParams, hashParams]
+        },
+    }),
 ])

--- a/products/workflows/frontend/Workflows/newWorkflowLogic.ts
+++ b/products/workflows/frontend/Workflows/newWorkflowLogic.ts
@@ -47,12 +47,12 @@ export const newWorkflowLogic = kea<newWorkflowLogicType>([
     })),
     actionToUrl({
         hideNewWorkflowModal: () => {
-            const hashParams = router.values.hashParams
+            const hashParams = { ...router.values.hashParams }
             delete hashParams['newWorkflow']
             return [router.values.location.pathname, router.values.searchParams, hashParams]
         },
         showNewWorkflowModal: () => {
-            const hashParams = router.values.hashParams
+            const hashParams = { ...router.values.hashParams }
             hashParams['newWorkflow'] = 'modal'
             return [router.values.location.pathname, router.values.searchParams, hashParams]
         },

--- a/products/workflows/frontend/Workflows/templates/workflowTemplatesLogic.test.ts
+++ b/products/workflows/frontend/Workflows/templates/workflowTemplatesLogic.test.ts
@@ -1,0 +1,39 @@
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { workflowTemplatesLogic } from './workflowTemplatesLogic'
+
+describe('workflowTemplatesLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    describe('urlToAction', () => {
+        it('sets template filter based on searchParams', async () => {
+            const logic = workflowTemplatesLogic()
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                router.actions.push('/workflows', { templateFilter: 'test search' }, {})
+            })
+                .toDispatchActions(['setTemplateFilter'])
+                .toMatchValues({
+                    templateFilter: 'test search',
+                })
+        })
+    })
+
+    describe('actionToUrl', () => {
+        it('sets URL based on template filter', () => {
+            const logic = workflowTemplatesLogic()
+            logic.mount()
+
+            router.actions.push('/workflows', {}, {})
+            logic.actions.setTemplateFilter('my filter')
+
+            expect(router.values.searchParams).toHaveProperty('templateFilter', 'my filter')
+        })
+    })
+})

--- a/products/workflows/frontend/Workflows/templates/workflowTemplatesLogic.ts
+++ b/products/workflows/frontend/Workflows/templates/workflowTemplatesLogic.ts
@@ -1,6 +1,7 @@
 import FuseClass from 'fuse.js'
 import { actions, afterMount, kea, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
 
@@ -65,6 +66,23 @@ export const workflowTemplatesLogic = kea<workflowTemplatesLogicType>([
             },
         ],
     }),
+    urlToAction(({ actions }) => ({
+        '/workflows': (_, searchParams) => {
+            if (searchParams.templateFilter) {
+                actions.setTemplateFilter(searchParams.templateFilter)
+            }
+        },
+    })),
+    actionToUrl(({ values }) => ({
+        setTemplateFilter: () => {
+            const searchParams = { ...router.values.searchParams }
+            searchParams.templateFilter = values.templateFilter
+            if (!values.templateFilter) {
+                delete searchParams.templateFilter
+            }
+            return ['/workflows', searchParams, router.values.hashParams, { replace: true }]
+        },
+    })),
     afterMount(({ actions }) => {
         actions.loadWorkflowTemplates()
     }),


### PR DESCRIPTION
## Problem

We want to link to specific workflow templates from our docs

## Changes

* Sync workflow template filter with url
* Open "New Workflow" modal when the hashtag param `newWorkflow` is present

<img width="1103" height="500" alt="image" src="https://github.com/user-attachments/assets/cde6479b-ac33-45d1-bc69-6e7c627b203d" />


## How did you test this code?

Manually and automatically
