### PR TITLE
feat(llma): Llm trace minimal mode

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -59,13 +59,13 @@ COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY = RetryPolicy(maximum_attempts=2)
 # Event properties
 EVENT_NAME = "$ai_trace_clusters"
 
-# Document type for LLM trace summaries (clustering uses detailed mode only)
+# Document type for LLM trace summaries (clustering uses minimal mode only)
 # New format includes mode suffix
-LLMA_TRACE_DOCUMENT_TYPE = "llm-trace-summary-detailed"
+LLMA_TRACE_DOCUMENT_TYPE = "llm-trace-summary-minimal"
 # Legacy format (before mode suffix was added) - used with rendering filter
 LLMA_TRACE_DOCUMENT_TYPE_LEGACY = "llm-trace-summary"
-# Legacy rendering value for detailed summaries
-LLMA_TRACE_RENDERING_LEGACY = "llma_trace_detailed"
+# Legacy rendering value for minimal summaries
+LLMA_TRACE_RENDERING_LEGACY = "llma_trace_minimal"
 
 # Product for LLM trace summaries (matches sorting key in posthog_document_embeddings)
 LLMA_TRACE_PRODUCT = "llm-analytics"

--- a/posthog/temporal/llm_analytics/trace_clustering/data.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/data.py
@@ -141,8 +141,8 @@ def fetch_trace_embeddings_for_clustering(
     # Build base query - add IN clause if we have eligible trace IDs
     # We also fetch rendering to link embeddings to their source summarization run
     # Backwards compatibility: support both old and new document type formats
-    # - New format: document_type = "llm-trace-summary-detailed" (mode in document_type, batch_run_id in rendering)
-    # - Old format: document_type = "llm-trace-summary" AND rendering = "llma_trace_detailed"
+    # - New format: document_type = "llm-trace-summary-minimal" (mode in document_type, batch_run_id in rendering)
+    # - Old format: document_type = "llm-trace-summary" AND rendering = "llma_trace_minimal"
     if eligible_trace_ids:
         query = parse_select(
             """
@@ -215,8 +215,8 @@ def fetch_trace_embeddings_for_clustering(
 
     # Legacy rendering values that are NOT batch_run_ids
     legacy_rendering_values = {
-        constants.LLMA_TRACE_RENDERING_LEGACY,  # "llma_trace_detailed"
-        "llma_trace_minimal",  # Other legacy mode
+        constants.LLMA_TRACE_RENDERING_LEGACY,  # "llma_trace_minimal"
+        "llma_trace_detailed",  # Other legacy mode
     }
 
     for row in rows:

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -9,7 +9,7 @@ from products.llm_analytics.backend.summarization.models import OpenAIModel, Sum
 # Window processing configuration
 DEFAULT_MAX_TRACES_PER_WINDOW = 10  # Max traces to process per window (conservative for worst-case 30s/trace)
 DEFAULT_BATCH_SIZE = 3  # Number of traces to process in parallel (reduced to avoid rate limits)
-DEFAULT_MODE = SummarizationMode.DETAILED
+DEFAULT_MODE = SummarizationMode.MINIMAL
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)
 DEFAULT_PROVIDER = SummarizationProvider.OPENAI
 DEFAULT_MODEL = OpenAIModel.GPT_4_1_MINI

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -325,7 +325,7 @@ class TestBatchTraceSummarizationWorkflow:
         assert inputs.team_id == 123
         assert inputs.max_traces == 10
         assert inputs.batch_size == 3
-        assert inputs.mode == "detailed"
+        assert inputs.mode == "minimal"
         assert inputs.window_minutes == 60
 
     def test_parse_inputs_full(self):


### PR DESCRIPTION
## Problem

The LLM analytics trace summarization and clustering workflows currently operate in 'detailed' mode. This PR switches them to 'minimal' mode to evaluate if it results in cleaner clusters.

## Changes

- Changed the default summarization mode from `SummarizationMode.DETAILED` to `SummarizationMode.MINIMAL` in `trace_summarization/constants.py`.
- Updated the clustering workflow to fetch embeddings for `llm-trace-summary-minimal` documents in `trace_clustering/constants.py` and `trace_clustering/data.py`.
- Adjusted legacy rendering values and comments in `trace_clustering/constants.py` and `trace_clustering/data.py` to reflect the new default.

## How did you test this code?

- Ran `make lint` and `make test`.
- Verified changes by manually inspecting the modified files.

## Publish to changelog?

no

---
<a href="https://cursor.com/background-agent?bcId=bc-2042f146-3dab-40e1-b6cd-75aab34d0c0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2042f146-3dab-40e1-b6cd-75aab34d0c0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

