### PR TITLE
fix: console errors on home page load

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelContextLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelContextLogic.ts
@@ -41,10 +41,15 @@ export const sidePanelContextLogic = kea<sidePanelContextLogicType>([
                     const activeSceneLogic = sceneLogic.selectors.activeSceneLogic(state, props)
                     if (activeSceneLogic && SIDE_PANEL_CONTEXT_KEY in activeSceneLogic.selectors) {
                         const activeLoadedScene = sceneLogic.selectors.activeLoadedScene(state, props)
-                        return activeSceneLogic.selectors[SIDE_PANEL_CONTEXT_KEY](
-                            state,
-                            activeLoadedScene?.paramsToProps?.(activeLoadedScene?.sceneParams) || props
-                        )
+                        try {
+                            return activeSceneLogic.selectors[SIDE_PANEL_CONTEXT_KEY](
+                                state,
+                                activeLoadedScene?.paramsToProps?.(activeLoadedScene?.sceneParams) || props
+                            )
+                        } catch {
+                            // Scene logic may not be mounted yet, return null
+                            return null
+                        }
                     }
                     return null
                 },

--- a/frontend/src/layout/scenes/components/SceneBreadcrumbs.tsx
+++ b/frontend/src/layout/scenes/components/SceneBreadcrumbs.tsx
@@ -22,7 +22,7 @@ export function SceneBreadcrumbBackButton({
     const backTo = forceBackTo || breadcrumbs[breadcrumbs.length - 2]
 
     const BackToProps = {
-        ariaLabel: `Go back to ${backTo.name}`,
+        'aria-label': `Go back to ${backTo.name}`,
         to: backTo.path,
     }
 

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -1,7 +1,7 @@
 import { Placement } from '@floating-ui/react'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { useRef, useState } from 'react'
+import { forwardRef, useRef, useState } from 'react'
 
 import { IconCalendar, IconInfo } from '@posthog/icons'
 import { LemonButton, LemonButtonProps, LemonDivider, LemonSwitch, Popover } from '@posthog/lemon-ui'
@@ -68,33 +68,36 @@ interface RawDateFilterProps extends DateFilterProps {
     showExplicitDateToggle?: boolean
 }
 
-export function DateFilter({
-    showCustom,
-    showRollingRangePicker = true,
-    className,
-    disabledReason,
-    makeLabel,
-    onChange,
-    dateFrom,
-    dateTo,
-    dateOptions = dateMapping,
-    isDateFormatted = true,
-    size,
-    type,
-    dropdownPlacement = 'bottom-start',
-    max,
-    isFixedDateMode = false,
-    allowedRollingDateOptions,
-    allowTimePrecision = false,
-    allowFixedRangeWithTime = false,
-    placeholder,
-    fullWidth = false,
-    forceGranularity,
-    use24HourFormat = false,
-    explicitDate,
-    showExplicitDateToggle = false,
-    resolvedDateRange,
-}: RawDateFilterProps): JSX.Element {
+export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(function DateFilter(
+    {
+        showCustom,
+        showRollingRangePicker = true,
+        className,
+        disabledReason,
+        makeLabel,
+        onChange,
+        dateFrom,
+        dateTo,
+        dateOptions = dateMapping,
+        isDateFormatted = true,
+        size,
+        type,
+        dropdownPlacement = 'bottom-start',
+        max,
+        isFixedDateMode = false,
+        allowedRollingDateOptions,
+        allowTimePrecision = false,
+        allowFixedRangeWithTime = false,
+        placeholder,
+        fullWidth = false,
+        forceGranularity,
+        use24HourFormat = false,
+        explicitDate,
+        showExplicitDateToggle = false,
+        resolvedDateRange,
+    },
+    ref
+) {
     const key = useRef(uuid()).current
     const logicProps: DateFilterLogicProps = {
         key,
@@ -317,6 +320,7 @@ export function DateFilter({
             closeParentPopoverOnClickInside={false}
         >
             <LemonButton
+                ref={ref}
                 id="daterange_selector"
                 size={size ?? 'small'}
                 type={type ?? 'secondary'}
@@ -331,4 +335,4 @@ export function DateFilter({
             </LemonButton>
         </Popover>
     )
-}
+})

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -784,11 +784,18 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                 walkTreeItems(data, defaultSelectedFolderOrNodeId)
             }
 
-            // Remove duplicates and update parent state if callback provided
+            // Remove duplicates
             const uniqueIds = [...new Set(ids)]
-            onSetExpandedItemIds && onSetExpandedItemIds(uniqueIds)
             return uniqueIds
         })
+
+        // Notify parent of initial expanded item IDs after mount
+        const initialExpandedIdsRef = useRef(expandedItemIdsState)
+        useEffect(() => {
+            onSetExpandedItemIds?.(initialExpandedIdsRef.current)
+            // Only run once on mount
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [])
 
         // Flatten visible tree items for keyboard navigation
         const getVisibleItems = useCallback((): TreeDataItem[] => {

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -790,9 +790,8 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
         })
 
         // Notify parent of initial expanded item IDs after mount
-        const initialExpandedIdsRef = useRef(expandedItemIdsState)
         useEffect(() => {
-            onSetExpandedItemIds?.(initialExpandedIdsRef.current)
+            onSetExpandedItemIds?.(expandedItemIdsState)
             // Only run once on mount
             // eslint-disable-next-line react-hooks/exhaustive-deps
         }, [])

--- a/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
+++ b/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
@@ -277,6 +277,7 @@ export const ButtonPrimitive = forwardRef<HTMLButtonElement, ButtonPrimitiveProp
         autoHeight,
         inert,
         forceVariant = false,
+        truncate,
         ...rest
     } = props
     // If inside a ButtonGroup, use the context values, otherwise use props
@@ -300,6 +301,7 @@ export const ButtonPrimitive = forwardRef<HTMLButtonElement, ButtonPrimitiveProp
                     isSideActionRight,
                     autoHeight,
                     inert,
+                    truncate,
                     className,
                 })
             ),

--- a/frontend/src/lib/ui/PopoverPrimitive/PopoverPrimitive.tsx
+++ b/frontend/src/lib/ui/PopoverPrimitive/PopoverPrimitive.tsx
@@ -7,9 +7,13 @@ function PopoverPrimitive({ ...props }: React.ComponentProps<typeof PopoverPrimi
     return <PopoverPrimitiveBase.Root data-slot="popover" {...props} />
 }
 
-function PopoverPrimitiveTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitiveBase.Trigger>): JSX.Element {
-    return <PopoverPrimitiveBase.Trigger data-slot="popover-trigger" {...props} />
-}
+const PopoverPrimitiveTrigger = React.forwardRef<
+    React.ComponentRef<typeof PopoverPrimitiveBase.Trigger>,
+    React.ComponentProps<typeof PopoverPrimitiveBase.Trigger>
+>(({ ...props }, ref): JSX.Element => {
+    return <PopoverPrimitiveBase.Trigger ref={ref} data-slot="popover-trigger" {...props} />
+})
+PopoverPrimitiveTrigger.displayName = 'PopoverPrimitiveTrigger'
 
 function PopoverPrimitiveContent({
     className,


### PR DESCRIPTION
- Fix KEA subscription failures in sidePanelContextLogic by wrapping scene selector calls in try-catch to handle unmounted logic
- Fix React setState during render warning in LemonTree by moving parent notification callback to useEffect
- Fix invalid ARIA attribute in SceneBreadcrumbs (ariaLabel -> aria-label)
- Fix non-boolean truncate attribute on ButtonPrimitive by extracting it from props before spreading to DOM
- Add forwardRef support to DateFilter component for AppShortcut refs

a user in their feedback mentioned it eroded trust to see a bunch of errors in the console