### PR TITLE
feat(replay): add a stagedpersons subquery for more accurate filter results

### DIFF
--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -33,6 +33,17 @@ from posthog.session_recordings.queries.utils import (
 )
 from posthog.types import AnyPropertyFilter
 
+# Person properties eligible for hybrid query optimization
+# These are high-selectivity identity properties where the three-stage query provides value
+HYBRID_QUERY_ELIGIBLE_PROPERTIES = {
+    "email",
+    "name",
+    "username",
+    "user_id",
+    "external_id",
+    "distinct_id",
+}
+
 
 def get_negative_entity_properties(
     entities: list[EventsNode | ActionsNode | DataWarehouseNode | str],
@@ -102,6 +113,246 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
             limit=limit_expr,
         )
 
+    def _is_hybrid_query_mode_enabled(self) -> bool:
+        """
+        Hybrid mode uses a three-stage query to find all sessions for persons matching properties,
+        including sessions from before the person was identified.
+
+        This solves the "late identification problem" where filtering by person properties
+        in standard PoE mode only finds sessions where those properties existed at event time.
+        """
+        return posthoganalytics.feature_enabled(
+            "enable-hybrid-poe-replay-filtering",
+            str(self._team.id),
+            send_feature_flag_events=False,
+        )
+
+    def _should_use_hybrid_query(self, person_properties: list) -> bool:
+        """
+        Determine if hybrid query is appropriate for the given person properties.
+
+        Returns:
+            True if at least one property is in the allowlist and feature flag is enabled
+        """
+        if not self._is_hybrid_query_mode_enabled():
+            return False
+
+        # Check if at least one property is eligible for hybrid query
+        for prop in person_properties:
+            if hasattr(prop, "key") and prop.key in HYBRID_QUERY_ELIGIBLE_PROPERTIES:
+                return True
+
+        return False
+
+    def _build_persons_query(
+        self,
+        person_properties: list,
+        person_id_limit: int,
+    ) -> ast.SelectQuery:
+        """
+        Stage 1: Build query to find person_ids from persons table.
+
+        Returns:
+            SelectQuery that finds person_ids matching the property filters
+        """
+        # Build person property filter expression
+        person_filter_expr = property_to_expr(
+            person_properties,
+            team=self._team,
+            scope="person",
+        )
+
+        # Query persons table directly
+        return ast.SelectQuery(
+            select=[ast.Alias(alias="person_id", expr=ast.Field(chain=["id"]))],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["persons"])),
+            where=person_filter_expr,
+            limit=ast.Constant(value=person_id_limit),
+        )
+
+    def _build_distinct_ids_query(
+        self,
+        persons_subquery: ast.SelectQuery,
+    ) -> ast.SelectQuery:
+        """
+        Stage 2: Build query to find all distinct_ids for the person_ids from Stage 1.
+
+        This expands from person_ids to all distinct_ids associated with those persons,
+        including distinct_ids from before the person was identified.
+
+        Args:
+            persons_subquery: The query from Stage 1 that returns person_ids
+
+        Returns:
+            SelectQuery that finds all distinct_ids for those person_ids
+        """
+        return ast.SelectQuery(
+            select=[ast.Field(chain=["distinct_id"])],
+            select_from=ast.JoinExpr(
+                table=ast.Field(chain=["person_distinct_ids"])  # HogQL virtual table
+            ),
+            where=ast.CompareOperation(
+                op=ast.CompareOperationOp.In,
+                left=ast.Field(chain=["person_id"]),
+                right=persons_subquery,  # Nested subquery
+            ),
+        )
+
+    def _build_sessions_query(
+        self,
+        distinct_ids_subquery: ast.SelectQuery,
+    ) -> ast.SelectQuery:
+        """
+        Stage 3: Build query to find all sessions for the distinct_ids from Stage 2.
+
+        This finds all session_ids from events where the distinct_id matches any of
+        the distinct_ids from Stage 2, within the query date range (with buffers).
+
+        Args:
+            distinct_ids_subquery: The query from Stage 2 that returns distinct_ids
+
+        Returns:
+            SelectQuery that finds all session_ids for those distinct_ids
+        """
+        # Calculate date range with ±1 day buffer to match events_subquery behavior
+        # Events can arrive before session starts or after it ends
+        date_from_buffered = self.query_date_range.date_from() - timedelta(days=1)
+        date_to_buffered = self.query_date_range.date_to() + timedelta(days=1)
+
+        return ast.SelectQuery(
+            select=[ast.Alias(alias="session_id", expr=ast.Field(chain=["$session_id"]))],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.And(
+                exprs=[
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.Eq,
+                        left=ast.Field(chain=["team_id"]),
+                        right=ast.Constant(value=self._team.pk),
+                    ),
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.In,
+                        left=ast.Field(chain=["distinct_id"]),
+                        right=distinct_ids_subquery,
+                    ),
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.GtEq,
+                        left=ast.Field(chain=["timestamp"]),
+                        right=ast.Constant(value=date_from_buffered),
+                    ),
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.LtEq,
+                        left=ast.Field(chain=["timestamp"]),
+                        right=ast.Constant(value=date_to_buffered),
+                    ),
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.NotEq,
+                        left=ast.Call(name="empty", args=[ast.Field(chain=["$session_id"])]),
+                        right=ast.Constant(value=1),
+                    ),
+                ]
+            ),
+            group_by=[ast.Field(chain=["$session_id"])],  # DISTINCT session_id
+            limit=ast.Constant(value=1000000),
+        )
+
+    def _get_person_id_based_sessions_query(
+        self,
+        person_properties: list,
+    ) -> ast.SelectQuery:
+        """
+        Build three-stage hybrid query for person properties in PoE mode.
+
+        This is the Pure AST implementation that:
+        1. Queries persons table for person_ids (Phase 1 optimization - 100x faster)
+        2. Finds all distinct_ids for those person_ids
+        3. Finds all sessions for those distinct_ids
+
+        The three-stage approach ensures we find ALL sessions for a person,
+        including sessions from before they were identified (solves late identification problem).
+
+        Example timeline:
+            Day 1: User browses anonymously → session "abc" with distinct_id "anon123"
+            Day 3: User signs up with email → person gets email property, merges with "anon123"
+
+            Standard PoE: Filtering by email only finds Day 3+ sessions
+            Hybrid query: Finds ALL sessions (Day 1+) because we find all distinct_ids for the person
+
+        Returns:
+            SelectQuery that returns session_ids for persons matching the properties
+        """
+        # Detect if we're using fuzzy operators that might match many people
+        has_fuzzy_operators = False
+        for prop in person_properties:
+            if hasattr(prop, "operator") and prop.operator in [
+                PropertyOperator.ICONTAINS,
+                PropertyOperator.NOT_ICONTAINS,
+                PropertyOperator.REGEX,
+                PropertyOperator.NOT_REGEX,
+                PropertyOperator.IS_SET,
+                PropertyOperator.IS_NOT_SET,
+            ]:
+                has_fuzzy_operators = True
+                break
+
+        # Exact operators (email="user@example.com") typically match 1-10 people
+        # Fuzzy operators (email icontains "gmail") might match thousands
+        person_id_limit = 1000 if has_fuzzy_operators else 100
+
+        # Track hybrid query usage for monitoring
+        try:
+            from opentelemetry import trace
+
+            property_keys = [p.key if hasattr(p, "key") else "unknown" for p in person_properties]
+            operators = [str(p.operator) if hasattr(p, "operator") else "unknown" for p in person_properties]
+
+            # Check which properties are in the allowlist
+            eligible_properties = [
+                p.key for p in person_properties if hasattr(p, "key") and p.key in HYBRID_QUERY_ELIGIBLE_PROPERTIES
+            ]
+            ineligible_properties = [
+                p.key for p in person_properties if hasattr(p, "key") and p.key not in HYBRID_QUERY_ELIGIBLE_PROPERTIES
+            ]
+
+            posthoganalytics.capture(
+                distinct_id=str(self._team.id),
+                event="hybrid_poe_replay_query_executed",
+                properties={
+                    "team_id": self._team.id,
+                    "property_count": len(person_properties),
+                    "property_keys": property_keys,
+                    "eligible_property_keys": eligible_properties,
+                    "ineligible_property_keys": ineligible_properties,
+                    "operators": operators,
+                    "has_fuzzy_operators": has_fuzzy_operators,
+                    "person_id_limit": person_id_limit,
+                    "date_range_days": (self.query_date_range.date_to() - self.query_date_range.date_from()).days,
+                    "$feature/hybrid-poe-replay-filtering": True,
+                },
+            )
+
+            # Add OpenTelemetry span attributes for tracing
+            span = trace.get_current_span()
+            if span:
+                span.set_attribute("replay.hybrid_query.property_count", len(person_properties))
+                span.set_attribute("replay.hybrid_query.eligible_property_count", len(eligible_properties))
+                span.set_attribute("replay.hybrid_query.has_fuzzy_operators", has_fuzzy_operators)
+                span.set_attribute("replay.hybrid_query.person_id_limit", person_id_limit)
+
+        except Exception as e:
+            posthoganalytics.capture_exception(e, properties={"context": "hybrid_query_monitoring"})
+
+        # Build the three-stage query using Pure AST
+        # Stage 1: Find person_ids from persons table
+        persons_query = self._build_persons_query(person_properties, person_id_limit)
+
+        # Stage 2: Find distinct_ids for those person_ids
+        distinct_ids_query = self._build_distinct_ids_query(persons_query)
+
+        # Stage 3: Find sessions for those distinct_ids
+        sessions_query = self._build_sessions_query(distinct_ids_query)
+
+        return sessions_query
+
     def _get_queries_for_matching(self, select_expr: ast.Expr, group_by: list[ast.Expr]) -> list[ast.SelectQuery]:
         """
         takes each filter in the query that can be queried from the events table
@@ -155,13 +406,25 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
                 continue
             gathered_exprs.append(property_to_expr(p, team=self._team))
 
+        # Handle person properties with hybrid query mode if enabled and appropriate
+        hybrid_query: Optional[ast.SelectQuery] = None
         if self._team.person_on_events_mode and self.person_properties:
-            for p in self.person_properties:
-                if skip_negative_properties and is_negative_prop(p):
-                    continue
-                gathered_exprs.append(property_to_expr(p, team=self._team, scope="event"))
+            if self._should_use_hybrid_query(self.person_properties):
+                hybrid_query = self._get_person_id_based_sessions_query(self.person_properties)
+                # Don't add person properties to gathered_exprs - we've handled them via hybrid query
+            else:
+                # Use standard PoE approach (fast but potentially incomplete)
+                # Used for all non-identity properties or when feature flag is off
+                for p in self.person_properties:
+                    if skip_negative_properties and is_negative_prop(p):
+                        continue
+                    gathered_exprs.append(property_to_expr(p, team=self._team, scope="event"))
 
         queries: list[ast.SelectQuery] = []
+
+        # Add hybrid query first if we used it for person properties
+        if hybrid_query:
+            queries.append(hybrid_query)
         for expr in gathered_exprs:
             # Increased LIMIT from 10000 to 1000000 to handle cases where:
             # 1. Session recording sampling is enabled (only small % of sessions have recordings)

--- a/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
@@ -1,0 +1,206 @@
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from unittest.mock import patch
+
+from django.test import override_settings
+from django.utils.timezone import now
+
+from dateutil.relativedelta import relativedelta
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.log_entries import TRUNCATE_LOG_ENTRIES_TABLE_SQL
+from posthog.models import Person
+from posthog.session_recordings.queries.test.listing_recordings.test_utils import (
+    assert_query_matches_session_ids,
+    create_event,
+)
+from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
+from posthog.session_recordings.sql.session_replay_event_sql import TRUNCATE_SESSION_REPLAY_EVENTS_TABLE_SQL
+
+
+@freeze_time("2021-01-01T13:46:23")
+@override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=True)
+class TestPersonPropertyHybridQuery(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        sync_execute(TRUNCATE_SESSION_REPLAY_EVENTS_TABLE_SQL())
+        sync_execute(TRUNCATE_LOG_ENTRIES_TABLE_SQL)
+
+    def _assert_query_matches_session_ids(
+        self, query: dict | None, expected: list[str], sort_results_when_asserting: bool = True
+    ) -> None:
+        assert_query_matches_session_ids(
+            team=self.team, query=query, expected=expected, sort_results_when_asserting=sort_results_when_asserting
+        )
+
+    @property
+    def an_hour_ago(self):
+        return (now() - relativedelta(hours=1)).replace(microsecond=0, second=0)
+
+    def test_hybrid_query_disabled_by_default(self) -> None:
+        with freeze_time("2021-08-21T20:00:00.000Z"):
+            anonymous_id = "anonymous_user_123"
+            identified_id = "identified_user_123"
+            session_id_after = "session_after_identification"
+
+            Person.objects.create(
+                team=self.team,
+                distinct_ids=[anonymous_id, identified_id],
+                properties={"email": "user@example.com"},
+            )
+
+            produce_replay_summary(
+                distinct_id=identified_id,
+                session_id=session_id_after,
+                first_timestamp=self.an_hour_ago,
+                team_id=self.team.id,
+            )
+            create_event(
+                identified_id,
+                self.an_hour_ago,
+                team=self.team,
+                event_name="$pageview",
+                properties={"$session_id": session_id_after},
+            )
+
+            self._assert_query_matches_session_ids(
+                {
+                    "properties": [
+                        {
+                            "key": "email",
+                            "value": "user@example.com",
+                            "type": "person",
+                            "operator": "exact",
+                        }
+                    ]
+                },
+                [session_id_after],
+            )
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_hybrid_query_enabled_finds_sessions(self, mock_feature_enabled) -> None:
+        with freeze_time("2021-08-21T20:00:00.000Z"):
+            anonymous_id = "anonymous_user_456"
+            identified_id = "identified_user_456"
+            session_id_before = "session_before_identification_456"
+            session_id_after = "session_after_identification_456"
+
+            produce_replay_summary(
+                distinct_id=anonymous_id,
+                session_id=session_id_before,
+                first_timestamp=self.an_hour_ago - relativedelta(minutes=10),
+                team_id=self.team.id,
+            )
+            create_event(
+                anonymous_id,
+                self.an_hour_ago - relativedelta(minutes=10),
+                team=self.team,
+                event_name="$pageview",
+                properties={"$session_id": session_id_before},
+            )
+
+            Person.objects.create(
+                team=self.team,
+                distinct_ids=[anonymous_id, identified_id],
+                properties={"email": "user@example.com"},
+            )
+
+            produce_replay_summary(
+                distinct_id=identified_id,
+                session_id=session_id_after,
+                first_timestamp=self.an_hour_ago,
+                team_id=self.team.id,
+            )
+            create_event(
+                identified_id,
+                self.an_hour_ago,
+                team=self.team,
+                event_name="$pageview",
+                properties={"$session_id": session_id_after},
+            )
+
+            self._assert_query_matches_session_ids(
+                {
+                    "properties": [
+                        {
+                            "key": "email",
+                            "value": "user@example.com",
+                            "type": "person",
+                            "operator": "exact",
+                        }
+                    ]
+                },
+                [session_id_before, session_id_after],
+            )
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_hybrid_query_finds_all_person_sessions(self, mock_feature_enabled) -> None:
+        with freeze_time("2021-08-21T20:00:00.000Z"):
+            distinct_id_1 = "distinct_1"
+            distinct_id_2 = "distinct_2"
+            distinct_id_3 = "distinct_3"
+            session_id_1 = "session_1"
+            session_id_2 = "session_2"
+            session_id_3 = "session_3"
+
+            Person.objects.create(
+                team=self.team,
+                distinct_ids=[distinct_id_1, distinct_id_2, distinct_id_3],
+                properties={"email": "multi@example.com"},
+            )
+
+            produce_replay_summary(
+                distinct_id=distinct_id_1,
+                session_id=session_id_1,
+                first_timestamp=self.an_hour_ago,
+                team_id=self.team.id,
+            )
+            create_event(
+                distinct_id_1,
+                self.an_hour_ago,
+                team=self.team,
+                event_name="$pageview",
+                properties={"$session_id": session_id_1},
+            )
+
+            produce_replay_summary(
+                distinct_id=distinct_id_2,
+                session_id=session_id_2,
+                first_timestamp=self.an_hour_ago + relativedelta(minutes=10),
+                team_id=self.team.id,
+            )
+            create_event(
+                distinct_id_2,
+                self.an_hour_ago + relativedelta(minutes=10),
+                team=self.team,
+                event_name="$pageview",
+                properties={"$session_id": session_id_2},
+            )
+
+            produce_replay_summary(
+                distinct_id=distinct_id_3,
+                session_id=session_id_3,
+                first_timestamp=self.an_hour_ago + relativedelta(minutes=20),
+                team_id=self.team.id,
+            )
+            create_event(
+                distinct_id_3,
+                self.an_hour_ago + relativedelta(minutes=20),
+                team=self.team,
+                event_name="$pageview",
+                properties={"$session_id": session_id_3},
+            )
+
+            self._assert_query_matches_session_ids(
+                {
+                    "properties": [
+                        {
+                            "key": "email",
+                            "value": "multi@example.com",
+                            "type": "person",
+                            "operator": "exact",
+                        }
+                    ]
+                },
+                [session_id_1, session_id_2, session_id_3],
+            )


### PR DESCRIPTION
## Problem

have a few various bug reports about this -- basically when POE is enabled we oNLY check events. The bad user experience:

1. go to person profile with email xyz@person.com
2. see ~3 recordings
3. later, filter by xyz@person.com
4. only see 1 recording

this is because although we've since linked this distinct id to this person, the email wasnt present on the EVENTS at hte time of the recording.

its confusing bc we clearly can link it to the person so it looks like a bug 
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

FIRST ADD A FLAG to protect this change. 
For person properties that are high-intent (email, user id, etc):

1. query persons table to find all people who match these filters
2. query again to find all distinct ids of these people
3. get all sessions for those distinct IDs in our date params
4. add THIS query to the main query

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?


Added tests. Also gated behind a flag so we can roll out slowly/track perf impact
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->


## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
