### PR TITLE
feat(kafka-deduplicator): fix rebalance race + ensure rebalance flag is decremented in all outcomes

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -940,8 +940,8 @@ mod tests {
             ..Default::default()
         };
 
-        // Set rebalancing BEFORE starting checkpoint manager
-        store_manager.set_rebalancing(true);
+        // Start rebalancing BEFORE starting checkpoint manager
+        store_manager.start_rebalancing();
 
         let mut manager = CheckpointManager::new(config.clone(), store_manager.clone(), None);
         manager.start();
@@ -1035,14 +1035,14 @@ mod tests {
         // Wait for the first checkpoint cycle to potentially start
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        // Set rebalancing mid-flight
-        store_manager.set_rebalancing(true);
+        // Start rebalancing mid-flight
+        store_manager.start_rebalancing();
 
         // Let the manager process - workers should skip due to rebalancing
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        // Clear rebalancing to allow clean shutdown
-        store_manager.set_rebalancing(false);
+        // Finish rebalancing to allow clean shutdown
+        store_manager.finish_rebalancing();
 
         manager.stop().await;
 

--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -217,6 +217,14 @@ async fn main() -> Result<()> {
         .with(otel_layer)
         .init();
 
+    // Create a root span with pod hostname for all logs
+    // This adds "pod" field to every log line for Loki/Grafana filtering
+    let pod = config
+        .pod_hostname
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
+    let _root_span = tracing::info_span!("service", pod = %pod).entered();
+
     // Start continuous profiling if enabled (keep _agent alive for the duration of the program)
     // NOTE: Must be after tracing is initialized so logs are visible
     let _profiling_agent = match config.continuous_profiling.start_agent() {

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -108,6 +108,10 @@ pub const STORE_CREATION_EVENTS: &str = "store_creation_events_total";
 /// Gauge for active store count
 pub const ACTIVE_STORE_COUNT: &str = "active_store_count";
 
+/// Gauge for number of overlapping rebalances in progress
+/// Value > 0 means rebalance async work is ongoing; used to block orphan cleanup
+pub const REBALANCING_COUNT: &str = "rebalancing_count";
+
 // ==== Partition Batch Processing Diagnostics ====
 /// Histogram for partition batch processing duration (in milliseconds)
 pub const PARTITION_BATCH_PROCESSING_DURATION_MS: &str = "partition_batch_processing_duration_ms";

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use dashmap::DashMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 use tokio::task::JoinHandle;
@@ -12,7 +12,8 @@ use crate::kafka::types::Partition;
 use crate::metrics::MetricsHelper;
 use crate::metrics_const::{
     ACTIVE_STORE_COUNT, CLEANUP_BYTES_FREED_HISTOGRAM, CLEANUP_DURATION_HISTOGRAM,
-    CLEANUP_OPERATIONS_COUNTER, STORE_CREATION_DURATION_MS, STORE_CREATION_EVENTS,
+    CLEANUP_OPERATIONS_COUNTER, REBALANCING_COUNT, STORE_CREATION_DURATION_MS,
+    STORE_CREATION_EVENTS,
 };
 use crate::rocksdb::metrics_consts::ROCKSDB_OLDEST_DATA_AGE_SECONDS_GAUGE;
 use crate::store::{DeduplicationStore, DeduplicationStoreConfig};
@@ -115,10 +116,10 @@ pub struct StoreManager {
     /// Flag to prevent concurrent cleanup operations
     cleanup_running: AtomicBool,
 
-    /// Flag indicating whether a Kafka rebalance is in progress
-    /// When true, orphan cleanup should be skipped to avoid deleting directories
-    /// that are about to be assigned
-    rebalancing: AtomicBool,
+    /// Counter tracking the number of overlapping rebalances in progress
+    /// When > 0, orphan cleanup should be skipped to avoid deleting directories
+    /// that are being populated with imported checkpoints
+    rebalancing_count: AtomicUsize,
 }
 
 impl StoreManager {
@@ -131,21 +132,52 @@ impl StoreManager {
             store_config,
             metrics,
             cleanup_running: AtomicBool::new(false),
-            rebalancing: AtomicBool::new(false),
+            rebalancing_count: AtomicUsize::new(0),
         }
     }
 
-    /// Set the rebalancing flag to indicate a Kafka rebalance is in progress
-    ///
-    /// When true, operations like orphan directory cleanup will be skipped
-    /// to avoid deleting directories that are about to be assigned.
-    pub fn set_rebalancing(&self, rebalancing: bool) {
-        self.rebalancing.store(rebalancing, Ordering::SeqCst);
+    /// Signal that a rebalance has started. Increments the counter.
+    /// While counter > 0, operations like orphan cleanup are blocked.
+    pub fn start_rebalancing(&self) {
+        let prev = self.rebalancing_count.fetch_add(1, Ordering::SeqCst);
+        let new_count = prev + 1;
+        metrics::gauge!(REBALANCING_COUNT).set(new_count as f64);
+        info!(
+            previous_count = prev,
+            new_count = new_count,
+            "Rebalance started, incremented rebalancing counter"
+        );
     }
 
-    /// Check if a Kafka rebalance is currently in progress
+    /// Signal that a rebalance's async work has completed. Decrements the counter.
+    pub fn finish_rebalancing(&self) {
+        let prev = self.rebalancing_count.fetch_sub(1, Ordering::SeqCst);
+        let new_count = prev.saturating_sub(1);
+        metrics::gauge!(REBALANCING_COUNT).set(new_count as f64);
+        if prev == 0 {
+            warn!("finish_rebalancing called when counter was already 0");
+        } else if new_count == 0 {
+            info!("All rebalances completed, counter returned to 0");
+        } else {
+            info!(
+                previous_count = prev,
+                new_count = new_count,
+                "Rebalance finished, decremented rebalancing counter (other rebalances still in progress)"
+            );
+        }
+    }
+
+    /// Check if any rebalance async work is currently in progress
     pub fn is_rebalancing(&self) -> bool {
-        self.rebalancing.load(Ordering::SeqCst)
+        self.rebalancing_count.load(Ordering::SeqCst) > 0
+    }
+
+    /// Get a guard that will decrement the counter when dropped.
+    /// Call this AFTER start_rebalancing() to ensure cleanup on panic/cancellation.
+    pub fn rebalancing_guard(self: &Arc<Self>) -> RebalancingGuard {
+        RebalancingGuard {
+            store_manager: Arc::clone(self),
+        }
     }
 
     /// Get an existing store for a partition, if it exists
@@ -1118,6 +1150,18 @@ impl CleanupTaskHandle {
     }
 }
 
+/// RAII guard that decrements the rebalancing counter when dropped.
+/// This ensures the counter is decremented even if the async work panics or is cancelled.
+pub struct RebalancingGuard {
+    store_manager: Arc<StoreManager>,
+}
+
+impl Drop for RebalancingGuard {
+    fn drop(&mut self) {
+        self.store_manager.finish_rebalancing();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::store::{TimestampKey, TimestampMetadata};
@@ -1648,8 +1692,8 @@ mod tests {
         std::fs::write(timestamp_subdir.join("dummy.txt"), b"test data").unwrap();
         assert!(timestamp_subdir.exists());
 
-        // Set rebalancing flag
-        manager.set_rebalancing(true);
+        // Start rebalancing
+        manager.start_rebalancing();
         assert!(manager.is_rebalancing());
 
         // During rebalance, cleanup should skip and not remove the orphan
@@ -1662,8 +1706,8 @@ mod tests {
             "Orphan should NOT be removed during rebalance"
         );
 
-        // Clear rebalancing flag
-        manager.set_rebalancing(false);
+        // Finish rebalancing
+        manager.finish_rebalancing();
         assert!(!manager.is_rebalancing());
 
         // Now cleanup should remove the orphan again
@@ -1704,16 +1748,16 @@ mod tests {
             store.put_timestamp_record(&key, &metadata).unwrap();
         }
 
-        // Set rebalancing flag
-        manager.set_rebalancing(true);
+        // Start rebalancing
+        manager.start_rebalancing();
         assert!(manager.is_rebalancing());
 
         // During rebalance, capacity cleanup should skip
         let freed = manager.cleanup_old_entries_if_needed().unwrap();
         assert_eq!(freed, 0, "Should skip cleanup during rebalance");
 
-        // Clear rebalancing flag
-        manager.set_rebalancing(false);
+        // Finish rebalancing
+        manager.finish_rebalancing();
         assert!(!manager.is_rebalancing());
 
         // Now cleanup should run (may or may not free bytes depending on actual size)


### PR DESCRIPTION
## Problem
I've identified one more situation where async rebalance handling could set the `is_rebalancing` atomic flag `false` interleaved with another incomplete rebalance attempt as pods join the consumer group on startup.

This is exacerbated by the fact that pods still regularly OOM triggering rebalances, and our statefulset deploy w/PVs tends to spin up new pods slowly, sometimes causing transient rebalances as the group reaches full size.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Swap out atomic flag for atomic `usize` "reference counter" to track pod-internal rebalance state
* Ensure rebalancing counter is incremented in sync, without leaving a potential race with other async processes (checkpointing and orphan dir cleaner) at the beginning of a rebalance
* Use RAII (guard pattern) to ensure counter is decremented no matter the outcome of async rebalance handlers
* Misc. updates to metrics and tests to better observe and validate the race condition is eliminated
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Smoke test in prod EU (PoC deploy) 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
