### PR TITLE
fix: gemini timeout in milliseconds not seconds

### DIFF
--- a/products/llm_analytics/backend/llm/providers/gemini.py
+++ b/products/llm_analytics/backend/llm/providers/gemini.py
@@ -29,9 +29,9 @@ logger = logging.getLogger(__name__)
 
 class GeminiConfig:
     TEMPERATURE: float = 0
-    # Timeout in seconds for API calls. Set high to accommodate slow reasoning models.
+    # Timeout in milliseconds for API calls. Set high to accommodate slow reasoning models.
     # Note: Infrastructure-level timeouts (load balancers, proxies) may still limit actual request duration.
-    TIMEOUT: int = 300
+    TIMEOUT: int = 300_000
 
     SUPPORTED_MODELS: list[str] = [
         "gemini-3-flash-preview",

--- a/products/llm_analytics/backend/providers/test/test_gemini.py
+++ b/products/llm_analytics/backend/providers/test/test_gemini.py
@@ -13,7 +13,7 @@ class TestGeminiConfig(SimpleTestCase):
         assert GeminiConfig.TEMPERATURE == 0
 
     def test_timeout_setting(self):
-        assert GeminiConfig.TIMEOUT == 300
+        assert GeminiConfig.TIMEOUT == 300_000
 
     def test_supported_models_include_expected(self):
         expected_models = [


### PR DESCRIPTION
Fixes a Gemini timeout that should be in milliseconds, right now Gemini is broken in the playground as the timeout is lower than the minimum 1s limit. I found the issue while implementing #45001, which touched this code path, but it was originally introduced in #45343, so it's been broken for a couple of days.