### PR TITLE
feat(experiments): add breakdown support for session property metrics

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -33,7 +33,7 @@ const getExposureEvent = (experiment: Experiment): string => {
     return '$feature_flag_called'
 }
 
-// AddBreakdownButton component for event property breakdowns
+// AddBreakdownButton component for event and session property breakdowns
 const AddBreakdownButton = ({
     experiment,
     onChange,
@@ -63,11 +63,16 @@ const AddBreakdownButton = ({
         <LemonDropdown
             overlay={
                 <TaxonomicFilter
-                    onChange={(_, value) => {
-                        onChange({ type: 'event', property: value?.toString() || '' })
+                    onChange={(group, value) => {
+                        const breakdownType =
+                            group.type === TaxonomicFilterGroupType.SessionProperties ? 'session' : 'event'
+                        onChange({ type: breakdownType, property: value?.toString() || '' })
                         setDropdownOpen(false)
                     }}
-                    taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
+                    taxonomicGroupTypes={[
+                        TaxonomicFilterGroupType.EventProperties,
+                        TaxonomicFilterGroupType.SessionProperties,
+                    ]}
                     metadataSource={metadataSource}
                 />
             }

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_session_properties.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_session_properties.ambr
@@ -1,4 +1,83 @@
 # serializer version: 1
+# name: TestExperimentSessionPropertyMetrics.test_session_duration_breakdown_from_metric_events_not_exposures
+  '''
+  SELECT entity_metrics.variant AS variant,
+         entity_metrics.breakdown_value_1 AS breakdown_value_1,
+         count(entity_metrics.entity_id) AS num_users,
+         sum(entity_metrics.value) AS total_sum,
+         sum(power(entity_metrics.value, 2)) AS total_sum_of_squares
+  FROM
+    (SELECT metric_events.entity_id AS entity_id,
+            metric_events.variant AS variant,
+            sum(coalesce(accurateCastOrNull(metric_events.value, 'Float64'), 0)) AS value,
+            metric_events.breakdown_value_1 AS breakdown_value_1
+     FROM
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               accurateCastOrNull(coalesce(metric_events_by_session.session_value, 0), 'Float64') AS value,
+               metric_events_by_session.session_id AS session_id,
+               metric_events_by_session.breakdown_value_1 AS breakdown_value_1
+        FROM
+          (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+                  if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+                  min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+                  max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+                  argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+                  argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id,
+                  argMin(coalesce(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$browser'), ''), 'null'), '^"|"$', '')), '$$_posthog_breakdown_null_$$'), toTimeZone(events.timestamp, 'UTC')) AS breakdown_value_1
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+           GROUP BY entity_id) AS exposures
+        INNER JOIN
+          (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+                  events.`$session_id` AS session_id,
+                  any(events__session.`$session_duration`) AS session_value,
+                  min(toTimeZone(events.timestamp, 'UTC')) AS first_event_timestamp,
+                  argMin(coalesce(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$browser'), ''), 'null'), '^"|"$', '')), '$$_posthog_breakdown_null_$$'), toTimeZone(events.timestamp, 'UTC')) AS breakdown_value_1
+           FROM events
+           LEFT JOIN
+             (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                     raw_sessions.session_id_v7 AS session_id_v7
+              FROM raw_sessions
+              WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0)), toIntervalDay(3))))
+              GROUP BY raw_sessions.session_id_v7,
+                       raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, '$pageview')), isNotNull(events.`$session_id`), notEquals(events.`$session_id`, ''))
+           GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
+                    events.`$session_id`) AS metric_events_by_session ON and(equals(exposures.entity_id, metric_events_by_session.entity_id), greaterOrEquals(metric_events_by_session.first_event_timestamp, exposures.first_exposure_time))) AS metric_events
+     GROUP BY metric_events.entity_id,
+              metric_events.variant,
+              breakdown_value_1) AS entity_metrics
+  GROUP BY entity_metrics.variant,
+           entity_metrics.breakdown_value_1
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=600,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=39728447488,
+                     allow_experimental_analyzer=1,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
 # name: TestExperimentSessionPropertyMetrics.test_session_duration_not_multiplied_across_events
   '''
   SELECT entity_metrics.variant AS variant,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
@@ -399,6 +399,7 @@ class TestExperimentSessionPropertyMetrics(ExperimentQueryRunnerBaseTest):
 
         # Should have Chrome and Firefox breakdowns (NOT Safari)
         self.assertIsNotNone(result.breakdown_results)
+        assert result.breakdown_results is not None
         self.assertEqual(len(result.breakdown_results), 2)
 
         # breakdown_value is a list (e.g., ["Chrome"])
@@ -479,6 +480,7 @@ class TestExperimentSessionPropertyMetrics(ExperimentQueryRunnerBaseTest):
         result = cast(ExperimentQueryResponse, query_runner.calculate())
 
         self.assertIsNotNone(result.breakdown_results)
+        assert result.breakdown_results is not None
         self.assertEqual(len(result.breakdown_results), 1)
 
         # NULL breakdown should use BREAKDOWN_NULL_STRING_LABEL
@@ -578,6 +580,7 @@ class TestExperimentSessionPropertyMetrics(ExperimentQueryRunnerBaseTest):
         result = cast(ExperimentQueryResponse, query_runner.calculate())
 
         self.assertIsNotNone(result.breakdown_results)
+        assert result.breakdown_results is not None
         self.assertEqual(len(result.breakdown_results), 1)
 
         chrome_result = result.breakdown_results[0]

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_session_properties.py
@@ -6,6 +6,8 @@ from posthog.test.base import _create_event, _create_person, flush_persons_and_e
 from django.test import override_settings
 
 from posthog.schema import (
+    Breakdown,
+    BreakdownFilter,
     EventsNode,
     ExperimentMeanMetric,
     ExperimentMetricMathType,
@@ -13,6 +15,7 @@ from posthog.schema import (
     ExperimentQueryResponse,
 )
 
+from posthog.hogql_queries.experiments.experiment_query_builder import BREAKDOWN_NULL_STRING_LABEL
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
 from posthog.hogql_queries.experiments.test.experiment_query_runner.base import ExperimentQueryRunnerBaseTest
 from posthog.models.utils import uuid7
@@ -302,3 +305,282 @@ class TestExperimentSessionPropertyMetrics(ExperimentQueryRunnerBaseTest):
         test_variant = result.variant_results[0]
         assert test_variant.sum == 60
         assert test_variant.number_of_samples == 1
+
+    @snapshot_clickhouse_queries
+    @freeze_time("2024-01-01T12:00:00Z")
+    def test_session_duration_breakdown_from_metric_events_not_exposures(self):
+        """
+        Verify breakdown attribution comes from session events, not exposure events.
+
+        User is exposed on Safari but has sessions on Chrome (60s) and Firefox (120s).
+        If breakdown came from exposures, both sessions would be attributed to Safari.
+        Correct behavior: Chrome=60s, Firefox=120s (no Safari breakdown).
+        """
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        ff_property = f"$feature/{feature_flag.key}"
+
+        _create_person(distinct_ids=["user"], team_id=self.team.pk)
+
+        # Exposure on SAFARI (different from all session browsers)
+        _create_event(
+            team=self.team,
+            event="$feature_flag_called",
+            distinct_id="user",
+            timestamp="2024-01-02T11:00:00Z",
+            properties={
+                "$feature_flag_response": "test",
+                ff_property: "test",
+                "$feature_flag": feature_flag.key,
+                "$browser": "Safari",  # Exposure browser
+            },
+        )
+
+        # Session 1: CHROME, 60s duration
+        chrome_session = str(uuid7("2024-01-02"))
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user",
+            timestamp="2024-01-02T12:00:00Z",
+            properties={ff_property: "test", "$session_id": chrome_session, "$browser": "Chrome"},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user",
+            timestamp="2024-01-02T12:01:00Z",
+            properties={ff_property: "test", "$session_id": chrome_session, "$browser": "Chrome"},
+        )
+
+        # Session 2: FIREFOX, 120s duration
+        firefox_session = str(uuid7("2024-01-02"))
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user",
+            timestamp="2024-01-02T13:00:00Z",
+            properties={ff_property: "test", "$session_id": firefox_session, "$browser": "Firefox"},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user",
+            timestamp="2024-01-02T13:02:00Z",
+            properties={ff_property: "test", "$session_id": firefox_session, "$browser": "Firefox"},
+        )
+
+        flush_persons_and_events()
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(
+                event="$pageview",
+                math=ExperimentMetricMathType.SUM,
+                math_property="$session_duration",
+                math_property_type="session_properties",
+            ),
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")]),
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        # Should have Chrome and Firefox breakdowns (NOT Safari)
+        self.assertIsNotNone(result.breakdown_results)
+        self.assertEqual(len(result.breakdown_results), 2)
+
+        # breakdown_value is a list (e.g., ["Chrome"])
+        breakdown_values = {r.breakdown_value[0] for r in result.breakdown_results}
+        self.assertIn("Chrome", breakdown_values)
+        self.assertIn("Firefox", breakdown_values)
+        self.assertNotIn("Safari", breakdown_values)  # Exposure browser should NOT appear
+
+        chrome_result = next(r for r in result.breakdown_results if r.breakdown_value[0] == "Chrome")
+        firefox_result = next(r for r in result.breakdown_results if r.breakdown_value[0] == "Firefox")
+
+        self.assertEqual(chrome_result.variants[0].sum, 60)
+        self.assertEqual(firefox_result.variants[0].sum, 120)
+
+    @freeze_time("2024-01-01T12:00:00Z")
+    def test_session_duration_breakdown_with_null_values(self):
+        """Verify NULL breakdown values are handled correctly with BREAKDOWN_NULL_STRING_LABEL."""
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        ff_property = f"$feature/{feature_flag.key}"
+
+        _create_person(distinct_ids=["user"], team_id=self.team.pk)
+
+        _create_event(
+            team=self.team,
+            event="$feature_flag_called",
+            distinct_id="user",
+            timestamp="2024-01-02T11:00:00Z",
+            properties={
+                "$feature_flag_response": "test",
+                ff_property: "test",
+                "$feature_flag": feature_flag.key,
+            },
+        )
+
+        # Session with NO $browser property (NULL breakdown)
+        session_id = str(uuid7("2024-01-02"))
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user",
+            timestamp="2024-01-02T12:00:00Z",
+            properties={ff_property: "test", "$session_id": session_id},  # No $browser
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user",
+            timestamp="2024-01-02T12:01:00Z",
+            properties={ff_property: "test", "$session_id": session_id},
+        )
+
+        flush_persons_and_events()
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(
+                event="$pageview",
+                math=ExperimentMetricMathType.SUM,
+                math_property="$session_duration",
+                math_property_type="session_properties",
+            ),
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")]),
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        self.assertIsNotNone(result.breakdown_results)
+        self.assertEqual(len(result.breakdown_results), 1)
+
+        # NULL breakdown should use BREAKDOWN_NULL_STRING_LABEL
+        self.assertEqual(result.breakdown_results[0].breakdown_value[0], BREAKDOWN_NULL_STRING_LABEL)
+        self.assertEqual(result.breakdown_results[0].variants[0].sum, 60)
+
+    @freeze_time("2024-01-01T12:00:00Z")
+    def test_session_duration_breakdown_multiple_users(self):
+        """Verify aggregation works correctly across multiple users with different breakdowns."""
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        ff_property = f"$feature/{feature_flag.key}"
+
+        # User 1: Chrome session, 60s
+        _create_person(distinct_ids=["user_1"], team_id=self.team.pk)
+        _create_event(
+            team=self.team,
+            event="$feature_flag_called",
+            distinct_id="user_1",
+            timestamp="2024-01-02T11:00:00Z",
+            properties={
+                "$feature_flag_response": "test",
+                ff_property: "test",
+                "$feature_flag": feature_flag.key,
+            },
+        )
+        session_1 = str(uuid7("2024-01-02"))
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user_1",
+            timestamp="2024-01-02T12:00:00Z",
+            properties={ff_property: "test", "$session_id": session_1, "$browser": "Chrome"},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user_1",
+            timestamp="2024-01-02T12:01:00Z",
+            properties={ff_property: "test", "$session_id": session_1, "$browser": "Chrome"},
+        )
+
+        # User 2: Chrome session, 120s
+        _create_person(distinct_ids=["user_2"], team_id=self.team.pk)
+        _create_event(
+            team=self.team,
+            event="$feature_flag_called",
+            distinct_id="user_2",
+            timestamp="2024-01-02T11:00:00Z",
+            properties={
+                "$feature_flag_response": "test",
+                ff_property: "test",
+                "$feature_flag": feature_flag.key,
+            },
+        )
+        session_2 = str(uuid7("2024-01-02"))
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user_2",
+            timestamp="2024-01-02T12:00:00Z",
+            properties={ff_property: "test", "$session_id": session_2, "$browser": "Chrome"},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user_2",
+            timestamp="2024-01-02T12:02:00Z",
+            properties={ff_property: "test", "$session_id": session_2, "$browser": "Chrome"},
+        )
+
+        flush_persons_and_events()
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(
+                event="$pageview",
+                math=ExperimentMetricMathType.SUM,
+                math_property="$session_duration",
+                math_property_type="session_properties",
+            ),
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")]),
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        self.assertIsNotNone(result.breakdown_results)
+        self.assertEqual(len(result.breakdown_results), 1)
+
+        chrome_result = result.breakdown_results[0]
+        self.assertEqual(chrome_result.breakdown_value[0], "Chrome")
+        self.assertEqual(chrome_result.variants[0].number_of_samples, 2)  # 2 users
+        self.assertEqual(chrome_result.variants[0].sum, 180)  # 60 + 120


### PR DESCRIPTION
## Problem

Add breakdown injection for session property metrics in experiments. Session properties use a 3-layer CTE structure (metric_events_by_session -> metric_events -> entity_metrics) so breakdowns must be injected at all three layers, unlike regular metrics which use 2 layers.

## Changes

- Add shared helper _inject_breakdown_into_final_select() to reduce duplication
- Add _inject_session_property_breakdown_columns() for 3-layer CTE injection
- Use argMin() for deterministic breakdown extraction from first event in session
- Update _build_mean_query() and _build_mean_query_with_winsorization() to choose correct injection method based on metric type

<img width="2030" height="1414" alt="CleanShot 2026-01-22 at 18 41 04@2x" src="https://github.com/user-attachments/assets/22ea149e-8d9d-4e72-a651-184084e9f284" />


## How did you test this code?

- Add 3 test cases verifying breakdown behavior with session properties
- Locally

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
