### PR TITLE
chore: request review from team client libraries when changing posthog-js

### DIFF
--- a/.github/workflows/pr-posthog-js-reviewer.yml
+++ b/.github/workflows/pr-posthog-js-reviewer.yml
@@ -1,0 +1,56 @@
+name: Request review for posthog-js updates
+
+# This workflow uses pull_request_target to get write access for requesting reviewers.
+# SECURITY: We never checkout or execute code from the PR branch.
+# We only use the GitHub API to check the diff and request reviewers.
+
+on:
+    pull_request_target:
+        types: [opened, synchronize]
+        paths:
+            - '**/package.json'
+
+permissions:
+    contents: read
+
+jobs:
+    check-posthog-js:
+        name: Check for posthog-js updates
+        runs-on: ubuntu-24.04
+
+        # Skip forks for security - they could manipulate package.json to trigger unwanted reviews
+        if: github.event.pull_request.head.repo.fork == false
+
+        steps:
+            - name: Get app token
+              id: app-token
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
+              with:
+                  app_id: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY }}
+
+            - name: Check if posthog-js version changed and request review
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  echo "Checking PR #${PR_NUMBER} for posthog-js version changes..."
+
+                  # Get the diff for this PR, filtering to package.json files only
+                  DIFF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[] | select(.filename | endswith("package.json")) | .patch // empty')
+
+                  if [ -z "$DIFF" ]; then
+                      echo "No package.json changes found"
+                      exit 0
+                  fi
+
+                  # Check if the diff contains posthog-js version changes
+                  # We look for lines that add or remove posthog-js with a version
+                  if echo "$DIFF" | grep -qE '^\+.*"posthog-js":\s*"[^"]+"|^-.*"posthog-js":\s*"[^"]+"'; then
+                      echo "posthog-js version change detected, requesting review from team-client-libraries"
+                      gh pr edit "${PR_NUMBER}" --repo "${REPO}" --add-reviewer "PostHog/team-client-libraries"
+                      echo "Review requested successfully"
+                  else
+                      echo "No posthog-js version changes detected"
+                  fi


### PR DESCRIPTION
when run from the posthog-js repo this needed extra permissions

so let's not run it from that repo

when a PR is opened that is going to change the posthog-js version

ping client libraries team

## why?

this is a critical step in the release of posthog-js and we keep missing it leaving the CDN and NPM out of sync