### PR TITLE
feat(recordings): add batch check for session existence and integrate with ViewRecordingButton

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3535,6 +3535,13 @@ const api = {
             return await new ApiRequest().recording(recordingId).delete()
         },
 
+        async batchCheckExists(sessionIds: string[]): Promise<{ results: Record<string, boolean> }> {
+            return await new ApiRequest()
+                .recordings()
+                .withAction('batch_check_exists')
+                .create({ data: { session_ids: sessionIds } })
+        },
+
         async createExternalReference(
             sessionRecordingId: SessionRecordingType['id'],
             integrationId: number,

--- a/frontend/src/lib/components/ViewRecordingButton/sessionRecordingExistsLogic.ts
+++ b/frontend/src/lib/components/ViewRecordingButton/sessionRecordingExistsLogic.ts
@@ -1,0 +1,118 @@
+import { actions, kea, listeners, path, reducers, selectors } from 'kea'
+
+import api from 'lib/api'
+import { permanentlyMount } from 'lib/utils/kea-logic-builders'
+
+import type { sessionRecordingExistsLogicType } from './sessionRecordingExistsLogicType'
+
+export enum RecordingExistsState {
+    Pending = 'pending',
+    Loading = 'loading',
+    Exists = 'exists',
+    NotExists = 'not_exists',
+    Error = 'error',
+}
+
+export type RecordingExistsStorage = Record<string, RecordingExistsState>
+
+export const sessionRecordingExistsLogic = kea<sessionRecordingExistsLogicType>([
+    path(['lib', 'components', 'ViewRecordingButton', 'sessionRecordingExistsLogic']),
+    actions({
+        checkRecordingExists: (sessionId: string) => ({ sessionId }),
+        updateRecordingExistsStorage: (updates: RecordingExistsStorage) => ({ updates }),
+        fetchAllPendingChecks: true,
+    }),
+    reducers({
+        recordingExistsStorage: [
+            {} as RecordingExistsStorage, // Choosing not to persist here as we cache on the BE, I don't want to kill client memory
+            {
+                updateRecordingExistsStorage: (state, { updates }) => ({
+                    ...state,
+                    ...updates,
+                }),
+            },
+        ],
+    }),
+    listeners(({ actions, values }) => ({
+        checkRecordingExists: ({ sessionId }) => {
+            const { recordingExistsStorage } = values
+
+            if (sessionId in recordingExistsStorage) {
+                return
+            }
+
+            actions.updateRecordingExistsStorage({ [sessionId]: RecordingExistsState.Pending })
+            actions.fetchAllPendingChecks()
+        },
+
+        fetchAllPendingChecks: async (_, breakpoint) => {
+            await breakpoint(10)
+
+            const pendingSessionIds = values.pendingSessionIds
+            if (pendingSessionIds.length === 0) {
+                return
+            }
+
+            const toCheck = pendingSessionIds.slice(0, 100)
+
+            actions.updateRecordingExistsStorage(
+                Object.fromEntries(toCheck.map((id: string) => [id, RecordingExistsState.Loading]))
+            )
+
+            try {
+                const response = await api.recordings.batchCheckExists(toCheck)
+
+                await breakpoint()
+
+                const updates: RecordingExistsStorage = {}
+                for (const sessionId of toCheck) {
+                    updates[sessionId] = response.results[sessionId]
+                        ? RecordingExistsState.Exists
+                        : RecordingExistsState.NotExists
+                }
+                actions.updateRecordingExistsStorage(updates)
+            } catch {
+                actions.updateRecordingExistsStorage(
+                    Object.fromEntries(toCheck.map((id: string) => [id, RecordingExistsState.Error]))
+                )
+            }
+
+            await breakpoint()
+            if (values.pendingSessionIds.length > 0) {
+                actions.fetchAllPendingChecks()
+            }
+        },
+    })),
+    selectors({
+        pendingSessionIds: [
+            (s) => [s.recordingExistsStorage],
+            (storage: RecordingExistsStorage): string[] =>
+                Object.entries(storage)
+                    .filter(([_, state]) => state === RecordingExistsState.Pending)
+                    .map(([id]) => id),
+        ],
+        getRecordingExists: [
+            (s) => [s.recordingExistsStorage],
+            (storage: RecordingExistsStorage) =>
+                (sessionId: string): boolean | undefined => {
+                    const state = storage[sessionId]
+                    if (state === RecordingExistsState.Exists) {
+                        return true
+                    }
+                    if (state === RecordingExistsState.NotExists) {
+                        return false
+                    }
+                    return undefined
+                },
+        ],
+        isRecordingExistsLoading: [
+            (s) => [s.recordingExistsStorage],
+            (storage: RecordingExistsStorage) =>
+                (sessionId: string): boolean => {
+                    const state = storage[sessionId]
+                    return state === RecordingExistsState.Pending || state === RecordingExistsState.Loading
+                },
+        ],
+    }),
+    permanentlyMount(),
+])

--- a/posthog/session_recordings/queries/session_replay_events.py
+++ b/posthog/session_recordings/queries/session_replay_events.py
@@ -74,15 +74,21 @@ class SessionReplayEvents:
 
         # Query ClickHouse for uncached session IDs
         found_sessions = self._find_with_timestamps(uncached_session_ids, team)
-        existing_session_ids = {row[0] for row in found_sessions}
+        # Build a mapping from session_id to expiry_time (tuple is: session_id, min_ts, max_ts, expiry_time)
+        session_expiry_map = {session_id: expiry_time for session_id, _, _, expiry_time in found_sessions}
 
-        # Build results and cache positive results
+        now = datetime.now(pytz.timezone("UTC"))
+
+        # Build results and cache positive results with expiry-based TTL
         for sid in uncached_session_ids:
-            exists = sid in existing_session_ids
+            exists = sid in session_expiry_map
             results[sid] = exists
             if exists:
-                cache_key = f"session_recording_existence_team_{team.pk}_id_{sid}"
-                cache.set(cache_key, True, timeout=seconds_until_midnight())
+                expiry_time = session_expiry_map[sid]
+                ttl_seconds = int((expiry_time - now).total_seconds())
+                if ttl_seconds > 0:
+                    cache_key = f"session_recording_existence_team_{team.pk}_id_{sid}"
+                    cache.set(cache_key, True, timeout=ttl_seconds)
 
         return results
 
@@ -131,27 +137,27 @@ class SessionReplayEvents:
         if not found_sessions:
             return set(), None, None
         # Calculate min/max timestamps for the entire list of sessions
-        replay_session_ids = [session_id for session_id, _, _ in found_sessions]
-        min_timestamp = min(ts for _, ts, _ in found_sessions)
-        max_timestamp = max(ts for _, _, ts in found_sessions)
+        replay_session_ids = [session_id for session_id, _, _, _ in found_sessions]
+        min_timestamp = min(ts for _, ts, _, _ in found_sessions)
+        max_timestamp = max(ts for _, _, ts, _ in found_sessions)
         # Check which sessions also have events in the events table
         sessions_with_events = self._find_sessions_in_events(replay_session_ids, min_timestamp, max_timestamp, team)
         if not sessions_with_events:
             return set(), None, None
         # Filter to only sessions that exist in both tables
-        session_ids_found = {session_id for session_id, _, _ in found_sessions if session_id in sessions_with_events}
+        session_ids_found = {session_id for session_id, _, _, _ in found_sessions if session_id in sessions_with_events}
         if not session_ids_found:
             return set(), None, None
         # Recalculate timestamps for filtered sessions only
-        min_timestamp = min(ts for session_id, ts, _ in found_sessions if session_id in session_ids_found)
-        max_timestamp = max(ts for session_id, _, ts in found_sessions if session_id in session_ids_found)
+        min_timestamp = min(ts for session_id, ts, _, _ in found_sessions if session_id in session_ids_found)
+        max_timestamp = max(ts for session_id, _, ts, _ in found_sessions if session_id in session_ids_found)
         return session_ids_found, min_timestamp, max_timestamp
 
     @staticmethod
-    def _find_with_timestamps(session_ids: list[str], team: Team) -> list[tuple[str, datetime, datetime]]:
+    def _find_with_timestamps(session_ids: list[str], team: Team) -> list[tuple[str, datetime, datetime, datetime]]:
         """
         Check which session IDs exist in session_replay_events within retention period.
-        Returns a list of tuples of (session_id, min_timestamp, max_timestamp).
+        Returns a list of tuples of (session_id, min_timestamp, max_timestamp, expiry_time).
         Timestamps are per session, not for the entire list of sessions.
         """
         from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
@@ -184,7 +190,9 @@ class SessionReplayEvents:
         result = HogQLQueryRunner(team=team, query=query).calculate()
         if not result.results:
             return []
-        sessions_found: list[tuple[str, datetime, datetime]] = [(row[0], row[1], row[2]) for row in result.results]
+        sessions_found: list[tuple[str, datetime, datetime, datetime]] = [
+            (row[0], row[1], row[2], row[4]) for row in result.results
+        ]
         return sessions_found
 
     @staticmethod

--- a/posthog/session_recordings/queries/session_replay_events.py
+++ b/posthog/session_recordings/queries/session_replay_events.py
@@ -33,7 +33,7 @@ def seconds_until_midnight():
 
 class SessionReplayEvents:
     def exists(self, session_id: str, team: Team) -> bool:
-        cache_key = f"summarize_recording_existence_team_{team.pk}_id_{session_id}"
+        cache_key = f"session_recording_existence_team_{team.pk}_id_{session_id}"
         cached_response = cache.get(cache_key)
         if isinstance(cached_response, bool):
             return cached_response
@@ -62,7 +62,7 @@ class SessionReplayEvents:
 
         # Check cache first
         for sid in session_ids:
-            cache_key = f"summarize_recording_existence_team_{team.pk}_id_{sid}"
+            cache_key = f"session_recording_existence_team_{team.pk}_id_{sid}"
             cached_value = cache.get(cache_key)
             if cached_value is True:
                 results[sid] = True
@@ -81,7 +81,7 @@ class SessionReplayEvents:
             exists = sid in existing_session_ids
             results[sid] = exists
             if exists:
-                cache_key = f"summarize_recording_existence_team_{team.pk}_id_{sid}"
+                cache_key = f"session_recording_existence_team_{team.pk}_id_{sid}"
                 cache.set(cache_key, True, timeout=seconds_until_midnight())
 
         return results

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1719,3 +1719,116 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
         for unexpected in must_not_be_in_results:
             assert unexpected not in session_ids, f"Expected {unexpected} to NOT be in results, but got {session_ids}"
+
+    def test_batch_check_exists_returns_correct_results(self):
+        """Test that batch_check_exists returns correct existence status for session IDs."""
+        base_time = now() - relativedelta(days=1)
+
+        # Create some recordings
+        self.produce_replay_summary("user1", "existing_session_1", base_time)
+        self.produce_replay_summary("user2", "existing_session_2", base_time)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/session_recordings/batch_check_exists",
+            {"session_ids": ["existing_session_1", "existing_session_2", "non_existent_session"]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+
+        assert results["existing_session_1"] is True
+        assert results["existing_session_2"] is True
+        assert results["non_existent_session"] is False
+
+    @parameterized.expand(
+        [
+            ("empty_list", {"session_ids": []}, "session_ids must be provided as a non-empty array"),
+            ("missing_session_ids", {}, "session_ids must be provided as a non-empty array"),
+            ("not_a_list", {"session_ids": "not_a_list"}, "session_ids must be provided as a non-empty array"),
+            (
+                "too_many_ids",
+                {"session_ids": [f"session_{i}" for i in range(101)]},
+                "Cannot check more than 100 session IDs at once",
+            ),
+        ]
+    )
+    def test_batch_check_exists_validation_errors(self, _test_name, request_data, expected_error_message):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/session_recordings/batch_check_exists",
+            request_data,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == expected_error_message
+
+    def test_batch_check_exists_doesnt_leak_teams(self):
+        """Test that batch_check_exists doesn't return recordings from other teams."""
+        other_team = Team.objects.create(organization=self.organization)
+
+        base_time = now() - relativedelta(days=1)
+
+        # Create recording in other team
+        self.produce_replay_summary("user1", "other_team_session", base_time, team_id=other_team.pk)
+
+        # Create recording in current team
+        self.produce_replay_summary("user1", "current_team_session", base_time)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/session_recordings/batch_check_exists",
+            {"session_ids": ["other_team_session", "current_team_session"]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+
+        # Should only find the current team's recording
+        assert results["other_team_session"] is False
+        assert results["current_team_session"] is True
+
+    def test_batch_check_exists_caches_positive_results(self):
+        """Test that positive results (exists=True) are cached."""
+        from django.core.cache import cache
+
+        base_time = now() - relativedelta(days=1)
+        session_id = "cached_session"
+
+        self.produce_replay_summary("user1", session_id, base_time)
+
+        # Clear any existing cache
+        cache_key = f"summarize_recording_existence_team_{self.team.pk}_id_{session_id}"
+        cache.delete(cache_key)
+
+        # First request - should query ClickHouse and cache result
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/session_recordings/batch_check_exists",
+            {"session_ids": [session_id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"][session_id] is True
+
+        # Check cache was set
+        cached_value = cache.get(cache_key)
+        assert cached_value is True
+
+    def test_batch_check_exists_does_not_cache_negative_results(self):
+        """Test that negative results (exists=False) are NOT cached."""
+        from django.core.cache import cache
+
+        session_id = "non_existent_session_nocache"
+
+        # Clear any existing cache
+        cache_key = f"summarize_recording_existence_team_{self.team.pk}_id_{session_id}"
+        cache.delete(cache_key)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/session_recordings/batch_check_exists",
+            {"session_ids": [session_id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"][session_id] is False
+
+        # Check cache was NOT set for negative result
+        cached_value = cache.get(cache_key)
+        assert cached_value is None

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1795,7 +1795,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         self.produce_replay_summary("user1", session_id, base_time)
 
         # Clear any existing cache
-        cache_key = f"summarize_recording_existence_team_{self.team.pk}_id_{session_id}"
+        cache_key = f"session_recording_existence_team_{self.team.pk}_id_{session_id}"
         cache.delete(cache_key)
 
         # First request - should query ClickHouse and cache result
@@ -1818,7 +1818,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         session_id = "non_existent_session_nocache"
 
         # Clear any existing cache
-        cache_key = f"summarize_recording_existence_team_{self.team.pk}_id_{session_id}"
+        cache_key = f"session_recording_existence_team_{self.team.pk}_id_{session_id}"
         cache.delete(cache_key)
 
         response = self.client.post(

--- a/products/logs/frontend/components/LogsViewer/LogAttributes.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogAttributes.tsx
@@ -141,6 +141,7 @@ export function LogAttributes({ attributes, type, logUuid, title }: LogAttribute
                                             openPlayerIn={RecordingPlayerType.Modal}
                                             label={record.value}
                                             variant={ViewRecordingButtonVariant.Link}
+                                            checkRecordingExists
                                         />
                                     ) : (
                                         <span>{record.value}</span>

--- a/products/logs/frontend/components/VirtualizedLogsList/cells/AttributeCell.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/cells/AttributeCell.tsx
@@ -53,6 +53,7 @@ export const AttributeCell = memo(function AttributeCell({
                             label={value}
                             variant={ViewRecordingButtonVariant.Link}
                             className="font-mono text-xs whitespace-nowrap pr-24"
+                            checkRecordingExists
                         />
                     ) : (
                         <span className="font-mono text-xs text-muted whitespace-nowrap pr-24" title={value}>


### PR DESCRIPTION
## Problem

![2026-01-23 16.02.04.gif](https://app.graphite.com/user-attachments/assets/ee5fe556-1935-44e8-a9f1-5544e77b6173.gif)

When viewing logs or other data with session IDs, users can't easily tell if a recording exists for that session without clicking through to check. This creates friction in the workflow and can lead to wasted time clicking on sessions that don't have recordings.

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/dfd1b413-2c98-4561-9e3e-a8e6479e0351.png)
![image.png](https://app.graphite.com/user-attachments/assets/26aad677-5866-441d-9bab-ce67f7a06e17.png)

- Added a new API endpoint `batch_check_exists` to efficiently check if recordings exist for multiple session IDs
- Created a new `sessionRecordingExistsLogic` to manage batched API calls and cache results
- Enhanced `ViewRecordingButton` with a `checkRecordingExists` prop that automatically verifies if a recording exists
- Applied this improvement to session ID links in logs UI components
- Added proper caching for positive results to reduce API load
- Added comprehensive tests for the new functionality

## How did you test this code?

- Added unit tests for the new `batch_check_exists` API endpoint
- Tested caching behavior to ensure positive results are cached while negative results are not
- Verified the UI correctly shows disabled state for non-existent recordings
- Tested with both existing and non-existing session IDs to ensure correct behavior
- Verified that the batching mechanism correctly handles multiple session IDs