### PR TITLE
fix(experiments): Fix empty variant panel under simple creation form experiment

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanel.tsx
@@ -121,7 +121,10 @@ export function VariantsPanel({
             updateFeatureFlag({
                 feature_flag_key: selected,
                 parameters: {
-                    feature_flag_variants: experiment.parameters?.feature_flag_variants || [],
+                    feature_flag_variants: experiment.parameters?.feature_flag_variants || [
+                        { key: 'control', rollout_percentage: 50 },
+                        { key: 'test', rollout_percentage: 50 },
+                    ],
                 },
             })
             // Change mode after updating the key to avoid validating the old key in setMode listener


### PR DESCRIPTION
## Problem

When a user is exposed to the simple creation form experiment, the following sequence is a bug:
- Enter a feature flag key
- Remove the feature flag (backspace or clear button)
- Enter a custom feature flag name
- Now the variant panel is rendered empty, instead of showing the default control/test variants

## Changes

Fix the described behavior

## How did you test this code?

Manually

## Publish to changelog?

No