### PR TITLE
fix(filters): values breakdown for dw tables

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -33,6 +33,7 @@ export interface PropertyFiltersProps {
     showNestedArrow?: boolean
     eventNames?: string[]
     schemaColumns?: DatabaseSchemaField[]
+    dataWarehouseTableName?: string
     logicalRowDivider?: boolean
     orFiltering?: boolean
     propertyGroupType?: FilterLogicalOperator | null
@@ -67,6 +68,7 @@ export function PropertyFilters({
     showNestedArrow = false,
     eventNames = [],
     schemaColumns = [],
+    dataWarehouseTableName,
     orFiltering = false,
     logicalRowDivider = false,
     propertyGroupType = null,
@@ -143,6 +145,7 @@ export function PropertyFilters({
                                             metadataSource={metadataSource}
                                             eventNames={eventNames}
                                             schemaColumns={schemaColumns}
+                                            dataWarehouseTableName={dataWarehouseTableName}
                                             propertyGroupType={propertyGroupType}
                                             disablePopover={disablePopover || orFiltering}
                                             addText={addText}

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -23,8 +23,9 @@ import {
     TaxonomicFilterGroupType,
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
-import { isOperatorMulti, isOperatorRegex } from 'lib/utils'
+import { isOperatorMulti, isOperatorRegex, toParams } from 'lib/utils'
 import { dataWarehouseJoinsLogic } from 'scenes/data-warehouse/external/dataWarehouseJoinsLogic'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import {
@@ -58,6 +59,7 @@ export function TaxonomicPropertyFilter({
     taxonomicGroupTypes,
     eventNames,
     schemaColumns,
+    dataWarehouseTableName,
     propertyGroupType,
     orFiltering,
     addText = 'Add filter',
@@ -120,6 +122,7 @@ export function TaxonomicPropertyFilter({
 
     const { propertyDefinitionsByType } = useValues(propertyDefinitionsModel)
     const { columnsJoinedToPersons } = useValues(dataWarehouseJoinsLogic)
+    const { currentTeamId } = useValues(teamLogic)
 
     // We don't support array filter values here. Multiple-cohort only supported in TaxonomicBreakdownFilter.
     // This is mostly to make TypeScript happy.
@@ -166,7 +169,17 @@ export function TaxonomicPropertyFilter({
             operator={isPropertyFilterWithOperator(filter) ? filter.operator : null}
             value={filter?.value}
             placeholder="Enter value..."
-            endpoint={filter?.key && activeTaxonomicGroup?.valuesEndpoint?.(filter.key)}
+            endpoint={
+                filter?.key &&
+                filter?.type === PropertyFilterType.DataWarehouse &&
+                dataWarehouseTableName &&
+                currentTeamId
+                    ? `api/environments/${currentTeamId}/data_warehouse/property_values?${toParams({
+                          table_name: dataWarehouseTableName,
+                          key: filter.key,
+                      })}`
+                    : filter?.key && activeTaxonomicGroup?.valuesEndpoint?.(filter.key)
+            }
             eventNames={eventNames}
             addRelativeDateTimeOptions={allowRelativeDateOptions}
             onChange={(newOperator, newValue) => {

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -51,6 +51,7 @@ export interface PropertyFilterInternalProps {
     propertyAllowList?: AllowedProperties
     eventNames?: string[]
     schemaColumns?: DatabaseSchemaField[]
+    dataWarehouseTableName?: string
     propertyGroupType?: FilterLogicalOperator | null
     orFiltering?: boolean
     addText?: string | null

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -798,7 +798,9 @@ export function ActionFilterRow({
                                 : []
                         }
                         dataWarehouseTableName={
-                            filter.type == TaxonomicFilterGroupType.DataWarehouse ? filter.name : undefined
+                            filter.type == TaxonomicFilterGroupType.DataWarehouse
+                                ? (filter.name ?? undefined)
+                                : undefined
                         }
                         addFilterDocLink={addFilterDocLink}
                         excludedProperties={excludedProperties}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -797,6 +797,9 @@ export function ActionFilterRow({
                                 ? Object.values(dataWarehouseTablesMap[filter.name]?.fields ?? [])
                                 : []
                         }
+                        dataWarehouseTableName={
+                            filter.type == TaxonomicFilterGroupType.DataWarehouse ? filter.name : undefined
+                        }
                         addFilterDocLink={addFilterDocLink}
                         excludedProperties={excludedProperties}
                     />

--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -57,7 +57,7 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         if key not in columns:
             raise serializers.ValidationError("The provided key does not exist on this table")
 
-        chain = key.split(".")
+        chain: list[str | int] = key.split(".")
         conditions: list[ast.Expr] = [
             ast.CompareOperation(
                 op=ast.CompareOperationOp.NotEq,

--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -7,19 +7,24 @@ from django.db.models.functions import TruncDate, TruncHour
 
 import structlog
 from dateutil import parser
-from rest_framework import status, viewsets
+from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
+
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.batch_exports.models import BatchExportRun
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.models.hog_functions.hog_function import HogFunction, HogFunctionState, HogFunctionType
+from posthog.utils import convert_property_value, flatten
 
 from products.data_warehouse.backend.models import ExternalDataJob, ExternalDataSchema, ExternalDataSource
 from products.data_warehouse.backend.models.data_modeling_job import DataModelingJob
 from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.data_warehouse.backend.models.util import get_view_or_table_by_name
 
 from ee.billing.billing_manager import BillingManager
 
@@ -32,6 +37,68 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     """
 
     scope_object = "INTERNAL"
+
+    @action(methods=["GET"], detail=False, required_scopes=["query:read"])
+    def property_values(self, request: Request, **kwargs) -> Response:
+        key = request.GET.get("key")
+        table_name = request.GET.get("table_name")
+        value = request.GET.get("value")
+
+        if not key:
+            raise serializers.ValidationError("You must provide a key")
+        if not table_name:
+            raise serializers.ValidationError("You must provide a table name")
+
+        table = get_view_or_table_by_name(self.team, table_name)
+        if table is None:
+            return Response(status=status.HTTP_404_NOT_FOUND, data={"error": "Data warehouse table not found"})
+
+        columns = table.columns or table.get_columns()
+        if key not in columns:
+            raise serializers.ValidationError("The provided key does not exist on this table")
+
+        chain = key.split(".")
+        conditions: list[ast.Expr] = [
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.NotEq,
+                left=ast.Field(chain=chain),
+                right=ast.Constant(value=None),
+            )
+        ]
+
+        if value:
+            conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.ILike,
+                    left=ast.Call(name="toString", args=[ast.Field(chain=chain)]),
+                    right=ast.Constant(value=f"%{value}%"),
+                )
+            )
+
+        order_by = []
+        if value:
+            order_by = [
+                ast.OrderExpr(
+                    expr=ast.Call(name="length", args=[ast.Call(name="toString", args=[ast.Field(chain=chain)])]),
+                    order="ASC",
+                )
+            ]
+
+        query = ast.SelectQuery(
+            select=[ast.Field(chain=chain)],
+            distinct=True,
+            select_from=ast.JoinExpr(table=ast.Field(chain=table.name_chain)),
+            where=ast.And(exprs=conditions),
+            order_by=order_by,
+            limit=ast.Constant(value=10),
+        )
+
+        result = execute_hogql_query(query, team=self.team)
+
+        values = [row[0] for row in result.results]
+        response = Response([{"name": convert_property_value(value)} for value in flatten(values)])
+        response["Cache-Control"] = "max-age=10"
+        return response
 
     @action(methods=["GET"], detail=False)
     def total_rows_stats(self, request: Request, **kwargs) -> Response:

--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import cast
 from zoneinfo import ZoneInfo
 
 from django.db import connection
@@ -57,7 +58,7 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         if key not in columns:
             raise serializers.ValidationError("The provided key does not exist on this table")
 
-        chain: list[str | int] = key.split(".")
+        chain: list[str | int] = cast(list[str | int], key.split("."))
         conditions: list[ast.Expr] = [
             ast.CompareOperation(
                 op=ast.CompareOperationOp.NotEq,
@@ -87,7 +88,7 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         query = ast.SelectQuery(
             select=[ast.Field(chain=chain)],
             distinct=True,
-            select_from=ast.JoinExpr(table=ast.Field(chain=table.name_chain)),
+            select_from=ast.JoinExpr(table=ast.Field(chain=cast(list[str | int], table.name_chain))),
             where=ast.And(exprs=conditions),
             order_by=order_by,
             limit=ast.Constant(value=10),


### PR DESCRIPTION
## Problem

Data warehouse tables couldn't show property value autocomplete:

![2026-01-22 11 43 02](https://github.com/user-attachments/assets/3d87529c-d52b-44a5-b648-5af576973b47)

## Changes

Adds it:

![2026-01-22 11 45 20](https://github.com/user-attachments/assets/6c5dbefe-3c00-4dc9-b030-9fa4b517924b)


## How did you test this code?

Clicked around, added a backend test.