### PR TITLE
fix(storybook): skip networkidle wait for iframe stories

### DIFF
--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.stories.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.stories.tsx
@@ -79,6 +79,7 @@ export const IframeExample: Story = {
         pageUrl: urls.heatmap('hm_iframe'),
         testOptions: {
             waitForSelector: '#heatmap-iframe',
+            skipIframeWait: true,
         },
     },
     decorators: [


### PR DESCRIPTION
**What?** Makes `skipIframeWait` also skip the `networkidle` wait in the storybook test-runner.

**Why?** Stories with iframes (like `HeatmapScene.IframeExample`) cause ongoing network activity that prevents `networkidle` from being reached, causing 10s timeouts in CI. The `skipIframeWait` option already existed but only skipped the iframe load tracking, not the networkidle wait.

**How?** Pass the `skipIframeWait` flag to `waitForPageReady()` to skip `page.waitForLoadState('networkidle')` for these stories.