### PR TITLE
feat(ph-ai): survey mode

### DIFF
--- a/ee/hogai/chat_agent/mode_manager.py
+++ b/ee/hogai/chat_agent/mode_manager.py
@@ -21,9 +21,14 @@ from ee.hogai.core.agent_modes.presets.product_analytics import (
 )
 from ee.hogai.core.agent_modes.presets.session_replay import chat_agent_plan_session_replay_agent, session_replay_agent
 from ee.hogai.core.agent_modes.presets.sql import chat_agent_plan_sql_agent, sql_agent
+from ee.hogai.core.agent_modes.presets.survey import survey_agent
 from ee.hogai.core.agent_modes.prompt_builder import AgentPromptBuilder
 from ee.hogai.core.agent_modes.toolkit import AgentToolkit, AgentToolkitManager
-from ee.hogai.utils.feature_flags import has_error_tracking_mode_feature_flag, has_plan_mode_feature_flag
+from ee.hogai.utils.feature_flags import (
+    has_error_tracking_mode_feature_flag,
+    has_plan_mode_feature_flag,
+    has_survey_mode_feature_flag,
+)
 from ee.hogai.utils.types.base import AssistantState, NodePath
 
 # Execution and plan mode definitions - fictitious modes used to trigger transition in and out of plan mode
@@ -94,6 +99,8 @@ class ChatAgentModeManager(AgentModeManager):
                 registry[AgentMode.ERROR_TRACKING] = chat_agent_plan_error_tracking_agent
             else:
                 registry[AgentMode.ERROR_TRACKING] = error_tracking_agent
+        if has_survey_mode_feature_flag(self._team, self._user):
+            registry[AgentMode.SURVEY] = survey_agent
         return registry
 
     @property

--- a/ee/hogai/context/survey/__init__.py
+++ b/ee/hogai/context/survey/__init__.py
@@ -1,0 +1,3 @@
+from .context import SurveyContext
+
+__all__ = ["SurveyContext"]

--- a/ee/hogai/context/survey/context.py
+++ b/ee/hogai/context/survey/context.py
@@ -1,0 +1,167 @@
+from posthog.schema import HogQLQuery
+
+from posthog.hogql_queries.query_runner import get_query_runner
+from posthog.models import Survey, Team
+from posthog.sync import database_sync_to_async
+
+from .prompts import SURVEY_CONTEXT_TEMPLATE
+
+
+class SurveyContext:
+    """
+    Context class for surveys used across the assistant.
+
+    Provides methods to fetch survey data and format it for AI consumption.
+    Used by the ReadDataTool to provide survey context.
+    """
+
+    def __init__(
+        self,
+        team: Team,
+        survey_id: str,
+        survey_name: str | None = None,
+    ):
+        self._team = team
+        self._survey_id = survey_id
+        self._survey_name = survey_name
+
+    async def aget_survey(self) -> Survey | None:
+        """Fetch the survey from the database using async."""
+        try:
+            return await Survey.objects.select_related("linked_flag").aget(id=self._survey_id, team=self._team)
+        except Survey.DoesNotExist:
+            return None
+
+    async def aget_response_count(self) -> int:
+        """Get count of responses for this survey."""
+
+        @database_sync_to_async
+        def _get_count() -> int:
+            query = HogQLQuery(
+                query=f"""
+                SELECT count() as count
+                FROM events
+                WHERE event = 'survey sent'
+                AND properties.$survey_id = '{self._survey_id}'
+                """
+            )
+            runner = get_query_runner(query, self._team)
+            result = runner.calculate()
+            if result.results and len(result.results) > 0:
+                return result.results[0][0]
+            return 0
+
+        return await _get_count()
+
+    def format_questions(self, survey: Survey) -> str:
+        """Format survey questions for display."""
+        questions = survey.questions or []
+        if not questions:
+            return "No questions defined."
+
+        lines: list[str] = []
+        for i, question in enumerate(questions, 1):
+            q_type = question.get("type", "unknown")
+            q_text = question.get("question", "Untitled question")
+            q_optional = question.get("optional", False)
+
+            lines.append(f"{i}. **{q_text}**")
+            lines.append(f"   - Type: {q_type}")
+            lines.append(f"   - Optional: {'Yes' if q_optional else 'No'}")
+
+            if q_type == "rating":
+                scale = question.get("scale", 5)
+                display = question.get("display", "number")
+                lines.append(f"   - Scale: 1-{scale} ({display})")
+                lower = question.get("lowerBoundLabel")
+                upper = question.get("upperBoundLabel")
+                if lower or upper:
+                    lines.append(f"   - Labels: {lower or '(none)'} to {upper or '(none)'}")
+
+            elif q_type in ("single_choice", "multiple_choice"):
+                choices = question.get("choices", [])
+                if choices:
+                    lines.append(f"   - Choices: {', '.join(choices)}")
+
+            elif q_type == "link":
+                link = question.get("link")
+                if link:
+                    lines.append(f"   - Link: {link}")
+
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def format_targeting(self, survey: Survey) -> str:
+        """Format targeting configuration."""
+        lines: list[str] = []
+
+        # URL targeting
+        conditions = survey.conditions or {}
+        url_matching = conditions.get("url")
+        if url_matching:
+            lines.append(f"- URL targeting: {url_matching}")
+
+        # Device targeting
+        device_type = conditions.get("device_type")
+        if device_type:
+            lines.append(f"- Device type: {device_type}")
+
+        # Feature flag targeting
+        if survey.linked_flag:
+            lines.append(f"- Linked feature flag: {survey.linked_flag.key} (ID: {survey.linked_flag.id})")
+            linked_flag_variant = conditions.get("linkedFlagVariant")
+            if linked_flag_variant:
+                lines.append(f"  - Variant: {linked_flag_variant}")
+
+        # Wait period
+        wait_period = conditions.get("wait_period")
+        if wait_period:
+            lines.append(f"- Wait period: {wait_period} seconds")
+
+        # Selector targeting
+        selector = conditions.get("selector")
+        if selector:
+            lines.append(f"- CSS selector: {selector}")
+
+        if not lines:
+            return "No specific targeting configured (shows to all users)."
+
+        return "\n".join(lines)
+
+    def _get_status(self, survey: Survey) -> str:
+        """Determine the survey status."""
+        if survey.archived:
+            return "archived"
+        if survey.start_date and not survey.end_date:
+            return "active"
+        if survey.start_date and survey.end_date:
+            return "completed"
+        return "draft"
+
+    async def execute_and_format(self) -> str:
+        """
+        Execute the context gathering and format results for AI consumption.
+
+        Returns a formatted string with all survey context.
+        """
+        survey = await self.aget_survey()
+        if survey is None:
+            return f"Survey with ID '{self._survey_id}' not found."
+
+        survey_name = self._survey_name or survey.name or f"Survey {self._survey_id}"
+        status = self._get_status(survey)
+
+        response_count = await self.aget_response_count()
+        response_summary = f"Total responses: {response_count}"
+
+        return SURVEY_CONTEXT_TEMPLATE.format(
+            survey_id=self._survey_id,
+            survey_name=survey_name,
+            survey_type=survey.type,
+            survey_status=status,
+            survey_description=survey.description or "No description provided.",
+            questions=self.format_questions(survey),
+            targeting=self.format_targeting(survey),
+            response_summary=response_summary,
+        )

--- a/ee/hogai/context/survey/prompts.py
+++ b/ee/hogai/context/survey/prompts.py
@@ -1,0 +1,20 @@
+SURVEY_CONTEXT_TEMPLATE = """
+## Survey: {survey_name}
+
+**Survey ID:** {survey_id}
+**Type:** {survey_type}
+**Status:** {survey_status}
+**Description:** {survey_description}
+
+### Questions
+
+{questions}
+
+### Targeting Configuration
+
+{targeting}
+
+### Response Summary
+
+{response_summary}
+""".strip()

--- a/ee/hogai/context/survey/test/test_context.py
+++ b/ee/hogai/context/survey/test/test_context.py
@@ -1,0 +1,197 @@
+import pytest
+from posthog.test.base import BaseTest
+from unittest.mock import AsyncMock, patch
+
+from posthog.models import Survey
+
+from ee.hogai.context.survey.context import SurveyContext
+
+
+class TestSurveyContext(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.survey = Survey.objects.create(
+            team=self.team,
+            name="Test NPS Survey",
+            description="A test survey for NPS feedback",
+            type="popover",
+            questions=[
+                {
+                    "id": "q1",
+                    "type": "rating",
+                    "question": "How likely are you to recommend us?",
+                    "scale": 10,
+                    "display": "number",
+                    "lowerBoundLabel": "Not likely",
+                    "upperBoundLabel": "Very likely",
+                    "optional": False,
+                },
+                {
+                    "id": "q2",
+                    "type": "open",
+                    "question": "What could we improve?",
+                    "optional": True,
+                },
+            ],
+            conditions={"url": "/pricing", "wait_period": 30},
+        )
+
+    def test_format_questions_rating(self):
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        formatted = context.format_questions(self.survey)
+
+        assert "How likely are you to recommend us?" in formatted
+        assert "Type: rating" in formatted
+        assert "Scale: 1-10 (number)" in formatted
+        assert "Labels: Not likely to Very likely" in formatted
+        assert "Optional: No" in formatted
+
+    def test_format_questions_open(self):
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        formatted = context.format_questions(self.survey)
+
+        assert "What could we improve?" in formatted
+        assert "Type: open" in formatted
+        assert "Optional: Yes" in formatted
+
+    def test_format_questions_empty(self):
+        self.survey.questions = []
+        self.survey.save()
+
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        formatted = context.format_questions(self.survey)
+
+        assert formatted == "No questions defined."
+
+    def test_format_targeting_url(self):
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        formatted = context.format_targeting(self.survey)
+
+        assert "URL targeting: /pricing" in formatted
+
+    def test_format_targeting_wait_period(self):
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        formatted = context.format_targeting(self.survey)
+
+        assert "Wait period: 30 seconds" in formatted
+
+    def test_format_targeting_no_conditions(self):
+        self.survey.conditions = {}
+        self.survey.save()
+
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        formatted = context.format_targeting(self.survey)
+
+        assert formatted == "No specific targeting configured (shows to all users)."
+
+    def test_get_status_draft(self):
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        status = context._get_status(self.survey)
+        assert status == "draft"
+
+    def test_get_status_active(self):
+        from django.utils import timezone
+
+        self.survey.start_date = timezone.now()
+        self.survey.save()
+
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        status = context._get_status(self.survey)
+        assert status == "active"
+
+    def test_get_status_completed(self):
+        from django.utils import timezone
+
+        self.survey.start_date = timezone.now()
+        self.survey.end_date = timezone.now()
+        self.survey.save()
+
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        status = context._get_status(self.survey)
+        assert status == "completed"
+
+    def test_get_status_archived(self):
+        self.survey.archived = True
+        self.survey.save()
+
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        status = context._get_status(self.survey)
+        assert status == "archived"
+
+    @pytest.mark.asyncio
+    async def test_aget_survey(self):
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        survey = await context.aget_survey()
+
+        assert survey is not None
+        assert survey.name == "Test NPS Survey"
+
+    @pytest.mark.asyncio
+    async def test_aget_survey_not_found(self):
+        context = SurveyContext(team=self.team, survey_id="00000000-0000-0000-0000-000000000000")
+        survey = await context.aget_survey()
+
+        assert survey is None
+
+    @pytest.mark.asyncio
+    async def test_execute_and_format(self):
+        with patch.object(SurveyContext, "aget_response_count", new_callable=AsyncMock) as mock_count:
+            mock_count.return_value = 42
+
+            context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+            result = await context.execute_and_format()
+
+            assert "Test NPS Survey" in result
+            assert "popover" in result
+            assert "draft" in result
+            assert "How likely are you to recommend us?" in result
+            assert "Total responses: 42" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_and_format_not_found(self):
+        context = SurveyContext(team=self.team, survey_id="00000000-0000-0000-0000-000000000000")
+        result = await context.execute_and_format()
+
+        assert "not found" in result
+
+
+class TestSurveyContextChoiceQuestions(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.survey = Survey.objects.create(
+            team=self.team,
+            name="Choice Survey",
+            type="popover",
+            questions=[
+                {
+                    "id": "q1",
+                    "type": "single_choice",
+                    "question": "What feature do you use most?",
+                    "choices": ["Dashboard", "Insights", "Session Replay"],
+                    "optional": False,
+                },
+                {
+                    "id": "q2",
+                    "type": "multiple_choice",
+                    "question": "Which products interest you?",
+                    "choices": ["Analytics", "Experiments", "Surveys"],
+                    "optional": True,
+                },
+            ],
+        )
+
+    def test_format_questions_single_choice(self):
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        formatted = context.format_questions(self.survey)
+
+        assert "What feature do you use most?" in formatted
+        assert "Type: single_choice" in formatted
+        assert "Choices: Dashboard, Insights, Session Replay" in formatted
+
+    def test_format_questions_multiple_choice(self):
+        context = SurveyContext(team=self.team, survey_id=str(self.survey.id))
+        formatted = context.format_questions(self.survey)
+
+        assert "Which products interest you?" in formatted
+        assert "Type: multiple_choice" in formatted
+        assert "Choices: Analytics, Experiments, Surveys" in formatted

--- a/ee/hogai/core/agent_modes/presets/survey.py
+++ b/ee/hogai/core/agent_modes/presets/survey.py
@@ -1,0 +1,86 @@
+from typing import TYPE_CHECKING
+
+from posthog.schema import AgentMode
+
+from ee.hogai.core.agent_modes.factory import AgentModeDefinition
+from ee.hogai.core.agent_modes.toolkit import AgentToolkit
+from ee.hogai.tools.todo_write import TodoWriteExample
+
+if TYPE_CHECKING:
+    from ee.hogai.tool import MaxTool
+
+
+POSITIVE_EXAMPLE_CREATE_SURVEY = """
+User: Create an NPS survey for my pricing page
+Assistant: I'll create an NPS survey that appears on your pricing page.
+*Uses create_survey with instructions: "Create an NPS survey that appears on the pricing page"*
+""".strip()
+
+POSITIVE_EXAMPLE_CREATE_SURVEY_REASONING = """
+The assistant used the create_survey tool because:
+1. The user wants to create a new survey with clear requirements
+2. The survey type (NPS) and targeting (pricing page) are specified
+3. This is a straightforward survey creation that doesn't require multiple steps
+""".strip()
+
+POSITIVE_EXAMPLE_ANALYZE_SURVEY = """
+User: What are users saying in the feedback survey?
+Assistant: I'll analyze the survey responses to extract themes and insights.
+*Uses analyze_survey_responses to analyze open-ended responses*
+""".strip()
+
+POSITIVE_EXAMPLE_ANALYZE_SURVEY_REASONING = """
+The assistant used the analyze_survey_responses tool because:
+1. The user wants to understand feedback from survey responses
+2. The tool can extract themes, sentiment, and actionable insights from open-ended questions
+3. This is a straightforward analysis that doesn't require multiple steps
+""".strip()
+
+POSITIVE_EXAMPLE_SURVEY_WITH_FLAG = """
+User: Create a survey for users who have the new-checkout feature flag enabled
+Assistant: I'll first search for the feature flag to get its ID, then create the survey targeting those users.
+*Creates todo list with the following items:*
+1. Search for the new-checkout feature flag to get its ID
+2. Create a survey targeting users with that flag enabled
+*Uses search with kind: "feature_flags" and query: "new-checkout"*
+After getting the flag ID, the assistant uses create_survey with the flag targeting.
+""".strip()
+
+POSITIVE_EXAMPLE_SURVEY_WITH_FLAG_REASONING = """
+The assistant used the todo list because:
+1. The user wants to target a survey based on a feature flag
+2. This requires multiple steps: first find the flag ID, then create the survey
+3. The search tool with feature_flags kind retrieves the flag information
+4. Breaking this into steps ensures the assistant gets the flag ID before creating the survey
+""".strip()
+
+
+class SurveyAgentToolkit(AgentToolkit):
+    POSITIVE_TODO_EXAMPLES = [
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_CREATE_SURVEY,
+            reasoning=POSITIVE_EXAMPLE_CREATE_SURVEY_REASONING,
+        ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_ANALYZE_SURVEY,
+            reasoning=POSITIVE_EXAMPLE_ANALYZE_SURVEY_REASONING,
+        ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_SURVEY_WITH_FLAG,
+            reasoning=POSITIVE_EXAMPLE_SURVEY_WITH_FLAG_REASONING,
+        ),
+    ]
+
+    @property
+    def tools(self) -> list[type["MaxTool"]]:
+        from products.surveys.backend.max_tools import CreateSurveyTool, SurveyAnalysisTool
+
+        tools: list[type[MaxTool]] = [CreateSurveyTool, SurveyAnalysisTool]
+        return tools
+
+
+survey_agent = AgentModeDefinition(
+    mode=AgentMode.SURVEY,
+    mode_description="Specialized mode for creating and analyzing surveys. Create surveys with natural language including targeting by URL, user properties, and feature flags. Analyze survey responses to extract themes, sentiment, and actionable insights.",
+    toolkit_class=SurveyAgentToolkit,
+)

--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -23,7 +23,9 @@ from ee.hogai.artifacts.types import ModelArtifactResult
 from ee.hogai.chat_agent.sql.mixins import HogQLDatabaseMixin
 from ee.hogai.context.context import AssistantContextManager
 from ee.hogai.context.dashboard.context import DashboardContext, DashboardInsightContext
+from ee.hogai.context.error_tracking import ErrorTrackingIssueContext
 from ee.hogai.context.insight.context import InsightContext
+from ee.hogai.context.survey import SurveyContext
 from ee.hogai.tool import MaxTool, ToolMessagesArtifact
 from ee.hogai.tool_errors import MaxToolFatalError, MaxToolRetryableError
 from ee.hogai.tools.read_billing_tool.tool import ReadBillingTool
@@ -96,6 +98,13 @@ class ReadErrorTrackingIssue(BaseModel):
     issue_id: str = Field(description="The UUID of the error tracking issue.")
 
 
+class ReadSurvey(BaseModel):
+    """Retrieves survey details including questions, targeting, and response summary."""
+
+    kind: Literal["survey"] = "survey"
+    survey_id: str = Field(description="The UUID of the survey.")
+
+
 ReadDataQuery = (
     ReadDataWarehouseSchema
     | ReadDataWarehouseTableSchema
@@ -104,6 +113,7 @@ ReadDataQuery = (
     | ReadBillingInfo
     | ReadErrorTrackingIssue
     | ReadArtifact
+    | ReadSurvey
 )
 
 
@@ -154,6 +164,7 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
             ReadDashboard,
             ReadErrorTrackingIssue,
             ReadArtifact,
+            ReadSurvey,
         )
         ReadDataKind = Union[tuple(base_kinds + tuple(kinds))]  # type: ignore[valid-type]
 
@@ -207,6 +218,8 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
                 return await self._read_dashboard(schema.dashboard_id, schema.execute)
             case ReadErrorTrackingIssue() as schema:
                 return await self._read_error_tracking_issue(schema.issue_id), None
+            case ReadSurvey() as schema:
+                return await self._read_survey(schema.survey_id), None
 
     async def _read_insight(
         self, artifact_or_insight_id: str, execute: bool
@@ -394,11 +407,16 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
         return text_result, None
 
     async def _read_error_tracking_issue(self, issue_id: str) -> str:
-        from ee.hogai.context.error_tracking import ErrorTrackingIssueContext
-
         context = ErrorTrackingIssueContext(
             team=self._team,
             issue_id=issue_id,
+        )
+        return await context.execute_and_format()
+
+    async def _read_survey(self, survey_id: str) -> str:
+        context = SurveyContext(
+            team=self._team,
+            survey_id=survey_id,
         )
         return await context.execute_and_format()
 

--- a/ee/hogai/utils/feature_flags.py
+++ b/ee/hogai/utils/feature_flags.py
@@ -94,3 +94,13 @@ def has_plan_mode_feature_flag(team: Team, user: User) -> bool:
         group_properties={"organization": {"id": str(team.organization_id)}},
         send_feature_flag_events=False,
     )
+
+
+def has_survey_mode_feature_flag(team: Team, user: User) -> bool:
+    return posthoganalytics.feature_enabled(
+        "posthog-ai-survey-mode",
+        str(user.distinct_id),
+        groups={"organization": str(team.organization_id)},
+        group_properties={"organization": {"id": str(team.organization_id)}},
+        send_feature_flag_events=False,
+    )

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -313,6 +313,7 @@ export const FEATURE_FLAGS = {
     PAGE_REPORTS_AVERAGE_PAGE_VIEW: 'page-reports-average-page-view', // owner: @jordanm-posthog #team-web-analytics
     PHAI_ERROR_TRACKING_MODE: 'posthog-ai-error-tracking-mode', // owner: #team-posthog-ai
     PHAI_PLAN_MODE: 'phai-plan-mode', // owner: #team-posthog-ai
+    PHAI_SURVEY_MODE: 'posthog-ai-survey-mode', // owner: #team-posthog-ai
     PHAI_TASKS: 'phai-tasks', // owner: #team-array
     PHAI_WEB_SEARCH: 'phai-web-search', // owner: @Twixes #team-posthog-ai
     PRODUCT_ANALYTICS_AI_INSIGHT_ANALYSIS: 'product-analytics-ai-insight-analysis', // owner: #team-analytics-platform, used to show AI analysis section in insights

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -353,7 +353,7 @@
             "type": "object"
         },
         "AgentMode": {
-            "enum": ["product_analytics", "sql", "session_replay", "error_tracking", "plan", "execution"],
+            "enum": ["product_analytics", "sql", "session_replay", "error_tracking", "plan", "execution", "survey"],
             "type": "string"
         },
         "AggregationAxisFormat": {

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -445,6 +445,7 @@ export enum AgentMode {
     ErrorTracking = 'error_tracking',
     Plan = 'plan',
     Execution = 'execution',
+    Survey = 'survey',
 }
 
 export enum SlashCommandName {

--- a/frontend/src/scenes/max/components/ModeSelector.tsx
+++ b/frontend/src/scenes/max/components/ModeSelector.tsx
@@ -144,6 +144,7 @@ interface GetModeOptionsParams {
     deepResearchEnabled: boolean
     webSearchEnabled: boolean
     errorTrackingModeEnabled: boolean
+    surveyModeEnabled: boolean
 }
 
 function getModeOptions({
@@ -151,6 +152,7 @@ function getModeOptions({
     deepResearchEnabled,
     webSearchEnabled,
     errorTrackingModeEnabled,
+    surveyModeEnabled,
 }: GetModeOptionsParams): LemonSelectSection<ModeValue>[] {
     const specialOptions = [
         {
@@ -182,6 +184,9 @@ function getModeOptions({
         if (mode === AgentMode.ErrorTracking && !errorTrackingModeEnabled) {
             return false
         }
+        if (mode === AgentMode.Survey && !surveyModeEnabled) {
+            return false
+        }
         return true
     })
 
@@ -205,13 +210,21 @@ export function ModeSelector(): JSX.Element | null {
     const planModeEnabled = useFeatureFlag('PHAI_PLAN_MODE')
     const webSearchEnabled = useFeatureFlag('PHAI_WEB_SEARCH')
     const errorTrackingModeEnabled = useFeatureFlag('PHAI_ERROR_TRACKING_MODE')
+    const surveyModeEnabled = useFeatureFlag('PHAI_SURVEY_MODE')
 
     const currentValue: ModeValue =
         agentMode && (deepResearchMode ? 'deep_research' : agentMode === AgentMode.Plan ? 'plan' : agentMode)
 
     const modeOptions = useMemo(
-        () => getModeOptions({ planModeEnabled, deepResearchEnabled, webSearchEnabled, errorTrackingModeEnabled }),
-        [planModeEnabled, deepResearchEnabled, webSearchEnabled, errorTrackingModeEnabled]
+        () =>
+            getModeOptions({
+                planModeEnabled,
+                deepResearchEnabled,
+                webSearchEnabled,
+                errorTrackingModeEnabled,
+                surveyModeEnabled,
+            }),
+        [planModeEnabled, deepResearchEnabled, webSearchEnabled, errorTrackingModeEnabled, surveyModeEnabled]
     )
 
     const handleChange = useCallback(

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -609,6 +609,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
         description: 'Create surveys in seconds',
         product: Scene.Surveys,
         icon: iconForType('survey'),
+        modes: [AgentMode.Survey],
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {
                 return 'Created surveys'
@@ -621,6 +622,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
         description: 'Analyze survey responses to extract themes and actionable insights',
         product: Scene.Surveys,
         icon: iconForType('survey'),
+        modes: [AgentMode.Survey],
         displayFormatter: (toolCall) => {
             if (toolCall.status === 'completed') {
                 return 'Analyzed survey responses'
@@ -955,6 +957,12 @@ export const MODE_DEFINITIONS: Record<Exclude<AgentMode, AgentMode.Plan | AgentM
         description: 'Searches and analyzes error tracking issues to help you understand and fix bugs.',
         icon: iconForType('error_tracking'),
         scenes: new Set([Scene.ErrorTracking]),
+    },
+    [AgentMode.Survey]: {
+        name: 'Surveys',
+        description: 'Creates and analyzes surveys to collect user feedback.',
+        icon: iconForType('survey'),
+        scenes: new Set([Scene.Surveys, Scene.Survey]),
     },
 }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -41,6 +41,7 @@ class AgentMode(StrEnum):
     ERROR_TRACKING = "error_tracking"
     PLAN = "plan"
     EXECUTION = "execution"
+    SURVEY = "survey"
 
 
 class AggregationAxisFormat(StrEnum):

--- a/products/surveys/backend/max_tools.py
+++ b/products/surveys/backend/max_tools.py
@@ -2,34 +2,23 @@
 MaxTool for AI-powered survey creation.
 """
 
+from textwrap import dedent
 from typing import Any, Literal
 
 import django.utils.timezone
 
-from asgiref.sync import async_to_sync
-from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field
 
 from posthog.schema import SurveyAnalysisQuestionGroup, SurveyCreationSchema
 
 from posthog.constants import DEFAULT_SURVEY_APPEARANCE
 from posthog.exceptions_capture import capture_exception
-from posthog.models import FeatureFlag, Survey, Team, User
-from posthog.sync import database_sync_to_async
+from posthog.models import Survey, Team
 
-from ee.hogai.chat_agent.taxonomy.agent import TaxonomyAgent
-from ee.hogai.chat_agent.taxonomy.nodes import TaxonomyAgentNode, TaxonomyAgentToolsNode
-from ee.hogai.chat_agent.taxonomy.toolkit import TaxonomyAgentToolkit
-from ee.hogai.chat_agent.taxonomy.tools import TaxonomyTool, ask_user_for_help, base_final_answer
-from ee.hogai.chat_agent.taxonomy.types import TaxonomyAgentState
 from ee.hogai.llm import MaxChatOpenAI
 from ee.hogai.tool import MaxTool
 
-from .prompts import SURVEY_ANALYSIS_SYSTEM_PROMPT, SURVEY_CREATION_SYSTEM_PROMPT
-
-
-class SurveyCreatorArgs(BaseModel):
-    instructions: str = Field(description="Natural language description of the survey to create")
+from .prompts import SURVEY_ANALYSIS_SYSTEM_PROMPT
 
 
 def get_team_survey_config(team: Team) -> dict[str, Any]:
@@ -41,90 +30,218 @@ def get_team_survey_config(team: Team) -> dict[str, Any]:
     }
 
 
+SURVEY_CREATION_TOOL_DESCRIPTION = dedent("""
+    Use this tool to create and optionally launch in-app surveys based on structured survey configurations.
+
+    # When to use
+    - The user wants to create a new survey
+    - The user wants to launch a survey for collecting feedback
+    - The user mentions NPS, CSAT, PMF, or feedback surveys
+
+    # Critical Survey Design Principles
+    **These are in-app surveys that appear as overlays while users are actively using the product.**
+    - **Keep surveys SHORT**: 1-3 questions maximum - users are trying to accomplish tasks
+    - **Focus on ONE key insight**: Don't try to gather everything at once
+    - **Prioritize user experience**: A short survey with high completion is better than a long abandoned one
+
+    # Survey Types
+    - **popover** (default): Small overlay that appears on the page - most common for in-app surveys
+    - **widget**: Widget that appears via CSS selector or embedded button
+    - **api**: Headless survey for custom implementations
+
+    # Question Types
+    1. **open**: Free-form text input (feedback, suggestions)
+    2. **single_choice**: Select one option (Yes/No, satisfaction levels)
+    3. **multiple_choice**: Select multiple options (feature preferences)
+    4. **rating**: Numeric (1-10 for NPS, 1-5 for CSAT) or emoji scale
+    5. **link**: Display a link with call-to-action
+
+    # Common Survey Patterns
+    - **NPS**: "How likely are you to recommend us?" (rating scale 10, number display)
+    - **CSAT**: "How satisfied are you with X?" (rating scale 5)
+    - **PMF**: "How would you feel if you could no longer use X?" (single_choice with specific options)
+    - **Feedback**: Open-ended questions about experience
+
+    # Feature Flag Targeting
+    When targeting by feature flag:
+    - User must provide the flag ID (integer) from a prior search
+    - Set `linked_flag_id` to the integer flag ID
+    - For variant targeting, add `linkedFlagVariant` in conditions
+    """).strip()
+
+
+class CreateSurveyToolArgs(BaseModel):
+    survey: SurveyCreationSchema = Field(
+        description=dedent("""
+        The complete survey configuration to create.
+
+        # Required Fields
+        - **name**: Survey name (e.g., "NPS Survey", "Onboarding Feedback")
+        - **description**: Brief survey description
+        - **type**: "popover" (default), "widget", or "api"
+        - **questions**: Array of question objects (see Question Structure below)
+
+        # Optional Fields
+        - **should_launch**: Set to true to launch immediately, false for draft (default: false)
+        - **linked_flag_id**: Integer feature flag ID for targeting users with a specific flag
+        - **conditions**: Display conditions object (URL targeting, wait period, etc.)
+        - **appearance**: Custom appearance settings (colors, positioning)
+        - **start_date**: ISO date string to schedule launch
+        - **end_date**: ISO date string to end survey
+        - **responses_limit**: Maximum number of responses to collect
+
+        # Question Structure
+        Each question requires:
+        - **type**: "open", "rating", "single_choice", "multiple_choice", or "link"
+        - **question**: The question text to display
+
+        Optional per question:
+        - **id**: Unique identifier (auto-generated if not provided)
+        - **description**: Additional context below the question
+        - **optional**: Whether the question can be skipped (default: false)
+        - **buttonText**: Text for the continue button
+
+        For **rating** questions:
+        - **scale**: Number of points (5, 7, or 10). Use 10 for NPS, 5 for CSAT
+        - **display**: "number" or "emoji"
+        - **lowerBoundLabel**: Label for low end (e.g., "Not likely")
+        - **upperBoundLabel**: Label for high end (e.g., "Very likely")
+
+        For **single_choice**/**multiple_choice** questions:
+        - **choices**: Array of option strings
+
+        For **link** questions:
+        - **link**: URL to link to
+        - **buttonText**: Link button text
+
+        # Conditions Structure
+        - **url**: URL path string to match (e.g., "/pricing", "/dashboard")
+        - **urlMatchType**: How to match URL - "exact", "icontains" (contains, case-insensitive), "not_icontains", "regex", "not_regex", "is_not"
+        - **seenSurveyWaitPeriodInDays**: Number of days to wait after user has seen any survey before showing this one
+        - **deviceTypes**: Array of device types to target, e.g., ["Mobile"], ["Desktop", "Tablet"]
+        - **deviceTypesMatchType**: Match type for devices - same options as urlMatchType
+        - **linkedFlagVariant**: Feature flag variant to target (requires linked_flag_id)
+        - **selector**: CSS selector for element-based targeting (e.g., "#signup-button")
+
+        # Examples
+
+        ## NPS Survey
+        ```json
+        {
+            "name": "NPS Survey",
+            "description": "Net Promoter Score survey",
+            "type": "popover",
+            "questions": [{
+                "type": "rating",
+                "question": "How likely are you to recommend us to a friend or colleague?",
+                "scale": 10,
+                "display": "number",
+                "lowerBoundLabel": "Not likely at all",
+                "upperBoundLabel": "Extremely likely"
+            }],
+            "should_launch": false
+        }
+        ```
+
+        ## NPS with Follow-up
+        ```json
+        {
+            "name": "NPS with Feedback",
+            "description": "NPS with optional follow-up question",
+            "type": "popover",
+            "questions": [
+                {
+                    "type": "rating",
+                    "question": "How likely are you to recommend us?",
+                    "scale": 10,
+                    "display": "number",
+                    "lowerBoundLabel": "Not likely",
+                    "upperBoundLabel": "Very likely"
+                },
+                {
+                    "type": "open",
+                    "question": "What could we improve?",
+                    "optional": true
+                }
+            ],
+            "should_launch": false
+        }
+        ```
+
+        ## Targeted Survey (URL + Feature Flag)
+        ```json
+        {
+            "name": "Pricing Page Feedback",
+            "description": "Feedback from pricing page visitors",
+            "type": "popover",
+            "linked_flag_id": 123,
+            "conditions": {
+                "url": "/pricing",
+                "urlMatchType": "icontains"
+            },
+            "questions": [{
+                "type": "single_choice",
+                "question": "Is our pricing clear?",
+                "choices": ["Yes, very clear", "Somewhat clear", "Not clear at all"]
+            }],
+            "should_launch": true
+        }
+        ```
+
+        # Critical Rules
+        - Keep to 1-3 questions maximum
+        - DO NOT set should_launch=true unless the user explicitly requests to launch
+        - NPS uses scale=10, CSAT uses scale=5
+        - First question should typically be required (optional: false), follow-ups can be optional
+        """).strip()
+    )
+
+
 class CreateSurveyTool(MaxTool):
     name: str = "create_survey"
-    description: str = "Create and optionally launch a survey based on natural language instructions"
-
-    args_schema: type[BaseModel] = SurveyCreatorArgs
+    description: str = SURVEY_CREATION_TOOL_DESCRIPTION
+    args_schema: type[BaseModel] = CreateSurveyToolArgs
 
     def get_required_resource_access(self):
         return [("survey", "editor")]
 
-    async def _create_survey_from_instructions(self, instructions: str) -> SurveyCreationSchema:
+    async def _arun_impl(self, survey: SurveyCreationSchema) -> tuple[str, dict[str, Any]]:
         """
-        Create a survey from natural language instructions.
-        """
-
-        graph = FeatureFlagLookupGraph(team=self._team, user=self._user)
-
-        graph_context = {
-            "change": f"Create a survey based on these instructions: {instructions}",
-            "output": None,
-            "tool_progress_messages": [],
-            "billable": True,
-            **self.context,
-        }
-
-        result = await graph.compile_full_graph().ainvoke(graph_context)
-
-        if isinstance(result["output"], SurveyCreationSchema):
-            return result["output"]
-        else:
-            survey_creation_schema = SurveyCreationSchema(
-                questions=[], should_launch=False, name="", description="", type="popover"
-            )
-            capture_exception(
-                Exception(f"Survey creation graph returned unexpected output type: {type(result.get('output'))}"),
-                {"team_id": self._team.id, "user_id": self._user.id, "result": str(result)},
-            )
-            return survey_creation_schema
-
-    async def _arun_impl(self, instructions: str) -> tuple[str, dict[str, Any]]:
-        """
-        Generate survey configuration from natural language instructions.
+        Create a survey from the structured configuration.
         """
         try:
             user = self._user
             team = self._team
 
-            result = await self._create_survey_from_instructions(instructions)
-
-            try:
-                if not result.questions:
-                    return "❌ Survey must have at least one question", {
-                        "error": "validation_failed",
-                        "error_message": "No questions were created from the survey instructions.",
-                    }
-
-                # Apply appearance defaults and prepare survey data
-                survey_data = self._prepare_survey_data(result, team)
-
-                # Set launch date if requested
-                if result.should_launch:
-                    survey_data["start_date"] = django.utils.timezone.now()
-
-                # Link to insight if provided in context (e.g., from funnel cross-sell)
-                if self.context.get("insight_id"):
-                    survey_data["linked_insight_id"] = self.context["insight_id"]
-
-                # Create the survey directly using Django ORM
-                survey = await Survey.objects.acreate(team=team, created_by=user, **survey_data)
-
-                launch_msg = " and launched" if result.should_launch else ""
-                return f"✅ Survey '{survey.name}' created{launch_msg} successfully!", {
-                    "survey_id": survey.id,
-                    "survey_name": survey.name,
-                }
-
-            except Exception as validation_error:
-                return f"❌ Survey validation failed: {str(validation_error)}", {
+            if not survey.questions:
+                return "Survey must have at least one question", {
                     "error": "validation_failed",
-                    "error_message": str(validation_error),
+                    "error_message": "No questions provided in the survey configuration.",
                 }
+
+            # Apply appearance defaults and prepare survey data
+            survey_data = self._prepare_survey_data(survey, team)
+
+            # Set launch date if requested
+            if survey.should_launch:
+                survey_data["start_date"] = django.utils.timezone.now()
+
+            # Link to insight if provided in context (e.g., from funnel cross-sell)
+            if self.context.get("insight_id"):
+                survey_data["linked_insight_id"] = self.context["insight_id"]
+
+            # Create the survey directly using Django ORM
+            created_survey = await Survey.objects.acreate(team=team, created_by=user, **survey_data)
+
+            launch_msg = " and launched" if survey.should_launch else ""
+            return f"Survey '{created_survey.name}' created{launch_msg} successfully!", {
+                "survey_id": created_survey.id,
+                "survey_name": created_survey.name,
+            }
 
         except Exception as e:
             capture_exception(e, {"team_id": self._team.id, "user_id": self._user.id})
-            return "❌ Failed to create survey", {"error": "creation_failed", "details": str(e)}
+            return f"Failed to create survey: {str(e)}", {"error": "creation_failed", "details": str(e)}
 
     def _prepare_survey_data(self, survey_schema: SurveyCreationSchema, team: Team) -> dict[str, Any]:
         """Prepare survey data with appearance defaults applied."""
@@ -163,145 +280,6 @@ class CreateSurveyTool(MaxTool):
         survey_data["appearance"] = appearance
 
         return survey_data
-
-
-class SurveyToolkit(TaxonomyAgentToolkit):
-    """Toolkit for survey creation and feature flag lookup operations."""
-
-    def __init__(self, team: Team, user: User):
-        super().__init__(team, user)
-
-    def get_tools(self) -> list:
-        """Get all tools (default + custom). Override in subclasses to add custom tools."""
-        return self._get_custom_tools()
-
-    def _get_custom_tools(self) -> list:
-        """Get custom tools for feature flag lookup."""
-
-        class lookup_feature_flag(BaseModel):
-            """
-            Use this tool to lookup a feature flag by its key/name to get detailed information including ID and variants.
-            Returns a message with the flag ID and the variants if the flag is found and the variants are available.
-            """
-
-            flag_key: str = Field(description="The key/name of the feature flag to look up")
-
-        class final_answer(base_final_answer[SurveyCreationSchema]):
-            __doc__ = base_final_answer.__doc__
-
-        return [lookup_feature_flag, final_answer, ask_user_for_help]
-
-    async def handle_tools(self, tool_metadata: dict[str, list[tuple[TaxonomyTool, str]]]) -> dict[str, str]:
-        """Handle custom tool execution."""
-        results = {}
-        unhandled_tools = {}
-        for tool_name, tool_inputs in tool_metadata.items():
-            if tool_name == "lookup_feature_flag":
-                if tool_inputs:
-                    for tool_input, tool_call_id in tool_inputs:
-                        result = await self._lookup_feature_flag(tool_input.arguments.flag_key)  # type: ignore
-                        results[tool_call_id] = result
-            else:
-                unhandled_tools[tool_name] = tool_inputs
-
-        if unhandled_tools:
-            results.update(await super().handle_tools(unhandled_tools))
-        return results
-
-    @database_sync_to_async(thread_sensitive=False)
-    def _lookup_feature_flag(self, flag_key: str) -> str:
-        """Look up feature flag information by key."""
-        try:
-            # Look up the feature flag by key for the current team
-            feature_flag = FeatureFlag.objects.get(key=flag_key, team_id=self._team.id)
-
-            # Get available variants
-            variants = [variant["key"] for variant in feature_flag.variants]
-
-            message = f"Found feature flag '{flag_key}' (ID: {feature_flag.id})"
-            if variants:
-                message += f" with variants: {', '.join(variants)}"
-            else:
-                message += " (no variants)"
-
-            return message
-
-        except FeatureFlag.DoesNotExist:
-            return f"Feature flag '{flag_key}' not found in the team's feature flags."
-        except Exception as e:
-            capture_exception(e, {"team_id": self._team.id})
-            return f"Error looking up feature flag: '{flag_key}'"
-
-
-class SurveyLoopNode(TaxonomyAgentNode[TaxonomyAgentState, TaxonomyAgentState[SurveyCreationSchema]]):
-    """Node for feature flag lookup operations."""
-
-    def __init__(self, team: Team, user: User, toolkit_class: type[SurveyToolkit]):
-        super().__init__(team, user, toolkit_class=toolkit_class)
-
-    async def _get_existing_surveys_summary(self) -> str:
-        """Get summary of existing surveys for context."""
-        try:
-            surveys = [survey async for survey in Survey.objects.filter(team_id=self._team.id, archived=False)[:5]]
-
-            if not surveys:
-                return "No existing surveys"
-
-            summaries = []
-            for survey in surveys:
-                status = "active" if survey.start_date and not survey.end_date else "draft"
-                summaries.append(f"- '{survey.name}' ({survey.type}, {status})")
-
-            return "\n".join(summaries)
-        except Exception as e:
-            capture_exception(e, {"team_id": self._team.id, "user_id": self._user.id})
-            return "Unable to load existing surveys"
-
-    def _get_system_prompt(self) -> ChatPromptTemplate:
-        """Get system prompts for feature flag lookup."""
-        existing_surveys = async_to_sync(self._get_existing_surveys_summary)()
-
-        prompt = ChatPromptTemplate([("system", SURVEY_CREATION_SYSTEM_PROMPT)], template_format="mustache").format(
-            existing_surveys=existing_surveys,
-            team_survey_config=get_team_survey_config(self._team),
-        )
-
-        return ChatPromptTemplate([("system", prompt)], template_format="mustache")
-
-    def _construct_messages(self, state: TaxonomyAgentState) -> ChatPromptTemplate:
-        """
-        Construct the conversation thread for the agent. Handles both initial conversation setup
-        and continuation with intermediate steps.
-        """
-        system_prompt = self._get_system_prompt()
-        conversation = list(system_prompt.messages)
-        human_content = state.change or ""
-        all_messages = [*conversation, ("human", human_content)]
-
-        progress_messages = state.tool_progress_messages or []
-        all_messages.extend(progress_messages)
-
-        return ChatPromptTemplate(all_messages, template_format="mustache")
-
-
-class SurveyLookupToolsNode(TaxonomyAgentToolsNode[TaxonomyAgentState, TaxonomyAgentState[SurveyCreationSchema]]):
-    """Tools node for feature flag lookup operations."""
-
-    def __init__(self, team: Team, user: User, toolkit_class: type[SurveyToolkit]):
-        super().__init__(team, user, toolkit_class=toolkit_class)
-
-
-class FeatureFlagLookupGraph(TaxonomyAgent[TaxonomyAgentState, TaxonomyAgentState[SurveyCreationSchema]]):
-    """Graph for feature flag lookup operations."""
-
-    def __init__(self, team: Team, user: User):
-        super().__init__(
-            team,
-            user,
-            loop_node_class=SurveyLoopNode,
-            tools_node_class=SurveyLookupToolsNode,
-            toolkit_class=SurveyToolkit,
-        )
 
 
 class SurveyAnalysisArgs(BaseModel):
@@ -452,7 +430,7 @@ class SurveyAnalysisTool(MaxTool):
             capture_exception(e, {"team_id": self._team.id, "user_id": self._user.id})
 
             # Return an error message instead of a fake success
-            error_message = f"❌ Survey analysis failed: {str(e)}"
+            error_message = f"Survey analysis failed: {str(e)}"
             return SurveyAnalysisOutput(
                 themes=[],
                 sentiment="neutral",
@@ -493,20 +471,20 @@ class SurveyAnalysisTool(MaxTool):
         lines = []
 
         # Header with response count
-        header = f"✅ **Survey Analysis: '{survey_name}'**"
+        header = f"**Survey Analysis: '{survey_name}'**"
         lines.append(header)
         lines.append(f"*Analyzed {analysis.response_count} open-ended responses*")
         lines.append("\n---")
 
         # Overall sentiment first for context
-        sentiment_emoji = {"positive": "😊", "negative": "😞", "mixed": "🤔", "neutral": "😐"}.get(
-            analysis.sentiment, "😐"
+        sentiment_emoji = {"positive": ":)", "negative": ":(", "mixed": ":/", "neutral": ":|"}.get(
+            analysis.sentiment, ":|"
         )
-        lines.append(f"**📊 Overall Sentiment:** {sentiment_emoji} {analysis.sentiment.title()}")
+        lines.append(f"**Overall Sentiment:** {sentiment_emoji} {analysis.sentiment.title()}")
 
         # Key themes with examples
         if analysis.themes:
-            lines.append("\n**🎯 Key Themes:**")
+            lines.append("\n**Key Themes:**")
             for i, theme in enumerate(analysis.themes[:5], 1):  # Limit to top 5 themes
                 lines.append(f"\n**{i}. {theme.theme}**")
                 lines.append(f"{theme.description}")
@@ -519,19 +497,19 @@ class SurveyAnalysisTool(MaxTool):
 
         # Key insights with better formatting
         if analysis.insights:
-            lines.append("\n**💡 Key Insights:**")
+            lines.append("\n**Key Insights:**")
             for i, insight in enumerate(analysis.insights[:3], 1):  # Limit to top 3 insights
                 lines.append(f"\n{i}. {insight}")
 
         # Recommendations with action-oriented formatting
         if analysis.recommendations:
-            lines.append("\n**🚀 Recommendations:**")
+            lines.append("\n**Recommendations:**")
             for i, rec in enumerate(analysis.recommendations[:3], 1):  # Top 3 recommendations
                 lines.append(f"\n**{i}.** {rec}")
 
         # Question breakdown with improved structure
         if analysis.question_breakdown:
-            lines.append("\n**📝 Question Breakdown:**")
+            lines.append("\n**Question Breakdown:**")
             for question, breakdown in list(analysis.question_breakdown.items())[:3]:  # Top 3 questions
                 lines.append(f"\n**Q: {question}**")
                 lines.append(f"\nTheme: {breakdown.theme}")
@@ -542,7 +520,7 @@ class SurveyAnalysisTool(MaxTool):
                         lines.append(f"- {insight}")
 
         lines.append("\n---")
-        lines.append("💡 *Need more detail? Ask me to dive deeper into any specific aspect.*")
+        lines.append("*Need more detail? Ask me to dive deeper into any specific aspect.*")
 
         return "\n".join(lines)
 
@@ -572,7 +550,7 @@ class SurveyAnalysisTool(MaxTool):
                 ]
 
             if not survey_id or not responses:
-                return "❌ No survey data provided", {
+                return "No survey data provided", {
                     "error": "no_survey_data",
                     "details": "Survey information not found in context",
                 }
@@ -581,7 +559,7 @@ class SurveyAnalysisTool(MaxTool):
             analysis_result = await self._analyze_responses(responses)
 
             if analysis_result.response_count == 0:
-                success_message = f"ℹ️ No open-ended responses found in survey '{survey_name}' to analyze"
+                success_message = f"No open-ended responses found in survey '{survey_name}' to analyze"
                 return success_message, {
                     "survey_id": survey_id,
                     "survey_name": survey_name,
@@ -599,4 +577,4 @@ class SurveyAnalysisTool(MaxTool):
 
         except Exception as e:
             capture_exception(e, {"team_id": self._team.id, "user_id": self._user.id})
-            return f"❌ Failed to analyze survey responses: {str(e)}", {"error": "analysis_failed", "details": str(e)}
+            return f"Failed to analyze survey responses: {str(e)}", {"error": "analysis_failed", "details": str(e)}

--- a/products/surveys/backend/test_max_tools.py
+++ b/products/surveys/backend/test_max_tools.py
@@ -8,8 +8,6 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
-import django.utils.timezone
-
 import orjson
 from asgiref.sync import sync_to_async
 from langchain_core.runnables import RunnableConfig
@@ -20,7 +18,7 @@ from posthog.models import FeatureFlag, Insight, Survey
 
 from products.surveys.backend.max_tools import SurveyAnalysisOutput, ThemeWithExamples
 
-from .max_tools import CreateSurveyTool, SurveyAnalysisTool, SurveyLoopNode, SurveyToolkit
+from .max_tools import CreateSurveyTool, SurveyAnalysisTool
 
 OPENAI_PATCH_PATH = "products.surveys.backend.max_tools.MaxChatOpenAI"
 
@@ -58,15 +56,14 @@ class TestSurveyCreatorTool(BaseTest):
         assert "default_settings" in config
         assert config["default_settings"]["type"] == "popover"
 
-    @patch.object(CreateSurveyTool, "_create_survey_from_instructions")
     @pytest.mark.django_db
     @pytest.mark.asyncio
-    async def test_arun_impl_success(self, mock_create_survey):
+    async def test_arun_impl_success(self):
         """Test successful survey creation through _arun_impl"""
         tool = self._setup_tool()
 
-        # Mock the LLM response
-        mock_output = SurveyCreationSchema(
+        # Create the survey schema directly (no more LLM call)
+        survey_schema = SurveyCreationSchema(
             name="Test Survey",
             description="A simple test survey",
             type=SurveyType.POPOVER,
@@ -82,14 +79,11 @@ class TestSurveyCreatorTool(BaseTest):
             enable_partial_responses=True,
         )
 
-        # Set up the mock to return our test data
-        mock_create_survey.return_value = mock_output
-
-        # Run the method
-        content, artifact = await tool._arun_impl("Create a test survey")
+        # Run the method with the schema directly
+        content, artifact = await tool._arun_impl(survey=survey_schema)
 
         # Verify success response
-        assert "✅ Survey" in content
+        assert "Survey" in content
         assert "created" in content
         assert "successfully" in content
         assert "survey_id" in artifact
@@ -103,15 +97,14 @@ class TestSurveyCreatorTool(BaseTest):
         assert len(survey.questions) == 1
         assert not survey.archived
 
-    @patch.object(CreateSurveyTool, "_create_survey_from_instructions")
     @pytest.mark.django_db
     @pytest.mark.asyncio
-    async def test_arun_impl_no_questions_validation(self, mock_create_survey):
+    async def test_arun_impl_no_questions_validation(self):
         """Test validation error when no questions are provided"""
         tool = self._setup_tool()
 
-        # Mock LLM response with no questions
-        mock_output = SurveyCreationSchema(
+        # Create schema with no questions
+        survey_schema = SurveyCreationSchema(
             name="Test Survey",
             description="A test survey",
             type=SurveyType.POPOVER,
@@ -120,25 +113,22 @@ class TestSurveyCreatorTool(BaseTest):
             enable_partial_responses=True,
         )
 
-        mock_create_survey.return_value = mock_output
-
         # Run the method
-        content, artifact = await tool._arun_impl("Create a survey")
+        content, artifact = await tool._arun_impl(survey=survey_schema)
 
         # Verify error response
-        assert "❌ Survey must have at least one question" in content
+        assert "Survey must have at least one question" in content
         assert artifact["error"] == "validation_failed"
-        assert "No questions were created from the survey instructions" in artifact["error_message"]
+        assert "No questions provided" in artifact["error_message"]
 
-    @patch.object(CreateSurveyTool, "_create_survey_from_instructions")
     @pytest.mark.django_db
     @pytest.mark.asyncio
-    async def test_arun_impl_with_launch(self, mock_create_survey):
+    async def test_arun_impl_with_launch(self):
         """Test survey creation with immediate launch"""
         tool = self._setup_tool()
 
-        # Mock the LLM response with launch=True
-        mock_output = SurveyCreationSchema(
+        # Create schema with launch=True
+        survey_schema = SurveyCreationSchema(
             name="Launch Survey",
             description="A survey to launch",
             type=SurveyType.POPOVER,
@@ -153,23 +143,20 @@ class TestSurveyCreatorTool(BaseTest):
             enable_partial_responses=True,
         )
 
-        mock_create_survey.return_value = mock_output
-
         # Run the method
-        content, artifact = await tool._arun_impl("Create and launch a survey")
+        content, artifact = await tool._arun_impl(survey=survey_schema)
 
         # Verify success response with launch message
-        assert "✅ Survey" in content
+        assert "Survey" in content
         assert "successfully" in content
 
         # Verify survey was created and launched
         survey = await sync_to_async(Survey.objects.get)(id=artifact["survey_id"])
         assert survey.start_date is not None  # Should have a start date when launched
 
-    @patch.object(CreateSurveyTool, "_create_survey_from_instructions")
     @pytest.mark.django_db
     @pytest.mark.asyncio
-    async def test_create_survey_with_feature_flag(self, mock_create_survey):
+    async def test_create_survey_with_feature_flag(self):
         """Test creating a survey with a linked feature flag"""
         tool = self._setup_tool()
 
@@ -182,8 +169,8 @@ class TestSurveyCreatorTool(BaseTest):
             filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
         )
 
-        # Mock the LLM response with linked flag
-        mock_output = SurveyCreationSchema(
+        # Create schema with linked flag
+        survey_schema = SurveyCreationSchema(
             name="Feature Flag Survey",
             description="Survey for users with test feature",
             type=SurveyType.POPOVER,
@@ -200,13 +187,11 @@ class TestSurveyCreatorTool(BaseTest):
             enable_partial_responses=True,
         )
 
-        mock_create_survey.return_value = mock_output
-
         # Run the method
-        content, artifact = await tool._arun_impl("Create a survey for users with test-feature flag")
+        content, artifact = await tool._arun_impl(survey=survey_schema)
 
         # Verify success response
-        assert "✅ Survey" in content
+        assert "Survey" in content
         assert "successfully" in content
 
         # Verify survey was created with feature flag
@@ -214,10 +199,9 @@ class TestSurveyCreatorTool(BaseTest):
         assert survey.name == "Feature Flag Survey"
         assert survey.linked_flag_id == flag.id
 
-    @patch.object(CreateSurveyTool, "_create_survey_from_instructions")
     @pytest.mark.django_db
     @pytest.mark.asyncio
-    async def test_create_survey_with_feature_flag_variant(self, mock_create_survey):
+    async def test_create_survey_with_feature_flag_variant(self):
         """Test creating a survey with a feature flag variant"""
         tool = self._setup_tool()
 
@@ -238,8 +222,8 @@ class TestSurveyCreatorTool(BaseTest):
             },
         )
 
-        # Mock the LLM response with linked flag and variant
-        mock_output = SurveyCreationSchema(
+        # Create schema with linked flag and variant
+        survey_schema = SurveyCreationSchema(
             name="A/B Test Control Survey",
             description="Survey for users in control variant",
             type=SurveyType.POPOVER,
@@ -257,13 +241,11 @@ class TestSurveyCreatorTool(BaseTest):
             enable_partial_responses=True,
         )
 
-        mock_create_survey.return_value = mock_output
-
         # Run the method
-        content, artifact = await tool._arun_impl("Create a survey for users in control variant of ab-test-feature")
+        content, artifact = await tool._arun_impl(survey=survey_schema)
 
         # Verify success response
-        assert "✅ Survey" in content
+        assert "Survey" in content
         assert "successfully" in content
 
         # Verify survey was created with feature flag and variant
@@ -272,10 +254,9 @@ class TestSurveyCreatorTool(BaseTest):
         assert survey.linked_flag_id == flag.id
         assert survey.conditions["linkedFlagVariant"] == "control"
 
-    @patch.object(CreateSurveyTool, "_create_survey_from_instructions")
     @pytest.mark.django_db
     @pytest.mark.asyncio
-    async def test_create_survey_with_feature_flag_variant_any(self, mock_create_survey):
+    async def test_create_survey_with_feature_flag_variant_any(self):
         """Test creating a survey with linkedFlagVariant set to 'any'"""
         tool = self._setup_tool()
 
@@ -297,8 +278,8 @@ class TestSurveyCreatorTool(BaseTest):
             },
         )
 
-        # Mock the LLM response with linked flag and 'any' variant
-        mock_output = SurveyCreationSchema(
+        # Create schema with linked flag and 'any' variant
+        survey_schema = SurveyCreationSchema(
             name="All Variants Survey",
             description="Survey for all users with the feature enabled",
             type=SurveyType.POPOVER,
@@ -315,13 +296,11 @@ class TestSurveyCreatorTool(BaseTest):
             enable_partial_responses=True,
         )
 
-        mock_create_survey.return_value = mock_output
-
         # Run the method
-        content, artifact = await tool._arun_impl("Create a survey for all users with multivariate-feature enabled")
+        content, artifact = await tool._arun_impl(survey=survey_schema)
 
         # Verify success response
-        assert "✅ Survey" in content
+        assert "Survey" in content
         assert "successfully" in content
 
         # Verify survey was created with feature flag and 'any' variant
@@ -330,10 +309,9 @@ class TestSurveyCreatorTool(BaseTest):
         assert survey.linked_flag_id == flag.id
         assert survey.conditions["linkedFlagVariant"] == "any"
 
-    @patch.object(CreateSurveyTool, "_create_survey_from_instructions")
     @pytest.mark.django_db
     @pytest.mark.asyncio
-    async def test_create_survey_with_linked_insight(self, mock_create_survey):
+    async def test_create_survey_with_linked_insight(self):
         """Test creating a survey with a linked insight (from funnel cross-sell)"""
         # Create a test insight
         insight = await sync_to_async(Insight.objects.create)(
@@ -355,8 +333,8 @@ class TestSurveyCreatorTool(BaseTest):
             },
         )
 
-        # Mock the LLM response
-        mock_output = SurveyCreationSchema(
+        # Create schema
+        survey_schema = SurveyCreationSchema(
             name="Funnel Survey",
             description="Survey for funnel conversion",
             type=SurveyType.POPOVER,
@@ -371,133 +349,17 @@ class TestSurveyCreatorTool(BaseTest):
             enable_partial_responses=True,
         )
 
-        mock_create_survey.return_value = mock_output
-
         # Run the method
-        content, artifact = await tool._arun_impl("Create a survey for this funnel")
+        content, artifact = await tool._arun_impl(survey=survey_schema)
 
         # Verify success response
-        assert "✅ Survey" in content
+        assert "Survey" in content
         assert "successfully" in content
 
         # Verify survey was created with linked insight
         survey = await sync_to_async(Survey.objects.select_related("linked_insight").get)(id=artifact["survey_id"])
         assert survey.name == "Funnel Survey"
         assert survey.linked_insight_id == insight.id
-
-
-class TestSurveyLoopNode(BaseTest):
-    def setUp(self):
-        super().setUp()
-
-    def _setup_node(self):
-        """Helper to create a TestSurveyLoopNode instance"""
-        return SurveyLoopNode(team=self.team, user=self.user, toolkit_class=SurveyToolkit)
-
-    @pytest.mark.django_db
-    @pytest.mark.asyncio
-    async def test_get_existing_surveys_summary_empty(self):
-        """Test getting existing surveys summary when no surveys exist"""
-        node = self._setup_node()
-
-        summary = await node._get_existing_surveys_summary()
-
-        assert summary == "No existing surveys"
-
-    @pytest.mark.django_db
-    @pytest.mark.asyncio
-    async def test_get_existing_surveys_summary_with_surveys(self):
-        """Test getting existing surveys summary with existing surveys"""
-        node = self._setup_node()
-
-        # Create test surveys
-        await sync_to_async(Survey.objects.create)(
-            team=self.team,
-            name="Draft Survey",
-            type="popover",
-            questions=[{"type": "open", "question": "Test?"}],
-            created_by=self.user,
-        )
-
-        # Create an active survey (with start_date but no end_date)
-        await sync_to_async(Survey.objects.create)(
-            team=self.team,
-            name="Active Survey",
-            type="email",
-            questions=[{"type": "rating", "question": "How satisfied?", "scale": 5}],
-            created_by=self.user,
-            start_date=django.utils.timezone.now(),
-        )
-
-        summary = await node._get_existing_surveys_summary()
-
-        # Verify both surveys are included
-        assert "Draft Survey" in summary
-        assert "Active Survey" in summary
-        assert "draft" in summary
-        assert "active" in summary
-        assert "popover" in summary
-        assert "email" in summary
-
-    @pytest.mark.django_db
-    @pytest.mark.asyncio
-    async def test_get_existing_surveys_summary_excludes_archived(self):
-        """Test that archived surveys are excluded from the summary"""
-        node = self._setup_node()
-
-        # Create a regular survey
-        await sync_to_async(Survey.objects.create)(
-            team=self.team,
-            name="Regular Survey",
-            type="popover",
-            questions=[{"type": "open", "question": "Test?"}],
-            created_by=self.user,
-        )
-
-        # Create an archived survey (should be excluded)
-        await sync_to_async(Survey.objects.create)(
-            team=self.team,
-            name="Archived Survey",
-            type="popover",
-            questions=[{"type": "open", "question": "Test?"}],
-            created_by=self.user,
-            archived=True,
-        )
-
-        summary = await node._get_existing_surveys_summary()
-
-        # Only the non-archived survey should be included
-        assert "Regular Survey" in summary
-        assert "Archived Survey" not in summary
-
-    @pytest.mark.django_db
-    @pytest.mark.asyncio
-    async def test_get_existing_surveys_summary_limits_to_five(self):
-        """Test that the summary is limited to 5 surveys"""
-        node = self._setup_node()
-
-        # Create 6 surveys
-        survey_names = []
-        for i in range(6):
-            name = f"Survey {i + 1}"
-            survey_names.append(name)
-            await sync_to_async(Survey.objects.create)(
-                team=self.team,
-                name=name,
-                type="popover",
-                questions=[{"type": "open", "question": "Test?"}],
-                created_by=self.user,
-            )
-
-        summary = await node._get_existing_surveys_summary()
-
-        # Count the number of survey entries (lines starting with "- '")
-        summary_lines = [line for line in summary.split("\n") if line.strip().startswith("- '")]
-        assert len(summary_lines) == 5  # Should be limited to 5
-
-        # Verify it contains survey information
-        assert "Survey" in summary
-        assert "draft" in summary
 
 
 class TestSurveyAnalysisTool(BaseTest):
@@ -814,7 +676,7 @@ class TestSurveyAnalysisTool(BaseTest):
         result = await tool._analyze_responses(responses_data, "comprehensive")
 
         # Should return error structure for LLM failure
-        assert "❌ Survey analysis failed" in result.insights[0]
+        assert "Survey analysis failed" in result.insights[0]
         assert "LLM API error" in result.insights[0]
 
     def test_format_analysis_for_user_success(self):
@@ -843,15 +705,15 @@ class TestSurveyAnalysisTool(BaseTest):
         tool = self._setup_tool_with_context()
         formatted = tool._format_analysis_for_user(analysis, "Test Product Survey")
 
-        assert "✅ **Survey Analysis: 'Test Product Survey'**" in formatted
-        assert "**🎯 Key Themes:**" in formatted
+        assert "**Survey Analysis: 'Test Product Survey'**" in formatted
+        assert "**Key Themes:**" in formatted
         assert "User Interface" in formatted
         assert "Performance" in formatted
-        assert "**📊 Overall Sentiment:**" in formatted
+        assert "**Overall Sentiment:**" in formatted
         assert "Mixed" in formatted
-        assert "**💡 Key Insights:**" in formatted
+        assert "**Key Insights:**" in formatted
         assert "Users love the design" in formatted
-        assert "**🚀 Recommendations:**" in formatted
+        assert "**Recommendations:**" in formatted
         assert "Implement caching" in formatted
         assert "5 open-ended responses" in formatted
 
@@ -874,9 +736,9 @@ class TestSurveyAnalysisTool(BaseTest):
         tool = self._setup_tool_with_context()
         formatted = tool._format_analysis_for_user(analysis, "Test Survey")
 
-        assert "**🎯 Key Themes:**" in formatted
+        assert "**Key Themes:**" in formatted
         assert "Test Data" in formatted
-        assert "**💡 Key Insights:**" in formatted
+        assert "**Key Insights:**" in formatted
         assert "Most responses appear" in formatted
 
     def test_format_analysis_for_user_error(self):
@@ -894,8 +756,8 @@ class TestSurveyAnalysisTool(BaseTest):
         tool = self._setup_tool_with_context()
         formatted = tool._format_analysis_for_user(analysis, "Test Survey")
 
-        assert "**💡 Key Insights:**" in formatted
-        assert "❌ Analysis failed" in formatted
+        assert "**Key Insights:**" in formatted
+        assert "Analysis failed" in formatted
         assert "LLM analysis failed due to API timeout" in formatted
 
     @patch(OPENAI_PATCH_PATH)
@@ -1054,8 +916,10 @@ class TestSurveyAnalysisTool(BaseTest):
         user_message, artifact = await tool._arun_impl()
 
         # Should handle error gracefully - check if it's handled in analysis or formatted
-        has_error_in_message = "❌ Failed to analyze survey responses" in user_message
-        has_error_in_insights = any("❌" in insight for insight in artifact.get("analysis", {}).get("insights", []))
+        has_error_in_message = "Failed to analyze survey responses" in user_message
+        has_error_in_insights = any(
+            "failed" in insight.lower() for insight in artifact.get("analysis", {}).get("insights", [])
+        )
         assert has_error_in_message or has_error_in_insights
         if "error" in artifact:
             assert artifact["error"] == "analysis_failed"


### PR DESCRIPTION
## Problem

Surveys were not integrated into PostHog AI in a full-fledged mode and survey creation was just usable from the contextual page. We need the integration to be more pervasive in the entire experience, introducing its own ad-hoc mode.

<img width="707" height="533" alt="image" src="https://github.com/user-attachments/assets/85ceaad2-f4d9-4a3a-8212-6119a0d98514" />

<img width="1190" height="547" alt="image" src="https://github.com/user-attachments/assets/aeead9f9-3190-40d9-8cba-7a106a347aed" />


## Changes

* Introduced survey mode
* Gated behind FF
* Refactor creation tool to use the SLE root
* Removed legacy `TaxonomyAgent`
* Updated evals

## How did you test this code?

- [x] unit tests
- [x] manual tests
- [x] evals

## Publish to changelog?

No, will do in another PR (https://github.com/PostHog/posthog/pull/45693)