### PR TITLE
feat(workflows): add wait for event action

### DIFF
--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -93,6 +93,7 @@ export class HogFlowExecutorService {
             trigger: new TriggerHandler(),
             conditional_branch: new ConditionalBranchHandler(),
             wait_until_condition: new ConditionalBranchHandler(),
+            wait_for_event: new ConditionalBranchHandler(),
             delay: new DelayHandler(),
             wait_until_time_window: new WaitUntilTimeWindowHandler(),
             random_cohort_branch: new RandomCohortBranchHandler(),

--- a/nodejs/src/schema/hogflow.ts
+++ b/nodejs/src/schema/hogflow.ts
@@ -121,6 +121,18 @@ const HogFlowActionSchema = z.discriminatedUnion('type', [
 
     z.object({
         ..._commonActionFields,
+        type: z.literal('wait_for_event'),
+        config: z.object({
+            event_filters: z.object({
+                filters: z.any(), // type this stronger
+                name: z.string().optional(), // Custom name for the event condition
+            }),
+            max_wait_duration: z.string(),
+        }),
+    }),
+
+    z.object({
+        ..._commonActionFields,
         type: z.literal('wait_until_time_window'),
         config: z.object({
             timezone: z.string().nullable(),

--- a/products/workflows/frontend/Workflows/hogflows/steps/HogFlowSteps.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/HogFlowSteps.tsx
@@ -29,6 +29,7 @@ import { StepRandomCohortBranchConfiguration } from './StepRandomCohortBranch'
 import { StepTriggerConfiguration } from './StepTrigger'
 import { StepWaitUntilConditionConfiguration } from './StepWaitUntilCondition'
 import { StepWaitUntilTimeWindowConfiguration } from './StepWaitUntilTimeWindow'
+import { StepWaitForEventConfiguration } from './StepWaitForEvent'
 
 type HogFlowStepBuilder<T extends HogFlowAction['type']> = {
     type: T
@@ -92,6 +93,12 @@ const HogFlowStepConfigs: Partial<{
         icon: () => <IconDay />,
         color: () => '#FF653F',
         renderConfiguration: (node) => <StepWaitUntilTimeWindowConfiguration key={node.id} node={node} />,
+    },
+    wait_for_event: {
+        type: 'wait_for_event',
+        icon: () => <IconHourglass />,
+        color: () => '#8B5CF6',
+        renderConfiguration: (node) => <StepWaitForEventConfiguration key={node.id} node={node} />,
     },
 
     // We can remove these later

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepWaitForEvent.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepWaitForEvent.tsx
@@ -1,0 +1,63 @@
+import { Node } from '@xyflow/react'
+import { useActions } from 'kea'
+
+import { LemonLabel } from '@posthog/lemon-ui'
+
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+
+import { workflowLogic } from '../../workflowLogic'
+import { HogFlowPropertyFilters } from '../filters/HogFlowFilters'
+import { HogFlowAction } from '../types'
+import { HogFlowDuration } from './components/HogFlowDuration'
+import { StepSchemaErrors } from './components/StepSchemaErrors'
+import { useDebouncedNameInput } from './utils'
+
+export function StepWaitForEventConfiguration({
+    node,
+}: {
+    node: Node<Extract<HogFlowAction, { type: 'wait_for_event' }>>
+}): JSX.Element {
+    const action = node.data
+    const { event_filters, max_wait_duration } = action.config
+
+    const { partialSetWorkflowActionConfig } = useActions(workflowLogic)
+
+    const { localName: localEventName, handleNameChange } = useDebouncedNameInput(event_filters, (updatedEventFilters) =>
+        partialSetWorkflowActionConfig(action.id, { event_filters: updatedEventFilters })
+    )
+
+    return (
+        <>
+            <StepSchemaErrors />
+
+            <div className="flex flex-col gap-1">
+                <LemonLabel>Maximum wait time</LemonLabel>
+                <HogFlowDuration
+                    value={max_wait_duration}
+                    onChange={(value) => {
+                        partialSetWorkflowActionConfig(action.id, { max_wait_duration: value })
+                    }}
+                />
+            </div>
+
+            <div className="flex flex-col gap-1">
+                <LemonLabel>Event to wait for</LemonLabel>
+                <LemonInput
+                    value={localEventName || ''}
+                    onChange={handleNameChange}
+                    placeholder="When event matches"
+                    size="small"
+                />
+                <HogFlowPropertyFilters
+                    filtersKey={`wait-for-event-${action.id}`}
+                    filters={event_filters.filters ?? {}}
+                    setFilters={(filters) =>
+                        partialSetWorkflowActionConfig(action.id, { event_filters: { ...event_filters, filters } })
+                    }
+                    typeKey="workflow-wait-for-event"
+                />
+            </div>
+        </>
+    )
+}
+

--- a/products/workflows/frontend/Workflows/hogflows/steps/types.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/types.ts
@@ -218,6 +218,18 @@ export const HogFlowActionSchema = z.discriminatedUnion('type', [
         }),
     }),
 
+    z.object({
+        ..._commonActionFields,
+        type: z.literal('wait_for_event'),
+        config: z.object({
+            event_filters: z.object({
+                filters: ActionFiltersSchema.optional().nullable(),
+                name: z.string().optional(), // Custom name for the event condition
+            }),
+            max_wait_duration: z.string(),
+        }),
+    }),
+
     // CDP functions
     z.object({
         ..._commonActionFields,


### PR DESCRIPTION
### Problem

- Users need to pause workflows until specific events occur from customers, enabling more sophisticated workflow logic.

### Changes

- Added `wait_for_event` action type with event filters and timeout duration
- Created UI component for configuring event waiting
- Registered backend handler using existing conditional branch logic

### How did you test this code?

- TypeScript compilation passes
- Component renders in workflow editor
- Schema validation works
- Backend handler registered correctly

fix: #45743