### PR TITLE
fix: filtering without event

### DIFF
--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -116,7 +116,7 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
                         where_exprs.extend(
                             property_to_expr(property, self.team) for property in self.query.fixedProperties
                         )
-                all_events: list[str] = [e for e in [self.query.event, *(self.query.events or [])] if e is not None]
+                all_events: list[str] = [e for e in [self.query.event, *(self.query.events or [])] if e]
                 if all_events:
                     with self.timings.measure("event"):
                         if len(all_events) == 1:


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C08UM214Z50/p1769111904032319

## Changes

Reverted event filter check, now this filters out both None and empty strings '' again.

## How did you test this code?

Ran locally

## Publish to changelog?

No