### PR TITLE
feat(logs): add controlled config pattern to LogsViewer (Phase 2a)

### DIFF
--- a/products/logs/frontend/LogsScene.stories.tsx
+++ b/products/logs/frontend/LogsScene.stories.tsx
@@ -342,7 +342,7 @@ export default {
         viewMode: 'story',
         mockDate: '2023-02-18',
         testOptions: {
-            waitForSelector: 'text=/Logs is in beta/i',
+            waitForSelector: '[data-attr="logs-total-count"]',
         },
     }, // scene mode
 } as Meta

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { useCallback } from 'react'
 
 import { LemonBanner } from '@posthog/lemon-ui'
 
@@ -9,6 +10,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
+import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
 import { LogsSetupPrompt } from 'products/logs/frontend/components/SetupPrompt/SetupPrompt'
 import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPrompt/logsIngestionLogic'
 
@@ -41,10 +43,19 @@ const LogsSceneContent = (): JSX.Element => {
         orderBy,
         sparklineData,
         sparklineBreakdownBy,
+        filters,
     } = useValues(logsSceneLogic)
+    const { setFilters } = useActions(logsSceneLogic)
     const { teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
     const { runQuery, fetchNextLogsPage, setOrderBy, addFilter, setDateRange, setSparklineBreakdownBy, zoomDateRange } =
         useActions(logsSceneLogic)
+
+    const handleFiltersChanged = useCallback(
+        (filters: LogsViewerFilters) => {
+            setFilters(filters)
+        },
+        [setFilters]
+    )
 
     return (
         <>
@@ -81,6 +92,9 @@ const LogsSceneContent = (): JSX.Element => {
             </LemonBanner>
             <div className="flex flex-col gap-2 py-2 h-[calc(100vh_-_var(--breadcrumbs-height-compact,_0px)_-_var(--scene-title-section-height,_0px)_-_5px_+_10rem)]">
                 <LogsViewer
+                    config={{
+                        filters,
+                    }}
                     tabId={tabId}
                     logs={parsedLogs}
                     loading={logsLoading}
@@ -97,6 +111,7 @@ const LogsSceneContent = (): JSX.Element => {
                     sparklineBreakdownBy={sparklineBreakdownBy}
                     onSparklineBreakdownByChange={setSparklineBreakdownBy}
                     onExpandTimeRange={() => zoomDateRange(2)}
+                    onFiltersChanged={handleFiltersChanged}
                 />
             </div>
         </>

--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
@@ -9,8 +9,6 @@ import { LogMessage } from '~/queries/schema/schema-general'
 
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 
-import { logsSceneLogic } from '../../../logsSceneLogic'
-
 const options: Record<LogMessage['severity_text'], string> = {
     trace: 'Trace',
     info: 'Info',
@@ -23,8 +21,11 @@ const options: Record<LogMessage['severity_text'], string> = {
 const ALL_LOG_LEVELS = Object.values(options) as LogMessage['severity_text'][]
 
 export const SeverityLevelsFilter = (): JSX.Element => {
-    const { severityLevels } = useValues(logsSceneLogic)
-    const { setSeverityLevels } = useActions(logsSceneLogic)
+    const {
+        config: {
+            filters: { severityLevels },
+        },
+    } = useValues(logsViewerConfigLogic)
     const { setFilter } = useActions(logsViewerConfigLogic)
 
     const onClick = (level: LogMessage['severity_text']): void => {
@@ -38,7 +39,6 @@ export const SeverityLevelsFilter = (): JSX.Element => {
             levels.push(level)
         }
 
-        setSeverityLevels(levels)
         setFilter('severityLevels', levels)
     }
 

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -12,6 +12,7 @@ import { PropertyFilterType, PropertyOperator } from '~/types'
 import { LogsFilterBar } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar'
 import { LogsFilterBar as LogsFilterBarV2 } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar'
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+import { LogsViewerConfig, LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
 import { VirtualizedLogsList } from 'products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList'
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
 import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
@@ -27,6 +28,7 @@ const SCROLL_INTERVAL_MS = 16 // ~60fps
 const SCROLL_AMOUNT_PX = 8
 
 export interface LogsViewerProps {
+    config: LogsViewerConfig
     tabId: string
     logs: ParsedLogMessage[]
     loading: boolean
@@ -43,9 +45,12 @@ export interface LogsViewerProps {
     sparklineBreakdownBy: LogsSparklineBreakdownBy
     onSparklineBreakdownByChange: (breakdownBy: LogsSparklineBreakdownBy) => void
     onExpandTimeRange?: () => void
+    onFiltersChanged?: (filters: LogsViewerFilters) => void
+    onConfigChanged?: (config: LogsViewerConfig) => void
 }
 
 export function LogsViewer({
+    config,
     tabId,
     logs,
     loading,
@@ -62,9 +67,11 @@ export function LogsViewer({
     sparklineBreakdownBy,
     onSparklineBreakdownByChange,
     onExpandTimeRange,
+    onFiltersChanged,
+    onConfigChanged,
 }: LogsViewerProps): JSX.Element {
     return (
-        <BindLogic logic={logsViewerConfigLogic} props={{ id: tabId }}>
+        <BindLogic logic={logsViewerConfigLogic} props={{ id: tabId, config, onFiltersChanged, onConfigChanged }}>
             <BindLogic logic={logDetailsModalLogic} props={{ tabId }}>
                 <BindLogic logic={logsViewerLogic} props={{ tabId, logs, orderBy, onAddFilter }}>
                     <LogsViewerContent

--- a/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
@@ -55,7 +55,9 @@ export const LogsViewerToolbar = ({
             </div>
             <div className="flex items-center gap-4 flex-wrap">
                 {totalLogsCount !== undefined && totalLogsCount > 0 && (
-                    <span className="text-muted text-xs">{humanFriendlyNumber(totalLogsCount)} logs</span>
+                    <span className="text-muted text-xs" data-attr="logs-total-count">
+                        {humanFriendlyNumber(totalLogsCount)} logs
+                    </span>
                 )}
                 <span className="text-muted text-xs flex items-center gap-1">
                     <KeyboardShortcut arrowup />

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.test.ts
@@ -3,7 +3,7 @@ import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
 import { FilterLogicalOperator } from '~/types'
 
-import { logsViewerConfigLogic } from './logsViewerConfigLogic'
+import { DEFAULT_LOGS_VIEWER_CONFIG, logsViewerConfigLogic } from './logsViewerConfigLogic'
 import { LogsViewerFilters } from './types'
 
 describe('logsViewerConfigLogic', () => {
@@ -11,7 +11,7 @@ describe('logsViewerConfigLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        logic = logsViewerConfigLogic({ id: 'test-tab' })
+        logic = logsViewerConfigLogic({ id: 'test-tab', config: DEFAULT_LOGS_VIEWER_CONFIG })
         logic.mount()
     })
 
@@ -66,8 +66,8 @@ describe('logsViewerConfigLogic', () => {
 
     describe('keyed instances', () => {
         it('maintains separate state for different keys', async () => {
-            const logic1 = logsViewerConfigLogic({ id: 'tab-1' })
-            const logic2 = logsViewerConfigLogic({ id: 'tab-2' })
+            const logic1 = logsViewerConfigLogic({ id: 'tab-1', config: DEFAULT_LOGS_VIEWER_CONFIG })
+            const logic2 = logsViewerConfigLogic({ id: 'tab-2', config: DEFAULT_LOGS_VIEWER_CONFIG })
             logic1.mount()
             logic2.mount()
 

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
@@ -1,8 +1,11 @@
-import { actions, kea, key, path, props, propsChanged, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
 import { subscriptions } from 'kea-subscriptions'
+import posthog from 'posthog-js'
 
 import { objectsEqual } from 'lib/utils'
+import { teamLogic } from 'scenes/teamLogic'
 
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import { FilterLogicalOperator } from '~/types'
 
 import { LogsViewerConfig, LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
@@ -31,8 +34,12 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
     props({ id: 'default', config: DEFAULT_LOGS_VIEWER_CONFIG } as LogsViewerConfigProps),
     key((props) => props.id),
 
+    connect(() => ({
+        actions: [teamLogic, ['addProductIntent']],
+    })),
+
     actions({
-        setFilters: (filters: LogsViewerFilters) => ({ filters }),
+        setFilters: (filters: LogsViewerFilters) => ({ filters }), // Does not trigger analytics
         setFilter: (filter: keyof LogsViewerFilters, value: LogsViewerFilters[keyof LogsViewerFilters]) => ({
             filter,
             value,
@@ -56,6 +63,45 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
         config: [(s) => [s.filters], (filters: LogsViewerFilters): LogsViewerConfig => ({ filters })],
     }),
 
+    listeners(({ actions }) => ({
+        setFilter: ({ filter, value }) => {
+            if (!value) {
+                return
+            }
+            const event = 'logs filter changed'
+            let attributes: Record<string, any> = {}
+
+            switch (filter) {
+                case 'dateRange':
+                    attributes.filter_type = 'date_range'
+                    attributes.date_from = (value as LogsViewerFilters['dateRange']).date_from
+                    attributes.date_to = (value as LogsViewerFilters['dateRange']).date_to
+                    break
+                case 'searchTerm':
+                    attributes.filter_type = 'search'
+                    attributes.search_term_length = (value as LogsViewerFilters['searchTerm'])?.length ?? 0
+                    break
+                case 'severityLevels':
+                    attributes.filter_type = 'severity'
+                    attributes.severity_levels = value ?? []
+                    break
+                case 'serviceNames':
+                    attributes.filter_type = 'service'
+                    attributes.service_count = (value as LogsViewerFilters['serviceNames'])?.length ?? 0
+                    break
+                case 'filterGroup':
+                    attributes.filter_type = 'attributes'
+                    break
+            }
+
+            posthog.capture(event, attributes)
+            actions.addProductIntent({
+                product_type: ProductKey.LOGS,
+                intent_context: ProductIntentContext.LOGS_SET_FILTERS,
+            })
+        },
+    })),
+
     subscriptions(({ props, values }) => ({
         filters: (filters: LogsViewerFilters, oldFilters: LogsViewerFilters) => {
             if (objectsEqual(filters, oldFilters)) {
@@ -67,7 +113,7 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
     })),
 
     propsChanged(({ actions, props }, oldProps) => {
-        if (!objectsEqual(props.config.filters, oldProps.config.filters)) {
+        if (oldProps?.config && !objectsEqual(props.config.filters, oldProps.config.filters)) {
             actions.setFilters(props.config.filters)
         }
     }),

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -859,11 +859,6 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
         },
         setFilters: ({ pushToHistory }) => {
             if (values.hasRunQuery) {
-                posthog.capture('logs filter changed', { filter_type: 'bulk' })
-                actions.addProductIntent({
-                    product_type: ProductKey.LOGS,
-                    intent_context: ProductIntentContext.LOGS_SET_FILTERS,
-                })
                 if (pushToHistory) {
                     actions.pushToFilterHistory(values.filters)
                 }


### PR DESCRIPTION
## Problem

Following on from the Phase 1 PR that established `logsViewerConfigLogic`, we need to enable bidirectional communication between the LogsViewer component and its parent. This is required so that:

1. Parents can provide initial filter state (e.g., from URL params)
2. LogsViewer can notify parents when filters change (for URL sync, data fetching)
3. The component remains portable - no tight coupling between logics

## Changes

- Add `config` prop to LogsViewer (controlled component pattern)
- Add `onFiltersChanged` and `onConfigChanged` callback props
- `logsViewerConfigLogic` now:
  - Initializes its reducer from `props.config.filters`
  - Uses `propsChanged` to sync when parent updates config
  - Uses `subscriptions` to call callbacks when filters change
  - Both use `objectsEqual` checks to prevent infinite loops
- `LogsScene` wires up the controlled pattern:
  - Passes `config={{ filters }}` from its state
  - Handles `onFiltersChanged` by calling `setFilters`
- Migrate `SeverityLevelsFilter` to read/write only from `logsViewerConfigLogic` (proof of concept for remaining filters)

## Communication pattern

Loop prevention via `objectsEqual` checks in both `propsChanged` and `subscriptions`.

## How did you test this code?

- Updated unit tests to include required `config` prop
- All 8 tests pass
- TypeScript check passes
- Manually verified severity filter still works

## Next steps

Migrate remaining filters (`DateRangeFilter`, `SearchTermFilter`, `ServiceFilter`, `FilterGroup`) to read/write only from `logsViewerConfigLogic` in a follow-up PR.

## Publish to changelog?

No
