### PR TITLE
chore(ci): add junit reporting to playwright and storybook tests

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -470,6 +470,14 @@ jobs:
                   retention-days: 30
                   if-no-files-found: ignore
 
+            - name: Upload test results
+              if: always()
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: junit-results-playwright
+                  path: playwright/junit-results.xml
+                  if-no-files-found: ignore
+
     capture-run-time:
         name: Capture run time
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -315,6 +315,14 @@ jobs:
                   name: failure-screenshots-${{ matrix.browser }}-${{ matrix.shard }}
                   path: frontend/__snapshots__/__failures__/
 
+            - name: Upload test results
+              if: always()
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: junit-results-storybook-${{ matrix.browser }}-${{ matrix.shard }}
+                  path: common/storybook/junit.xml
+                  if-no-files-found: ignore
+
             - name: Configure global git diff log
               run: git config --global --add safe.directory '*'
 

--- a/common/storybook/package.json
+++ b/common/storybook/package.json
@@ -50,8 +50,8 @@
         "build:products": "pnpm --filter=@posthog/frontend build:products",
         "build": "pnpm build:products && DEBUG=0 storybook build -o dist",
         "start": "pnpm build:products && DEBUG=0 storybook dev -p 6006",
-        "test:visual:ci:update": "pnpm build:products && test-storybook -u --no-index-json --maxWorkers=$(( $(nproc 2>/dev/null || echo 3) - 1 ))",
-        "test:visual:ci:verify": "pnpm build:products && test-storybook --ci --no-index-json --maxWorkers=$(( $(nproc 2>/dev/null || echo 3) - 1 ))",
+        "test:visual:ci:update": "pnpm build:products && test-storybook -u --junit --no-index-json --maxWorkers=$(( $(nproc 2>/dev/null || echo 3) - 1 ))",
+        "test:visual:ci:verify": "pnpm build:products && test-storybook --ci --junit --no-index-json --maxWorkers=$(( $(nproc 2>/dev/null || echo 3) - 1 ))",
         "test:visual:debug": "pnpm build:products && PWDEBUG=1 NODE_OPTIONS=--max-old-space-size=16384 test-storybook --browsers chromium webkit --no-index-json",
         "test:visual:update": "pnpm build:products && cd ../.. && rm -rf frontend/__snapshots__/__failures__/ && docker compose -f docker-compose.playwright.yml run --rm -it --build playwright pnpm test:visual:update:docker --url http://host.docker.internal:6006",
         "test:visual:update:docker": "pnpm build:products && NODE_OPTIONS=--max-old-space-size=16384 test-storybook -u --browsers chromium webkit --no-index-json"

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -39,7 +39,10 @@ export default defineConfig({
     */
     workers: process.env.CI ? 3 : 6,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-    reporter: [['html', { open: 'never' }]],
+    reporter: [
+        ['html', { open: 'never' }],
+        ...(process.env.CI ? [['junit', { outputFile: 'junit-results.xml' }] as const] : []),
+    ],
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */


### PR DESCRIPTION
**What?** Adds JUnit XML output to Playwright e2e tests and Storybook visual regression tests.

**Why?** Backend tests already use JUnit for consistent CI reporting. This brings frontend tests in line for unified test result handling.

**Changes:**
- Playwright config: adds junit reporter when running in CI
- Storybook test-runner: adds `--junit` flag to CI test commands
- Both workflows: upload JUnit XML artifacts