### PR TITLE
fix: Usage syntax should use only one curly brace

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelVariables.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelVariables.tsx
@@ -97,10 +97,10 @@ export function HogFlowEditorPanelVariables(): JSX.Element | null {
                         />
                     </LemonField.Pure>
                     <LemonField.Pure label="Usage syntax">
-                        <Tooltip title={`{{ variables.${variable.key} }}`}>
+                        <Tooltip title={`{ variables.${variable.key} }`}>
                             <span className="group relative">
                                 <code className="w-36 py-2 bg-primary-alt-highlight-secondary rounded-sm text-center text-xs truncate block">
-                                    {`{{ variables.${variable.key} }}`}
+                                    {`{ variables.${variable.key} }`}
                                 </code>
                                 <span className="absolute top-0 right-0 z-10 p-px opacity-0 transition-opacity group-hover:opacity-100">
                                     <LemonButton


### PR DESCRIPTION
## Problem

Suggested usage syntax is wrong.
<img width="1268" height="566" alt="image" src="https://github.com/user-attachments/assets/3f8c55c8-261e-4ebf-b5c2-7c7d18240ca4" />
<img width="1236" height="904" alt="image" src="https://github.com/user-attachments/assets/afc38e08-b963-4541-9c60-bec7084f1713" />
<img width="880" height="214" alt="image" src="https://github.com/user-attachments/assets/2617a260-389b-4f16-86a1-5ea66997686f" />

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Use single curly braces to reference variable
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
