### PR TITLE
feat(workflows): re-arrange nodes

### DIFF
--- a/nodejs/src/cdp/utils/hog-function-filtering.test.ts
+++ b/nodejs/src/cdp/utils/hog-function-filtering.test.ts
@@ -357,5 +357,40 @@ describe('hog-function-filtering', () => {
             // Should execute bytecode because properties filters are present
             expect(result.match).toBe(true)
         })
+
+        it('should match all events when event filter has id: null (All Events filter)', async () => {
+            // This is what the database contains when "All Events" is selected in the UI
+            mockHogFunction.filters = {
+                events: [{ id: null, name: 'All events', type: 'events', order: 0 }],
+                source: 'events',
+                actions: [],
+                bytecode: ['_H', 1, 29], // Bytecode that returns true
+            }
+
+            // Test with various event names - all should match
+            mockFilterGlobals.event = '$pageview'
+            let result = await filterFunctionInstrumented({
+                fn: mockHogFunction,
+                filters: mockHogFunction.filters,
+                filterGlobals: mockFilterGlobals,
+            })
+            expect(result.match).toBe(true)
+
+            mockFilterGlobals.event = 'custom_event'
+            result = await filterFunctionInstrumented({
+                fn: mockHogFunction,
+                filters: mockHogFunction.filters,
+                filterGlobals: mockFilterGlobals,
+            })
+            expect(result.match).toBe(true)
+
+            mockFilterGlobals.event = '$autocapture'
+            result = await filterFunctionInstrumented({
+                fn: mockHogFunction,
+                filters: mockHogFunction.filters,
+                filterGlobals: mockFilterGlobals,
+            })
+            expect(result.match).toBe(true)
+        })
     })
 })

--- a/nodejs/src/cdp/utils/hog-function-filtering.test.ts
+++ b/nodejs/src/cdp/utils/hog-function-filtering.test.ts
@@ -357,40 +357,5 @@ describe('hog-function-filtering', () => {
             // Should execute bytecode because properties filters are present
             expect(result.match).toBe(true)
         })
-
-        it('should match all events when event filter has id: null (All Events filter)', async () => {
-            // This is what the database contains when "All Events" is selected in the UI
-            mockHogFunction.filters = {
-                events: [{ id: null, name: 'All events', type: 'events', order: 0 }],
-                source: 'events',
-                actions: [],
-                bytecode: ['_H', 1, 29], // Bytecode that returns true
-            }
-
-            // Test with various event names - all should match
-            mockFilterGlobals.event = '$pageview'
-            let result = await filterFunctionInstrumented({
-                fn: mockHogFunction,
-                filters: mockHogFunction.filters,
-                filterGlobals: mockFilterGlobals,
-            })
-            expect(result.match).toBe(true)
-
-            mockFilterGlobals.event = 'custom_event'
-            result = await filterFunctionInstrumented({
-                fn: mockHogFunction,
-                filters: mockHogFunction.filters,
-                filterGlobals: mockFilterGlobals,
-            })
-            expect(result.match).toBe(true)
-
-            mockFilterGlobals.event = '$autocapture'
-            result = await filterFunctionInstrumented({
-                fn: mockHogFunction,
-                filters: mockHogFunction.filters,
-                filterGlobals: mockFilterGlobals,
-            })
-            expect(result.match).toBe(true)
-        })
     })
 })

--- a/products/workflows/frontend/Workflows/hogflows/steps/Nodes.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/Nodes.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
-import { IconCopy, IconPlus } from '@posthog/icons'
+import { IconCopy, IconDrag, IconPlus } from '@posthog/icons'
 
 import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { NODE_HEIGHT, NODE_WIDTH } from '../react_flow_utils/constants'
@@ -20,12 +20,21 @@ export const REACT_FLOW_NODE_TYPES: Record<ReactFlowNodeType, React.ComponentTyp
 
 function DropzoneNode({ id }: HogFlowStepNodeProps): JSX.Element {
     const [isHighlighted, setIsHighlighted] = useState(false)
-    const { isCopyingNode } = useValues(hogFlowEditorLogic)
-    const { setHighlightedDropzoneNodeId, copyNodeToHighlightedDropzone } = useActions(hogFlowEditorLogic)
+    const { isCopyingNode, isMovingNode } = useValues(hogFlowEditorLogic)
+    const { setHighlightedDropzoneNodeId, copyNodeToHighlightedDropzone, moveNodeToHighlightedDropzone } =
+        useActions(hogFlowEditorLogic)
 
     useEffect(() => {
         setHighlightedDropzoneNodeId(isHighlighted ? id : null)
     }, [id, isHighlighted, setHighlightedDropzoneNodeId])
+
+    const handleClick = (): void => {
+        if (isCopyingNode) {
+            copyNodeToHighlightedDropzone()
+        } else if (isMovingNode) {
+            moveNodeToHighlightedDropzone()
+        }
+    }
 
     return (
         <div
@@ -33,7 +42,7 @@ function DropzoneNode({ id }: HogFlowStepNodeProps): JSX.Element {
             onDragLeave={() => setIsHighlighted(false)}
             onMouseOver={() => setIsHighlighted(true)}
             onMouseOut={() => setIsHighlighted(false)}
-            onClick={isCopyingNode ? () => copyNodeToHighlightedDropzone() : undefined}
+            onClick={isCopyingNode || isMovingNode ? handleClick : undefined}
             className={clsx(
                 'flex justify-center items-center p-2 rounded border border-dashed transition-all cursor-pointer hover:border-primary hover:bg-surface-primary',
                 isHighlighted ? 'border-primary bg-surface-primary' : 'border-transparent'
@@ -47,6 +56,8 @@ function DropzoneNode({ id }: HogFlowStepNodeProps): JSX.Element {
             <div className="flex flex-col justify-center items-center w-4 h-4 rounded-full border bg-surface-primary">
                 {isCopyingNode ? (
                     <IconCopy className="text-sm text-primary" />
+                ) : isMovingNode ? (
+                    <IconDrag className="text-sm text-primary" />
                 ) : (
                     <IconPlus className="text-sm text-primary" />
                 )}
@@ -58,7 +69,7 @@ function DropzoneNode({ id }: HogFlowStepNodeProps): JSX.Element {
 function HogFlowActionNode(props: HogFlowStepNodeProps): JSX.Element | null {
     const updateNodeInternals = useUpdateNodeInternals()
 
-    const { nodesById, isCopyingNode, nodeToBeAdded } = useValues(hogFlowEditorLogic)
+    const { nodesById, isCopyingNode, isMovingNode, nodeToBeAdded, movingNodeId } = useValues(hogFlowEditorLogic)
 
     useEffect(() => {
         updateNodeInternals(props.id)
@@ -68,9 +79,15 @@ function HogFlowActionNode(props: HogFlowStepNodeProps): JSX.Element | null {
 
     const shouldWiggleCopyingNode =
         isCopyingNode && nodeToBeAdded && 'id' in nodeToBeAdded && (nodeToBeAdded as HogFlowActionNode).id === props.id
+    const shouldWiggleMovingNode = isMovingNode && movingNodeId === props.id
 
     return (
-        <div className={clsx('transition-all hover:translate-y-[-2px]', shouldWiggleCopyingNode && 'animate-bounce')}>
+        <div
+            className={clsx(
+                'transition-all hover:translate-y-[-2px]',
+                (shouldWiggleCopyingNode || shouldWiggleMovingNode) && 'animate-bounce'
+            )}
+        >
             {node?.handles?.map((handle) => (
                 // isConnectable={false} prevents edges from being manually added
                 <Handle key={handle.id} className="opacity-0" {...handle} isConnectable={false} />

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -2,7 +2,7 @@ import { useReactFlow } from '@xyflow/react'
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { IconCopy, IconEllipsis, IconTrash } from '@posthog/icons'
+import { IconCopy, IconDrag, IconEllipsis, IconTrash } from '@posthog/icons'
 import { LemonInput, LemonTextArea, Tooltip } from '@posthog/lemon-ui'
 
 import { LemonBadge } from 'lib/lemon-ui/LemonBadge'
@@ -18,8 +18,9 @@ import { StepViewMetrics } from './StepViewMetrics'
 import { StepViewLogicProps, stepViewLogic } from './stepViewLogic'
 
 export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
-    const { selectedNode, mode, nodesById, selectedNodeCanBeDeleted } = useValues(hogFlowEditorLogic)
-    const { setSelectedNodeId, startCopyingNode } = useActions(hogFlowEditorLogic)
+    const { selectedNode, mode, nodesById, selectedNodeCanBeDeleted, selectedNodeCanBeCopiedOrMoved } =
+        useValues(hogFlowEditorLogic)
+    const { setSelectedNodeId, startCopyingNode, startMovingNode } = useActions(hogFlowEditorLogic)
     const { actionValidationErrorsById, logicProps } = useValues(workflowLogic)
     const { deleteElements } = useReactFlow()
 
@@ -178,12 +179,21 @@ export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
                         <LemonMenu
                             items={[
                                 // Copying a node allows re-adding it elsewhere in the workflow
-                                selectedNodeCanBeDeleted
+                                selectedNodeCanBeCopiedOrMoved
                                     ? {
                                           label: 'Copy',
                                           icon: <IconCopy />,
                                           status: 'default',
                                           onClick: () => startCopyingNode(node),
+                                      }
+                                    : null,
+                                // Moving a node deletes the original and places it at a new location
+                                selectedNodeCanBeCopiedOrMoved
+                                    ? {
+                                          label: 'Move',
+                                          icon: <IconDrag />,
+                                          status: 'default',
+                                          onClick: () => startMovingNode(node),
                                       }
                                     : null,
                                 {


### PR DESCRIPTION
## Problem

Folks want to move nodes around. They _could_ use the copy node feature for that but thats not great UX and feels like a workaround. Lets get the nodes moving.

## Changes

![2026-01-26 09 50 17](https://github.com/user-attachments/assets/78b8838f-3c58-4745-b0f8-1463720d683a)

- folks can now move nodes around into slots that make sense (differs from copy)

## How did you test this code?

- local dev
