### PR TITLE
fix(surveys): fix UI copy on survey repeat scheduling

### DIFF
--- a/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
+++ b/frontend/src/scenes/surveys/SurveyRepeatSchedule.tsx
@@ -121,54 +121,63 @@ function SurveyIterationOptions(): JSX.Element {
                             label: 'Repeat on a schedule',
                             'data-attr': 'survey-iteration-frequency-days',
                             description: showSurveyRepeatSchedule ? (
-                                <div className="flex flex-row gap-2 items-center text-secondary">
-                                    Repeat this survey{' '}
-                                    <LemonField name="iteration_count">
-                                        {({ onChange, value }) => {
-                                            return (
-                                                <LemonInput
-                                                    type="number"
-                                                    data-attr="survey-iteration-count"
-                                                    size="small"
-                                                    min={1}
-                                                    // NB this is enforced in the API too
-                                                    max={500}
-                                                    value={value || 2}
-                                                    onChange={(newValue) => {
-                                                        if (newValue && newValue > 0) {
-                                                            onChange(newValue)
-                                                        } else {
-                                                            onChange(null)
-                                                        }
-                                                    }}
-                                                    className="w-16"
-                                                />
-                                            )
-                                        }}
-                                    </LemonField>{' '}
-                                    times, once every
-                                    <LemonField name="iteration_frequency_days">
-                                        {({ onChange, value }) => {
-                                            return (
-                                                <LemonInput
-                                                    type="number"
-                                                    data-attr="survey-iteration-frequency-days"
-                                                    size="small"
-                                                    min={1}
-                                                    value={value || 90}
-                                                    onChange={(newValue) => {
-                                                        if (newValue && newValue > 0) {
-                                                            onChange(newValue)
-                                                        } else {
-                                                            onChange(null)
-                                                        }
-                                                    }}
-                                                    className="w-16"
-                                                />
-                                            )
-                                        }}
-                                    </LemonField>{' '}
-                                    days
+                                <div className="flex flex-col gap-1">
+                                    <div className="flex flex-row gap-2 items-center text-secondary">
+                                        Show up to{' '}
+                                        <LemonField name="iteration_count">
+                                            {({ onChange, value }) => {
+                                                return (
+                                                    <LemonInput
+                                                        type="number"
+                                                        data-attr="survey-iteration-count"
+                                                        size="small"
+                                                        min={1}
+                                                        // NB this is enforced in the API too
+                                                        max={500}
+                                                        value={value || 2}
+                                                        onChange={(newValue) => {
+                                                            if (newValue && newValue > 0) {
+                                                                onChange(newValue)
+                                                            } else {
+                                                                onChange(null)
+                                                            }
+                                                        }}
+                                                        className="w-16"
+                                                    />
+                                                )
+                                            }}
+                                        </LemonField>{' '}
+                                        times total, once every
+                                        <LemonField name="iteration_frequency_days">
+                                            {({ onChange, value }) => {
+                                                return (
+                                                    <LemonInput
+                                                        type="number"
+                                                        data-attr="survey-iteration-frequency-days"
+                                                        size="small"
+                                                        min={1}
+                                                        value={value || 90}
+                                                        onChange={(newValue) => {
+                                                            if (newValue && newValue > 0) {
+                                                                onChange(newValue)
+                                                            } else {
+                                                                onChange(null)
+                                                            }
+                                                        }}
+                                                        className="w-16"
+                                                    />
+                                                )
+                                            }}
+                                        </LemonField>{' '}
+                                        days
+                                    </div>
+                                    {survey.iteration_count && survey.iteration_frequency_days && (
+                                        <div className="text-xs text-muted">
+                                            {survey.iteration_count === 1
+                                                ? 'This survey will only be shown once (no repeats).'
+                                                : `This survey will be shown now, then ${survey.iteration_count - 1} more ${pluralize(survey.iteration_count - 1, 'time', 'times', false)} with ${pluralize(survey.iteration_frequency_days, 'day')} between each.`}
+                                        </div>
+                                    )}
                                 </div>
                             ) : undefined,
                         },


### PR DESCRIPTION
## Problem

our UI copy for repeated surveys is misleading

it says "Repeat this survey X times, once every Y days"

if i input x=1, y=120, that sounds like the survey is going to show now, then **repeat 1 time in 120 days**, for a total of **two** showings

BUT that's not how the backend works -- it treats `x` as the TOTAL number of times a survey can be shown

the [docs](https://posthog.com/docs/surveys/creating-surveys) are right, but the UI is misleading

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

updates UI copy to be clearer here. i think the better fix is updating the backend, but we have ~260 active surveys with iteration_count=1, and this is less risky for backwards compat... and if a user has an issue with this in the future, they'll see the new UI messaging

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

|  |  |  |
| --- | --- | --- |
| ![Screenshot 2026-01-23 at 9.39.34 AM.png](https://app.graphite.com/user-attachments/assets/bb4a8a78-b1fa-4590-9ed8-1065afa54dff.png)<br> | ![Screenshot 2026-01-23 at 9.39.38 AM.png](https://app.graphite.com/user-attachments/assets/6e5173a0-2ff8-4fab-b8a4-308709ccbed9.png)<br> | ![Screenshot 2026-01-23 at 9.39.45 AM.png](https://app.graphite.com/user-attachments/assets/dc8ce286-859f-45f2-8089-5ded586bfbd5.png)<br> |

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->