### PR TITLE
feat(web-analytics): serve favicons from static CDN and add to domain selector

### DIFF
--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -4,6 +4,7 @@ import { ExportedData } from '~/exporter/types'
 
 declare global {
     interface Window {
+        JS_URL?: string
         JS_POSTHOG_API_KEY?: string
         JS_POSTHOG_HOST?: string
         JS_POSTHOG_UI_HOST?: string

--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -219,7 +219,7 @@ const WebAnalyticsDomainSelector = (): JSX.Element => {
                                               src={faviconUrl(domain)}
                                               width={16}
                                               height={16}
-                                              alt=""
+                                              alt={`${domain} favicon`}
                                               onError={(e) => (e.currentTarget.style.display = 'none')}
                                           />
                                       ),

--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -184,6 +184,7 @@ const WebAnalyticsDomainSelector = (): JSX.Element => {
     const { validatedDomainFilter, hasHostFilter, authorizedDomains, showProposedURLForm } =
         useValues(webAnalyticsLogic)
     const { setDomainFilter } = useActions(webAnalyticsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <LemonSelect
@@ -208,7 +209,23 @@ const WebAnalyticsDomainSelector = (): JSX.Element => {
                                   },
                               ]
                             : []),
-                        ...authorizedDomains.map((domain) => ({ label: domain, value: domain })),
+                        ...authorizedDomains.map((domain) => ({
+                            label: domain,
+                            value: domain,
+                            ...(featureFlags[FEATURE_FLAGS.SHOW_REFERRER_FAVICON]
+                                ? {
+                                      icon: (
+                                          <img
+                                              src={`${window.JS_URL}/favicons/${domain}.png`}
+                                              width={16}
+                                              height={16}
+                                              alt=""
+                                              onError={(e) => (e.currentTarget.style.display = 'none')}
+                                          />
+                                      ),
+                                  }
+                                : {}),
+                        })),
                     ],
                     footer: showProposedURLForm ? <AddAuthorizedUrlForm /> : <AddSuggestedAuthorizedUrlList />,
                 },

--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -36,7 +36,7 @@ import {
     WebPropertyFilters,
     getWebAnalyticsTaxonomicGroupTypes,
 } from './WebPropertyFilters'
-import { ProductTab } from './common'
+import { ProductTab, faviconUrl } from './common'
 import { webAnalyticsFilterPresetsLogic } from './webAnalyticsFilterPresetsLogic'
 import { webAnalyticsLogic } from './webAnalyticsLogic'
 
@@ -216,7 +216,7 @@ const WebAnalyticsDomainSelector = (): JSX.Element => {
                                 ? {
                                       icon: (
                                           <img
-                                              src={`${window.JS_URL}/favicons/${domain}.png`}
+                                              src={faviconUrl(domain)}
                                               width={16}
                                               height={16}
                                               alt=""

--- a/frontend/src/scenes/web-analytics/common.ts
+++ b/frontend/src/scenes/web-analytics/common.ts
@@ -554,6 +554,8 @@ export interface ParsedURL {
     isValid: boolean
 }
 
+export const faviconUrl = (domain: string): string => `${window.JS_URL}/static/favicons/${domain}`
+
 export const parseWebAnalyticsURL = (urlString: string): ParsedURL => {
     try {
         const trimmed = urlString.trim()

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -27,7 +27,13 @@ import {
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
-import { GeographyTab, ProductTab, TileId, webStatsBreakdownToPropertyName } from 'scenes/web-analytics/common'
+import {
+    GeographyTab,
+    ProductTab,
+    TileId,
+    faviconUrl,
+    webStatsBreakdownToPropertyName,
+} from 'scenes/web-analytics/common'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
 import { actionsModel } from '~/models/actionsModel'
@@ -323,7 +329,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                     return (
                         <div className="flex items-center gap-2">
                             <img
-                                src={`${window.JS_URL}/static/favicons/${value}`}
+                                src={faviconUrl(value)}
                                 width={24}
                                 height={24}
                                 alt={`Favicon for ${value}`}

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -332,7 +332,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                                 src={faviconUrl(value)}
                                 width={24}
                                 height={24}
-                                alt={`Favicon for ${value}`}
+                                alt={`${value} favicon`}
                                 onError={(e) => (e.currentTarget.style.display = 'none')}
                             />
                             {value}

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -323,7 +323,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                     return (
                         <div className="flex items-center gap-2">
                             <img
-                                src={`/static/favicons/${value}`}
+                                src={`${window.JS_URL}/static/favicons/${value}`}
                                 width={24}
                                 height={24}
                                 alt={`Favicon for ${value}`}


### PR DESCRIPTION
## Problem

Referrer favicons are requested from the app server (`us.posthog.com/static/favicons/`) instead of the static CDN (`app-static-prod.posthog.com/favicons/`). Additionally, the domain dashboard selector doesn't show favicons.

## Changes

- Use `window.JS_URL` (the CDN base URL injected at runtime) for favicon `src` instead of `/static/`
- Add `JS_URL` to the Window type declaration
- Add favicon icons to the domain selector dropdown options (behind `SHOW_REFERRER_FAVICON` flag)

## How did you test this code?

- TypeScript type check passes
- In production, favicon URLs resolve to `https://app-static-prod.posthog.com/favicons/{domain}.png`
- Missing favicons gracefully hide via `onError` handler

## Publish to changelog?

No