### PR TITLE
fix(llma): disable timezone conversion for cluster queries

### DIFF
--- a/products/llm_analytics/frontend/clusters/clusterDetailLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clusterDetailLogic.ts
@@ -94,7 +94,9 @@ export const clusterDetailLogic = kea<clusterDetailLogicType>([
                                 AND JSONExtractString(properties, '$ai_clustering_run_id') = ${props.runId}
                             LIMIT 1
                         `,
-                        { productKey: 'llm_analytics', scene: 'LLMAnalyticsCluster' }
+                        { productKey: 'llm_analytics', scene: 'LLMAnalyticsCluster' },
+                        // Run IDs and bounds are in UTC, so compare timestamps in UTC
+                        { queryParams: { modifiers: { convertToProjectTimezone: false } } }
                     )
 
                     if (!response.results?.length) {

--- a/products/llm_analytics/frontend/clusters/clustersLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clustersLogic.ts
@@ -118,7 +118,11 @@ export const clustersLogic = kea<clustersLogicType>([
                             LIMIT ${MAX_CLUSTERING_RUNS}
                         `,
                         { productKey: 'llm_analytics', scene: 'LLMAnalyticsClusters' },
-                        { refresh: 'force_blocking' }
+                        {
+                            refresh: 'force_blocking',
+                            // Run IDs are generated in UTC, so compare timestamps in UTC
+                            queryParams: { modifiers: { convertToProjectTimezone: false } },
+                        }
                     )
 
                     return (response.results || []).map((row: string[]) => ({
@@ -153,7 +157,9 @@ export const clustersLogic = kea<clustersLogicType>([
                                 AND JSONExtractString(properties, '$ai_clustering_run_id') = ${runId}
                             LIMIT 1
                         `,
-                        { productKey: 'llm_analytics', scene: 'LLMAnalyticsClusters' }
+                        { productKey: 'llm_analytics', scene: 'LLMAnalyticsClusters' },
+                        // Run IDs and bounds are in UTC, so compare timestamps in UTC
+                        { queryParams: { modifiers: { convertToProjectTimezone: false } } }
                     )
 
                     if (!response.results?.length) {

--- a/products/llm_analytics/frontend/clusters/traceSummaryLoader.ts
+++ b/products/llm_analytics/frontend/clusters/traceSummaryLoader.ts
@@ -55,7 +55,9 @@ export async function loadTraceSummaries(
             GROUP BY trace_id
             LIMIT 10000
         `,
-        { productKey: 'llm_analytics', scene: 'LLMAnalyticsClusters' }
+        { productKey: 'llm_analytics', scene: 'LLMAnalyticsClusters' },
+        // Window bounds are in UTC (from backend), so compare timestamps in UTC
+        { queryParams: { modifiers: { convertToProjectTimezone: false } } }
     )
 
     const summaries: Record<string, TraceSummary> = {}


### PR DESCRIPTION
## Problem

LLM Analytics Clusters tab shows no chart data for projects with non-UTC timezones (e.g., US/Pacific).

## Changes

Added `convertToProjectTimezone: false` to all cluster-related HogQL queries.

The clustering run IDs and bounds are generated in UTC by the backend. The previous fix (#45680) correctly parsed run IDs as UTC, but queries still applied timezone conversion by default, causing timestamp mismatches.

## How did you test this code?

Manual testing on project 2 (US/Pacific timezone) to verify cluster runs display correctly.

## Publish to changelog?

No