### PR TITLE
fix(llma): handle string array inputs in trace search

### DIFF
--- a/products/llm_analytics/frontend/searchUtils.ts
+++ b/products/llm_analytics/frontend/searchUtils.ts
@@ -46,7 +46,7 @@ export function findSearchMatches(text: string, searchQuery: string): SearchMatc
  * Check if a text contains a search query (case-insensitive)
  */
 export function containsSearchQuery(text: string, searchQuery: string): boolean {
-    if (!searchQuery.trim()) {
+    if (!text || !searchQuery.trim()) {
         return false
     }
 


### PR DESCRIPTION
## Problem

Searching in trace view crashes with `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` for embedding events where `$ai_input` is an array of strings, not message objects.

## Changes

- Add guard in `findSearchMatches` for null/undefined text
- Handle string messages in non-generation event fallbacks  
- Guard `additionalKwargs` extraction for object messages only

## How did you test this code?

Tested search on traces with embedding events.

## Publish to changelog?

no