### PR TITLE
fix(ph-ai): fix random thinking message

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -356,6 +356,18 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             },
         ],
 
+        // Stable thinking message that doesn't change during streaming
+        currentThinkingMessage: [
+            null as string | null,
+            {
+                askMax: () => getRandomThinkingMessage(),
+                reconnectToStream: () => getRandomThinkingMessage(),
+                streamConversation: () => getRandomThinkingMessage(),
+                addMessage: () => getRandomThinkingMessage(),
+                completeThreadGeneration: () => null,
+            },
+        ],
+
         retryCount: [
             0,
             {
@@ -996,13 +1008,15 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 s.toolCallUpdateMap,
                 s.pendingApprovalsData,
                 s.resolvedApprovalStatuses,
+                s.currentThinkingMessage,
             ],
             (
                 thread,
                 threadLoading,
                 toolCallUpdateMap,
                 pendingApprovalsData,
-                resolvedApprovalStatuses
+                resolvedApprovalStatuses,
+                currentThinkingMessage
             ): ThreadMessage[] => {
                 // Filter out messages that shouldn't be displayed
                 let processedThread: ThreadMessage[] = []
@@ -1046,7 +1060,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                             thinking: [
                                 {
                                     type: 'thinking',
-                                    thinking: getRandomThinkingMessage(),
+                                    thinking: currentThinkingMessage ?? getRandomThinkingMessage(),
                                 },
                             ],
                         },


### PR DESCRIPTION
## Problem

When PostHog AI is thinking, the thinking message changes randomly during streaming.

## Changes
Added a `currentThinkingMessage` state to the Max thread logic that:
- Gets set to a random thinking message when starting a new conversation or reconnecting
- Remains stable throughout the streaming process
- Gets reset to null when thread generation completes
- Is used instead of generating a new random message each time the UI renders

## How did you test this code?
Locally

## Publish to changelog?

No