### PR TITLE
fix: Discussion comment deletion bug

### DIFF
--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -69,11 +69,14 @@ class CommentSerializer(serializers.ModelSerializer):
             if instance.created_by != request.user:
                 raise exceptions.PermissionDenied("You can only modify your own comments")
 
-        content = data.get("content", "")
-        rich_content = data.get("rich_content")
+        # Skip content validation when soft-deleting a comment
+        is_deleting = data.get("deleted") is True
+        if not is_deleting:
+            content = data.get("content", "")
+            rich_content = data.get("rich_content")
 
-        if not content.strip() and (not rich_content or self.has_empty_paragraph(rich_content)):
-            raise exceptions.ValidationError("A comment must have content")
+            if not content.strip() and (not rich_content or self.has_empty_paragraph(rich_content)):
+                raise exceptions.ValidationError("A comment must have content")
 
         data["created_by"] = request.user
 

--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -78,7 +78,8 @@ class CommentSerializer(serializers.ModelSerializer):
             if not content.strip() and (not rich_content or self.has_empty_paragraph(rich_content)):
                 raise exceptions.ValidationError("A comment must have content")
 
-        data["created_by"] = request.user
+        if not instance:
+            data["created_by"] = request.user
 
         return data
 


### PR DESCRIPTION
## Problem

Users are unable to delete discussion comments because the API returns "A comment must have content". This occurs because the `CommentSerializer`'s `validate` method incorrectly enforces content presence even when a soft-delete (setting `deleted=True`) is being performed.

## Changes

Modified `posthog/api/comments.py` to skip content validation in `CommentSerializer`'s `validate` method when a comment is being soft-deleted (i.e., `deleted` is set to `True` in the request data).

## How did you test this code?

- Added new unit tests in `posthog/api/test/test_comments.py`:
    - `test_soft_delete_comment_without_providing_content`
    - `test_soft_deleted_comments_excluded_from_list_by_default`
    - `test_hard_delete_returns_method_not_allowed`
- Verified all 26 comment-related tests pass.
- Ran linter to ensure code quality.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C08UM214Z50/p1769163795446179?thread_ts=1769163795.446179&cid=C08UM214Z50)

<a href="https://cursor.com/background-agent?bcId=bc-0806460e-37fe-4cb6-91d2-3dddbd232900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0806460e-37fe-4cb6-91d2-3dddbd232900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

