### PR TITLE
fix(trends): fix warning for wau/mau with weekly or monthly interval

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -941,7 +941,7 @@ function useMathSelectorOptions({
 
             return {
                 value: mathTypeKey,
-                icon: warning !== null ? <IconWarning /> : undefined,
+                icon: warning !== null ? <IconWarning className="text-warning" /> : undefined,
                 label: definition.name,
                 'data-attr': `math-${key}-${index}`,
                 tooltip:
@@ -1117,29 +1117,38 @@ function useMathSelectorOptions({
             days: '30' | '7',
             optionIndex: number
         ): LemonSelectOption<string> => {
-            const actor = activeActorShown === 'users' ? 'users' : aggregationLabel(mathGroupTypeIndex).plural
+            const baseOption = options[optionIndex] as LemonSelectOption<string>
+            const isUsers = activeActorShown === 'users'
+            const actor = isUsers ? 'users' : aggregationLabel(mathGroupTypeIndex).plural
             const capitalizedActor = capitalizeFirstLetter(actor)
             const label = `${capitalizeFirstLetter(period)}ly active ${actor}`
-            const tooltip =
-                actor === 'user' ? (
-                    options[optionIndex].tooltip
-                ) : (
-                    <>
-                        <b>
-                            {capitalizedActor} active in the past {period} ({days} days).
-                        </b>
-                        <br />
-                        <br />
-                        This is a trailing count that aggregates distinct {actor} in the past {days} days for each day
-                        in the time series.
-                        <br />
-                        <br />
-                        If the group by interval is a {period} or longer, this is the same as "Unique {capitalizedActor}
-                        " math.
-                    </>
-                )
+            const tooltip = isUsers ? (
+                baseOption.tooltip
+            ) : (
+                <>
+                    {baseOption.tooltip ? (
+                        <>
+                            {baseOption.tooltip}
+                            <br />
+                            <br />
+                        </>
+                    ) : null}
+                    <b>
+                        {capitalizedActor} active in the past {period} ({days} days).
+                    </b>
+                    <br />
+                    <br />
+                    This is a trailing count that aggregates distinct {actor} in the past {days} days for each day in
+                    the time series.
+                    <br />
+                    <br />
+                    If the group by interval is a {period} or longer, this is the same as "Unique {capitalizedActor} "
+                    math.
+                </>
+            )
 
             return {
+                ...baseOption,
                 value: mathType,
                 label,
                 tooltip,


### PR DESCRIPTION
## Problem

The warning icon/tooltip for wau/mau wasn't showing when using a weekly or monthly interval any more.

Tooltip I'm talking about:
https://github.com/PostHog/posthog/blob/master/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx#L944-L978

## Changes

This is because it's overwritten here: https://github.com/PostHog/posthog/blob/master/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx#L1117-L1178

In this PR: https://github.com/PostHog/posthog/pull/34901

## How did you test this code?

Tested that the insight version works again.

![Screenshot 2026-01-22 at 23.19.03.png](https://app.graphite.com/user-attachments/assets/f7c36c65-8d47-42a2-9e8c-f86b24fc5714.png)

