### PR TITLE
feat(gateway): add model endpoint for model discovery

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/models.py
+++ b/services/llm-gateway/src/llm_gateway/api/models.py
@@ -1,0 +1,53 @@
+from typing import Literal
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from llm_gateway.api.products import validate_product
+from llm_gateway.services.model_registry import get_available_models
+
+models_router = APIRouter(tags=["models"])
+
+CREATED_TIMESTAMP = 1669766400  # Nov 30, 2022 - ChatGPT release date - we don't have data on this so just return a default for the field to match OpenAI's API
+
+
+class ModelObject(BaseModel):
+    id: str
+    object: Literal["model"] = "model"
+    created: int = CREATED_TIMESTAMP
+    owned_by: str
+    context_window: int
+    supports_streaming: bool
+    supports_vision: bool
+
+
+class ModelsResponse(BaseModel):
+    object: Literal["list"] = "list"
+    data: list[ModelObject]
+
+
+def _build_response(product: str) -> ModelsResponse:
+    models = get_available_models(product)
+    return ModelsResponse(
+        data=[
+            ModelObject(
+                id=m.id,
+                owned_by=m.provider,
+                context_window=m.context_window,
+                supports_streaming=m.supports_streaming,
+                supports_vision=m.supports_vision,
+            )
+            for m in models
+        ]
+    )
+
+
+@models_router.get("/v1/models")
+async def list_models() -> ModelsResponse:
+    return _build_response("llm_gateway")
+
+
+@models_router.get("/{product}/v1/models")
+async def list_models_for_product(product: str) -> ModelsResponse:
+    validate_product(product)
+    return _build_response(product)

--- a/services/llm-gateway/src/llm_gateway/api/routes.py
+++ b/services/llm-gateway/src/llm_gateway/api/routes.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
 
 from llm_gateway.api.anthropic import anthropic_router
+from llm_gateway.api.models import models_router
 from llm_gateway.api.openai import openai_router
 
 router = APIRouter()
 router.include_router(anthropic_router, tags=["Anthropic"])
+router.include_router(models_router, tags=["Models"])
 router.include_router(openai_router, tags=["OpenAI"])

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_service.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_service.py
@@ -41,6 +41,10 @@ class ModelCost(TypedDict, total=False):
     """Legacy field: defaults to max_output_tokens if set, otherwise max_input_tokens."""
     litellm_provider: str
     """Provider identifier (e.g., "anthropic", "openai", "vertex_ai")."""
+    supports_vision: bool
+    """Whether the model supports image/vision input."""
+    mode: str
+    """Model mode (e.g., "chat", "completion", "embedding")."""
 
 
 class ModelCostService:

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_service.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_service.py
@@ -102,6 +102,10 @@ class ModelCostService:
         self._ensure_fresh()
         return self._costs.get(model)
 
+    def get_all_models(self) -> dict[str, ModelCost]:
+        self._ensure_fresh()
+        return self._costs
+
 
 def get_model_limits(model: str) -> ModelLimits:
     return ModelCostService.get_instance().get_limits(model)

--- a/services/llm-gateway/src/llm_gateway/services/__init__.py
+++ b/services/llm-gateway/src/llm_gateway/services/__init__.py
@@ -1,0 +1,13 @@
+from llm_gateway.services.model_registry import (
+    ModelInfo,
+    ModelRegistryService,
+    get_available_models,
+    is_model_available,
+)
+
+__all__ = [
+    "ModelInfo",
+    "ModelRegistryService",
+    "get_available_models",
+    "is_model_available",
+]

--- a/services/llm-gateway/src/llm_gateway/services/model_registry.py
+++ b/services/llm-gateway/src/llm_gateway/services/model_registry.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import ClassVar, Final
+
+from llm_gateway.config import get_settings
+from llm_gateway.products.config import get_product_config
+from llm_gateway.rate_limiting.model_cost_service import ModelCostService
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    id: str
+    provider: str
+    context_window: int
+    supports_streaming: bool = True
+    supports_vision: bool = False
+
+
+# Map LiteLLM provider names to (settings_attr, env_var) tuples
+# Settings use LLM_GATEWAY_ prefix, but litellm also checks unprefixed env vars
+_PROVIDER_TO_API_KEY: Final[dict[str, tuple[str, str]]] = {
+    "openai": ("openai_api_key", "OPENAI_API_KEY"),
+    "anthropic": ("anthropic_api_key", "ANTHROPIC_API_KEY"),
+    "vertex_ai": ("gemini_api_key", "GEMINI_API_KEY"),
+    "vertex_ai-language-models": ("gemini_api_key", "GEMINI_API_KEY"),
+    "gemini": ("gemini_api_key", "GEMINI_API_KEY"),
+}
+
+
+def _get_configured_providers() -> frozenset[str]:
+    """Return the set of providers that have API keys configured."""
+    settings = get_settings()
+    configured = set()
+    for provider, (settings_attr, env_var) in _PROVIDER_TO_API_KEY.items():
+        if getattr(settings, settings_attr, None) or os.environ.get(env_var):
+            configured.add(provider)
+    return frozenset(configured)
+
+
+def _is_chat_model(cost_data: dict) -> bool:
+    """Check if a model is a chat model (not embedding, image generation, etc)."""
+    mode = cost_data.get("mode", "")
+    return mode in ("chat", "completion", "")
+
+
+class ModelRegistryService:
+    """Singleton service for model discovery using LiteLLM data."""
+
+    _instance: ClassVar[ModelRegistryService | None] = None
+
+    @classmethod
+    def get_instance(cls) -> ModelRegistryService:
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """For testing."""
+        cls._instance = None
+
+    def get_model(self, model_id: str) -> ModelInfo | None:
+        """Get model info from LiteLLM's cost data."""
+        cost_data = ModelCostService.get_instance().get_costs(model_id)
+        if cost_data is None:
+            return None
+        return ModelInfo(
+            id=model_id,
+            provider=cost_data.get("litellm_provider", "unknown"),
+            context_window=cost_data.get("max_input_tokens") or 0,
+            supports_vision=cost_data.get("supports_vision", False),
+            supports_streaming=True,
+        )
+
+    def get_available_models(self, product: str) -> list[ModelInfo]:
+        """Get models available to a product, filtered by configured providers."""
+        config = get_product_config(product)
+        configured_providers = _get_configured_providers()
+
+        # If product has explicit allowed_models, use those
+        if config is not None and config.allowed_models is not None:
+            models = []
+            for model_id in config.allowed_models:
+                model = self.get_model(model_id)
+                if model is not None and model.provider in configured_providers:
+                    models.append(model)
+            return models
+
+        # Otherwise, return all chat models from configured providers
+        all_models = ModelCostService.get_instance().get_all_models()
+        models = []
+        for model_id, cost_data in all_models.items():
+            provider = cost_data.get("litellm_provider", "")
+            if provider in configured_providers and _is_chat_model(cost_data):
+                model = self.get_model(model_id)
+                if model is not None:
+                    models.append(model)
+        return models
+
+    def is_model_available(self, model_id: str, product: str) -> bool:
+        """Check if a model is available for a product."""
+        config = get_product_config(product)
+
+        # If product has explicit allowed_models, check against those
+        if config is not None and config.allowed_models is not None:
+            if model_id not in config.allowed_models:
+                return False
+
+        model = self.get_model(model_id)
+        if model is None:
+            return False
+        return model.provider in _get_configured_providers()
+
+
+def get_available_models(product: str) -> list[ModelInfo]:
+    return ModelRegistryService.get_instance().get_available_models(product)
+
+
+def is_model_available(model_id: str, product: str) -> bool:
+    return ModelRegistryService.get_instance().is_model_available(model_id, product)

--- a/services/llm-gateway/src/llm_gateway/services/model_registry.py
+++ b/services/llm-gateway/src/llm_gateway/services/model_registry.py
@@ -6,7 +6,7 @@ from typing import ClassVar, Final
 
 from llm_gateway.config import get_settings
 from llm_gateway.products.config import get_product_config
-from llm_gateway.rate_limiting.model_cost_service import ModelCostService
+from llm_gateway.rate_limiting.model_cost_service import ModelCost, ModelCostService
 
 
 @dataclass(frozen=True)
@@ -39,7 +39,7 @@ def _get_configured_providers() -> frozenset[str]:
     return frozenset(configured)
 
 
-def _is_chat_model(cost_data: dict) -> bool:
+def _is_chat_model(cost_data: ModelCost) -> bool:
     """Check if a model is a chat model (not embedding, image generation, etc)."""
     mode = cost_data.get("mode", "")
     return mode in ("chat", "completion", "")
@@ -70,7 +70,7 @@ class ModelRegistryService:
             id=model_id,
             provider=cost_data.get("litellm_provider", "unknown"),
             context_window=cost_data.get("max_input_tokens") or 0,
-            supports_vision=cost_data.get("supports_vision", False),
+            supports_vision=bool(cost_data.get("supports_vision", False)),
             supports_streaming=True,
         )
 

--- a/services/llm-gateway/tests/integration/conftest.py
+++ b/services/llm-gateway/tests/integration/conftest.py
@@ -5,6 +5,7 @@ import socket
 import threading
 import time
 from contextlib import contextmanager
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -104,7 +105,7 @@ def run_gateway_server(configure_all_providers: bool = False):
 
         # Pre-populate the ModelCostService cache to avoid network calls in CI
         cost_service = ModelCostService.get_instance()
-        cost_service._costs = MOCK_MODEL_COSTS
+        cost_service._costs = cast(dict, MOCK_MODEL_COSTS)
         cost_service._last_refresh = time.monotonic()
 
         with patch("llm_gateway.main.init_db_pool", return_value=mock_db_pool):

--- a/services/llm-gateway/tests/test_model_registry.py
+++ b/services/llm-gateway/tests/test_model_registry.py
@@ -1,0 +1,230 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llm_gateway.rate_limiting.model_cost_service import ModelCost, ModelCostService
+from llm_gateway.services.model_registry import (
+    ModelInfo,
+    ModelRegistryService,
+    get_available_models,
+    is_model_available,
+)
+
+PROVIDER_ENV_VARS = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"]
+
+MOCK_COST_DATA: dict[str, ModelCost] = {
+    "gpt-4o": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "gpt-4o-mini": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "o1": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "claude-3-5-sonnet-20241022": {
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "claude-3-5-haiku-20241022": {
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "gemini-2.0-flash": {
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 1048576,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "gemini-1.5-pro": {
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 2097152,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "text-embedding-ada-002": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 8191,
+        "supports_vision": False,
+        "mode": "embedding",
+    },
+}
+
+
+def mock_get_costs(self: ModelCostService, model: str) -> ModelCost | None:
+    return MOCK_COST_DATA.get(model)
+
+
+def mock_get_all_models(self: ModelCostService) -> dict[str, ModelCost]:
+    return MOCK_COST_DATA
+
+
+def create_mock_settings(
+    openai: bool = True,
+    anthropic: bool = True,
+    gemini: bool = True,
+) -> MagicMock:
+    settings = MagicMock()
+    settings.openai_api_key = "sk-test" if openai else None
+    settings.anthropic_api_key = "sk-ant-test" if anthropic else None
+    settings.gemini_api_key = "gemini-test" if gemini else None
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def reset_services():
+    ModelRegistryService.reset_instance()
+    ModelCostService.reset_instance()
+    yield
+    ModelRegistryService.reset_instance()
+    ModelCostService.reset_instance()
+
+
+@pytest.fixture(autouse=True)
+def mock_cost_service():
+    with (
+        patch.object(ModelCostService, "get_costs", mock_get_costs),
+        patch.object(ModelCostService, "get_all_models", mock_get_all_models),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_settings():
+    with patch(
+        "llm_gateway.services.model_registry.get_settings",
+        return_value=create_mock_settings(),
+    ):
+        yield
+
+
+class TestModelRegistryService:
+    def test_get_instance_returns_singleton(self):
+        instance1 = ModelRegistryService.get_instance()
+        instance2 = ModelRegistryService.get_instance()
+        assert instance1 is instance2
+
+    def test_reset_instance_clears_singleton(self):
+        instance1 = ModelRegistryService.get_instance()
+        ModelRegistryService.reset_instance()
+        instance2 = ModelRegistryService.get_instance()
+        assert instance1 is not instance2
+
+
+class TestGetModel:
+    @pytest.mark.parametrize(
+        "model_id,expected_provider",
+        [
+            ("gpt-4o", "openai"),
+            ("claude-3-5-sonnet-20241022", "anthropic"),
+            ("gemini-2.0-flash", "vertex_ai"),
+        ],
+    )
+    def test_returns_model_info_for_known_model(self, model_id: str, expected_provider: str):
+        service = ModelRegistryService.get_instance()
+        model = service.get_model(model_id)
+        assert model is not None
+        assert model.id == model_id
+        assert model.provider == expected_provider
+
+    def test_returns_none_for_unknown_model(self):
+        service = ModelRegistryService.get_instance()
+        model = service.get_model("unknown-model")
+        assert model is None
+
+
+class TestGetAvailableModels:
+    def test_returns_all_chat_models_from_configured_providers(self):
+        models = get_available_models("llm_gateway")
+        model_ids = {m.id for m in models}
+        assert "gpt-4o" in model_ids
+        assert "claude-3-5-sonnet-20241022" in model_ids
+        assert "gemini-2.0-flash" in model_ids
+
+    def test_excludes_embedding_models(self):
+        models = get_available_models("llm_gateway")
+        model_ids = {m.id for m in models}
+        assert "text-embedding-ada-002" not in model_ids
+
+    def test_returns_model_info_objects(self):
+        models = get_available_models("llm_gateway")
+        assert all(isinstance(m, ModelInfo) for m in models)
+
+
+class TestProviderFiltering:
+    @pytest.fixture(autouse=True)
+    def clear_env_api_keys(self):
+        with patch.dict(os.environ, {}, clear=False):
+            for var in PROVIDER_ENV_VARS:
+                os.environ.pop(var, None)
+            yield
+
+    def test_only_returns_models_from_configured_providers(self):
+        with patch(
+            "llm_gateway.services.model_registry.get_settings",
+            return_value=create_mock_settings(openai=True, anthropic=False, gemini=False),
+        ):
+            models = get_available_models("llm_gateway")
+            providers = {m.provider for m in models}
+            assert providers == {"openai"}
+            model_ids = {m.id for m in models}
+            assert "gpt-4o" in model_ids
+            assert "claude-3-5-sonnet-20241022" not in model_ids
+            assert "gemini-2.0-flash" not in model_ids
+
+    def test_returns_empty_when_no_providers_configured(self):
+        with patch(
+            "llm_gateway.services.model_registry.get_settings",
+            return_value=create_mock_settings(openai=False, anthropic=False, gemini=False),
+        ):
+            models = get_available_models("llm_gateway")
+            assert len(models) == 0
+
+    def test_returns_multiple_providers_when_configured(self):
+        with patch(
+            "llm_gateway.services.model_registry.get_settings",
+            return_value=create_mock_settings(openai=True, anthropic=True, gemini=False),
+        ):
+            models = get_available_models("llm_gateway")
+            providers = {m.provider for m in models}
+            assert providers == {"openai", "anthropic"}
+
+
+class TestIsModelAvailable:
+    @pytest.mark.parametrize(
+        "model_id,product,expected",
+        [
+            ("gpt-4o", "llm_gateway", True),
+            ("gpt-4o", "array", True),
+            ("o1", "llm_gateway", True),
+            ("o1", "array", True),
+            ("unknown-model", "llm_gateway", False),
+        ],
+    )
+    def test_model_availability(self, model_id: str, product: str, expected: bool):
+        assert is_model_available(model_id, product) == expected
+
+    def test_model_not_available_when_provider_not_configured(self):
+        with patch.dict(os.environ, {}, clear=False):
+            for var in PROVIDER_ENV_VARS:
+                os.environ.pop(var, None)
+            with patch(
+                "llm_gateway.services.model_registry.get_settings",
+                return_value=create_mock_settings(openai=False, anthropic=True, gemini=True),
+            ):
+                assert is_model_available("gpt-4o", "llm_gateway") is False
+                assert is_model_available("claude-3-5-sonnet-20241022", "llm_gateway") is True

--- a/services/llm-gateway/tests/test_model_registry.py
+++ b/services/llm-gateway/tests/test_model_registry.py
@@ -26,12 +26,6 @@ MOCK_COST_DATA: dict[str, ModelCost] = {
         "supports_vision": True,
         "mode": "chat",
     },
-    "gpt-4o-2024-05-13": {
-        "litellm_provider": "openai",
-        "max_input_tokens": 128000,
-        "supports_vision": True,
-        "mode": "chat",
-    },
     "o1": {
         "litellm_provider": "openai",
         "max_input_tokens": 200000,
@@ -219,11 +213,6 @@ class TestIsModelAvailable:
             ("o1", "llm_gateway", True),
             ("o1", "array", True),
             ("unknown-model", "llm_gateway", False),
-            # Prefix matching for growth product
-            ("gpt-4o", "growth", True),
-            ("gpt-4o-mini", "growth", True),
-            ("gpt-4o-2024-05-13", "growth", True),  # Prefix match on gpt-4o
-            ("claude-3-5-sonnet-20241022", "growth", False),  # Not in growth allowlist
         ],
     )
     def test_model_availability(self, model_id: str, product: str, expected: bool):

--- a/services/llm-gateway/tests/test_model_registry.py
+++ b/services/llm-gateway/tests/test_model_registry.py
@@ -26,6 +26,12 @@ MOCK_COST_DATA: dict[str, ModelCost] = {
         "supports_vision": True,
         "mode": "chat",
     },
+    "gpt-4o-2024-05-13": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
     "o1": {
         "litellm_provider": "openai",
         "max_input_tokens": 200000,
@@ -213,6 +219,11 @@ class TestIsModelAvailable:
             ("o1", "llm_gateway", True),
             ("o1", "array", True),
             ("unknown-model", "llm_gateway", False),
+            # Prefix matching for growth product
+            ("gpt-4o", "growth", True),
+            ("gpt-4o-mini", "growth", True),
+            ("gpt-4o-2024-05-13", "growth", True),  # Prefix match on gpt-4o
+            ("claude-3-5-sonnet-20241022", "growth", False),  # Not in growth allowlist
         ],
     )
     def test_model_availability(self, model_id: str, product: str, expected: bool):

--- a/services/llm-gateway/tests/test_models_api.py
+++ b/services/llm-gateway/tests/test_models_api.py
@@ -1,0 +1,131 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from llm_gateway.rate_limiting.model_cost_service import ModelCost, ModelCostService
+from llm_gateway.services.model_registry import ModelRegistryService
+
+MOCK_COST_DATA: dict[str, ModelCost] = {
+    "gpt-4o": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "gpt-4o-mini": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "o1": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "claude-3-5-sonnet-20241022": {
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "gemini-2.0-flash": {
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 1048576,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+}
+
+
+def mock_get_costs(self: ModelCostService, model: str) -> ModelCost | None:
+    return MOCK_COST_DATA.get(model)
+
+
+def mock_get_all_models(self: ModelCostService) -> dict[str, ModelCost]:
+    return MOCK_COST_DATA
+
+
+def create_mock_settings() -> MagicMock:
+    settings = MagicMock()
+    settings.openai_api_key = "sk-test"
+    settings.anthropic_api_key = "sk-ant-test"
+    settings.gemini_api_key = "gemini-test"
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def reset_services():
+    ModelRegistryService.reset_instance()
+    ModelCostService.reset_instance()
+    yield
+    ModelRegistryService.reset_instance()
+    ModelCostService.reset_instance()
+
+
+@pytest.fixture(autouse=True)
+def mock_cost_service():
+    with (
+        patch.object(ModelCostService, "get_costs", mock_get_costs),
+        patch.object(ModelCostService, "get_all_models", mock_get_all_models),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_settings():
+    with patch(
+        "llm_gateway.services.model_registry.get_settings",
+        return_value=create_mock_settings(),
+    ):
+        yield
+
+
+class TestListModelsEndpoint:
+    def test_returns_models_list(self, client: TestClient):
+        response = client.get("/v1/models")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["object"] == "list"
+        assert isinstance(data["data"], list)
+        assert len(data["data"]) > 0
+
+    def test_model_object_has_required_fields(self, client: TestClient):
+        response = client.get("/v1/models")
+        data = response.json()
+        model = data["data"][0]
+        assert "id" in model
+        assert "object" in model
+        assert model["object"] == "model"
+        assert "created" in model
+        assert "owned_by" in model
+        assert "context_window" in model
+        assert "supports_streaming" in model
+        assert "supports_vision" in model
+
+
+class TestListModelsForProductEndpoint:
+    def test_returns_models_for_llm_gateway(self, client: TestClient):
+        response = client.get("/llm_gateway/v1/models")
+        assert response.status_code == 200
+        data = response.json()
+        model_ids = {m["id"] for m in data["data"]}
+        assert "gpt-4o" in model_ids
+        assert "o1" in model_ids
+
+    def test_array_returns_all_models_from_configured_providers(self, client: TestClient):
+        response = client.get("/array/v1/models")
+        assert response.status_code == 200
+        data = response.json()
+        model_ids = {m["id"] for m in data["data"]}
+        assert "gpt-4o" in model_ids
+        assert "o1" in model_ids
+        assert "claude-3-5-sonnet-20241022" in model_ids
+        assert "gemini-2.0-flash" in model_ids
+
+    def test_returns_error_for_invalid_product(self, client: TestClient):
+        response = client.get("/invalid_product/v1/models")
+        assert response.status_code == 400
+        assert "Invalid product" in response.json()["detail"]

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -59,19 +59,16 @@ class TestCheckProductAccess:
             assert expected_error_contains in error
 
     @pytest.mark.parametrize(
-        "model,expected_allowed",
+        "model",
         [
-            ("claude-3-5-haiku-20241022", True),
-            ("gpt-4o-mini", True),
-            ("gpt-4o", True),
-            ("claude-3-opus", False),
-            ("o1", False),
+            "claude-3-5-haiku-20241022",
+            "gpt-4o-mini",
+            "gpt-4o",
+            "claude-3-opus",
+            "o1",
         ],
     )
-    def test_array_model_restrictions_with_valid_app_id(self, model: str, expected_allowed: bool):
+    def test_array_allows_all_models_with_valid_app_id(self, model: str):
         allowed, error = check_product_access("array", "oauth_access_token", ARRAY_US_APP_ID, model)
-        assert allowed is expected_allowed
-        if expected_allowed:
-            assert error is None
-        else:
-            assert error is not None
+        assert allowed is True
+        assert error is None

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -59,15 +59,19 @@ class TestCheckProductAccess:
             assert expected_error_contains in error
 
     @pytest.mark.parametrize(
-        "model",
+        "model,expected_allowed",
         [
-            "claude-3-5-haiku-20241022",
-            "gpt-4o-mini",
-            "claude-3-opus",
-            "gpt-4o",
+            ("claude-3-5-haiku-20241022", True),
+            ("gpt-4o-mini", True),
+            ("gpt-4o", True),
+            ("claude-3-opus", False),
+            ("o1", False),
         ],
     )
-    def test_array_allows_all_models_with_valid_app_id(self, model: str):
+    def test_array_model_restrictions_with_valid_app_id(self, model: str, expected_allowed: bool):
         allowed, error = check_product_access("array", "oauth_access_token", ARRAY_US_APP_ID, model)
-        assert allowed is True
-        assert error is None
+        assert allowed is expected_allowed
+        if expected_allowed:
+            assert error is None
+        else:
+            assert error is not None


### PR DESCRIPTION
Adds an endpoint for discovering what models are available for using.

This is currently a basic implementation, taking the models from litellm and supports specifying a fixed model set per product.

We will use this in array to limit which models we support, and to load the latest models in the app rather than requiring an update to the app to use a new model.