### PR TITLE
fix(data-warehouse): Use greater than and not gte for getting incremental values GAds

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/posthog/temporal/data_imports/sources/google_ads/google_ads.py
@@ -335,7 +335,7 @@ def google_ads_source(
             if isinstance(last_value, dt.datetime) or isinstance(last_value, dt.date):
                 last_value = f"'{last_value.isoformat()}'"
 
-            query += f" WHERE {incremental_field} >= {last_value}"
+            query += f" WHERE {incremental_field} > {last_value}"
 
             if incremental_field_type == IncrementalFieldType.Date:
                 # Dates require an upper bound too, so we pick something very in the future.


### PR DESCRIPTION
## Problem
Same issue as #44999 but for Google Ads.

We've been using a gte (`>=`) comparison on the incremental value for Google Ads, meaning we're always pulling the last record(s) from the last sync as well as the new updated rows.

This causes data accuracy issues because Google Ads adjusts metrics retroactively (invalid click removal, conversion attribution changes, etc.), and the Delta Lake merge replaces historical values with the re-fetched data.

I ran the same SQL query over the customer's data for Jan 1-12 and after triggering a full refresh, the total spend changed by ~0.08% (from the previous synced value to the refreshed value), which confirms that the current incremental sync is replacing historical data.

## Changes
- Switch to using just gt (`>`) instead, so we're only pulling new records

@Gilbert09  We have the same issue here as in Postgres. Was there a reason why this was originally implemented with `>=`? I can't think of any reason to have gte instead of gt.

## How did you test this code?
Existing tests pass.

## Publish to changelog?
NO
