### PR TITLE
fix(llma): parse clustering run ID timestamps as UTC

### DIFF
--- a/frontend/src/lib/dayjs.ts
+++ b/frontend/src/lib/dayjs.ts
@@ -1,5 +1,6 @@
 // oxlint-disable-next-line no-restricted-imports
 import dayjs, { Dayjs as DayjsOriginal, isDayjs } from 'dayjs'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
 import duration from 'dayjs/plugin/duration'
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
@@ -11,6 +12,8 @@ import updateLocale from 'dayjs/plugin/updateLocale'
 import utc from 'dayjs/plugin/utc'
 import weekOfYear from 'dayjs/plugin/weekOfYear'
 
+// necessary for parsing custom date formats like 'YYYYMMDD_HHmmss'
+dayjs.extend(customParseFormat)
 // necessary for any localized date formatting to work
 dayjs.extend(LocalizedFormat)
 dayjs.extend(relativeTime)

--- a/products/llm_analytics/frontend/clusters/types.test.ts
+++ b/products/llm_analytics/frontend/clusters/types.test.ts
@@ -1,0 +1,38 @@
+import { getTimestampBoundsFromRunId } from './types'
+
+describe('getTimestampBoundsFromRunId', () => {
+    it.each([
+        // Run ID generated at midnight UTC should return that UTC day's bounds
+        {
+            runId: '2_20260122_000043',
+            expectedDayStart: '2026-01-22 00:00:00',
+            expectedDayEnd: '2026-01-22 23:59:59',
+            description: 'midnight UTC run',
+        },
+        // Run ID generated mid-day UTC
+        {
+            runId: '112495_20260121_033113',
+            expectedDayStart: '2026-01-21 00:00:00',
+            expectedDayEnd: '2026-01-21 23:59:59',
+            description: 'mid-day UTC run',
+        },
+        // Run ID with optional label suffix
+        {
+            runId: '123_20260115_143022_experiment_v2',
+            expectedDayStart: '2026-01-15 00:00:00',
+            expectedDayEnd: '2026-01-15 23:59:59',
+            description: 'run with label suffix',
+        },
+    ])('returns correct UTC day bounds for $description', ({ runId, expectedDayStart, expectedDayEnd }) => {
+        const result = getTimestampBoundsFromRunId(runId)
+        expect(result.dayStart).toBe(expectedDayStart)
+        expect(result.dayEnd).toBe(expectedDayEnd)
+    })
+
+    it('returns fallback bounds for invalid run ID format', () => {
+        const result = getTimestampBoundsFromRunId('invalid_runid')
+        // Should return some valid date range (last 7 days fallback)
+        expect(result.dayStart).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+        expect(result.dayEnd).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+    })
+})

--- a/products/llm_analytics/frontend/clusters/types.ts
+++ b/products/llm_analytics/frontend/clusters/types.ts
@@ -16,8 +16,8 @@ export function getTimestampBoundsFromRunId(runId: string): { dayStart: string; 
         const dateStr = parts[1]
         const timeStr = parts[2]
 
-        // Parse YYYYMMDD_HHMMSS format
-        const parsed = dayjs(`${dateStr}_${timeStr}`, 'YYYYMMDD_HHmmss')
+        // Parse YYYYMMDD_HHMMSS format as UTC (backend generates run_id using workflow.now() which is UTC)
+        const parsed = dayjs.utc(`${dateStr}_${timeStr}`, 'YYYYMMDD_HHmmss')
         if (parsed.isValid()) {
             return {
                 dayStart: parsed.startOf('day').utc().format(dateFormat),


### PR DESCRIPTION
## Problem

LLM Analytics clusters tab shows no data for projects using non-UTC timezones (e.g., US/Pacific) when the clustering workflow runs near midnight UTC.

The clustering run ID is generated using `workflow.now()` on the backend which returns UTC time. The frontend was parsing this date in local time, causing a mismatch: the event timestamp in the project's timezone would fall on a different day than the UTC date encoded in the run_id.

## Changes

- Parse run ID timestamps as UTC using `dayjs.utc()` in `getTimestampBoundsFromRunId`
- Add `customParseFormat` plugin to dayjs (required for custom format parsing)
- Add unit tests for `getTimestampBoundsFromRunId`

## How did you test this code?

- Added unit tests for the timestamp parsing function
- Ran existing cluster tests (61 passed)
- Verified TypeScript check passes

## Publish to changelog?

No