### PR TITLE
fix(workflows): handle MAIL FROM errors gracefully in email verification

### DIFF
--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -120,9 +120,11 @@ class SESProvider:
                 MailFromDomain=f"{mail_from_subdomain}.{domain}",
                 BehaviorOnMXFailure="UseDefaultValue",
             )
-        except (ClientError, BotoCoreError) as e:
+        except ClientError as e:
             # Log but continue - MAIL FROM is optional and shouldn't block verification
             # SES will fall back to default MAIL FROM domain (amazonses.com)
+            # Note: BotoCoreError (network issues) should propagate - if we can't reach AWS,
+            # the status checks below will also fail
             logger.warning(f"Failed to set MAIL FROM domain for {domain}: {e}")
 
         ses_region = getattr(settings, "SES_REGION", "us-east-1")

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -115,14 +115,15 @@ class SESProvider:
 
         # Start/ensure MAIL FROM setup (MX + TXT) ---
         try:
-            resp = self.ses_client.set_identity_mail_from_domain(
+            self.ses_client.set_identity_mail_from_domain(
                 Identity=domain,
                 MailFromDomain=f"{mail_from_subdomain}.{domain}",
                 BehaviorOnMXFailure="UseDefaultValue",
             )
-        except ClientError as e:
-            if e.response["Error"]["Code"] not in ("InvalidParameterValue",):
-                raise
+        except (ClientError, BotoCoreError) as e:
+            # Log but continue - MAIL FROM is optional and shouldn't block verification
+            # SES will fall back to default MAIL FROM domain (amazonses.com)
+            logger.warning(f"Failed to set MAIL FROM domain for {domain}: {e}")
 
         ses_region = getattr(settings, "SES_REGION", "us-east-1")
 


### PR DESCRIPTION
## Summary                                                                                                    
                                                                                                                
- Fixes 500 errors on `/api/environments/{id}/integrations/{id}/email/verify/` endpoint                       
- The recent MAIL FROM feature (#45212) introduced a bug where `set_identity_mail_from_domain` errors would crash verification                                                                                            
- Changed error handling to log warnings and continue instead of re-raising 
- MAIL FROM is optional and SES falls back to `amazonses.com`