### PR TITLE
chore: reduce boilerplate for onboarding docs

### DIFF
--- a/docs/onboarding/experiments/_snippets/experiment-implementation.tsx
+++ b/docs/onboarding/experiments/_snippets/experiment-implementation.tsx
@@ -1,11 +1,7 @@
 import { memo } from 'react'
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const ExperimentImplementationSnippet = memo(function ExperimentImplementationSnippet({
-    language = 'javascript',
-}: {
-    language?: string
-}): JSX.Element {
+export const ExperimentImplementationSnippet = memo(({ language = 'javascript' }: { language?: string }): JSX.Element => {
     const { CodeBlock, dedent } = useMDXComponents()
 
     const snippets: Record<string, string> = {

--- a/docs/onboarding/experiments/android.tsx
+++ b/docs/onboarding/experiments/android.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getAndroidSteps as getAndroidStepsPA } from '../product-analytics/android'
 import { StepDefinition } from '../steps'
 
-export const getAndroidSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAndroidSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/android.tsx
+++ b/docs/onboarding/experiments/android.tsx
@@ -1,18 +1,14 @@
-import { getAndroidSteps as getAndroidStepsPA } from '../product-analytics/android'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getAndroidSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getAndroidSteps as getAndroidStepsPA } from '../product-analytics/android'
+import { StepDefinition } from '../steps'
+
+export const getAndroidSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only (exclude "Send events")
-    const installationSteps = getAndroidStepsPA(CodeBlock, Markdown, dedent).filter(
+    const installationSteps = getAndroidStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -45,21 +41,7 @@ export const getAndroidSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const AndroidInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getAndroidSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const AndroidInstallation = createInstallation(getAndroidSteps)

--- a/docs/onboarding/experiments/angular.tsx
+++ b/docs/onboarding/experiments/angular.tsx
@@ -1,18 +1,14 @@
-import { getAngularSteps as getAngularStepsPA } from '../product-analytics/angular'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getAngularSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getAngularSteps as getAngularStepsPA } from '../product-analytics/angular'
+import { StepDefinition } from '../steps'
+
+export const getAngularSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getAngularStepsPA(CodeBlock, Markdown, dedent, snippets).filter(
+    const installationSteps = getAngularStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -45,21 +41,7 @@ export const getAngularSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const AngularInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getAngularSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const AngularInstallation = createInstallation(getAngularSteps)

--- a/docs/onboarding/experiments/angular.tsx
+++ b/docs/onboarding/experiments/angular.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getAngularSteps as getAngularStepsPA } from '../product-analytics/angular'
 import { StepDefinition } from '../steps'
 
-export const getAngularSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAngularSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/astro.tsx
+++ b/docs/onboarding/experiments/astro.tsx
@@ -1,18 +1,14 @@
-import { getAstroSteps as getAstroStepsPA } from '../product-analytics/astro'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getAstroSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getAstroSteps as getAstroStepsPA } from '../product-analytics/astro'
+import { StepDefinition } from '../steps'
+
+export const getAstroSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getAstroStepsPA(CodeBlock, Markdown, dedent, snippets).filter(
+    const installationSteps = getAstroStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -45,21 +41,7 @@ export const getAstroSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const AstroInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getAstroSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const AstroInstallation = createInstallation(getAstroSteps)

--- a/docs/onboarding/experiments/astro.tsx
+++ b/docs/onboarding/experiments/astro.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getAstroSteps as getAstroStepsPA } from '../product-analytics/astro'
 import { StepDefinition } from '../steps'
 
-export const getAstroSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAstroSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/bubble.tsx
+++ b/docs/onboarding/experiments/bubble.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getBubbleSteps as getBubbleStepsPA } from '../product-analytics/bubble'
 import { StepDefinition } from '../steps'
 
-export const getBubbleSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getBubbleSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/bubble.tsx
+++ b/docs/onboarding/experiments/bubble.tsx
@@ -1,18 +1,14 @@
-import { getBubbleSteps as getBubbleStepsPA } from '../product-analytics/bubble'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getBubbleSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getBubbleSteps as getBubbleStepsPA } from '../product-analytics/bubble'
+import { StepDefinition } from '../steps'
+
+export const getBubbleSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getBubbleStepsPA(CodeBlock, Markdown, dedent, snippets).filter(
+    const installationSteps = getBubbleStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -45,21 +41,7 @@ export const getBubbleSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const BubbleInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getBubbleSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const BubbleInstallation = createInstallation(getBubbleSteps)

--- a/docs/onboarding/experiments/django.tsx
+++ b/docs/onboarding/experiments/django.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getDjangoSteps as getDjangoStepsPA } from '../product-analytics/django'
 import { StepDefinition } from '../steps'
 
-export const getDjangoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getDjangoSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/django.tsx
+++ b/docs/onboarding/experiments/django.tsx
@@ -1,18 +1,14 @@
-import { getDjangoSteps as getDjangoStepsPA } from '../product-analytics/django'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getDjangoSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getDjangoSteps as getDjangoStepsPA } from '../product-analytics/django'
+import { StepDefinition } from '../steps'
+
+export const getDjangoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getDjangoStepsPA(CodeBlock, Markdown, dedent, snippets).filter(
+    const installationSteps = getDjangoStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -47,21 +43,7 @@ export const getDjangoSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const DjangoInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getDjangoSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const DjangoInstallation = createInstallation(getDjangoSteps)

--- a/docs/onboarding/experiments/flutter.tsx
+++ b/docs/onboarding/experiments/flutter.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getFlutterSteps as getFlutterStepsPA } from '../product-analytics/flutter'
 import { StepDefinition } from '../steps'
 
-export const getFlutterSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getFlutterSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/flutter.tsx
+++ b/docs/onboarding/experiments/flutter.tsx
@@ -1,18 +1,14 @@
-import { getFlutterSteps as getFlutterStepsPA } from '../product-analytics/flutter'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getFlutterSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getFlutterSteps as getFlutterStepsPA } from '../product-analytics/flutter'
+import { StepDefinition } from '../steps'
+
+export const getFlutterSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getFlutterStepsPA(CodeBlock, Markdown, dedent).filter(
+    const installationSteps = getFlutterStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -45,21 +41,7 @@ export const getFlutterSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const FlutterInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getFlutterSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const FlutterInstallation = createInstallation(getFlutterSteps)

--- a/docs/onboarding/experiments/framer.tsx
+++ b/docs/onboarding/experiments/framer.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getFramerSteps as getFramerStepsPA } from '../product-analytics/framer'
 import { StepDefinition } from '../steps'
 
-export const getFramerSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getFramerSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/framer.tsx
+++ b/docs/onboarding/experiments/framer.tsx
@@ -1,18 +1,14 @@
-import { getFramerSteps as getFramerStepsPA } from '../product-analytics/framer'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getFramerSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getFramerSteps as getFramerStepsPA } from '../product-analytics/framer'
+import { StepDefinition } from '../steps'
+
+export const getFramerSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getFramerStepsPA(CodeBlock, Markdown, dedent, snippets).filter(
+    const installationSteps = getFramerStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -45,21 +41,7 @@ export const getFramerSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const FramerInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getFramerSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const FramerInstallation = createInstallation(getFramerSteps)

--- a/docs/onboarding/experiments/go.tsx
+++ b/docs/onboarding/experiments/go.tsx
@@ -1,18 +1,14 @@
-import { getGoSteps as getGoStepsPA } from '../product-analytics/go'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getGoSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getGoSteps as getGoStepsPA } from '../product-analytics/go'
+import { StepDefinition } from '../steps'
+
+export const getGoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getGoStepsPA(CodeBlock, Markdown, dedent).filter(
+    const installationSteps = getGoStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -47,21 +43,7 @@ export const getGoSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const GoInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getGoSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const GoInstallation = createInstallation(getGoSteps)

--- a/docs/onboarding/experiments/go.tsx
+++ b/docs/onboarding/experiments/go.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getGoSteps as getGoStepsPA } from '../product-analytics/go'
 import { StepDefinition } from '../steps'
 
-export const getGoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getGoSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/ios.tsx
+++ b/docs/onboarding/experiments/ios.tsx
@@ -1,18 +1,14 @@
-import { getIOSSteps as getIOSStepsPA } from '../product-analytics/ios'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getIOSSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getIOSSteps as getIOSStepsPA } from '../product-analytics/ios'
+import { StepDefinition } from '../steps'
+
+export const getIOSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getIOSStepsPA(CodeBlock, Markdown, dedent).filter(
+    const installationSteps = getIOSStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -45,21 +41,7 @@ export const getIOSSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const IOSInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getIOSSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const IOSInstallation = createInstallation(getIOSSteps)

--- a/docs/onboarding/experiments/ios.tsx
+++ b/docs/onboarding/experiments/ios.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getIOSSteps as getIOSStepsPA } from '../product-analytics/ios'
 import { StepDefinition } from '../steps'
 
-export const getIOSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/js-web.tsx
+++ b/docs/onboarding/experiments/js-web.tsx
@@ -1,18 +1,14 @@
-import { getJSWebSteps as getJSWebStepsPA } from '../product-analytics/js-web'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getJSWebSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getJSWebSteps as getJSWebStepsPA } from '../product-analytics/js-web'
+import { StepDefinition } from '../steps'
+
+export const getJSWebSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only (exclude "Send events")
-    const installationSteps = getJSWebStepsPA(CodeBlock, Markdown, dedent, snippets).filter(
+    const installationSteps = getJSWebStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -45,21 +41,7 @@ export const getJSWebSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const JSWebInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getJSWebSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const JSWebInstallation = createInstallation(getJSWebSteps)

--- a/docs/onboarding/experiments/js-web.tsx
+++ b/docs/onboarding/experiments/js-web.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getJSWebSteps as getJSWebStepsPA } from '../product-analytics/js-web'
 import { StepDefinition } from '../steps'
 
-export const getJSWebSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getJSWebSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/laravel.tsx
+++ b/docs/onboarding/experiments/laravel.tsx
@@ -1,18 +1,14 @@
-import { getLaravelSteps as getLaravelStepsPA } from '../product-analytics/laravel'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getLaravelSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getLaravelSteps as getLaravelStepsPA } from '../product-analytics/laravel'
+import { StepDefinition } from '../steps'
+
+export const getLaravelSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getLaravelStepsPA(CodeBlock, Markdown, dedent).filter(
+    const installationSteps = getLaravelStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -47,21 +43,7 @@ export const getLaravelSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const LaravelInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getLaravelSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const LaravelInstallation = createInstallation(getLaravelSteps)

--- a/docs/onboarding/experiments/laravel.tsx
+++ b/docs/onboarding/experiments/laravel.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getLaravelSteps as getLaravelStepsPA } from '../product-analytics/laravel'
 import { StepDefinition } from '../steps'
 
-export const getLaravelSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getLaravelSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/nextjs.tsx
+++ b/docs/onboarding/experiments/nextjs.tsx
@@ -1,21 +1,15 @@
-import { getNextJSSteps as getNextJSStepsPA } from '../product-analytics/nextjs'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getNextJSSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    Tab: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getNextJSSteps as getNextJSStepsPA } from '../product-analytics/nextjs'
+import { StepDefinition } from '../steps'
+
+export const getNextJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, Tab, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics (not feature-flags)
     // Filter to only keep installation-related steps, not usage steps
-    const installationSteps = getNextJSStepsPA(CodeBlock, Markdown, CalloutBox, Tab, dedent, snippets).filter(
+    const installationSteps = getNextJSStepsPA(ctx).filter(
         (step: StepDefinition) =>
             step.title === 'Install the package' ||
             step.title === 'Add environment variables' ||
@@ -75,21 +69,7 @@ export const getNextJSSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const NextJSInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, Tab, dedent, snippets } = useMDXComponents()
-    const steps = getNextJSSteps(CodeBlock, Markdown, CalloutBox, Tab, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const NextJSInstallation = createInstallation(getNextJSSteps)

--- a/docs/onboarding/experiments/nextjs.tsx
+++ b/docs/onboarding/experiments/nextjs.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getNextJSSteps as getNextJSStepsPA } from '../product-analytics/nextjs'
 import { StepDefinition } from '../steps'
 
-export const getNextJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, Tab, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/nodejs.tsx
+++ b/docs/onboarding/experiments/nodejs.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getNodeJSSteps as getNodeJSStepsPA } from '../product-analytics/nodejs'
 import { StepDefinition } from '../steps'
 
-export const getNodeJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getNodeJSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/nodejs.tsx
+++ b/docs/onboarding/experiments/nodejs.tsx
@@ -1,20 +1,14 @@
-import { getNodeJSSteps as getNodeJSStepsPA } from '../product-analytics/nodejs'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getNodeJSSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getNodeJSSteps as getNodeJSStepsPA } from '../product-analytics/nodejs'
+import { StepDefinition } from '../steps'
+
+export const getNodeJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only (exclude "Send an event")
-    const installationSteps = getNodeJSStepsPA(CodeBlock, Markdown, dedent).filter(
-        (step: StepDefinition) => step.title !== 'Send an event'
-    )
+    const installationSteps = getNodeJSStepsPA(ctx).filter((step: StepDefinition) => step.title !== 'Send an event')
 
     // Add experiments-specific steps
     const experimentSteps: StepDefinition[] = [
@@ -47,21 +41,7 @@ export const getNodeJSSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const NodeJSInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getNodeJSSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const NodeJSInstallation = createInstallation(getNodeJSSteps)

--- a/docs/onboarding/experiments/nuxt.tsx
+++ b/docs/onboarding/experiments/nuxt.tsx
@@ -1,19 +1,14 @@
-import { getNuxtSteps as getNuxtStepsPA } from '../product-analytics/nuxt'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getNuxtSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getNuxtSteps as getNuxtStepsPA } from '../product-analytics/nuxt'
+import { StepDefinition } from '../steps'
+
+export const getNuxtSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getNuxtStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets).filter(
+    const installationSteps = getNuxtStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -48,21 +43,7 @@ export const getNuxtSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const NuxtInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getNuxtSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const NuxtInstallation = createInstallation(getNuxtSteps)

--- a/docs/onboarding/experiments/nuxt.tsx
+++ b/docs/onboarding/experiments/nuxt.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getNuxtSteps as getNuxtStepsPA } from '../product-analytics/nuxt'
 import { StepDefinition } from '../steps'
 
-export const getNuxtSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getNuxtSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/php.tsx
+++ b/docs/onboarding/experiments/php.tsx
@@ -1,18 +1,14 @@
-import { getPHPSteps as getPHPStepsPA } from '../product-analytics/php'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getPHPSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getPHPSteps as getPHPStepsPA } from '../product-analytics/php'
+import { StepDefinition } from '../steps'
+
+export const getPHPSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getPHPStepsPA(CodeBlock, Markdown, dedent).filter(
+    const installationSteps = getPHPStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -47,21 +43,7 @@ export const getPHPSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const PHPInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getPHPSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const PHPInstallation = createInstallation(getPHPSteps)

--- a/docs/onboarding/experiments/php.tsx
+++ b/docs/onboarding/experiments/php.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getPHPSteps as getPHPStepsPA } from '../product-analytics/php'
 import { StepDefinition } from '../steps'
 
-export const getPHPSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getPHPSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/python.tsx
+++ b/docs/onboarding/experiments/python.tsx
@@ -1,19 +1,14 @@
-import { getPythonSteps as getPythonStepsPA } from '../product-analytics/python'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getPythonSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getPythonSteps as getPythonStepsPA } from '../product-analytics/python'
+import { StepDefinition } from '../steps'
+
+export const getPythonSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only (exclude "Send events")
-    const installationSteps = getPythonStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets).filter(
+    const installationSteps = getPythonStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -48,21 +43,7 @@ export const getPythonSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const PythonInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getPythonSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const PythonInstallation = createInstallation(getPythonSteps)

--- a/docs/onboarding/experiments/python.tsx
+++ b/docs/onboarding/experiments/python.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getPythonSteps as getPythonStepsPA } from '../product-analytics/python'
 import { StepDefinition } from '../steps'
 
-export const getPythonSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/react-native.tsx
+++ b/docs/onboarding/experiments/react-native.tsx
@@ -1,18 +1,14 @@
-import { getReactNativeSteps as getReactNativeStepsPA } from '../product-analytics/react-native'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getReactNativeSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getReactNativeSteps as getReactNativeStepsPA } from '../product-analytics/react-native'
+import { StepDefinition } from '../steps'
+
+export const getReactNativeSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getReactNativeStepsPA(CodeBlock, Markdown, dedent).filter(
+    const installationSteps = getReactNativeStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -45,21 +41,7 @@ export const getReactNativeSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const ReactNativeInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getReactNativeSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const ReactNativeInstallation = createInstallation(getReactNativeSteps)

--- a/docs/onboarding/experiments/react-native.tsx
+++ b/docs/onboarding/experiments/react-native.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getReactNativeSteps as getReactNativeStepsPA } from '../product-analytics/react-native'
 import { StepDefinition } from '../steps'
 
-export const getReactNativeSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/react.tsx
+++ b/docs/onboarding/experiments/react.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getReactSteps as getReactStepsPA } from '../product-analytics/react'
 import { StepDefinition } from '../steps'
 
-export const getReactSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getReactSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/react.tsx
+++ b/docs/onboarding/experiments/react.tsx
@@ -1,19 +1,14 @@
-import { getReactSteps as getReactStepsPA } from '../product-analytics/react'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getReactSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getReactSteps as getReactStepsPA } from '../product-analytics/react'
+import { StepDefinition } from '../steps'
+
+export const getReactSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only (exclude "Send events")
-    const installationSteps = getReactStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets).filter(
+    const installationSteps = getReactStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -48,21 +43,7 @@ export const getReactSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const ReactInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getReactSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const ReactInstallation = createInstallation(getReactSteps)

--- a/docs/onboarding/experiments/remix.tsx
+++ b/docs/onboarding/experiments/remix.tsx
@@ -1,19 +1,14 @@
-import { getRemixSteps as getRemixStepsPA } from '../product-analytics/remix'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getRemixSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getRemixSteps as getRemixStepsPA } from '../product-analytics/remix'
+import { StepDefinition } from '../steps'
+
+export const getRemixSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getRemixStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets).filter(
+    const installationSteps = getRemixStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -48,21 +43,7 @@ export const getRemixSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const RemixInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getRemixSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const RemixInstallation = createInstallation(getRemixSteps)

--- a/docs/onboarding/experiments/remix.tsx
+++ b/docs/onboarding/experiments/remix.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getRemixSteps as getRemixStepsPA } from '../product-analytics/remix'
 import { StepDefinition } from '../steps'
 
-export const getRemixSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getRemixSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/ruby.tsx
+++ b/docs/onboarding/experiments/ruby.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getRubySteps as getRubyStepsPA } from '../product-analytics/ruby'
 import { StepDefinition } from '../steps'
 
-export const getRubySteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getRubySteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/ruby.tsx
+++ b/docs/onboarding/experiments/ruby.tsx
@@ -1,18 +1,14 @@
-import { getRubySteps as getRubyStepsPA } from '../product-analytics/ruby'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getRubySteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getRubySteps as getRubyStepsPA } from '../product-analytics/ruby'
+import { StepDefinition } from '../steps'
+
+export const getRubySteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getRubyStepsPA(CodeBlock, Markdown, dedent).filter(
+    const installationSteps = getRubyStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -47,21 +43,7 @@ export const getRubySteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const RubyInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getRubySteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const RubyInstallation = createInstallation(getRubySteps)

--- a/docs/onboarding/experiments/svelte.tsx
+++ b/docs/onboarding/experiments/svelte.tsx
@@ -1,19 +1,14 @@
-import { getSvelteSteps as getSvelteStepsPA } from '../product-analytics/svelte'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getSvelteSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getSvelteSteps as getSvelteStepsPA } from '../product-analytics/svelte'
+import { StepDefinition } from '../steps'
+
+export const getSvelteSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getSvelteStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets).filter(
+    const installationSteps = getSvelteStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -48,21 +43,7 @@ export const getSvelteSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const SvelteInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getSvelteSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const SvelteInstallation = createInstallation(getSvelteSteps)

--- a/docs/onboarding/experiments/svelte.tsx
+++ b/docs/onboarding/experiments/svelte.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getSvelteSteps as getSvelteStepsPA } from '../product-analytics/svelte'
 import { StepDefinition } from '../steps'
 
-export const getSvelteSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getSvelteSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/vue.tsx
+++ b/docs/onboarding/experiments/vue.tsx
@@ -1,19 +1,14 @@
-import { getVueSteps as getVueStepsPA } from '../product-analytics/vue'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getVueSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getVueSteps as getVueStepsPA } from '../product-analytics/vue'
+import { StepDefinition } from '../steps'
+
+export const getVueSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getVueStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets).filter(
+    const installationSteps = getVueStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -46,21 +41,7 @@ export const getVueSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const VueInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getVueSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const VueInstallation = createInstallation(getVueSteps)

--- a/docs/onboarding/experiments/vue.tsx
+++ b/docs/onboarding/experiments/vue.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getVueSteps as getVueStepsPA } from '../product-analytics/vue'
 import { StepDefinition } from '../steps'
 
-export const getVueSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getVueSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/webflow.tsx
+++ b/docs/onboarding/experiments/webflow.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getWebflowSteps as getWebflowStepsPA } from '../product-analytics/webflow'
 import { StepDefinition } from '../steps'
 
-export const getWebflowSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getWebflowSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 

--- a/docs/onboarding/experiments/webflow.tsx
+++ b/docs/onboarding/experiments/webflow.tsx
@@ -1,18 +1,14 @@
-import { getWebflowSteps as getWebflowStepsPA } from '../product-analytics/webflow'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getWebflowSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getWebflowSteps as getWebflowStepsPA } from '../product-analytics/webflow'
+import { StepDefinition } from '../steps'
+
+export const getWebflowSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const ExperimentImplementation = snippets?.ExperimentImplementationSnippet
 
     // Get installation steps from product-analytics only
-    const installationSteps = getWebflowStepsPA(CodeBlock, Markdown, dedent, snippets).filter(
+    const installationSteps = getWebflowStepsPA(ctx).filter(
         (step: StepDefinition) => step.title !== 'Send events'
     )
 
@@ -45,21 +41,7 @@ export const getWebflowSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...experimentSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...experimentSteps]
 }
 
-export const WebflowInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getWebflowSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const WebflowInstallation = createInstallation(getWebflowSteps)

--- a/docs/onboarding/feature-flags/_snippets/boolean-flag.tsx
+++ b/docs/onboarding/feature-flags/_snippets/boolean-flag.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const BooleanFlagSnippet = memo(function BooleanFlagSnippet({ language = 'javascript' }: { language?: string }): JSX.Element {
+export const BooleanFlagSnippet = memo(({ language = 'javascript' }: { language?: string }): JSX.Element => {
     const { CodeBlock, dedent } = useMDXComponents()
 
     const snippets: Record<string, string> = {

--- a/docs/onboarding/feature-flags/_snippets/flag-payload.tsx
+++ b/docs/onboarding/feature-flags/_snippets/flag-payload.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const FlagPayloadSnippet = memo(function FlagPayloadSnippet({ language = 'javascript' }: { language?: string }): JSX.Element {
+export const FlagPayloadSnippet = memo(({ language = 'javascript' }: { language?: string }): JSX.Element => {
     const { CodeBlock, dedent } = useMDXComponents()
 
     const snippets: Record<string, string> = {

--- a/docs/onboarding/feature-flags/_snippets/multivariate-flag.tsx
+++ b/docs/onboarding/feature-flags/_snippets/multivariate-flag.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const MultivariateFlagSnippet = memo(function MultivariateFlagSnippet({ language = 'javascript' }: { language?: string }): JSX.Element {
+export const MultivariateFlagSnippet = memo(({ language = 'javascript' }: { language?: string }): JSX.Element => {
     const { CodeBlock, dedent } = useMDXComponents()
 
     const snippets: Record<string, string> = {

--- a/docs/onboarding/feature-flags/_snippets/override-properties.tsx
+++ b/docs/onboarding/feature-flags/_snippets/override-properties.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const OverridePropertiesSnippet = memo(function OverridePropertiesSnippet({ language = 'javascript' }: { language?: string }): JSX.Element {
+export const OverridePropertiesSnippet = memo(({ language = 'javascript' }: { language?: string }): JSX.Element => {
     const { CodeBlock, dedent, Markdown } = useMDXComponents()
 
     const snippets: Record<string, string> = {

--- a/docs/onboarding/feature-flags/_snippets/reload-flags.tsx
+++ b/docs/onboarding/feature-flags/_snippets/reload-flags.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const ReloadFlagsSnippet = memo(function ReloadFlagsSnippet({ language = 'javascript' }: { language?: string }): JSX.Element {
+export const ReloadFlagsSnippet = memo(({ language = 'javascript' }: { language?: string }): JSX.Element => {
     const { CodeBlock, dedent } = useMDXComponents()
 
     const snippets: Record<string, string> = {

--- a/docs/onboarding/feature-flags/android.tsx
+++ b/docs/onboarding/feature-flags/android.tsx
@@ -1,10 +1,13 @@
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { getAndroidSteps as getAndroidStepsPA } from '../product-analytics/android'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 import { StepDefinition } from '../steps'
 
-export const getAndroidSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
+export const getAndroidSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
     // Get installation steps from product-analytics
-    const installationSteps = getAndroidStepsPA(CodeBlock, Markdown, dedent)
+    const installationSteps = getAndroidStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -82,17 +85,4 @@ export const getAndroidSteps = (CodeBlock: any, Markdown: any, dedent: any): Ste
     return [...installationSteps, ...flagSteps]
 }
 
-export const AndroidInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getAndroidSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const AndroidInstallation = createInstallation(getAndroidSteps)

--- a/docs/onboarding/feature-flags/android.tsx
+++ b/docs/onboarding/feature-flags/android.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getAndroidSteps as getAndroidStepsPA } from '../product-analytics/android'
 import { StepDefinition } from '../steps'
 
-export const getAndroidSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAndroidSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     // Get installation steps from product-analytics

--- a/docs/onboarding/feature-flags/angular.tsx
+++ b/docs/onboarding/feature-flags/angular.tsx
@@ -1,19 +1,15 @@
-import { getAngularSteps as getAngularStepsPA } from '../product-analytics/angular'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getAngularSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getAngularSteps as getAngularStepsPA } from '../product-analytics/angular'
+import { StepDefinition } from '../steps'
+
+export const getAngularSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getAngularStepsPA(CodeBlock, Markdown, dedent, snippets)
+    const installationSteps = getAngularStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -58,21 +54,7 @@ export const getAngularSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const AngularInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getAngularSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const AngularInstallation = createInstallation(getAngularSteps)

--- a/docs/onboarding/feature-flags/angular.tsx
+++ b/docs/onboarding/feature-flags/angular.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getAngularSteps as getAngularStepsPA } from '../product-analytics/angular'
 import { StepDefinition } from '../steps'
 
-export const getAngularSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAngularSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/api.tsx
+++ b/docs/onboarding/feature-flags/api.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getAPISteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAPISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/feature-flags/api.tsx
+++ b/docs/onboarding/feature-flags/api.tsx
@@ -1,13 +1,11 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getAPISteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    options?: StepModifier
-): StepDefinition[] => {
-    const steps: StepDefinition[] = [
+import { StepDefinition } from '../steps'
+
+export const getAPISteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
         {
             title: 'Evaluate the feature flag value using flags',
             badge: 'required',
@@ -214,21 +212,6 @@ export const getAPISteps = (
             ),
         },
     ]
-    return options?.modifySteps ? options.modifySteps(steps) : steps
 }
 
-export const APIInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-
-    const steps = getAPISteps(CodeBlock, Markdown, dedent, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const APIInstallation = createInstallation(getAPISteps)

--- a/docs/onboarding/feature-flags/astro.tsx
+++ b/docs/onboarding/feature-flags/astro.tsx
@@ -1,19 +1,15 @@
-import { getAstroSteps as getAstroStepsPA } from '../product-analytics/astro'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getAstroSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getAstroSteps as getAstroStepsPA } from '../product-analytics/astro'
+import { StepDefinition } from '../steps'
+
+export const getAstroSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getAstroStepsPA(CodeBlock, Markdown, dedent, snippets)
+    const installationSteps = getAstroStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -58,21 +54,7 @@ export const getAstroSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const AstroInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getAstroSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const AstroInstallation = createInstallation(getAstroSteps)

--- a/docs/onboarding/feature-flags/astro.tsx
+++ b/docs/onboarding/feature-flags/astro.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getAstroSteps as getAstroStepsPA } from '../product-analytics/astro'
 import { StepDefinition } from '../steps'
 
-export const getAstroSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAstroSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/bubble.tsx
+++ b/docs/onboarding/feature-flags/bubble.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getBubbleSteps as getBubbleStepsPA } from '../product-analytics/bubble'
 import { StepDefinition } from '../steps'
 
-export const getBubbleSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getBubbleSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/bubble.tsx
+++ b/docs/onboarding/feature-flags/bubble.tsx
@@ -1,19 +1,15 @@
-import { getBubbleSteps as getBubbleStepsPA } from '../product-analytics/bubble'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getBubbleSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getBubbleSteps as getBubbleStepsPA } from '../product-analytics/bubble'
+import { StepDefinition } from '../steps'
+
+export const getBubbleSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getBubbleStepsPA(CodeBlock, Markdown, dedent, snippets)
+    const installationSteps = getBubbleStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -58,21 +54,7 @@ export const getBubbleSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const BubbleInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getBubbleSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const BubbleInstallation = createInstallation(getBubbleSteps)

--- a/docs/onboarding/feature-flags/django.tsx
+++ b/docs/onboarding/feature-flags/django.tsx
@@ -1,19 +1,15 @@
-import { getDjangoSteps as getDjangoStepsPA } from '../product-analytics/django'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getDjangoSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getDjangoSteps as getDjangoStepsPA } from '../product-analytics/django'
+import { StepDefinition } from '../steps'
+
+export const getDjangoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getDjangoStepsPA(CodeBlock, Markdown, dedent, snippets)
+    const installationSteps = getDjangoStepsPA(ctx)
 
     // Add flag-specific steps (using Python flag implementation)
     const flagSteps: StepDefinition[] = [
@@ -58,21 +54,7 @@ export const getDjangoSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const DjangoInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getDjangoSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const DjangoInstallation = createInstallation(getDjangoSteps)

--- a/docs/onboarding/feature-flags/django.tsx
+++ b/docs/onboarding/feature-flags/django.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getDjangoSteps as getDjangoStepsPA } from '../product-analytics/django'
 import { StepDefinition } from '../steps'
 
-export const getDjangoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getDjangoSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/flutter.tsx
+++ b/docs/onboarding/feature-flags/flutter.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getFlutterSteps as getFlutterStepsPA } from '../product-analytics/flutter'
 import { StepDefinition } from '../steps'
 
-export const getFlutterSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getFlutterSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     // Get installation steps from product-analytics

--- a/docs/onboarding/feature-flags/flutter.tsx
+++ b/docs/onboarding/feature-flags/flutter.tsx
@@ -1,10 +1,13 @@
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { getFlutterSteps as getFlutterStepsPA } from '../product-analytics/flutter'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 import { StepDefinition } from '../steps'
 
-export const getFlutterSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
+export const getFlutterSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
     // Get installation steps from product-analytics
-    const installationSteps = getFlutterStepsPA(CodeBlock, Markdown, dedent)
+    const installationSteps = getFlutterStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -82,17 +85,4 @@ export const getFlutterSteps = (CodeBlock: any, Markdown: any, dedent: any): Ste
     return [...installationSteps, ...flagSteps]
 }
 
-export const FlutterInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getFlutterSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const FlutterInstallation = createInstallation(getFlutterSteps)

--- a/docs/onboarding/feature-flags/framer.tsx
+++ b/docs/onboarding/feature-flags/framer.tsx
@@ -1,19 +1,15 @@
-import { getFramerSteps as getFramerStepsPA } from '../product-analytics/framer'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getFramerSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getFramerSteps as getFramerStepsPA } from '../product-analytics/framer'
+import { StepDefinition } from '../steps'
+
+export const getFramerSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getFramerStepsPA(CodeBlock, Markdown, dedent, snippets)
+    const installationSteps = getFramerStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -58,21 +54,7 @@ export const getFramerSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const FramerInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getFramerSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const FramerInstallation = createInstallation(getFramerSteps)

--- a/docs/onboarding/feature-flags/framer.tsx
+++ b/docs/onboarding/feature-flags/framer.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getFramerSteps as getFramerStepsPA } from '../product-analytics/framer'
 import { StepDefinition } from '../steps'
 
-export const getFramerSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getFramerSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/go.tsx
+++ b/docs/onboarding/feature-flags/go.tsx
@@ -1,21 +1,16 @@
-import { getGoSteps as getGoStepsPA } from '../product-analytics/go'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getGoSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    Tab: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getGoSteps as getGoStepsPA } from '../product-analytics/go'
+import { StepDefinition } from '../steps'
+
+export const getGoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
     const OverrideProperties = snippets?.OverridePropertiesSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getGoStepsPA(CodeBlock, Markdown, dedent)
+    const installationSteps = getGoStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -133,21 +128,7 @@ export const getGoSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const GoInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets, Tab } = useMDXComponents()
-    const steps = getGoSteps(CodeBlock, Markdown, dedent, Tab, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const GoInstallation = createInstallation(getGoSteps)

--- a/docs/onboarding/feature-flags/go.tsx
+++ b/docs/onboarding/feature-flags/go.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getGoSteps as getGoStepsPA } from '../product-analytics/go'
 import { StepDefinition } from '../steps'
 
-export const getGoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getGoSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/ios.tsx
+++ b/docs/onboarding/feature-flags/ios.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getIOSSteps as getIOSStepsPA } from '../product-analytics/ios'
 import { StepDefinition } from '../steps'
 
-export const getIOSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     // Get installation steps from product-analytics

--- a/docs/onboarding/feature-flags/ios.tsx
+++ b/docs/onboarding/feature-flags/ios.tsx
@@ -1,10 +1,13 @@
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { getIOSSteps as getIOSStepsPA } from '../product-analytics/ios'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 import { StepDefinition } from '../steps'
 
-export const getIOSSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
+export const getIOSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
     // Get installation steps from product-analytics
-    const installationSteps = getIOSStepsPA(CodeBlock, Markdown, dedent)
+    const installationSteps = getIOSStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -82,17 +85,4 @@ export const getIOSSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDef
     return [...installationSteps, ...flagSteps]
 }
 
-export const IOSInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getIOSSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const IOSInstallation = createInstallation(getIOSSteps)

--- a/docs/onboarding/feature-flags/js-web.tsx
+++ b/docs/onboarding/feature-flags/js-web.tsx
@@ -1,14 +1,10 @@
-import { getJSWebSteps as getJSWebStepsPA } from '../product-analytics/js-web'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getJSWebSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getJSWebSteps as getJSWebStepsPA } from '../product-analytics/js-web'
+import { StepDefinition } from '../steps'
+
+export const getJSWebSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
     const FlagPayload = snippets?.FlagPayloadSnippet
@@ -16,7 +12,7 @@ export const getJSWebSteps = (
     const ReloadFlags = snippets?.ReloadFlagsSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getJSWebStepsPA(CodeBlock, Markdown, dedent, snippets)
+    const installationSteps = getJSWebStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -94,21 +90,7 @@ export const getJSWebSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const JSWebInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getJSWebSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const JSWebInstallation = createInstallation(getJSWebSteps)

--- a/docs/onboarding/feature-flags/js-web.tsx
+++ b/docs/onboarding/feature-flags/js-web.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getJSWebSteps as getJSWebStepsPA } from '../product-analytics/js-web'
 import { StepDefinition } from '../steps'
 
-export const getJSWebSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getJSWebSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/laravel.tsx
+++ b/docs/onboarding/feature-flags/laravel.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getLaravelSteps as getLaravelStepsPA } from '../product-analytics/laravel'
 import { StepDefinition } from '../steps'
 
-export const getLaravelSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getLaravelSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/laravel.tsx
+++ b/docs/onboarding/feature-flags/laravel.tsx
@@ -1,19 +1,15 @@
-import { getLaravelSteps as getLaravelStepsPA } from '../product-analytics/laravel'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getLaravelSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getLaravelSteps as getLaravelStepsPA } from '../product-analytics/laravel'
+import { StepDefinition } from '../steps'
+
+export const getLaravelSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getLaravelStepsPA(CodeBlock, Markdown, dedent)
+    const installationSteps = getLaravelStepsPA(ctx)
 
     // Add flag-specific steps (using PHP flag implementation)
     const flagSteps: StepDefinition[] = [
@@ -58,21 +54,7 @@ export const getLaravelSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const LaravelInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getLaravelSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const LaravelInstallation = createInstallation(getLaravelSteps)

--- a/docs/onboarding/feature-flags/nextjs.tsx
+++ b/docs/onboarding/feature-flags/nextjs.tsx
@@ -1,21 +1,15 @@
-import { getNextJSSteps as getNextJSStepsPA } from '../product-analytics/nextjs'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getNextJSSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    Tab: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getNextJSSteps as getNextJSStepsPA } from '../product-analytics/nextjs'
+import { StepDefinition } from '../steps'
+
+export const getNextJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getNextJSStepsPA(CodeBlock, Markdown, CalloutBox, Tab, dedent, snippets)
+    const installationSteps = getNextJSStepsPA(ctx)
 
     // Add flag implementation steps
     const flagSteps: StepDefinition[] = [
@@ -79,21 +73,7 @@ export const getNextJSSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const NextJSInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, Tab, dedent, snippets } = useMDXComponents()
-    const steps = getNextJSSteps(CodeBlock, Markdown, CalloutBox, Tab, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const NextJSInstallation = createInstallation(getNextJSSteps)

--- a/docs/onboarding/feature-flags/nextjs.tsx
+++ b/docs/onboarding/feature-flags/nextjs.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getNextJSSteps as getNextJSStepsPA } from '../product-analytics/nextjs'
 import { StepDefinition } from '../steps'
 
-export const getNextJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/nodejs.tsx
+++ b/docs/onboarding/feature-flags/nodejs.tsx
@@ -1,21 +1,16 @@
-import { getNodeJSSteps as getNodeJSStepsPA } from '../product-analytics/nodejs'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getNodeJSSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    Tab: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getNodeJSSteps as getNodeJSStepsPA } from '../product-analytics/nodejs'
+import { StepDefinition } from '../steps'
+
+export const getNodeJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
     const OverrideProperties = snippets?.OverridePropertiesSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getNodeJSStepsPA(CodeBlock, Markdown, dedent)
+    const installationSteps = getNodeJSStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -134,21 +129,7 @@ export const getNodeJSSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const NodeJSInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets, Tab } = useMDXComponents()
-    const steps = getNodeJSSteps(CodeBlock, Markdown, dedent, Tab, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const NodeJSInstallation = createInstallation(getNodeJSSteps)

--- a/docs/onboarding/feature-flags/nodejs.tsx
+++ b/docs/onboarding/feature-flags/nodejs.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getNodeJSSteps as getNodeJSStepsPA } from '../product-analytics/nodejs'
 import { StepDefinition } from '../steps'
 
-export const getNodeJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getNodeJSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/nuxt.tsx
+++ b/docs/onboarding/feature-flags/nuxt.tsx
@@ -1,20 +1,15 @@
-import { getNuxtSteps as getNuxtStepsPA } from '../product-analytics/nuxt'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getNuxtSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getNuxtSteps as getNuxtStepsPA } from '../product-analytics/nuxt'
+import { StepDefinition } from '../steps'
+
+export const getNuxtSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getNuxtStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets)
+    const installationSteps = getNuxtStepsPA(ctx)
 
     // Add flag implementation steps
     const flagSteps: StepDefinition[] = [
@@ -75,21 +70,7 @@ export const getNuxtSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const NuxtInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getNuxtSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const NuxtInstallation = createInstallation(getNuxtSteps)

--- a/docs/onboarding/feature-flags/nuxt.tsx
+++ b/docs/onboarding/feature-flags/nuxt.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getNuxtSteps as getNuxtStepsPA } from '../product-analytics/nuxt'
 import { StepDefinition } from '../steps'
 
-export const getNuxtSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getNuxtSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/php.tsx
+++ b/docs/onboarding/feature-flags/php.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getPHPSteps as getPHPStepsPA } from '../product-analytics/php'
 import { StepDefinition } from '../steps'
 
-export const getPHPSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getPHPSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/php.tsx
+++ b/docs/onboarding/feature-flags/php.tsx
@@ -1,21 +1,16 @@
-import { getPHPSteps as getPHPStepsPA } from '../product-analytics/php'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getPHPSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    Tab: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getPHPSteps as getPHPStepsPA } from '../product-analytics/php'
+import { StepDefinition } from '../steps'
+
+export const getPHPSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
     const OverrideProperties = snippets?.OverridePropertiesSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getPHPStepsPA(CodeBlock, Markdown, dedent)
+    const installationSteps = getPHPStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -134,21 +129,7 @@ export const getPHPSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const PHPInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets, Tab } = useMDXComponents()
-    const steps = getPHPSteps(CodeBlock, Markdown, dedent, Tab, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const PHPInstallation = createInstallation(getPHPSteps)

--- a/docs/onboarding/feature-flags/python.tsx
+++ b/docs/onboarding/feature-flags/python.tsx
@@ -1,22 +1,16 @@
-import { getPythonSteps as getPythonStepsPA } from '../product-analytics/python'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getPythonSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    Tab: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getPythonSteps as getPythonStepsPA } from '../product-analytics/python'
+import { StepDefinition } from '../steps'
+
+export const getPythonSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
     const OverrideProperties = snippets?.OverridePropertiesSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getPythonStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets)
+    const installationSteps = getPythonStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -135,21 +129,7 @@ export const getPythonSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const PythonInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets, Tab } = useMDXComponents()
-    const steps = getPythonSteps(CodeBlock, Markdown, CalloutBox, dedent, Tab, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const PythonInstallation = createInstallation(getPythonSteps)

--- a/docs/onboarding/feature-flags/python.tsx
+++ b/docs/onboarding/feature-flags/python.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getPythonSteps as getPythonStepsPA } from '../product-analytics/python'
 import { StepDefinition } from '../steps'
 
-export const getPythonSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/react-native.tsx
+++ b/docs/onboarding/feature-flags/react-native.tsx
@@ -1,10 +1,13 @@
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { getReactNativeSteps as getReactNativeStepsPA } from '../product-analytics/react-native'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 import { StepDefinition } from '../steps'
 
-export const getReactNativeSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
+export const getReactNativeSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
     // Get installation steps from product-analytics
-    const installationSteps = getReactNativeStepsPA(CodeBlock, Markdown, dedent)
+    const installationSteps = getReactNativeStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -92,17 +95,4 @@ export const getReactNativeSteps = (CodeBlock: any, Markdown: any, dedent: any):
     return [...installationSteps, ...flagSteps]
 }
 
-export const ReactNativeInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getReactNativeSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const ReactNativeInstallation = createInstallation(getReactNativeSteps)

--- a/docs/onboarding/feature-flags/react-native.tsx
+++ b/docs/onboarding/feature-flags/react-native.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getReactNativeSteps as getReactNativeStepsPA } from '../product-analytics/react-native'
 import { StepDefinition } from '../steps'
 
-export const getReactNativeSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     // Get installation steps from product-analytics

--- a/docs/onboarding/feature-flags/react.tsx
+++ b/docs/onboarding/feature-flags/react.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getReactSteps as getReactStepsPA } from '../product-analytics/react'
 import { StepDefinition } from '../steps'
 
-export const getReactSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getReactSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/react.tsx
+++ b/docs/onboarding/feature-flags/react.tsx
@@ -1,22 +1,16 @@
-import { getReactSteps as getReactStepsPA } from '../product-analytics/react'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getReactSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    Tab: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getReactSteps as getReactStepsPA } from '../product-analytics/react'
+import { StepDefinition } from '../steps'
+
+export const getReactSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
     const FlagPayload = snippets?.FlagPayloadSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getReactStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets)
+    const installationSteps = getReactStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -127,21 +121,7 @@ export const getReactSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const ReactInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets, Tab } = useMDXComponents()
-    const steps = getReactSteps(CodeBlock, Markdown, CalloutBox, dedent, Tab, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const ReactInstallation = createInstallation(getReactSteps)

--- a/docs/onboarding/feature-flags/remix.tsx
+++ b/docs/onboarding/feature-flags/remix.tsx
@@ -1,20 +1,15 @@
-import { getRemixSteps as getRemixStepsPA } from '../product-analytics/remix'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getRemixSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getRemixSteps as getRemixStepsPA } from '../product-analytics/remix'
+import { StepDefinition } from '../steps'
+
+export const getRemixSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getRemixStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets)
+    const installationSteps = getRemixStepsPA(ctx)
 
     // Add flag implementation steps
     const flagSteps: StepDefinition[] = [
@@ -73,21 +68,7 @@ export const getRemixSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const RemixInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getRemixSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const RemixInstallation = createInstallation(getRemixSteps)

--- a/docs/onboarding/feature-flags/remix.tsx
+++ b/docs/onboarding/feature-flags/remix.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getRemixSteps as getRemixStepsPA } from '../product-analytics/remix'
 import { StepDefinition } from '../steps'
 
-export const getRemixSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getRemixSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/ruby.tsx
+++ b/docs/onboarding/feature-flags/ruby.tsx
@@ -1,21 +1,16 @@
-import { getRubySteps as getRubyStepsPA } from '../product-analytics/ruby'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getRubySteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    Tab: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getRubySteps as getRubyStepsPA } from '../product-analytics/ruby'
+import { StepDefinition } from '../steps'
+
+export const getRubySteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
     const OverrideProperties = snippets?.OverridePropertiesSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getRubyStepsPA(CodeBlock, Markdown, dedent)
+    const installationSteps = getRubyStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -134,21 +129,7 @@ export const getRubySteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const RubyInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets, Tab } = useMDXComponents()
-    const steps = getRubySteps(CodeBlock, Markdown, dedent, Tab, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const RubyInstallation = createInstallation(getRubySteps)

--- a/docs/onboarding/feature-flags/ruby.tsx
+++ b/docs/onboarding/feature-flags/ruby.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getRubySteps as getRubyStepsPA } from '../product-analytics/ruby'
 import { StepDefinition } from '../steps'
 
-export const getRubySteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getRubySteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, Tab, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/svelte.tsx
+++ b/docs/onboarding/feature-flags/svelte.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getSvelteSteps as getSvelteStepsPA } from '../product-analytics/svelte'
 import { StepDefinition } from '../steps'
 
-export const getSvelteSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getSvelteSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/svelte.tsx
+++ b/docs/onboarding/feature-flags/svelte.tsx
@@ -1,20 +1,15 @@
-import { getSvelteSteps as getSvelteStepsPA } from '../product-analytics/svelte'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getSvelteSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getSvelteSteps as getSvelteStepsPA } from '../product-analytics/svelte'
+import { StepDefinition } from '../steps'
+
+export const getSvelteSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getSvelteStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets)
+    const installationSteps = getSvelteStepsPA(ctx)
 
     // Add flag implementation steps
     const flagSteps: StepDefinition[] = [
@@ -73,21 +68,7 @@ export const getSvelteSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const SvelteInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getSvelteSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const SvelteInstallation = createInstallation(getSvelteSteps)

--- a/docs/onboarding/feature-flags/vue.tsx
+++ b/docs/onboarding/feature-flags/vue.tsx
@@ -1,20 +1,15 @@
-import { getVueSteps as getVueStepsPA } from '../product-analytics/vue'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getVueSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getVueSteps as getVueStepsPA } from '../product-analytics/vue'
+import { StepDefinition } from '../steps'
+
+export const getVueSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getVueStepsPA(CodeBlock, Markdown, CalloutBox, dedent, snippets)
+    const installationSteps = getVueStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -59,21 +54,7 @@ export const getVueSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const VueInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getVueSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const VueInstallation = createInstallation(getVueSteps)

--- a/docs/onboarding/feature-flags/vue.tsx
+++ b/docs/onboarding/feature-flags/vue.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getVueSteps as getVueStepsPA } from '../product-analytics/vue'
 import { StepDefinition } from '../steps'
 
-export const getVueSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getVueSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/feature-flags/webflow.tsx
+++ b/docs/onboarding/feature-flags/webflow.tsx
@@ -1,19 +1,15 @@
-import { getWebflowSteps as getWebflowStepsPA } from '../product-analytics/webflow'
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { StepDefinition, StepModifier } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getWebflowSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    dedent: any,
-    snippets: any,
-    options?: StepModifier
-): StepDefinition[] => {
+import { getWebflowSteps as getWebflowStepsPA } from '../product-analytics/webflow'
+import { StepDefinition } from '../steps'
+
+export const getWebflowSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet
 
     // Get installation steps from product-analytics
-    const installationSteps = getWebflowStepsPA(CodeBlock, Markdown, dedent, snippets)
+    const installationSteps = getWebflowStepsPA(ctx)
 
     // Add flag-specific steps
     const flagSteps: StepDefinition[] = [
@@ -58,21 +54,7 @@ export const getWebflowSteps = (
         },
     ]
 
-    const allSteps = [...installationSteps, ...flagSteps]
-    return options?.modifySteps ? options.modifySteps(allSteps) : allSteps
+    return [...installationSteps, ...flagSteps]
 }
 
-export const WebflowInstallation = ({ modifySteps }: StepModifier = {}): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getWebflowSteps(CodeBlock, Markdown, dedent, snippets, { modifySteps })
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const WebflowInstallation = createInstallation(getWebflowSteps)

--- a/docs/onboarding/feature-flags/webflow.tsx
+++ b/docs/onboarding/feature-flags/webflow.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { getWebflowSteps as getWebflowStepsPA } from '../product-analytics/webflow'
 import { StepDefinition } from '../steps'
 
-export const getWebflowSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getWebflowSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, dedent, snippets } = ctx
     const BooleanFlag = snippets?.BooleanFlagSnippet
     const MultivariateFlag = snippets?.MultivariateFlagSnippet

--- a/docs/onboarding/llm-analytics/anthropic.tsx
+++ b/docs/onboarding/llm-analytics/anthropic.tsx
@@ -1,7 +1,7 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 import { StepDefinition } from '../steps'
 
-export const getAnthropicSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties

--- a/docs/onboarding/llm-analytics/anthropic.tsx
+++ b/docs/onboarding/llm-analytics/anthropic.tsx
@@ -1,238 +1,227 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { StepDefinition } from '../steps'
 
-export const AnthropicInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, CalloutBox, ProductScreenshot, OSButton, Markdown, Blockquote, dedent, snippets } =
-        useMDXComponents()
+export const getAnthropicSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
-    return (
-        <Steps>
-            <Step title="Install the PostHog SDK" badge="required">
-                <Markdown>
-                    Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics works
-                    best with our Python and Node SDKs.
-                </Markdown>
 
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Python',
-                            code: dedent`
-                                pip install posthog
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Node',
-                            code: dedent`
-                                npm install @posthog/ai posthog-node
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Install the Anthropic SDK" badge="required">
-                <Markdown>
-                    Install the Anthropic SDK. The PostHog SDK instruments your LLM calls by wrapping the Anthropic client.
-                    The PostHog SDK **does not** proxy your calls.
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Python',
-                            code: dedent`
-                                pip install anthropic
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Node',
-                            code: dedent`
-                                npm install @anthropic-ai/sdk
-                            `,
-                        },
-                    ]}
-                />
-
-                <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+    return [
+        {
+            title: 'Install the PostHog SDK',
+            badge: 'required',
+            content: (
+                <>
                     <Markdown>
-                        These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                        background to send the data. You can also use LLM analytics with other SDKs or our API, but you
-                        will need to capture the data in the right format. See the schema in the [manual capture
-                        section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics works
+                        best with our Python and Node SDKs.
                     </Markdown>
-                </CalloutBox>
-            </Step>
 
-            <Step title="Initialize PostHog and the Anthropic wrapper" badge="required">
-                <Markdown>
-                    Initialize PostHog with your project API key and host from [your project
-                    settings](https://app.posthog.com/settings/project), then pass it to our Anthropic wrapper.
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
-                                from posthog.ai.anthropic import Anthropic
-                                from posthog import Posthog
-
-                                posthog = Posthog(
-                                    "<ph_project_api_key>",
-                                    host="<ph_client_api_host>"
-                                )
-
-                                client = Anthropic(
-                                    api_key="sk-ant-api...", # Replace with your Anthropic API key
-                                    posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
-                                )
-                            `,
-                        },
-                        {
-                            language: 'ts',
-                            file: 'Node',
-                            code: dedent`
-                                import { Anthropic } from '@posthog/ai'
-                                import { PostHog } from 'posthog-node'
-
-                                const phClient = new PostHog(
-                                  '<ph_project_api_key>',
-                                  { host: '<ph_client_api_host>' }
-                                )
-
-                                const client = new Anthropic({
-                                  apiKey: 'sk-ant-api...', // Replace with your Anthropic API key
-                                  posthog: phClient
-                                })
-                            `,
-                        },
-                    ]}
-                />
-
-                <Blockquote>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install posthog
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install @posthog/ai posthog-node
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Install the Anthropic SDK',
+            badge: 'required',
+            content: (
+                <>
                     <Markdown>
-                        **Note:** This also works with the `AsyncAnthropic` client as well as `AnthropicBedrock`,
-                        `AnthropicVertex`, and the async versions of those.
+                        Install the Anthropic SDK. The PostHog SDK instruments your LLM calls by wrapping the Anthropic client.
+                        The PostHog SDK **does not** proxy your calls.
                     </Markdown>
-                </Blockquote>
-            </Step>
 
-            <Step title="Call Anthropic LLMs" badge="required">
-                <Markdown>
-                    Now, when you use the Anthropic SDK to call LLMs, PostHog automatically captures an `$ai_generation`
-                    event. You can enrich the event with additional data such as the trace ID, distinct ID, custom
-                    properties, groups, and privacy mode options.
-                </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install anthropic
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install @anthropic-ai/sdk
+                                `,
+                            },
+                        ]}
+                    />
 
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
-                                response = client.messages.create(
-                                    model="claude-3-opus-20240229",
-                                    messages=[
+                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
+                            background to send the data. You can also use LLM analytics with other SDKs or our API, but you
+                            will need to capture the data in the right format. See the schema in the [manual capture
+                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+        {
+            title: 'Initialize PostHog and the Anthropic wrapper',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Initialize PostHog with your project API key and host from [your project
+                        settings](https://app.posthog.com/settings/project), then pass it to our Anthropic wrapper.
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    from posthog.ai.anthropic import Anthropic
+                                    from posthog import Posthog
+
+                                    posthog = Posthog(
+                                        "<ph_project_api_key>",
+                                        host="<ph_client_api_host>"
+                                    )
+
+                                    client = Anthropic(
+                                        api_key="sk-ant-api...", # Replace with your Anthropic API key
+                                        posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
+                                    )
+                                `,
+                            },
+                            {
+                                language: 'ts',
+                                file: 'Node',
+                                code: dedent`
+                                    import { Anthropic } from '@posthog/ai'
+                                    import { PostHog } from 'posthog-node'
+
+                                    const phClient = new PostHog(
+                                      '<ph_project_api_key>',
+                                      { host: '<ph_client_api_host>' }
+                                    )
+
+                                    const client = new Anthropic({
+                                      apiKey: 'sk-ant-api...', // Replace with your Anthropic API key
+                                      posthog: phClient
+                                    })
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** This also works with the `AsyncAnthropic` client as well as `AnthropicBedrock`,
+                            `AnthropicVertex`, and the async versions of those.
+                        </Markdown>
+                    </Blockquote>
+                </>
+            ),
+        },
+        {
+            title: 'Call Anthropic LLMs',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Now, when you use the Anthropic SDK to call LLMs, PostHog automatically captures an `$ai_generation`
+                        event. You can enrich the event with additional data such as the trace ID, distinct ID, custom
+                        properties, groups, and privacy mode options.
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    response = client.messages.create(
+                                        model="claude-3-opus-20240229",
+                                        messages=[
+                                            {
+                                                "role": "user",
+                                                "content": "Tell me a fun fact about hedgehogs"
+                                            }
+                                        ],
+                                        posthog_distinct_id="user_123", # optional
+                                        posthog_trace_id="trace_123", # optional
+                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
+                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
+                                        posthog_privacy_mode=False # optional
+                                    )
+
+                                    print(response.content[0].text)
+                                `,
+                            },
+                            {
+                                language: 'ts',
+                                file: 'Node',
+                                code: dedent`
+                                    const response = await client.messages.create({
+                                      model: "claude-3-5-sonnet-latest",
+                                      messages: [
                                         {
-                                            "role": "user",
-                                            "content": "Tell me a fun fact about hedgehogs"
+                                          role: "user",
+                                          content: "Tell me a fun fact about hedgehogs"
                                         }
-                                    ],
-                                    posthog_distinct_id="user_123", # optional
-                                    posthog_trace_id="trace_123", # optional
-                                    posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                    posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                    posthog_privacy_mode=False # optional
-                                )
+                                      ],
+                                      posthogDistinctId: "user_123", // optional
+                                      posthogTraceId: "trace_123", // optional
+                                      posthogProperties: { conversationId: "abc123", paid: true }, // optional
+                                      posthogGroups: { company: "company_id_in_your_db" }, // optional
+                                      posthogPrivacyMode: false // optional
+                                    })
 
-                                print(response.content[0].text)
-                            `,
-                        },
-                        {
-                            language: 'ts',
-                            file: 'Node',
-                            code: dedent`
-                                const response = await client.messages.create({
-                                  model: "claude-3-5-sonnet-latest",
-                                  messages: [
-                                    {
-                                      role: "user",
-                                      content: "Tell me a fun fact about hedgehogs"
-                                    }
-                                  ],
-                                  posthogDistinctId: "user_123", // optional
-                                  posthogTraceId: "trace_123", // optional
-                                  posthogProperties: { conversationId: "abc123", paid: true }, // optional
-                                  posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                  posthogPrivacyMode: false // optional
-                                })
+                                    console.log(response.content[0].text)
+                                    phClient.shutdown()
+                                `,
+                            },
+                        ]}
+                    />
 
-                                console.log(response.content[0].text)
-                                phClient.shutdown()
-                            `,
-                        },
-                    ]}
-                />
+                    <Blockquote>
+                        <Markdown>
+                            {dedent`
+                            **Notes:**
+                            - This also works when message streams are used (e.g. \`stream=True\` or \`client.messages.stream(...)\`).
+                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
 
-                <Blockquote>
+                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            `}
+                        </Markdown>
+                    </Blockquote>
+
                     <Markdown>
                         {dedent`
-                        **Notes:**
-                        - This also works when message streams are used (e.g. \`stream=True\` or \`client.messages.stream(...)\`).
-                        - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                        See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            You can expect captured \`$ai_generation\` events to have the following properties:
                         `}
                     </Markdown>
-                </Blockquote>
 
-                <Markdown>
-                    {dedent`
-                        You can expect captured \`$ai_generation\` events to have the following properties:
-                    `}
-                </Markdown>
-
-                {NotableGenerationProperties && <NotableGenerationProperties />}
-            </Step>
-
-            <Step
-                checkpoint
-                title="Verify traces and generations"
-                subtitle="Confirm LLM events are being sent to PostHog"
-                docsOnly
-            >
-                <Markdown>
-                    Let's make sure LLM events are being captured and sent to PostHog. Under **LLM analytics**, you
-                    should see rows of data appear in the **Traces** and **Generations** tabs.
-                </Markdown>
-
-                <br />
-                <ProductScreenshot
-                    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syne_ecd0801880.png"
-                    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syjm_5baab36590.png"
-                    alt="LLM generations in PostHog"
-                    classes="rounded"
-                    className="mt-10"
-                    padding={false}
-                />
-
-                <OSButton
-                    variant="secondary"
-                    asLink
-                    className="my-2"
-                    size="sm"
-                    to="https://app.posthog.com/llm-analytics/generations"
-                    external
-                >
-                    Check for LLM events in PostHog
-                </OSButton>
-            </Step>
-        </Steps>
-    )
+                    {NotableGenerationProperties && <NotableGenerationProperties />}
+                </>
+            ),
+        },
+    ]
 }
+
+export const AnthropicInstallation = createInstallation(getAnthropicSteps)

--- a/docs/onboarding/llm-analytics/google.tsx
+++ b/docs/onboarding/llm-analytics/google.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getGoogleSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getGoogleSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 

--- a/docs/onboarding/llm-analytics/google.tsx
+++ b/docs/onboarding/llm-analytics/google.tsx
@@ -1,287 +1,278 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const GoogleInstallation = (): JSX.Element => {
-    const {
-        Steps,
-        Step,
-        CodeBlock,
-        CalloutBox,
-        ProductScreenshot,
-        OSButton,
-        Markdown,
-        Blockquote,
-        dedent,
-        snippets,
-    } = useMDXComponents()
-    
+import { StepDefinition } from '../steps'
+
+export const getGoogleSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
-    return (
-        <Steps>
-            <Step title="Install the PostHog SDK" badge="required">
-                <Markdown>
-                    Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics works best with our Python and Node SDKs.
-                </Markdown>
 
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Python',
-                            code: dedent`
-                                pip install posthog
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Node',
-                            code: dedent`
-                                npm install @posthog/ai posthog-node
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Install the Google Gen AI SDK" badge="required">
-                <Markdown>
-                    Install the Google Gen AI SDK. The PostHog SDK instruments your LLM calls by wrapping the Google Gen
-                    AI client. The PostHog SDK **does not** proxy your calls.
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Python',
-                            code: dedent`
-                                pip install google-genai
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Node',
-                            code: dedent`
-                                npm install @google/genai
-                            `,
-                        },
-                    ]}
-                />
-
-                <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+    return [
+        {
+            title: 'Install the PostHog SDK',
+            badge: 'required',
+            content: (
+                <>
                     <Markdown>
-                        These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the background to send the data.
-
-                        You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics works best with our Python and Node SDKs.
                     </Markdown>
-                </CalloutBox>
-            </Step>
 
-            <Step title="Initialize PostHog and Google Gen AI client" badge="required">
-                <Markdown>
-                    Initialize PostHog with your project API key and host from [your project settings](https://app.posthog.com/settings/project), then pass it to our Google Gen AI wrapper.
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
-                                from posthog.ai.gemini import Client
-                                from posthog import Posthog
-
-                                posthog = Posthog(
-                                    "<ph_project_api_key>",
-                                    host="<ph_client_api_host>"
-                                )
-
-                                client = Client(
-                                    api_key="...", # Replace with your Gemini API key
-                                    posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
-                                )
-                            `,
-                        },
-                        {
-                            language: 'ts',
-                            file: 'Node',
-                            code: dedent`
-                                import { GoogleGenAI } from '@posthog/ai'
-                                import { PostHog } from 'posthog-node'
-
-                                const phClient = new PostHog(
-                                    '<ph_project_api_key>',
-                                    { host: '<ph_client_api_host>' }
-                                )
-
-                                const client = new GoogleGenAI({
-                                    apiKey: '...', // Replace with your Gemini API key
-                                    posthog: phClient
-                                })
-                            `,
-                        },
-                    ]}
-                />
-
-                <Blockquote>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install posthog
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install @posthog/ai posthog-node
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Install the Google Gen AI SDK',
+            badge: 'required',
+            content: (
+                <>
                     <Markdown>
-                        **Note:** This integration also works with Vertex AI via Google Cloud Platform. You can use the Google Gen AI SDK's Vertex AI client with PostHog analytics.
+                        Install the Google Gen AI SDK. The PostHog SDK instruments your LLM calls by wrapping the Google Gen
+                        AI client. The PostHog SDK **does not** proxy your calls.
                     </Markdown>
-                </Blockquote>
 
-                <Markdown>
-                    **Vertex AI code example:**
-                </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install google-genai
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install @google/genai
+                                `,
+                            },
+                        ]}
+                    />
 
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
-                                from posthog import Posthog
-                                from posthog.ai.gemini import Client
+                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the background to send the data.
 
-                                # Initialize PostHog
-                                posthog = Posthog(
-                                    project_api_key="<ph_project_api_key>",
-                                    host="<ph_client_api_host>"
-                                )
-
-                                # Initialize Gemini client with Vertex AI
-                                client = Client(
-                                    vertexai=True,
-                                    project="your-gcp-project-id",
-                                    location="us-central1",
-                                    posthog_client=posthog,
-                                    posthog_distinct_id="user-123"
-                                )
-
-                                # Use it
-                                response = client.models.generate_content(
-                                    model="gemini-2.0-flash",
-                                    contents=["Hello, world!"]
-                                )
-
-                                print(response.text)
-                            `,
-                        },
-                        {
-                            language: 'ts',
-                            file: 'Node',
-                            code: dedent`
-                                import { PostHog } from 'posthog-node'
-                                import { PostHogGoogleGenAI } from '@posthog/ai'
-
-                                // Initialize PostHog
-                                const posthog = new PostHog(
-                                  '<ph_project_api_key>',
-                                  { host: '<ph_client_api_host>' }
-                                )
-
-                                // Initialize Gemini client with Vertex AI
-                                const client = new PostHogGoogleGenAI({
-                                  vertexai: true,
-                                  project: 'your-gcp-project-id',
-                                  location: 'us-central1',
-                                  posthog: posthog
-                                })
-
-                                // Use it
-                                const response = await client.models.generateContent({
-                                  model: 'gemini-2.0-flash',
-                                  contents: 'Hello, world!',
-                                  posthogDistinctId: 'user-123'
-                                })
-
-                                console.log(response.text)
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Call Google Gen AI LLMs" badge="required">
-                <Markdown>
-                    Now, when you use the Google Gen AI SDK to call LLMs, PostHog automatically captures an `$ai_generation` event.
-
-                    You can enrich the event with additional data such as the trace ID, distinct ID, custom properties, groups, and privacy mode options.
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
-                                response = client.models.generate_content(
-                                    model="gemini-2.5-flash",
-                                    contents=["Tell me a fun fact about hedgehogs"],
-                                    posthog_distinct_id="user_123", # optional
-                                    posthog_trace_id="trace_123", # optional
-                                    posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                    posthog_groups={"company": "company_id_in_your_db"},  # optional 
-                                    posthog_privacy_mode=False # optional
-                                )
-
-                                print(response.text)
-                            `,
-                        },
-                        {
-                            language: 'ts',
-                            file: 'Node',
-                            code: dedent`
-                                const response = await client.models.generateContent({
-                                  model: "gemini-2.5-flash",
-                                  contents: ["Tell me a fun fact about hedgehogs"],
-                                  posthogDistinctId: "user_123", // optional
-                                  posthogTraceId: "trace_123", // optional
-                                  posthogProperties: { conversationId: "abc123", paid: true }, // optional
-                                  posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                  posthogPrivacyMode: false // optional
-                                })
-
-                                console.log(response.text)
-                                phClient.shutdown()
-                            `,
-                        },
-                    ]}
-                />
-
-                <Blockquote>
+                            You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+        {
+            title: 'Initialize PostHog and Google Gen AI client',
+            badge: 'required',
+            content: (
+                <>
                     <Markdown>
-                        **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        Initialize PostHog with your project API key and host from [your project settings](https://app.posthog.com/settings/project), then pass it to our Google Gen AI wrapper.
                     </Markdown>
-                </Blockquote>
 
-                <Markdown>
-                    {dedent`
-                        You can expect captured \`$ai_generation\` events to have the following properties:
-                    `}
-                </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    from posthog.ai.gemini import Client
+                                    from posthog import Posthog
 
-                {NotableGenerationProperties && <NotableGenerationProperties />}
-            </Step>
+                                    posthog = Posthog(
+                                        "<ph_project_api_key>",
+                                        host="<ph_client_api_host>"
+                                    )
 
-            <Step checkpoint title="Verify traces and generations" subtitle="Confirm LLM events are being sent to PostHog" docsOnly>
-                <Markdown>
-                    Let's make sure LLM events are being captured and sent to PostHog. Under **LLM analytics**, you should see rows of data appear in the **Traces** and **Generations** tabs.
-                </Markdown>
+                                    client = Client(
+                                        api_key="...", # Replace with your Gemini API key
+                                        posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
+                                    )
+                                `,
+                            },
+                            {
+                                language: 'ts',
+                                file: 'Node',
+                                code: dedent`
+                                    import { GoogleGenAI } from '@posthog/ai'
+                                    import { PostHog } from 'posthog-node'
 
-                <br />
-                <ProductScreenshot
-                    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syne_ecd0801880.png"
-                    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syjm_5baab36590.png"
-                    alt="LLM generations in PostHog"
-                    classes="rounded"
-                    className="mt-10"
-                    padding={false}
-                />
+                                    const phClient = new PostHog(
+                                        '<ph_project_api_key>',
+                                        { host: '<ph_client_api_host>' }
+                                    )
 
-                <OSButton variant="secondary" asLink className="my-2" size="sm" to="https://app.posthog.com/llm-analytics/generations" external>
-                    Check for LLM events in PostHog
-                </OSButton>
-            </Step>
-        </Steps>
-    )
+                                    const client = new GoogleGenAI({
+                                        apiKey: '...', // Replace with your Gemini API key
+                                        posthog: phClient
+                                    })
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** This integration also works with Vertex AI via Google Cloud Platform. You can use the Google Gen AI SDK's Vertex AI client with PostHog analytics.
+                        </Markdown>
+                    </Blockquote>
+
+                    <Markdown>
+                        **Vertex AI code example:**
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    from posthog import Posthog
+                                    from posthog.ai.gemini import Client
+
+                                    # Initialize PostHog
+                                    posthog = Posthog(
+                                        project_api_key="<ph_project_api_key>",
+                                        host="<ph_client_api_host>"
+                                    )
+
+                                    # Initialize Gemini client with Vertex AI
+                                    client = Client(
+                                        vertexai=True,
+                                        project="your-gcp-project-id",
+                                        location="us-central1",
+                                        posthog_client=posthog,
+                                        posthog_distinct_id="user-123"
+                                    )
+
+                                    # Use it
+                                    response = client.models.generate_content(
+                                        model="gemini-2.0-flash",
+                                        contents=["Hello, world!"]
+                                    )
+
+                                    print(response.text)
+                                `,
+                            },
+                            {
+                                language: 'ts',
+                                file: 'Node',
+                                code: dedent`
+                                    import { PostHog } from 'posthog-node'
+                                    import { PostHogGoogleGenAI } from '@posthog/ai'
+
+                                    // Initialize PostHog
+                                    const posthog = new PostHog(
+                                      '<ph_project_api_key>',
+                                      { host: '<ph_client_api_host>' }
+                                    )
+
+                                    // Initialize Gemini client with Vertex AI
+                                    const client = new PostHogGoogleGenAI({
+                                      vertexai: true,
+                                      project: 'your-gcp-project-id',
+                                      location: 'us-central1',
+                                      posthog: posthog
+                                    })
+
+                                    // Use it
+                                    const response = await client.models.generateContent({
+                                      model: 'gemini-2.0-flash',
+                                      contents: 'Hello, world!',
+                                      posthogDistinctId: 'user-123'
+                                    })
+
+                                    console.log(response.text)
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Call Google Gen AI LLMs',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Now, when you use the Google Gen AI SDK to call LLMs, PostHog automatically captures an `$ai_generation` event.
+
+                        You can enrich the event with additional data such as the trace ID, distinct ID, custom properties, groups, and privacy mode options.
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    response = client.models.generate_content(
+                                        model="gemini-2.5-flash",
+                                        contents=["Tell me a fun fact about hedgehogs"],
+                                        posthog_distinct_id="user_123", # optional
+                                        posthog_trace_id="trace_123", # optional
+                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
+                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
+                                        posthog_privacy_mode=False # optional
+                                    )
+
+                                    print(response.text)
+                                `,
+                            },
+                            {
+                                language: 'ts',
+                                file: 'Node',
+                                code: dedent`
+                                    const response = await client.models.generateContent({
+                                      model: "gemini-2.5-flash",
+                                      contents: ["Tell me a fun fact about hedgehogs"],
+                                      posthogDistinctId: "user_123", // optional
+                                      posthogTraceId: "trace_123", // optional
+                                      posthogProperties: { conversationId: "abc123", paid: true }, // optional
+                                      posthogGroups: { company: "company_id_in_your_db" }, // optional
+                                      posthogPrivacyMode: false // optional
+                                    })
+
+                                    console.log(response.text)
+                                    phClient.shutdown()
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
+
+                    <Markdown>
+                        {dedent`
+                            You can expect captured \`$ai_generation\` events to have the following properties:
+                        `}
+                    </Markdown>
+
+                    {NotableGenerationProperties && <NotableGenerationProperties />}
+                </>
+            ),
+        },
+    ]
 }
 
+export const GoogleInstallation = createInstallation(getGoogleSteps)

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -1,236 +1,227 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { StepDefinition } from '../steps'
 
-export const LangChainInstallation = (): JSX.Element => {
-    const {
-        Steps,
-        Step,
-        CodeBlock,
-        CalloutBox,
-        ProductScreenshot,
-        OSButton,
-        Markdown,
-        Blockquote,
-        dedent,
-        snippets,
-    } = useMDXComponents()
-    
+export const getLangChainSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
-    return (
-        <Steps>
-            <Step title="Install the PostHog SDK" badge="required">
-                <Markdown>
-                    Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics works best with our Python and Node SDKs.
-                </Markdown>
 
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Python',
-                            code: dedent`
-                                pip install posthog
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Node',
-                            code: dedent`
-                                npm install @posthog/ai posthog-node
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Install LangChain and OpenAI SDKs" badge="required">
-                <Markdown>
-                    Install LangChain. The PostHog SDK instruments your LLM calls by wrapping LangChain. The PostHog SDK
-                    **does not** proxy your calls.
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Python',
-                            code: dedent`
-                                pip install langchain openai langchain-openai
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Node',
-                            code: dedent`
-                                npm install langchain @langchain/core @posthog/ai
-                            `,
-                        },
-                    ]}
-                />
-
-                <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+    return [
+        {
+            title: 'Install the PostHog SDK',
+            badge: 'required',
+            content: (
+                <>
                     <Markdown>
-                        These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the background to send the data.
-
-                        You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics works best with our Python and Node SDKs.
                     </Markdown>
-                </CalloutBox>
-            </Step>
 
-            <Step title="Initialize PostHog and LangChain" badge="required">
-                <Markdown>
-                    Initialize PostHog with your project API key and host from [your project settings](https://app.posthog.com/settings/project), then pass it to the LangChain `CallbackHandler` wrapper.
-
-                    Optionally, you can provide a user distinct ID, trace ID, PostHog properties, [groups](https://posthog.com/docs/product-analytics/group-analytics), and privacy mode.
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
-                                from posthog.ai.langchain import CallbackHandler
-                                from langchain_openai import ChatOpenAI
-                                from langchain_core.prompts import ChatPromptTemplate
-                                from posthog import Posthog
-
-                                posthog = Posthog(
-                                    "<ph_project_api_key>",
-                                    host="<ph_client_api_host>"
-                                )
-
-                                callback_handler = CallbackHandler(
-                                    client=posthog, # This is an optional parameter. If it is not provided, a default client will be used.
-                                    distinct_id="user_123", # optional
-                                    trace_id="trace_456", # optional
-                                    properties={"conversation_id": "abc123"} # optional
-                                    groups={"company": "company_id_in_your_db"} # optional
-                                    privacy_mode=False # optional
-                                )
-                            `,
-                        },
-                        {
-                            language: 'ts',
-                            file: 'Node',
-                            code: dedent`
-                                import { PostHog } from 'posthog-node';
-                                import { LangChainCallbackHandler } from '@posthog/ai';
-                                import { ChatOpenAI } from '@langchain/openai';
-                                import { ChatPromptTemplate } from '@langchain/core/prompts';
-
-                                const phClient = new PostHog(
-                                  '<ph_project_api_key>',
-                                  { host: '<ph_client_api_host>' }
-                                );
-
-                                const callbackHandler = new LangChainCallbackHandler({
-                                  client: phClient,
-                                  distinctId: 'user_123', // optional
-                                  traceId: 'trace_456', // optional
-                                  properties: { conversationId: 'abc123' }, // optional
-                                  groups: { company: 'company_id_in_your_db' }, // optional
-                                  privacyMode: false, // optional
-                                  debug: false // optional - when true, logs all events to console
-                                });
-                            `,
-                        },
-                    ]}
-                />
-
-                <Blockquote>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install posthog
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install @posthog/ai posthog-node
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Install LangChain and OpenAI SDKs',
+            badge: 'required',
+            content: (
+                <>
                     <Markdown>
-                        **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the `CallbackHandler`. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        Install LangChain. The PostHog SDK instruments your LLM calls by wrapping LangChain. The PostHog SDK
+                        **does not** proxy your calls.
                     </Markdown>
-                </Blockquote>
-            </Step>
 
-            <Step title="Call LangChain" badge="required">
-                <Markdown>
-                    When you invoke your chain, pass the `callback_handler` in the `config` as part of your `callbacks`:
-                </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install langchain openai langchain-openai
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install langchain @langchain/core @posthog/ai
+                                `,
+                            },
+                        ]}
+                    />
 
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
-                                prompt = ChatPromptTemplate.from_messages([
-                                    ("system", "You are a helpful assistant."),
-                                    ("user", "{input}")
-                                ])
+                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the background to send the data.
 
-                                model = ChatOpenAI(openai_api_key="your_openai_api_key")
-                                chain = prompt | model
+                            You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+        {
+            title: 'Initialize PostHog and LangChain',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Initialize PostHog with your project API key and host from [your project settings](https://app.posthog.com/settings/project), then pass it to the LangChain `CallbackHandler` wrapper.
 
-                                # Execute the chain with the callback handler
-                                response = chain.invoke(
-                                    {"input": "Tell me a joke about programming"},
-                                    config={"callbacks": [callback_handler]}
-                                )
+                        Optionally, you can provide a user distinct ID, trace ID, PostHog properties, [groups](https://posthog.com/docs/product-analytics/group-analytics), and privacy mode.
+                    </Markdown>
 
-                                print(response.content)
-                            `,
-                        },
-                        {
-                            language: 'ts',
-                            file: 'Node',
-                            code: dedent`
-                                const prompt = ChatPromptTemplate.fromMessages([
-                                  ["system", "You are a helpful assistant."],
-                                  ["user", "{input}"]
-                                ]);
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    from posthog.ai.langchain import CallbackHandler
+                                    from langchain_openai import ChatOpenAI
+                                    from langchain_core.prompts import ChatPromptTemplate
+                                    from posthog import Posthog
 
-                                const model = new ChatOpenAI({
-                                  apiKey: "your_openai_api_key"
-                                });
+                                    posthog = Posthog(
+                                        "<ph_project_api_key>",
+                                        host="<ph_client_api_host>"
+                                    )
 
-                                const chain = prompt.pipe(model);
+                                    callback_handler = CallbackHandler(
+                                        client=posthog, # This is an optional parameter. If it is not provided, a default client will be used.
+                                        distinct_id="user_123", # optional
+                                        trace_id="trace_456", # optional
+                                        properties={"conversation_id": "abc123"} # optional
+                                        groups={"company": "company_id_in_your_db"} # optional
+                                        privacy_mode=False # optional
+                                    )
+                                `,
+                            },
+                            {
+                                language: 'ts',
+                                file: 'Node',
+                                code: dedent`
+                                    import { PostHog } from 'posthog-node';
+                                    import { LangChainCallbackHandler } from '@posthog/ai';
+                                    import { ChatOpenAI } from '@langchain/openai';
+                                    import { ChatPromptTemplate } from '@langchain/core/prompts';
 
-                                // Execute the chain with the callback handler
-                                const response = await chain.invoke(
-                                  { input: "Tell me a joke about programming" },
-                                  { callbacks: [callbackHandler] }
-                                );
+                                    const phClient = new PostHog(
+                                      '<ph_project_api_key>',
+                                      { host: '<ph_client_api_host>' }
+                                    );
 
-                                console.log(response.content);
-                                phClient.shutdown();
-                            `,
-                        },
-                    ]}
-                />
+                                    const callbackHandler = new LangChainCallbackHandler({
+                                      client: phClient,
+                                      distinctId: 'user_123', // optional
+                                      traceId: 'trace_456', // optional
+                                      properties: { conversationId: 'abc123' }, // optional
+                                      groups: { company: 'company_id_in_your_db' }, // optional
+                                      privacyMode: false, // optional
+                                      debug: false // optional - when true, logs all events to console
+                                    });
+                                `,
+                            },
+                        ]}
+                    />
 
-                <Markdown>
-                    PostHog automatically captures an `$ai_generation` event along with these properties:
-                </Markdown>
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the `CallbackHandler`. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
+                </>
+            ),
+        },
+        {
+            title: 'Call LangChain',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        When you invoke your chain, pass the `callback_handler` in the `config` as part of your `callbacks`:
+                    </Markdown>
 
-                {NotableGenerationProperties && <NotableGenerationProperties />}
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    prompt = ChatPromptTemplate.from_messages([
+                                        ("system", "You are a helpful assistant."),
+                                        ("user", "{input}")
+                                    ])
 
-                <Markdown>
-                    It also automatically creates a trace hierarchy based on how LangChain components are nested.
-                </Markdown>
-            </Step>
+                                    model = ChatOpenAI(openai_api_key="your_openai_api_key")
+                                    chain = prompt | model
 
-            <Step checkpoint title="Verify traces and generations" subtitle="Confirm LLM events are being sent to PostHog" docsOnly>
-                <Markdown>
-                    Let's make sure LLM events are being captured and sent to PostHog. Under **LLM analytics**, you should see rows of data appear in the **Traces** and **Generations** tabs.
-                </Markdown>
+                                    # Execute the chain with the callback handler
+                                    response = chain.invoke(
+                                        {"input": "Tell me a joke about programming"},
+                                        config={"callbacks": [callback_handler]}
+                                    )
 
-                <br />
-                <ProductScreenshot
-                    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syne_ecd0801880.png"
-                    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syjm_5baab36590.png"
-                    alt="LLM generations in PostHog"
-                    classes="rounded"
-                    className="mt-10"
-                    padding={false}
-                />
+                                    print(response.content)
+                                `,
+                            },
+                            {
+                                language: 'ts',
+                                file: 'Node',
+                                code: dedent`
+                                    const prompt = ChatPromptTemplate.fromMessages([
+                                      ["system", "You are a helpful assistant."],
+                                      ["user", "{input}"]
+                                    ]);
 
-                <OSButton variant="secondary" asLink className="my-2" size="sm" to="https://app.posthog.com/llm-analytics/generations" external>
-                    Check for LLM events in PostHog
-                </OSButton>
-            </Step>
-        </Steps>
-    )
+                                    const model = new ChatOpenAI({
+                                      apiKey: "your_openai_api_key"
+                                    });
+
+                                    const chain = prompt.pipe(model);
+
+                                    // Execute the chain with the callback handler
+                                    const response = await chain.invoke(
+                                      { input: "Tell me a joke about programming" },
+                                      { callbacks: [callbackHandler] }
+                                    );
+
+                                    console.log(response.content);
+                                    phClient.shutdown();
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <Markdown>
+                        PostHog automatically captures an `$ai_generation` event along with these properties:
+                    </Markdown>
+
+                    {NotableGenerationProperties && <NotableGenerationProperties />}
+
+                    <Markdown>
+                        It also automatically creates a trace hierarchy based on how LangChain components are nested.
+                    </Markdown>
+                </>
+            ),
+        },
+    ]
 }
 
+export const LangChainInstallation = createInstallation(getLangChainSteps)

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -1,7 +1,7 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 import { StepDefinition } from '../steps'
 
-export const getLangChainSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties

--- a/docs/onboarding/llm-analytics/litellm.tsx
+++ b/docs/onboarding/llm-analytics/litellm.tsx
@@ -1,241 +1,235 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const LiteLLMInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, ProductScreenshot, OSButton, Markdown, Blockquote, dedent, snippets } =
-        useMDXComponents()
+import { StepDefinition } from '../steps'
 
+export const getLiteLLMSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
-    return (
-        <Steps>
-            <Blockquote>
-                <Markdown>
-                    **Note:** LiteLLM can be used as a Python SDK or as a proxy server. PostHog observability requires
-                    LiteLLM version 1.77.3 or higher.
-                </Markdown>
-            </Blockquote>
 
-            <Step title="Install LiteLLM" badge="required">
-                <Markdown>Choose your installation method based on how you want to use LiteLLM:</Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'SDK',
-                            code: dedent`
-                                pip install litellm
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Proxy',
-                            code: dedent`
-                                # Install via pip
-                                pip install 'litellm[proxy]'
-
-                                # Or run via Docker
-                                docker run --rm -p 4000:4000 ghcr.io/berriai/litellm:latest
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Configure PostHog observability" badge="required">
-                <Markdown>
-                    Configure PostHog by setting your project API key and host as well as adding `posthog` to your
-                    LiteLLM callback handlers. You can find your API key in [your project
-                    settings](https://app.posthog.com/settings/project).
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'SDK',
-                            code: dedent`
-                                import os
-                                import litellm
-
-                                # Set environment variables
-                                os.environ["POSTHOG_API_KEY"] = "<ph_project_api_key>"
-                                os.environ["POSTHOG_API_URL"] = "<ph_client_api_host>"  # Optional, defaults to https://app.posthog.com
-
-                                # Enable PostHog callbacks
-                                litellm.success_callback = ["posthog"]
-                                litellm.failure_callback = ["posthog"]  # Optional: also log failures
-                            `,
-                        },
-                        {
-                            language: 'yaml',
-                            file: 'Proxy',
-                            code: dedent`
-                                # config.yaml
-                                model_list:
-                                - model_name: gpt-4o-mini
-                                  litellm_params:
-                                    model: gpt-4o-mini
-
-                                litellm_settings:
-                                  success_callback: ["posthog"]
-                                  failure_callback: ["posthog"]  # Optional: also log failures
-
-                                environment_variables:
-                                  POSTHOG_API_KEY: "<ph_project_api_key>"
-                                  POSTHOG_API_URL: "<ph_client_api_host>"  # Optional
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Call LLMs through LiteLLM" badge="required">
-                <Markdown>
-                    Now, when you use LiteLLM to call various LLM providers, PostHog automatically captures an
-                    `$ai_generation` event.
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'SDK',
-                            code: dedent`
-                                response = litellm.completion(
-                                    model="gpt-4o-mini",
-                                    messages=[
-                                        {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
-                                    ],
-                                    metadata={
-                                        "user_id": "user_123",  # Maps to PostHog distinct_id
-                                        "company": "company_id_in_your_db"  # Custom property
-                                    }
-                                )
-
-                                print(response.choices[0].message.content)
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Proxy',
-                            code: dedent`
-                                # Start the proxy (if not already running)
-                                litellm --config config.yaml
-
-                                # Make a request to the proxy
-                                curl -X POST http://localhost:4000/chat/completions \
-                                  -H "Content-Type: application/json" \
-                                  -d '{
-                                    "model": "gpt-4o-mini",
-                                    "messages": [
-                                      {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
-                                    ],
-                                    "metadata": {
-                                      "user_id": "user_123",
-                                      "company": "company_id_in_your_db" # Custom property
-                                    }
-                                  }'
-                            `,
-                        },
-                    ]}
-                />
-
+    return [
+        {
+            title: 'LiteLLM Requirements',
+            badge: 'required',
+            content: (
                 <Blockquote>
                     <Markdown>
-                        {dedent`
-                            **Notes:**
-                            - This works with streaming responses by setting \`stream=True\`.
-                            - To disable logging for specific requests, add \`{"no-log": true}\` to metadata.
-                            - If you want to capture LLM events anonymously, **don't** pass a \`user_id\` in metadata.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                        `}
+                        **Note:** LiteLLM can be used as a Python SDK or as a proxy server. PostHog observability requires
+                        LiteLLM version 1.77.3 or higher.
                     </Markdown>
                 </Blockquote>
+            ),
+        },
+        {
+            title: 'Install LiteLLM',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Choose your installation method based on how you want to use LiteLLM:</Markdown>
 
-                <Markdown>
-                    {dedent`
-                        You can expect captured \`$ai_generation\` events to have the following properties:
-                    `}
-                </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'SDK',
+                                code: dedent`
+                                    pip install litellm
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Proxy',
+                                code: dedent`
+                                    # Install via pip
+                                    pip install 'litellm[proxy]'
 
-                {NotableGenerationProperties && <NotableGenerationProperties />}
-            </Step>
+                                    # Or run via Docker
+                                    docker run --rm -p 4000:4000 ghcr.io/berriai/litellm:latest
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure PostHog observability',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Configure PostHog by setting your project API key and host as well as adding `posthog` to your
+                        LiteLLM callback handlers. You can find your API key in [your project
+                        settings](https://app.posthog.com/settings/project).
+                    </Markdown>
 
-            <Step
-                checkpoint
-                title="Verify traces and generations"
-                subtitle="Confirm LLM events are being sent to PostHog"
-                docsOnly
-            >
-                <Markdown>
-                    Let's make sure LLM events are being captured and sent to PostHog. Under **LLM analytics**, you
-                    should see rows of data appear in the **Traces** and **Generations** tabs.
-                </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'SDK',
+                                code: dedent`
+                                    import os
+                                    import litellm
 
-                <br />
-                <ProductScreenshot
-                    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syne_ecd0801880.png"
-                    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syjm_5baab36590.png"
-                    alt="LLM generations in PostHog"
-                    classes="rounded"
-                    className="mt-10"
-                    padding={false}
-                />
+                                    # Set environment variables
+                                    os.environ["POSTHOG_API_KEY"] = "<ph_project_api_key>"
+                                    os.environ["POSTHOG_API_URL"] = "<ph_client_api_host>"  # Optional, defaults to https://app.posthog.com
 
-                <OSButton
-                    variant="secondary"
-                    asLink
-                    className="my-2"
-                    size="sm"
-                    to="https://app.posthog.com/llm-analytics/generations"
-                    external
-                >
-                    Check for LLM events in PostHog
-                </OSButton>
-            </Step>
+                                    # Enable PostHog callbacks
+                                    litellm.success_callback = ["posthog"]
+                                    litellm.failure_callback = ["posthog"]  # Optional: also log failures
+                                `,
+                            },
+                            {
+                                language: 'yaml',
+                                file: 'Proxy',
+                                code: dedent`
+                                    # config.yaml
+                                    model_list:
+                                    - model_name: gpt-4o-mini
+                                      litellm_params:
+                                        model: gpt-4o-mini
 
-            <Step title="Capture embeddings" badge="optional">
-                <Markdown>
-                    PostHog can also capture embedding generations as `$ai_embedding` events through LiteLLM:
-                </Markdown>
+                                    litellm_settings:
+                                      success_callback: ["posthog"]
+                                      failure_callback: ["posthog"]  # Optional: also log failures
 
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'SDK',
-                            code: dedent`
-                                response = litellm.embedding(
-                                    input="The quick brown fox",
-                                    model="text-embedding-3-small",
-                                    metadata={
-                                        "user_id": "user_123",  # Maps to PostHog distinct_id
-                                        "company": "company_id_in_your_db"  # Custom property
-                                    }
-                                )
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Proxy',
-                            code: dedent`
-                                # Make an embeddings request to the proxy
-                                curl -X POST http://localhost:4000/embeddings \
-                                  -H "Content-Type: application/json" \
-                                  -d '{
-                                    "input": "The quick brown fox",
-                                    "model": "text-embedding-3-small",
-                                    "metadata": {
-                                      "user_id": "user_123",
-                                      "company": "company_id_in_your_db" # Custom property
-                                    }
-                                  }'
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-        </Steps>
-    )
+                                    environment_variables:
+                                      POSTHOG_API_KEY: "<ph_project_api_key>"
+                                      POSTHOG_API_URL: "<ph_client_api_host>"  # Optional
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Call LLMs through LiteLLM',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Now, when you use LiteLLM to call various LLM providers, PostHog automatically captures an
+                        `$ai_generation` event.
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'SDK',
+                                code: dedent`
+                                    response = litellm.completion(
+                                        model="gpt-4o-mini",
+                                        messages=[
+                                            {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
+                                        ],
+                                        metadata={
+                                            "user_id": "user_123",  # Maps to PostHog distinct_id
+                                            "company": "company_id_in_your_db"  # Custom property
+                                        }
+                                    )
+
+                                    print(response.choices[0].message.content)
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Proxy',
+                                code: dedent`
+                                    # Start the proxy (if not already running)
+                                    litellm --config config.yaml
+
+                                    # Make a request to the proxy
+                                    curl -X POST http://localhost:4000/chat/completions \
+                                      -H "Content-Type: application/json" \
+                                      -d '{
+                                        "model": "gpt-4o-mini",
+                                        "messages": [
+                                          {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
+                                        ],
+                                        "metadata": {
+                                          "user_id": "user_123",
+                                          "company": "company_id_in_your_db" # Custom property
+                                        }
+                                      }'
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <Blockquote>
+                        <Markdown>
+                            {dedent`
+                                **Notes:**
+                                - This works with streaming responses by setting \`stream=True\`.
+                                - To disable logging for specific requests, add \`{"no-log": true}\` to metadata.
+                                - If you want to capture LLM events anonymously, **don't** pass a \`user_id\` in metadata.
+
+                                See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            `}
+                        </Markdown>
+                    </Blockquote>
+
+                    <Markdown>
+                        {dedent`
+                            You can expect captured \`$ai_generation\` events to have the following properties:
+                        `}
+                    </Markdown>
+
+                    {NotableGenerationProperties && <NotableGenerationProperties />}
+                </>
+            ),
+        },
+        {
+            title: 'Capture embeddings',
+            badge: 'optional',
+            content: (
+                <>
+                    <Markdown>
+                        PostHog can also capture embedding generations as `$ai_embedding` events through LiteLLM:
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'SDK',
+                                code: dedent`
+                                    response = litellm.embedding(
+                                        input="The quick brown fox",
+                                        model="text-embedding-3-small",
+                                        metadata={
+                                            "user_id": "user_123",  # Maps to PostHog distinct_id
+                                            "company": "company_id_in_your_db"  # Custom property
+                                        }
+                                    )
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Proxy',
+                                code: dedent`
+                                    # Make an embeddings request to the proxy
+                                    curl -X POST http://localhost:4000/embeddings \
+                                      -H "Content-Type: application/json" \
+                                      -d '{
+                                        "input": "The quick brown fox",
+                                        "model": "text-embedding-3-small",
+                                        "metadata": {
+                                          "user_id": "user_123",
+                                          "company": "company_id_in_your_db" # Custom property
+                                        }
+                                      }'
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+    ]
 }
+
+export const LiteLLMInstallation = createInstallation(getLiteLLMSteps)

--- a/docs/onboarding/llm-analytics/litellm.tsx
+++ b/docs/onboarding/llm-analytics/litellm.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getLiteLLMSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getLiteLLMSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 

--- a/docs/onboarding/llm-analytics/manual.tsx
+++ b/docs/onboarding/llm-analytics/manual.tsx
@@ -1,7 +1,7 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 import { StepDefinition } from '../steps'
 
-export const getManualSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getManualSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { Markdown, Tab, CodeBlock, snippets, dedent } = ctx
 
     const GenerationEvent = snippets?.GenerationEvent

--- a/docs/onboarding/llm-analytics/manual.tsx
+++ b/docs/onboarding/llm-analytics/manual.tsx
@@ -1,7 +1,8 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { StepDefinition } from '../steps'
 
-export const ManualInstallation = (): JSX.Element => {
-    const { Markdown, Tab, CodeBlock, snippets, dedent } = useMDXComponents()
+export const getManualSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { Markdown, Tab, CodeBlock, snippets, dedent } = ctx
 
     const GenerationEvent = snippets?.GenerationEvent
     const TraceEvent = snippets?.TraceEvent
@@ -17,281 +18,288 @@ export const ManualInstallation = (): JSX.Element => {
         { key: 'PHP', label: 'PHP' },
     ]
 
-    return (
-        <>
-            <Markdown>
-                If you're using a different server-side SDK or prefer to use the API, you can manually capture the data
-                by calling the `capture` method or using the [capture API](https://posthog.com/docs/api/capture).
-            </Markdown>
+    return [
+        {
+            title: 'Capture LLM events manually',
+            content: (
+                <>
+                    <Markdown>
+                        If you're using a different server-side SDK or prefer to use the API, you can manually capture the data
+                        by calling the `capture` method or using the [capture API](https://posthog.com/docs/api/capture).
+                    </Markdown>
 
-            <Tab.Group tabs={languages.map((l) => l.label)}>
-                <Tab.List>
-                    {languages.map((l) => (
-                        <Tab key={l.key}>{l.label}</Tab>
-                    ))}
-                </Tab.List>
-                <Tab.Panels>
-                    {languages.map((l) => (
-                        <Tab.Panel key={l.key}>
-                            <>
-                                {l.key === 'Node.js' && (
+                    <Tab.Group tabs={languages.map((l) => l.label)}>
+                        <Tab.List>
+                            {languages.map((l) => (
+                                <Tab key={l.key}>{l.label}</Tab>
+                            ))}
+                        </Tab.List>
+                        <Tab.Panels>
+                            {languages.map((l) => (
+                                <Tab.Panel key={l.key}>
                                     <>
-                                        <Markdown>### 1. Install</Markdown>
-                                        <CodeBlock language="bash" code="npm install posthog-node" />
+                                        {l.key === 'Node.js' && (
+                                            <>
+                                                <Markdown>### 1. Install</Markdown>
+                                                <CodeBlock language="bash" code="npm install posthog-node" />
 
-                                        <Markdown>### 2. Initialize PostHog</Markdown>
-                                        <CodeBlock
-                                            language="javascript"
-                                            code={dedent`
-                                                import { PostHog } from 'posthog-node'
+                                                <Markdown>### 2. Initialize PostHog</Markdown>
+                                                <CodeBlock
+                                                    language="javascript"
+                                                    code={dedent`
+                                                        import { PostHog } from 'posthog-node'
 
-                                                const client = new PostHog('<ph_project_api_key>', {
-                                                    host: '<ph_client_api_host>'
-                                                })
-                                            `}
-                                        />
+                                                        const client = new PostHog('<ph_project_api_key>', {
+                                                            host: '<ph_client_api_host>'
+                                                        })
+                                                    `}
+                                                />
 
-                                        <Markdown>### 3. Capture Event</Markdown>
-                                        <CodeBlock
-                                            language="javascript"
-                                            code={dedent`
-                                                // After your LLM call
-                                                client.capture({
-                                                    distinctId: 'user_123',
-                                                    event: '$ai_generation',
-                                                    properties: {
-                                                        $ai_trace_id: 'trace_id_here',
-                                                        $ai_model: 'gpt-4o-mini',
-                                                        $ai_provider: 'openai',
-                                                        $ai_input: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
-                                                        $ai_input_tokens: 10,
-                                                        $ai_output_choices: [{ role: 'assistant', content: 'Hedgehogs have around 5,000 to 7,000 spines on their backs!' }],
-                                                        $ai_output_tokens: 20,
-                                                        $ai_latency: 1.5
-                                                    }
-                                                })
-
-                                                client.shutdown()
-                                            `}
-                                        />
-                                    </>
-                                )}
-
-                                {l.key === 'Python' && (
-                                    <>
-                                        <Markdown>### 1. Install</Markdown>
-                                        <CodeBlock language="bash" code="pip install posthog" />
-
-                                        <Markdown>### 2. Initialize PostHog</Markdown>
-                                        <CodeBlock
-                                            language="python"
-                                            code={dedent`
-                                                from posthog import Posthog
-
-                                                posthog = Posthog("<ph_project_api_key>", host="<ph_client_api_host>")
-                                            `}
-                                        />
-
-                                        <Markdown>### 3. Capture Event</Markdown>
-                                        <CodeBlock
-                                            language="python"
-                                            code={dedent`
-                                                # After your LLM call
-                                                posthog.capture(
-                                                    distinct_id='user_123',
-                                                    event='$ai_generation',
-                                                    properties={
-                                                        '$ai_trace_id': 'trace_id_here',
-                                                        '$ai_model': 'gpt-4o-mini',
-                                                        '$ai_provider': 'openai',
-                                                        '$ai_input': [{'role': 'user', 'content': 'Tell me a fun fact about hedgehogs'}],
-                                                        '$ai_input_tokens': 10,
-                                                        '$ai_output_choices': [{'role': 'assistant', 'content': 'Hedgehogs have around 5,000 to 7,000 spines on their backs!'}],
-                                                        '$ai_output_tokens': 20,
-                                                        '$ai_latency': 1.5
-                                                    }
-                                                )
-                                            `}
-                                        />
-                                    </>
-                                )}
-
-                                {l.key === 'Go' && (
-                                    <>
-                                        <Markdown>### 1. Install</Markdown>
-                                        <CodeBlock language="bash" code="go get github.com/posthog/posthog-go" />
-
-                                        <Markdown>### 2. Initialize PostHog</Markdown>
-                                        <CodeBlock
-                                            language="go"
-                                            code={dedent`
-                                                import "github.com/posthog/posthog-go"
-
-                                                client, _ := posthog.NewWithConfig("<ph_project_api_key>", posthog.Config{
-                                                    Endpoint: "<ph_client_api_host>",
-                                                })
-                                                defer client.Close()
-                                            `}
-                                        />
-
-                                        <Markdown>### 3. Capture Event</Markdown>
-                                        <CodeBlock
-                                            language="go"
-                                            code={dedent`
-                                                // After your LLM call
-                                                client.Enqueue(posthog.Capture{
-                                                    DistinctId: "user_123",
-                                                    Event:      "$ai_generation",
-                                                    Properties: map[string]interface{}{
-                                                        "$ai_trace_id":        "trace_id_here",
-                                                        "$ai_model":           "gpt-4o-mini",
-                                                        "$ai_provider":        "openai",
-                                                        "$ai_input_tokens":    10,
-                                                        "$ai_output_tokens":   20,
-                                                        "$ai_latency":         1.5,
-                                                    },
-                                                })
-                                            `}
-                                        />
-                                    </>
-                                )}
-
-                                {l.key === 'Ruby' && (
-                                    <>
-                                        <Markdown>### 1. Install</Markdown>
-                                        <CodeBlock language="bash" code="gem install posthog-ruby" />
-
-                                        <Markdown>### 2. Initialize PostHog</Markdown>
-                                        <CodeBlock
-                                            language="ruby"
-                                            code={dedent`
-                                                require 'posthog-ruby'
-
-                                                posthog = PostHog::Client.new({
-                                                    api_key: '<ph_project_api_key>',
-                                                    host: '<ph_client_api_host>'
-                                                })
-                                            `}
-                                        />
-
-                                        <Markdown>### 3. Capture Event</Markdown>
-                                        <CodeBlock
-                                            language="ruby"
-                                            code={dedent`
-                                                # After your LLM call
-                                                posthog.capture({
-                                                    distinct_id: 'user_123',
-                                                    event: '$ai_generation',
-                                                    properties: {
-                                                    '$ai_trace_id' => 'trace_id_here',
-                                                    '$ai_model' => 'gpt-4o-mini',
-                                                    '$ai_provider' => 'openai',
-                                                    '$ai_input_tokens' => 10,
-                                                    '$ai_output_tokens' => 20,
-                                                    '$ai_latency' => 1.5
-                                                    }
-                                                })
-                                            `}
-                                        />
-                                    </>
-                                )}
-
-                                {l.key === 'PHP' && (
-                                    <>
-                                        <Markdown>### 1. Install</Markdown>
-                                        <CodeBlock language="bash" code="composer require posthog/posthog-php" />
-
-                                        <Markdown>### 2. Initialize PostHog</Markdown>
-                                        <CodeBlock
-                                            language="php"
-                                            code={dedent`
-                                                <?php
-                                                require_once __DIR__ . '/vendor/autoload.php';
-                                                use PostHog\\PostHog;
-
-                                                PostHog::init('<ph_project_api_key>', [
-                                                    'host' => '<ph_client_api_host>'
-                                                ]);
-                                            `}
-                                        />
-
-                                        <Markdown>### 3. Capture Event</Markdown>
-                                        <CodeBlock
-                                            language="php"
-                                            code={dedent`
-                                                // After your LLM call
-                                                PostHog::capture([
-                                                    'distinctId' => 'user_123',
-                                                    'event' => '$ai_generation',
-                                                    'properties' => [
-                                                        '$ai_trace_id' => 'trace_id_here',
-                                                        '$ai_model' => 'gpt-4o-mini',
-                                                        '$ai_provider' => 'openai',
-                                                        '$ai_input_tokens' => 10,
-                                                        '$ai_output_tokens' => 20,
-                                                        '$ai_latency' => 1.5
-                                                    ]
-                                                ]);
-                                            `}
-                                        />
-                                    </>
-                                )}
-
-                                {l.key === 'API' && (
-                                    <>
-                                        <Markdown>### Capture via API</Markdown>
-                                        <CodeBlock
-                                            language="bash"
-                                            code={dedent`
-                                                curl -X POST "<ph_client_api_host>/i/v0/e/" \\
-                                                        -H "Content-Type: application/json" \\
-                                                        -d '{
-                                                            "api_key": "<ph_project_api_key>",
-                                                            "event": "$ai_generation",
-                                                            "properties": {
-                                                                "distinct_id": "user_123",
-                                                                "$ai_trace_id": "trace_id_here",
-                                                                "$ai_model": "gpt-4o-mini",
-                                                                "$ai_provider": "openai",
-                                                                "$ai_input": [{"role": "user", "content": "Tell me a fun fact about hedgehogs"}],
-                                                                "$ai_input_tokens": 10,
-                                                                "$ai_output_choices": [{"role": "assistant", "content": "Hedgehogs have around 5,000 to 7,000 spines on their backs!"}],
-                                                                "$ai_output_tokens": 20,
-                                                                "$ai_latency": 1.5
+                                                <Markdown>### 3. Capture Event</Markdown>
+                                                <CodeBlock
+                                                    language="javascript"
+                                                    code={dedent`
+                                                        // After your LLM call
+                                                        client.capture({
+                                                            distinctId: 'user_123',
+                                                            event: '$ai_generation',
+                                                            properties: {
+                                                                $ai_trace_id: 'trace_id_here',
+                                                                $ai_model: 'gpt-4o-mini',
+                                                                $ai_provider: 'openai',
+                                                                $ai_input: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                                                $ai_input_tokens: 10,
+                                                                $ai_output_choices: [{ role: 'assistant', content: 'Hedgehogs have around 5,000 to 7,000 spines on their backs!' }],
+                                                                $ai_output_tokens: 20,
+                                                                $ai_latency: 1.5
                                                             }
-                                                        }'
-                                            `}
-                                        />
+                                                        })
+
+                                                        client.shutdown()
+                                                    `}
+                                                />
+                                            </>
+                                        )}
+
+                                        {l.key === 'Python' && (
+                                            <>
+                                                <Markdown>### 1. Install</Markdown>
+                                                <CodeBlock language="bash" code="pip install posthog" />
+
+                                                <Markdown>### 2. Initialize PostHog</Markdown>
+                                                <CodeBlock
+                                                    language="python"
+                                                    code={dedent`
+                                                        from posthog import Posthog
+
+                                                        posthog = Posthog("<ph_project_api_key>", host="<ph_client_api_host>")
+                                                    `}
+                                                />
+
+                                                <Markdown>### 3. Capture Event</Markdown>
+                                                <CodeBlock
+                                                    language="python"
+                                                    code={dedent`
+                                                        # After your LLM call
+                                                        posthog.capture(
+                                                            distinct_id='user_123',
+                                                            event='$ai_generation',
+                                                            properties={
+                                                                '$ai_trace_id': 'trace_id_here',
+                                                                '$ai_model': 'gpt-4o-mini',
+                                                                '$ai_provider': 'openai',
+                                                                '$ai_input': [{'role': 'user', 'content': 'Tell me a fun fact about hedgehogs'}],
+                                                                '$ai_input_tokens': 10,
+                                                                '$ai_output_choices': [{'role': 'assistant', 'content': 'Hedgehogs have around 5,000 to 7,000 spines on their backs!'}],
+                                                                '$ai_output_tokens': 20,
+                                                                '$ai_latency': 1.5
+                                                            }
+                                                        )
+                                                    `}
+                                                />
+                                            </>
+                                        )}
+
+                                        {l.key === 'Go' && (
+                                            <>
+                                                <Markdown>### 1. Install</Markdown>
+                                                <CodeBlock language="bash" code="go get github.com/posthog/posthog-go" />
+
+                                                <Markdown>### 2. Initialize PostHog</Markdown>
+                                                <CodeBlock
+                                                    language="go"
+                                                    code={dedent`
+                                                        import "github.com/posthog/posthog-go"
+
+                                                        client, _ := posthog.NewWithConfig("<ph_project_api_key>", posthog.Config{
+                                                            Endpoint: "<ph_client_api_host>",
+                                                        })
+                                                        defer client.Close()
+                                                    `}
+                                                />
+
+                                                <Markdown>### 3. Capture Event</Markdown>
+                                                <CodeBlock
+                                                    language="go"
+                                                    code={dedent`
+                                                        // After your LLM call
+                                                        client.Enqueue(posthog.Capture{
+                                                            DistinctId: "user_123",
+                                                            Event:      "$ai_generation",
+                                                            Properties: map[string]interface{}{
+                                                                "$ai_trace_id":        "trace_id_here",
+                                                                "$ai_model":           "gpt-4o-mini",
+                                                                "$ai_provider":        "openai",
+                                                                "$ai_input_tokens":    10,
+                                                                "$ai_output_tokens":   20,
+                                                                "$ai_latency":         1.5,
+                                                            },
+                                                        })
+                                                    `}
+                                                />
+                                            </>
+                                        )}
+
+                                        {l.key === 'Ruby' && (
+                                            <>
+                                                <Markdown>### 1. Install</Markdown>
+                                                <CodeBlock language="bash" code="gem install posthog-ruby" />
+
+                                                <Markdown>### 2. Initialize PostHog</Markdown>
+                                                <CodeBlock
+                                                    language="ruby"
+                                                    code={dedent`
+                                                        require 'posthog-ruby'
+
+                                                        posthog = PostHog::Client.new({
+                                                            api_key: '<ph_project_api_key>',
+                                                            host: '<ph_client_api_host>'
+                                                        })
+                                                    `}
+                                                />
+
+                                                <Markdown>### 3. Capture Event</Markdown>
+                                                <CodeBlock
+                                                    language="ruby"
+                                                    code={dedent`
+                                                        # After your LLM call
+                                                        posthog.capture({
+                                                            distinct_id: 'user_123',
+                                                            event: '$ai_generation',
+                                                            properties: {
+                                                            '$ai_trace_id' => 'trace_id_here',
+                                                            '$ai_model' => 'gpt-4o-mini',
+                                                            '$ai_provider' => 'openai',
+                                                            '$ai_input_tokens' => 10,
+                                                            '$ai_output_tokens' => 20,
+                                                            '$ai_latency' => 1.5
+                                                            }
+                                                        })
+                                                    `}
+                                                />
+                                            </>
+                                        )}
+
+                                        {l.key === 'PHP' && (
+                                            <>
+                                                <Markdown>### 1. Install</Markdown>
+                                                <CodeBlock language="bash" code="composer require posthog/posthog-php" />
+
+                                                <Markdown>### 2. Initialize PostHog</Markdown>
+                                                <CodeBlock
+                                                    language="php"
+                                                    code={dedent`
+                                                        <?php
+                                                        require_once __DIR__ . '/vendor/autoload.php';
+                                                        use PostHog\\PostHog;
+
+                                                        PostHog::init('<ph_project_api_key>', [
+                                                            'host' => '<ph_client_api_host>'
+                                                        ]);
+                                                    `}
+                                                />
+
+                                                <Markdown>### 3. Capture Event</Markdown>
+                                                <CodeBlock
+                                                    language="php"
+                                                    code={dedent`
+                                                        // After your LLM call
+                                                        PostHog::capture([
+                                                            'distinctId' => 'user_123',
+                                                            'event' => '$ai_generation',
+                                                            'properties' => [
+                                                                '$ai_trace_id' => 'trace_id_here',
+                                                                '$ai_model' => 'gpt-4o-mini',
+                                                                '$ai_provider' => 'openai',
+                                                                '$ai_input_tokens' => 10,
+                                                                '$ai_output_tokens' => 20,
+                                                                '$ai_latency' => 1.5
+                                                            ]
+                                                        ]);
+                                                    `}
+                                                />
+                                            </>
+                                        )}
+
+                                        {l.key === 'API' && (
+                                            <>
+                                                <Markdown>### Capture via API</Markdown>
+                                                <CodeBlock
+                                                    language="bash"
+                                                    code={dedent`
+                                                        curl -X POST "<ph_client_api_host>/i/v0/e/" \\
+                                                                -H "Content-Type: application/json" \\
+                                                                -d '{
+                                                                    "api_key": "<ph_project_api_key>",
+                                                                    "event": "$ai_generation",
+                                                                    "properties": {
+                                                                        "distinct_id": "user_123",
+                                                                        "$ai_trace_id": "trace_id_here",
+                                                                        "$ai_model": "gpt-4o-mini",
+                                                                        "$ai_provider": "openai",
+                                                                        "$ai_input": [{"role": "user", "content": "Tell me a fun fact about hedgehogs"}],
+                                                                        "$ai_input_tokens": 10,
+                                                                        "$ai_output_choices": [{"role": "assistant", "content": "Hedgehogs have around 5,000 to 7,000 spines on their backs!"}],
+                                                                        "$ai_output_tokens": 20,
+                                                                        "$ai_latency": 1.5
+                                                                    }
+                                                                }'
+                                                    `}
+                                                />
+                                            </>
+                                        )}
                                     </>
-                                )}
-                            </>
-                        </Tab.Panel>
-                    ))}
-                </Tab.Panels>
-            </Tab.Group>
+                                </Tab.Panel>
+                            ))}
+                        </Tab.Panels>
+                    </Tab.Group>
 
-            <Markdown>
-                {dedent`
-                    ### Event Properties
+                    <Markdown>
+                        {dedent`
+                            ### Event Properties
 
-                    Each event type has specific properties. See the tabs below for detailed property documentation for each event type.
-                `}
-            </Markdown>
+                            Each event type has specific properties. See the tabs below for detailed property documentation for each event type.
+                        `}
+                    </Markdown>
 
-            <Tab.Group tabs={['Generation', 'Trace', 'Span', 'Embedding']}>
-                <Tab.List>
-                    <Tab>Generation</Tab>
-                    <Tab>Trace</Tab>
-                    <Tab>Span</Tab>
-                    <Tab>Embedding</Tab>
-                </Tab.List>
-                <Tab.Panels>
-                    <Tab.Panel>{GenerationEvent && <GenerationEvent />}</Tab.Panel>
-                    <Tab.Panel>{TraceEvent && <TraceEvent />}</Tab.Panel>
-                    <Tab.Panel>{SpanEvent && <SpanEvent />}</Tab.Panel>
-                    <Tab.Panel>{EmbeddingEvent && <EmbeddingEvent />}</Tab.Panel>
-                </Tab.Panels>
-            </Tab.Group>
-        </>
-    )
+                    <Tab.Group tabs={['Generation', 'Trace', 'Span', 'Embedding']}>
+                        <Tab.List>
+                            <Tab>Generation</Tab>
+                            <Tab>Trace</Tab>
+                            <Tab>Span</Tab>
+                            <Tab>Embedding</Tab>
+                        </Tab.List>
+                        <Tab.Panels>
+                            <Tab.Panel>{GenerationEvent && <GenerationEvent />}</Tab.Panel>
+                            <Tab.Panel>{TraceEvent && <TraceEvent />}</Tab.Panel>
+                            <Tab.Panel>{SpanEvent && <SpanEvent />}</Tab.Panel>
+                            <Tab.Panel>{EmbeddingEvent && <EmbeddingEvent />}</Tab.Panel>
+                        </Tab.Panels>
+                    </Tab.Group>
+                </>
+            ),
+        },
+    ]
 }
+
+export const ManualInstallation = createInstallation(getManualSteps)

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -1,255 +1,248 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { StepDefinition } from '../steps'
 
-export const OpenAIInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, CalloutBox, ProductScreenshot, OSButton, Markdown, Blockquote, dedent, snippets } =
-        useMDXComponents()
-    
+export const getOpenAISteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
-    
-    return (
-        <Steps>
-            <Step title="Install the PostHog SDK" badge="required">
-                <Markdown>
-                    Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics works
-                    best with our Python and Node SDKs.
-                </Markdown>
 
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Python',
-                            code: dedent`
-                                pip install posthog
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Node',
-                            code: dedent`
-                                npm install @posthog/ai posthog-node
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Install the OpenAI SDK" badge="required">
-                <Markdown>
-                    Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI client. The
-                    PostHog SDK **does not** proxy your calls.
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Python',
-                            code: dedent`
-                                pip install openai
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Node',
-                            code: dedent`
-                                npm install openai
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Initialize PostHog and OpenAI client" badge="required">
-                <Markdown>
-                    Initialize PostHog with your project API key and host from [your project
-                    settings](https://app.posthog.com/settings/project), then pass it to our OpenAI wrapper.
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
-                                from posthog.ai.openai import OpenAI
-                                from posthog import Posthog
-
-                                posthog = Posthog(
-                                    "<ph_project_api_key>",
-                                    host="<ph_client_api_host>"
-                                )
-
-                                client = OpenAI(
-                                    api_key="your_openai_api_key",
-                                    posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
-                                )
-                            `,
-                        },
-                        {
-                            language: 'ts',
-                            file: 'Node',
-                            code: dedent`
-                                import { OpenAI } from '@posthog/ai'
-                                import { PostHog } from 'posthog-node'
-
-                                const phClient = new PostHog(
-                                  '<ph_project_api_key>',
-                                  { host: '<ph_client_api_host>' }
-                                );
-
-                                const openai = new OpenAI({
-                                  apiKey: 'your_openai_api_key',
-                                  posthog: phClient,
-                                });
-
-                                // ... your code here ...
-
-                                // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                phClient.shutdown()
-                            `,
-                        },
-                    ]}
-                />
-
-                <Blockquote>
-                    <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                </Blockquote>
-
-                <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+    return [
+        {
+            title: 'Install the PostHog SDK',
+            badge: 'required',
+            content: (
+                <>
                     <Markdown>
-                        These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                        background to send the data. You can also use LLM analytics with other SDKs or our API, but you
-                        will need to capture the data in the right format. See the schema in the [manual capture
-                        section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics works
+                        best with our Python and Node SDKs.
                     </Markdown>
-                </CalloutBox>
-            </Step>
 
-            <Step title="Call OpenAI LLMs" badge="required">
-                <Markdown>
-                    Now, when you use the OpenAI SDK to call LLMs, PostHog automatically captures an `$ai_generation`
-                    event. You can enrich the event with additional data such as the trace ID, distinct ID, custom
-                    properties, groups, and privacy mode options.
-                </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install posthog
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install @posthog/ai posthog-node
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Install the OpenAI SDK',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI client. The
+                        PostHog SDK **does not** proxy your calls.
+                    </Markdown>
 
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
-                                response = client.responses.create(
-                                    model="gpt-4o-mini",
-                                    input=[
-                                        {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
-                                    ],
-                                    posthog_distinct_id="user_123", # optional
-                                    posthog_trace_id="trace_123", # optional
-                                    posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                    posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                    posthog_privacy_mode=False # optional
-                                )
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install openai
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install openai
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Initialize PostHog and OpenAI client',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Initialize PostHog with your project API key and host from [your project
+                        settings](https://app.posthog.com/settings/project), then pass it to our OpenAI wrapper.
+                    </Markdown>
 
-                                print(response.choices[0].message.content)
-                            `,
-                        },
-                        {
-                            language: 'ts',
-                            file: 'Node',
-                            code: dedent`
-                                const completion = await openai.responses.create({
-                                    model: "gpt-4o-mini",
-                                    input: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                    posthogDistinctId: "user_123", // optional
-                                    posthogTraceId: "trace_123", // optional
-                                    posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                    posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                    posthogPrivacyMode: false // optional
-                                });
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    from posthog.ai.openai import OpenAI
+                                    from posthog import Posthog
 
-                                console.log(completion.choices[0].message.content)
-                            `,
-                        },
-                    ]}
-                />
+                                    posthog = Posthog(
+                                        "<ph_project_api_key>",
+                                        host="<ph_client_api_host>"
+                                    )
 
-                <Blockquote>
+                                    client = OpenAI(
+                                        api_key="your_openai_api_key",
+                                        posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
+                                    )
+                                `,
+                            },
+                            {
+                                language: 'ts',
+                                file: 'Node',
+                                code: dedent`
+                                    import { OpenAI } from '@posthog/ai'
+                                    import { PostHog } from 'posthog-node'
+
+                                    const phClient = new PostHog(
+                                      '<ph_project_api_key>',
+                                      { host: '<ph_client_api_host>' }
+                                    );
+
+                                    const openai = new OpenAI({
+                                      apiKey: 'your_openai_api_key',
+                                      posthog: phClient,
+                                    });
+
+                                    // ... your code here ...
+
+                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
+                                    phClient.shutdown()
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <Blockquote>
+                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
+                    </Blockquote>
+
+                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
+                            background to send the data. You can also use LLM analytics with other SDKs or our API, but you
+                            will need to capture the data in the right format. See the schema in the [manual capture
+                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+        {
+            title: 'Call OpenAI LLMs',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Now, when you use the OpenAI SDK to call LLMs, PostHog automatically captures an `$ai_generation`
+                        event. You can enrich the event with additional data such as the trace ID, distinct ID, custom
+                        properties, groups, and privacy mode options.
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    response = client.responses.create(
+                                        model="gpt-4o-mini",
+                                        input=[
+                                            {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
+                                        ],
+                                        posthog_distinct_id="user_123", # optional
+                                        posthog_trace_id="trace_123", # optional
+                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
+                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
+                                        posthog_privacy_mode=False # optional
+                                    )
+
+                                    print(response.choices[0].message.content)
+                                `,
+                            },
+                            {
+                                language: 'ts',
+                                file: 'Node',
+                                code: dedent`
+                                    const completion = await openai.responses.create({
+                                        model: "gpt-4o-mini",
+                                        input: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
+                                        posthogDistinctId: "user_123", // optional
+                                        posthogTraceId: "trace_123", // optional
+                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
+                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
+                                        posthogPrivacyMode: false // optional
+                                    });
+
+                                    console.log(completion.choices[0].message.content)
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <Blockquote>
+                        <Markdown>
+                            {dedent`
+                            **Notes:**
+                            - We also support the old \`chat.completions\` API.
+                            - This works with responses where \`stream=True\`.
+                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
+
+                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            `}
+                        </Markdown>
+                    </Blockquote>
+
                     <Markdown>
                         {dedent`
-                        **Notes:**
-                        - We also support the old \`chat.completions\` API.
-                        - This works with responses where \`stream=True\`.
-                        - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                        See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            You can expect captured \`$ai_generation\` events to have the following properties:
                         `}
                     </Markdown>
-                </Blockquote>
 
-                <Markdown>
-                    {dedent`
-                        You can expect captured \`$ai_generation\` events to have the following properties:
-                    `}
-                </Markdown>
+                    {NotableGenerationProperties && <NotableGenerationProperties />}
+                </>
+            ),
+        },
+        {
+            title: 'Capture embeddings',
+            badge: 'optional',
+            content: (
+                <>
+                    <Markdown>
+                        PostHog can also capture embedding generations as `$ai_embedding` events. Just make sure to use the
+                        same `posthog.ai.openai` client to do so:
+                    </Markdown>
 
-                {NotableGenerationProperties && <NotableGenerationProperties />}
-            </Step>
-
-            <Step
-                checkpoint
-                title="Verify traces and generations"
-                subtitle="Confirm LLM events are being sent to PostHog"
-                docsOnly
-            >
-                <Markdown>
-                    Let's make sure LLM events are being captured and sent to PostHog. Under **LLM analytics**, you
-                    should see rows of data appear in the **Traces** and **Generations** tabs.
-                </Markdown>
-
-                <br />
-                <ProductScreenshot
-                    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syne_ecd0801880.png"
-                    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syjm_5baab36590.png"
-                    alt="LLM generations in PostHog"
-                    classes="rounded"
-                    className="mt-10"
-                    padding={false}
-                />
-
-                <OSButton
-                    variant="secondary"
-                    asLink
-                    className="my-2"
-                    size="sm"
-                    to="https://app.posthog.com/llm-analytics/generations"
-                    external
-                >
-                    Check for LLM events in PostHog
-                </OSButton>
-            </Step>
-
-            <Step title="Capture embeddings" badge="optional">
-                <Markdown>
-                    PostHog can also capture embedding generations as `$ai_embedding` events. Just make sure to use the
-                    same `posthog.ai.openai` client to do so:
-                </Markdown>
-
-                <CodeBlock
-                    language="python"
-                    code={dedent`
-                        response = client.embeddings.create(
-                            input="The quick brown fox",
-                            model="text-embedding-3-small",
-                            posthog_distinct_id="user_123", # optional
-                            posthog_trace_id="trace_123",   # optional
-                            posthog_properties={"key": "value"} # optional
-                            posthog_groups={"company": "company_id_in_your_db"}  # optional
-                            posthog_privacy_mode=False # optional
-                        )
-                    `}
-                />
-            </Step>
-        </Steps>
-    )
+                    <CodeBlock
+                        language="python"
+                        code={dedent`
+                            response = client.embeddings.create(
+                                input="The quick brown fox",
+                                model="text-embedding-3-small",
+                                posthog_distinct_id="user_123", # optional
+                                posthog_trace_id="trace_123",   # optional
+                                posthog_properties={"key": "value"} # optional
+                                posthog_groups={"company": "company_id_in_your_db"}  # optional
+                                posthog_privacy_mode=False # optional
+                            )
+                        `}
+                    />
+                </>
+            ),
+        },
+    ]
 }
+
+export const OpenAIInstallation = createInstallation(getOpenAISteps)

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -1,7 +1,7 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 import { StepDefinition } from '../steps'
 
-export const getOpenAISteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties

--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -1,7 +1,7 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 import { StepDefinition } from '../steps'
 
-export const getOpenRouterSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties

--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -1,239 +1,228 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { StepDefinition } from '../steps'
 
-export const OpenRouterInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, CalloutBox, ProductScreenshot, OSButton, Markdown, Blockquote, dedent, snippets } =
-        useMDXComponents()
+export const getOpenRouterSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
-    return (
-        <Steps>
-            <CalloutBox type="fyi" icon="IconInfo" title="Alternative: OpenRouter Broadcast">
-                <Markdown>
-                    OpenRouter also offers a native [Broadcast feature](https://openrouter.ai/docs/guides/features/broadcast/posthog) that can automatically send LLM analytics data to PostHog without requiring SDK instrumentation. This is a simpler option if you don't need the additional customization that our SDK provides.
-                </Markdown>
-            </CalloutBox>
 
-            <Step title="Install the PostHog SDK" badge="required">
-                <Markdown>
-                    Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics works
-                    best with our Python and Node SDKs.
-                </Markdown>
+    return [
+        {
+            title: 'Install the PostHog SDK',
+            badge: 'required',
+            content: (
+                <>
+                    <CalloutBox type="fyi" icon="IconInfo" title="Alternative: OpenRouter Broadcast">
+                        <Markdown>
+                            OpenRouter also offers a native [Broadcast feature](https://openrouter.ai/docs/guides/features/broadcast/posthog) that can automatically send LLM analytics data to PostHog without requiring SDK instrumentation. This is a simpler option if you don't need the additional customization that our SDK provides.
+                        </Markdown>
+                    </CalloutBox>
 
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Python',
-                            code: dedent`
-                                pip install posthog
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Node',
-                            code: dedent`
-                                npm install @posthog/ai posthog-node
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Install the OpenAI SDK" badge="required">
-                <Markdown>Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI client. The PostHog SDK **does not** proxy your calls.</Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Python',
-                            code: dedent`
-                                pip install openai
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'Node',
-                            code: dedent`
-                                npm install openai
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Initialize PostHog and OpenAI client" badge="required">
-                <Markdown>
-                    We call OpenRouter through the OpenAI client and generate a response. We'll use PostHog's OpenAI
-                    provider to capture all the details of the call. Initialize PostHog with your PostHog project API
-                    key and host from [your project settings](https://app.posthog.com/settings/project), then pass the
-                    PostHog client along with the OpenRouter config (the base URL and API key) to our OpenAI wrapper.
-                </Markdown>
-
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
-                                from posthog.ai.openai import OpenAI
-                                from posthog import Posthog
-
-                                posthog = Posthog(
-                                    "<ph_project_api_key>",
-                                    host="<ph_client_api_host>"
-                                )
-
-                                client = OpenAI(
-                                    baseURL="https://openrouter.ai/api/v1",
-                                    api_key="<openrouter_api_key>",
-                                    posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
-                                )
-                            `,
-                        },
-                        {
-                            language: 'ts',
-                            file: 'Node',
-                            code: dedent`
-                                import { OpenAI } from '@posthog/ai'
-                                import { PostHog } from 'posthog-node'
-
-                                const phClient = new PostHog(
-                                  '<ph_project_api_key>',
-                                  { host: '<ph_client_api_host>' }
-                                );
-
-                                const openai = new OpenAI({
-                                  baseURL: 'https://openrouter.ai/api/v1',
-                                  apiKey: '<openrouter_api_key>',
-                                  posthog: phClient,
-                                });
-
-                                // ... your code here ...
-
-                                // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                phClient.shutdown()
-                            `,
-                        },
-                    ]}
-                />
-
-                <Blockquote>
-                    <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                </Blockquote>
-
-                <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
                     <Markdown>
-                        These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                        background to send the data. You can also use LLM analytics with other SDKs or our API, but you
-                        will need to capture the data in the right format. See the schema in the [manual capture
-                        section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics works
+                        best with our Python and Node SDKs.
                     </Markdown>
-                </CalloutBox>
-            </Step>
 
-            <Step title="Call OpenRouter" badge="required">
-                <Markdown>
-                    Now, when you call OpenRouter with the OpenAI SDK, PostHog automatically captures an
-                    `$ai_generation` event. You can also capture or modify additional properties with the distinct ID,
-                    trace ID, properties, groups, and privacy mode parameters.
-                </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install posthog
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install @posthog/ai posthog-node
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Install the OpenAI SDK',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI client. The PostHog SDK **does not** proxy your calls.</Markdown>
 
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
-                                response = client.responses.create(
-                                    model="gpt-5-mini",
-                                    input=[
-                                        {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
-                                    ],
-                                    posthog_distinct_id="user_123", # optional
-                                    posthog_trace_id="trace_123", # optional
-                                    posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                    posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                    posthog_privacy_mode=False # optional
-                                )
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install openai
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install openai
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Initialize PostHog and OpenAI client',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        We call OpenRouter through the OpenAI client and generate a response. We'll use PostHog's OpenAI
+                        provider to capture all the details of the call. Initialize PostHog with your PostHog project API
+                        key and host from [your project settings](https://app.posthog.com/settings/project), then pass the
+                        PostHog client along with the OpenRouter config (the base URL and API key) to our OpenAI wrapper.
+                    </Markdown>
 
-                                print(response.choices[0].message.content)
-                            `,
-                        },
-                        {
-                            language: 'ts',
-                            file: 'Node',
-                            code: dedent`
-                                const completion = await openai.responses.create({
-                                    model: "gpt-5-mini",
-                                    input: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                    posthogDistinctId: "user_123", // optional
-                                    posthogTraceId: "trace_123", // optional
-                                    posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                    posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                    posthogPrivacyMode: false // optional
-                                });
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    from posthog.ai.openai import OpenAI
+                                    from posthog import Posthog
 
-                                console.log(completion.choices[0].message.content)
-                            `,
-                        },
-                    ]}
-                />
+                                    posthog = Posthog(
+                                        "<ph_project_api_key>",
+                                        host="<ph_client_api_host>"
+                                    )
 
-                <Blockquote>
+                                    client = OpenAI(
+                                        baseURL="https://openrouter.ai/api/v1",
+                                        api_key="<openrouter_api_key>",
+                                        posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
+                                    )
+                                `,
+                            },
+                            {
+                                language: 'ts',
+                                file: 'Node',
+                                code: dedent`
+                                    import { OpenAI } from '@posthog/ai'
+                                    import { PostHog } from 'posthog-node'
+
+                                    const phClient = new PostHog(
+                                      '<ph_project_api_key>',
+                                      { host: '<ph_client_api_host>' }
+                                    );
+
+                                    const openai = new OpenAI({
+                                      baseURL: 'https://openrouter.ai/api/v1',
+                                      apiKey: '<openrouter_api_key>',
+                                      posthog: phClient,
+                                    });
+
+                                    // ... your code here ...
+
+                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
+                                    phClient.shutdown()
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <Blockquote>
+                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
+                    </Blockquote>
+
+                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
+                            background to send the data. You can also use LLM analytics with other SDKs or our API, but you
+                            will need to capture the data in the right format. See the schema in the [manual capture
+                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+        {
+            title: 'Call OpenRouter',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Now, when you call OpenRouter with the OpenAI SDK, PostHog automatically captures an
+                        `$ai_generation` event. You can also capture or modify additional properties with the distinct ID,
+                        trace ID, properties, groups, and privacy mode parameters.
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    response = client.responses.create(
+                                        model="gpt-5-mini",
+                                        input=[
+                                            {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
+                                        ],
+                                        posthog_distinct_id="user_123", # optional
+                                        posthog_trace_id="trace_123", # optional
+                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
+                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
+                                        posthog_privacy_mode=False # optional
+                                    )
+
+                                    print(response.choices[0].message.content)
+                                `,
+                            },
+                            {
+                                language: 'ts',
+                                file: 'Node',
+                                code: dedent`
+                                    const completion = await openai.responses.create({
+                                        model: "gpt-5-mini",
+                                        input: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
+                                        posthogDistinctId: "user_123", // optional
+                                        posthogTraceId: "trace_123", // optional
+                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
+                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
+                                        posthogPrivacyMode: false // optional
+                                    });
+
+                                    console.log(completion.choices[0].message.content)
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <Blockquote>
+                        <Markdown>
+                            {dedent`
+                            **Notes:**
+                            - We also support the old \`chat.completions\` API.
+                            - This works with responses where \`stream=True\`.
+                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
+
+                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            `}
+                        </Markdown>
+                    </Blockquote>
+
                     <Markdown>
                         {dedent`
-                        **Notes:**
-                        - We also support the old \`chat.completions\` API.
-                        - This works with responses where \`stream=True\`.
-                        - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                        See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            You can expect captured \`$ai_generation\` events to have the following properties:
                         `}
                     </Markdown>
-                </Blockquote>
 
-                <Markdown>
-                    {dedent`
-                        You can expect captured \`$ai_generation\` events to have the following properties:
-                    `}
-                </Markdown>
-
-                {NotableGenerationProperties && <NotableGenerationProperties />}
-            </Step>
-
-            <Step
-                checkpoint
-                title="Verify traces and generations"
-                subtitle="Confirm LLM events are being sent to PostHog"
-                docsOnly
-            >
-                <Markdown>
-                    Let's make sure LLM events are being captured and sent to PostHog. Under **LLM analytics**, you
-                    should see rows of data appear in the **Traces** and **Generations** tabs.
-                </Markdown>
-
-                <br />
-                <ProductScreenshot
-                    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syne_ecd0801880.png"
-                    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syjm_5baab36590.png"
-                    alt="LLM generations in PostHog"
-                    classes="rounded"
-                    className="mt-10"
-                    padding={false}
-                />
-
-                <OSButton
-                    variant="secondary"
-                    asLink
-                    className="my-2"
-                    size="sm"
-                    to="https://app.posthog.com/llm-analytics/generations"
-                    external
-                >
-                    Check for LLM events in PostHog
-                </OSButton>
-            </Step>
-        </Steps>
-    )
+                    {NotableGenerationProperties && <NotableGenerationProperties />}
+                </>
+            ),
+        },
+    ]
 }
+
+export const OpenRouterInstallation = createInstallation(getOpenRouterSteps)

--- a/docs/onboarding/llm-analytics/vercel-ai.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai.tsx
@@ -1,151 +1,142 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { StepDefinition } from '../steps'
 
-export const VercelAIInstallation = (): JSX.Element => {
-    const {
-        Steps,
-        Step,
-        CodeBlock,
-        CalloutBox,
-        ProductScreenshot,
-        OSButton,
-        Markdown,
-        Blockquote,
-        dedent,
-        snippets,
-    } = useMDXComponents()
-    
+export const getVercelAISteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
-    return (
-        <Steps>
-            <Step title="Install the PostHog SDK" badge="required">
-                <Markdown>
-                    Setting up analytics starts with installing the PostHog SDK.
-                </Markdown>
 
-                <CodeBlock
-                    language="bash"
-                    code={dedent`
-                        npm install @posthog/ai posthog-node
-                    `}
-                />
-            </Step>
-
-            <Step title="Install the Vercel AI SDK" badge="required">
-                <Markdown>
-                    Install the Vercel AI SDK. The PostHog SDK instruments your LLM calls by wrapping the Vercel AI client.
-                    The PostHog SDK **does not** proxy your calls.
-                </Markdown>
-
-                <CodeBlock
-                    language="bash"
-                    code={dedent`
-                        npm install ai @ai-sdk/openai
-                    `}
-                />
-
-                <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+    return [
+        {
+            title: 'Install the PostHog SDK',
+            badge: 'required',
+            content: (
+                <>
                     <Markdown>
-                        These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the background to send the data.
-
-                        You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        Setting up analytics starts with installing the PostHog SDK.
                     </Markdown>
-                </CalloutBox>
-            </Step>
 
-            <Step title="Initialize PostHog and Vercel AI" badge="required">
-                <Markdown>
-                    Initialize PostHog with your project API key and host from [your project settings](https://app.posthog.com/settings/project), then pass the Vercel AI OpenAI client and the PostHog client to the `withTracing` wrapper.
-                </Markdown>
-
-                <CodeBlock
-                    language="ts"
-                    code={dedent`
-                        import { PostHog } from "posthog-node";
-                        import { withTracing } from "@posthog/ai"
-                        import { generateText } from "ai"
-                        import { createOpenAI } from "@ai-sdk/openai"
-
-                        const phClient = new PostHog(
-                          '<ph_project_api_key>',
-                          { host: '<ph_client_api_host>' }
-                        );
-
-                        const openaiClient = createOpenAI({
-                          apiKey: 'your_openai_api_key',
-                          compatibility: 'strict'
-                        });
-
-                        const model = withTracing(openaiClient("gpt-4-turbo"), phClient, {
-                          posthogDistinctId: "user_123", // optional
-                          posthogTraceId: "trace_123", // optional
-                          posthogProperties: { conversationId: "abc123", paid: true }, // optional
-                          posthogPrivacyMode: false, // optional
-                          posthogGroups: { company: "companyIdInYourDb" }, // optional
-                        });
-
-                        phClient.shutdown()
-                    `}
-                />
-
-                <Markdown>
-                    You can enrich LLM events with additional data by passing parameters such as the trace ID, distinct ID, custom properties, groups, and privacy mode options.
-                </Markdown>
-            </Step>
-
-            <Step title="Call Vercel AI" badge="required">
-                <Markdown>
-                    Now, when you use the Vercel AI SDK to call LLMs, PostHog automatically captures an `$ai_generation` event.
-
-                    This works for both `text` and `image` message types.
-                </Markdown>
-
-                <CodeBlock
-                    language="ts"
-                    code={dedent`
-                        const { text } = await generateText({
-                          model: model,
-                          prompt: message
-                        });
-
-                        console.log(text)
-                    `}
-                />
-
-                <Blockquote>
+                    <CodeBlock
+                        language="bash"
+                        code={dedent`
+                            npm install @posthog/ai posthog-node
+                        `}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Install the Vercel AI SDK',
+            badge: 'required',
+            content: (
+                <>
                     <Markdown>
-                        **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        Install the Vercel AI SDK. The PostHog SDK instruments your LLM calls by wrapping the Vercel AI client.
+                        The PostHog SDK **does not** proxy your calls.
                     </Markdown>
-                </Blockquote>
 
-                <Markdown>
-                    {dedent`
-                        You can expect captured \`$ai_generation\` events to have the following properties:
-                    `}
-                </Markdown>
+                    <CodeBlock
+                        language="bash"
+                        code={dedent`
+                            npm install ai @ai-sdk/openai
+                        `}
+                    />
 
-                {NotableGenerationProperties && <NotableGenerationProperties />}
-            </Step>
+                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the background to send the data.
 
-            <Step checkpoint title="Verify traces and generations" subtitle="Confirm LLM events are being sent to PostHog" docsOnly>
-                <Markdown>
-                    Let's make sure LLM events are being captured and sent to PostHog. Under **LLM analytics**, you should see rows of data appear in the **Traces** and **Generations** tabs.
-                </Markdown>
+                            You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+        {
+            title: 'Initialize PostHog and Vercel AI',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Initialize PostHog with your project API key and host from [your project settings](https://app.posthog.com/settings/project), then pass the Vercel AI OpenAI client and the PostHog client to the `withTracing` wrapper.
+                    </Markdown>
 
-                <br />
-                <ProductScreenshot
-                    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syne_ecd0801880.png"
-                    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250807_syjm_5baab36590.png"
-                    alt="LLM generations in PostHog"
-                    classes="rounded"
-                    className="mt-10"
-                    padding={false}
-                />
+                    <CodeBlock
+                        language="ts"
+                        code={dedent`
+                            import { PostHog } from "posthog-node";
+                            import { withTracing } from "@posthog/ai"
+                            import { generateText } from "ai"
+                            import { createOpenAI } from "@ai-sdk/openai"
 
-                <OSButton variant="secondary" asLink className="my-2" size="sm" to="https://app.posthog.com/llm-analytics/generations" external>
-                    Check for LLM events in PostHog
-                </OSButton>
-            </Step>
-        </Steps>
-    )
+                            const phClient = new PostHog(
+                              '<ph_project_api_key>',
+                              { host: '<ph_client_api_host>' }
+                            );
+
+                            const openaiClient = createOpenAI({
+                              apiKey: 'your_openai_api_key',
+                              compatibility: 'strict'
+                            });
+
+                            const model = withTracing(openaiClient("gpt-4-turbo"), phClient, {
+                              posthogDistinctId: "user_123", // optional
+                              posthogTraceId: "trace_123", // optional
+                              posthogProperties: { conversationId: "abc123", paid: true }, // optional
+                              posthogPrivacyMode: false, // optional
+                              posthogGroups: { company: "companyIdInYourDb" }, // optional
+                            });
+
+                            phClient.shutdown()
+                        `}
+                    />
+
+                    <Markdown>
+                        You can enrich LLM events with additional data by passing parameters such as the trace ID, distinct ID, custom properties, groups, and privacy mode options.
+                    </Markdown>
+                </>
+            ),
+        },
+        {
+            title: 'Call Vercel AI',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Now, when you use the Vercel AI SDK to call LLMs, PostHog automatically captures an `$ai_generation` event.
+
+                        This works for both `text` and `image` message types.
+                    </Markdown>
+
+                    <CodeBlock
+                        language="ts"
+                        code={dedent`
+                            const { text } = await generateText({
+                              model: model,
+                              prompt: message
+                            });
+
+                            console.log(text)
+                        `}
+                    />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
+
+                    <Markdown>
+                        {dedent`
+                            You can expect captured \`$ai_generation\` events to have the following properties:
+                        `}
+                    </Markdown>
+
+                    {NotableGenerationProperties && <NotableGenerationProperties />}
+                </>
+            ),
+        },
+    ]
 }
 
+export const VercelAIInstallation = createInstallation(getVercelAISteps)

--- a/docs/onboarding/llm-analytics/vercel-ai.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai.tsx
@@ -1,7 +1,7 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 import { StepDefinition } from '../steps'
 
-export const getVercelAISteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getVercelAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties

--- a/docs/onboarding/product-analytics/_snippets/js-event-capture.tsx
+++ b/docs/onboarding/product-analytics/_snippets/js-event-capture.tsx
@@ -1,6 +1,6 @@
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const JSEventCapture = function JSEventCapture(): JSX.Element {
+export const JSEventCapture = (): JSX.Element => {
     const { Markdown, CodeBlock, dedent } = useMDXComponents()
 
     return (

--- a/docs/onboarding/product-analytics/_snippets/node-event-capture.tsx
+++ b/docs/onboarding/product-analytics/_snippets/node-event-capture.tsx
@@ -1,6 +1,6 @@
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const NodeEventCapture =function NodeEventCapture(): JSX.Element {
+export const NodeEventCapture = function NodeEventCapture(): JSX.Element {
     const { Markdown, CodeBlock, CalloutBox, dedent } = useMDXComponents()
 
     return (

--- a/docs/onboarding/product-analytics/_snippets/node-event-capture.tsx
+++ b/docs/onboarding/product-analytics/_snippets/node-event-capture.tsx
@@ -1,6 +1,6 @@
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const NodeEventCapture = function NodeEventCapture(): JSX.Element {
+export const NodeEventCapture = (): JSX.Element => {
     const { Markdown, CodeBlock, CalloutBox, dedent } = useMDXComponents()
 
     return (

--- a/docs/onboarding/product-analytics/_snippets/person-profiles.tsx
+++ b/docs/onboarding/product-analytics/_snippets/person-profiles.tsx
@@ -7,10 +7,7 @@ interface PersonProfilesProps {
     file?: string
 }
 
-export const PersonProfiles = memo(function PersonProfiles({
-    language = 'javascript',
-    file,
-}: PersonProfilesProps): JSX.Element {
+export const PersonProfiles = memo(({ language = 'javascript', file }: PersonProfilesProps): JSX.Element => {
     const { Markdown, CodeBlock, dedent } = useMDXComponents()
 
     const getCodeAndFile = () => {

--- a/docs/onboarding/product-analytics/_snippets/person-profiles.tsx
+++ b/docs/onboarding/product-analytics/_snippets/person-profiles.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react'
+
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 interface PersonProfilesProps {
@@ -6,7 +7,10 @@ interface PersonProfilesProps {
     file?: string
 }
 
-export const PersonProfiles = memo(function PersonProfiles({ language = 'javascript', file }: PersonProfilesProps): JSX.Element {
+export const PersonProfiles = memo(function PersonProfiles({
+    language = 'javascript',
+    file,
+}: PersonProfilesProps): JSX.Element {
     const { Markdown, CodeBlock, dedent } = useMDXComponents()
 
     const getCodeAndFile = () => {
@@ -18,7 +22,10 @@ export const PersonProfiles = memo(function PersonProfiles({ language = 'javascr
             case 'elixir':
                 return { code: '"$process_person_profile" => false', file: file || 'Elixir' }
             default:
-                return { code: '"$process_person_profile": false', file: file || language.charAt(0).toUpperCase() + language.slice(1) }
+                return {
+                    code: '"$process_person_profile": false',
+                    file: file || language.charAt(0).toUpperCase() + language.slice(1),
+                }
         }
     }
 

--- a/docs/onboarding/product-analytics/_snippets/python-event-capture.tsx
+++ b/docs/onboarding/product-analytics/_snippets/python-event-capture.tsx
@@ -2,7 +2,7 @@ import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper
 
 import { PersonProfiles } from './person-profiles'
 
-export const PythonEventCapture = function PythonEventCapture(): JSX.Element {
+export const PythonEventCapture = (): JSX.Element => {
     const { Markdown, CodeBlock, dedent } = useMDXComponents()
 
     return (

--- a/docs/onboarding/product-analytics/_snippets/python-event-capture.tsx
+++ b/docs/onboarding/product-analytics/_snippets/python-event-capture.tsx
@@ -1,4 +1,5 @@
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { PersonProfiles } from './person-profiles'
 
 export const PythonEventCapture = function PythonEventCapture(): JSX.Element {

--- a/docs/onboarding/product-analytics/android.tsx
+++ b/docs/onboarding/product-analytics/android.tsx
@@ -3,7 +3,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getAndroidSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => {
+export const getAndroidSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
     return [
         {
             title: 'Install the dependency',

--- a/docs/onboarding/product-analytics/android.tsx
+++ b/docs/onboarding/product-analytics/android.tsx
@@ -1,8 +1,9 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { PersonProfiles } from './_snippets/person-profiles'
-import { StepDefinition } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getAndroidSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
+import { StepDefinition } from '../steps'
+import { PersonProfiles } from './_snippets/person-profiles'
+
+export const getAndroidSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => {
     return [
         {
             title: 'Install the dependency',
@@ -99,17 +100,4 @@ export const getAndroidSteps = (CodeBlock: any, Markdown: any, dedent: any): Ste
     ]
 }
 
-export const AndroidInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getAndroidSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const AndroidInstallation = createInstallation(getAndroidSteps)

--- a/docs/onboarding/product-analytics/android.tsx
+++ b/docs/onboarding/product-analytics/android.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getAndroidSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAndroidSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/angular.tsx
+++ b/docs/onboarding/product-analytics/angular.tsx
@@ -2,7 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getAngularSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
+export const getAngularSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [

--- a/docs/onboarding/product-analytics/angular.tsx
+++ b/docs/onboarding/product-analytics/angular.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getAngularSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAngularSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/angular.tsx
+++ b/docs/onboarding/product-analytics/angular.tsx
@@ -1,7 +1,8 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getAngularSteps = (CodeBlock: any, Markdown: any, dedent: any, snippets: any): StepDefinition[] => {
+export const getAngularSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -82,17 +83,4 @@ export const getAngularSteps = (CodeBlock: any, Markdown: any, dedent: any, snip
     ]
 }
 
-export const AngularInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getAngularSteps(CodeBlock, Markdown, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const AngularInstallation = createInstallation(getAngularSteps)

--- a/docs/onboarding/product-analytics/api.tsx
+++ b/docs/onboarding/product-analytics/api.tsx
@@ -1,93 +1,79 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getAPISteps = (CodeBlock: any, Markdown: any, CalloutBox: any, dedent: any): StepDefinition[] => {
-    return [
-        {
-            title: 'Send events via the API',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        You can send events directly to the PostHog API from any programming language or platform that
-                        can make HTTP requests:
-                    </Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'http',
-                                file: 'HTTP',
-                                code: dedent`
-                                    POST <ph_client_api_host>/capture/
-                                    Content-Type: application/json
+export const getAPISteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Send events via the API',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>
+                    You can send events directly to the PostHog API from any programming language or platform that
+                    can make HTTP requests:
+                </Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'http',
+                            file: 'HTTP',
+                            code: dedent`
+                                POST <ph_client_api_host>/capture/
+                                Content-Type: application/json
 
-                                    {
-                                        "api_key": "<ph_project_api_key>",
-                                        "event": "[event name]",
-                                        "properties": {
-                                            "distinct_id": "[your users' distinct id]",
-                                            "key1": "value1",
-                                            "key2": "value2"
-                                        },
-                                        "timestamp": "[optional timestamp in ISO 8601 format]"
+                                {
+                                    "api_key": "<ph_project_api_key>",
+                                    "event": "[event name]",
+                                    "properties": {
+                                        "distinct_id": "[your users' distinct id]",
+                                        "key1": "value1",
+                                        "key2": "value2"
+                                    },
+                                    "timestamp": "[optional timestamp in ISO 8601 format]"
+                                }
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Person profiles',
+        badge: 'optional',
+        content: (
+            <>
+                <Markdown>
+                    By default, events are sent with person profile processing enabled. To disable this for specific
+                    events, add the following property:
+                </Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'json',
+                            file: 'JSON',
+                            code: dedent`
+                                {
+                                    "api_key": "<ph_project_api_key>",
+                                    "event": "page_viewed",
+                                    "properties": {
+                                        "distinct_id": "user_123",
+                                        "$process_person_profile": false
                                     }
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Person profiles',
-            badge: 'optional',
-            content: (
-                <>
+                                }
+                            `,
+                        },
+                    ]}
+                />
+                <CalloutBox type="fyi" title="Learn more">
                     <Markdown>
-                        By default, events are sent with person profile processing enabled. To disable this for specific
-                        events, add the following property:
+                        Read more about [person profiles](https://posthog.com/docs/data/persons) in our
+                        documentation.
                     </Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'json',
-                                file: 'JSON',
-                                code: dedent`
-                                    {
-                                        "api_key": "<ph_project_api_key>",
-                                        "event": "page_viewed",
-                                        "properties": {
-                                            "distinct_id": "user_123",
-                                            "$process_person_profile": false
-                                        }
-                                    }
-                                `,
-                            },
-                        ]}
-                    />
-                    <CalloutBox type="fyi" title="Learn more">
-                        <Markdown>
-                            Read more about [person profiles](https://posthog.com/docs/data/persons) in our
-                            documentation.
-                        </Markdown>
-                    </CalloutBox>
-                </>
-            ),
-        },
-    ]
-}
+                </CalloutBox>
+            </>
+        ),
+    },
+]
 
-export const APIInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent } = useMDXComponents()
-    const steps = getAPISteps(CodeBlock, Markdown, CalloutBox, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const APIInstallation = createInstallation(getAPISteps)

--- a/docs/onboarding/product-analytics/api.tsx
+++ b/docs/onboarding/product-analytics/api.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getAPISteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAPISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/api.tsx
+++ b/docs/onboarding/product-analytics/api.tsx
@@ -2,22 +2,25 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getAPISteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Send events via the API',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>
-                    You can send events directly to the PostHog API from any programming language or platform that
-                    can make HTTP requests:
-                </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'http',
-                            file: 'HTTP',
-                            code: dedent`
+export const getAPISteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
+
+    return [
+        {
+            title: 'Send events via the API',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        You can send events directly to the PostHog API from any programming language or platform that
+                        can make HTTP requests:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'http',
+                                file: 'HTTP',
+                                code: dedent`
                                 POST <ph_client_api_host>/capture/
                                 Content-Type: application/json
 
@@ -32,27 +35,27 @@ export const getAPISteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: Onboard
                                     "timestamp": "[optional timestamp in ISO 8601 format]"
                                 }
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Person profiles',
-        badge: 'optional',
-        content: (
-            <>
-                <Markdown>
-                    By default, events are sent with person profile processing enabled. To disable this for specific
-                    events, add the following property:
-                </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'json',
-                            file: 'JSON',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Person profiles',
+            badge: 'optional',
+            content: (
+                <>
+                    <Markdown>
+                        By default, events are sent with person profile processing enabled. To disable this for specific
+                        events, add the following property:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'json',
+                                file: 'JSON',
+                                code: dedent`
                                 {
                                     "api_key": "<ph_project_api_key>",
                                     "event": "page_viewed",
@@ -62,18 +65,19 @@ export const getAPISteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: Onboard
                                     }
                                 }
                             `,
-                        },
-                    ]}
-                />
-                <CalloutBox type="fyi" title="Learn more">
-                    <Markdown>
-                        Read more about [person profiles](https://posthog.com/docs/data/persons) in our
-                        documentation.
-                    </Markdown>
-                </CalloutBox>
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <CalloutBox type="fyi" title="Learn more">
+                        <Markdown>
+                            Read more about [person profiles](https://posthog.com/docs/data/persons) in our
+                            documentation.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+    ]
+}
 
 export const APIInstallation = createInstallation(getAPISteps)

--- a/docs/onboarding/product-analytics/astro.tsx
+++ b/docs/onboarding/product-analytics/astro.tsx
@@ -1,7 +1,8 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getAstroSteps = (CodeBlock: any, Markdown: any, dedent: any, snippets: any): StepDefinition[] => {
+export const getAstroSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -125,17 +126,4 @@ export const getAstroSteps = (CodeBlock: any, Markdown: any, dedent: any, snippe
     ]
 }
 
-export const AstroInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getAstroSteps(CodeBlock, Markdown, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const AstroInstallation = createInstallation(getAstroSteps)

--- a/docs/onboarding/product-analytics/astro.tsx
+++ b/docs/onboarding/product-analytics/astro.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getAstroSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getAstroSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/astro.tsx
+++ b/docs/onboarding/product-analytics/astro.tsx
@@ -2,7 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getAstroSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
+export const getAstroSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -26,8 +28,8 @@ export const getAstroSteps = ({ CodeBlock, Markdown, dedent, snippets }: Onboard
                         ]}
                     />
                     <Markdown>
-                        In this file, add your PostHog web snippet. Be sure to include the `is:inline` directive to prevent
-                        Astro from processing it:
+                        In this file, add your PostHog web snippet. Be sure to include the `is:inline` directive to
+                        prevent Astro from processing it:
                     </Markdown>
                     <CodeBlock
                         blocks={[
@@ -58,8 +60,8 @@ export const getAstroSteps = ({ CodeBlock, Markdown, dedent, snippets }: Onboard
             content: (
                 <>
                     <Markdown>
-                        Create a layout where we will use `posthog.astro`. Create a new file `PostHogLayout.astro` in your
-                        `src/layouts` folder:
+                        Create a layout where we will use `posthog.astro`. Create a new file `PostHogLayout.astro` in
+                        your `src/layouts` folder:
                     </Markdown>
                     <CodeBlock
                         blocks={[

--- a/docs/onboarding/product-analytics/bubble.tsx
+++ b/docs/onboarding/product-analytics/bubble.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getBubbleSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getBubbleSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/bubble.tsx
+++ b/docs/onboarding/product-analytics/bubble.tsx
@@ -1,7 +1,8 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getBubbleSteps = (CodeBlock: any, Markdown: any, dedent: any, snippets: any): StepDefinition[] => {
+export const getBubbleSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -54,17 +55,4 @@ export const getBubbleSteps = (CodeBlock: any, Markdown: any, dedent: any, snipp
     ]
 }
 
-export const BubbleInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getBubbleSteps(CodeBlock, Markdown, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const BubbleInstallation = createInstallation(getBubbleSteps)

--- a/docs/onboarding/product-analytics/bubble.tsx
+++ b/docs/onboarding/product-analytics/bubble.tsx
@@ -2,7 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getBubbleSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
+export const getBubbleSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [

--- a/docs/onboarding/product-analytics/django.tsx
+++ b/docs/onboarding/product-analytics/django.tsx
@@ -2,7 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getDjangoSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
+export const getDjangoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
+
     const PythonEventCapture = snippets?.PythonEventCapture
 
     return [

--- a/docs/onboarding/product-analytics/django.tsx
+++ b/docs/onboarding/product-analytics/django.tsx
@@ -1,7 +1,8 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getDjangoSteps = (CodeBlock: any, Markdown: any, dedent: any, snippets: any): StepDefinition[] => {
+export const getDjangoSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
     const PythonEventCapture = snippets?.PythonEventCapture
 
     return [
@@ -31,7 +32,8 @@ export const getDjangoSteps = (CodeBlock: any, Markdown: any, dedent: any, snipp
             content: (
                 <>
                     <Markdown>
-                        Set the PostHog API key and host in your `AppConfig` in `apps.py` so that it's available everywhere:
+                        Set the PostHog API key and host in your `AppConfig` in `apps.py` so that it's available
+                        everywhere:
                     </Markdown>
                     <CodeBlock
                         blocks={[
@@ -53,8 +55,8 @@ export const getDjangoSteps = (CodeBlock: any, Markdown: any, dedent: any, snipp
                         ]}
                     />
                     <Markdown>
-                        Next, if you haven't done so already, make sure you add your `AppConfig` to your `settings.py` under
-                        `INSTALLED_APPS`:
+                        Next, if you haven't done so already, make sure you add your `AppConfig` to your `settings.py`
+                        under `INSTALLED_APPS`:
                     </Markdown>
                     <CodeBlock
                         blocks={[
@@ -80,17 +82,4 @@ export const getDjangoSteps = (CodeBlock: any, Markdown: any, dedent: any, snipp
     ]
 }
 
-export const DjangoInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getDjangoSteps(CodeBlock, Markdown, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const DjangoInstallation = createInstallation(getDjangoSteps)

--- a/docs/onboarding/product-analytics/django.tsx
+++ b/docs/onboarding/product-analytics/django.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getDjangoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getDjangoSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const PythonEventCapture = snippets?.PythonEventCapture

--- a/docs/onboarding/product-analytics/docusaurus.tsx
+++ b/docs/onboarding/product-analytics/docusaurus.tsx
@@ -2,42 +2,45 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getDocusaurusSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Install the plugin',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>
-                    Docusaurus is a popular static site generator for documentation. You can add PostHog using the
-                    official plugin:
-                </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Terminal',
-                            code: dedent`
+export const getDocusaurusSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
+
+    return [
+        {
+            title: 'Install the plugin',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Docusaurus is a popular static site generator for documentation. You can add PostHog using the
+                        official plugin:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Terminal',
+                                code: dedent`
                                 npm install --save posthog-docusaurus
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Configure the plugin',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Add the plugin to your `docusaurus.config.js`:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'javascript',
-                            file: 'docusaurus.config.js',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure the plugin',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Add the plugin to your `docusaurus.config.js`:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'javascript',
+                                file: 'docusaurus.config.js',
+                                code: dedent`
                                 module.exports = {
                                   plugins: [
                                     [
@@ -51,27 +54,28 @@ export const getDocusaurusSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: 
                                   ],
                                 }
                             `,
-                        },
-                    ]}
-                />
-                <CalloutBox type="fyi" title="More options">
-                    <Markdown>
-                        See the [Docusaurus integration docs](https://posthog.com/docs/libraries/docusaurus) for more
-                        configuration options.
-                    </Markdown>
-                </CalloutBox>
-            </>
-        ),
-    },
-    {
-        title: 'View events',
-        content: (
-            <Markdown>
-                Start your Docusaurus site and visit a few pages. PostHog will automatically capture pageviews and
-                other events.
-            </Markdown>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <CalloutBox type="fyi" title="More options">
+                        <Markdown>
+                            See the [Docusaurus integration docs](https://posthog.com/docs/libraries/docusaurus) for
+                            more configuration options.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+        {
+            title: 'View events',
+            content: (
+                <Markdown>
+                    Start your Docusaurus site and visit a few pages. PostHog will automatically capture pageviews and
+                    other events.
+                </Markdown>
+            ),
+        },
+    ]
+}
 
 export const DocusaurusInstallation = createInstallation(getDocusaurusSteps)

--- a/docs/onboarding/product-analytics/docusaurus.tsx
+++ b/docs/onboarding/product-analytics/docusaurus.tsx
@@ -1,11 +1,13 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const DocusaurusInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Install the plugin" badge="required">
+export const getDocusaurusSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Install the plugin',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>
                     Docusaurus is a popular static site generator for documentation. You can add PostHog using the
                     official plugin:
@@ -21,9 +23,14 @@ export const DocusaurusInstallation = (): JSX.Element => {
                         },
                     ]}
                 />
-            </Step>
-
-            <Step title="Configure the plugin" badge="required">
+            </>
+        ),
+    },
+    {
+        title: 'Configure the plugin',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>Add the plugin to your `docusaurus.config.js`:</Markdown>
                 <CodeBlock
                     blocks={[
@@ -53,14 +60,18 @@ export const DocusaurusInstallation = (): JSX.Element => {
                         configuration options.
                     </Markdown>
                 </CalloutBox>
-            </Step>
+            </>
+        ),
+    },
+    {
+        title: 'View events',
+        content: (
+            <Markdown>
+                Start your Docusaurus site and visit a few pages. PostHog will automatically capture pageviews and
+                other events.
+            </Markdown>
+        ),
+    },
+]
 
-            <Step title="View events">
-                <Markdown>
-                    Start your Docusaurus site and visit a few pages. PostHog will automatically capture pageviews and
-                    other events.
-                </Markdown>
-            </Step>
-        </Steps>
-    )
-}
+export const DocusaurusInstallation = createInstallation(getDocusaurusSteps)

--- a/docs/onboarding/product-analytics/docusaurus.tsx
+++ b/docs/onboarding/product-analytics/docusaurus.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getDocusaurusSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getDocusaurusSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/elixir.tsx
+++ b/docs/onboarding/product-analytics/elixir.tsx
@@ -3,76 +3,80 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getElixirSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Install',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Add the PostHog Elixir library to your `mix.exs` dependencies:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'elixir',
-                            file: 'mix.exs',
-                            code: dedent`
+export const getElixirSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Install',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Add the PostHog Elixir library to your `mix.exs` dependencies:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'elixir',
+                                file: 'mix.exs',
+                                code: dedent`
                                 def deps do
                                     [
                                         {:posthog, "~> 1.1.0"}
                                     ]
                                 end
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Configure',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Add your PostHog configuration to your config file:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'elixir',
-                            file: 'config/config.exs',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Add your PostHog configuration to your config file:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'elixir',
+                                file: 'config/config.exs',
+                                code: dedent`
                                 config :posthog,
                                     api_url: "<ph_client_api_host>",
                                     api_key: "<ph_project_api_key>"
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Send events',
-        badge: 'recommended',
-        content: (
-            <>
-                <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'elixir',
-                            file: 'Elixir',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send events',
+            badge: 'recommended',
+            content: (
+                <>
+                    <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'elixir',
+                                file: 'Elixir',
+                                code: dedent`
                                 Posthog.capture("user_123", "button_clicked", %{
                                     button_name: "signup"
                                 })
                             `,
-                        },
-                    ]}
-                />
-                <PersonProfiles language="elixir" />
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <PersonProfiles language="elixir" />
+                </>
+            ),
+        },
+    ]
+}
 
 export const ElixirInstallation = createInstallation(getElixirSteps)

--- a/docs/onboarding/product-analytics/elixir.tsx
+++ b/docs/onboarding/product-analytics/elixir.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getElixirSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getElixirSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/elixir.tsx
+++ b/docs/onboarding/product-analytics/elixir.tsx
@@ -1,94 +1,78 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { PersonProfiles } from './_snippets/person-profiles'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
+import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getElixirSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
-    return [
-        {
-            title: 'Install',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>Add the PostHog Elixir library to your `mix.exs` dependencies:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'elixir',
-                                file: 'mix.exs',
-                                code: dedent`
-                                    def deps do
-                                        [
-                                            {:posthog, "~> 1.1.0"}
-                                        ]
-                                    end
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Configure',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>Add your PostHog configuration to your config file:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'elixir',
-                                file: 'config/config.exs',
-                                code: dedent`
-                                    config :posthog,
-                                        api_url: "<ph_client_api_host>",
-                                        api_key: "<ph_project_api_key>"
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Send events',
-            badge: 'recommended',
-            content: (
-                <>
-                    <Markdown>
-                        Once installed, you can manually send events to test your integration:
-                    </Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'elixir',
-                                file: 'Elixir',
-                                code: dedent`
-                                    Posthog.capture("user_123", "button_clicked", %{
-                                        button_name: "signup"
-                                    })
-                                `,
-                            },
-                        ]}
-                    />
-                    <PersonProfiles language="elixir" />
-                </>
-            ),
-        },
-    ]
-}
+export const getElixirSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Install',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Add the PostHog Elixir library to your `mix.exs` dependencies:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'elixir',
+                            file: 'mix.exs',
+                            code: dedent`
+                                def deps do
+                                    [
+                                        {:posthog, "~> 1.1.0"}
+                                    ]
+                                end
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Configure',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Add your PostHog configuration to your config file:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'elixir',
+                            file: 'config/config.exs',
+                            code: dedent`
+                                config :posthog,
+                                    api_url: "<ph_client_api_host>",
+                                    api_key: "<ph_project_api_key>"
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Send events',
+        badge: 'recommended',
+        content: (
+            <>
+                <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'elixir',
+                            file: 'Elixir',
+                            code: dedent`
+                                Posthog.capture("user_123", "button_clicked", %{
+                                    button_name: "signup"
+                                })
+                            `,
+                        },
+                    ]}
+                />
+                <PersonProfiles language="elixir" />
+            </>
+        ),
+    },
+]
 
-export const ElixirInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getElixirSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const ElixirInstallation = createInstallation(getElixirSteps)

--- a/docs/onboarding/product-analytics/flutter.tsx
+++ b/docs/onboarding/product-analytics/flutter.tsx
@@ -3,7 +3,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getFlutterSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => {
+export const getFlutterSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
     return [
         {
             title: 'Install the package',

--- a/docs/onboarding/product-analytics/flutter.tsx
+++ b/docs/onboarding/product-analytics/flutter.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getFlutterSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getFlutterSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/flutter.tsx
+++ b/docs/onboarding/product-analytics/flutter.tsx
@@ -1,8 +1,9 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { PersonProfiles } from './_snippets/person-profiles'
-import { StepDefinition } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getFlutterSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
+import { StepDefinition } from '../steps'
+import { PersonProfiles } from './_snippets/person-profiles'
+
+export const getFlutterSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => {
     return [
         {
             title: 'Install the package',
@@ -178,17 +179,4 @@ export const getFlutterSteps = (CodeBlock: any, Markdown: any, dedent: any): Ste
     ]
 }
 
-export const FlutterInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getFlutterSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const FlutterInstallation = createInstallation(getFlutterSteps)

--- a/docs/onboarding/product-analytics/framer.tsx
+++ b/docs/onboarding/product-analytics/framer.tsx
@@ -1,7 +1,8 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getFramerSteps = (CodeBlock: any, Markdown: any, dedent: any, snippets: any): StepDefinition[] => {
+export const getFramerSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -56,17 +57,4 @@ export const getFramerSteps = (CodeBlock: any, Markdown: any, dedent: any, snipp
     ]
 }
 
-export const FramerInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getFramerSteps(CodeBlock, Markdown, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const FramerInstallation = createInstallation(getFramerSteps)

--- a/docs/onboarding/product-analytics/framer.tsx
+++ b/docs/onboarding/product-analytics/framer.tsx
@@ -2,7 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getFramerSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
+export const getFramerSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -38,8 +40,8 @@ export const getFramerSteps = ({ CodeBlock, Markdown, dedent, snippets }: Onboar
             content: (
                 <>
                     <Markdown>
-                        Go to your Framer project settings by clicking the gear in the top right. If you haven't already,
-                        sign up for at least the **Mini** site plan. This enables you to add custom code. Then:
+                        Go to your Framer project settings by clicking the gear in the top right. If you haven't
+                        already, sign up for at least the **Mini** site plan. This enables you to add custom code. Then:
                     </Markdown>
                     <Markdown>
                         {`1. Go to the **General** tab in site settings.

--- a/docs/onboarding/product-analytics/framer.tsx
+++ b/docs/onboarding/product-analytics/framer.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getFramerSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getFramerSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/go.tsx
+++ b/docs/onboarding/product-analytics/go.tsx
@@ -3,39 +3,42 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getGoSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Install the package',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Install the PostHog Go library:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Terminal',
-                            code: dedent`
+export const getGoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Install the package',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Install the PostHog Go library:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Terminal',
+                                code: dedent`
                                 go get "github.com/posthog/posthog-go"
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Configure PostHog',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'go',
-                            file: 'main.go',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure PostHog',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'go',
+                                file: 'main.go',
+                                code: dedent`
                                 package main
 
                                 import (
@@ -47,24 +50,24 @@ export const getGoSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents
                                     defer client.Close()
                                 }
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Send events',
-        badge: 'recommended',
-        content: (
-            <>
-                <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'go',
-                            file: 'Go',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send events',
+            badge: 'recommended',
+            content: (
+                <>
+                    <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'go',
+                                file: 'Go',
+                                code: dedent`
                                 client.Enqueue(posthog.Capture{
                                     DistinctId: "user_123",
                                     Event: "button_clicked",
@@ -72,13 +75,14 @@ export const getGoSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents
                                         Set("button_name", "signup"),
                                 })
                             `,
-                        },
-                    ]}
-                />
-                <PersonProfiles language="go" />
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <PersonProfiles language="go" />
+                </>
+            ),
+        },
+    ]
+}
 
 export const GoInstallation = createInstallation(getGoSteps)

--- a/docs/onboarding/product-analytics/go.tsx
+++ b/docs/onboarding/product-analytics/go.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getGoSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getGoSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/go.tsx
+++ b/docs/onboarding/product-analytics/go.tsx
@@ -1,100 +1,84 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { PersonProfiles } from './_snippets/person-profiles'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
+import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getGoSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
-    return [
-        {
-            title: 'Install the package',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>Install the PostHog Go library:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Terminal',
-                                code: dedent`
-                                    go get "github.com/posthog/posthog-go"
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Configure PostHog',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'go',
-                                file: 'main.go',
-                                code: dedent`
-                                    package main
+export const getGoSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Install the package',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Install the PostHog Go library:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'bash',
+                            file: 'Terminal',
+                            code: dedent`
+                                go get "github.com/posthog/posthog-go"
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Configure PostHog',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'go',
+                            file: 'main.go',
+                            code: dedent`
+                                package main
 
-                                    import (
-                                        "github.com/posthog/posthog-go"
-                                    )
+                                import (
+                                    "github.com/posthog/posthog-go"
+                                )
 
-                                    func main() {
-                                        client, _ := posthog.NewWithConfig("<ph_project_api_key>", posthog.Config{Endpoint: "<ph_client_api_host>"})
-                                        defer client.Close()
-                                    }
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Send events',
-            badge: 'recommended',
-            content: (
-                <>
-                    <Markdown>
-                        Once installed, you can manually send events to test your integration:
-                    </Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'go',
-                                file: 'Go',
-                                code: dedent`
-                                    client.Enqueue(posthog.Capture{
-                                        DistinctId: "user_123",
-                                        Event: "button_clicked",
-                                        Properties: posthog.NewProperties().
-                                            Set("button_name", "signup"),
-                                    })
-                                `,
-                            },
-                        ]}
-                    />
-                    <PersonProfiles language="go" />
-                </>
-            ),
-        },
-    ]
-}
+                                func main() {
+                                    client, _ := posthog.NewWithConfig("<ph_project_api_key>", posthog.Config{Endpoint: "<ph_client_api_host>"})
+                                    defer client.Close()
+                                }
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Send events',
+        badge: 'recommended',
+        content: (
+            <>
+                <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'go',
+                            file: 'Go',
+                            code: dedent`
+                                client.Enqueue(posthog.Capture{
+                                    DistinctId: "user_123",
+                                    Event: "button_clicked",
+                                    Properties: posthog.NewProperties().
+                                        Set("button_name", "signup"),
+                                })
+                            `,
+                        },
+                    ]}
+                />
+                <PersonProfiles language="go" />
+            </>
+        ),
+    },
+]
 
-export const GoInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getGoSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const GoInstallation = createInstallation(getGoSteps)

--- a/docs/onboarding/product-analytics/google-tag-manager.tsx
+++ b/docs/onboarding/product-analytics/google-tag-manager.tsx
@@ -1,52 +1,70 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const GoogleTagManagerInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
+export const getGoogleTagManagerSteps = ({
+    CodeBlock,
+    Markdown,
+    dedent,
+    snippets,
+}: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
-    return (
-        <Steps>
-            <Step title="Create a custom HTML tag" badge="required">
-                <Markdown>
-                    Google Tag Manager (GTM) lets you manage tracking scripts without code changes. You can add PostHog
-                    to your site using a custom HTML tag.
-                </Markdown>
-                <Markdown>
-                    {`1. Log into your Google Tag Manager account and open your container.
+    return [
+        {
+            title: 'Create a custom HTML tag',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Google Tag Manager (GTM) lets you manage tracking scripts without code changes. You can add PostHog
+                        to your site using a custom HTML tag.
+                    </Markdown>
+                    <Markdown>
+                        {`1. Log into your Google Tag Manager account and open your container.
 2. Click **Tags** > **New** > **Tag Configuration** > **Custom HTML**.
 3. Paste the following code:`}
-                </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'html',
-                            file: 'Custom HTML Tag',
-                            code: dedent`
-                                <script>
-                                    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-                                    posthog.init('<ph_project_api_key>', {
-                                        api_host: '<ph_client_api_host>',
-                                        defaults: '2025-11-30'
-                                    })
-                                </script>
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Configure the trigger" badge="required">
-                <Markdown>
-                    {`1. Under **Triggering**, select **All Pages** to load PostHog on every page.
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'html',
+                                file: 'Custom HTML Tag',
+                                code: dedent`
+                                    <script>
+                                        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+                                        posthog.init('<ph_project_api_key>', {
+                                            api_host: '<ph_client_api_host>',
+                                            defaults: '2025-11-30'
+                                        })
+                                    </script>
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure the trigger',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        {`1. Under **Triggering**, select **All Pages** to load PostHog on every page.
 2. Save the tag, then click **Submit** to publish your changes.`}
-                </Markdown>
-                <Markdown>
-                    Once published, PostHog will automatically capture pageviews, clicks, and other events on your site.
-                </Markdown>
-            </Step>
-
-            <Step title="Send events">{JSEventCapture && <JSEventCapture />}</Step>
-        </Steps>
-    )
+                    </Markdown>
+                    <Markdown>
+                        Once published, PostHog will automatically capture pageviews, clicks, and other events on your site.
+                    </Markdown>
+                </>
+            ),
+        },
+        {
+            title: 'Send events',
+            content: <>{JSEventCapture && <JSEventCapture />}</>,
+        },
+    ]
 }
+
+export const GoogleTagManagerInstallation = createInstallation(getGoogleTagManagerSteps)

--- a/docs/onboarding/product-analytics/google-tag-manager.tsx
+++ b/docs/onboarding/product-analytics/google-tag-manager.tsx
@@ -2,12 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getGoogleTagManagerSteps = ({
-    CodeBlock,
-    Markdown,
-    dedent,
-    snippets,
-}: OnboardingComponents): StepDefinition[] => {
+export const getGoogleTagManagerSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -17,8 +14,8 @@ export const getGoogleTagManagerSteps = ({
             content: (
                 <>
                     <Markdown>
-                        Google Tag Manager (GTM) lets you manage tracking scripts without code changes. You can add PostHog
-                        to your site using a custom HTML tag.
+                        Google Tag Manager (GTM) lets you manage tracking scripts without code changes. You can add
+                        PostHog to your site using a custom HTML tag.
                     </Markdown>
                     <Markdown>
                         {`1. Log into your Google Tag Manager account and open your container.
@@ -55,7 +52,8 @@ export const getGoogleTagManagerSteps = ({
 2. Save the tag, then click **Submit** to publish your changes.`}
                     </Markdown>
                     <Markdown>
-                        Once published, PostHog will automatically capture pageviews, clicks, and other events on your site.
+                        Once published, PostHog will automatically capture pageviews, clicks, and other events on your
+                        site.
                     </Markdown>
                 </>
             ),

--- a/docs/onboarding/product-analytics/google-tag-manager.tsx
+++ b/docs/onboarding/product-analytics/google-tag-manager.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getGoogleTagManagerSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getGoogleTagManagerSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/helicone.tsx
+++ b/docs/onboarding/product-analytics/helicone.tsx
@@ -1,18 +1,23 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const HeliconeInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Set up Helicone" badge="required">
-                <Markdown>
-                    Helicone supports most popular LLM models and you can bring your Helicone data into PostHog for
-                    analysis. Sign up to [Helicone](https://www.helicone.ai/) and add it to your LLM app.
-                </Markdown>
-            </Step>
-
-            <Step title="Add PostHog headers" badge="required">
+export const getHeliconeSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Set up Helicone',
+        badge: 'required',
+        content: (
+            <Markdown>
+                Helicone supports most popular LLM models and you can bring your Helicone data into PostHog for
+                analysis. Sign up to [Helicone](https://www.helicone.ai/) and add it to your LLM app.
+            </Markdown>
+        ),
+    },
+    {
+        title: 'Add PostHog headers',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>
                     Similar to how you add a [Helicone-Auth
                     header](https://docs.helicone.ai/helicone-headers/header-directory#supported-headers) when
@@ -41,7 +46,9 @@ export const HeliconeInstallation = (): JSX.Element => {
                     ]}
                 />
                 <Markdown>Helicone events will now be exported into PostHog as soon as they're available.</Markdown>
-            </Step>
-        </Steps>
-    )
-}
+            </>
+        ),
+    },
+]
+
+export const HeliconeInstallation = createInstallation(getHeliconeSteps)

--- a/docs/onboarding/product-analytics/helicone.tsx
+++ b/docs/onboarding/product-analytics/helicone.tsx
@@ -2,34 +2,37 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getHeliconeSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Set up Helicone',
-        badge: 'required',
-        content: (
-            <Markdown>
-                Helicone supports most popular LLM models and you can bring your Helicone data into PostHog for
-                analysis. Sign up to [Helicone](https://www.helicone.ai/) and add it to your LLM app.
-            </Markdown>
-        ),
-    },
-    {
-        title: 'Add PostHog headers',
-        badge: 'required',
-        content: (
-            <>
+export const getHeliconeSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Set up Helicone',
+            badge: 'required',
+            content: (
                 <Markdown>
-                    Similar to how you add a [Helicone-Auth
-                    header](https://docs.helicone.ai/helicone-headers/header-directory#supported-headers) when
-                    installing Helicone, add two new headers **Helicone-Posthog-Key** and **Helicone-Posthog-Host** with
-                    your PostHog details:
+                    Helicone supports most popular LLM models and you can bring your Helicone data into PostHog for
+                    analysis. Sign up to [Helicone](https://www.helicone.ai/) and add it to your LLM app.
                 </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'python',
-                            file: 'Python',
-                            code: dedent`
+            ),
+        },
+        {
+            title: 'Add PostHog headers',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Similar to how you add a [Helicone-Auth
+                        header](https://docs.helicone.ai/helicone-headers/header-directory#supported-headers) when
+                        installing Helicone, add two new headers **Helicone-Posthog-Key** and **Helicone-Posthog-Host**
+                        with your PostHog details:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
                                 # Example for adding it to OpenAI in Python
 
                                 client = OpenAI(
@@ -42,13 +45,14 @@ export const getHeliconeSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComp
                                     }
                                 )
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Helicone events will now be exported into PostHog as soon as they're available.</Markdown>
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <Markdown>Helicone events will now be exported into PostHog as soon as they're available.</Markdown>
+                </>
+            ),
+        },
+    ]
+}
 
 export const HeliconeInstallation = createInstallation(getHeliconeSteps)

--- a/docs/onboarding/product-analytics/helicone.tsx
+++ b/docs/onboarding/product-analytics/helicone.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getHeliconeSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/html-snippet.tsx
+++ b/docs/onboarding/product-analytics/html-snippet.tsx
@@ -1,37 +1,50 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const HTMLSnippetInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
+export const getHTMLSnippetSteps = ({
+    CodeBlock,
+    Markdown,
+    dedent,
+    snippets,
+}: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
-    return (
-        <Steps>
-            <Step title="Add the snippet to your website" badge="required">
-                <Markdown>
-                    Add this snippet to your website within the `&lt;head&gt;` tag. This can also be used in services
-                    like Google Tag Manager:
-                </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'html',
-                            file: 'HTML',
-                            code: dedent`
-                                <script>
-                                    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-                                    posthog.init('<ph_project_api_key>', {
-                                        api_host: '<ph_client_api_host>',
-                                        defaults: '2025-11-30'
-                                    })
-                                </script>
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Send events">{JSEventCapture && <JSEventCapture />}</Step>
-        </Steps>
-    )
+    return [
+        {
+            title: 'Add the snippet to your website',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Add this snippet to your website within the `&lt;head&gt;` tag. This can also be used in services
+                        like Google Tag Manager:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'html',
+                                file: 'HTML',
+                                code: dedent`
+                                    <script>
+                                        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+                                        posthog.init('<ph_project_api_key>', {
+                                            api_host: '<ph_client_api_host>',
+                                            defaults: '2025-11-30'
+                                        })
+                                    </script>
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send events',
+            content: <>{JSEventCapture && <JSEventCapture />}</>,
+        },
+    ]
 }
+
+export const HTMLSnippetInstallation = createInstallation(getHTMLSnippetSteps)

--- a/docs/onboarding/product-analytics/html-snippet.tsx
+++ b/docs/onboarding/product-analytics/html-snippet.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getHTMLSnippetSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getHTMLSnippetSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/html-snippet.tsx
+++ b/docs/onboarding/product-analytics/html-snippet.tsx
@@ -2,12 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getHTMLSnippetSteps = ({
-    CodeBlock,
-    Markdown,
-    dedent,
-    snippets,
-}: OnboardingComponents): StepDefinition[] => {
+export const getHTMLSnippetSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -17,8 +14,8 @@ export const getHTMLSnippetSteps = ({
             content: (
                 <>
                     <Markdown>
-                        Add this snippet to your website within the `&lt;head&gt;` tag. This can also be used in services
-                        like Google Tag Manager:
+                        Add this snippet to your website within the `&lt;head&gt;` tag. This can also be used in
+                        services like Google Tag Manager:
                     </Markdown>
                     <CodeBlock
                         blocks={[

--- a/docs/onboarding/product-analytics/ios.tsx
+++ b/docs/onboarding/product-analytics/ios.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getIOSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getIOSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/ios.tsx
+++ b/docs/onboarding/product-analytics/ios.tsx
@@ -3,7 +3,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getIOSSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => {
+export const getIOSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
     return [
         {
             title: 'Install via CocoaPods',

--- a/docs/onboarding/product-analytics/ios.tsx
+++ b/docs/onboarding/product-analytics/ios.tsx
@@ -1,8 +1,9 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { PersonProfiles } from './_snippets/person-profiles'
-import { StepDefinition } from '../steps'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const getIOSSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
+import { StepDefinition } from '../steps'
+import { PersonProfiles } from './_snippets/person-profiles'
+
+export const getIOSSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => {
     return [
         {
             title: 'Install via CocoaPods',
@@ -99,17 +100,4 @@ export const getIOSSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDef
     ]
 }
 
-export const IOSInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getIOSSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const IOSInstallation = createInstallation(getIOSSteps)

--- a/docs/onboarding/product-analytics/js-web.tsx
+++ b/docs/onboarding/product-analytics/js-web.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getJSWebSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getJSWebSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/js-web.tsx
+++ b/docs/onboarding/product-analytics/js-web.tsx
@@ -1,7 +1,8 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getJSWebSteps = (CodeBlock: any, Markdown: any, dedent: any, snippets: any): StepDefinition[] => {
+export const getJSWebSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -82,17 +83,4 @@ export const getJSWebSteps = (CodeBlock: any, Markdown: any, dedent: any, snippe
     ]
 }
 
-export const JSWebInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getJSWebSteps(CodeBlock, Markdown, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const JSWebInstallation = createInstallation(getJSWebSteps)

--- a/docs/onboarding/product-analytics/js-web.tsx
+++ b/docs/onboarding/product-analytics/js-web.tsx
@@ -2,7 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getJSWebSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
+export const getJSWebSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -45,9 +47,7 @@ export const getJSWebSteps = ({ CodeBlock, Markdown, dedent, snippets }: Onboard
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Import and initialize the PostHog library with your project API key and host:
-                    </Markdown>
+                    <Markdown>Import and initialize the PostHog library with your project API key and host:</Markdown>
                     <CodeBlock
                         blocks={[
                             {

--- a/docs/onboarding/product-analytics/langfuse.tsx
+++ b/docs/onboarding/product-analytics/langfuse.tsx
@@ -1,11 +1,13 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const LangfuseInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Add Langfuse Tracing" badge="required">
+export const getLangfuseSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Add Langfuse Tracing',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>
                     Langfuse supports most popular LLM models and you can bring your Langfuse data into PostHog for
                     analysis.
@@ -14,9 +16,14 @@ export const LangfuseInstallation = (): JSX.Element => {
                     {`1. First add [Langfuse Tracing](https://langfuse.com/docs/tracing) to your LLM app.
 2. In your [Langfuse dashboard](https://cloud.langfuse.com/), click on **Settings** and scroll down to the **Integrations** section to find the PostHog integration.`}
                 </Markdown>
-            </Step>
-
-            <Step title="Configure the integration" badge="required">
+            </>
+        ),
+    },
+    {
+        title: 'Configure the integration',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>Click **Configure** and paste in your PostHog project API key:</Markdown>
                 <CodeBlock
                     blocks={[
@@ -48,7 +55,9 @@ export const LangfuseInstallation = (): JSX.Element => {
                         Langfuse data to appear in PostHog.
                     </Markdown>
                 </CalloutBox>
-            </Step>
-        </Steps>
-    )
-}
+            </>
+        ),
+    },
+]
+
+export const LangfuseInstallation = createInstallation(getLangfuseSteps)

--- a/docs/onboarding/product-analytics/langfuse.tsx
+++ b/docs/onboarding/product-analytics/langfuse.tsx
@@ -2,62 +2,66 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getLangfuseSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Add Langfuse Tracing',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>
-                    Langfuse supports most popular LLM models and you can bring your Langfuse data into PostHog for
-                    analysis.
-                </Markdown>
-                <Markdown>
-                    {`1. First add [Langfuse Tracing](https://langfuse.com/docs/tracing) to your LLM app.
+export const getLangfuseSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
+
+    return [
+        {
+            title: 'Add Langfuse Tracing',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Langfuse supports most popular LLM models and you can bring your Langfuse data into PostHog for
+                        analysis.
+                    </Markdown>
+                    <Markdown>
+                        {`1. First add [Langfuse Tracing](https://langfuse.com/docs/tracing) to your LLM app.
 2. In your [Langfuse dashboard](https://cloud.langfuse.com/), click on **Settings** and scroll down to the **Integrations** section to find the PostHog integration.`}
-                </Markdown>
-            </>
-        ),
-    },
-    {
-        title: 'Configure the integration',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Click **Configure** and paste in your PostHog project API key:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'API Key',
-                            code: dedent`
+                    </Markdown>
+                </>
+            ),
+        },
+        {
+            title: 'Configure the integration',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Click **Configure** and paste in your PostHog project API key:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'API Key',
+                                code: dedent`
                                 <ph_project_api_key>
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Paste in your PostHog host:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'Host',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                    <Markdown>Paste in your PostHog host:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'Host',
+                                code: dedent`
                                 <ph_client_api_host>
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Click **Enable** and then **Save**.</Markdown>
-                <CalloutBox type="fyi" title="Data sync timing">
-                    <Markdown>
-                        Langfuse batch exports your data into PostHog once a day, so it can take up to 24 hours for your
-                        Langfuse data to appear in PostHog.
-                    </Markdown>
-                </CalloutBox>
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <Markdown>Click **Enable** and then **Save**.</Markdown>
+                    <CalloutBox type="fyi" title="Data sync timing">
+                        <Markdown>
+                            Langfuse batch exports your data into PostHog once a day, so it can take up to 24 hours for
+                            your Langfuse data to appear in PostHog.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+    ]
+}
 
 export const LangfuseInstallation = createInstallation(getLangfuseSteps)

--- a/docs/onboarding/product-analytics/langfuse.tsx
+++ b/docs/onboarding/product-analytics/langfuse.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getLangfuseSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getLangfuseSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/laravel.tsx
+++ b/docs/onboarding/product-analytics/laravel.tsx
@@ -1,107 +1,93 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { PersonProfiles } from './_snippets/person-profiles'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
+import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getLaravelSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
-    return [
-        {
-            title: 'Install the package',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>Install the PostHog PHP library using Composer:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Terminal',
-                                code: dedent`
-                                    composer require posthog/posthog-php
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Configure PostHog',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Initialize PostHog in the `boot` method of `app/Providers/AppServiceProvider.php`:
-                    </Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'php',
-                                file: 'app/Providers/AppServiceProvider.php',
-                                code: dedent`
-                                    <?php
+export const getLaravelSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Install the package',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Install the PostHog PHP library using Composer:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'bash',
+                            file: 'Terminal',
+                            code: dedent`
+                                composer require posthog/posthog-php
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Configure PostHog',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>
+                    Initialize PostHog in the `boot` method of `app/Providers/AppServiceProvider.php`:
+                </Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'php',
+                            file: 'app/Providers/AppServiceProvider.php',
+                            code: dedent`
+                                <?php
 
-                                    namespace App\\Providers;
+                                namespace App\\Providers;
 
-                                    use Illuminate\\Support\\ServiceProvider;
-                                    use PostHog\\PostHog;
+                                use Illuminate\\Support\\ServiceProvider;
+                                use PostHog\\PostHog;
 
-                                    class AppServiceProvider extends ServiceProvider
+                                class AppServiceProvider extends ServiceProvider
+                                {
+                                    public function boot(): void
                                     {
-                                        public function boot(): void
-                                        {
-                                            PostHog::init(
-                                                '<ph_project_api_key>',
-                                                [
-                                                    'host' => '<ph_client_api_host>'
-                                                ]
-                                            );
-                                        }
+                                        PostHog::init(
+                                            '<ph_project_api_key>',
+                                            [
+                                                'host' => '<ph_client_api_host>'
+                                            ]
+                                        );
                                     }
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Send events',
-            badge: 'optional',
-            content: (
-                <>
-                    <Markdown>Capture custom events using the PostHog client:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'php',
-                                file: 'PHP',
-                                code: dedent`
-                                    PostHog::capture([
-                                        'distinctId' => 'test-user',
-                                        'event' => 'test-event',
-                                    ]);
-                                `,
-                            },
-                        ]}
-                    />
-                    <PersonProfiles language="php" />
-                </>
-            ),
-        },
-    ]
-}
+                                }
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Send events',
+        badge: 'optional',
+        content: (
+            <>
+                <Markdown>Capture custom events using the PostHog client:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'php',
+                            file: 'PHP',
+                            code: dedent`
+                                PostHog::capture([
+                                    'distinctId' => 'test-user',
+                                    'event' => 'test-event',
+                                ]);
+                            `,
+                        },
+                    ]}
+                />
+                <PersonProfiles language="php" />
+            </>
+        ),
+    },
+]
 
-export const LaravelInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getLaravelSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const LaravelInstallation = createInstallation(getLaravelSteps)

--- a/docs/onboarding/product-analytics/laravel.tsx
+++ b/docs/onboarding/product-analytics/laravel.tsx
@@ -3,41 +3,44 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getLaravelSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Install the package',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Install the PostHog PHP library using Composer:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Terminal',
-                            code: dedent`
+export const getLaravelSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Install the package',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Install the PostHog PHP library using Composer:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Terminal',
+                                code: dedent`
                                 composer require posthog/posthog-php
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Configure PostHog',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>
-                    Initialize PostHog in the `boot` method of `app/Providers/AppServiceProvider.php`:
-                </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'php',
-                            file: 'app/Providers/AppServiceProvider.php',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure PostHog',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Initialize PostHog in the `boot` method of `app/Providers/AppServiceProvider.php`:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'php',
+                                file: 'app/Providers/AppServiceProvider.php',
+                                code: dedent`
                                 <?php
 
                                 namespace App\\Providers;
@@ -58,36 +61,37 @@ export const getLaravelSteps = ({ CodeBlock, Markdown, dedent }: OnboardingCompo
                                     }
                                 }
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Send events',
-        badge: 'optional',
-        content: (
-            <>
-                <Markdown>Capture custom events using the PostHog client:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'php',
-                            file: 'PHP',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send events',
+            badge: 'optional',
+            content: (
+                <>
+                    <Markdown>Capture custom events using the PostHog client:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'php',
+                                file: 'PHP',
+                                code: dedent`
                                 PostHog::capture([
                                     'distinctId' => 'test-user',
                                     'event' => 'test-event',
                                 ]);
                             `,
-                        },
-                    ]}
-                />
-                <PersonProfiles language="php" />
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <PersonProfiles language="php" />
+                </>
+            ),
+        },
+    ]
+}
 
 export const LaravelInstallation = createInstallation(getLaravelSteps)

--- a/docs/onboarding/product-analytics/laravel.tsx
+++ b/docs/onboarding/product-analytics/laravel.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getLaravelSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getLaravelSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/moengage.tsx
+++ b/docs/onboarding/product-analytics/moengage.tsx
@@ -1,18 +1,23 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const MoEngageInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Open the MoEngage integration" badge="required">
-                <Markdown>
-                    MoEngage is a customer engagement platform. Follow the [MoEngage PostHog integration
-                    guide](https://posthog.com/docs/libraries/moengage) to set up the connection.
-                </Markdown>
-            </Step>
-
-            <Step title="Enter your credentials" badge="required">
+export const getMoEngageSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Open the MoEngage integration',
+        badge: 'required',
+        content: (
+            <Markdown>
+                MoEngage is a customer engagement platform. Follow the [MoEngage PostHog integration
+                guide](https://posthog.com/docs/libraries/moengage) to set up the connection.
+            </Markdown>
+        ),
+    },
+    {
+        title: 'Enter your credentials',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>When prompted, enter your PostHog project API key:</Markdown>
                 <CodeBlock
                     blocks={[
@@ -37,14 +42,19 @@ export const MoEngageInstallation = (): JSX.Element => {
                         },
                     ]}
                 />
-            </Step>
+            </>
+        ),
+    },
+    {
+        title: 'Verify the connection',
+        badge: 'recommended',
+        content: (
+            <Markdown>
+                Once configured, MoEngage will send event data to PostHog, allowing you to analyze customer engagement
+                alongside your other product analytics data.
+            </Markdown>
+        ),
+    },
+]
 
-            <Step title="Verify the connection" badge="recommended">
-                <Markdown>
-                    Once configured, MoEngage will send event data to PostHog, allowing you to analyze customer engagement
-                    alongside your other product analytics data.
-                </Markdown>
-            </Step>
-        </Steps>
-    )
-}
+export const MoEngageInstallation = createInstallation(getMoEngageSteps)

--- a/docs/onboarding/product-analytics/moengage.tsx
+++ b/docs/onboarding/product-analytics/moengage.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getMoEngageSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getMoEngageSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/moengage.tsx
+++ b/docs/onboarding/product-analytics/moengage.tsx
@@ -2,59 +2,63 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getMoEngageSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Open the MoEngage integration',
-        badge: 'required',
-        content: (
-            <Markdown>
-                MoEngage is a customer engagement platform. Follow the [MoEngage PostHog integration
-                guide](https://posthog.com/docs/libraries/moengage) to set up the connection.
-            </Markdown>
-        ),
-    },
-    {
-        title: 'Enter your credentials',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>When prompted, enter your PostHog project API key:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'API Key',
-                            code: dedent`
+export const getMoEngageSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Open the MoEngage integration',
+            badge: 'required',
+            content: (
+                <Markdown>
+                    MoEngage is a customer engagement platform. Follow the [MoEngage PostHog integration
+                    guide](https://posthog.com/docs/libraries/moengage) to set up the connection.
+                </Markdown>
+            ),
+        },
+        {
+            title: 'Enter your credentials',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>When prompted, enter your PostHog project API key:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'API Key',
+                                code: dedent`
                                 <ph_project_api_key>
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Enter your PostHog host:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'Host',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                    <Markdown>Enter your PostHog host:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'Host',
+                                code: dedent`
                                 <ph_client_api_host>
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Verify the connection',
-        badge: 'recommended',
-        content: (
-            <Markdown>
-                Once configured, MoEngage will send event data to PostHog, allowing you to analyze customer engagement
-                alongside your other product analytics data.
-            </Markdown>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Verify the connection',
+            badge: 'recommended',
+            content: (
+                <Markdown>
+                    Once configured, MoEngage will send event data to PostHog, allowing you to analyze customer
+                    engagement alongside your other product analytics data.
+                </Markdown>
+            ),
+        },
+    ]
+}
 
 export const MoEngageInstallation = createInstallation(getMoEngageSteps)

--- a/docs/onboarding/product-analytics/n8n.tsx
+++ b/docs/onboarding/product-analytics/n8n.tsx
@@ -1,18 +1,23 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const N8nInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Add the PostHog node" badge="required">
-                <Markdown>
-                    n8n is an open-source workflow automation tool. In your n8n workflow, add the [PostHog
-                    node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.posthog/).
-                </Markdown>
-            </Step>
-
-            <Step title="Create credentials" badge="required">
+export const getN8nSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Add the PostHog node',
+        badge: 'required',
+        content: (
+            <Markdown>
+                n8n is an open-source workflow automation tool. In your n8n workflow, add the [PostHog
+                node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.posthog/).
+            </Markdown>
+        ),
+    },
+    {
+        title: 'Create credentials',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>Create credentials with your PostHog project API key:</Markdown>
                 <CodeBlock
                     blocks={[
@@ -37,14 +42,19 @@ export const N8nInstallation = (): JSX.Element => {
                         },
                     ]}
                 />
-            </Step>
+            </>
+        ),
+    },
+    {
+        title: 'Configure events',
+        badge: 'recommended',
+        content: (
+            <Markdown>
+                Configure the node to capture events, identify users, or create aliases based on your workflow needs.
+                Events from n8n will appear in PostHog just like events from any other source.
+            </Markdown>
+        ),
+    },
+]
 
-            <Step title="Configure events" badge="recommended">
-                <Markdown>
-                    Configure the node to capture events, identify users, or create aliases based on your workflow needs.
-                    Events from n8n will appear in PostHog just like events from any other source.
-                </Markdown>
-            </Step>
-        </Steps>
-    )
-}
+export const N8nInstallation = createInstallation(getN8nSteps)

--- a/docs/onboarding/product-analytics/n8n.tsx
+++ b/docs/onboarding/product-analytics/n8n.tsx
@@ -2,59 +2,63 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getN8nSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Add the PostHog node',
-        badge: 'required',
-        content: (
-            <Markdown>
-                n8n is an open-source workflow automation tool. In your n8n workflow, add the [PostHog
-                node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.posthog/).
-            </Markdown>
-        ),
-    },
-    {
-        title: 'Create credentials',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Create credentials with your PostHog project API key:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'API Key',
-                            code: dedent`
+export const getN8nSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Add the PostHog node',
+            badge: 'required',
+            content: (
+                <Markdown>
+                    n8n is an open-source workflow automation tool. In your n8n workflow, add the [PostHog
+                    node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.posthog/).
+                </Markdown>
+            ),
+        },
+        {
+            title: 'Create credentials',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Create credentials with your PostHog project API key:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'API Key',
+                                code: dedent`
                                 <ph_project_api_key>
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Set the PostHog host URL:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'Host',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                    <Markdown>Set the PostHog host URL:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'Host',
+                                code: dedent`
                                 <ph_client_api_host>
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Configure events',
-        badge: 'recommended',
-        content: (
-            <Markdown>
-                Configure the node to capture events, identify users, or create aliases based on your workflow needs.
-                Events from n8n will appear in PostHog just like events from any other source.
-            </Markdown>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure events',
+            badge: 'recommended',
+            content: (
+                <Markdown>
+                    Configure the node to capture events, identify users, or create aliases based on your workflow
+                    needs. Events from n8n will appear in PostHog just like events from any other source.
+                </Markdown>
+            ),
+        },
+    ]
+}
 
 export const N8nInstallation = createInstallation(getN8nSteps)

--- a/docs/onboarding/product-analytics/n8n.tsx
+++ b/docs/onboarding/product-analytics/n8n.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getN8nSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getN8nSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/nextjs.tsx
+++ b/docs/onboarding/product-analytics/nextjs.tsx
@@ -1,14 +1,9 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getNextJSSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    Tab: any,
-    dedent: any,
-    snippets: any
-): StepDefinition[] => {
+export const getNextJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, Tab, dedent, snippets } = ctx
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -109,8 +104,9 @@ export const getNextJSSteps = (
                             </Tab.Panel>
                             <Tab.Panel>
                                 <Markdown>
-                                    For the App router, create a `providers.tsx` file in your `app` folder. The `posthog-js`
-                                    library needs to be initialized on the client-side using the `'use client'` directive:
+                                    For the App router, create a `providers.tsx` file in your `app` folder. The
+                                    `posthog-js` library needs to be initialized on the client-side using the `'use
+                                    client'` directive:
                                 </Markdown>
                                 <CodeBlock
                                     blocks={[
@@ -145,8 +141,8 @@ export const getNextJSSteps = (
                                     ]}
                                 />
                                 <Markdown>
-                                    Then import the `PostHogProvider` component in your `app/layout.tsx` and wrap your app
-                                    with it:
+                                    Then import the `PostHogProvider` component in your `app/layout.tsx` and wrap your
+                                    app with it:
                                 </Markdown>
                                 <CodeBlock
                                     blocks={[
@@ -218,7 +214,8 @@ export const getNextJSSteps = (
                     <CalloutBox type="fyi" title="Defaults option">
                         <Markdown>
                             The `defaults` option automatically configures PostHog with recommended settings for new
-                            projects. See [SDK defaults](https://posthog.com/docs/libraries/js#sdk-defaults) for details.
+                            projects. See [SDK defaults](https://posthog.com/docs/libraries/js#sdk-defaults) for
+                            details.
                         </Markdown>
                     </CalloutBox>
                 </>
@@ -263,9 +260,7 @@ export const getNextJSSteps = (
                                 />
                             </Tab.Panel>
                             <Tab.Panel>
-                                <Markdown>
-                                    Use the `usePostHog` hook to access PostHog in client components:
-                                </Markdown>
+                                <Markdown>Use the `usePostHog` hook to access PostHog in client components:</Markdown>
                                 <CodeBlock
                                     blocks={[
                                         {
@@ -300,9 +295,7 @@ export const getNextJSSteps = (
             badge: 'optional',
             content: (
                 <>
-                    <Markdown>
-                        To capture events from API routes or server actions, install `posthog-node`:
-                    </Markdown>
+                    <Markdown>To capture events from API routes or server actions, install `posthog-node`:</Markdown>
                     <CodeBlock
                         blocks={[
                             {
@@ -341,8 +334,8 @@ export const getNextJSSteps = (
                         <Tab.Panels>
                             <Tab.Panel>
                                 <Markdown>
-                                    For the App router, you can use PostHog in API routes or server actions. Create a new
-                                    PostHog client instance for each request, or reuse a singleton instance across
+                                    For the App router, you can use PostHog in API routes or server actions. Create a
+                                    new PostHog client instance for each request, or reuse a singleton instance across
                                     requests:
                                 </Markdown>
                                 <CodeBlock
@@ -369,9 +362,7 @@ export const getNextJSSteps = (
                                         },
                                     ]}
                                 />
-                                <Markdown>
-                                    You can also use PostHog in server actions:
-                                </Markdown>
+                                <Markdown>You can also use PostHog in server actions:</Markdown>
                                 <CodeBlock
                                     blocks={[
                                         {
@@ -400,9 +391,7 @@ export const getNextJSSteps = (
                                 />
                             </Tab.Panel>
                             <Tab.Panel>
-                                <Markdown>
-                                    For the Pages router, use PostHog in your API routes:
-                                </Markdown>
+                                <Markdown>For the Pages router, use PostHog in your API routes:</Markdown>
                                 <CodeBlock
                                     blocks={[
                                         {
@@ -450,26 +439,9 @@ export const getNextJSSteps = (
         {
             title: 'Send events',
             badge: 'recommended',
-            content: (
-                <>
-                    {JSEventCapture && <JSEventCapture />}
-                </>
-            ),
+            content: <>{JSEventCapture && <JSEventCapture />}</>,
         },
     ]
 }
 
-export const NextJSInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, Tab, dedent, snippets } = useMDXComponents()
-    const steps = getNextJSSteps(CodeBlock, Markdown, CalloutBox, Tab, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const NextJSInstallation = createInstallation(getNextJSSteps)

--- a/docs/onboarding/product-analytics/nextjs.tsx
+++ b/docs/onboarding/product-analytics/nextjs.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getNextJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getNextJSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, Tab, dedent, snippets } = ctx
     const JSEventCapture = snippets?.JSEventCapture
 

--- a/docs/onboarding/product-analytics/nodejs.tsx
+++ b/docs/onboarding/product-analytics/nodejs.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getNodeJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getNodeJSSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/nodejs.tsx
+++ b/docs/onboarding/product-analytics/nodejs.tsx
@@ -3,53 +3,56 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getNodeJSSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Install the package',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Install the PostHog Node.js library using your package manager:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'npm',
-                            code: dedent`
+export const getNodeJSSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Install the package',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Install the PostHog Node.js library using your package manager:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'npm',
+                                code: dedent`
                                 npm install posthog-node
                             `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'yarn',
-                            code: dedent`
+                            },
+                            {
+                                language: 'bash',
+                                file: 'yarn',
+                                code: dedent`
                                 yarn add posthog-node
                             `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'pnpm',
-                            code: dedent`
+                            },
+                            {
+                                language: 'bash',
+                                file: 'pnpm',
+                                code: dedent`
                                 pnpm add posthog-node
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Initialize PostHog',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Initialize the PostHog client with your project API key:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'javascript',
-                            file: 'Node.js',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Initialize PostHog',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Initialize the PostHog client with your project API key:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'javascript',
+                                file: 'Node.js',
+                                code: dedent`
                                 import { PostHog } from 'posthog-node'
 
                                 const client = new PostHog(
@@ -59,24 +62,24 @@ export const getNodeJSSteps = ({ CodeBlock, Markdown, dedent }: OnboardingCompon
                                     }
                                 )
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Send an event',
-        badge: 'recommended',
-        content: (
-            <>
-                <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'javascript',
-                            file: 'Node.js',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send an event',
+            badge: 'recommended',
+            content: (
+                <>
+                    <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'javascript',
+                                file: 'Node.js',
+                                code: dedent`
                                 client.capture({
                                     distinctId: 'distinct_id_of_the_user',
                                     event: 'event_name',
@@ -86,13 +89,14 @@ export const getNodeJSSteps = ({ CodeBlock, Markdown, dedent }: OnboardingCompon
                                     },
                                 })
                             `,
-                        },
-                    ]}
-                />
-                <PersonProfiles language="javascript" file="Node.js" />
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <PersonProfiles language="javascript" file="Node.js" />
+                </>
+            ),
+        },
+    ]
+}
 
 export const NodeJSInstallation = createInstallation(getNodeJSSteps)

--- a/docs/onboarding/product-analytics/nodejs.tsx
+++ b/docs/onboarding/product-analytics/nodejs.tsx
@@ -1,114 +1,98 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { PersonProfiles } from './_snippets/person-profiles'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
+import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getNodeJSSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
-    return [
-        {
-            title: 'Install the package',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>Install the PostHog Node.js library using your package manager:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'npm',
-                                code: dedent`
-                                    npm install posthog-node
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'yarn',
-                                code: dedent`
-                                    yarn add posthog-node
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'pnpm',
-                                code: dedent`
-                                    pnpm add posthog-node
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Initialize PostHog',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>Initialize the PostHog client with your project API key:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'javascript',
-                                file: 'Node.js',
-                                code: dedent`
-                                    import { PostHog } from 'posthog-node'
+export const getNodeJSSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Install the package',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Install the PostHog Node.js library using your package manager:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'bash',
+                            file: 'npm',
+                            code: dedent`
+                                npm install posthog-node
+                            `,
+                        },
+                        {
+                            language: 'bash',
+                            file: 'yarn',
+                            code: dedent`
+                                yarn add posthog-node
+                            `,
+                        },
+                        {
+                            language: 'bash',
+                            file: 'pnpm',
+                            code: dedent`
+                                pnpm add posthog-node
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Initialize PostHog',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Initialize the PostHog client with your project API key:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'javascript',
+                            file: 'Node.js',
+                            code: dedent`
+                                import { PostHog } from 'posthog-node'
 
-                                    const client = new PostHog(
-                                        '<ph_project_api_key>',
-                                        {
-                                            host: '<ph_client_api_host>'
-                                        }
-                                    )
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Send an event',
-            badge: 'recommended',
-            content: (
-                <>
-                    <Markdown>
-                        Once installed, you can manually send events to test your integration:
-                    </Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'javascript',
-                                file: 'Node.js',
-                                code: dedent`
-                                    client.capture({
-                                        distinctId: 'distinct_id_of_the_user',
-                                        event: 'event_name',
-                                        properties: {
-                                            property1: 'value',
-                                            property2: 'value',
-                                        },
-                                    })
-                                `,
-                            },
-                        ]}
-                    />
-                    <PersonProfiles language="javascript" file="Node.js" />
-                </>
-            ),
-        },
-    ]
-}
+                                const client = new PostHog(
+                                    '<ph_project_api_key>',
+                                    {
+                                        host: '<ph_client_api_host>'
+                                    }
+                                )
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Send an event',
+        badge: 'recommended',
+        content: (
+            <>
+                <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'javascript',
+                            file: 'Node.js',
+                            code: dedent`
+                                client.capture({
+                                    distinctId: 'distinct_id_of_the_user',
+                                    event: 'event_name',
+                                    properties: {
+                                        property1: 'value',
+                                        property2: 'value',
+                                    },
+                                })
+                            `,
+                        },
+                    ]}
+                />
+                <PersonProfiles language="javascript" file="Node.js" />
+            </>
+        ),
+    },
+]
 
-export const NodeJSInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getNodeJSSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const NodeJSInstallation = createInstallation(getNodeJSSteps)

--- a/docs/onboarding/product-analytics/nuxt.tsx
+++ b/docs/onboarding/product-analytics/nuxt.tsx
@@ -1,13 +1,14 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getNuxtSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any
-): StepDefinition[] => {
+export const getNuxtSteps = ({
+    CodeBlock,
+    Markdown,
+    CalloutBox,
+    dedent,
+    snippets,
+}: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -191,17 +192,4 @@ export const getNuxtSteps = (
     ]
 }
 
-export const NuxtInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getNuxtSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const NuxtInstallation = createInstallation(getNuxtSteps)

--- a/docs/onboarding/product-analytics/nuxt.tsx
+++ b/docs/onboarding/product-analytics/nuxt.tsx
@@ -2,13 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getNuxtSteps = ({
-    CodeBlock,
-    Markdown,
-    CalloutBox,
-    dedent,
-    snippets,
-}: OnboardingComponents): StepDefinition[] => {
+export const getNuxtSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [

--- a/docs/onboarding/product-analytics/nuxt.tsx
+++ b/docs/onboarding/product-analytics/nuxt.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getNuxtSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getNuxtSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/php.tsx
+++ b/docs/onboarding/product-analytics/php.tsx
@@ -3,74 +3,78 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getPHPSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Install the package',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Install the PostHog PHP library using Composer:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Terminal',
-                            code: dedent`
+export const getPHPSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Install the package',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Install the PostHog PHP library using Composer:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Terminal',
+                                code: dedent`
                                 composer require posthog/posthog-php
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Configure PostHog',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'php',
-                            file: 'PHP',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure PostHog',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'php',
+                                file: 'PHP',
+                                code: dedent`
                                 PostHog\\PostHog::init(
                                     '<ph_project_api_key>',
                                     ['host' => '<ph_client_api_host>']
                                 );
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Send events',
-        badge: 'recommended',
-        content: (
-            <>
-                <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'php',
-                            file: 'PHP',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send events',
+            badge: 'recommended',
+            content: (
+                <>
+                    <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'php',
+                                file: 'PHP',
+                                code: dedent`
                                 PostHog::capture([
                                     'distinctId' => 'test-user',
                                     'event' => 'test-event',
                                 ]);
                             `,
-                        },
-                    ]}
-                />
-                <PersonProfiles language="php" />
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <PersonProfiles language="php" />
+                </>
+            ),
+        },
+    ]
+}
 
 export const PHPInstallation = createInstallation(getPHPSteps)

--- a/docs/onboarding/product-analytics/php.tsx
+++ b/docs/onboarding/product-analytics/php.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getPHPSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getPHPSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/php.tsx
+++ b/docs/onboarding/product-analytics/php.tsx
@@ -1,92 +1,76 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { PersonProfiles } from './_snippets/person-profiles'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
+import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getPHPSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
-    return [
-        {
-            title: 'Install the package',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>Install the PostHog PHP library using Composer:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Terminal',
-                                code: dedent`
-                                    composer require posthog/posthog-php
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Configure PostHog',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'php',
-                                file: 'PHP',
-                                code: dedent`
-                                    PostHog\\PostHog::init(
-                                        '<ph_project_api_key>',
-                                        ['host' => '<ph_client_api_host>']
-                                    );
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Send events',
-            badge: 'recommended',
-            content: (
-                <>
-                    <Markdown>
-                        Once installed, you can manually send events to test your integration:
-                    </Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'php',
-                                file: 'PHP',
-                                code: dedent`
-                                    PostHog::capture([
-                                        'distinctId' => 'test-user',
-                                        'event' => 'test-event',
-                                    ]);
-                                `,
-                            },
-                        ]}
-                    />
-                    <PersonProfiles language="php" />
-                </>
-            ),
-        },
-    ]
-}
+export const getPHPSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Install the package',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Install the PostHog PHP library using Composer:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'bash',
+                            file: 'Terminal',
+                            code: dedent`
+                                composer require posthog/posthog-php
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Configure PostHog',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'php',
+                            file: 'PHP',
+                            code: dedent`
+                                PostHog\\PostHog::init(
+                                    '<ph_project_api_key>',
+                                    ['host' => '<ph_client_api_host>']
+                                );
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Send events',
+        badge: 'recommended',
+        content: (
+            <>
+                <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'php',
+                            file: 'PHP',
+                            code: dedent`
+                                PostHog::capture([
+                                    'distinctId' => 'test-user',
+                                    'event' => 'test-event',
+                                ]);
+                            `,
+                        },
+                    ]}
+                />
+                <PersonProfiles language="php" />
+            </>
+        ),
+    },
+]
 
-export const PHPInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getPHPSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const PHPInstallation = createInstallation(getPHPSteps)

--- a/docs/onboarding/product-analytics/python.tsx
+++ b/docs/onboarding/product-analytics/python.tsx
@@ -1,13 +1,14 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getPythonSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any
-): StepDefinition[] => {
+export const getPythonSteps = ({
+    CodeBlock,
+    Markdown,
+    CalloutBox,
+    dedent,
+    snippets,
+}: OnboardingComponents): StepDefinition[] => {
     const PythonEventCapture = snippets?.PythonEventCapture
 
     return [
@@ -80,17 +81,4 @@ export const getPythonSteps = (
     ]
 }
 
-export const PythonInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getPythonSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const PythonInstallation = createInstallation(getPythonSteps)

--- a/docs/onboarding/product-analytics/python.tsx
+++ b/docs/onboarding/product-analytics/python.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getPythonSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getPythonSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
 
     const PythonEventCapture = snippets?.PythonEventCapture

--- a/docs/onboarding/product-analytics/python.tsx
+++ b/docs/onboarding/product-analytics/python.tsx
@@ -2,13 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getPythonSteps = ({
-    CodeBlock,
-    Markdown,
-    CalloutBox,
-    dedent,
-    snippets,
-}: OnboardingComponents): StepDefinition[] => {
+export const getPythonSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
+
     const PythonEventCapture = snippets?.PythonEventCapture
 
     return [

--- a/docs/onboarding/product-analytics/react-native.tsx
+++ b/docs/onboarding/product-analytics/react-native.tsx
@@ -2,7 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getReactNativeSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => {
+export const getReactNativeSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
     return [
         {
             title: 'Install the package',
@@ -50,7 +52,8 @@ export const getReactNativeSteps = ({ CodeBlock, Markdown, dedent }: OnboardingC
             content: (
                 <>
                     <Markdown>
-                        PostHog is most easily used via the `PostHogProvider` component. Wrap your app with the provider:
+                        PostHog is most easily used via the `PostHogProvider` component. Wrap your app with the
+                        provider:
                     </Markdown>
                     <CodeBlock
                         blocks={[

--- a/docs/onboarding/product-analytics/react-native.tsx
+++ b/docs/onboarding/product-analytics/react-native.tsx
@@ -1,7 +1,8 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getReactNativeSteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
+export const getReactNativeSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => {
     return [
         {
             title: 'Install the package',
@@ -116,17 +117,4 @@ export const getReactNativeSteps = (CodeBlock: any, Markdown: any, dedent: any):
     ]
 }
 
-export const ReactNativeInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getReactNativeSteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const ReactNativeInstallation = createInstallation(getReactNativeSteps)

--- a/docs/onboarding/product-analytics/react-native.tsx
+++ b/docs/onboarding/product-analytics/react-native.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getReactNativeSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/react.tsx
+++ b/docs/onboarding/product-analytics/react.tsx
@@ -2,13 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getReactSteps = ({
-    CodeBlock,
-    Markdown,
-    CalloutBox,
-    dedent,
-    snippets,
-}: OnboardingComponents): StepDefinition[] => {
+export const getReactSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -110,7 +106,8 @@ export const getReactSteps = ({
                     <CalloutBox type="fyi" title="defaults option">
                         <Markdown>
                             The `defaults` option automatically configures PostHog with recommended settings for new
-                            projects. See [SDK defaults](https://posthog.com/docs/libraries/js#sdk-defaults) for details.
+                            projects. See [SDK defaults](https://posthog.com/docs/libraries/js#sdk-defaults) for
+                            details.
                         </Markdown>
                     </CalloutBox>
                 </>
@@ -146,9 +143,7 @@ export const getReactSteps = ({
                             },
                         ]}
                     />
-                    <Markdown>
-                        You can also import `posthog` directly for non-React code or utility functions:
-                    </Markdown>
+                    <Markdown>You can also import `posthog` directly for non-React code or utility functions:</Markdown>
                     <CodeBlock
                         blocks={[
                             {

--- a/docs/onboarding/product-analytics/react.tsx
+++ b/docs/onboarding/product-analytics/react.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getReactSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getReactSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/react.tsx
+++ b/docs/onboarding/product-analytics/react.tsx
@@ -1,13 +1,14 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getReactSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any
-): StepDefinition[] => {
+export const getReactSteps = ({
+    CodeBlock,
+    Markdown,
+    CalloutBox,
+    dedent,
+    snippets,
+}: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -51,8 +52,8 @@ export const getReactSteps = (
             content: (
                 <>
                     <Markdown>
-                        Add your PostHog API key and host to your environment variables. For Vite-based React apps, use the
-                        `VITE_PUBLIC_` prefix:
+                        Add your PostHog API key and host to your environment variables. For Vite-based React apps, use
+                        the `VITE_PUBLIC_` prefix:
                     </Markdown>
                     <CodeBlock
                         blocks={[
@@ -174,17 +175,4 @@ export const getReactSteps = (
     ]
 }
 
-export const ReactInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getReactSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const ReactInstallation = createInstallation(getReactSteps)

--- a/docs/onboarding/product-analytics/remix.tsx
+++ b/docs/onboarding/product-analytics/remix.tsx
@@ -2,13 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getRemixSteps = ({
-    CodeBlock,
-    Markdown,
-    CalloutBox,
-    dedent,
-    snippets,
-}: OnboardingComponents): StepDefinition[] => {
+export const getRemixSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -139,7 +135,9 @@ export const getRemixSteps = ({
             badge: 'required',
             content: (
                 <>
-                    <Markdown>Import the `PHProvider` component in your `app/root.tsx` file and use it to wrap your app:</Markdown>
+                    <Markdown>
+                        Import the `PHProvider` component in your `app/root.tsx` file and use it to wrap your app:
+                    </Markdown>
                     <CodeBlock
                         blocks={[
                             {

--- a/docs/onboarding/product-analytics/remix.tsx
+++ b/docs/onboarding/product-analytics/remix.tsx
@@ -1,13 +1,14 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getRemixSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any
-): StepDefinition[] => {
+export const getRemixSteps = ({
+    CodeBlock,
+    Markdown,
+    CalloutBox,
+    dedent,
+    snippets,
+}: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -188,17 +189,4 @@ export const getRemixSteps = (
     ]
 }
 
-export const RemixInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getRemixSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const RemixInstallation = createInstallation(getRemixSteps)

--- a/docs/onboarding/product-analytics/remix.tsx
+++ b/docs/onboarding/product-analytics/remix.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getRemixSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getRemixSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/retool.tsx
+++ b/docs/onboarding/product-analytics/retool.tsx
@@ -2,29 +2,32 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getRetoolSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Open custom scripts',
-        badge: 'required',
-        content: (
-            <Markdown>
-                Retool is a platform for building internal tools. In your Retool app, go to **Settings** &gt;
-                **Custom Scripts**.
-            </Markdown>
-        ),
-    },
-    {
-        title: 'Add the PostHog snippet',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Add the following code to the **Head** section:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'html',
-                            file: 'Head section',
-                            code: dedent`
+export const getRetoolSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
+
+    return [
+        {
+            title: 'Open custom scripts',
+            badge: 'required',
+            content: (
+                <Markdown>
+                    Retool is a platform for building internal tools. In your Retool app, go to **Settings** &gt;
+                    **Custom Scripts**.
+                </Markdown>
+            ),
+        },
+        {
+            title: 'Add the PostHog snippet',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Add the following code to the **Head** section:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'html',
+                                file: 'Head section',
+                                code: dedent`
                                 <script>
                                     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
                                     posthog.init('<ph_project_api_key>', {
@@ -33,29 +36,31 @@ export const getRetoolSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: Onbo
                                     })
                                 </script>
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Verify installation',
-        badge: 'recommended',
-        content: (
-            <>
-                <Markdown>
-                    Save and refresh your app. PostHog will now automatically capture pageviews, clicks, and other
-                    events as your app is used.
-                </Markdown>
-                <CalloutBox type="fyi" title="Learn more">
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Verify installation',
+            badge: 'recommended',
+            content: (
+                <>
                     <Markdown>
-                        See the [Retool integration docs](https://posthog.com/docs/libraries/retool) for more details.
+                        Save and refresh your app. PostHog will now automatically capture pageviews, clicks, and other
+                        events as your app is used.
                     </Markdown>
-                </CalloutBox>
-            </>
-        ),
-    },
-]
+                    <CalloutBox type="fyi" title="Learn more">
+                        <Markdown>
+                            See the [Retool integration docs](https://posthog.com/docs/libraries/retool) for more
+                            details.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+    ]
+}
 
 export const RetoolInstallation = createInstallation(getRetoolSteps)

--- a/docs/onboarding/product-analytics/retool.tsx
+++ b/docs/onboarding/product-analytics/retool.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getRetoolSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getRetoolSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/retool.tsx
+++ b/docs/onboarding/product-analytics/retool.tsx
@@ -1,18 +1,23 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const RetoolInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Open custom scripts" badge="required">
-                <Markdown>
-                    Retool is a platform for building internal tools. In your Retool app, go to **Settings** &gt;
-                    **Custom Scripts**.
-                </Markdown>
-            </Step>
-
-            <Step title="Add the PostHog snippet" badge="required">
+export const getRetoolSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Open custom scripts',
+        badge: 'required',
+        content: (
+            <Markdown>
+                Retool is a platform for building internal tools. In your Retool app, go to **Settings** &gt;
+                **Custom Scripts**.
+            </Markdown>
+        ),
+    },
+    {
+        title: 'Add the PostHog snippet',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>Add the following code to the **Head** section:</Markdown>
                 <CodeBlock
                     blocks={[
@@ -31,9 +36,14 @@ export const RetoolInstallation = (): JSX.Element => {
                         },
                     ]}
                 />
-            </Step>
-
-            <Step title="Verify installation" badge="recommended">
+            </>
+        ),
+    },
+    {
+        title: 'Verify installation',
+        badge: 'recommended',
+        content: (
+            <>
                 <Markdown>
                     Save and refresh your app. PostHog will now automatically capture pageviews, clicks, and other
                     events as your app is used.
@@ -43,7 +53,9 @@ export const RetoolInstallation = (): JSX.Element => {
                         See the [Retool integration docs](https://posthog.com/docs/libraries/retool) for more details.
                     </Markdown>
                 </CalloutBox>
-            </Step>
-        </Steps>
-    )
-}
+            </>
+        ),
+    },
+]
+
+export const RetoolInstallation = createInstallation(getRetoolSteps)

--- a/docs/onboarding/product-analytics/ruby.tsx
+++ b/docs/onboarding/product-analytics/ruby.tsx
@@ -1,9 +1,9 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getRubySteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getRubySteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/ruby.tsx
+++ b/docs/onboarding/product-analytics/ruby.tsx
@@ -1,96 +1,80 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
-import { PersonProfiles } from './_snippets/person-profiles'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
+import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getRubySteps = (CodeBlock: any, Markdown: any, dedent: any): StepDefinition[] => {
-    return [
-        {
-            title: 'Install the gem',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>Add the PostHog Ruby gem to your Gemfile:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'ruby',
-                                file: 'Gemfile',
-                                code: dedent`
-                                    gem "posthog-ruby"
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Configure PostHog',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'ruby',
-                                file: 'Ruby',
-                                code: dedent`
-                                    posthog = PostHog::Client.new({
-                                        api_key: "<ph_project_api_key>",
-                                        host: "<ph_client_api_host>",
-                                        on_error: Proc.new { |status, msg| print msg }
-                                    })
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Send events',
-            badge: 'recommended',
-            content: (
-                <>
-                    <Markdown>
-                        Once installed, you can manually send events to test your integration:
-                    </Markdown>
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'ruby',
-                                file: 'Ruby',
-                                code: dedent`
-                                    posthog.capture({
-                                        distinct_id: 'user_123',
-                                        event: 'button_clicked',
-                                        properties: {
-                                            button_name: 'signup'
-                                        }
-                                    })
-                                `,
-                            },
-                        ]}
-                    />
-                    <PersonProfiles language="ruby" />
-                </>
-            ),
-        },
-    ]
-}
+export const getRubySteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Install the gem',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Add the PostHog Ruby gem to your Gemfile:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'ruby',
+                            file: 'Gemfile',
+                            code: dedent`
+                                gem "posthog-ruby"
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Configure PostHog',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'ruby',
+                            file: 'Ruby',
+                            code: dedent`
+                                posthog = PostHog::Client.new({
+                                    api_key: "<ph_project_api_key>",
+                                    host: "<ph_client_api_host>",
+                                    on_error: Proc.new { |status, msg| print msg }
+                                })
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Send events',
+        badge: 'recommended',
+        content: (
+            <>
+                <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'ruby',
+                            file: 'Ruby',
+                            code: dedent`
+                                posthog.capture({
+                                    distinct_id: 'user_123',
+                                    event: 'button_clicked',
+                                    properties: {
+                                        button_name: 'signup'
+                                    }
+                                })
+                            `,
+                        },
+                    ]}
+                />
+                <PersonProfiles language="ruby" />
+            </>
+        ),
+    },
+]
 
-export const RubyInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
-    const steps = getRubySteps(CodeBlock, Markdown, dedent)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const RubyInstallation = createInstallation(getRubySteps)

--- a/docs/onboarding/product-analytics/ruby.tsx
+++ b/docs/onboarding/product-analytics/ruby.tsx
@@ -3,63 +3,66 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 import { StepDefinition } from '../steps'
 import { PersonProfiles } from './_snippets/person-profiles'
 
-export const getRubySteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Install the gem',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Add the PostHog Ruby gem to your Gemfile:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'ruby',
-                            file: 'Gemfile',
-                            code: dedent`
+export const getRubySteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Install the gem',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Add the PostHog Ruby gem to your Gemfile:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'ruby',
+                                file: 'Gemfile',
+                                code: dedent`
                                 gem "posthog-ruby"
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Configure PostHog',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'ruby',
-                            file: 'Ruby',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure PostHog',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Initialize the PostHog client with your API key and host:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'ruby',
+                                file: 'Ruby',
+                                code: dedent`
                                 posthog = PostHog::Client.new({
                                     api_key: "<ph_project_api_key>",
                                     host: "<ph_client_api_host>",
                                     on_error: Proc.new { |status, msg| print msg }
                                 })
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Send events',
-        badge: 'recommended',
-        content: (
-            <>
-                <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'ruby',
-                            file: 'Ruby',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Send events',
+            badge: 'recommended',
+            content: (
+                <>
+                    <Markdown>Once installed, you can manually send events to test your integration:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'ruby',
+                                file: 'Ruby',
+                                code: dedent`
                                 posthog.capture({
                                     distinct_id: 'user_123',
                                     event: 'button_clicked',
@@ -68,13 +71,14 @@ export const getRubySteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponen
                                     }
                                 })
                             `,
-                        },
-                    ]}
-                />
-                <PersonProfiles language="ruby" />
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <PersonProfiles language="ruby" />
+                </>
+            ),
+        },
+    ]
+}
 
 export const RubyInstallation = createInstallation(getRubySteps)

--- a/docs/onboarding/product-analytics/rudderstack.tsx
+++ b/docs/onboarding/product-analytics/rudderstack.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getRudderstackSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getRudderstackSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/rudderstack.tsx
+++ b/docs/onboarding/product-analytics/rudderstack.tsx
@@ -2,73 +2,72 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getRudderstackSteps = ({
-    CodeBlock,
-    Markdown,
-    CalloutBox,
-    dedent,
-}: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Add PostHog destination',
-        badge: 'required',
-        content: (
-            <Markdown>
-                RudderStack is an open-source customer data platform that can route your analytics data to PostHog and
-                other destinations. In your RudderStack dashboard, go to **Destinations** &gt; **Add Destination** and
-                search for **PostHog**.
-            </Markdown>
-        ),
-    },
-    {
-        title: 'Enter your credentials',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Enter your PostHog project API key:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'API Key',
-                            code: dedent`
+export const getRudderstackSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
+
+    return [
+        {
+            title: 'Add PostHog destination',
+            badge: 'required',
+            content: (
+                <Markdown>
+                    RudderStack is an open-source customer data platform that can route your analytics data to PostHog
+                    and other destinations. In your RudderStack dashboard, go to **Destinations** &gt; **Add
+                    Destination** and search for **PostHog**.
+                </Markdown>
+            ),
+        },
+        {
+            title: 'Enter your credentials',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Enter your PostHog project API key:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'API Key',
+                                code: dedent`
                                 <ph_project_api_key>
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Enter your PostHog host:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'Host',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                    <Markdown>Enter your PostHog host:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'Host',
+                                code: dedent`
                                 <ph_client_api_host>
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Verify the connection',
-        badge: 'recommended',
-        content: (
-            <>
-                <Markdown>
-                    Connect your source to the PostHog destination. RudderStack will now forward `track`, `identify`,
-                    `page`, and `group` calls to PostHog.
-                </Markdown>
-                <CalloutBox type="fyi" title="Learn more">
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Verify the connection',
+            badge: 'recommended',
+            content: (
+                <>
                     <Markdown>
-                        See the [RudderStack integration docs](https://posthog.com/docs/libraries/rudderstack) for more
-                        details.
+                        Connect your source to the PostHog destination. RudderStack will now forward `track`,
+                        `identify`, `page`, and `group` calls to PostHog.
                     </Markdown>
-                </CalloutBox>
-            </>
-        ),
-    },
-]
+                    <CalloutBox type="fyi" title="Learn more">
+                        <Markdown>
+                            See the [RudderStack integration docs](https://posthog.com/docs/libraries/rudderstack) for
+                            more details.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+    ]
+}
 
 export const RudderstackInstallation = createInstallation(getRudderstackSteps)

--- a/docs/onboarding/product-analytics/rudderstack.tsx
+++ b/docs/onboarding/product-analytics/rudderstack.tsx
@@ -1,49 +1,74 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const RudderstackInstallation = (): JSX.Element => {
-    const { CodeBlock, Markdown, CalloutBox, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <>
+export const getRudderstackSteps = ({
+    CodeBlock,
+    Markdown,
+    CalloutBox,
+    dedent,
+}: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Add PostHog destination',
+        badge: 'required',
+        content: (
             <Markdown>
                 RudderStack is an open-source customer data platform that can route your analytics data to PostHog and
                 other destinations. In your RudderStack dashboard, go to **Destinations** &gt; **Add Destination** and
                 search for **PostHog**.
             </Markdown>
-            <Markdown>Enter your PostHog project API key:</Markdown>
-            <CodeBlock
-                blocks={[
-                    {
-                        language: 'text',
-                        file: 'API Key',
-                        code: dedent`
-                            <ph_project_api_key>
-                        `,
-                    },
-                ]}
-            />
-            <Markdown>Enter your PostHog host:</Markdown>
-            <CodeBlock
-                blocks={[
-                    {
-                        language: 'text',
-                        file: 'Host',
-                        code: dedent`
-                            <ph_client_api_host>
-                        `,
-                    },
-                ]}
-            />
-            <Markdown>
-                Connect your source to the PostHog destination. RudderStack will now forward `track`, `identify`,
-                `page`, and `group` calls to PostHog.
-            </Markdown>
-            <CalloutBox type="fyi" title="Learn more">
+        ),
+    },
+    {
+        title: 'Enter your credentials',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>Enter your PostHog project API key:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'text',
+                            file: 'API Key',
+                            code: dedent`
+                                <ph_project_api_key>
+                            `,
+                        },
+                    ]}
+                />
+                <Markdown>Enter your PostHog host:</Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'text',
+                            file: 'Host',
+                            code: dedent`
+                                <ph_client_api_host>
+                            `,
+                        },
+                    ]}
+                />
+            </>
+        ),
+    },
+    {
+        title: 'Verify the connection',
+        badge: 'recommended',
+        content: (
+            <>
                 <Markdown>
-                    See the [RudderStack integration docs](https://posthog.com/docs/libraries/rudderstack) for more
-                    details.
+                    Connect your source to the PostHog destination. RudderStack will now forward `track`, `identify`,
+                    `page`, and `group` calls to PostHog.
                 </Markdown>
-            </CalloutBox>
-        </>
-    )
-}
+                <CalloutBox type="fyi" title="Learn more">
+                    <Markdown>
+                        See the [RudderStack integration docs](https://posthog.com/docs/libraries/rudderstack) for more
+                        details.
+                    </Markdown>
+                </CalloutBox>
+            </>
+        ),
+    },
+]
+
+export const RudderstackInstallation = createInstallation(getRudderstackSteps)

--- a/docs/onboarding/product-analytics/segment.tsx
+++ b/docs/onboarding/product-analytics/segment.tsx
@@ -1,19 +1,24 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const SegmentInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Add PostHog destination" badge="required">
-                <Markdown>
-                    Segment is a customer data platform that can route your analytics data to PostHog and other
-                    destinations. In your Segment workspace, go to **Connections** &gt; **Catalog** and search for
-                    **PostHog**. Click **Add Destination** and select the source you want to connect.
-                </Markdown>
-            </Step>
-
-            <Step title="Enter your credentials" badge="required">
+export const getSegmentSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Add PostHog destination',
+        badge: 'required',
+        content: (
+            <Markdown>
+                Segment is a customer data platform that can route your analytics data to PostHog and other
+                destinations. In your Segment workspace, go to **Connections** &gt; **Catalog** and search for
+                **PostHog**. Click **Add Destination** and select the source you want to connect.
+            </Markdown>
+        ),
+    },
+    {
+        title: 'Enter your credentials',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>Enter your PostHog project API key:</Markdown>
                 <CodeBlock
                     blocks={[
@@ -38,9 +43,14 @@ export const SegmentInstallation = (): JSX.Element => {
                         },
                     ]}
                 />
-            </Step>
-
-            <Step title="Verify the connection" badge="recommended">
+            </>
+        ),
+    },
+    {
+        title: 'Verify the connection',
+        badge: 'recommended',
+        content: (
+            <>
                 <Markdown>
                     Segment will now forward `track`, `identify`, `page`, and `group` calls to PostHog.
                 </Markdown>
@@ -49,7 +59,9 @@ export const SegmentInstallation = (): JSX.Element => {
                         See the [Segment integration docs](https://posthog.com/docs/libraries/segment) for more details.
                     </Markdown>
                 </CalloutBox>
-            </Step>
-        </Steps>
-    )
-}
+            </>
+        ),
+    },
+]
+
+export const SegmentInstallation = createInstallation(getSegmentSteps)

--- a/docs/onboarding/product-analytics/segment.tsx
+++ b/docs/onboarding/product-analytics/segment.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getSegmentSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getSegmentSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/segment.tsx
+++ b/docs/onboarding/product-analytics/segment.tsx
@@ -2,66 +2,71 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getSegmentSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Add PostHog destination',
-        badge: 'required',
-        content: (
-            <Markdown>
-                Segment is a customer data platform that can route your analytics data to PostHog and other
-                destinations. In your Segment workspace, go to **Connections** &gt; **Catalog** and search for
-                **PostHog**. Click **Add Destination** and select the source you want to connect.
-            </Markdown>
-        ),
-    },
-    {
-        title: 'Enter your credentials',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Enter your PostHog project API key:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'API Key',
-                            code: dedent`
+export const getSegmentSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
+
+    return [
+        {
+            title: 'Add PostHog destination',
+            badge: 'required',
+            content: (
+                <Markdown>
+                    Segment is a customer data platform that can route your analytics data to PostHog and other
+                    destinations. In your Segment workspace, go to **Connections** &gt; **Catalog** and search for
+                    **PostHog**. Click **Add Destination** and select the source you want to connect.
+                </Markdown>
+            ),
+        },
+        {
+            title: 'Enter your credentials',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Enter your PostHog project API key:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'API Key',
+                                code: dedent`
                                 <ph_project_api_key>
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Enter your PostHog host:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'Host',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                    <Markdown>Enter your PostHog host:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'Host',
+                                code: dedent`
                                 <ph_client_api_host>
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Verify the connection',
-        badge: 'recommended',
-        content: (
-            <>
-                <Markdown>
-                    Segment will now forward `track`, `identify`, `page`, and `group` calls to PostHog.
-                </Markdown>
-                <CalloutBox type="fyi" title="Learn more">
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Verify the connection',
+            badge: 'recommended',
+            content: (
+                <>
                     <Markdown>
-                        See the [Segment integration docs](https://posthog.com/docs/libraries/segment) for more details.
+                        Segment will now forward `track`, `identify`, `page`, and `group` calls to PostHog.
                     </Markdown>
-                </CalloutBox>
-            </>
-        ),
-    },
-]
+                    <CalloutBox type="fyi" title="Learn more">
+                        <Markdown>
+                            See the [Segment integration docs](https://posthog.com/docs/libraries/segment) for more
+                            details.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+    ]
+}
 
 export const SegmentInstallation = createInstallation(getSegmentSteps)

--- a/docs/onboarding/product-analytics/sentry.tsx
+++ b/docs/onboarding/product-analytics/sentry.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getSentrySteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getSentrySteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/sentry.tsx
+++ b/docs/onboarding/product-analytics/sentry.tsx
@@ -1,11 +1,13 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const SentryInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Install the packages" badge="required">
+export const getSentrySteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Install the packages',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>
                     Sentry is an error tracking platform. The PostHog-Sentry integration links error data to your
                     analytics, allowing you to see which users experienced errors.
@@ -21,9 +23,14 @@ export const SentryInstallation = (): JSX.Element => {
                         },
                     ]}
                 />
-            </Step>
-
-            <Step title="Configure the integration" badge="required">
+            </>
+        ),
+    },
+    {
+        title: 'Configure the integration',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>Add the Sentry integration when initializing PostHog:</Markdown>
                 <CodeBlock
                     blocks={[
@@ -57,7 +64,9 @@ export const SentryInstallation = (): JSX.Element => {
                         docs](https://posthog.com/docs/libraries/sentry) for the full setup guide.
                     </Markdown>
                 </CalloutBox>
-            </Step>
-        </Steps>
-    )
-}
+            </>
+        ),
+    },
+]
+
+export const SentryInstallation = createInstallation(getSentrySteps)

--- a/docs/onboarding/product-analytics/sentry.tsx
+++ b/docs/onboarding/product-analytics/sentry.tsx
@@ -2,42 +2,45 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getSentrySteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Install the packages',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>
-                    Sentry is an error tracking platform. The PostHog-Sentry integration links error data to your
-                    analytics, allowing you to see which users experienced errors.
-                </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'Terminal',
-                            code: dedent`
+export const getSentrySteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
+
+    return [
+        {
+            title: 'Install the packages',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Sentry is an error tracking platform. The PostHog-Sentry integration links error data to your
+                        analytics, allowing you to see which users experienced errors.
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Terminal',
+                                code: dedent`
                                 npm install --save posthog-js @sentry/browser
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Configure the integration',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Add the Sentry integration when initializing PostHog:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'javascript',
-                            file: 'JavaScript',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Configure the integration',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Add the Sentry integration when initializing PostHog:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'javascript',
+                                file: 'JavaScript',
+                                code: dedent`
                                 import posthog from 'posthog-js'
                                 import * as Sentry from '@sentry/browser'
 
@@ -55,18 +58,19 @@ export const getSentrySteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: Onbo
                                 // Set PostHog session ID on Sentry scope
                                 Sentry.getCurrentScope().setTag('posthog_session_id', posthog.get_session_id())
                             `,
-                        },
-                    ]}
-                />
-                <CalloutBox type="fyi" title="Full setup guide">
-                    <Markdown>
-                        This allows you to link Sentry errors to PostHog sessions. See the [Sentry integration
-                        docs](https://posthog.com/docs/libraries/sentry) for the full setup guide.
-                    </Markdown>
-                </CalloutBox>
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <CalloutBox type="fyi" title="Full setup guide">
+                        <Markdown>
+                            This allows you to link Sentry errors to PostHog sessions. See the [Sentry integration
+                            docs](https://posthog.com/docs/libraries/sentry) for the full setup guide.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+    ]
+}
 
 export const SentryInstallation = createInstallation(getSentrySteps)

--- a/docs/onboarding/product-analytics/shopify.tsx
+++ b/docs/onboarding/product-analytics/shopify.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getShopifySteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getShopifySteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/shopify.tsx
+++ b/docs/onboarding/product-analytics/shopify.tsx
@@ -1,18 +1,23 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const ShopifyInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Open theme editor" badge="required">
-                <Markdown>
-                    In your Shopify admin, go to **Online Store** &gt; **Themes**. Click **Actions** &gt; **Edit code**
-                    on your current theme.
-                </Markdown>
-            </Step>
-
-            <Step title="Add the PostHog snippet" badge="required">
+export const getShopifySteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Open theme editor',
+        badge: 'required',
+        content: (
+            <Markdown>
+                In your Shopify admin, go to **Online Store** &gt; **Themes**. Click **Actions** &gt; **Edit code**
+                on your current theme.
+            </Markdown>
+        ),
+    },
+    {
+        title: 'Add the PostHog snippet',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>
                     Open `theme.liquid` and paste the following code just before the closing `&lt;/head&gt;` tag:
                 </Markdown>
@@ -34,15 +39,20 @@ export const ShopifyInstallation = (): JSX.Element => {
                     ]}
                 />
                 <Markdown>Click **Save**.</Markdown>
-            </Step>
+            </>
+        ),
+    },
+    {
+        title: 'Verify installation',
+        badge: 'recommended',
+        content: (
+            <Markdown>
+                PostHog will now capture pageviews, clicks, and other events on your Shopify store. See the [Shopify
+                integration docs](https://posthog.com/docs/libraries/shopify) for tracking checkout events and
+                revenue.
+            </Markdown>
+        ),
+    },
+]
 
-            <Step title="Verify installation" badge="recommended">
-                <Markdown>
-                    PostHog will now capture pageviews, clicks, and other events on your Shopify store. See the [Shopify
-                    integration docs](https://posthog.com/docs/libraries/shopify) for tracking checkout events and
-                    revenue.
-                </Markdown>
-            </Step>
-        </Steps>
-    )
-}
+export const ShopifyInstallation = createInstallation(getShopifySteps)

--- a/docs/onboarding/product-analytics/shopify.tsx
+++ b/docs/onboarding/product-analytics/shopify.tsx
@@ -2,31 +2,34 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getShopifySteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Open theme editor',
-        badge: 'required',
-        content: (
-            <Markdown>
-                In your Shopify admin, go to **Online Store** &gt; **Themes**. Click **Actions** &gt; **Edit code**
-                on your current theme.
-            </Markdown>
-        ),
-    },
-    {
-        title: 'Add the PostHog snippet',
-        badge: 'required',
-        content: (
-            <>
+export const getShopifySteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Open theme editor',
+            badge: 'required',
+            content: (
                 <Markdown>
-                    Open `theme.liquid` and paste the following code just before the closing `&lt;/head&gt;` tag:
+                    In your Shopify admin, go to **Online Store** &gt; **Themes**. Click **Actions** &gt; **Edit code**
+                    on your current theme.
                 </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'html',
-                            file: 'theme.liquid',
-                            code: dedent`
+            ),
+        },
+        {
+            title: 'Add the PostHog snippet',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Open `theme.liquid` and paste the following code just before the closing `&lt;/head&gt;` tag:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'html',
+                                file: 'theme.liquid',
+                                code: dedent`
                                 <script>
                                     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
                                     posthog.init('<ph_project_api_key>', {
@@ -35,24 +38,25 @@ export const getShopifySteps = ({ CodeBlock, Markdown, dedent }: OnboardingCompo
                                     })
                                 </script>
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Click **Save**.</Markdown>
-            </>
-        ),
-    },
-    {
-        title: 'Verify installation',
-        badge: 'recommended',
-        content: (
-            <Markdown>
-                PostHog will now capture pageviews, clicks, and other events on your Shopify store. See the [Shopify
-                integration docs](https://posthog.com/docs/libraries/shopify) for tracking checkout events and
-                revenue.
-            </Markdown>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <Markdown>Click **Save**.</Markdown>
+                </>
+            ),
+        },
+        {
+            title: 'Verify installation',
+            badge: 'recommended',
+            content: (
+                <Markdown>
+                    PostHog will now capture pageviews, clicks, and other events on your Shopify store. See the [Shopify
+                    integration docs](https://posthog.com/docs/libraries/shopify) for tracking checkout events and
+                    revenue.
+                </Markdown>
+            ),
+        },
+    ]
+}
 
 export const ShopifyInstallation = createInstallation(getShopifySteps)

--- a/docs/onboarding/product-analytics/svelte.tsx
+++ b/docs/onboarding/product-analytics/svelte.tsx
@@ -1,13 +1,14 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getSvelteSteps = (
-    CodeBlock: any,
-    Markdown: any,
-    CalloutBox: any,
-    dedent: any,
-    snippets: any
-): StepDefinition[] => {
+export const getSvelteSteps = ({
+    CodeBlock,
+    Markdown,
+    CalloutBox,
+    dedent,
+    snippets,
+}: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -169,17 +170,4 @@ export const getSvelteSteps = (
     ]
 }
 
-export const SvelteInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getSvelteSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const SvelteInstallation = createInstallation(getSvelteSteps)

--- a/docs/onboarding/product-analytics/svelte.tsx
+++ b/docs/onboarding/product-analytics/svelte.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getSvelteSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getSvelteSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/svelte.tsx
+++ b/docs/onboarding/product-analytics/svelte.tsx
@@ -2,13 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getSvelteSteps = ({
-    CodeBlock,
-    Markdown,
-    CalloutBox,
-    dedent,
-    snippets,
-}: OnboardingComponents): StepDefinition[] => {
+export const getSvelteSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -84,8 +80,8 @@ export const getSvelteSteps = ({
                     />
                     <CalloutBox type="fyi" title="SvelteKit layout">
                         <Markdown>
-                            Learn more about [SvelteKit layouts](https://kit.svelte.dev/docs/routing#layout) in the official
-                            documentation.
+                            Learn more about [SvelteKit layouts](https://kit.svelte.dev/docs/routing#layout) in the
+                            official documentation.
                         </Markdown>
                     </CalloutBox>
                 </>
@@ -130,7 +126,8 @@ export const getSvelteSteps = ({
                         ]}
                     />
                     <Markdown>
-                        Then, initialize the PostHog Node client where you'd like to use it on the server side. For example, in a load function:
+                        Then, initialize the PostHog Node client where you'd like to use it on the server side. For
+                        example, in a load function:
                     </Markdown>
                     <CodeBlock
                         blocks={[
@@ -156,7 +153,9 @@ export const getSvelteSteps = ({
                     />
                     <CalloutBox type="fyi" title="Note">
                         <Markdown>
-                            Make sure to always call `posthog.shutdown()` after capturing events from the server-side. PostHog queues events into larger batches, and this call forces all batched events to be flushed immediately.
+                            Make sure to always call `posthog.shutdown()` after capturing events from the server-side.
+                            PostHog queues events into larger batches, and this call forces all batched events to be
+                            flushed immediately.
                         </Markdown>
                     </CalloutBox>
                 </>

--- a/docs/onboarding/product-analytics/tanstack.tsx
+++ b/docs/onboarding/product-analytics/tanstack.tsx
@@ -2,13 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getTanStackSteps = ({
-    CodeBlock,
-    Markdown,
-    CalloutBox,
-    dedent,
-    snippets,
-}: OnboardingComponents): StepDefinition[] => {
+export const getTanStackSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -107,7 +103,8 @@ export const getTanStackSteps = ({
                     <CalloutBox type="fyi" title="defaults option">
                         <Markdown>
                             The `defaults` option automatically configures PostHog with recommended settings for new
-                            projects. See [SDK defaults](https://posthog.com/docs/libraries/js#sdk-defaults) for details.
+                            projects. See [SDK defaults](https://posthog.com/docs/libraries/js#sdk-defaults) for
+                            details.
                         </Markdown>
                     </CalloutBox>
                 </>

--- a/docs/onboarding/product-analytics/tanstack.tsx
+++ b/docs/onboarding/product-analytics/tanstack.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getTanStackSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getTanStackSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/tanstack.tsx
+++ b/docs/onboarding/product-analytics/tanstack.tsx
@@ -1,99 +1,123 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const TanStackInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
+export const getTanStackSteps = ({
+    CodeBlock,
+    Markdown,
+    CalloutBox,
+    dedent,
+    snippets,
+}: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
-    return (
-        <Steps>
-            <Step title="Install the package" badge="required">
-                <Markdown>Install the PostHog JavaScript library using your package manager:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: 'npm',
-                            code: dedent`
-                                npm install posthog-js
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'yarn',
-                            code: dedent`
-                                yarn add posthog-js
-                            `,
-                        },
-                        {
-                            language: 'bash',
-                            file: 'pnpm',
-                            code: dedent`
-                                pnpm add posthog-js
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Add environment variables" badge="required">
-                <Markdown>Add your PostHog API key and host to your environment variables:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'bash',
-                            file: '.env',
-                            code: dedent`
-                                VITE_PUBLIC_POSTHOG_KEY=<ph_project_api_key>
-                                VITE_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
-                            `,
-                        },
-                    ]}
-                />
-            </Step>
-
-            <Step title="Initialize PostHog" badge="required">
-                <Markdown>
-                    Wrap your app with the `PostHogProvider` component at the root of your application (such as
-                    `main.tsx`):
-                </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'tsx',
-                            file: 'main.tsx',
-                            code: dedent`
-                                import { StrictMode } from 'react'
-                                import { createRoot } from 'react-dom/client'
-                                import './index.css'
-                                import App from './App.jsx'
-                                import { PostHogProvider } from 'posthog-js/react'
-
-                                const options = {
-                                  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
-                                  defaults: '2025-11-30',
-                                } as const
-
-                                createRoot(document.getElementById('root')).render(
-                                  <StrictMode>
-                                    <PostHogProvider apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_KEY} options={options}>
-                                      <App />
-                                    </PostHogProvider>
-                                  </StrictMode>
-                                )
-                            `,
-                        },
-                    ]}
-                />
-                <CalloutBox type="fyi" title="defaults option">
+    return [
+        {
+            title: 'Install the package',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Install the PostHog JavaScript library using your package manager:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'npm',
+                                code: dedent`
+                                    npm install posthog-js
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'yarn',
+                                code: dedent`
+                                    yarn add posthog-js
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'pnpm',
+                                code: dedent`
+                                    pnpm add posthog-js
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Add environment variables',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Add your PostHog API key and host to your environment variables:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: '.env',
+                                code: dedent`
+                                    VITE_PUBLIC_POSTHOG_KEY=<ph_project_api_key>
+                                    VITE_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Initialize PostHog',
+            badge: 'required',
+            content: (
+                <>
                     <Markdown>
-                        The `defaults` option automatically configures PostHog with recommended settings for new
-                        projects. See [SDK defaults](https://posthog.com/docs/libraries/js#sdk-defaults) for details.
+                        Wrap your app with the `PostHogProvider` component at the root of your application (such as
+                        `main.tsx`):
                     </Markdown>
-                </CalloutBox>
-            </Step>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'tsx',
+                                file: 'main.tsx',
+                                code: dedent`
+                                    import { StrictMode } from 'react'
+                                    import { createRoot } from 'react-dom/client'
+                                    import './index.css'
+                                    import App from './App.jsx'
+                                    import { PostHogProvider } from 'posthog-js/react'
 
-            <Step title="Send events">{JSEventCapture && <JSEventCapture />}</Step>
-        </Steps>
-    )
+                                    const options = {
+                                      api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+                                      defaults: '2025-11-30',
+                                    } as const
+
+                                    createRoot(document.getElementById('root')).render(
+                                      <StrictMode>
+                                        <PostHogProvider apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_KEY} options={options}>
+                                          <App />
+                                        </PostHogProvider>
+                                      </StrictMode>
+                                    )
+                                `,
+                            },
+                        ]}
+                    />
+                    <CalloutBox type="fyi" title="defaults option">
+                        <Markdown>
+                            The `defaults` option automatically configures PostHog with recommended settings for new
+                            projects. See [SDK defaults](https://posthog.com/docs/libraries/js#sdk-defaults) for details.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+        {
+            title: 'Send events',
+            content: <>{JSEventCapture && <JSEventCapture />}</>,
+        },
+    ]
 }
+
+export const TanStackInstallation = createInstallation(getTanStackSteps)

--- a/docs/onboarding/product-analytics/traceloop.tsx
+++ b/docs/onboarding/product-analytics/traceloop.tsx
@@ -1,11 +1,13 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const TraceloopInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Access the integrations page" badge="required">
+export const getTraceloopSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Access the integrations page',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>
                     Traceloop supports most popular LLM models and you can bring your Traceloop data into PostHog for
                     analysis.
@@ -14,9 +16,14 @@ export const TraceloopInstallation = (): JSX.Element => {
                     Go to the [integrations page](https://app.traceloop.com/settings/integrations) in your Traceloop
                     dashboard and click on the PostHog card.
                 </Markdown>
-            </Step>
-
-            <Step title="Configure the integration" badge="required">
+            </>
+        ),
+    },
+    {
+        title: 'Configure the integration',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>Paste in your PostHog project API key:</Markdown>
                 <CodeBlock
                     blocks={[
@@ -45,7 +52,9 @@ export const TraceloopInstallation = (): JSX.Element => {
                 <Markdown>
                     Traceloop events will now be exported into PostHog as soon as they're available.
                 </Markdown>
-            </Step>
-        </Steps>
-    )
-}
+            </>
+        ),
+    },
+]
+
+export const TraceloopInstallation = createInstallation(getTraceloopSteps)

--- a/docs/onboarding/product-analytics/traceloop.tsx
+++ b/docs/onboarding/product-analytics/traceloop.tsx
@@ -2,59 +2,63 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getTraceloopSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Access the integrations page',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>
-                    Traceloop supports most popular LLM models and you can bring your Traceloop data into PostHog for
-                    analysis.
-                </Markdown>
-                <Markdown>
-                    Go to the [integrations page](https://app.traceloop.com/settings/integrations) in your Traceloop
-                    dashboard and click on the PostHog card.
-                </Markdown>
-            </>
-        ),
-    },
-    {
-        title: 'Configure the integration',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>Paste in your PostHog project API key:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'API Key',
-                            code: dedent`
+export const getTraceloopSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Access the integrations page',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Traceloop supports most popular LLM models and you can bring your Traceloop data into PostHog
+                        for analysis.
+                    </Markdown>
+                    <Markdown>
+                        Go to the [integrations page](https://app.traceloop.com/settings/integrations) in your Traceloop
+                        dashboard and click on the PostHog card.
+                    </Markdown>
+                </>
+            ),
+        },
+        {
+            title: 'Configure the integration',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>Paste in your PostHog project API key:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'API Key',
+                                code: dedent`
                                 <ph_project_api_key>
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Paste in your PostHog host:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'Host',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                    <Markdown>Paste in your PostHog host:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'Host',
+                                code: dedent`
                                 <ph_client_api_host>
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Select the environment you want to connect to PostHog and click **Enable**.</Markdown>
-                <Markdown>
-                    Traceloop events will now be exported into PostHog as soon as they're available.
-                </Markdown>
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                    <Markdown>Select the environment you want to connect to PostHog and click **Enable**.</Markdown>
+                    <Markdown>
+                        Traceloop events will now be exported into PostHog as soon as they're available.
+                    </Markdown>
+                </>
+            ),
+        },
+    ]
+}
 
 export const TraceloopInstallation = createInstallation(getTraceloopSteps)

--- a/docs/onboarding/product-analytics/traceloop.tsx
+++ b/docs/onboarding/product-analytics/traceloop.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getTraceloopSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getTraceloopSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/vue.tsx
+++ b/docs/onboarding/product-analytics/vue.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getVueSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getVueSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/vue.tsx
+++ b/docs/onboarding/product-analytics/vue.tsx
@@ -1,7 +1,14 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getVueSteps = (CodeBlock: any, Markdown: any, CalloutBox: any, dedent: any, snippets: any): StepDefinition[] => {
+export const getVueSteps = ({
+    CodeBlock,
+    Markdown,
+    CalloutBox,
+    dedent,
+    snippets,
+}: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -123,17 +130,4 @@ export const getVueSteps = (CodeBlock: any, Markdown: any, CalloutBox: any, dede
     ]
 }
 
-export const VueInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent, snippets } = useMDXComponents()
-    const steps = getVueSteps(CodeBlock, Markdown, CalloutBox, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const VueInstallation = createInstallation(getVueSteps)

--- a/docs/onboarding/product-analytics/vue.tsx
+++ b/docs/onboarding/product-analytics/vue.tsx
@@ -2,13 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getVueSteps = ({
-    CodeBlock,
-    Markdown,
-    CalloutBox,
-    dedent,
-    snippets,
-}: OnboardingComponents): StepDefinition[] => {
+export const getVueSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [

--- a/docs/onboarding/product-analytics/webflow.tsx
+++ b/docs/onboarding/product-analytics/webflow.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getWebflowSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getWebflowSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture

--- a/docs/onboarding/product-analytics/webflow.tsx
+++ b/docs/onboarding/product-analytics/webflow.tsx
@@ -1,7 +1,8 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
 import { StepDefinition } from '../steps'
 
-export const getWebflowSteps = (CodeBlock: any, Markdown: any, dedent: any, snippets: any): StepDefinition[] => {
+export const getWebflowSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -55,17 +56,4 @@ export const getWebflowSteps = (CodeBlock: any, Markdown: any, dedent: any, snip
     ]
 }
 
-export const WebflowInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent, snippets } = useMDXComponents()
-    const steps = getWebflowSteps(CodeBlock, Markdown, dedent, snippets)
-
-    return (
-        <Steps>
-            {steps.map((step, index) => (
-                <Step key={index} title={step.title} badge={step.badge}>
-                    {step.content}
-                </Step>
-            ))}
-        </Steps>
-    )
-}
+export const WebflowInstallation = createInstallation(getWebflowSteps)

--- a/docs/onboarding/product-analytics/webflow.tsx
+++ b/docs/onboarding/product-analytics/webflow.tsx
@@ -2,7 +2,9 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getWebflowSteps = ({ CodeBlock, Markdown, dedent, snippets }: OnboardingComponents): StepDefinition[] => {
+export const getWebflowSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
+
     const JSEventCapture = snippets?.JSEventCapture
 
     return [
@@ -39,7 +41,8 @@ export const getWebflowSteps = ({ CodeBlock, Markdown, dedent, snippets }: Onboa
                 <>
                     <Markdown>
                         Go to your Webflow site settings by clicking on the menu icon in the top left. If you haven't
-                        already, sign up for at least the **Basic** site plan. This enables you to add custom code. Then:
+                        already, sign up for at least the **Basic** site plan. This enables you to add custom code.
+                        Then:
                     </Markdown>
                     <Markdown>
                         {`1. Go to the **Custom code** tab in site settings.

--- a/docs/onboarding/product-analytics/wordpress.tsx
+++ b/docs/onboarding/product-analytics/wordpress.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getWordpressSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getWordpressSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
 
     return [

--- a/docs/onboarding/product-analytics/wordpress.tsx
+++ b/docs/onboarding/product-analytics/wordpress.tsx
@@ -2,22 +2,26 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getWordpressSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Install via plugin (recommended)',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>
-                    Install a header/footer script plugin like [WPCode](https://wordpress.org/plugins/insert-headers-and-footers/)
-                    or similar. Go to the plugin settings and add a new header script with the following code:
-                </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'html',
-                            file: 'HTML',
-                            code: dedent`
+export const getWordpressSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, CalloutBox, dedent } = ctx
+
+    return [
+        {
+            title: 'Install via plugin (recommended)',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Install a header/footer script plugin like
+                        [WPCode](https://wordpress.org/plugins/insert-headers-and-footers/) or similar. Go to the plugin
+                        settings and add a new header script with the following code:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'html',
+                                file: 'HTML',
+                                code: dedent`
                                 <script>
                                     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
                                     posthog.init('<ph_project_api_key>', {
@@ -26,29 +30,30 @@ export const getWordpressSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: O
                                     })
                                 </script>
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Save and activate the script.</Markdown>
-            </>
-        ),
-    },
-    {
-        title: 'Alternative: Edit theme directly',
-        content: (
-            <>
-                <Markdown>
-                    {`Add the same code snippet to your theme's \`header.php\` file, just before the closing \`</head>\` tag. Note: this may be overwritten when updating themes.`}
-                </Markdown>
-                <CalloutBox type="fyi" title="More details">
+                            },
+                        ]}
+                    />
+                    <Markdown>Save and activate the script.</Markdown>
+                </>
+            ),
+        },
+        {
+            title: 'Alternative: Edit theme directly',
+            content: (
+                <>
                     <Markdown>
-                        See the [WordPress integration docs](https://posthog.com/docs/libraries/wordpress) for more
-                        details.
+                        {`Add the same code snippet to your theme's \`header.php\` file, just before the closing \`</head>\` tag. Note: this may be overwritten when updating themes.`}
                     </Markdown>
-                </CalloutBox>
-            </>
-        ),
-    },
-]
+                    <CalloutBox type="fyi" title="More details">
+                        <Markdown>
+                            See the [WordPress integration docs](https://posthog.com/docs/libraries/wordpress) for more
+                            details.
+                        </Markdown>
+                    </CalloutBox>
+                </>
+            ),
+        },
+    ]
+}
 
 export const WordpressInstallation = createInstallation(getWordpressSteps)

--- a/docs/onboarding/product-analytics/wordpress.tsx
+++ b/docs/onboarding/product-analytics/wordpress.tsx
@@ -1,11 +1,13 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const WordpressInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, CalloutBox, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Install via plugin (recommended)" badge="required">
+export const getWordpressSteps = ({ CodeBlock, Markdown, CalloutBox, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Install via plugin (recommended)',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>
                     Install a header/footer script plugin like [WPCode](https://wordpress.org/plugins/insert-headers-and-footers/)
                     or similar. Go to the plugin settings and add a new header script with the following code:
@@ -28,9 +30,13 @@ export const WordpressInstallation = (): JSX.Element => {
                     ]}
                 />
                 <Markdown>Save and activate the script.</Markdown>
-            </Step>
-
-            <Step title="Alternative: Edit theme directly">
+            </>
+        ),
+    },
+    {
+        title: 'Alternative: Edit theme directly',
+        content: (
+            <>
                 <Markdown>
                     {`Add the same code snippet to your theme's \`header.php\` file, just before the closing \`</head>\` tag. Note: this may be overwritten when updating themes.`}
                 </Markdown>
@@ -40,7 +46,9 @@ export const WordpressInstallation = (): JSX.Element => {
                         details.
                     </Markdown>
                 </CalloutBox>
-            </Step>
-        </Steps>
-    )
-}
+            </>
+        ),
+    },
+]
+
+export const WordpressInstallation = createInstallation(getWordpressSteps)

--- a/docs/onboarding/product-analytics/zapier.tsx
+++ b/docs/onboarding/product-analytics/zapier.tsx
@@ -2,60 +2,64 @@ import { OnboardingComponents, createInstallation } from 'scenes/onboarding/Onbo
 
 import { StepDefinition } from '../steps'
 
-export const getZapierSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
-    {
-        title: 'Connect PostHog to Zapier',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>
-                    Zapier lets you connect PostHog to thousands of other apps. You can use it to send events to
-                    PostHog from other services or trigger actions based on PostHog events. Go to the [PostHog
-                    integration page](https://zapier.com/apps/posthog/integrations) on Zapier and click **Connect
-                    PostHog**. When prompted, enter your PostHog project API key:
-                </Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'API Key',
-                            code: dedent`
+export const getZapierSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    return [
+        {
+            title: 'Connect PostHog to Zapier',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Zapier lets you connect PostHog to thousands of other apps. You can use it to send events to
+                        PostHog from other services or trigger actions based on PostHog events. Go to the [PostHog
+                        integration page](https://zapier.com/apps/posthog/integrations) on Zapier and click **Connect
+                        PostHog**. When prompted, enter your PostHog project API key:
+                    </Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'API Key',
+                                code: dedent`
                                 <ph_project_api_key>
                             `,
-                        },
-                    ]}
-                />
-                <Markdown>Enter your PostHog host:</Markdown>
-                <CodeBlock
-                    blocks={[
-                        {
-                            language: 'text',
-                            file: 'Host',
-                            code: dedent`
+                            },
+                        ]}
+                    />
+                    <Markdown>Enter your PostHog host:</Markdown>
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'text',
+                                file: 'Host',
+                                code: dedent`
                                 <ph_client_api_host>
                             `,
-                        },
-                    ]}
-                />
-            </>
-        ),
-    },
-    {
-        title: 'Create a Zap',
-        badge: 'required',
-        content: (
-            <>
-                <Markdown>
-                    Create a Zap that sends events to PostHog using the "Capture Event" action. Events captured via
-                    Zapier will appear in PostHog just like events from any other source.
-                </Markdown>
-                <Markdown>
-                    You can use Zapier to connect CRMs, payment processors, customer support tools, and more to your
-                    PostHog analytics.
-                </Markdown>
-            </>
-        ),
-    },
-]
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Create a Zap',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Create a Zap that sends events to PostHog using the "Capture Event" action. Events captured via
+                        Zapier will appear in PostHog just like events from any other source.
+                    </Markdown>
+                    <Markdown>
+                        You can use Zapier to connect CRMs, payment processors, customer support tools, and more to your
+                        PostHog analytics.
+                    </Markdown>
+                </>
+            ),
+        },
+    ]
+}
 
 export const ZapierInstallation = createInstallation(getZapierSteps)

--- a/docs/onboarding/product-analytics/zapier.tsx
+++ b/docs/onboarding/product-analytics/zapier.tsx
@@ -1,11 +1,13 @@
-import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
-export const ZapierInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, Markdown, dedent } = useMDXComponents()
+import { StepDefinition } from '../steps'
 
-    return (
-        <Steps>
-            <Step title="Connect PostHog to Zapier" badge="required">
+export const getZapierSteps = ({ CodeBlock, Markdown, dedent }: OnboardingComponents): StepDefinition[] => [
+    {
+        title: 'Connect PostHog to Zapier',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>
                     Zapier lets you connect PostHog to thousands of other apps. You can use it to send events to
                     PostHog from other services or trigger actions based on PostHog events. Go to the [PostHog
@@ -35,9 +37,14 @@ export const ZapierInstallation = (): JSX.Element => {
                         },
                     ]}
                 />
-            </Step>
-
-            <Step title="Create a Zap" badge="required">
+            </>
+        ),
+    },
+    {
+        title: 'Create a Zap',
+        badge: 'required',
+        content: (
+            <>
                 <Markdown>
                     Create a Zap that sends events to PostHog using the "Capture Event" action. Events captured via
                     Zapier will appear in PostHog just like events from any other source.
@@ -46,7 +53,9 @@ export const ZapierInstallation = (): JSX.Element => {
                     You can use Zapier to connect CRMs, payment processors, customer support tools, and more to your
                     PostHog analytics.
                 </Markdown>
-            </Step>
-        </Steps>
-    )
-}
+            </>
+        ),
+    },
+]
+
+export const ZapierInstallation = createInstallation(getZapierSteps)

--- a/docs/onboarding/product-analytics/zapier.tsx
+++ b/docs/onboarding/product-analytics/zapier.tsx
@@ -1,8 +1,8 @@
-import { OnboardingComponents, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
 
-export const getZapierSteps = (ctx: OnboardingComponents): StepDefinition[] => {
+export const getZapierSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
     const { CodeBlock, Markdown, dedent } = ctx
 
     return [

--- a/docs/onboarding/steps.ts
+++ b/docs/onboarding/steps.ts
@@ -4,6 +4,8 @@ export interface StepDefinition {
     title: string
     badge?: 'required' | 'recommended' | 'optional'
     content: ReactNode
+    subtitle?: string
+    checkpoint?: boolean
 }
 
 export interface StepModifier {

--- a/frontend/src/scenes/onboarding/OnboardingDocsContentWrapper.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingDocsContentWrapper.tsx
@@ -405,26 +405,6 @@ export function dedent(strings: TemplateStringsArray | string, ...values: any[])
 
 /**
  * Creates an Installation component from a steps function.
- * Eliminates boilerplate for the standard Installation pattern.
- *
- * @example
- * // Before (15 lines per framework):
- * export const NodeJSInstallation = (): JSX.Element => {
- *     const { Steps, Step, CodeBlock, Markdown, ... } = useMDXComponents()
- *     const steps = getNodeJSSteps(CodeBlock, Markdown, ...)
- *     return (
- *         <Steps>
- *             {steps.map((step, index) => (
- *                 <Step key={index} title={step.title} badge={step.badge}>
- *                     {step.content}
- *                 </Step>
- *             ))}
- *         </Steps>
- *     )
- * }
- *
- * // After (1 line):
- * export const NodeJSInstallation = createInstallation(getNodeJSSteps)
  */
 export function createInstallation(
     getSteps: (ctx: OnboardingComponents) => StepDefinition[]

--- a/frontend/src/scenes/onboarding/OnboardingDocsContentWrapper.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingDocsContentWrapper.tsx
@@ -13,7 +13,7 @@ import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
-export interface OnboardingComponents {
+export interface OnboardingComponentsContext {
     Steps: React.ComponentType<StepsProps>
     Step: React.ComponentType<StepProps>
     CodeBlock: React.ComponentType<{
@@ -51,7 +51,7 @@ export interface OnboardingComponents {
     setSelectedFile?: (file: string) => void
 }
 
-const OnboardingContext = createContext<OnboardingComponents | null>(null)
+const OnboardingContext = createContext<OnboardingComponentsContext | null>(null)
 
 function Steps({ children }: StepsProps): JSX.Element {
     let stepNumber = 0
@@ -323,11 +323,11 @@ export function OnboardingDocsContentWrapper({
 }: {
     children: ReactNode
     snippets?: Record<string, React.ComponentType<any>>
-    createSnippets?: (components: OnboardingComponents) => Record<string, React.ComponentType<any>>
+    createSnippets?: (components: OnboardingComponentsContext) => Record<string, React.ComponentType<any>>
 }): JSX.Element {
     const [selectedFile, setSelectedFile] = React.useState<string | null>(null)
 
-    const baseComponents = useMemo<Omit<OnboardingComponents, 'snippets'>>(
+    const baseComponents = useMemo<Omit<OnboardingComponentsContext, 'snippets'>>(
         () => ({
             Steps,
             Step,
@@ -347,17 +347,17 @@ export function OnboardingDocsContentWrapper({
 
     const finalSnippets = useMemo(() => {
         if (createSnippets) {
-            return createSnippets(baseComponents as OnboardingComponents)
+            return createSnippets(baseComponents as OnboardingComponentsContext)
         }
         return snippets
     }, [createSnippets, snippets, baseComponents])
 
-    const components = useMemo<OnboardingComponents>(
+    const components = useMemo<OnboardingComponentsContext>(
         () =>
             ({
                 ...baseComponents,
                 snippets: finalSnippets,
-            }) as OnboardingComponents,
+            }) as OnboardingComponentsContext,
         [baseComponents, finalSnippets]
     )
 
@@ -368,7 +368,7 @@ export function OnboardingDocsContentWrapper({
     )
 }
 
-export function useMDXComponents(): OnboardingComponents {
+export function useMDXComponents(): OnboardingComponentsContext {
     const context = useContext(OnboardingContext)
     if (!context) {
         throw new Error('useMDXComponents must be used within OnboardingDocsContentWrapper')
@@ -407,7 +407,7 @@ export function dedent(strings: TemplateStringsArray | string, ...values: any[])
  * Creates an Installation component from a steps function.
  */
 export function createInstallation(
-    getSteps: (ctx: OnboardingComponents) => StepDefinition[]
+    getSteps: (ctx: OnboardingComponentsContext) => StepDefinition[]
 ): React.ComponentType<StepModifier> {
     return function Installation({ modifySteps }: StepModifier = {}) {
         const components = useMDXComponents()


### PR DESCRIPTION
## Problem

Boilerplate was kinda gnarly

## Changes

- import source typed object for function parameters
- higher order `createInstallation` function in [frontend/src/scenes/onboarding/OnboardingDocsContentWrapper.tsx](https://github.com/PostHog/posthog/pull/45841/changes#diff-2a98e53edd825973cf416f2dc99c3c4d96beab85272d27b009a362230cd7d09d) which is used in all files
- product analytics, LLMA, feature flags, experiments

<img width="164" height="35" alt="image" src="https://github.com/user-attachments/assets/6c8ac418-b986-4084-87ab-f12508fd3c37" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
