### PR TITLE
fix(experiments): fix breakdows x axis max interval calculation

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -36,18 +36,36 @@ export function MetricsTable({
         useActions(experimentLogic)
 
     // Calculate shared axisRange across all metrics
-    const maxAbsValue = Math.max(
-        ...results.flatMap((result: NewExperimentQueryResponse) => {
-            const variantResults = result?.variant_results || []
-            return variantResults.flatMap((variant: ExperimentVariantResult) => {
-                const interval = getVariantInterval(variant)
-                return interval ? [Math.abs(interval[0]), Math.abs(interval[1])] : []
-            })
-        })
-    )
+    let hasBreakdowns = false
+    const allIntervalValues = results.flatMap((result: NewExperimentQueryResponse) => {
+        const allVariants: ExperimentVariantResult[] = []
 
+        // Include main variant results
+        if (result?.variant_results) {
+            allVariants.push(...result.variant_results)
+        }
+
+        // Include breakdown variant results
+        if (result?.breakdown_results && result.breakdown_results.length > 0) {
+            hasBreakdowns = true
+            result.breakdown_results.forEach((breakdownResult) => {
+                if (breakdownResult?.variants) {
+                    allVariants.push(...breakdownResult.variants)
+                }
+            })
+        }
+
+        return allVariants.flatMap((variant: ExperimentVariantResult) => {
+            const interval = getVariantInterval(variant)
+            return interval ? [Math.abs(interval[0]), Math.abs(interval[1])] : []
+        })
+    })
+
+    // Use 0 as default if no intervals exist, otherwise get the maximum value
+    const maxAbsValue = allIntervalValues.length > 0 ? Math.max(...allIntervalValues) : 0
     const axisMargin = Math.max(maxAbsValue * 0.05, 0.1)
-    const axisRange = Math.min(maxAbsValue + axisMargin, MAX_AXIS_RANGE)
+    // When breakdowns are present, ignore MAX_AXIS_RANGE to show full range of breakdown data
+    const axisRange = hasBreakdowns ? maxAbsValue + axisMargin : Math.min(maxAbsValue + axisMargin, MAX_AXIS_RANGE)
 
     if (metrics.length === 0) {
         return (


### PR DESCRIPTION
> [!NOTE]
> Depends on #45766

## Problem

When adding breakdowns to the metrics mix, some values can produce unusually large credible/confidence intervals. The chart is limited to +/- 150% 

| the max axis range limit |
| - |
| <img width="1401" height="329" alt="image" src="https://github.com/user-attachments/assets/64c2391a-b397-4b2d-8d4e-2331d4c7b71e" /> |

This is expected because breakdowns reduce the sample size, leading to statistical uncertainty and wider intervals. The maximum range limit is there to protect us from outliers; these wider intervals are statistically valid and signal that we need to collect more data on specific segments.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

| after |
| - |
| <img width="1371" height="326" alt="image" src="https://github.com/user-attachments/assets/9eaf6a36-6ac5-4c2a-89ae-8a45df8e5cc7" /> |

When breakdowns are present in any metric, we include their intervals in the axis calculation, and remove the +/- 150% limit.

This is a temporary measure until we implement additional visualization options for the metric results.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/2d065eb6-78dc-4cf8-a72d-5acd83c1e440)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
