### PR TITLE
feat(logs): add logsViewerConfigLogic for saved views foundation

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/AttributesFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/AttributesFilter.tsx
@@ -5,11 +5,14 @@ import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
 
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+
 import { logsSceneLogic } from '../../../logsSceneLogic'
 
 export const AttributesFilter = (): JSX.Element => {
     const { filterGroup } = useValues(logsSceneLogic)
     const { setFilterGroup } = useActions(logsSceneLogic)
+    const { setFilter } = useActions(logsViewerConfigLogic)
 
     const rootKey = 'logs'
 
@@ -22,7 +25,10 @@ export const AttributesFilter = (): JSX.Element => {
                 TaxonomicFilterGroupType.LogResourceAttributes,
                 TaxonomicFilterGroupType.LogAttributes,
             ]}
-            onChange={(filterGroup) => setFilterGroup(filterGroup)}
+            onChange={(filterGroup) => {
+                setFilterGroup(filterGroup)
+                setFilter('filterGroup', filterGroup)
+            }}
         >
             <NestedFilterGroup />
         </UniversalFilters>

--- a/products/logs/frontend/components/LogsViewer/Filters/DateRangeFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/DateRangeFilter.tsx
@@ -7,6 +7,8 @@ import { DATE_TIME_FORMAT, formatDateRange } from 'lib/utils'
 
 import { DateMappingOption } from '~/types'
 
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+
 import { logsSceneLogic } from '../../../logsSceneLogic'
 
 const dateMapping: DateMappingOption[] = [
@@ -56,6 +58,7 @@ const dateMapping: DateMappingOption[] = [
 export const DateRangeFilter = (): JSX.Element => {
     const { dateRange } = useValues(logsSceneLogic)
     const { setDateRange } = useActions(logsSceneLogic)
+    const { setFilter } = useActions(logsViewerConfigLogic)
 
     return (
         <DateFilter
@@ -65,6 +68,7 @@ export const DateRangeFilter = (): JSX.Element => {
             dateOptions={dateMapping}
             onChange={(changedDateFrom, changedDateTo) => {
                 setDateRange({ date_from: changedDateFrom, date_to: changedDateTo })
+                setFilter('dateRange', { date_from: changedDateFrom, date_to: changedDateTo })
             }}
             allowTimePrecision
             allowFixedRangeWithTime

--- a/products/logs/frontend/components/LogsViewer/Filters/FilterGroup.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/FilterGroup.tsx
@@ -21,6 +21,8 @@ import {
     UniversalFiltersGroup,
 } from '~/types'
 
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+
 import { logsSceneLogic } from '../../../logsSceneLogic'
 
 export const taxonomicFilterLogicKey = 'logs'
@@ -33,6 +35,7 @@ export const taxonomicGroupTypes = [
 export const LogsFilterGroup = (): JSX.Element => {
     const { filterGroup, tabId, utcDateRange, serviceNames } = useValues(logsSceneLogic)
     const { setFilterGroup } = useActions(logsSceneLogic)
+    const { setFilter } = useActions(logsViewerConfigLogic)
 
     const endpointFilters = {
         dateRange: { ...utcDateRange, date_to: utcDateRange.date_to ?? dayjs().toISOString() },
@@ -47,7 +50,9 @@ export const LogsFilterGroup = (): JSX.Element => {
             taxonomicGroupTypes={taxonomicGroupTypes}
             endpointFilters={endpointFilters}
             onChange={(group) => {
-                return setFilterGroup({ type: FilterLogicalOperator.And, values: [group] })
+                const newFilterGroup = { type: FilterLogicalOperator.And, values: [group] }
+                setFilterGroup(newFilterGroup)
+                setFilter('filterGroup', newFilterGroup)
             }}
         >
             <UniversalSearch />

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -27,6 +27,8 @@ import {
     UniversalFiltersGroup,
 } from '~/types'
 
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+
 import { logsSceneLogic } from '../../../../logsSceneLogic'
 import { DateRangeFilter } from '../DateRangeFilter'
 import { FilterHistoryDropdown } from '../FilterHistoryDropdown'
@@ -113,6 +115,7 @@ export const LogsFilterBar = (): JSX.Element => {
 const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Element => {
     const { filterGroup, tabId, utcDateRange, serviceNames, filterGroup: logsFilterGroup } = useValues(logsSceneLogic)
     const { setFilterGroup } = useActions(logsSceneLogic)
+    const { setFilter } = useActions(logsViewerConfigLogic)
 
     const endpointFilters = {
         dateRange: { ...utcDateRange, date_to: utcDateRange.date_to ?? dayjs().toISOString() },
@@ -127,7 +130,9 @@ const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Eleme
             taxonomicGroupTypes={taxonomicGroupTypes}
             endpointFilters={endpointFilters}
             onChange={(group) => {
-                return setFilterGroup({ type: FilterLogicalOperator.And, values: [group] })
+                const newFilterGroup = { type: FilterLogicalOperator.And, values: [group] }
+                setFilterGroup(newFilterGroup)
+                setFilter('filterGroup', newFilterGroup)
             }}
         >
             {children}

--- a/products/logs/frontend/components/LogsViewer/Filters/SearchTermFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SearchTermFilter.tsx
@@ -2,17 +2,23 @@ import { useActions, useValues } from 'kea'
 
 import { LemonInput } from '@posthog/lemon-ui'
 
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+
 import { logsSceneLogic } from '../../../logsSceneLogic'
 
 export const SearchTermFilter = (): JSX.Element => {
     const { searchTerm } = useValues(logsSceneLogic)
     const { setSearchTerm } = useActions(logsSceneLogic)
+    const { setFilter } = useActions(logsViewerConfigLogic)
 
     return (
         <LemonInput
             size="small"
             value={searchTerm}
-            onChange={(value) => setSearchTerm(value)}
+            onChange={(value) => {
+                setSearchTerm(value)
+                setFilter('searchTerm', value)
+            }}
             placeholder="Search logs..."
         />
     )

--- a/products/logs/frontend/components/LogsViewer/Filters/ServiceFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/ServiceFilter.tsx
@@ -4,7 +4,10 @@ import { combineUrl } from 'kea-router'
 import { PropertyValue } from 'lib/components/PropertyFilters/components/PropertyValue'
 import { projectLogic } from 'scenes/projectLogic'
 
+import { LogsQuery } from '~/queries/schema/schema-general'
 import { PropertyFilterType, PropertyOperator } from '~/types'
+
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 
 import { logsSceneLogic } from '../../../logsSceneLogic'
 
@@ -12,6 +15,7 @@ export const ServiceFilter = (): JSX.Element => {
     const { serviceNames, dateRange } = useValues(logsSceneLogic)
     const { currentProjectId } = useValues(projectLogic)
     const { setServiceNames } = useActions(logsSceneLogic)
+    const { setFilter } = useActions(logsViewerConfigLogic)
 
     const endpoint = combineUrl(`api/environments/${currentProjectId}/logs/values`, {
         key: 'service.name',
@@ -28,7 +32,10 @@ export const ServiceFilter = (): JSX.Element => {
                 propertyKey="service_name"
                 type={PropertyFilterType.Log}
                 value={serviceNames}
-                onSet={setServiceNames}
+                onSet={(value: LogsQuery['serviceNames']) => {
+                    setServiceNames(value)
+                    setFilter('serviceNames', value)
+                }}
                 placeholder="Service name"
                 preloadValues
             />

--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
@@ -7,6 +7,8 @@ import { capitalizeFirstLetter } from 'lib/utils'
 
 import { LogMessage } from '~/queries/schema/schema-general'
 
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+
 import { logsSceneLogic } from '../../../logsSceneLogic'
 
 const options: Record<LogMessage['severity_text'], string> = {
@@ -23,6 +25,7 @@ const ALL_LOG_LEVELS = Object.values(options) as LogMessage['severity_text'][]
 export const SeverityLevelsFilter = (): JSX.Element => {
     const { severityLevels } = useValues(logsSceneLogic)
     const { setSeverityLevels } = useActions(logsSceneLogic)
+    const { setFilter } = useActions(logsViewerConfigLogic)
 
     const onClick = (level: LogMessage['severity_text']): void => {
         const levels = [...severityLevels]
@@ -36,6 +39,7 @@ export const SeverityLevelsFilter = (): JSX.Element => {
         }
 
         setSeverityLevels(levels)
+        setFilter('severityLevels', levels)
     }
 
     const displayLevels =

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -11,6 +11,7 @@ import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { LogsFilterBar } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar'
 import { LogsFilterBar as LogsFilterBarV2 } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar'
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 import { VirtualizedLogsList } from 'products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList'
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
 import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
@@ -63,23 +64,25 @@ export function LogsViewer({
     onExpandTimeRange,
 }: LogsViewerProps): JSX.Element {
     return (
-        <BindLogic logic={logDetailsModalLogic} props={{ tabId }}>
-            <BindLogic logic={logsViewerLogic} props={{ tabId, logs, orderBy, onAddFilter }}>
-                <LogsViewerContent
-                    loading={loading}
-                    totalLogsCount={totalLogsCount}
-                    hasMoreLogsToLoad={hasMoreLogsToLoad}
-                    orderBy={orderBy}
-                    onChangeOrderBy={onChangeOrderBy}
-                    onRefresh={onRefresh}
-                    onLoadMore={onLoadMore}
-                    sparklineData={sparklineData}
-                    sparklineLoading={sparklineLoading}
-                    onDateRangeChange={onDateRangeChange}
-                    sparklineBreakdownBy={sparklineBreakdownBy}
-                    onSparklineBreakdownByChange={onSparklineBreakdownByChange}
-                    onExpandTimeRange={onExpandTimeRange}
-                />
+        <BindLogic logic={logsViewerConfigLogic} props={{ id: tabId }}>
+            <BindLogic logic={logDetailsModalLogic} props={{ tabId }}>
+                <BindLogic logic={logsViewerLogic} props={{ tabId, logs, orderBy, onAddFilter }}>
+                    <LogsViewerContent
+                        loading={loading}
+                        totalLogsCount={totalLogsCount}
+                        hasMoreLogsToLoad={hasMoreLogsToLoad}
+                        orderBy={orderBy}
+                        onChangeOrderBy={onChangeOrderBy}
+                        onRefresh={onRefresh}
+                        onLoadMore={onLoadMore}
+                        sparklineData={sparklineData}
+                        sparklineLoading={sparklineLoading}
+                        onDateRangeChange={onDateRangeChange}
+                        sparklineBreakdownBy={sparklineBreakdownBy}
+                        onSparklineBreakdownByChange={onSparklineBreakdownByChange}
+                        onExpandTimeRange={onExpandTimeRange}
+                    />
+                </BindLogic>
             </BindLogic>
         </BindLogic>
     )

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.test.ts
@@ -1,0 +1,86 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+import { FilterLogicalOperator } from '~/types'
+
+import { logsViewerConfigLogic } from './logsViewerConfigLogic'
+import { LogsViewerFilters } from './types'
+
+describe('logsViewerConfigLogic', () => {
+    let logic: ReturnType<typeof logsViewerConfigLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = logsViewerConfigLogic({ id: 'test-tab' })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    describe('setFilter', () => {
+        it.each([
+            ['dateRange', { date_from: '-24h', date_to: null }],
+            ['searchTerm', 'error message'],
+            ['severityLevels', ['error', 'warn']],
+            ['serviceNames', ['api', 'worker']],
+            ['filterGroup', { type: FilterLogicalOperator.Or, values: [] }],
+        ])('sets %s filter', async (filterKey, value) => {
+            await expectLogic(logic, () => {
+                logic.actions.setFilter(filterKey as keyof LogsViewerFilters, value)
+            }).toFinishAllListeners()
+
+            expect(logic.values.filters[filterKey as keyof LogsViewerFilters]).toEqual(value)
+        })
+
+        it('preserves other filters when setting a single filter', async () => {
+            logic.actions.setFilter('searchTerm', 'first')
+            await expectLogic(logic).toFinishAllListeners()
+
+            logic.actions.setFilter('severityLevels', ['error'])
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.filters.searchTerm).toBe('first')
+            expect(logic.values.filters.severityLevels).toEqual(['error'])
+        })
+    })
+
+    describe('setFilters', () => {
+        it('replaces all filters', async () => {
+            const newFilters: LogsViewerFilters = {
+                dateRange: { date_from: '-7d', date_to: null },
+                searchTerm: 'test query',
+                severityLevels: ['info', 'debug'],
+                serviceNames: ['frontend'],
+                filterGroup: { type: FilterLogicalOperator.And, values: [] },
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.setFilters(newFilters)
+            }).toMatchValues({
+                filters: newFilters,
+            })
+        })
+    })
+
+    describe('keyed instances', () => {
+        it('maintains separate state for different keys', async () => {
+            const logic1 = logsViewerConfigLogic({ id: 'tab-1' })
+            const logic2 = logsViewerConfigLogic({ id: 'tab-2' })
+            logic1.mount()
+            logic2.mount()
+
+            logic1.actions.setFilter('searchTerm', 'tab 1 search')
+            logic2.actions.setFilter('searchTerm', 'tab 2 search')
+            await expectLogic(logic1).toFinishAllListeners()
+            await expectLogic(logic2).toFinishAllListeners()
+
+            expect(logic1.values.filters.searchTerm).toBe('tab 1 search')
+            expect(logic2.values.filters.searchTerm).toBe('tab 2 search')
+
+            logic1.unmount()
+            logic2.unmount()
+        })
+    })
+})

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
@@ -1,0 +1,52 @@
+import { actions, kea, key, path, props, reducers, selectors } from 'kea'
+
+import { FilterLogicalOperator } from '~/types'
+
+import { LogsViewerConfig, LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
+
+import type { logsViewerConfigLogicType } from './logsViewerConfigLogicType'
+
+export const DEFAULT_LOGS_VIEWER_CONFIG: LogsViewerConfig = {
+    filters: {
+        dateRange: { date_from: '-1h', date_to: null },
+        searchTerm: '',
+        severityLevels: [],
+        serviceNames: [],
+        filterGroup: { type: FilterLogicalOperator.And, values: [] },
+    },
+}
+
+export interface LogsViewerConfigProps {
+    id: string
+}
+
+export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
+    path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'config', 'logsViewerConfigLogic']),
+    props({ id: 'default' } as LogsViewerConfigProps),
+    key((props) => props.id),
+
+    actions({
+        setFilters: (filters: LogsViewerFilters) => ({ filters }),
+        setFilter: (filter: keyof LogsViewerFilters, value: LogsViewerFilters[keyof LogsViewerFilters]) => ({
+            filter,
+            value,
+        }),
+    }),
+
+    reducers({
+        filters: [
+            DEFAULT_LOGS_VIEWER_CONFIG.filters,
+            {
+                setFilters: (_, { filters }) => filters,
+                setFilter: (state, { filter, value }) => ({
+                    ...state,
+                    [filter]: value,
+                }),
+            },
+        ],
+    }),
+
+    selectors({
+        config: [(s) => [s.filters], (filters: LogsViewerFilters): LogsViewerConfig => ({ filters })],
+    }),
+])

--- a/products/logs/frontend/components/LogsViewer/config/types.ts
+++ b/products/logs/frontend/components/LogsViewer/config/types.ts
@@ -1,0 +1,14 @@
+import { DateRange, LogsQuery } from '~/queries/schema/schema-general'
+import { UniversalFiltersGroup } from '~/types'
+
+export interface LogsViewerFilters {
+    dateRange: DateRange
+    searchTerm: LogsQuery['searchTerm']
+    severityLevels: LogsQuery['severityLevels']
+    serviceNames: LogsQuery['serviceNames']
+    filterGroup: UniversalFiltersGroup
+}
+
+export interface LogsViewerConfig {
+    filters: LogsViewerFilters
+}


### PR DESCRIPTION
## Problem

We want to enable saved views for the logs product, but the current filter state is spread across `logsSceneLogic` and tightly coupled to the scene. This makes it difficult to serialize the full view state for saving/loading, and prevents the LogsViewer component from being reusable in other contexts (error tracking, session replay).

This is Phase 1 of the saved views implementation - establishing the data model without changing existing behavior.

## Changes

- Create `LogsViewerFilters` and `LogsViewerConfig` types in `config/types.ts`
- Create `logsViewerConfigLogic` with `setFilter`/`setFilters` actions and `filters` reducer
- Wire all filter components to write to both `logsSceneLogic` (existing) and `logsViewerConfigLogic` (new) in parallel
- Bind `logsViewerConfigLogic` to the LogsViewer component tree via `BindLogic`

The old `logsSceneLogic` still drives the UI - this change only mirrors filter state to the new logic as groundwork for Phase 2 where we'll migrate ownership.

## How did you test this code?

- Added unit tests for `logsViewerConfigLogic` covering:
  - Setting individual filters (parameterized across all filter types)
  - Preserving other filters when setting a single filter
  - Replacing all filters via `setFilters`
  - Keyed instances maintaining separate state
  - Default config values
- TypeScript check passes
- No behavioral change to verify - existing functionality unchanged

## Publish to changelog?

No
