### PR TITLE
feat: cache conversations

### DIFF
--- a/products/conversations/backend/api/serializers.py
+++ b/products/conversations/backend/api/serializers.py
@@ -87,6 +87,7 @@ class WidgetMessagesQuerySerializer(serializers.Serializer):
 
     widget_session_id = serializers.UUIDField(required=True)
     after = serializers.DateTimeField(required=False, allow_null=True)
+    limit = serializers.IntegerField(required=False, default=500, min_value=1, max_value=500)
 
 
 class WidgetTicketsQuerySerializer(serializers.Serializer):

--- a/products/conversations/backend/api/tests/test_cache.py
+++ b/products/conversations/backend/api/tests/test_cache.py
@@ -1,0 +1,178 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from products.conversations.backend.cache import (
+    MESSAGES_CACHE_TTL,
+    TICKETS_CACHE_TTL,
+    get_cached_messages,
+    get_cached_tickets,
+    get_messages_cache_key,
+    get_tickets_cache_key,
+    invalidate_messages_cache,
+    invalidate_tickets_cache,
+    set_cached_messages,
+    set_cached_tickets,
+)
+
+
+class TestCacheKeyGeneration(TestCase):
+    def test_messages_cache_key_without_after(self):
+        key = get_messages_cache_key(team_id=1, ticket_id="abc-123")
+        assert key == "conversations:messages:1:abc-123:all"
+
+    def test_messages_cache_key_with_after(self):
+        key = get_messages_cache_key(team_id=1, ticket_id="abc-123", after="2024-01-01T00:00:00")
+        # after is hashed to 8 chars
+        assert key.startswith("conversations:messages:1:abc-123:")
+        assert key != "conversations:messages:1:abc-123:all"
+        assert len(key.split(":")[-1]) == 8  # md5 hash truncated to 8 chars
+
+    def test_messages_cache_key_different_after_different_keys(self):
+        key1 = get_messages_cache_key(team_id=1, ticket_id="abc", after="2024-01-01")
+        key2 = get_messages_cache_key(team_id=1, ticket_id="abc", after="2024-01-02")
+        assert key1 != key2
+
+    def test_tickets_cache_key_without_status(self):
+        key = get_tickets_cache_key(team_id=1, widget_session_id="session-123")
+        assert key == "conversations:tickets:1:session-123:all"
+
+    def test_tickets_cache_key_with_status(self):
+        key = get_tickets_cache_key(team_id=1, widget_session_id="session-123", status="open")
+        assert key == "conversations:tickets:1:session-123:open"
+
+
+class TestMessagesCacheOperations(TestCase):
+    @patch("products.conversations.backend.cache.cache")
+    def test_get_cached_messages_returns_cached_data(self, mock_cache):
+        mock_cache.get.return_value = {"messages": []}
+
+        result = get_cached_messages(team_id=1, ticket_id="abc")
+
+        assert result == {"messages": []}
+        mock_cache.get.assert_called_once()
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_get_cached_messages_returns_none_on_miss(self, mock_cache):
+        mock_cache.get.return_value = None
+
+        result = get_cached_messages(team_id=1, ticket_id="abc")
+
+        assert result is None
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_get_cached_messages_returns_none_on_exception(self, mock_cache):
+        mock_cache.get.side_effect = Exception("Redis error")
+
+        result = get_cached_messages(team_id=1, ticket_id="abc")
+
+        assert result is None
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_set_cached_messages_sets_with_ttl(self, mock_cache):
+        data = {"messages": [{"id": "1"}]}
+
+        set_cached_messages(team_id=1, ticket_id="abc", response_data=data)
+
+        mock_cache.set.assert_called_once()
+        call_args = mock_cache.set.call_args
+        assert call_args[0][1] == data
+        assert call_args[1]["timeout"] == MESSAGES_CACHE_TTL
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_set_cached_messages_swallows_exception(self, mock_cache):
+        mock_cache.set.side_effect = Exception("Redis error")
+
+        # Should not raise
+        set_cached_messages(team_id=1, ticket_id="abc", response_data={})
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_invalidate_messages_uses_delete_pattern(self, mock_cache):
+        mock_cache.delete_pattern = MagicMock()
+
+        invalidate_messages_cache(team_id=1, ticket_id="abc")
+
+        mock_cache.delete_pattern.assert_called_once_with("conversations:messages:1:abc:*")
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_invalidate_messages_falls_back_to_delete(self, mock_cache):
+        # Remove delete_pattern to simulate non-redis cache
+        del mock_cache.delete_pattern
+
+        invalidate_messages_cache(team_id=1, ticket_id="abc")
+
+        mock_cache.delete.assert_called_once_with("conversations:messages:1:abc:all")
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_invalidate_messages_swallows_exception(self, mock_cache):
+        mock_cache.delete_pattern = MagicMock(side_effect=Exception("Redis error"))
+
+        # Should not raise
+        invalidate_messages_cache(team_id=1, ticket_id="abc")
+
+
+class TestTicketsCacheOperations(TestCase):
+    @patch("products.conversations.backend.cache.cache")
+    def test_get_cached_tickets_returns_cached_data(self, mock_cache):
+        mock_cache.get.return_value = {"count": 5, "results": []}
+
+        result = get_cached_tickets(team_id=1, widget_session_id="session")
+
+        assert result == {"count": 5, "results": []}
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_get_cached_tickets_with_status_filter(self, mock_cache):
+        mock_cache.get.return_value = {"count": 2}
+
+        get_cached_tickets(team_id=1, widget_session_id="session", status="open")
+
+        call_key = mock_cache.get.call_args[0][0]
+        assert "open" in call_key
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_get_cached_tickets_returns_none_on_exception(self, mock_cache):
+        mock_cache.get.side_effect = Exception("Redis error")
+
+        result = get_cached_tickets(team_id=1, widget_session_id="session")
+
+        assert result is None
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_set_cached_tickets_sets_with_ttl(self, mock_cache):
+        data = {"count": 1, "results": []}
+
+        set_cached_tickets(team_id=1, widget_session_id="session", response_data=data)
+
+        call_args = mock_cache.set.call_args
+        assert call_args[0][1] == data
+        assert call_args[1]["timeout"] == TICKETS_CACHE_TTL
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_set_cached_tickets_swallows_exception(self, mock_cache):
+        mock_cache.set.side_effect = Exception("Redis error")
+
+        # Should not raise
+        set_cached_tickets(team_id=1, widget_session_id="session", response_data={})
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_invalidate_tickets_uses_delete_pattern(self, mock_cache):
+        mock_cache.delete_pattern = MagicMock()
+
+        invalidate_tickets_cache(team_id=1, widget_session_id="session")
+
+        mock_cache.delete_pattern.assert_called_once_with("conversations:tickets:1:session:*")
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_invalidate_tickets_falls_back_to_delete(self, mock_cache):
+        del mock_cache.delete_pattern
+
+        invalidate_tickets_cache(team_id=1, widget_session_id="session")
+
+        mock_cache.delete.assert_called_once_with("conversations:tickets:1:session:all")
+
+    @patch("products.conversations.backend.cache.cache")
+    def test_invalidate_tickets_swallows_exception(self, mock_cache):
+        mock_cache.delete_pattern = MagicMock(side_effect=Exception("Redis error"))
+
+        # Should not raise
+        invalidate_tickets_cache(team_id=1, widget_session_id="session")

--- a/products/conversations/backend/api/tests/test_signals.py
+++ b/products/conversations/backend/api/tests/test_signals.py
@@ -1,0 +1,224 @@
+import uuid
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from posthog.models.comment import Comment
+
+from products.conversations.backend.models import Ticket
+
+
+class TestTicketMessageSignals(BaseTest):
+    """Tests for signal handlers that maintain denormalized ticket stats."""
+
+    def setUp(self):
+        super().setUp()
+        self.widget_session_id = str(uuid.uuid4())
+        self.ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            widget_session_id=self.widget_session_id,
+            distinct_id="user-123",
+            channel_source="widget",
+        )
+
+    def _create_customer_message(self, content: str = "Hello") -> Comment:
+        return Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(self.ticket.id),
+            content=content,
+            item_context={"author_type": "customer", "is_private": False},
+        )
+
+    def _create_team_message(self, content: str = "Hi there") -> Comment:
+        return Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(self.ticket.id),
+            content=content,
+            created_by=self.user,
+            item_context={"author_type": "team", "is_private": False},
+        )
+
+    def test_customer_message_updates_stats(self):
+        comment = self._create_customer_message("Hello from customer")
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.message_count == 1
+        assert self.ticket.last_message_at == comment.created_at
+        assert self.ticket.last_message_text == "Hello from customer"
+        assert self.ticket.unread_customer_count == 0  # Customer messages don't increment this
+
+    def test_team_message_updates_stats_and_unread(self):
+        comment = self._create_team_message("Response from team")
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.message_count == 1
+        assert self.ticket.last_message_at == comment.created_at
+        assert self.ticket.last_message_text == "Response from team"
+        assert self.ticket.unread_customer_count == 1  # Team messages increment this
+
+    def test_multiple_messages_accumulate(self):
+        self._create_customer_message("First")
+        self._create_team_message("Second")
+        last = self._create_customer_message("Third")
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.message_count == 3
+        assert self.ticket.last_message_at == last.created_at
+        assert self.ticket.last_message_text == "Third"
+        assert self.ticket.unread_customer_count == 1  # Only 1 team message
+
+    def test_long_message_truncated_to_500_chars(self):
+        long_content = "x" * 600
+        self._create_customer_message(long_content)
+
+        self.ticket.refresh_from_db()
+        assert len(self.ticket.last_message_text) == 500
+        assert self.ticket.last_message_text == "x" * 500
+
+    def test_soft_delete_decrements_count(self):
+        comment = self._create_customer_message("To be deleted")
+        self.ticket.refresh_from_db()
+        assert self.ticket.message_count == 1
+
+        comment.deleted = True
+        comment.save()
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.message_count == 0
+
+    def test_soft_delete_recalculates_last_message(self):
+        first = self._create_customer_message("First message")
+        second = self._create_customer_message("Second message")
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.last_message_text == "Second message"
+
+        second.deleted = True
+        second.save()
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.message_count == 1
+        assert self.ticket.last_message_at == first.created_at
+        assert self.ticket.last_message_text == "First message"
+
+    def test_soft_delete_last_message_clears_last_message_fields(self):
+        comment = self._create_customer_message("Only message")
+        self.ticket.refresh_from_db()
+        assert self.ticket.last_message_text == "Only message"
+
+        comment.deleted = True
+        comment.save()
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.message_count == 0
+        assert self.ticket.last_message_at is None
+        assert self.ticket.last_message_text is None
+
+    def test_soft_delete_team_message_decrements_unread(self):
+        comment = self._create_team_message("Team response")
+        self.ticket.refresh_from_db()
+        assert self.ticket.unread_customer_count == 1
+
+        comment.deleted = True
+        comment.save()
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.unread_customer_count == 0
+
+    def test_soft_delete_prevents_negative_counts(self):
+        # Manually set count to 0 to simulate race condition / data inconsistency
+        Ticket.objects.filter(id=self.ticket.id).update(message_count=0, unread_customer_count=0)
+
+        comment = self._create_team_message("Message")
+        # Reset counts again before delete to simulate race
+        Ticket.objects.filter(id=self.ticket.id).update(message_count=0, unread_customer_count=0)
+
+        comment.deleted = True
+        comment.save()
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.message_count == 0  # Not -1
+        assert self.ticket.unread_customer_count == 0  # Not -1
+
+    def test_non_conversations_comment_ignored(self):
+        # Comment for a different scope (e.g., recordings)
+        Comment.objects.create(
+            team=self.team,
+            scope="recordings",
+            item_id="some-recording-id",
+            content="Recording comment",
+        )
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.message_count == 0  # Unchanged
+
+    def test_comment_without_item_id_ignored(self):
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=None,
+            content="Orphan comment",
+        )
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.message_count == 0  # Unchanged
+
+
+class TestCacheInvalidation(BaseTest):
+    """Tests that cache invalidation is called at the right times."""
+
+    def setUp(self):
+        super().setUp()
+        self.widget_session_id = str(uuid.uuid4())
+        self.ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            widget_session_id=self.widget_session_id,
+            distinct_id="user-123",
+            channel_source="widget",
+        )
+
+    @patch("products.conversations.backend.signals.invalidate_messages_cache")
+    @patch("products.conversations.backend.signals.invalidate_tickets_cache")
+    def test_message_create_invalidates_cache(self, mock_tickets_cache, mock_messages_cache):
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(self.ticket.id),
+            content="New message",
+            item_context={"author_type": "customer"},
+        )
+
+        mock_messages_cache.assert_called_once_with(self.team.id, str(self.ticket.id))
+        mock_tickets_cache.assert_called_once_with(self.team.id, self.widget_session_id)
+
+    @patch("products.conversations.backend.signals.invalidate_messages_cache")
+    @patch("products.conversations.backend.signals.invalidate_tickets_cache")
+    def test_soft_delete_invalidates_cache(self, mock_tickets_cache, mock_messages_cache):
+        comment = Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(self.ticket.id),
+            content="Message to delete",
+            item_context={"author_type": "customer"},
+        )
+        mock_messages_cache.reset_mock()
+        mock_tickets_cache.reset_mock()
+
+        comment.deleted = True
+        comment.save()
+
+        mock_messages_cache.assert_called_once_with(self.team.id, str(self.ticket.id))
+        mock_tickets_cache.assert_called_once_with(self.team.id, self.widget_session_id)
+
+    @patch("products.conversations.backend.signals.invalidate_messages_cache")
+    def test_non_conversations_comment_no_cache_invalidation(self, mock_cache):
+        Comment.objects.create(
+            team=self.team,
+            scope="recordings",
+            item_id="recording-id",
+            content="Recording comment",
+        )
+
+        mock_cache.assert_not_called()

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -34,6 +34,12 @@ from products.conversations.backend.api.serializers import (
     WidgetTicketsQuerySerializer,
     validate_origin,
 )
+from products.conversations.backend.cache import (
+    get_cached_messages,
+    get_cached_tickets,
+    set_cached_messages,
+    set_cached_tickets,
+)
 from products.conversations.backend.models import Ticket
 
 logger = logging.getLogger(__name__)
@@ -210,11 +216,7 @@ class WidgetMessagesView(APIView):
 
         widget_session_id = str(query_serializer.validated_data["widget_session_id"])
         after = query_serializer.validated_data.get("after")
-        limit = request.query_params.get("limit", 500)
-        try:
-            limit = min(int(limit), 500)
-        except (ValueError, TypeError):
-            limit = 500
+        limit = query_serializer.validated_data["limit"]
 
         # Get ticket
         try:
@@ -225,6 +227,12 @@ class WidgetMessagesView(APIView):
         # CRITICAL: Verify the ticket belongs to this widget_session_id (NOT distinct_id)
         if ticket.widget_session_id != widget_session_id:
             return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        # Check cache (after access control validation)
+        after_str = after.isoformat() if after else None
+        cached = get_cached_messages(team.id, ticket_id, after_str)
+        if cached is not None:
+            return Response(cached)
 
         # Build query - prefetch created_by to avoid N+1 queries
         messages_query = Comment.objects.filter(
@@ -267,15 +275,18 @@ class WidgetMessagesView(APIView):
                 }
             )
 
-        return Response(
-            {
-                "ticket_id": str(ticket.id),
-                "ticket_status": ticket.status,
-                "unread_count": ticket.unread_customer_count,
-                "messages": message_list,
-                "has_more": len(messages) == limit,  # Hint if there are more messages
-            }
-        )
+        response_data = {
+            "ticket_id": str(ticket.id),
+            "ticket_status": ticket.status,
+            "unread_count": ticket.unread_customer_count,
+            "messages": message_list,
+            "has_more": len(messages) == limit,  # Hint if there are more messages
+        }
+
+        # Cache the response
+        set_cached_messages(team.id, ticket_id, response_data, after_str)
+
+        return Response(response_data)
 
 
 class WidgetTicketsView(APIView):
@@ -311,6 +322,12 @@ class WidgetTicketsView(APIView):
         limit = query_serializer.validated_data["limit"]
         offset = query_serializer.validated_data["offset"]
 
+        # Check cache for first page (most common case for polling)
+        if offset == 0:
+            cached = get_cached_tickets(team.id, widget_session_id, status_filter)
+            if cached is not None:
+                return Response(cached)
+
         # Build query - filter by widget_session_id, not distinct_id
         tickets_query = Ticket.objects.filter(team=team, widget_session_id=widget_session_id)
 
@@ -338,7 +355,13 @@ class WidgetTicketsView(APIView):
                 }
             )
 
-        return Response({"count": total_count, "results": ticket_list})
+        response_data = {"count": total_count, "results": ticket_list}
+
+        # Cache first page
+        if offset == 0:
+            set_cached_tickets(team.id, widget_session_id, response_data, status_filter)
+
+        return Response(response_data)
 
 
 class WidgetMarkReadView(APIView):

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -228,7 +228,7 @@ class WidgetMessagesView(APIView):
         if ticket.widget_session_id != widget_session_id:
             return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
 
-        # Check cache (after access control validation, only for default limit)
+        # Check cache (after stays constant between polls until new message arrives)
         after_str = after.isoformat() if after else None
         use_cache = limit == 50  # Only cache the limit used by widget polling
         if use_cache:
@@ -285,7 +285,7 @@ class WidgetMessagesView(APIView):
             "has_more": len(messages) == limit,  # Hint if there are more messages
         }
 
-        # Cache the response (only for default limit)
+        # Cache the response
         if use_cache:
             set_cached_messages(team.id, ticket_id, response_data, after_str)
 

--- a/products/conversations/backend/cache.py
+++ b/products/conversations/backend/cache.py
@@ -29,7 +29,7 @@ def _make_cache_key(prefix: str, *args: str) -> str:
 
 def get_messages_cache_key(team_id: int, ticket_id: str, after: str | None = None) -> str:
     """Cache key for widget messages endpoint."""
-    after_hash = hashlib.md5((after or "").encode()).hexdigest()[:8] if after else "all"
+    after_hash = hashlib.sha256((after or "").encode()).hexdigest()[:8] if after else "all"
     return _make_cache_key("messages", str(team_id), ticket_id, after_hash)
 
 

--- a/products/conversations/backend/cache.py
+++ b/products/conversations/backend/cache.py
@@ -1,0 +1,115 @@
+"""
+Redis caching for Conversations widget polling endpoints.
+
+Caches responses to reduce database load from frequent polling.
+Invalidated automatically when messages are created or tickets updated.
+"""
+
+import hashlib
+
+from django.core.cache import cache
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Cache TTLs (seconds)
+MESSAGES_CACHE_TTL = 15  # Short TTL - messages need to appear quickly
+TICKETS_CACHE_TTL = 30  # Slightly longer - ticket list changes less frequently
+
+
+def _make_cache_key(prefix: str, *args: str) -> str:
+    """Create a namespaced cache key."""
+    key_parts = ":".join(str(arg) for arg in args)
+    return f"conversations:{prefix}:{key_parts}"
+
+
+# Widget Messages Cache
+
+
+def get_messages_cache_key(team_id: int, ticket_id: str, after: str | None = None) -> str:
+    """Cache key for widget messages endpoint."""
+    after_hash = hashlib.md5((after or "").encode()).hexdigest()[:8] if after else "all"
+    return _make_cache_key("messages", str(team_id), ticket_id, after_hash)
+
+
+def get_cached_messages(team_id: int, ticket_id: str, after: str | None = None) -> dict | None:
+    """Get cached messages response."""
+    key = get_messages_cache_key(team_id, ticket_id, after)
+    try:
+        return cache.get(key)
+    except Exception:
+        logger.warning("conversations_cache_get_error", key=key)
+        return None
+
+
+def set_cached_messages(team_id: int, ticket_id: str, response_data: dict, after: str | None = None) -> None:
+    """Cache messages response."""
+    key = get_messages_cache_key(team_id, ticket_id, after)
+    try:
+        cache.set(key, response_data, timeout=MESSAGES_CACHE_TTL)
+    except Exception:
+        logger.warning("conversations_cache_set_error", key=key)
+
+
+def invalidate_messages_cache(team_id: int, ticket_id: str) -> None:
+    """Invalidate all messages cache for a ticket.
+    Uses delete_pattern to clear all 'after' variations.
+    Falls back to deleting the base key if pattern delete not available.
+    Note: With fallback, 'after=<timestamp>' cached queries may serve stale data
+    for up to MESSAGES_CACHE_TTL seconds. This is acceptable given the short TTL.
+    """
+    pattern = _make_cache_key("messages", str(team_id), ticket_id, "*")
+    try:
+        if hasattr(cache, "delete_pattern"):
+            cache.delete_pattern(pattern)
+        else:
+            # Fallback: delete the "all" key. Other 'after' variations will expire via TTL.
+            cache.delete(get_messages_cache_key(team_id, ticket_id, None))
+            logger.info("conversations_cache_pattern_delete_unavailable", pattern=pattern)
+    except Exception:
+        logger.warning("conversations_cache_invalidate_error", pattern=pattern, exc_info=True)
+
+
+# Widget Tickets List Cache
+
+
+def get_tickets_cache_key(team_id: int, widget_session_id: str, status: str | None = None) -> str:
+    """Cache key for widget tickets list endpoint."""
+    return _make_cache_key("tickets", str(team_id), widget_session_id, status or "all")
+
+
+def get_cached_tickets(team_id: int, widget_session_id: str, status: str | None = None) -> dict | None:
+    """Get cached tickets list response."""
+    key = get_tickets_cache_key(team_id, widget_session_id, status)
+    try:
+        return cache.get(key)
+    except Exception:
+        logger.warning("conversations_cache_get_error", key=key)
+        return None
+
+
+def set_cached_tickets(team_id: int, widget_session_id: str, response_data: dict, status: str | None = None) -> None:
+    """Cache tickets list response."""
+    key = get_tickets_cache_key(team_id, widget_session_id, status)
+    try:
+        cache.set(key, response_data, timeout=TICKETS_CACHE_TTL)
+    except Exception:
+        logger.warning("conversations_cache_set_error", key=key)
+
+
+def invalidate_tickets_cache(team_id: int, widget_session_id: str) -> None:
+    """Invalidate all tickets cache for a widget session.
+    Note: With fallback (no delete_pattern), status-filtered caches may serve stale
+    data for up to TICKETS_CACHE_TTL seconds. This is acceptable given the short TTL.
+    """
+    pattern = _make_cache_key("tickets", str(team_id), widget_session_id, "*")
+    try:
+        if hasattr(cache, "delete_pattern"):
+            cache.delete_pattern(pattern)
+        else:
+            # Fallback: delete the "all" key. Status-filtered variations will expire via TTL.
+            cache.delete(get_tickets_cache_key(team_id, widget_session_id, None))
+            logger.info("conversations_cache_pattern_delete_unavailable", pattern=pattern)
+    except Exception:
+        logger.warning("conversations_cache_invalidate_error", pattern=pattern, exc_info=True)

--- a/products/conversations/backend/signals.py
+++ b/products/conversations/backend/signals.py
@@ -1,10 +1,16 @@
 from django.db.models import F
+from django.db.models.functions import Greatest
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
+import structlog
+
 from posthog.models.comment import Comment
 
+from .cache import invalidate_messages_cache, invalidate_tickets_cache
 from .models import Ticket
+
+logger = structlog.get_logger(__name__)
 
 
 @receiver(post_save, sender=Comment)
@@ -14,6 +20,7 @@ def update_ticket_on_message(sender, instance: Comment, created: bool, **kwargs)
     - Increment message_count, update last_message_at/text on create
     - Increment unread_customer_count for team messages
     - Handle soft-delete by decrementing count and recalculating last_message
+    - Invalidate widget cache for polling endpoints
     """
     if instance.scope != "conversations_ticket":
         return
@@ -36,6 +43,20 @@ def update_ticket_on_message(sender, instance: Comment, created: bool, **kwargs)
             update_fields["unread_customer_count"] = F("unread_customer_count") + 1
 
         Ticket.objects.filter(id=instance.item_id, team=instance.team).update(**update_fields)
+
+        # Invalidate widget cache so polling sees new messages
+        invalidate_messages_cache(instance.team_id, instance.item_id)
+        # Also invalidate tickets list cache (last_message changed)
+        try:
+            ticket = Ticket.objects.filter(id=instance.item_id, team=instance.team).values("widget_session_id").first()
+            if ticket:
+                invalidate_tickets_cache(instance.team_id, ticket["widget_session_id"])
+        except Exception:
+            logger.warning(
+                "conversations_ticket_cache_invalidate_failed",
+                ticket_id=instance.item_id,
+                exc_info=True,
+            )
 
 
 @receiver(pre_save, sender=Comment)
@@ -63,9 +84,10 @@ def handle_comment_soft_delete(sender, instance: Comment, **kwargs):
         author_type = instance.item_context.get("author_type") if isinstance(instance.item_context, dict) else None
         is_team_message = instance.created_by and author_type != "customer"
 
-        update_fields = {"message_count": F("message_count") - 1}
+        # Use Greatest to prevent negative counts from race conditions or data inconsistencies
+        update_fields = {"message_count": Greatest(F("message_count") - 1, 0)}
         if is_team_message:
-            update_fields["unread_customer_count"] = F("unread_customer_count") - 1
+            update_fields["unread_customer_count"] = Greatest(F("unread_customer_count") - 1, 0)
 
         Ticket.objects.filter(id=instance.item_id, team=instance.team).update(**update_fields)
 
@@ -91,4 +113,17 @@ def handle_comment_soft_delete(sender, instance: Comment, **kwargs):
             Ticket.objects.filter(id=instance.item_id, team=instance.team).update(
                 last_message_at=None,
                 last_message_text=None,
+            )
+
+        # Invalidate widget cache
+        invalidate_messages_cache(instance.team_id, instance.item_id)
+        try:
+            ticket = Ticket.objects.filter(id=instance.item_id, team=instance.team).values("widget_session_id").first()
+            if ticket:
+                invalidate_tickets_cache(instance.team_id, ticket["widget_session_id"])
+        except Exception:
+            logger.warning(
+                "conversations_ticket_cache_invalidate_failed",
+                ticket_id=instance.item_id,
+                exc_info=True,
             )


### PR DESCRIPTION
## Problem

The last (for now) step in optimization conversations is redis caching for polling

## Changes

1.  Widget Messages Cache:
   - Cache key: `conversations:messages:{team_id}:{ticket_id}:{after_hash}`
   - TTL: 15 seconds
   - Invalidated on message create/soft-delete via signal

2. Widget Tickets List Cache:
   - Cache key: `conversations:tickets:{team_id}:{widget_session_id}:{status}`
   - TTL: 30 seconds
   - Invalidated on message create (last_message changes)
   - Only caches first page (offset=0) - most common polling case

## How did you test this code?

Tests:
- `products/conversations/backend/api/tests/test_cache.py` - tests for cache operations
- `products/conversations/backend/api/tests/test_signals.py` - tests for signal handlers

