### PR TITLE
chore(surveys): convert guided editor flag to multivariate for experiment

### DIFF
--- a/frontend/src/scenes/surveys/surveysLogic.tsx
+++ b/frontend/src/scenes/surveys/surveysLogic.tsx
@@ -459,7 +459,7 @@ export const surveysLogic = kea<surveysLogicType>([
         ],
         guidedEditorEnabled: [
             (s) => [s.enabledFlags],
-            (enabledFlags) => !!enabledFlags[FEATURE_FLAGS.SURVEYS_GUIDED_EDITOR],
+            (enabledFlags) => !!(enabledFlags[FEATURE_FLAGS.SURVEYS_GUIDED_EDITOR] === 'test'),
         ],
         globalSurveyAppearanceConfigAvailable: [
             (s) => [s.hasAvailableFeature],


### PR DESCRIPTION
## Summary
- Converts the `SURVEYS_GUIDED_EDITOR` feature flag from a boolean check to a multivariate pattern
- Enables running an A/B experiment with `control`/`test` variants
- Feature remains enabled when variant is `test`, disabled for `control`

## Test plan
- [ ] Configure the flag as multivariate in PostHog admin with `control` and `test` variants
- [ ] Verify guided editor appears when variant is `test`
- [ ] Verify guided editor is hidden when variant is `control`