### PR TITLE
chore(web-analytics): change favicons cdn url

### DIFF
--- a/frontend/src/scenes/web-analytics/common.ts
+++ b/frontend/src/scenes/web-analytics/common.ts
@@ -554,7 +554,7 @@ export interface ParsedURL {
     isValid: boolean
 }
 
-export const faviconUrl = (domain: string): string => `${window.JS_URL}/static/favicons/${domain}`
+export const faviconUrl = (domain: string): string => `${window.JS_URL}/favicons/${domain}`
 
 export const parseWebAnalyticsURL = (urlString: string): ParsedURL => {
     try {


### PR DESCRIPTION
## Problem

We changed the S3 bucket directory, but the CDN options behave differently, we don't need to prepend `/static` when using the CDN destination 

❌ Doesn't work: 
https://app-static-prod.posthog.com/static/favicons/eu.posthog.com
✅ Works
https://app-static-prod.posthog.com/favicons/eu.posthog.com
