### PR TITLE
fix(sql-editor): underline selected columns

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -1130,12 +1130,14 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
         ],
         selectedQueryColumns: [
             (s) => [s.queryInput],
-            (queryInput: string | null): string[] => {
+            (queryInput: string | null): Record<string, boolean> => {
                 const tablesAndColumns = parseQueryTablesAndColumns(queryInput)
 
-                return Object.entries(tablesAndColumns).flatMap(([table, columns]) => {
-                    return Object.keys(columns).map((column) => `${table}.${column}`)
-                })
+                return Object.fromEntries(
+                    Object.entries(tablesAndColumns).flatMap(([table, columns]) => {
+                        return Object.keys(columns).map((column) => [`${table}.${column}`, true])
+                    })
+                )
             },
             { resultEqualityCheck: objectsEqual },
         ],

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -16,7 +16,7 @@ import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { initModel } from 'lib/monaco/CodeEditor'
 import { codeEditorLogic } from 'lib/monaco/codeEditorLogic'
-import { removeUndefinedAndNull } from 'lib/utils'
+import { objectsEqual, removeUndefinedAndNull } from 'lib/utils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { parseQueryTablesAndColumns } from 'scenes/data-warehouse/editor/sql-utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -1127,6 +1127,17 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             (queryInput: string | null): Record<string, Record<string, boolean>> => {
                 return parseQueryTablesAndColumns(queryInput)
             },
+        ],
+        selectedQueryColumns: [
+            (s) => [s.queryInput],
+            (queryInput: string | null): string[] => {
+                const tablesAndColumns = parseQueryTablesAndColumns(queryInput)
+
+                return Object.entries(tablesAndColumns).flatMap(([table, columns]) => {
+                    return Object.keys(columns).map((column) => `${table}.${column}`)
+                })
+            },
+            { resultEqualityCheck: objectsEqual },
         ],
     }),
     tabAwareActionToUrl(({ values }) => ({

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -53,7 +53,6 @@ export const QueryDatabase = (): JSX.Element => {
     const { setQueryInput } = useActions(multitabEditorLogic)
     const { selectedQueryColumns } = useValues(multitabEditorLogic)
     const builtTabLogic = useMountedLogic(multitabEditorLogic)
-    const selectedColumnKeys = new Set(selectedQueryColumns)
 
     const treeRef = useRef<LemonTreeRef>(null)
     useEffect(() => {
@@ -121,7 +120,7 @@ export const QueryDatabase = (): JSX.Element => {
                                         ].includes(item.record?.type) && 'font-semibold',
                                         item.record?.type === 'column' && 'font-mono text-xs',
                                         item.record?.type === 'column' &&
-                                            selectedColumnKeys.has(`${item.record.table}.${item.record.columnName}`) &&
+                                            selectedQueryColumns[`${item.record.table}.${item.record.columnName}`] &&
                                             'underline underline-offset-2',
                                         'truncate'
                                     )}

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -51,7 +51,9 @@ export const QueryDatabase = (): JSX.Element => {
     const { deleteJoin } = useActions(dataWarehouseSettingsLogic)
     const { deleteDraft } = useActions(draftsLogic)
     const { setQueryInput } = useActions(multitabEditorLogic)
+    const { selectedQueryColumns } = useValues(multitabEditorLogic)
     const builtTabLogic = useMountedLogic(multitabEditorLogic)
+    const selectedColumnKeys = new Set(selectedQueryColumns)
 
     const treeRef = useRef<LemonTreeRef>(null)
     useEffect(() => {
@@ -118,6 +120,9 @@ export const QueryDatabase = (): JSX.Element => {
                                             'endpoints',
                                         ].includes(item.record?.type) && 'font-semibold',
                                         item.record?.type === 'column' && 'font-mono text-xs',
+                                        item.record?.type === 'column' &&
+                                            selectedColumnKeys.has(`${item.record.table}.${item.record.columnName}`) &&
+                                            'underline underline-offset-2',
                                         'truncate'
                                     )}
                                 >


### PR DESCRIPTION
## Problem

The [quick fix of yesterday](https://github.com/PostHog/posthog/pull/45548) removed the ability to underline/highlight columns in the query.

## Changes

Works again, this time without killing performance:

![2026-01-22 11 57 14](https://github.com/user-attachments/assets/8d5dd115-f9b8-4f65-9d79-4c79f20a9b78)


## How did you test this code?

Clicked around, made long queries and had a large list of tables open --> it was still fast.
