### PR TITLE
fix(temporal): Convert the metrics server to be async

### DIFF
--- a/posthog/temporal/common/combined_metrics_server.py
+++ b/posthog/temporal/common/combined_metrics_server.py
@@ -1,12 +1,7 @@
-import sys
-import threading
-import urllib.request
-from concurrent.futures import (
-    ThreadPoolExecutor,
-    TimeoutError as FuturesTimeoutError,
-)
-from http.server import BaseHTTPRequestHandler, HTTPServer
+import asyncio
 
+import aiohttp
+from aiohttp import web
 from prometheus_client import CollectorRegistry, generate_latest
 
 from posthog.exceptions_capture import capture_exception
@@ -15,115 +10,14 @@ from posthog.temporal.common.logger import get_write_only_logger
 logger = get_write_only_logger(__name__)
 
 
-def create_handler(temporal_metrics_url: str, registry: CollectorRegistry) -> type[BaseHTTPRequestHandler]:
-    class CombinedMetricsHandler(BaseHTTPRequestHandler):
-        """HTTP handler that serves combined Temporal SDK and prometheus_client metrics."""
-
-        def do_GET(self) -> None:
-            if self.path in ("/metrics", "/"):
-                self._serve_combined_metrics()
-            else:
-                try:
-                    self.send_response(404)
-                    self.end_headers()
-                except (BrokenPipeError, ConnectionResetError):
-                    logger.debug("combined_metrics_server.client_disconnected_on_404")
-
-        def _serve_combined_metrics(self) -> None:
-            try:
-                # Fetch Temporal SDK metrics from its Prometheus endpoint
-                temporal_output = b""
-                try:
-                    # this url is controlled by us, so we don't have to worry about it being a file:// url
-                    # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-                    with urllib.request.urlopen(temporal_metrics_url, timeout=5) as response:
-                        temporal_output = response.read()
-                except Exception as e:
-                    logger.warning("combined_metrics_server.temporal_fetch_failed", error=str(e))
-
-                # Get prometheus_client metrics with timeout to prevent registry lock deadlock.
-                # Note: If timeout occurs, the background thread continues running but we don't
-                # wait for it (shutdown with wait=False). This is acceptable as it will eventually
-                # complete or remain blocked without affecting future scrapes.
-                executor = ThreadPoolExecutor(max_workers=1)
-                try:
-                    future = executor.submit(generate_latest, registry)
-                    client_output = future.result(timeout=5.0)
-                except FuturesTimeoutError:
-                    logger.warning("combined_metrics_server.registry_timeout")
-                    client_output = b"# Prometheus registry timeout\n"
-                finally:
-                    # Don't wait for the thread if it's still running (could be deadlocked)
-                    executor.shutdown(wait=False)
-
-                # Combine both outputs, ensuring proper newline separation.
-                # Prometheus text format requires metrics to be separated by exactly one newline.
-                # Strip any trailing newlines from Temporal output and add exactly one to prevent
-                # malformed output or extra blank lines between metric blocks.
-                if temporal_output:
-                    temporal_output = temporal_output.rstrip(b"\n") + b"\n"
-
-                output = temporal_output + client_output
-
-                try:
-                    self.send_response(200)
-                    self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-                    self.end_headers()
-                    self.wfile.write(output)
-                except (BrokenPipeError, ConnectionResetError):
-                    # Client disconnected before we could send the response
-                    logger.debug("combined_metrics_server.client_disconnected")
-                    return
-
-            except Exception as e:
-                capture_exception(e)
-                logger.exception("combined_metrics_server.error", error=str(e))
-                try:
-                    self.send_response(500)
-                    self.end_headers()
-                    self.wfile.write(f"Error: {e}".encode())
-                except (BrokenPipeError, ConnectionResetError):
-                    # Client disconnected, nothing we can do
-                    logger.debug("combined_metrics_server.client_disconnected_during_error")
-
-        def log_message(self, format: str, *args: object) -> None:
-            logger.debug(
-                "combined_metrics_server.request",
-                message=format % args,
-                client_address=self.client_address[0],
-            )
-
-        def handle_error(self, request, client_address) -> None:  # noqa: ARG002
-            """Override to handle errors during request processing gracefully.
-
-            This provides better observability by sending exceptions to error tracking
-            and using structured logging instead of stderr. Connection errors
-            are logged at debug level to reduce noise.
-            """
-            exc_type, exc_value, _ = sys.exc_info()
-            if exc_type in (BrokenPipeError, ConnectionResetError):
-                logger.debug(
-                    "combined_metrics_server.connection_error",
-                    client_address=client_address[0] if client_address else None,
-                )
-            else:
-                logger.exception(
-                    "combined_metrics_server.request_error",
-                    client_address=client_address[0] if client_address else None,
-                )
-
-            if exc_value is not None:
-                capture_exception(exc_value)
-
-    return CombinedMetricsHandler
-
-
 class CombinedMetricsServer:
-    """Metrics server combining Temporal SDK and prometheus_client metrics.
+    """Async metrics server combining Temporal SDK and prometheus_client metrics.
 
     Fetches Temporal metrics from its Prometheus HTTP endpoint and combines them
     with prometheus_client metrics on a single endpoint. This preserves the exact
     metric format that Temporal uses (including counter types without _total suffix).
+
+    Uses aiohttp to avoid GIL contention with Temporal activities.
     """
 
     def __init__(
@@ -134,35 +28,81 @@ class CombinedMetricsServer:
     ):
         self._port = port
         self._temporal_metrics_url = temporal_metrics_url
-        self._handler = create_handler(self._temporal_metrics_url, registry)
-        self._server: HTTPServer | None = None
-        self._thread: threading.Thread | None = None
+        self._registry = registry
+        self._app: web.Application | None = None
+        self._runner: web.AppRunner | None = None
+        self._site: web.TCPSite | None = None
 
-    def start(self) -> None:
-        if self._server is not None:
+    async def _handle_metrics(self, request: web.Request) -> web.Response:
+        """Handle GET /metrics requests by combining Temporal SDK and prometheus_client metrics."""
+        try:
+            # Fetch Temporal SDK metrics from its Prometheus endpoint asynchronously
+            temporal_output = b""
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(self._temporal_metrics_url, timeout=aiohttp.ClientTimeout(total=5)) as resp:
+                        temporal_output = await resp.read()
+            except Exception as e:
+                logger.warning("combined_metrics_server.temporal_fetch_failed", error=str(e))
+
+            # Get prometheus_client metrics in a thread pool to avoid blocking the event loop.
+            # Run with timeout to prevent registry lock issues.
+            try:
+                client_output = await asyncio.wait_for(
+                    asyncio.get_event_loop().run_in_executor(None, generate_latest, self._registry),
+                    timeout=5.0,
+                )
+            except TimeoutError:
+                logger.warning("combined_metrics_server.registry_timeout")
+                client_output = b"# Prometheus registry timeout\n"
+
+            # Combine both outputs, ensuring proper newline separation.
+            # Prometheus text format requires metrics to be separated by exactly one newline.
+            # Strip any trailing newlines from Temporal output and add exactly one to prevent
+            # malformed output or extra blank lines between metric blocks.
+            if temporal_output:
+                temporal_output = temporal_output.rstrip(b"\n") + b"\n"
+
+            output = temporal_output + client_output
+
+            return web.Response(
+                body=output,
+                status=200,
+                content_type="text/plain; version=0.0.4",
+                charset="utf-8",
+            )
+
+        except Exception as e:
+            capture_exception(e)
+            logger.exception("combined_metrics_server.error", error=str(e))
+            return web.Response(text=f"Error: {e}", status=500)
+
+    async def start(self) -> None:
+        if self._app is not None:
             raise RuntimeError("Server already started")
 
-        self._server = HTTPServer(("0.0.0.0", self._port), self._handler)
-        self._thread = threading.Thread(
-            target=self._server.serve_forever,
-            daemon=True,
-            name="combined-metrics-server",
-        )
-        self._thread.start()
+        self._app = web.Application()
+        self._app.router.add_get("/metrics", self._handle_metrics)
+        self._app.router.add_get("/", self._handle_metrics)
+
+        self._runner = web.AppRunner(self._app, access_log=None)
+        await self._runner.setup()
+
+        self._site = web.TCPSite(self._runner, "0.0.0.0", self._port)
+        await self._site.start()
 
         logger.info(
             "combined_metrics_server.started",
             port=self._port,
-            temporal_metrics_port=self._temporal_metrics_url,
+            temporal_metrics_url=self._temporal_metrics_url,
         )
 
-    def stop(self) -> None:
-        if self._server is None:
+    async def stop(self) -> None:
+        if self._runner is None:
             return
 
-        self._server.shutdown()
-        if self._thread is not None:
-            self._thread.join(timeout=5)
-        self._server = None
-        self._thread = None
+        await self._runner.cleanup()
+        self._runner = None
+        self._site = None
+        self._app = None
         logger.info("combined_metrics_server.stopped")

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -47,7 +47,7 @@ class ManagedWorker:
     metrics_server: CombinedMetricsServer
 
     async def run(self) -> None:
-        self.metrics_server.start()
+        await self.metrics_server.start()
         await self.worker.run()
 
     def is_shutdown(self) -> bool:
@@ -55,7 +55,7 @@ class ManagedWorker:
 
     async def shutdown(self) -> None:
         await self.worker.shutdown()
-        self.metrics_server.stop()
+        await self.metrics_server.stop()
 
 
 async def create_worker(

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -5,7 +5,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
-from aiohttp import ClientSession
+from aiohttp import ClientSession, ClientTimeout
 from prometheus_client import CollectorRegistry, Counter, Gauge
 
 from posthog.temporal.common.combined_metrics_server import CombinedMetricsServer
@@ -476,7 +476,7 @@ test_gauge 100.0
             url = f"http://127.0.0.1:{metrics_port}/metrics"
             # Use a longer timeout for the test request since we need to wait for the internal timeout
             async with ClientSession() as session:
-                async with session.get(url, timeout=15) as response:
+                async with session.get(url, timeout=ClientTimeout(15)) as response:
                     content = await response.text()
 
             # prometheus_client metrics should still be served despite Temporal timeout

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -1,12 +1,11 @@
 import time
 import socket
 import threading
-import urllib.error
-import urllib.request
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
+from aiohttp import ClientSession
 from prometheus_client import CollectorRegistry, Counter, Gauge
 
 from posthog.temporal.common.combined_metrics_server import CombinedMetricsServer
@@ -92,7 +91,8 @@ def test_gauge(isolated_registry):
 
 
 class TestCombinedMetricsServer:
-    def test_serves_combined_metrics(self, test_counter, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_serves_combined_metrics(self, test_counter, isolated_registry):
         temporal_port = get_free_port()
         metrics_port = get_free_port()
 
@@ -124,22 +124,24 @@ temporal_long_request_latency_bucket{namespace="default",operation="PollActivity
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             url = f"http://127.0.0.1:{metrics_port}/metrics"
-            with urllib.request.urlopen(url, timeout=5) as response:
-                content = response.read().decode("utf-8")
+            async with ClientSession() as session:
+                async with session.get(url) as response:
+                    content = await response.text()
 
             # Check Temporal metrics are included
             assert temporal_metrics.decode() in content
             # Check prometheus_client metrics are included
             assert test_counter in content
         finally:
-            server.stop()
+            await server.stop()
             mock_server.shutdown()
 
-    def test_serves_metrics_when_temporal_unavailable(self, test_counter, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_serves_metrics_when_temporal_unavailable(self, test_counter, isolated_registry):
         temporal_port = get_free_port()  # No server running on this port
         metrics_port = get_free_port()
 
@@ -148,20 +150,22 @@ temporal_long_request_latency_bucket{namespace="default",operation="PollActivity
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             url = f"http://127.0.0.1:{metrics_port}/metrics"
-            with urllib.request.urlopen(url, timeout=5) as response:
-                content = response.read().decode("utf-8")
+            async with ClientSession() as session:
+                async with session.get(url) as response:
+                    content = await response.text()
 
             # prometheus_client metrics should still be served
             assert test_counter in content
             assert "temporal" not in content
         finally:
-            server.stop()
+            await server.stop()
 
-    def test_returns_404_for_unknown_paths(self, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_returns_404_for_unknown_paths(self, isolated_registry):
         temporal_port = get_free_port()
         metrics_port = get_free_port()
 
@@ -170,18 +174,18 @@ temporal_long_request_latency_bucket{namespace="default",operation="PollActivity
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             url = f"http://127.0.0.1:{metrics_port}/unknown"
-            with pytest.raises(urllib.error.HTTPError) as exc_info:
-                urllib.request.urlopen(url, timeout=5)
-
-            assert exc_info.value.code == 404
+            async with ClientSession() as session:
+                async with session.get(url) as response:
+                    assert response.status == 404
         finally:
-            server.stop()
+            await server.stop()
 
-    def test_root_path_serves_metrics(self, test_counter, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_root_path_serves_metrics(self, test_counter, isolated_registry):
         temporal_port = get_free_port()
         metrics_port = get_free_port()
 
@@ -199,20 +203,22 @@ temporal_active_workers{task_queue="main"} 5
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             url = f"http://127.0.0.1:{metrics_port}/"
-            with urllib.request.urlopen(url, timeout=5) as response:
-                content = response.read().decode("utf-8")
+            async with ClientSession() as session:
+                async with session.get(url) as response:
+                    content = await response.text()
 
             assert temporal_metrics.decode() in content
             assert test_counter in content
         finally:
-            server.stop()
+            await server.stop()
             mock_server.shutdown()
 
-    def test_counter_metrics_preserve_type_without_total_suffix(self, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_counter_metrics_preserve_type_without_total_suffix(self, isolated_registry):
         """Verify that Temporal counter metrics preserve their format when passed through."""
         temporal_port = get_free_port()
         metrics_port = get_free_port()
@@ -234,12 +240,13 @@ temporal_request{operation="DescribeNamespace"} 2
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             url = f"http://127.0.0.1:{metrics_port}/metrics"
-            with urllib.request.urlopen(url, timeout=5) as response:
-                content = response.read().decode("utf-8")
+            async with ClientSession() as session:
+                async with session.get(url) as response:
+                    content = await response.text()
 
             # Verify counter type is preserved
             assert "# TYPE temporal_request counter" in content
@@ -247,10 +254,11 @@ temporal_request{operation="DescribeNamespace"} 2
             assert "temporal_request{" in content
             assert "temporal_request_total" not in content
         finally:
-            server.stop()
+            await server.stop()
             mock_server.shutdown()
 
-    def test_adds_newline_when_temporal_output_missing_trailing_newline(self, test_gauge, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_adds_newline_when_temporal_output_missing_trailing_newline(self, test_gauge, isolated_registry):
         """Ensure proper newline separation when Temporal output doesn't end with newline."""
         temporal_port = get_free_port()
         metrics_port = get_free_port()
@@ -267,12 +275,13 @@ temporal_request{operation="DescribeNamespace"} 2
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             url = f"http://127.0.0.1:{metrics_port}/metrics"
-            with urllib.request.urlopen(url, timeout=5) as response:
-                content = response.read().decode("utf-8")
+            async with ClientSession() as session:
+                async with session.get(url) as response:
+                    content = await response.text()
 
             # Full expected output - newline added after temporal_metric 42
             expected = """# HELP temporal_metric A metric
@@ -284,10 +293,11 @@ test_gauge 100.0
 """
             assert content == expected
         finally:
-            server.stop()
+            await server.stop()
             mock_server.shutdown()
 
-    def test_no_extra_newlines_when_temporal_output_empty(self, test_counter, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_no_extra_newlines_when_temporal_output_empty(self, test_counter, isolated_registry):
         """No extra newlines when Temporal returns empty response."""
         temporal_port = get_free_port()
         metrics_port = get_free_port()
@@ -304,22 +314,24 @@ test_gauge 100.0
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             url = f"http://127.0.0.1:{metrics_port}/metrics"
-            with urllib.request.urlopen(url, timeout=5) as response:
-                content = response.read().decode("utf-8")
+            async with ClientSession() as session:
+                async with session.get(url) as response:
+                    content = await response.text()
 
             # prometheus_client metrics should be present
             assert test_counter in content
             # Output should not start with empty lines
             assert not content.startswith("\n")
         finally:
-            server.stop()
+            await server.stop()
             mock_server.shutdown()
 
-    def test_duplicate_metric_names_both_present_in_output(self, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_duplicate_metric_names_both_present_in_output(self, isolated_registry):
         """Document: if both sources have same metric name, both appear in output.
 
         This is intentional - we pass through both outputs as-is and let Prometheus
@@ -350,12 +362,13 @@ test_gauge 100.0
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             url = f"http://127.0.0.1:{metrics_port}/metrics"
-            with urllib.request.urlopen(url, timeout=5) as response:
-                content = response.read().decode("utf-8")
+            async with ClientSession() as session:
+                async with session.get(url) as response:
+                    content = await response.text()
 
             # Full diff comparison - Temporal metrics first, then prometheus_client
             # Note: Both sources may define the same metric name, resulting in duplicates
@@ -368,10 +381,11 @@ test_gauge 100.0
 """
             assert content == expected
         finally:
-            server.stop()
+            await server.stop()
             mock_server.shutdown()
 
-    def test_strips_multiple_trailing_newlines(self, test_gauge, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_strips_multiple_trailing_newlines(self, test_gauge, isolated_registry):
         """Strip multiple trailing newlines to ensure exactly one newline separates outputs."""
         temporal_port = get_free_port()
         metrics_port = get_free_port()
@@ -388,12 +402,13 @@ test_gauge 100.0
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             url = f"http://127.0.0.1:{metrics_port}/metrics"
-            with urllib.request.urlopen(url, timeout=5) as response:
-                content = response.read().decode("utf-8")
+            async with ClientSession() as session:
+                async with session.get(url) as response:
+                    content = await response.text()
 
             # Full expected output - note exactly ONE newline between temporal and prometheus_client
             expected = """# HELP temporal_metric A metric
@@ -405,10 +420,11 @@ test_gauge 100.0
 """
             assert content == expected
         finally:
-            server.stop()
+            await server.stop()
             mock_server.shutdown()
 
-    def test_handles_temporal_http_error(self, test_counter, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_handles_temporal_http_error(self, test_counter, isolated_registry):
         """Gracefully degrade when Temporal returns HTTP error (e.g., 500)."""
         temporal_port = get_free_port()
         metrics_port = get_free_port()
@@ -422,22 +438,24 @@ test_gauge 100.0
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             url = f"http://127.0.0.1:{metrics_port}/metrics"
-            with urllib.request.urlopen(url, timeout=5) as response:
-                content = response.read().decode("utf-8")
+            async with ClientSession() as session:
+                async with session.get(url) as response:
+                    content = await response.text()
 
             # prometheus_client metrics should still be served despite Temporal error
             assert test_counter in content
             # No Temporal metrics since it returned an error
             assert "temporal" not in content.lower() or "temporal_metrics" not in content
         finally:
-            server.stop()
+            await server.stop()
             mock_server.shutdown()
 
-    def test_handles_temporal_timeout(self, test_counter, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_handles_temporal_timeout(self, test_counter, isolated_registry):
         """Gracefully degrade when Temporal is too slow to respond."""
         temporal_port = get_free_port()
         metrics_port = get_free_port()
@@ -452,23 +470,25 @@ test_gauge 100.0
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             url = f"http://127.0.0.1:{metrics_port}/metrics"
             # Use a longer timeout for the test request since we need to wait for the internal timeout
-            with urllib.request.urlopen(url, timeout=15) as response:
-                content = response.read().decode("utf-8")
+            async with ClientSession() as session:
+                async with session.get(url, timeout=15) as response:
+                    content = await response.text()
 
             # prometheus_client metrics should still be served despite Temporal timeout
             assert test_counter in content
             # No Temporal metrics since it returned an error
             assert "temporal" not in content.lower()
         finally:
-            server.stop()
+            await server.stop()
             mock_server.shutdown()
 
-    def test_start_twice_raises_error(self, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_start_twice_raises_error(self, isolated_registry):
         """Starting server twice should raise RuntimeError."""
         temporal_port = get_free_port()
         metrics_port = get_free_port()
@@ -478,15 +498,16 @@ test_gauge 100.0
             temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
             registry=isolated_registry,
         )
-        server.start()
+        await server.start()
 
         try:
             with pytest.raises(RuntimeError, match="Server already started"):
-                server.start()
+                await server.start()
         finally:
-            server.stop()
+            await server.stop()
 
-    def test_stop_when_not_started_is_noop(self, isolated_registry):
+    @pytest.mark.asyncio
+    async def test_stop_when_not_started_is_noop(self, isolated_registry):
         """Stopping server that wasn't started should be safe no-op."""
         temporal_port = get_free_port()
         metrics_port = get_free_port()
@@ -498,8 +519,8 @@ test_gauge 100.0
         )
 
         # Should not raise any exception
-        server.stop()
-        server.stop()  # Multiple stops should also be safe
+        await server.stop()
+        await server.stop()  # Multiple stops should also be safe
 
 
 class TestGetFreePort:


### PR DESCRIPTION
## Problem
- https://posthog.slack.com/archives/C0AA66SHDFU/p1769160782066039
- The temporal metrics server is synchronous and may be causing blocks in the GIL, causing slow downs to the dwh workers

## Changes
- Convert it to an async http server

## How did you test this code?
Updated unit tests!
