### PR TITLE
feat(capture-logs): add datadog-compatible endpoint to capture-logs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1681,6 +1681,7 @@ dependencies = [
  "common-metrics",
  "envconfig",
  "health",
+ "hex",
  "jsonwebtoken",
  "limiters",
  "metrics",

--- a/rust/capture-logs/Cargo.toml
+++ b/rust/capture-logs/Cargo.toml
@@ -34,6 +34,7 @@ apache-avro = { version = "0.21.0", features = ["zstandard"] }
 prost = { workspace = true }
 bytes = { workspace = true }
 tower-http = { workspace = true }
+hex = "0.4"
 
 [lints]
 workspace = true

--- a/rust/capture-logs/src/endpoints/datadog.rs
+++ b/rust/capture-logs/src/endpoints/datadog.rs
@@ -1,0 +1,291 @@
+use crate::log_record::KafkaLogRow;
+use crate::service::Service;
+use axum::{
+    extract::State,
+    extract::{Path, Query},
+    http::{HeaderMap, StatusCode},
+    response::Json,
+};
+use bytes::Bytes;
+use chrono::{TimeZone, Utc};
+use serde::Deserialize;
+use serde_json::json;
+use std::collections::HashMap;
+use tracing::{debug, error, instrument};
+use uuid::Uuid;
+
+#[derive(Deserialize, Debug)]
+pub struct DatadogLog {
+    #[serde(default)]
+    pub ddsource: Option<String>,
+    #[serde(default)]
+    pub ddtags: Option<String>,
+    #[serde(default)]
+    pub hostname: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub service: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub timestamp: Option<i64>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+pub fn normalize_datadog_severity(status: Option<&str>) -> (String, i32) {
+    match status.map(|s| s.to_lowercase()).as_deref() {
+        Some("emergency") | Some("emerg") | Some("critical") | Some("crit") | Some("alert") => {
+            ("fatal".to_string(), 21)
+        }
+        Some("error") | Some("err") => ("error".to_string(), 17),
+        Some("warning") | Some("warn") => ("warn".to_string(), 13),
+        Some("notice") | Some("info") => ("info".to_string(), 9),
+        Some("debug") => ("debug".to_string(), 5),
+        Some("trace") => ("trace".to_string(), 1),
+        _ => ("info".to_string(), 9),
+    }
+}
+
+pub fn parse_datadog_tags(ddtags: Option<&str>) -> HashMap<String, String> {
+    let mut attributes = HashMap::new();
+    if let Some(tags) = ddtags {
+        for tag in tags.split(',') {
+            let tag = tag.trim();
+            if let Some((key, value)) = tag.split_once(':') {
+                attributes.insert(key.to_string(), json!(value).to_string());
+            } else if !tag.is_empty() {
+                attributes.insert(tag.to_string(), json!(true).to_string());
+            }
+        }
+    }
+    attributes
+}
+
+fn extract_token_from_auth_header(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .map(|auth| {
+            // Support both "Bearer <token>" and just "<token>"
+            if let Some(token) = auth.strip_prefix("Bearer ") {
+                token.trim().to_string()
+            } else if let Some(token) = auth.strip_prefix("bearer ") {
+                token.trim().to_string()
+            } else {
+                auth.trim().to_string()
+            }
+        })
+}
+
+pub fn extract_trace_span_ids(extra: &HashMap<String, serde_json::Value>) -> (String, String) {
+    let trace_id = extra
+        .get("dd.trace_id")
+        .or_else(|| extra.get("trace_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let span_id = extra
+        .get("dd.span_id")
+        .or_else(|| extra.get("span_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    (trace_id, span_id)
+}
+
+pub fn datadog_log_to_kafka_row(log: DatadogLog, query_params: &DatadogQueryParams) -> KafkaLogRow {
+    // Body values take precedence over query params
+    let status = log.status.as_deref().or(query_params.status.as_deref());
+    let (severity_text, severity_number) = normalize_datadog_severity(status);
+
+    let timestamp = log
+        .timestamp
+        .and_then(|ts| {
+            // Datadog uses milliseconds since epoch
+            Utc.timestamp_millis_opt(ts).single()
+        })
+        .unwrap_or_else(Utc::now);
+
+    let service = log.service.or_else(|| query_params.service.clone());
+    let hostname = log.hostname.or_else(|| query_params.hostname.clone());
+    let ddsource = log.ddsource.or_else(|| query_params.ddsource.clone());
+    let message = log.message.or_else(|| query_params.message.clone());
+
+    let mut resource_attributes = HashMap::new();
+    if let Some(ref service_val) = service {
+        resource_attributes.insert("service.name".to_string(), json!(service_val).to_string());
+    }
+    if let Some(ref hostname_val) = hostname {
+        resource_attributes.insert("host.name".to_string(), json!(hostname_val).to_string());
+    }
+    if let Some(ref source_val) = ddsource {
+        resource_attributes.insert("ddsource".to_string(), json!(source_val).to_string());
+    }
+
+    // Add query param ddtags to resource_attributes
+    let query_tags = parse_datadog_tags(query_params.ddtags.as_deref());
+    resource_attributes.extend(query_tags);
+
+    // Add body ddtags to resource_attributes (takes precedence)
+    let body_tags = parse_datadog_tags(log.ddtags.as_deref());
+    resource_attributes.extend(body_tags);
+
+    // Extract trace and span IDs from body extra attributes
+    let (trace_id, span_id) = extract_trace_span_ids(&log.extra);
+
+    // Extract event name and instrumentation scope from body extra attributes
+    let event_name = log
+        .extra
+        .get("event.name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let instrumentation_scope = log
+        .extra
+        .get("otel.scope.name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    // Merge attributes: query params extra fields, then body extra fields
+    // Later values override earlier ones
+    let mut attributes = HashMap::new();
+
+    // Add arbitrary query params (excluding reserved fields)
+    for (key, value) in &query_params.extra {
+        attributes.insert(key.clone(), json!(value).to_string());
+    }
+
+    // Add body extra attributes (excluding trace/span IDs and event.name/otel.scope.name which go in dedicated fields)
+    for (key, value) in &log.extra {
+        if !matches!(
+            key.as_str(),
+            "dd.trace_id"
+                | "trace_id"
+                | "dd.span_id"
+                | "span_id"
+                | "event.name"
+                | "otel.scope.name"
+        ) {
+            attributes.insert(key.clone(), value.to_string());
+        }
+    }
+
+    KafkaLogRow {
+        uuid: Uuid::now_v7().to_string(),
+        trace_id,
+        span_id,
+        trace_flags: 0,
+        timestamp,
+        observed_timestamp: Utc::now(),
+        body: message.unwrap_or_default(),
+        severity_text,
+        severity_number,
+        service_name: service.unwrap_or_default(),
+        resource_attributes,
+        instrumentation_scope,
+        event_name,
+        attributes,
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct DatadogQueryParams {
+    pub token: Option<String>,
+    pub ddtags: Option<String>,
+    pub ddsource: Option<String>,
+    pub service: Option<String>,
+    pub hostname: Option<String>,
+    pub message: Option<String>,
+    pub status: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, String>,
+}
+
+#[instrument(skip_all, fields(
+    token = tracing::field::Empty,
+    content_type = %headers.get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(""),
+    user_agent = %headers.get("user-agent")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(""),
+    content_length = %headers.get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(""),
+    content_encoding = %headers.get("content-encoding")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")))
+]
+pub async fn export_datadog_logs_http(
+    State(service): State<Service>,
+    path_token: Option<Path<String>>,
+    Query(query_params): Query<DatadogQueryParams>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    // Try to get token from: path, Authorization header, or query param
+    let token = match path_token {
+        Some(Path(t)) if !t.is_empty() => t,
+        _ => match extract_token_from_auth_header(&headers) {
+            Some(t) if !t.is_empty() => t,
+            _ => match query_params.token.as_deref() {
+                Some(t) if !t.is_empty() => t.to_string(),
+                _ => {
+                    error!("No token provided");
+                    return Err((
+                        StatusCode::UNAUTHORIZED,
+                        Json(json!({"error": "No token provided"})),
+                    ));
+                }
+            },
+        },
+    };
+
+    let logs: Vec<DatadogLog> = match serde_json::from_slice::<Vec<DatadogLog>>(&body) {
+        Ok(logs) => logs,
+        Err(_) => match serde_json::from_slice::<DatadogLog>(&body) {
+            Ok(log) => vec![log],
+            Err(e) => {
+                error!("Failed to parse Datadog logs: {}", e);
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("Failed to parse Datadog logs: {}", e)})),
+                ));
+            }
+        },
+    };
+
+    if service.token_dropper.should_drop(&token, "") {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "Invalid token"})),
+        ));
+    }
+
+    tracing::Span::current().record("token", &token);
+
+    let rows: Vec<KafkaLogRow> = logs
+        .into_iter()
+        .map(|log| datadog_log_to_kafka_row(log, &query_params))
+        .collect();
+
+    let row_count = rows.len();
+    if let Err(e) = service.sink.write(&token, rows, body.len() as u64).await {
+        error!("Failed to send logs to Kafka: {}", e);
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "Internal server error"})),
+        ));
+    } else {
+        debug!("Successfully sent {} Datadog logs to Kafka", row_count);
+    }
+
+    // Datadog returns empty JSON object on success
+    Ok(Json(json!({})))
+}

--- a/rust/capture-logs/src/endpoints/mod.rs
+++ b/rust/capture-logs/src/endpoints/mod.rs
@@ -1,0 +1,1 @@
+pub mod datadog;

--- a/rust/capture-logs/src/lib.rs
+++ b/rust/capture-logs/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod avro_schema;
 pub mod config;
+pub mod endpoints;
 pub mod kafka;
 pub mod log_record;
 pub mod service;

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -97,8 +97,8 @@ pub fn parse_otel_message(json_bytes: &Bytes) -> Result<ExportLogsServiceRequest
 
 #[derive(Clone)]
 pub struct Service {
-    sink: KafkaSink,
-    token_dropper: Arc<TokenDropper>,
+    pub(crate) sink: KafkaSink,
+    pub(crate) token_dropper: Arc<TokenDropper>,
 }
 
 #[derive(Deserialize)]
@@ -109,11 +109,11 @@ pub struct QueryParams {
 impl Service {
     pub async fn new(
         kafka_sink: KafkaSink,
-        token_dropper: TokenDropper,
+        token_dropper: Arc<TokenDropper>,
     ) -> Result<Self, anyhow::Error> {
         Ok(Self {
             sink: kafka_sink,
-            token_dropper: token_dropper.into(),
+            token_dropper,
         })
     }
 }

--- a/rust/capture-logs/tests/datadog_test.rs
+++ b/rust/capture-logs/tests/datadog_test.rs
@@ -1,0 +1,537 @@
+use capture_logs::endpoints::datadog::*;
+use serde_json::json;
+use std::collections::HashMap;
+
+#[test]
+fn test_parse_datadog_tags() {
+    let result = parse_datadog_tags(Some("env:prod,region:us,version:1.2.3"));
+    assert_eq!(result.len(), 3);
+    assert_eq!(result.get("env").unwrap(), "\"prod\"");
+    assert_eq!(result.get("region").unwrap(), "\"us\"");
+    assert_eq!(result.get("version").unwrap(), "\"1.2.3\"");
+}
+
+#[test]
+fn test_normalize_datadog_severity() {
+    assert_eq!(
+        normalize_datadog_severity(Some("emergency")),
+        ("fatal".to_string(), 21)
+    );
+    assert_eq!(
+        normalize_datadog_severity(Some("CRITICAL")),
+        ("fatal".to_string(), 21)
+    );
+    assert_eq!(
+        normalize_datadog_severity(Some("error")),
+        ("error".to_string(), 17)
+    );
+    assert_eq!(
+        normalize_datadog_severity(Some("warn")),
+        ("warn".to_string(), 13)
+    );
+    assert_eq!(
+        normalize_datadog_severity(Some("info")),
+        ("info".to_string(), 9)
+    );
+    assert_eq!(
+        normalize_datadog_severity(Some("debug")),
+        ("debug".to_string(), 5)
+    );
+    assert_eq!(
+        normalize_datadog_severity(Some("trace")),
+        ("trace".to_string(), 1)
+    );
+    assert_eq!(normalize_datadog_severity(None), ("info".to_string(), 9));
+    assert_eq!(
+        normalize_datadog_severity(Some("unknown")),
+        ("info".to_string(), 9)
+    );
+}
+
+#[test]
+fn test_parse_datadog_tags_empty() {
+    let result = parse_datadog_tags(None);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_parse_datadog_tags_key_value() {
+    let result = parse_datadog_tags(Some("env:prod,region:us-east-1"));
+    assert_eq!(result.len(), 2);
+    assert_eq!(result.get("env").unwrap(), "\"prod\"");
+    assert_eq!(result.get("region").unwrap(), "\"us-east-1\"");
+}
+
+#[test]
+fn test_parse_datadog_tags_boolean() {
+    let result = parse_datadog_tags(Some("feature,enabled"));
+    assert_eq!(result.len(), 2);
+    assert_eq!(result.get("feature").unwrap(), "true");
+    assert_eq!(result.get("enabled").unwrap(), "true");
+}
+
+#[test]
+fn test_parse_datadog_tags_mixed() {
+    let result = parse_datadog_tags(Some("env:prod,feature,version:1.0.0"));
+    assert_eq!(result.len(), 3);
+    assert_eq!(result.get("env").unwrap(), "\"prod\"");
+    assert_eq!(result.get("feature").unwrap(), "true");
+    assert_eq!(result.get("version").unwrap(), "\"1.0.0\"");
+}
+
+#[test]
+fn test_parse_datadog_tags_with_spaces() {
+    let result = parse_datadog_tags(Some("env:prod , region:us-east-1 "));
+    assert_eq!(result.len(), 2);
+    assert_eq!(result.get("env").unwrap(), "\"prod\"");
+    assert_eq!(result.get("region").unwrap(), "\"us-east-1\"");
+}
+
+#[test]
+fn test_extract_trace_span_ids_with_dd_prefix() {
+    let mut extra = HashMap::new();
+    extra.insert("dd.trace_id".to_string(), json!("trace123"));
+    extra.insert("dd.span_id".to_string(), json!("span456"));
+
+    let (trace_id, span_id) = extract_trace_span_ids(&extra);
+    assert_eq!(trace_id, "trace123");
+    assert_eq!(span_id, "span456");
+}
+
+#[test]
+fn test_extract_trace_span_ids_without_prefix() {
+    let mut extra = HashMap::new();
+    extra.insert("trace_id".to_string(), json!("trace789"));
+    extra.insert("span_id".to_string(), json!("span012"));
+
+    let (trace_id, span_id) = extract_trace_span_ids(&extra);
+    assert_eq!(trace_id, "trace789");
+    assert_eq!(span_id, "span012");
+}
+
+#[test]
+fn test_extract_trace_span_ids_dd_prefix_takes_precedence() {
+    let mut extra = HashMap::new();
+    extra.insert("dd.trace_id".to_string(), json!("preferred_trace"));
+    extra.insert("trace_id".to_string(), json!("fallback_trace"));
+    extra.insert("dd.span_id".to_string(), json!("preferred_span"));
+    extra.insert("span_id".to_string(), json!("fallback_span"));
+
+    let (trace_id, span_id) = extract_trace_span_ids(&extra);
+    assert_eq!(trace_id, "preferred_trace");
+    assert_eq!(span_id, "preferred_span");
+}
+
+#[test]
+fn test_extract_trace_span_ids_empty() {
+    let extra = HashMap::new();
+    let (trace_id, span_id) = extract_trace_span_ids(&extra);
+    assert_eq!(trace_id, "");
+    assert_eq!(span_id, "");
+}
+
+#[test]
+fn test_extract_trace_span_ids_non_string_values() {
+    let mut extra = HashMap::new();
+    extra.insert("dd.trace_id".to_string(), json!(12345));
+    extra.insert("dd.span_id".to_string(), json!(true));
+
+    let (trace_id, span_id) = extract_trace_span_ids(&extra);
+    assert_eq!(trace_id, "");
+    assert_eq!(span_id, "");
+}
+
+#[test]
+fn test_datadog_log_to_kafka_row_basic() {
+    let log = DatadogLog {
+        ddsource: Some("python".to_string()),
+        ddtags: Some("env:prod".to_string()),
+        hostname: Some("web-1".to_string()),
+        message: Some("Test log message".to_string()),
+        service: Some("my-service".to_string()),
+        status: Some("info".to_string()),
+        timestamp: Some(1234567890000),
+        extra: HashMap::new(),
+    };
+
+    let query_params = DatadogQueryParams {
+        token: Some("test-token".to_string()),
+        ddtags: None,
+        ddsource: None,
+        service: None,
+        hostname: None,
+        message: None,
+        status: None,
+        extra: HashMap::new(),
+    };
+
+    let row = datadog_log_to_kafka_row(log, &query_params);
+
+    assert_eq!(row.body, "Test log message");
+    assert_eq!(row.service_name, "my-service");
+    assert_eq!(row.severity_text, "info");
+    assert_eq!(row.severity_number, 9);
+    assert!(row.resource_attributes.contains_key("service.name"));
+    assert!(row.resource_attributes.contains_key("host.name"));
+    assert!(row.resource_attributes.contains_key("ddsource"));
+    assert!(row.resource_attributes.contains_key("env"));
+}
+
+#[test]
+fn test_datadog_log_to_kafka_row_with_trace_ids() {
+    let mut extra = HashMap::new();
+    extra.insert("dd.trace_id".to_string(), json!("trace123"));
+    extra.insert("dd.span_id".to_string(), json!("span456"));
+    extra.insert("custom_field".to_string(), json!("custom_value"));
+
+    let log = DatadogLog {
+        ddsource: None,
+        ddtags: None,
+        hostname: None,
+        message: Some("Test".to_string()),
+        service: None,
+        status: None,
+        timestamp: None,
+        extra,
+    };
+
+    let query_params = DatadogQueryParams {
+        token: Some("test-token".to_string()),
+        ddtags: None,
+        ddsource: None,
+        service: None,
+        hostname: None,
+        message: None,
+        status: None,
+        extra: HashMap::new(),
+    };
+
+    let row = datadog_log_to_kafka_row(log, &query_params);
+
+    assert_eq!(row.trace_id, "trace123");
+    assert_eq!(row.span_id, "span456");
+    assert!(row.attributes.contains_key("custom_field"));
+    assert!(!row.attributes.contains_key("dd.trace_id"));
+    assert!(!row.attributes.contains_key("dd.span_id"));
+}
+
+#[test]
+fn test_datadog_log_to_kafka_row_query_params_override() {
+    let log = DatadogLog {
+        ddsource: None,
+        ddtags: None,
+        hostname: None,
+        message: None,
+        service: None,
+        status: None,
+        timestamp: None,
+        extra: HashMap::new(),
+    };
+
+    let mut extra_params = HashMap::new();
+    extra_params.insert("custom".to_string(), "query_value".to_string());
+
+    let query_params = DatadogQueryParams {
+        token: Some("test-token".to_string()),
+        ddtags: Some("env:dev".to_string()),
+        ddsource: Some("query-source".to_string()),
+        service: Some("query-service".to_string()),
+        hostname: Some("query-host".to_string()),
+        message: Some("Query message".to_string()),
+        status: Some("warn".to_string()),
+        extra: extra_params,
+    };
+
+    let row = datadog_log_to_kafka_row(log, &query_params);
+
+    assert_eq!(row.body, "Query message");
+    assert_eq!(row.service_name, "query-service");
+    assert_eq!(row.severity_text, "warn");
+    assert!(row.attributes.contains_key("custom"));
+    assert!(row.resource_attributes.contains_key("env"));
+}
+
+#[test]
+fn test_datadog_log_to_kafka_row_body_takes_precedence() {
+    let mut extra = HashMap::new();
+    extra.insert("custom".to_string(), json!("body_value"));
+
+    let log = DatadogLog {
+        ddsource: Some("body-source".to_string()),
+        ddtags: Some("env:prod".to_string()),
+        hostname: Some("body-host".to_string()),
+        message: Some("Body message".to_string()),
+        service: Some("body-service".to_string()),
+        status: Some("error".to_string()),
+        timestamp: None,
+        extra,
+    };
+
+    let mut extra_params = HashMap::new();
+    extra_params.insert("custom".to_string(), "query_value".to_string());
+
+    let query_params = DatadogQueryParams {
+        token: Some("test-token".to_string()),
+        ddtags: Some("env:dev".to_string()),
+        ddsource: Some("query-source".to_string()),
+        service: Some("query-service".to_string()),
+        hostname: Some("query-host".to_string()),
+        message: Some("Query message".to_string()),
+        status: Some("warn".to_string()),
+        extra: extra_params,
+    };
+
+    let row = datadog_log_to_kafka_row(log, &query_params);
+
+    assert_eq!(row.body, "Body message");
+    assert_eq!(row.service_name, "body-service");
+    assert_eq!(row.severity_text, "error");
+    assert_eq!(row.severity_number, 17);
+    // Body extra takes precedence over query extra
+    assert_eq!(row.attributes.get("custom").unwrap(), "\"body_value\"");
+    // Body ddtags take precedence over query ddtags
+    assert_eq!(row.resource_attributes.get("env").unwrap(), "\"prod\"");
+}
+
+#[test]
+fn test_datadog_log_to_kafka_row_timestamp_default() {
+    let log = DatadogLog {
+        ddsource: None,
+        ddtags: None,
+        hostname: None,
+        message: None,
+        service: None,
+        status: None,
+        timestamp: None,
+        extra: HashMap::new(),
+    };
+
+    let query_params = DatadogQueryParams {
+        token: Some("test-token".to_string()),
+        ddtags: None,
+        ddsource: None,
+        service: None,
+        hostname: None,
+        message: None,
+        status: None,
+        extra: HashMap::new(),
+    };
+
+    let row = datadog_log_to_kafka_row(log, &query_params);
+
+    // Should have a timestamp (current time)
+    assert!(row.timestamp.timestamp() > 0);
+}
+
+#[test]
+fn test_datadog_log_to_kafka_row_all_attributes_merged() {
+    let mut body_extra = HashMap::new();
+    body_extra.insert("body_attr".to_string(), json!("body_val"));
+
+    let log = DatadogLog {
+        ddsource: None,
+        ddtags: Some("body_tag:val1".to_string()),
+        hostname: None,
+        message: Some("Test".to_string()),
+        service: None,
+        status: None,
+        timestamp: None,
+        extra: body_extra,
+    };
+
+    let mut query_extra = HashMap::new();
+    query_extra.insert("query_attr".to_string(), "query_val".to_string());
+
+    let query_params = DatadogQueryParams {
+        token: Some("test-token".to_string()),
+        ddtags: Some("query_tag:val2".to_string()),
+        ddsource: None,
+        service: None,
+        hostname: None,
+        message: None,
+        status: None,
+        extra: query_extra,
+    };
+
+    let row = datadog_log_to_kafka_row(log, &query_params);
+
+    // Should have all attributes from both sources
+    assert!(row.attributes.contains_key("query_attr"));
+    assert!(row.attributes.contains_key("body_attr"));
+    assert!(row.resource_attributes.contains_key("query_tag"));
+    assert!(row.resource_attributes.contains_key("body_tag"));
+    assert_eq!(row.attributes.len(), 2);
+}
+
+#[test]
+fn test_datadog_log_to_kafka_row_event_name_extraction() {
+    let mut extra = HashMap::new();
+    extra.insert("event.name".to_string(), json!("user.signup"));
+    extra.insert("other_field".to_string(), json!("value"));
+
+    let log = DatadogLog {
+        ddsource: None,
+        ddtags: None,
+        hostname: None,
+        message: Some("Test".to_string()),
+        service: None,
+        status: None,
+        timestamp: None,
+        extra,
+    };
+
+    let query_params = DatadogQueryParams {
+        token: Some("test-token".to_string()),
+        ddtags: None,
+        ddsource: None,
+        service: None,
+        hostname: None,
+        message: None,
+        status: None,
+        extra: HashMap::new(),
+    };
+
+    let row = datadog_log_to_kafka_row(log, &query_params);
+
+    assert_eq!(row.event_name, "user.signup");
+    assert!(!row.attributes.contains_key("event.name"));
+    assert!(row.attributes.contains_key("other_field"));
+}
+
+#[test]
+fn test_datadog_log_to_kafka_row_instrumentation_scope_extraction() {
+    let mut extra = HashMap::new();
+    extra.insert("otel.scope.name".to_string(), json!("my.service.logger"));
+    extra.insert("other_field".to_string(), json!("value"));
+
+    let log = DatadogLog {
+        ddsource: None,
+        ddtags: None,
+        hostname: None,
+        message: Some("Test".to_string()),
+        service: None,
+        status: None,
+        timestamp: None,
+        extra,
+    };
+
+    let query_params = DatadogQueryParams {
+        token: Some("test-token".to_string()),
+        ddtags: None,
+        ddsource: None,
+        service: None,
+        hostname: None,
+        message: None,
+        status: None,
+        extra: HashMap::new(),
+    };
+
+    let row = datadog_log_to_kafka_row(log, &query_params);
+
+    assert_eq!(row.instrumentation_scope, "my.service.logger");
+    assert!(!row.attributes.contains_key("otel.scope.name"));
+    assert!(row.attributes.contains_key("other_field"));
+}
+
+#[test]
+fn test_datadog_log_to_kafka_row_event_name_and_scope_extraction() {
+    let mut extra = HashMap::new();
+    extra.insert("event.name".to_string(), json!("payment.processed"));
+    extra.insert("otel.scope.name".to_string(), json!("payment.service"));
+    extra.insert("custom_field".to_string(), json!("custom_value"));
+
+    let log = DatadogLog {
+        ddsource: None,
+        ddtags: None,
+        hostname: None,
+        message: Some("Payment processed".to_string()),
+        service: None,
+        status: None,
+        timestamp: None,
+        extra,
+    };
+
+    let query_params = DatadogQueryParams {
+        token: Some("test-token".to_string()),
+        ddtags: None,
+        ddsource: None,
+        service: None,
+        hostname: None,
+        message: None,
+        status: None,
+        extra: HashMap::new(),
+    };
+
+    let row = datadog_log_to_kafka_row(log, &query_params);
+
+    assert_eq!(row.event_name, "payment.processed");
+    assert_eq!(row.instrumentation_scope, "payment.service");
+    assert!(!row.attributes.contains_key("event.name"));
+    assert!(!row.attributes.contains_key("otel.scope.name"));
+    assert!(row.attributes.contains_key("custom_field"));
+    assert_eq!(row.attributes.len(), 1);
+}
+
+#[test]
+fn test_datadog_log_to_kafka_row_missing_event_name_and_scope() {
+    let log = DatadogLog {
+        ddsource: None,
+        ddtags: None,
+        hostname: None,
+        message: Some("Test".to_string()),
+        service: None,
+        status: None,
+        timestamp: None,
+        extra: HashMap::new(),
+    };
+
+    let query_params = DatadogQueryParams {
+        token: Some("test-token".to_string()),
+        ddtags: None,
+        ddsource: None,
+        service: None,
+        hostname: None,
+        message: None,
+        status: None,
+        extra: HashMap::new(),
+    };
+
+    let row = datadog_log_to_kafka_row(log, &query_params);
+
+    assert_eq!(row.event_name, "");
+    assert_eq!(row.instrumentation_scope, "");
+}
+
+#[test]
+fn test_datadog_log_to_kafka_row_non_string_event_name_and_scope() {
+    let mut extra = HashMap::new();
+    extra.insert("event.name".to_string(), json!(12345));
+    extra.insert("otel.scope.name".to_string(), json!(true));
+
+    let log = DatadogLog {
+        ddsource: None,
+        ddtags: None,
+        hostname: None,
+        message: Some("Test".to_string()),
+        service: None,
+        status: None,
+        timestamp: None,
+        extra,
+    };
+
+    let query_params = DatadogQueryParams {
+        token: Some("test-token".to_string()),
+        ddtags: None,
+        ddsource: None,
+        service: None,
+        hostname: None,
+        message: None,
+        status: None,
+        extra: HashMap::new(),
+    };
+
+    let row = datadog_log_to_kafka_row(log, &query_params);
+
+    assert_eq!(row.event_name, "");
+    assert_eq!(row.instrumentation_scope, "");
+}


### PR DESCRIPTION
## Problem

Lots of people use the datadog agent, or datadog apis, to consume logs - it can be a big change to swap this out for otel - so support it directly

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add a datadog-compatible endpoint, this allows people to set `DD_LOGS_CONFIG_LOGS_DD_URL=https://us.i.posthog.com/i/v1/logs/datadog/<posthog-api-key>` to switch from datadog to posthog logs
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

ran locally, ran the datadog agent and captured to local with it
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
yes
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
