### PR TITLE
feat(devex): Add generate demo data (disabled by default) to mproc-minimal

### DIFF
--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -65,5 +65,13 @@ procs:
         shell: 'bin/check_postgres_up && cd hedgebox-dummy && pnpm install && pnpm run dev'
         autostart: false
 
+    generate-demo-data:
+        shell: |-
+            bin/check_postgres_up && \
+            bin/check_kafka_clickhouse_up && \
+            bin/check_ducklake_up && \
+            ./manage.py generate_demo_data
+        autostart: false
+
 mouse_scroll_speed: 1
 scrollback: 10000

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -129,7 +129,6 @@ procs:
         shell: |-
             bin/check_postgres_up && \
             bin/check_kafka_clickhouse_up && \
-            bin/check_dagster_graphql_up && \
             bin/check_ducklake_up && \
             ./manage.py generate_demo_data
         autostart: false


### PR DESCRIPTION
Now that generate_demo_data doesn't need dagster, we can add it to mproc minimal. I also removed the requirement to use dagster in the regular mprocs file