### PR TITLE
feat(cli): use github provided variable

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.5.26
+
+- feat: use env variables provided by github actions when available
+
 # 0.5.24
 
 - chore: add endpoints use case to cli auth flow

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1566,7 +1566,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.25"
+version = "0.5.26"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.25"
+version = "0.5.26"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/utils/git.rs
+++ b/cli/src/utils/git.rs
@@ -15,6 +15,10 @@ pub struct GitInfo {
 }
 
 pub fn get_git_info(dir: Option<PathBuf>) -> Result<Option<GitInfo>> {
+    if let Some(info) = get_git_info_from_github() {
+        return Ok(Some(info));
+    }
+
     if let Some(info) = get_git_info_from_vercel() {
         return Ok(Some(info));
     }
@@ -26,8 +30,8 @@ pub fn get_git_info(dir: Option<PathBuf>) -> Result<Option<GitInfo>> {
 
     let remote_url = get_remote_url(&git_dir);
     let repo_name = get_repo_name(&git_dir);
-    let branch = get_current_branch(&git_dir).context("Failed to determine current branch")?;
-    let commit = get_head_commit(&git_dir, &branch).context("Failed to determine commit ID")?;
+    let branch = get_branch_name(&git_dir).context("Failed to determine current branch")?;
+    let commit = get_commit_sha(&git_dir, &branch).context("Failed to determine commit sha")?;
 
     Ok(Some(GitInfo {
         remote_url,
@@ -35,6 +39,25 @@ pub fn get_git_info(dir: Option<PathBuf>) -> Result<Option<GitInfo>> {
         branch,
         commit_id: commit,
     }))
+}
+
+fn get_git_info_from_github() -> Option<GitInfo> {
+    get_env_variable("GITHUB_ACTIONS")?;
+
+    let branch = get_env_variable("GITHUB_REF_NAME")?;
+    let commit_id = get_env_variable("GITHUB_SHA")?;
+    let repository = get_env_variable("GITHUB_REPOSITORY")?;
+    let server_url = get_env_variable("GITHUB_SERVER_URL")?;
+
+    let repo_name = repository.split('/').next_back().map(|s| s.to_string());
+    let remote_url = Some(format!("{server_url}/{repository}.git"));
+
+    Some(GitInfo {
+        remote_url,
+        repo_name,
+        branch,
+        commit_id,
+    })
 }
 
 fn get_git_info_from_vercel() -> Option<GitInfo> {
@@ -139,7 +162,7 @@ pub fn get_repo_name(git_dir: &Path) -> Option<String> {
     None
 }
 
-fn get_current_branch(git_dir: &Path) -> Result<String> {
+fn get_branch_name(git_dir: &Path) -> Result<String> {
     // First try to read from HEAD file
     let head_path = git_dir.join("HEAD");
     let mut head_content = String::new();
@@ -161,7 +184,7 @@ fn get_current_branch(git_dir: &Path) -> Result<String> {
     }
 }
 
-fn get_head_commit(git_dir: &Path, branch: &str) -> Result<String> {
+fn get_commit_sha(git_dir: &Path, branch: &str) -> Result<String> {
     if branch == "HEAD-detached" {
         // For detached HEAD, read directly from HEAD
         let head_path = git_dir.join("HEAD");

--- a/cli/tests/git.rs
+++ b/cli/tests/git.rs
@@ -112,3 +112,30 @@ fn test_get_git_info_from_vercel_env() {
     std::env::remove_var("VERCEL_GIT_COMMIT_REF");
     std::env::remove_var("VERCEL_GIT_COMMIT_SHA");
 }
+
+#[test]
+fn test_get_git_info_from_github_env() {
+    std::env::set_var("GITHUB_ACTIONS", "true");
+    std::env::set_var("GITHUB_SHA", "abc123def456");
+    std::env::set_var("GITHUB_REF_NAME", "main");
+    std::env::set_var("GITHUB_REPOSITORY", "PostHog/posthog");
+    std::env::set_var("GITHUB_SERVER_URL", "https://github.com");
+
+    let info = get_git_info(None)
+        .expect("should not error")
+        .expect("should return info");
+
+    assert_eq!(info.branch, "main");
+    assert_eq!(info.commit_id, "abc123def456");
+    assert_eq!(info.repo_name.as_deref(), Some("posthog"));
+    assert_eq!(
+        info.remote_url.as_deref(),
+        Some("https://github.com/PostHog/posthog.git")
+    );
+
+    std::env::remove_var("GITHUB_ACTIONS");
+    std::env::remove_var("GITHUB_SHA");
+    std::env::remove_var("GITHUB_REF_NAME");
+    std::env::remove_var("GITHUB_REPOSITORY");
+    std::env::remove_var("GITHUB_SERVER_URL");
+}


### PR DESCRIPTION
Fix: https://posthoghelp.zendesk.com/agent/tickets/48048 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50797)

## Changes

- Use env variable provided by github when possible
- Allow variable customization at the same time