### PR TITLE
feat(ph-ai): edit survey

### DIFF
--- a/ee/hogai/core/agent_modes/presets/survey.py
+++ b/ee/hogai/core/agent_modes/presets/survey.py
@@ -54,6 +54,24 @@ The assistant used the todo list because:
 4. Breaking this into steps ensures the assistant gets the flag ID before creating the survey
 """.strip()
 
+POSITIVE_EXAMPLE_EDIT_SURVEY = """
+User: Stop the NPS survey and archive it
+Assistant: I'll first search for the NPS survey, then stop and archive it.
+*Creates todo list with the following items:*
+1. Search for the NPS survey to get its ID
+2. Stop and archive the survey
+*Uses search with kind: "surveys" and query: "NPS"*
+After getting the survey ID, the assistant uses edit_survey with survey_id and updates: {end_date: "now", archived: true}
+""".strip()
+
+POSITIVE_EXAMPLE_EDIT_SURVEY_REASONING = """
+The assistant used the todo list because:
+1. The user wants to modify an existing survey (stop and archive)
+2. This requires multiple steps: first find the survey ID, then apply the updates
+3. The search tool with surveys kind retrieves the survey information
+4. The edit_survey tool is used with end_date="now" to stop and archived=true to archive
+""".strip()
+
 
 class SurveyAgentToolkit(AgentToolkit):
     POSITIVE_TODO_EXAMPLES = [
@@ -69,13 +87,17 @@ class SurveyAgentToolkit(AgentToolkit):
             example=POSITIVE_EXAMPLE_SURVEY_WITH_FLAG,
             reasoning=POSITIVE_EXAMPLE_SURVEY_WITH_FLAG_REASONING,
         ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_EDIT_SURVEY,
+            reasoning=POSITIVE_EXAMPLE_EDIT_SURVEY_REASONING,
+        ),
     ]
 
     @property
     def tools(self) -> list[type["MaxTool"]]:
-        from products.surveys.backend.max_tools import CreateSurveyTool, SurveyAnalysisTool
+        from products.surveys.backend.max_tools import CreateSurveyTool, EditSurveyTool, SurveyAnalysisTool
 
-        tools: list[type[MaxTool]] = [CreateSurveyTool, SurveyAnalysisTool]
+        tools: list[type[MaxTool]] = [CreateSurveyTool, EditSurveyTool, SurveyAnalysisTool]
         return tools
 
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1951,6 +1951,7 @@
                 "find_error_tracking_impactful_issue_event_list",
                 "experiment_results_summary",
                 "create_survey",
+                "edit_survey",
                 "analyze_survey_responses",
                 "create_dashboard",
                 "edit_current_dashboard",

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -406,6 +406,7 @@ export type AssistantTool =
     | 'find_error_tracking_impactful_issue_event_list'
     | 'experiment_results_summary'
     | 'create_survey'
+    | 'edit_survey'
     | 'analyze_survey_responses'
     | 'create_dashboard'
     | 'edit_current_dashboard'

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -617,6 +617,19 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
             return 'Creating surveys...'
         },
     },
+    edit_survey: {
+        name: 'Edit survey',
+        description: 'Edit survey',
+        product: Scene.Surveys,
+        icon: iconForType('survey'),
+        modes: [AgentMode.Survey],
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Edited survey'
+            }
+            return 'Editing survey...'
+        },
+    },
     analyze_survey_responses: {
         name: 'Analyze survey responses',
         description: 'Analyze survey responses to extract themes and actionable insights',

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -334,6 +334,7 @@ class AssistantTool(StrEnum):
     FIND_ERROR_TRACKING_IMPACTFUL_ISSUE_EVENT_LIST = "find_error_tracking_impactful_issue_event_list"
     EXPERIMENT_RESULTS_SUMMARY = "experiment_results_summary"
     CREATE_SURVEY = "create_survey"
+    EDIT_SURVEY = "edit_survey"
     ANALYZE_SURVEY_RESPONSES = "analyze_survey_responses"
     CREATE_DASHBOARD = "create_dashboard"
     EDIT_CURRENT_DASHBOARD = "edit_current_dashboard"


### PR DESCRIPTION
## Problem

Users lack the ability to edit existing surveys via our agent, let's add a write tool for that.

<img width="718" height="708" alt="image" src="https://github.com/user-attachments/assets/99716b33-8daf-4257-8fd5-5bdb5fa784d9" />

<img width="1189" height="477" alt="image" src="https://github.com/user-attachments/assets/3a1a0e99-fabe-4544-8938-c3110d788819" />


## Changes

* added  `edit_survey` tool to the specific mode
* marked as dangerous operations in order to avoid the agent doing something that hasn't been agreed upon

## How did you test this code?

- [x] unit tests
- [x] manual tests

## Publish to changelog?

Users are now able to create/edit surveys from PostHog AI directly (instead of relying on contextual tool, tied to the surveys page)