### PR TITLE
refactor: use generic restriction step in blobby

### DIFF
--- a/nodejs/src/ingestion/session_replay/index.ts
+++ b/nodejs/src/ingestion/session_replay/index.ts
@@ -1,0 +1,7 @@
+export {
+    applyRestrictions,
+    createRestrictionPipeline,
+    RestrictionPipelineConfig,
+    RestrictionPipelineInput,
+    RestrictionPipelineOutput,
+} from './restriction-pipeline'

--- a/nodejs/src/ingestion/session_replay/restriction-pipeline.test.ts
+++ b/nodejs/src/ingestion/session_replay/restriction-pipeline.test.ts
@@ -1,0 +1,221 @@
+import { Message } from 'node-rdkafka'
+
+import { KafkaProducerWrapper } from '../../kafka/producer'
+import { PromiseScheduler } from '../../utils/promise-scheduler'
+import { createApplyEventRestrictionsStep, createParseHeadersStep } from '../event-preprocessing'
+import { drop, ok, redirect } from '../pipelines/results'
+import { applyRestrictions, createRestrictionPipeline } from './restriction-pipeline'
+
+jest.mock('../event-preprocessing', () => ({
+    createParseHeadersStep: jest.fn(),
+    createApplyEventRestrictionsStep: jest.fn(),
+}))
+
+const mockCreateParseHeadersStep = createParseHeadersStep as jest.Mock
+const mockCreateApplyEventRestrictionsStep = createApplyEventRestrictionsStep as jest.Mock
+
+describe('restriction-pipeline', () => {
+    let mockKafkaProducer: jest.Mocked<KafkaProducerWrapper>
+    let mockRestrictionManager: any
+    let promiseScheduler: PromiseScheduler
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        mockKafkaProducer = {
+            produce: jest.fn().mockResolvedValue(undefined),
+            flush: jest.fn().mockResolvedValue(undefined),
+            disconnect: jest.fn().mockResolvedValue(undefined),
+        } as any
+
+        mockRestrictionManager = {}
+
+        promiseScheduler = new PromiseScheduler()
+
+        // Default: parse headers step passes through with parsed headers
+        mockCreateParseHeadersStep.mockReturnValue((input: any) => {
+            return Promise.resolve(ok({ ...input, headers: { token: input.message.headers?.[0]?.token?.toString() } }))
+        })
+
+        // Default: restrictions step passes through
+        mockCreateApplyEventRestrictionsStep.mockReturnValue((input: any) => {
+            return Promise.resolve(ok(input))
+        })
+    })
+
+    function createMessage(partition: number, offset: number, headers?: Record<string, string>): Message {
+        const kafkaHeaders = headers
+            ? Object.entries(headers).map(([key, value]) => ({ [key]: Buffer.from(value) }))
+            : []
+
+        return {
+            partition,
+            offset,
+            topic: 'test-topic',
+            value: Buffer.from('test-value'),
+            key: Buffer.from('test-key'),
+            timestamp: Date.now(),
+            headers: kafkaHeaders,
+            size: 100,
+        }
+    }
+
+    describe('applyRestrictions', () => {
+        it('passes through messages when no restrictions apply', async () => {
+            const pipeline = createRestrictionPipeline({
+                kafkaProducer: mockKafkaProducer,
+                eventIngestionRestrictionManager: mockRestrictionManager,
+                overflowEnabled: true,
+                overflowTopic: 'overflow-topic',
+                promiseScheduler,
+            })
+
+            const messages = [createMessage(0, 1), createMessage(0, 2)]
+
+            const result = await applyRestrictions(pipeline, messages)
+
+            expect(result).toHaveLength(2)
+            expect(result[0].offset).toBe(1)
+            expect(result[1].offset).toBe(2)
+        })
+
+        it('filters out dropped messages', async () => {
+            mockCreateApplyEventRestrictionsStep.mockReturnValue((input: any) => {
+                if (input.message.offset === 2) {
+                    return Promise.resolve(drop('blocked'))
+                }
+                return Promise.resolve(ok(input))
+            })
+
+            const pipeline = createRestrictionPipeline({
+                kafkaProducer: mockKafkaProducer,
+                eventIngestionRestrictionManager: mockRestrictionManager,
+                overflowEnabled: true,
+                overflowTopic: 'overflow-topic',
+                promiseScheduler,
+            })
+
+            const messages = [createMessage(0, 1), createMessage(0, 2), createMessage(0, 3)]
+
+            const result = await applyRestrictions(pipeline, messages)
+
+            expect(result).toHaveLength(2)
+            expect(result[0].offset).toBe(1)
+            expect(result[1].offset).toBe(3)
+        })
+
+        it('redirects overflow messages and filters them out', async () => {
+            mockCreateApplyEventRestrictionsStep.mockReturnValue((input: any) => {
+                if (input.message.offset === 2) {
+                    return Promise.resolve(redirect('overflow', 'overflow-topic', true, false))
+                }
+                return Promise.resolve(ok(input))
+            })
+
+            const pipeline = createRestrictionPipeline({
+                kafkaProducer: mockKafkaProducer,
+                eventIngestionRestrictionManager: mockRestrictionManager,
+                overflowEnabled: true,
+                overflowTopic: 'overflow-topic',
+                promiseScheduler,
+            })
+
+            const messages = [createMessage(0, 1), createMessage(0, 2), createMessage(0, 3)]
+
+            const result = await applyRestrictions(pipeline, messages)
+
+            // Wait for side effects to complete
+            await promiseScheduler.waitForAll()
+
+            expect(result).toHaveLength(2)
+            expect(result[0].offset).toBe(1)
+            expect(result[1].offset).toBe(3)
+
+            // Verify the overflow message was produced
+            expect(mockKafkaProducer.produce).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    topic: 'overflow-topic',
+                })
+            )
+        })
+
+        it('returns empty array for empty input', async () => {
+            const pipeline = createRestrictionPipeline({
+                kafkaProducer: mockKafkaProducer,
+                eventIngestionRestrictionManager: mockRestrictionManager,
+                overflowEnabled: true,
+                overflowTopic: 'overflow-topic',
+                promiseScheduler,
+            })
+
+            const result = await applyRestrictions(pipeline, [])
+
+            expect(result).toHaveLength(0)
+        })
+
+        it('processes large batch with mixed dropped and passed messages correctly', async () => {
+            // Drop every 10th message
+            mockCreateApplyEventRestrictionsStep.mockReturnValue((input: any) => {
+                if (input.message.offset % 10 === 0) {
+                    return Promise.resolve(drop('blocked'))
+                }
+                return Promise.resolve(ok(input))
+            })
+
+            const pipeline = createRestrictionPipeline({
+                kafkaProducer: mockKafkaProducer,
+                eventIngestionRestrictionManager: mockRestrictionManager,
+                overflowEnabled: true,
+                overflowTopic: 'overflow-topic',
+                promiseScheduler,
+            })
+
+            // Create 1000 messages
+            const messages: Message[] = []
+            for (let i = 1; i <= 1000; i++) {
+                messages.push(createMessage(0, i))
+            }
+
+            const result = await applyRestrictions(pipeline, messages)
+
+            // 100 messages should be dropped (10, 20, 30, ..., 1000)
+            // 900 messages should pass through
+            expect(result).toHaveLength(900)
+
+            // Verify the offsets are correct (all non-multiples of 10)
+            const resultOffsets = result.map((m) => m.offset)
+            for (let i = 1; i <= 1000; i++) {
+                if (i % 10 === 0) {
+                    expect(resultOffsets).not.toContain(i)
+                } else {
+                    expect(resultOffsets).toContain(i)
+                }
+            }
+        })
+
+        it('processes large batch with all messages passing through', async () => {
+            const pipeline = createRestrictionPipeline({
+                kafkaProducer: mockKafkaProducer,
+                eventIngestionRestrictionManager: mockRestrictionManager,
+                overflowEnabled: true,
+                overflowTopic: 'overflow-topic',
+                promiseScheduler,
+            })
+
+            // Create 500 messages
+            const messages: Message[] = []
+            for (let i = 1; i <= 500; i++) {
+                messages.push(createMessage(0, i))
+            }
+
+            const result = await applyRestrictions(pipeline, messages)
+
+            expect(result).toHaveLength(500)
+
+            // Verify all offsets are present and in order
+            for (let i = 0; i < 500; i++) {
+                expect(result[i].offset).toBe(i + 1)
+            }
+        })
+    })
+})

--- a/nodejs/src/ingestion/session_replay/restriction-pipeline.ts
+++ b/nodejs/src/ingestion/session_replay/restriction-pipeline.ts
@@ -1,0 +1,84 @@
+import { Message } from 'node-rdkafka'
+
+import { KafkaProducerWrapper } from '../../kafka/producer'
+import { EventHeaders } from '../../types'
+import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restrictions'
+import { PromiseScheduler } from '../../utils/promise-scheduler'
+import { createApplyEventRestrictionsStep, createParseHeadersStep } from '../event-preprocessing'
+import { BatchPipelineUnwrapper } from '../pipelines/batch-pipeline-unwrapper'
+import { newBatchPipelineBuilder } from '../pipelines/builders'
+import { createBatch, createUnwrapper } from '../pipelines/helpers'
+import { PipelineConfig } from '../pipelines/result-handling-pipeline'
+
+export interface RestrictionPipelineInput {
+    message: Message
+}
+
+export interface RestrictionPipelineOutput {
+    message: Message
+    headers: EventHeaders
+}
+
+export interface RestrictionPipelineConfig {
+    kafkaProducer: KafkaProducerWrapper
+    eventIngestionRestrictionManager: EventIngestionRestrictionManager
+    overflowEnabled: boolean
+    overflowTopic: string
+    promiseScheduler: PromiseScheduler
+}
+
+export function createRestrictionPipeline(
+    config: RestrictionPipelineConfig
+): BatchPipelineUnwrapper<RestrictionPipelineInput, RestrictionPipelineOutput, { message: Message }> {
+    const { kafkaProducer, eventIngestionRestrictionManager, overflowEnabled, overflowTopic, promiseScheduler } = config
+
+    const pipelineConfig: PipelineConfig = {
+        kafkaProducer,
+        dlqTopic: '', // Session recordings don't use DLQ for restrictions
+        promiseScheduler,
+    }
+
+    const pipeline = newBatchPipelineBuilder<RestrictionPipelineInput, { message: Message }>()
+        .messageAware((b) =>
+            b.sequentially((b) =>
+                b.pipe(createParseHeadersStep()).pipe(
+                    createApplyEventRestrictionsStep(eventIngestionRestrictionManager, {
+                        overflowEnabled,
+                        overflowTopic,
+                        preservePartitionLocality: true, // Sessions must stay on the same partition
+                    })
+                )
+            )
+        )
+        .handleResults(pipelineConfig)
+        .handleSideEffects(promiseScheduler, { await: false })
+        .gather()
+        .build()
+
+    return createUnwrapper(pipeline)
+}
+
+/**
+ * Apply restrictions to a batch of messages using the pipeline.
+ * Returns only the messages that passed restriction checks.
+ */
+export async function applyRestrictions(
+    pipeline: BatchPipelineUnwrapper<RestrictionPipelineInput, RestrictionPipelineOutput, { message: Message }>,
+    messages: Message[]
+): Promise<Message[]> {
+    if (messages.length === 0) {
+        return []
+    }
+
+    const batch = createBatch(messages.map((message) => ({ message })))
+    pipeline.feed(batch)
+
+    const allResults: RestrictionPipelineOutput[] = []
+    let results = await pipeline.next()
+    while (results !== null) {
+        allResults.push(...results)
+        results = await pipeline.next()
+    }
+
+    return allResults.map((result) => result.message)
+}

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -26,6 +26,7 @@ import {
 } from './config/kafka-topics'
 import { startEvaluationScheduler } from './evaluation-scheduler/evaluation-scheduler'
 import { IngestionConsumer } from './ingestion/ingestion-consumer'
+import { KafkaProducerWrapper } from './kafka/producer'
 import { onShutdown } from './lifecycle'
 import { LogsIngestionConsumer } from './logs-ingestion/logs-ingestion-consumer'
 import { SessionRecordingIngester } from './session-recording/consumer'
@@ -142,9 +143,19 @@ export class PluginServer {
                 serviceLoaders.push(async () => {
                     const actualHub = hub ?? (await createHub(this.config))
                     const postgres = actualHub.postgres
-                    const producer = actualHub.kafkaProducer
+                    const kafkaMetadataProducer = actualHub.kafkaProducer
+                    const kafkaMessageProducer = await KafkaProducerWrapper.create(
+                        actualHub.KAFKA_CLIENT_RACK,
+                        'WARPSTREAM_PRODUCER'
+                    )
 
-                    const ingester = new SessionRecordingIngester(actualHub, false, postgres, producer)
+                    const ingester = new SessionRecordingIngester(
+                        actualHub,
+                        false,
+                        postgres,
+                        kafkaMetadataProducer,
+                        kafkaMessageProducer
+                    )
                     await ingester.start()
                     return ingester.service
                 })
@@ -154,9 +165,19 @@ export class PluginServer {
                 serviceLoaders.push(async () => {
                     const actualHub = hub ?? (await createHub(this.config))
                     const postgres = actualHub.postgres
-                    const producer = actualHub.kafkaProducer
+                    const kafkaMetadataProducer = actualHub.kafkaProducer
+                    const kafkaMessageProducer = await KafkaProducerWrapper.create(
+                        actualHub.KAFKA_CLIENT_RACK,
+                        'WARPSTREAM_PRODUCER'
+                    )
 
-                    const ingester = new SessionRecordingIngester(actualHub, true, postgres, producer)
+                    const ingester = new SessionRecordingIngester(
+                        actualHub,
+                        true,
+                        postgres,
+                        kafkaMetadataProducer,
+                        kafkaMessageProducer
+                    )
                     await ingester.start()
                     return ingester.service
                 })

--- a/nodejs/src/session-recording/consumer.ts
+++ b/nodejs/src/session-recording/consumer.ts
@@ -442,6 +442,13 @@ export class SessionRecordingIngester {
 
         const promiseResults = await this.promiseScheduler.waitForAllSettled()
 
+        // Clean up resources owned by this ingester
+        await this.kafkaMessageProducer.disconnect()
+        await this.redisPool.drain()
+        await this.redisPool.clear()
+        await this.restrictionRedisPool.drain()
+        await this.restrictionRedisPool.clear()
+
         logger.info('👍', 'blob_ingester_consumer_v2 - stopped!')
 
         return promiseResults


### PR DESCRIPTION
## Problem

Blobby is all custom code and it's inconsistent with the other pipelines.

## Changes

Does the first step of refactoring by moving event restriction handling into a pipeline that reuses the common step.

## How did you test this code?

- Added unit tests for the new pipeline
- Restrictions step is covered by tests already