### PR TITLE
feat(sql-editor): improve sidebar styling

### DIFF
--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Literal, Self, Union
 from uuid import uuid4
 
@@ -290,7 +291,7 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
     @database_sync_to_async
     def _build_table_schema(self, database: Database, hogql_context: HogQLContext, table_name: str) -> str:
         # Load tables on demand: warehouse first, then views, then posthog tables
-        table_sources = [
+        table_sources: list[Callable[[], list[str]]] = [
             database.get_warehouse_table_names,
             database.get_view_names,
             database.get_posthog_table_names,

--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
@@ -94,12 +94,6 @@ export const databaseTableListLogic = kea<databaseTableListLogicType>([
             },
             { resultEqualityCheck: objectsEqual },
         ],
-        allPosthogTablesMap: [
-            (s) => [s.allPosthogTables],
-            (allPosthogTables: DatabaseSchemaTable[]): Record<string, DatabaseSchemaTable> =>
-                toMapByName(allPosthogTables),
-            { resultEqualityCheck: objectsEqual },
-        ],
         posthogTablesMap: [
             (s) => [s.posthogTables],
             (posthogTables: DatabaseSchemaTable[]): Record<string, DatabaseSchemaTable> => toMapByName(posthogTables),

--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
@@ -54,6 +54,13 @@ export const databaseTableListLogic = kea<databaseTableListLogicType>([
     }),
     reducers({ searchTerm: ['', { setSearchTerm: (_, { searchTerm }) => searchTerm }] }),
     selectors({
+        allPosthogTables: [
+            (s) => [s.allTables],
+            (allTables: DatabaseSchemaTable[]): DatabaseSchemaTable[] => {
+                return allTables.filter((n) => n.type === 'posthog')
+            },
+            { resultEqualityCheck: objectsEqual },
+        ],
         filteredTables: [
             (s) => [s.allTables, s.searchTerm],
             (allTables, searchTerm): DatabaseSchemaTable[] => {
@@ -80,10 +87,17 @@ export const databaseTableListLogic = kea<databaseTableListLogicType>([
             { resultEqualityCheck: objectsEqual },
         ],
         posthogTables: [
-            (s) => [s.allTables],
-            (allTables: DatabaseSchemaTable[]): DatabaseSchemaTable[] => {
-                return allTables.filter((n) => n.type === 'posthog')
+            (s) => [s.allPosthogTables],
+            (allPosthogTables: DatabaseSchemaTable[]): DatabaseSchemaTable[] => {
+                const visiblePosthogTableNames = new Set(['events', 'groups', 'persons', 'sessions'])
+                return allPosthogTables.filter((table) => visiblePosthogTableNames.has(table.name))
             },
+            { resultEqualityCheck: objectsEqual },
+        ],
+        allPosthogTablesMap: [
+            (s) => [s.allPosthogTables],
+            (allPosthogTables: DatabaseSchemaTable[]): Record<string, DatabaseSchemaTable> =>
+                toMapByName(allPosthogTables),
             { resultEqualityCheck: objectsEqual },
         ],
         posthogTablesMap: [

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -65,6 +65,36 @@ export const QueryDatabase = (): JSX.Element => {
     const { setQueryInput } = useActions(multitabEditorLogic)
     const { selectedQueryColumns } = useValues(multitabEditorLogic)
     const builtTabLogic = useMountedLogic(multitabEditorLogic)
+    const getFieldTypeIconClassName = (fieldType: DatabaseSerializedFieldType): string => {
+        switch (fieldType) {
+            case 'string':
+                return 'text-sky-500'
+            case 'integer':
+            case 'float':
+            case 'decimal':
+                return 'text-emerald-500'
+            case 'boolean':
+                return 'text-purple-500'
+            case 'datetime':
+                return 'text-amber-500'
+            case 'date':
+                return 'text-orange-500'
+            case 'array':
+            case 'json':
+                return 'text-teal-500'
+            case 'expression':
+            case 'field_traverser':
+                return 'text-slate-500'
+            case 'view':
+            case 'materialized_view':
+            case 'lazy_table':
+            case 'virtual_table':
+                return 'text-blue-500'
+            default:
+                return 'text-tertiary'
+        }
+    }
+
     const getFieldTypeIcon = (fieldType?: DatabaseSerializedFieldType): JSX.Element | null => {
         if (!fieldType) {
             return null
@@ -72,31 +102,31 @@ export const QueryDatabase = (): JSX.Element => {
 
         switch (fieldType) {
             case 'string':
-                return <IconTextSize className="text-tertiary" />
+                return <IconTextSize className={getFieldTypeIconClassName(fieldType)} />
             case 'integer':
             case 'float':
             case 'decimal':
-                return <IconCalculator className="text-tertiary" />
+                return <IconCalculator className={getFieldTypeIconClassName(fieldType)} />
             case 'boolean':
-                return <IconCheck className="text-tertiary" />
+                return <IconCheck className={getFieldTypeIconClassName(fieldType)} />
             case 'datetime':
-                return <IconClock className="text-tertiary" />
+                return <IconClock className={getFieldTypeIconClassName(fieldType)} />
             case 'date':
-                return <IconCalendar className="text-tertiary" />
+                return <IconCalendar className={getFieldTypeIconClassName(fieldType)} />
             case 'array':
             case 'json':
-                return <IconBrackets className="text-tertiary" />
+                return <IconBrackets className={getFieldTypeIconClassName(fieldType)} />
             case 'expression':
-                return <IconCode className="text-tertiary" />
+                return <IconCode className={getFieldTypeIconClassName(fieldType)} />
             case 'field_traverser':
-                return <IconCode2 className="text-tertiary" />
+                return <IconCode2 className={getFieldTypeIconClassName(fieldType)} />
             case 'view':
             case 'materialized_view':
             case 'lazy_table':
             case 'virtual_table':
-                return <IconDatabase className="text-tertiary" />
+                return <IconDatabase className={getFieldTypeIconClassName(fieldType)} />
             default:
-                return <IconCode2 className="text-tertiary" />
+                return <IconCode2 className={getFieldTypeIconClassName(fieldType)} />
         }
     }
 

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -65,6 +65,13 @@ export const QueryDatabase = (): JSX.Element => {
     const { setQueryInput } = useActions(multitabEditorLogic)
     const { selectedQueryColumns } = useValues(multitabEditorLogic)
     const builtTabLogic = useMountedLogic(multitabEditorLogic)
+    const formatTraversalChain = (chain?: (string | number)[]): string | null => {
+        if (!chain || chain.length === 0) {
+            return null
+        }
+
+        return chain.map((segment) => String(segment)).join('.')
+    }
     const getFieldTypeIconClassName = (fieldType: DatabaseSerializedFieldType): string => {
         switch (fieldType) {
             case 'string':
@@ -558,6 +565,19 @@ export const QueryDatabase = (): JSX.Element => {
                 // Show tooltip with full name for items that could be truncated
                 const tooltipTypes = ['table', 'view', 'managed-view', 'endpoint', 'draft', 'column', 'unsaved-query']
                 if (tooltipTypes.includes(item.record?.type)) {
+                    if (item.record?.type === 'column' && item.record?.field?.type === 'field_traverser') {
+                        const traversalChain = formatTraversalChain(item.record.field.chain)
+                        if (traversalChain) {
+                            return `${item.name} → ${traversalChain}`
+                        }
+                    }
+                    return item.name
+                }
+                if (item.record?.type === 'field-traverser') {
+                    const traversalChain = formatTraversalChain(item.record?.field?.chain)
+                    if (traversalChain) {
+                        return `${item.name} → ${traversalChain}`
+                    }
                     return item.name
                 }
                 return undefined

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -102,34 +102,50 @@ export const QueryDatabase = (): JSX.Element => {
                 // Check if item has search matches for highlighting
                 const matches = item.record?.searchMatches
                 const hasMatches = matches && matches.length > 0
+                const isColumn = item.record?.type === 'column'
+                const columnType = isColumn ? item.record?.field?.type : null
+
                 return (
                     <span className="truncate">
-                        {hasMatches && searchTerm ? (
-                            <SearchHighlightMultiple string={item.name} substring={searchTerm} className="text-xs" />
-                        ) : (
-                            <div className="flex flex-row gap-1 justify-between">
-                                <span
-                                    className={cn(
-                                        [
-                                            'managed-views',
-                                            'views',
-                                            'sources',
-                                            'drafts',
-                                            'unsaved-folder',
-                                            'endpoints',
-                                        ].includes(item.record?.type) && 'font-semibold',
-                                        item.record?.type === 'column' && 'font-mono text-xs',
-                                        item.record?.type === 'column' &&
-                                            selectedQueryColumns[`${item.record.table}.${item.record.columnName}`] &&
-                                            'underline underline-offset-2',
-                                        'truncate'
-                                    )}
-                                >
-                                    {item.name}
-                                </span>
-                                {renderTableCount(item.record?.row_count)}
+                        <div className="flex flex-row gap-1 justify-between">
+                            <div className="shrink-0 flex min-w-0 items-center gap-2">
+                                {hasMatches && searchTerm ? (
+                                    <SearchHighlightMultiple
+                                        string={item.name}
+                                        substring={searchTerm}
+                                        className={cn(isColumn && 'font-mono text-xs')}
+                                    />
+                                ) : (
+                                    <span
+                                        className={cn(
+                                            [
+                                                'managed-views',
+                                                'views',
+                                                'sources',
+                                                'drafts',
+                                                'unsaved-folder',
+                                                'endpoints',
+                                            ].includes(item.record?.type) && 'font-semibold',
+                                            isColumn && 'font-mono text-xs',
+                                            isColumn &&
+                                                selectedQueryColumns[
+                                                    `${item.record.table}.${item.record.columnName}`
+                                                ] &&
+                                                'underline underline-offset-2',
+                                            'truncate shrink-0'
+                                        )}
+                                    >
+                                        {item.name}
+                                    </span>
+                                )}
+                                {isColumn && columnType ? (
+                                    <span className="shrink-1 rounded px-1.5 py-0.5 text-xs text-muted-alt">
+                                        {columnType}
+                                    </span>
+                                ) : null}
                             </div>
-                        )}
+                            {renderTableCount(item.record?.row_count)}
+                        </div>
                     </span>
                 )
             }}

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -221,7 +221,7 @@ export const QueryDatabase = (): JSX.Element => {
                                     </span>
                                 )}
                                 {isColumn && columnType ? (
-                                    <span className="shrink-1 rounded px-1.5 py-0.5 text-xs text-muted-alt">
+                                    <span className="shrink rounded px-1.5 py-0.5 text-xs text-muted-alt">
                                         {columnType}
                                     </span>
                                 ) : null}

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -2,11 +2,22 @@ import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useEffect, useRef } from 'react'
 
-import { IconPlusSmall } from '@posthog/icons'
+import {
+    IconBrackets,
+    IconCalculator,
+    IconCalendar,
+    IconCheck,
+    IconClock,
+    IconCode,
+    IconCode2,
+    IconDatabase,
+    IconPlusSmall,
+} from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 
 import { LemonTree, LemonTreeRef } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { TreeNodeDisplayIcon } from 'lib/lemon-ui/LemonTree/LemonTreeUtils'
+import { IconTextSize } from 'lib/lemon-ui/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuSeparator } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
@@ -18,6 +29,7 @@ import { sceneLogic } from 'scenes/sceneLogic'
 import { urls } from 'scenes/urls'
 
 import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/SearchHighlight'
+import { DatabaseSerializedFieldType } from '~/queries/schema/schema-general'
 
 import { dataWarehouseViewsLogic } from '../../saved_queries/dataWarehouseViewsLogic'
 import { draftsLogic } from '../draftsLogic'
@@ -53,6 +65,40 @@ export const QueryDatabase = (): JSX.Element => {
     const { setQueryInput } = useActions(multitabEditorLogic)
     const { selectedQueryColumns } = useValues(multitabEditorLogic)
     const builtTabLogic = useMountedLogic(multitabEditorLogic)
+    const getFieldTypeIcon = (fieldType?: DatabaseSerializedFieldType): JSX.Element | null => {
+        if (!fieldType) {
+            return null
+        }
+
+        switch (fieldType) {
+            case 'string':
+                return <IconTextSize className="text-tertiary" />
+            case 'integer':
+            case 'float':
+            case 'decimal':
+                return <IconCalculator className="text-tertiary" />
+            case 'boolean':
+                return <IconCheck className="text-tertiary" />
+            case 'datetime':
+                return <IconClock className="text-tertiary" />
+            case 'date':
+                return <IconCalendar className="text-tertiary" />
+            case 'array':
+            case 'json':
+                return <IconBrackets className="text-tertiary" />
+            case 'expression':
+                return <IconCode className="text-tertiary" />
+            case 'field_traverser':
+                return <IconCode2 className="text-tertiary" />
+            case 'view':
+            case 'materialized_view':
+            case 'lazy_table':
+            case 'virtual_table':
+                return <IconDatabase className="text-tertiary" />
+            default:
+                return <IconCode2 className="text-tertiary" />
+        }
+    }
 
     const treeRef = useRef<LemonTreeRef>(null)
     useEffect(() => {
@@ -488,7 +534,7 @@ export const QueryDatabase = (): JSX.Element => {
             }}
             renderItemIcon={(item) => {
                 if (item.record?.type === 'column') {
-                    return <></>
+                    return getFieldTypeIcon(item.record.field?.type)
                 }
                 return (
                     <TreeNodeDisplayIcon

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -187,6 +187,7 @@ export const QueryDatabase = (): JSX.Element => {
                 const hasMatches = matches && matches.length > 0
                 const isColumn = item.record?.type === 'column'
                 const columnType = isColumn ? item.record?.field?.type : null
+                const columnKey = isColumn && item.record ? `${item.record.table}.${item.record.columnName}` : null
 
                 return (
                     <span className="truncate">
@@ -210,10 +211,8 @@ export const QueryDatabase = (): JSX.Element => {
                                                 'endpoints',
                                             ].includes(item.record?.type) && 'font-semibold',
                                             isColumn && 'font-mono text-xs',
-                                            isColumn &&
-                                                selectedQueryColumns[
-                                                    `${item.record.table}.${item.record.columnName}`
-                                                ] &&
+                                            columnKey &&
+                                                selectedQueryColumns[columnKey] &&
                                                 'underline underline-offset-2',
                                             'truncate shrink-0'
                                         )}

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -301,13 +301,11 @@ const createTableNode = (
     }
 
     const tableId = `${isSearch ? 'search-' : ''}table-${table.name}`
-    const isPostHogTable = 'type' in table && table.type === 'posthog'
-
     return {
         id: tableId,
         name: table.name,
         type: 'node',
-        icon: isPostHogTable ? <IconDocument /> : <IconDatabase />,
+        icon: <IconDatabase />,
         record: {
             type: 'table',
             table: table,

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -95,7 +95,7 @@ const draftsFuse = new Fuse<DataWarehouseSavedQueryDraft>([], FUSE_OPTIONS)
 // Factory functions for creating tree nodes
 const createColumnNode = (tableName: string, field: DatabaseSchemaField, isSearch = false): TreeDataItem => ({
     id: `${isSearch ? 'search-' : ''}col-${tableName}-${field.name}`,
-    name: `${field.name} (${field.type})`,
+    name: field.name,
     type: 'node',
     record: {
         type: 'column',

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -119,6 +119,11 @@ const sortFieldsWithPrimary = (tableName: string, fields: DatabaseSchemaField[])
         if (primaryKeyName && b.name === primaryKeyName) {
             return 1
         }
+        const aIsVirtual = a.name.startsWith('$')
+        const bIsVirtual = b.name.startsWith('$')
+        if (aIsVirtual !== bIsVirtual) {
+            return aIsVirtual ? 1 : -1
+        }
         return a.name.localeCompare(b.name)
     })
 }

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -37,6 +37,10 @@ import type { queryDatabaseLogicType } from './queryDatabaseLogicType'
 
 export type EditorSidebarTreeRef = React.RefObject<LemonTreeRef> | null
 
+const isLazyNodeId = (id: string): boolean => {
+    return id.startsWith('lazy-') || id.includes('-lazy-')
+}
+
 const isDataWarehouseTable = (
     table: DatabaseSchemaDataWarehouseTable | DatabaseSchemaTable | DataWarehouseSavedQuery
 ): table is DatabaseSchemaDataWarehouseTable => {
@@ -877,7 +881,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                         ([table]) => [table.name, table]
                     )
                 )
-                const expandedLazyNodeIds = new Set(expandedSearchFolders.filter((id) => id.includes('-lazy-')))
+                const expandedLazyNodeIds = new Set(expandedSearchFolders.filter(isLazyNodeId))
                 const sourcesChildren: TreeDataItem[] = []
                 const expandedIds: string[] = []
                 const tableNodeOptions = { expandedLazyNodeIds }
@@ -1033,7 +1037,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                 const tableLookup = Object.fromEntries(
                     [...posthogTables, ...systemTables, ...dataWarehouseTables].map((table) => [table.name, table])
                 )
-                const expandedLazyNodeIds = new Set(expandedFolders.filter((id) => id.includes('-lazy-')))
+                const expandedLazyNodeIds = new Set(expandedFolders.filter(isLazyNodeId))
                 const tableNodeOptions = { expandedLazyNodeIds }
 
                 // Add loading indicator for sources if still loading

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -611,6 +611,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
             ['joins', 'joinsLoading'],
             databaseTableListLogic,
             [
+                'allPosthogTables',
                 'posthogTables',
                 'dataWarehouseTables',
                 'posthogTablesMap',
@@ -849,6 +850,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
         ],
         searchTreeData: [
             (s) => [
+                s.allPosthogTables,
                 s.relevantPosthogTables,
                 s.relevantSystemTables,
                 s.relevantDataWarehouseTables,
@@ -861,6 +863,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                 s.expandedSearchFolders,
             ],
             (
+                allPosthogTables: DatabaseSchemaTable[],
                 relevantPosthogTables: [DatabaseSchemaTable, FuseSearchMatch[] | null][],
                 relevantSystemTables: [DatabaseSchemaTable, FuseSearchMatch[] | null][],
                 relevantDataWarehouseTables: [DatabaseSchemaDataWarehouseTable, FuseSearchMatch[] | null][],
@@ -877,9 +880,11 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                 }
 
                 const tableLookup = Object.fromEntries(
-                    [...relevantPosthogTables, ...relevantSystemTables, ...relevantDataWarehouseTables].map(
-                        ([table]) => [table.name, table]
-                    )
+                    [
+                        ...allPosthogTables,
+                        ...relevantSystemTables.map(([table]) => table),
+                        ...relevantDataWarehouseTables.map(([table]) => table),
+                    ].map((table) => [table.name, table])
                 )
                 const expandedLazyNodeIds = new Set(expandedSearchFolders.filter(isLazyNodeId))
                 const sourcesChildren: TreeDataItem[] = []
@@ -1002,6 +1007,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
         ],
         treeData: [
             (s) => [
+                s.allPosthogTables,
                 s.posthogTables,
                 s.systemTables,
                 s.dataWarehouseTables,
@@ -1018,6 +1024,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                 s.expandedFolders,
             ],
             (
+                allPosthogTables: DatabaseSchemaTable[],
                 posthogTables: DatabaseSchemaTable[],
                 systemTables: DatabaseSchemaTable[],
                 dataWarehouseTables: DatabaseSchemaDataWarehouseTable[],
@@ -1035,7 +1042,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
             ): TreeDataItem[] => {
                 const sourcesChildren: TreeDataItem[] = []
                 const tableLookup = Object.fromEntries(
-                    [...posthogTables, ...systemTables, ...dataWarehouseTables].map((table) => [table.name, table])
+                    [...allPosthogTables, ...systemTables, ...dataWarehouseTables].map((table) => [table.name, table])
                 )
                 const expandedLazyNodeIds = new Set(expandedFolders.filter(isLazyNodeId))
                 const tableNodeOptions = { expandedLazyNodeIds }

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -197,7 +197,7 @@ const resolveFieldTraverserTarget = (
     let index = 0
 
     while (index < field.chain.length) {
-        const segment = field.chain[index]
+        const segment: string | number = field.chain[index]
         const segmentKey = String(segment)
 
         if (segmentKey === '..') {
@@ -205,7 +205,7 @@ const resolveFieldTraverserTarget = (
         }
 
         if (!currentField) {
-            const nextField = currentTable?.fields?.[segmentKey]
+            const nextField: DatabaseSchemaField | undefined = currentTable?.fields?.[segmentKey]
             if (!nextField) {
                 return null
             }

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -168,7 +168,7 @@ def process_query_model(
             database = Database.create_for(team=team, modifiers=create_default_modifiers_for_team(team))
             context = HogQLContext(team_id=team.pk, team=team, database=database)
             result = DatabaseSchemaQueryResponse(
-                tables=database.serialize(context),
+                tables=database.serialize(context, include_hidden_posthog_tables=True),
                 joins=[
                     DataWarehouseViewLink.model_validate(
                         {

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -315,7 +315,10 @@ class Database(BaseModel):
         )
 
     # These are the tables exposed via SQL editor autocomplete and data management
-    def get_posthog_table_names(self) -> list[str]:
+    def get_posthog_table_names(self, include_hidden: bool = False) -> list[str]:
+        if include_hidden:
+            return sorted(ROOT_TABLES__DO_NOT_ADD_ANY_MORE.keys())
+
         return [
             "events",
             "groups",
@@ -352,6 +355,7 @@ class Database(BaseModel):
         self,
         context: HogQLContext,
         include_only: set[str] | None = None,
+        include_hidden_posthog_tables: bool = False,
     ) -> dict[str, DatabaseSchemaTable]:
         from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
         from products.revenue_analytics.backend.views import RevenueAnalyticsBaseView
@@ -362,7 +366,7 @@ class Database(BaseModel):
             raise ResolutionError("Must provide team_id to serialize database")
 
         # PostHog tables
-        posthog_table_names = self.get_posthog_table_names()
+        posthog_table_names = self.get_posthog_table_names(include_hidden=include_hidden_posthog_tables)
         for table_name in posthog_table_names:
             if include_only and table_name not in include_only:
                 continue


### PR DESCRIPTION
## Problem

The SQL editor's sidebar could use some improvements when it comes to tables and columns:

![2026-01-22 13 33 57](https://github.com/user-attachments/assets/c153b61d-fde2-4dd4-9286-18f270cb465f)

## Changes

- Expand virtual tables, lazy tables and field traversers --> now you can select the columns inside them
- Add icons for each column (was needed if the lazy/virtual tables got folder icons)
- Reduce the styling of the type behind the name. We could even remove it altogether now that we have icons
- Sort things alphabetically, except for the primary key which remains on top if available

![2026-01-22 14 02 34](https://github.com/user-attachments/assets/d87e24bf-487a-4994-bbde-c13f7cf43440)


## How did you test this code?

Clicked around a lot in the UI
