### PR TITLE
fix(llma): workflow task timeouts

### DIFF
--- a/nodejs/src/llm-analytics/services/temporal.service.test.ts
+++ b/nodejs/src/llm-analytics/services/temporal.service.test.ts
@@ -108,6 +108,7 @@ describe('TemporalService', () => {
                 taskQueue: 'llm-analytics-evals-task-queue',
                 workflowId: 'eval-123-event-456-ingestion',
                 workflowIdConflictPolicy: 'USE_EXISTING',
+                workflowTaskTimeout: '2 minutes',
                 args: [
                     {
                         evaluation_id: 'eval-123',

--- a/nodejs/src/llm-analytics/services/temporal.service.ts
+++ b/nodejs/src/llm-analytics/services/temporal.service.ts
@@ -119,6 +119,7 @@ export class TemporalService {
             taskQueue: EVALUATION_TASK_QUEUE,
             workflowId,
             workflowIdConflictPolicy: 'USE_EXISTING',
+            workflowTaskTimeout: '2 minutes',
         })
 
         temporalWorkflowsStarted.labels({ status: 'success' }).inc()

--- a/products/llm_analytics/backend/api/evaluation_runs.py
+++ b/products/llm_analytics/backend/api/evaluation_runs.py
@@ -1,5 +1,6 @@
 import time
 import asyncio
+from datetime import timedelta
 from typing import cast
 
 from django.conf import settings
@@ -126,6 +127,7 @@ class EvaluationRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                     task_queue=settings.LLMA_EVALS_TASK_QUEUE,
                     id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
                     retry_policy=RetryPolicy(maximum_attempts=3),
+                    task_timeout=timedelta(seconds=60),
                 )
             )
 

--- a/products/llm_analytics/backend/api/evaluation_runs.py
+++ b/products/llm_analytics/backend/api/evaluation_runs.py
@@ -127,7 +127,7 @@ class EvaluationRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                     task_queue=settings.LLMA_EVALS_TASK_QUEUE,
                     id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
                     retry_policy=RetryPolicy(maximum_attempts=3),
-                    task_timeout=timedelta(seconds=60),
+                    task_timeout=timedelta(minutes=2),
                 )
             )
 


### PR DESCRIPTION
## Problem

Fixes timeouts for Temporal when running evals. It was timing out on "workflow task execution", that is, getting the worker ready to run our own code. This is most likely due to the large histories on these workflows.

## Publish to changelog?

No
