### PR TITLE
feat(temporal): make combined_metric_server configurable

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -358,9 +358,9 @@ class Command(BaseCommand):
             help="Maximum seconds without workflow/activity execution before unhealthy",
         )
         parser.add_argument(
-            "--enable-metrics-server",
+            "--enable-combined-metrics-server",
             type=lambda x: x.lower() in ["1", "true", "t", "y", "yes"],
-            default=settings.TEMPORAL_METRICS_SERVER_ENABLED,
+            default=settings.TEMPORAL_COMBINED_METRICS_SERVER_ENABLED,
             help="Enable the combined metrics server (default: true, set to false for workers with GIL contention issues)",
         )
 
@@ -380,7 +380,7 @@ class Command(BaseCommand):
         target_cpu_usage = options.get("target_cpu_usage", None)
         health_port = options.get("health_port", None)
         health_max_idle_seconds = options.get("health_max_idle_seconds", None)
-        enable_metrics_server = options.get("enable_metrics_server", True)
+        enable_combined_metrics_server = options.get("enable_combined_metrics_server", True)
 
         try:
             workflows = list(WORKFLOWS_DICT[task_queue])
@@ -452,7 +452,7 @@ class Command(BaseCommand):
                 target_cpu_usage=target_cpu_usage,
                 health_port=health_port,
                 health_max_idle_seconds=health_max_idle_seconds,
-                metrics_server_enabled=enable_metrics_server,
+                combined_metrics_server_enabled=enable_combined_metrics_server,
             )
             logger.info("Starting Temporal Worker")
 
@@ -479,7 +479,7 @@ class Command(BaseCommand):
                     use_pydantic_converter=use_pydantic_converter,
                     target_memory_usage=target_memory_usage,
                     target_cpu_usage=target_cpu_usage,
-                    enable_metrics_server=enable_metrics_server,
+                    enable_combined_metrics_server=enable_combined_metrics_server,
                 )
             )
 

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -357,6 +357,12 @@ class Command(BaseCommand):
             default=settings.TEMPORAL_HEALTH_MAX_IDLE_SECONDS,
             help="Maximum seconds without workflow/activity execution before unhealthy",
         )
+        parser.add_argument(
+            "--disable-metrics-server",
+            action="store_true",
+            default=not settings.TEMPORAL_METRICS_SERVER_ENABLED,
+            help="Disable the combined metrics server (useful for workers with GIL contention issues)",
+        )
 
     def handle(self, *args, **options):
         temporal_host = options["temporal_host"]
@@ -374,6 +380,7 @@ class Command(BaseCommand):
         target_cpu_usage = options.get("target_cpu_usage", None)
         health_port = options.get("health_port", None)
         health_max_idle_seconds = options.get("health_max_idle_seconds", None)
+        disable_metrics_server = options.get("disable_metrics_server", False)
 
         try:
             workflows = list(WORKFLOWS_DICT[task_queue])
@@ -445,6 +452,7 @@ class Command(BaseCommand):
                 target_cpu_usage=target_cpu_usage,
                 health_port=health_port,
                 health_max_idle_seconds=health_max_idle_seconds,
+                metrics_server_enabled=not disable_metrics_server,
             )
             logger.info("Starting Temporal Worker")
 
@@ -471,6 +479,7 @@ class Command(BaseCommand):
                     use_pydantic_converter=use_pydantic_converter,
                     target_memory_usage=target_memory_usage,
                     target_cpu_usage=target_cpu_usage,
+                    enable_metrics_server=not disable_metrics_server,
                 )
             )
 

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -358,10 +358,10 @@ class Command(BaseCommand):
             help="Maximum seconds without workflow/activity execution before unhealthy",
         )
         parser.add_argument(
-            "--enable-combined-metrics-server",
-            type=lambda x: x.lower() in ["1", "true", "t", "y", "yes"],
-            default=settings.TEMPORAL_COMBINED_METRICS_SERVER_ENABLED,
-            help="Enable the combined metrics server (default: true, set to false for workers with GIL contention issues)",
+            "--disable-combined-metrics-server",
+            action="store_true",
+            default=not settings.TEMPORAL_COMBINED_METRICS_SERVER_ENABLED,
+            help="Disable the combined metrics server (useful for workers with GIL contention issues)",
         )
 
     def handle(self, *args, **options):
@@ -380,7 +380,7 @@ class Command(BaseCommand):
         target_cpu_usage = options.get("target_cpu_usage", None)
         health_port = options.get("health_port", None)
         health_max_idle_seconds = options.get("health_max_idle_seconds", None)
-        enable_combined_metrics_server = options.get("enable_combined_metrics_server", True)
+        disable_combined_metrics_server = options.get("disable_combined_metrics_server", False)
 
         try:
             workflows = list(WORKFLOWS_DICT[task_queue])
@@ -452,7 +452,7 @@ class Command(BaseCommand):
                 target_cpu_usage=target_cpu_usage,
                 health_port=health_port,
                 health_max_idle_seconds=health_max_idle_seconds,
-                combined_metrics_server_enabled=enable_combined_metrics_server,
+                combined_metrics_server_enabled=not disable_combined_metrics_server,
             )
             logger.info("Starting Temporal Worker")
 
@@ -479,7 +479,7 @@ class Command(BaseCommand):
                     use_pydantic_converter=use_pydantic_converter,
                     target_memory_usage=target_memory_usage,
                     target_cpu_usage=target_cpu_usage,
-                    enable_combined_metrics_server=enable_combined_metrics_server,
+                    enable_combined_metrics_server=not disable_combined_metrics_server,
                 )
             )
 

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -358,10 +358,10 @@ class Command(BaseCommand):
             help="Maximum seconds without workflow/activity execution before unhealthy",
         )
         parser.add_argument(
-            "--disable-metrics-server",
-            action="store_true",
-            default=not settings.TEMPORAL_METRICS_SERVER_ENABLED,
-            help="Disable the combined metrics server (useful for workers with GIL contention issues)",
+            "--enable-metrics-server",
+            type=lambda x: x.lower() in ["1", "true", "t", "y", "yes"],
+            default=settings.TEMPORAL_METRICS_SERVER_ENABLED,
+            help="Enable the combined metrics server (default: true, set to false for workers with GIL contention issues)",
         )
 
     def handle(self, *args, **options):
@@ -380,7 +380,7 @@ class Command(BaseCommand):
         target_cpu_usage = options.get("target_cpu_usage", None)
         health_port = options.get("health_port", None)
         health_max_idle_seconds = options.get("health_max_idle_seconds", None)
-        disable_metrics_server = options.get("disable_metrics_server", False)
+        enable_metrics_server = options.get("enable_metrics_server", True)
 
         try:
             workflows = list(WORKFLOWS_DICT[task_queue])
@@ -452,7 +452,7 @@ class Command(BaseCommand):
                 target_cpu_usage=target_cpu_usage,
                 health_port=health_port,
                 health_max_idle_seconds=health_max_idle_seconds,
-                metrics_server_enabled=not disable_metrics_server,
+                metrics_server_enabled=enable_metrics_server,
             )
             logger.info("Starting Temporal Worker")
 
@@ -479,7 +479,7 @@ class Command(BaseCommand):
                     use_pydantic_converter=use_pydantic_converter,
                     target_memory_usage=target_memory_usage,
                     target_cpu_usage=target_cpu_usage,
-                    enable_metrics_server=not disable_metrics_server,
+                    enable_metrics_server=enable_metrics_server,
                 )
             )
 

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -29,6 +29,13 @@ TARGET_CPU_USAGE: float | None = get_from_env("TARGET_CPU_USAGE", None, optional
 
 TEMPORAL_HEALTH_PORT: int = get_from_env("TEMPORAL_HEALTH_PORT", 8011, type_cast=int)
 TEMPORAL_HEALTH_MAX_IDLE_SECONDS: float = get_from_env("TEMPORAL_HEALTH_MAX_IDLE_SECONDS", 300.0, type_cast=float)
+TEMPORAL_METRICS_SERVER_ENABLED: bool = get_from_env("TEMPORAL_METRICS_SERVER_ENABLED", "1").lower() in [
+    "1",
+    "true",
+    "t",
+    "y",
+    "yes",
+]
 
 TEMPORAL_LOG_LEVEL: str = os.getenv("TEMPORAL_LOG_LEVEL", "INFO")
 

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -1,7 +1,7 @@
 import os
 
 from posthog.settings.base_variables import DEBUG
-from posthog.settings.utils import get_from_env
+from posthog.settings.utils import get_from_env, str_to_bool
 
 TEMPORAL_NAMESPACE: str = os.getenv("TEMPORAL_NAMESPACE", "default")
 TEMPORAL_HOST: str = os.getenv("TEMPORAL_HOST", "127.0.0.1")
@@ -10,13 +10,7 @@ TEMPORAL_CLIENT_ROOT_CA: str | None = os.getenv("TEMPORAL_CLIENT_ROOT_CA", None)
 TEMPORAL_CLIENT_CERT: str | None = os.getenv("TEMPORAL_CLIENT_CERT", None)
 TEMPORAL_CLIENT_KEY: str | None = os.getenv("TEMPORAL_CLIENT_KEY", None)
 TEMPORAL_WORKFLOW_MAX_ATTEMPTS: str = os.getenv("TEMPORAL_WORKFLOW_MAX_ATTEMPTS", "3")
-TEMPORAL_USE_PYDANTIC_CONVERTER: bool = get_from_env("TEMPORAL_USE_PYDANTIC_CONVERTER", "0").lower() in [
-    "1",
-    "true",
-    "t",
-    "y",
-    "yes",
-]
+TEMPORAL_USE_PYDANTIC_CONVERTER: bool = get_from_env("TEMPORAL_USE_PYDANTIC_CONVERTER", False, type_cast=str_to_bool)
 GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS: int | None = get_from_env(
     "GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS", None, optional=True, type_cast=int
 )
@@ -30,14 +24,8 @@ TARGET_CPU_USAGE: float | None = get_from_env("TARGET_CPU_USAGE", None, optional
 TEMPORAL_HEALTH_PORT: int = get_from_env("TEMPORAL_HEALTH_PORT", 8011, type_cast=int)
 TEMPORAL_HEALTH_MAX_IDLE_SECONDS: float = get_from_env("TEMPORAL_HEALTH_MAX_IDLE_SECONDS", 300.0, type_cast=float)
 TEMPORAL_COMBINED_METRICS_SERVER_ENABLED: bool = get_from_env(
-    "TEMPORAL_COMBINED_METRICS_SERVER_ENABLED", "1"
-).lower() in [
-    "1",
-    "true",
-    "t",
-    "y",
-    "yes",
-]
+    "TEMPORAL_COMBINED_METRICS_SERVER_ENABLED", True, type_cast=str_to_bool
+)
 
 TEMPORAL_LOG_LEVEL: str = os.getenv("TEMPORAL_LOG_LEVEL", "INFO")
 

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -29,7 +29,9 @@ TARGET_CPU_USAGE: float | None = get_from_env("TARGET_CPU_USAGE", None, optional
 
 TEMPORAL_HEALTH_PORT: int = get_from_env("TEMPORAL_HEALTH_PORT", 8011, type_cast=int)
 TEMPORAL_HEALTH_MAX_IDLE_SECONDS: float = get_from_env("TEMPORAL_HEALTH_MAX_IDLE_SECONDS", 300.0, type_cast=float)
-TEMPORAL_METRICS_SERVER_ENABLED: bool = get_from_env("TEMPORAL_METRICS_SERVER_ENABLED", "1").lower() in [
+TEMPORAL_COMBINED_METRICS_SERVER_ENABLED: bool = get_from_env(
+    "TEMPORAL_COMBINED_METRICS_SERVER_ENABLED", "1"
+).lower() in [
     "1",
     "true",
     "t",

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -78,7 +78,7 @@ async def create_worker(
     use_pydantic_converter: bool = False,
     target_memory_usage: float | None = None,
     target_cpu_usage: float | None = None,
-    enable_metrics_server: bool = True,
+    enable_combined_metrics_server: bool = True,
 ) -> ManagedWorker:
     """Connect to Temporal server and return a ManagedWorker containing the Worker and metrics server.
 
@@ -107,13 +107,13 @@ async def create_worker(
             If not set, worker will use max_concurrent_{activities, workflow_tasks} to dictate number of slots.
         target_cpu_usage: Fraction of available CPU to use, between 0.0 and 1.0.
             Defaults to 1.0. Only takes effect if target_memory_usage is set.
-        enable_metrics_server: Whether to start the combined metrics server. Defaults to True.
+        enable_combined_metrics_server: Whether to start the combined metrics server. Defaults to True.
             Set to False to disable the metrics server (useful when it causes GIL contention issues).
     """
 
     metrics_server: CombinedMetricsServer | None = None
 
-    if enable_metrics_server:
+    if enable_combined_metrics_server:
         temporal_metrics_port = get_free_port()
         temporal_metrics_bind_address = f"127.0.0.1:{temporal_metrics_port}"
 


### PR DESCRIPTION
## Problem

The `temporal-worker-data-warehouse` deployments are experiencing Prometheus scrape timeouts (45s+), heartbeat failures, and health check failures. This is caused by GIL contention - the data warehouse workers use synchronous activities that hold the GIL while doing CPU work, starving the combined metrics server thread.

Slack thread: https://posthog.slack.com/archives/C0AA66SHDFU/p1769178815043979?thread_ts=1769160782.066039&cid=C0AA66SHDFU

## Changes

- Add `TEMPORAL_COMBINED_METRICS_SERVER_ENABLED` environment variable (defaults to `true`)
- Add `--disable-combined-metrics-server` CLI flag to `start_temporal_worker` command
- When disabled, Temporal SDK metrics are exposed directly on the public metrics port instead of through the combined metrics server, removing one source of thread contention
- Also refactored `TEMPORAL_USE_PYDANTIC_CONVERTER` to use `str_to_bool` for consistent boolean parsing

## How did you test this code?

✅  CI is passing

## Publish to changelog?

no
