### PR TITLE
fix(experiments): fix breakdowns alignment

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/hooks/useColumnWidthSync.ts
+++ b/frontend/src/scenes/experiments/MetricsView/hooks/useColumnWidthSync.ts
@@ -1,0 +1,214 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+
+interface UseColumnWidthSyncParams {
+    /** Ref to the breakdown row in the parent table */
+    parentRowRef: React.RefObject<HTMLTableRowElement>
+    /** Ref to the nested breakdown table */
+    nestedTableRef: React.RefObject<HTMLTableElement>
+    /** Dependencies to trigger re-measurement */
+    deps?: any[]
+}
+
+// Constants for table structure validation
+const BASELINE_ROW_CELL_COUNT = 7
+const VARIANT_ROW_CELL_COUNT = 5
+const EXPECTED_COLUMN_COUNT = 7
+
+/**
+ * Custom hook to sync column widths between a parent table and a nested breakdown table.
+ *
+ * This hook measures the actual rendered widths of columns in the parent table and applies
+ * them to the nested table to ensure perfect alignment, regardless of content differences.
+ *
+ * @param parentRowRef - Reference to the breakdown row in the parent table
+ * @param nestedTableRef - Reference to the nested table that needs width syncing
+ * @param deps - Optional dependencies that trigger re-measurement
+ */
+export function useColumnWidthSync({ parentRowRef, nestedTableRef, deps = [] }: UseColumnWidthSyncParams): void {
+    const [columnWidths, setColumnWidths] = useState<number[]>([])
+    const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+    const mutationTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+    const previousWidthsRef = useRef<number[]>([])
+
+    // Memoized helper to check if widths have actually changed
+    const widthsHaveChanged = useCallback((newWidths: number[]): boolean => {
+        const prev = previousWidthsRef.current
+        if (prev.length !== newWidths.length) {
+            return true
+        }
+        // Compare with small tolerance for sub-pixel rendering differences
+        const tolerance = 0.5
+        return newWidths.some((width, i) => Math.abs(width - prev[i]) > tolerance)
+    }, [])
+
+    // Memoized column mapping function
+    const getParentColumnIndex = useCallback((cellIndex: number, cellCount: number): number | null => {
+        if (cellCount === BASELINE_ROW_CELL_COUNT) {
+            // Baseline row: maps 1:1 with parent columns
+            return cellIndex
+        } else if (cellCount === VARIANT_ROW_CELL_COUNT) {
+            // Variant row: skip breakdown label (col 0) and details (col 5)
+            if (cellIndex < 4) {
+                return cellIndex + 1 // Columns 1-4
+            }
+            return cellIndex + 2 // Column 6 (chart)
+        }
+        return null
+    }, [])
+
+    // Measure parent table column widths
+    useLayoutEffect(() => {
+        if (!parentRowRef.current) {
+            return
+        }
+
+        const measureColumnWidths = (): void => {
+            try {
+                // Check if nested table exists (it might not be rendered yet if collapse is closed)
+                if (!nestedTableRef.current) {
+                    return
+                }
+
+                // Find the parent table by traversing up from the breakdown row
+                const parentTable = parentRowRef.current?.closest('table')
+                if (!parentTable) {
+                    return
+                }
+
+                // Get the first data row from the parent table (not the header, not the breakdown row)
+                const firstDataRow = parentTable.querySelector(
+                    'tbody tr:not([data-breakdown-row])'
+                ) as HTMLTableRowElement
+                if (!firstDataRow) {
+                    return
+                }
+
+                // Measure each cell's actual width (offsetWidth includes borders and padding)
+                const cells = Array.from(firstDataRow.querySelectorAll('td'))
+
+                // Validate we have the expected number of columns
+                if (cells.length !== EXPECTED_COLUMN_COUNT) {
+                    console.warn(
+                        `[useColumnWidthSync] Unexpected parent table structure: expected ${EXPECTED_COLUMN_COUNT} columns, got ${cells.length}`
+                    )
+                    return
+                }
+
+                const widths = cells.map((cell) => {
+                    const width = (cell as HTMLElement).offsetWidth
+                    if (width <= 0) {
+                        throw new Error('Measured column width is invalid (zero or negative)')
+                    }
+                    return width
+                })
+
+                // Only update state if widths have actually changed (prevent unnecessary re-renders)
+                if (widthsHaveChanged(widths)) {
+                    previousWidthsRef.current = widths
+                    setColumnWidths(widths)
+                }
+            } catch (error) {
+                console.error('[useColumnWidthSync] Error measuring column widths:', error)
+                // Don't show toast to user - this is a visual layout issue, not a critical error
+                // Fail silently and let the table render with default widths
+            }
+        }
+
+        // Debounced resize handler
+        const handleResize = (): void => {
+            if (resizeTimeoutRef.current) {
+                clearTimeout(resizeTimeoutRef.current)
+            }
+            resizeTimeoutRef.current = setTimeout(measureColumnWidths, 150)
+        }
+
+        // Initial measurement with a small delay to allow DOM to settle
+        const timeoutId = setTimeout(measureColumnWidths, 0)
+        window.addEventListener('resize', handleResize)
+
+        // Use MutationObserver to detect when nested table appears (with debouncing)
+        const observer = new MutationObserver(() => {
+            if (nestedTableRef.current) {
+                // Debounce mutation observations to avoid excessive measurements
+                if (mutationTimeoutRef.current) {
+                    clearTimeout(mutationTimeoutRef.current)
+                }
+                mutationTimeoutRef.current = setTimeout(measureColumnWidths, 50)
+            }
+        })
+
+        if (parentRowRef.current) {
+            observer.observe(parentRowRef.current, {
+                childList: true,
+                subtree: true,
+            })
+        }
+
+        return () => {
+            clearTimeout(timeoutId)
+            if (resizeTimeoutRef.current) {
+                clearTimeout(resizeTimeoutRef.current)
+            }
+            if (mutationTimeoutRef.current) {
+                clearTimeout(mutationTimeoutRef.current)
+            }
+            window.removeEventListener('resize', handleResize)
+            observer.disconnect()
+        }
+    }, [...deps, widthsHaveChanged])
+
+    // Apply measured widths to nested table columns
+    useLayoutEffect(() => {
+        if (!nestedTableRef.current || columnWidths.length === 0) {
+            return
+        }
+
+        // Validate column widths array
+        if (columnWidths.length !== EXPECTED_COLUMN_COUNT) {
+            console.warn(
+                `[useColumnWidthSync] Column widths array has unexpected length: expected ${EXPECTED_COLUMN_COUNT}, got ${columnWidths.length}`
+            )
+            return
+        }
+
+        try {
+            const rows = nestedTableRef.current.querySelectorAll('tbody tr')
+
+            rows.forEach((row) => {
+                const cells = Array.from(row.querySelectorAll('td'))
+                const cellCount = cells.length
+
+                cells.forEach((cell, cellIndex) => {
+                    // Use memoized column mapping function
+                    const parentColumnIndex = getParentColumnIndex(cellIndex, cellCount)
+
+                    if (parentColumnIndex === null) {
+                        // Unknown structure - log warning once per unique cell count
+                        console.warn(
+                            `[useColumnWidthSync] Unexpected row structure: expected ${BASELINE_ROW_CELL_COUNT} or ${VARIANT_ROW_CELL_COUNT} cells, got ${cellCount}`
+                        )
+                        return
+                    }
+
+                    // Validate parent column index is within bounds
+                    if (parentColumnIndex < 0 || parentColumnIndex >= columnWidths.length) {
+                        console.warn(
+                            `[useColumnWidthSync] Parent column index out of bounds: ${parentColumnIndex} (max: ${columnWidths.length - 1})`
+                        )
+                        return
+                    }
+
+                    const width = columnWidths[parentColumnIndex]
+                    if (width && width > 0) {
+                        const cellElement = cell as HTMLElement
+                        // Batch style updates to minimize reflows
+                        cellElement.style.cssText += `width: ${width}px; min-width: ${width}px; max-width: ${width}px; box-sizing: border-box;`
+                    }
+                })
+            })
+        } catch (error) {
+            console.error('[useColumnWidthSync] Error applying column widths:', error)
+            // Fail silently - table will render with default widths
+        }
+    }, [columnWidths, nestedTableRef, getParentColumnIndex])
+}

--- a/frontend/src/scenes/experiments/MetricsView/hooks/useColumnWidthSync.ts
+++ b/frontend/src/scenes/experiments/MetricsView/hooks/useColumnWidthSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 
 interface UseColumnWidthSyncParams {
     /** Ref to the breakdown row in the parent table */
@@ -11,6 +11,130 @@ interface UseColumnWidthSyncParams {
 const BASELINE_ROW_CELL_COUNT = 7
 const VARIANT_ROW_CELL_COUNT = 5
 const EXPECTED_COLUMN_COUNT = 7
+const WIDTH_COMPARISON_TOLERANCE = 0.5 // Tolerance for sub-pixel rendering differences
+
+/**
+ * Check if widths have actually changed between measurements
+ */
+const widthsHaveChanged = (newWidths: number[], previousWidths: number[]): boolean => {
+    if (previousWidths.length !== newWidths.length) {
+        return true
+    }
+    return newWidths.some((width, i) => Math.abs(width - previousWidths[i]) > WIDTH_COMPARISON_TOLERANCE)
+}
+
+/**
+ * Get the parent column index for a cell in the nested breakdown table
+ */
+const getParentColumnIndex = (cellIndex: number, cellCount: number): number | null => {
+    if (cellCount === BASELINE_ROW_CELL_COUNT) {
+        // Baseline row: maps 1:1 with parent columns
+        return cellIndex
+    }
+
+    if (cellCount === VARIANT_ROW_CELL_COUNT) {
+        // Variant row: skip breakdown label (col 0) and details (col 5)
+        if (cellIndex < 4) {
+            return cellIndex + 1 // Columns 1-4
+        }
+        return cellIndex + 2 // Column 6 (chart)
+    }
+
+    return null
+}
+
+/**
+ * Measure column widths from a parent table's first data row
+ */
+const measureColumnWidths = (parentTable: HTMLTableElement): number[] => {
+    // Get the first data row from the parent table (not the header, not the breakdown row)
+    const firstDataRow = parentTable.querySelector('tbody tr:not([data-breakdown-row])') as HTMLTableRowElement
+    if (!firstDataRow) {
+        throw new Error('No data row found in parent table')
+    }
+
+    // Measure each cell's actual width (offsetWidth includes borders and padding)
+    const cells = Array.from(firstDataRow.querySelectorAll('td'))
+
+    // Validate we have the expected number of columns
+    if (cells.length !== EXPECTED_COLUMN_COUNT) {
+        console.warn(
+            `[useColumnWidthSync] Unexpected parent table structure: expected ${EXPECTED_COLUMN_COUNT} columns, got ${cells.length}`
+        )
+        throw new Error('Unexpected column count')
+    }
+
+    const widths = cells.map((cell) => {
+        const width = (cell as HTMLElement).offsetWidth
+        if (width <= 0) {
+            throw new Error('Measured column width is invalid (zero or negative)')
+        }
+        return width
+    })
+
+    return widths
+}
+
+/**
+ * Clear inline width styles from nested table rows
+ */
+const clearRowStyles = (rows: NodeListOf<Element>): void => {
+    rows.forEach((row) => {
+        const cells = Array.from(row.querySelectorAll('td'))
+        cells.forEach((cell) => {
+            const cellElement = cell as HTMLElement
+            cellElement.style.width = ''
+            cellElement.style.minWidth = ''
+            cellElement.style.maxWidth = ''
+        })
+    })
+}
+
+/**
+ * Apply measured widths to nested table rows
+ */
+const applyWidthsToRows = (rows: NodeListOf<Element>, widths: number[]): void => {
+    // Validate column widths array
+    if (widths.length !== EXPECTED_COLUMN_COUNT) {
+        console.warn(
+            `[useColumnWidthSync] Column widths array has unexpected length: expected ${EXPECTED_COLUMN_COUNT}, got ${widths.length}`
+        )
+        return
+    }
+
+    rows.forEach((row) => {
+        const cells = Array.from(row.querySelectorAll('td'))
+        const cellCount = cells.length
+
+        cells.forEach((cell, cellIndex) => {
+            // Get parent column index for this cell
+            const parentColumnIndex = getParentColumnIndex(cellIndex, cellCount)
+
+            if (parentColumnIndex === null) {
+                // Unknown structure - log warning once per unique cell count
+                console.warn(
+                    `[useColumnWidthSync] Unexpected row structure: expected ${BASELINE_ROW_CELL_COUNT} or ${VARIANT_ROW_CELL_COUNT} cells, got ${cellCount}`
+                )
+                return
+            }
+
+            // Validate parent column index is within bounds
+            if (parentColumnIndex < 0 || parentColumnIndex >= widths.length) {
+                console.warn(
+                    `[useColumnWidthSync] Parent column index out of bounds: ${parentColumnIndex} (max: ${widths.length - 1})`
+                )
+                return
+            }
+
+            const width = widths[parentColumnIndex]
+            if (width && width > 0) {
+                const cellElement = cell as HTMLElement
+                // Batch style updates to minimize reflows
+                cellElement.style.cssText += `width: ${width}px; min-width: ${width}px; max-width: ${width}px; box-sizing: border-box;`
+            }
+        })
+    })
+}
 
 /**
  * Custom hook to sync column widths between a parent table and a nested breakdown table.
@@ -27,108 +151,13 @@ const EXPECTED_COLUMN_COUNT = 7
  *   nestedTableRef: breakdownTableRef
  * }, [breakdownResults, axisRange])
  */
-export function useColumnWidthSync(
+export const useColumnWidthSync = (
     { parentRowRef, nestedTableRef }: UseColumnWidthSyncParams,
     deps: React.DependencyList = []
-): void {
+): void => {
     const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-    const mutationTimeoutRef = useRef<NodeJS.Timeout | null>(null)
     const previousWidthsRef = useRef<number[]>([])
     const previousNestedTableRef = useRef<HTMLTableElement | null>(null)
-
-    /**
-     * we check if the widths have actually changed
-     * we use useCallback to provide a stable reference to the function
-     */
-    const widthsHaveChanged = useCallback((newWidths: number[]): boolean => {
-        const prev = previousWidthsRef.current
-        if (prev.length !== newWidths.length) {
-            return true
-        }
-        // Compare with small tolerance for sub-pixel rendering differences
-        const tolerance = 0.5
-        return newWidths.some((width, i) => Math.abs(width - prev[i]) > tolerance)
-    }, [])
-
-    /**
-     * we get the parent column index for the nested table
-     * we use useCallback to provide a stable reference to the function
-     */
-    const getParentColumnIndex = useCallback((cellIndex: number, cellCount: number): number | null => {
-        if (cellCount === BASELINE_ROW_CELL_COUNT) {
-            // Baseline row: maps 1:1 with parent columns
-            return cellIndex
-        } else if (cellCount === VARIANT_ROW_CELL_COUNT) {
-            // Variant row: skip breakdown label (col 0) and details (col 5)
-            if (cellIndex < 4) {
-                return cellIndex + 1 // Columns 1-4
-            }
-            return cellIndex + 2 // Column 6 (chart)
-        }
-        return null
-    }, [])
-
-    /**
-     * we apply the widths to the nested table after the parent table has been measured
-     *
-     * we use useCallback to provide a stable reference to the function
-     */
-    const applyWidthsToNestedTable = useCallback(
-        (widths: number[]): void => {
-            if (!nestedTableRef.current || widths.length === 0) {
-                return
-            }
-
-            // Validate column widths array
-            if (widths.length !== EXPECTED_COLUMN_COUNT) {
-                console.warn(
-                    `[useColumnWidthSync] Column widths array has unexpected length: expected ${EXPECTED_COLUMN_COUNT}, got ${widths.length}`
-                )
-                return
-            }
-
-            try {
-                const rows = nestedTableRef.current.querySelectorAll('tbody tr')
-
-                rows.forEach((row) => {
-                    const cells = Array.from(row.querySelectorAll('td'))
-                    const cellCount = cells.length
-
-                    cells.forEach((cell, cellIndex) => {
-                        // Use memoized column mapping function
-                        const parentColumnIndex = getParentColumnIndex(cellIndex, cellCount)
-
-                        if (parentColumnIndex === null) {
-                            // Unknown structure - log warning once per unique cell count
-                            console.warn(
-                                `[useColumnWidthSync] Unexpected row structure: expected ${BASELINE_ROW_CELL_COUNT} or ${VARIANT_ROW_CELL_COUNT} cells, got ${cellCount}`
-                            )
-                            return
-                        }
-
-                        // Validate parent column index is within bounds
-                        if (parentColumnIndex < 0 || parentColumnIndex >= widths.length) {
-                            console.warn(
-                                `[useColumnWidthSync] Parent column index out of bounds: ${parentColumnIndex} (max: ${widths.length - 1})`
-                            )
-                            return
-                        }
-
-                        const width = widths[parentColumnIndex]
-                        if (width && width > 0) {
-                            const cellElement = cell as HTMLElement
-                            // Batch style updates to minimize reflows
-                            cellElement.style.cssText += `width: ${width}px; min-width: ${width}px; max-width: ${width}px; box-sizing: border-box;`
-                        }
-                    })
-                })
-            } catch (error) {
-                console.error('[useColumnWidthSync] Error applying column widths:', error)
-                // Fail silently - table will render with default widths
-            }
-        },
-        [nestedTableRef, getParentColumnIndex]
-    )
 
     // Single effect to measure and apply column widths
     useLayoutEffect(() => {
@@ -144,51 +173,28 @@ export function useColumnWidthSync(
                 }
 
                 // Find the parent table by traversing up from the breakdown row
-                const parentTable = parentRowRef.current?.closest('table')
+                const parentTable = parentRowRef.current?.closest('table') as HTMLTableElement
                 if (!parentTable) {
                     return
                 }
 
-                // Get the first data row from the parent table (not the header, not the breakdown row)
-                const firstDataRow = parentTable.querySelector(
-                    'tbody tr:not([data-breakdown-row])'
-                ) as HTMLTableRowElement
-                if (!firstDataRow) {
-                    return
-                }
-
-                // Measure each cell's actual width (offsetWidth includes borders and padding)
-                const cells = Array.from(firstDataRow.querySelectorAll('td'))
-
-                // Validate we have the expected number of columns
-                if (cells.length !== EXPECTED_COLUMN_COUNT) {
-                    console.warn(
-                        `[useColumnWidthSync] Unexpected parent table structure: expected ${EXPECTED_COLUMN_COUNT} columns, got ${cells.length}`
-                    )
-                    return
-                }
-
-                const widths = cells.map((cell) => {
-                    const width = (cell as HTMLElement).offsetWidth
-                    if (width <= 0) {
-                        throw new Error('Measured column width is invalid (zero or negative)')
-                    }
-                    return width
-                })
+                // Measure column widths from parent table
+                const widths = measureColumnWidths(parentTable)
 
                 // Check if nested table is new (different instance from last time)
                 const isNewNestedTable = nestedTableRef.current !== previousNestedTableRef.current
                 previousNestedTableRef.current = nestedTableRef.current
 
                 // Check if widths have changed
-                const widthsChanged = widthsHaveChanged(widths)
+                const widthsChanged = widthsHaveChanged(widths, previousWidthsRef.current)
 
                 // Store the new widths
                 previousWidthsRef.current = widths
 
                 // Apply widths if they changed OR if nested table is new (reopened collapse)
                 if (widthsChanged || isNewNestedTable) {
-                    applyWidthsToNestedTable(widths)
+                    const rows = nestedTableRef.current.querySelectorAll('tbody tr')
+                    applyWidthsToRows(rows, widths)
                 }
             } catch (error) {
                 console.error('[useColumnWidthSync] Error measuring column widths:', error)
@@ -197,46 +203,32 @@ export function useColumnWidthSync(
             }
         }
 
-        // Debounced resize handler
+        // Debounced resize handler - clear styles first to allow natural reflow
         const handleResize = (): void => {
             if (resizeTimeoutRef.current) {
                 clearTimeout(resizeTimeoutRef.current)
             }
-            resizeTimeoutRef.current = setTimeout(measureAndApplyWidths, 150)
+            resizeTimeoutRef.current = setTimeout(() => {
+                // Clear existing styles to allow parent table to reflow naturally
+                if (nestedTableRef.current) {
+                    const rows = nestedTableRef.current.querySelectorAll('tbody tr')
+                    clearRowStyles(rows)
+                }
+                // Small delay to let DOM reflow, then remeasure
+                setTimeout(measureAndApplyWidths, 10)
+            }, 150)
         }
 
         // Initial measurement with a small delay to allow DOM to settle
         const timeoutId = setTimeout(measureAndApplyWidths, 0)
         window.addEventListener('resize', handleResize)
 
-        // Use MutationObserver to detect when nested table appears (with debouncing)
-        const observer = new MutationObserver(() => {
-            if (nestedTableRef.current) {
-                // Debounce mutation observations to avoid excessive measurements
-                if (mutationTimeoutRef.current) {
-                    clearTimeout(mutationTimeoutRef.current)
-                }
-                mutationTimeoutRef.current = setTimeout(measureAndApplyWidths, 50)
-            }
-        })
-
-        if (parentRowRef.current) {
-            observer.observe(parentRowRef.current, {
-                childList: true,
-                subtree: true,
-            })
-        }
-
         return () => {
             clearTimeout(timeoutId)
             if (resizeTimeoutRef.current) {
                 clearTimeout(resizeTimeoutRef.current)
             }
-            if (mutationTimeoutRef.current) {
-                clearTimeout(mutationTimeoutRef.current)
-            }
             window.removeEventListener('resize', handleResize)
-            observer.disconnect()
         }
-    }, [...deps, widthsHaveChanged, applyWidthsToNestedTable])
+    }, deps)
 }

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -22,6 +22,7 @@ import {
 import { Experiment, InsightType } from '~/types'
 
 import { experimentLogic } from '../../experimentLogic'
+import { useColumnWidthSync } from '../hooks/useColumnWidthSync'
 import { ChartEmptyState } from '../shared/ChartEmptyState'
 import { ChartLoadingState } from '../shared/ChartLoadingState'
 import { MetricHeader } from '../shared/MetricHeader'
@@ -90,11 +91,18 @@ function CollapsibleBreakdownSection({
     handleTooltipMouseLeave,
     handleTooltipMouseMove,
 }: CollapsibleBreakdownSectionProps): JSX.Element {
-    const [_, setIsExpanded] = useState(false)
+    const [isExpanded, setIsExpanded] = useState(false)
     const mainTableRef = useRef<HTMLTableRowElement>(null)
     const nestedTableRef = useRef<HTMLTableElement>(null)
 
     const totalRows = 1 + (breakdownResults[0]?.variants?.length || 0)
+
+    // Sync nested breakdown table column widths with parent table (only when expanded)
+    useColumnWidthSync({
+        parentRowRef: mainTableRef,
+        nestedTableRef,
+        deps: [breakdownResults, axisRange, isExpanded],
+    })
 
     const ratioMetricLabel = (variant: ExperimentStatsBaseValidated, metric: ExperimentMetric): JSX.Element => {
         return (
@@ -770,7 +778,7 @@ export function MetricRowGroup({
 
                 {/* Details column - with rowspan */}
                 <td
-                    className={`pt-3 align-top relative overflow-hidden border-b ${
+                    className={`w-20 pt-3 align-top relative overflow-hidden border-b ${
                         isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                     }`}
                     rowSpan={totalRows}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -98,11 +98,13 @@ function CollapsibleBreakdownSection({
     const totalRows = 1 + (breakdownResults[0]?.variants?.length || 0)
 
     // Sync nested breakdown table column widths with parent table (only when expanded)
-    useColumnWidthSync({
-        parentRowRef: mainTableRef,
-        nestedTableRef,
-        deps: [breakdownResults, axisRange, isExpanded],
-    })
+    useColumnWidthSync(
+        {
+            parentRowRef: mainTableRef,
+            nestedTableRef,
+        },
+        [breakdownResults, axisRange, isExpanded]
+    )
 
     const ratioMetricLabel = (variant: ExperimentStatsBaseValidated, metric: ExperimentMetric): JSX.Element => {
         return (


### PR DESCRIPTION
## Problem

When adding a breakdown to a metric, we need to maintain alignment between the metric's grid and its breakdown events.
The original implementation just added more `tr` elements to the metrics table, keeping things relatively simple. When we introduced a collapsible panel, we had to duplicate a `table` element, which caused small differences due to the compounding of margins, paddings, and other box-model oddities.

| metrics grid missalignment |
| - |
| <img width="1439" height="366" alt="image" src="https://github.com/user-attachments/assets/a033f7d8-7350-472e-9698-f1430fd46614" /> |


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

A first implementation attempted to solve the problem using `table-layout: fixed` and `colgroups` and was almost successful, but there were still some alignment issues, and it also fixed column width, making the UI fail with longer variant names.

### layout effects

To mitigate the box model problems of using `table-layout: fixed`, we implemented a small custom hook that we can call from the `CollapsibleBreakdownSection` to monitor changes in the parent table, read the width of all columns, and apply them to the child breakdown table.

| alignment fixed |
| - |
| <img width="1355" height="374" alt="image" src="https://github.com/user-attachments/assets/af877bda-703e-4030-9a37-dcba2da7b633" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/4cea60be-59c9-49cc-85ba-02e9e66b45fa)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
