### PR TITLE
fix: charts memory leak

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
@@ -65,13 +65,14 @@ export function AnnotationsOverlay({
     const { insightProps } = useValues(insightLogic)
     const { tickIntervalPx, firstTickLeftPx } = useAnnotationsPositioning(chart, chartWidth, chartHeight)
 
-    // FIXME: This pollutes insightProps with dates and ticks, which is not ideal
     const annotationsOverlayLogicProps: AnnotationsOverlayLogicProps = {
         ...insightProps,
         dashboardId: insightProps.dashboardId,
         insightNumericId,
         dates,
-        ticks: chart.scales.x.ticks,
+        // Extract only primitive values to avoid retaining Chart.js internal references
+        // (tick objects contain $context which holds references to scales/chart/canvas)
+        ticks: chart.scales.x.ticks.map(({ value }) => ({ value })),
     }
     const { activeBadgeElement, tickDates } = useValues(annotationsOverlayLogic(annotationsOverlayLogicProps))
 

--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
@@ -1,6 +1,5 @@
 import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 
-import { Tick } from 'lib/Chart'
 import { isPersonPropertyFilter, parseProperties } from 'lib/components/PropertyFilters/utils'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { Dayjs, dayjs, dayjsLocalToTimezone } from 'lib/dayjs'
@@ -30,7 +29,7 @@ export interface AnnotationsOverlayLogicProps extends Omit<InsightLogicProps, 'd
     dashboardId: DashboardType['id'] | undefined
     insightNumericId: QueryBasedInsightModel['id'] | 'new'
     dates: string[]
-    ticks: Tick[]
+    ticks: { value: number }[]
 }
 
 export function determineAnnotationsDateGroup(
@@ -120,6 +119,8 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
             null as HTMLButtonElement | null,
             {
                 activateDate: (_, { badgeElement }) => badgeElement,
+                deactivateDate: () => null,
+                closePopover: () => null,
             },
         ],
         isDateLocked: [

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1258,6 +1258,19 @@ export const sceneLogic = kea<sceneLogicType>([
                     }
                 }
                 actions.setExportedScene(exportedScene, sceneId, sceneKey, tabId, params)
+
+                if (exportedScene.logic) {
+                    // initialize the logic and give it 50ms to load before opening the scene
+                    const props = { ...exportedScene.paramsToProps?.(params), tabId }
+                    const unmount = exportedScene.logic.build(props).mount()
+                    try {
+                        await breakpoint(50)
+                    } catch (e) {
+                        // if we change the scene while waiting these 50ms, unmount
+                        unmount()
+                        throw e
+                    }
+                }
             }
             actions.setScene(sceneId, sceneKey, tabId, params, clickedLink || wasNotLoaded, exportedScene)
         },

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1258,19 +1258,6 @@ export const sceneLogic = kea<sceneLogicType>([
                     }
                 }
                 actions.setExportedScene(exportedScene, sceneId, sceneKey, tabId, params)
-
-                if (exportedScene.logic) {
-                    // initialize the logic and give it 50ms to load before opening the scene
-                    const props = { ...exportedScene.paramsToProps?.(params), tabId }
-                    const unmount = exportedScene.logic.build(props).mount()
-                    try {
-                        await breakpoint(50)
-                    } catch (e) {
-                        // if we change the scene while waiting these 50ms, unmount
-                        unmount()
-                        throw e
-                    }
-                }
             }
             actions.setScene(sceneId, sceneKey, tabId, params, clickedLink || wasNotLoaded, exportedScene)
         },


### PR DESCRIPTION
following my nose trying to track down more of the sources of memory leaks

using visual detached element tracking with memlabs https://facebook.github.io/memlab/docs/guides/visually-debug-memory-leaks-with-memlens/

then checking what code is keeping the detached element held alive

## here all the insights from a dashboard till in memory (with all their data) after two client-side navigations

![CleanShot 2026-01-22 at 12.47.05@2x.png](https://app.graphite.com/user-attachments/assets/c585a858-e297-47e6-89a3-c8a9176e9f62.png)

Related to #32479
