### PR TITLE
feat(personhog-replica): use shutdown status for readiness endpoint

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5923,6 +5923,7 @@ dependencies = [
  "common-database",
  "common-metrics",
  "envconfig",
+ "health",
  "personhog-proto",
  "rand 0.8.5",
  "serde_json",

--- a/rust/personhog-replica/Cargo.toml
+++ b/rust/personhog-replica/Cargo.toml
@@ -9,6 +9,7 @@ personhog-proto = { path = "../personhog-proto" }
 common-database = { path = "../common/database" }
 common-metrics = { path = "../common/metrics" }
 common-alloc = { path = "../common/alloc" }
+health = { path = "../common/health" }
 
 async-trait = { workspace = true }
 axum = { workspace = true }

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -13,6 +13,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
+use health::readiness_handler;
 use personhog_replica::config::Config;
 use personhog_replica::service::PersonHogReplicaService;
 use personhog_replica::storage::postgres::PostgresStorage;
@@ -86,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start HTTP server for metrics and health checks
     let metrics_port = config.metrics_port;
     let health_router = Router::new()
-        .route("/_readiness", get(|| async { "ok" }))
+        .route("/_readiness", get(readiness_handler))
         .route("/_liveness", get(|| async { "ok" }));
     let metrics_router = setup_metrics_routes(health_router);
 


### PR DESCRIPTION
## Problem

The personhog-replica should have a useful readiness probe so that rolling deploys are graceful.

## Changes

- moves the shutdown/readiness probe logic from capture into /common/health crate
- updates capture to import factored out readiness probe from shared crate
- adds readiness probe implementation to personhog-replica

## How did you test this code?

There are unit tests written that cover some of the shutdown code.
The implementation should not have changed and was working for capture.