### PR TITLE
fix: single worker per pod

### DIFF
--- a/services/llm-gateway/Dockerfile
+++ b/services/llm-gateway/Dockerfile
@@ -38,7 +38,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
 
 CMD ["gunicorn", "llm_gateway.main:app", \
      "--bind", "0.0.0.0:8080", \
-     "--workers", "2", \
+     "--workers", "1", \
      "--worker-class", "uvicorn.workers.UvicornWorker", \
      "--access-logfile", "-", \
      "--error-logfile", "-"]


### PR DESCRIPTION
the service is mostly I/O bound, so we don’t need multiple workers per pod here, we can scale smaller pods instead.