### PR TITLE
spike: upgrade all autosizer instances in one go to spike this out

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -318,6 +318,8 @@
         "pixelmatch": "^5.3.0",
         "pngjs": "^6.0.0",
         "process": "^0.11.10",
+        "react-virtualized-auto-sizer": "^2.0.2",
+        "react-window": "^2.2.5",
         "redis": "^4.6.13",
         "safe-stable-stringify": "^2.4.3",
         "stream-browserify": "^3.0.0",

--- a/frontend/src/layout/navigation-3000/components/AlgoliaSearch.tsx
+++ b/frontend/src/layout/navigation-3000/components/AlgoliaSearch.tsx
@@ -1,9 +1,9 @@
 import algoliasearch from 'algoliasearch/lite'
 import { useActions } from 'kea'
-import { useEffect, useRef, useState } from 'react'
+import { CSSProperties, useEffect, useRef, useState } from 'react'
 import { InstantSearch, useHits, useRefinementList, useSearchBox } from 'react-instantsearch'
-import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
-import { List } from 'react-virtualized/dist/es/List'
+import { AutoSizer } from 'react-virtualized-auto-sizer'
+import { List, useListRef } from 'react-window'
 
 import { IconCheckCircle } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonTag } from '@posthog/lemon-ui'
@@ -15,11 +15,25 @@ import { SidePanelTab } from '~/types'
 
 const searchClient = algoliasearch('7VNQB5W0TX', '37f41fd37095bc85af76ed4edc85eb5a')
 
-const rowRenderer = ({ key, index, style, hits, activeOption }: any): JSX.Element => {
+interface HitRowProps {
+    hits: any[]
+    activeOption?: number
+}
+
+const HitRow = ({
+    index,
+    style,
+    hits,
+    activeOption,
+}: {
+    ariaAttributes: Record<string, unknown>
+    index: number
+    style: CSSProperties
+} & HitRowProps): JSX.Element => {
     const { slug, title, type, resolved } = hits[index]
     return (
         // eslint-disable-next-line react/forbid-dom-props
-        <li key={key} style={style} role="listitem" tabIndex={-1} className="p-1 border-b last:border-b-0">
+        <li style={style} role="listitem" tabIndex={-1} className="p-1 border-b last:border-b-0">
             <LemonButton
                 active={activeOption === index}
                 to={`https://posthog.com/${slug}`}
@@ -41,20 +55,32 @@ const rowRenderer = ({ key, index, style, hits, activeOption }: any): JSX.Elemen
 
 const Hits = ({ activeOption }: { activeOption?: number }): JSX.Element => {
     const { hits } = useHits()
+    const listRef = useListRef()
+
+    useEffect(() => {
+        if (activeOption !== undefined && activeOption >= 0 && listRef.current) {
+            listRef.current.scrollToRow({ index: activeOption, align: 'smart' })
+        }
+    }, [activeOption])
+
+    const rowProps: HitRowProps = { hits, activeOption }
+
     return (
         <ol role="listbox" className="list-none m-0 p-0 h-[80vh]">
-            <AutoSizer>
-                {({ height, width }: { height: number; width: number }) => (
-                    <List
-                        scrollToIndex={activeOption}
-                        width={width}
-                        height={height}
-                        rowCount={hits.length}
-                        rowHeight={50}
-                        rowRenderer={(options: any) => rowRenderer({ ...options, hits, activeOption })}
-                    />
-                )}
-            </AutoSizer>
+            <AutoSizer
+                renderProp={({ height, width }) =>
+                    height && width ? (
+                        <List
+                            listRef={listRef}
+                            style={{ width, height }}
+                            rowCount={hits.length}
+                            rowHeight={50}
+                            rowComponent={HitRow}
+                            rowProps={rowProps}
+                        />
+                    ) : null
+                }
+            />
         </ol>
     )
 }

--- a/frontend/src/lib/KeaDevTools.tsx
+++ b/frontend/src/lib/KeaDevTools.tsx
@@ -1,9 +1,9 @@
 // KeaDevtools.tsx
 import { getContext } from 'kea'
 import type { BuiltLogic, Context as KeaContext } from 'kea'
-import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
-import { List, ListRowProps } from 'react-virtualized/dist/es/List'
+import React, { CSSProperties, useEffect, useMemo, useRef, useState } from 'react'
+import { AutoSizer } from 'react-virtualized-auto-sizer'
+import { List, useListRef } from 'react-window'
 
 type MountedMap = Record<string, BuiltLogic>
 type SortMode = 'alpha' | 'recent'
@@ -2546,7 +2546,7 @@ function ActionsTab({
     }
 
     // Calculate dynamic row height based on whether payload is expanded
-    const getRowHeight = ({ index }: { index: number }): number => {
+    const getRowHeight = (index: number): number => {
         const action = filtered[index]
         if (!action) {
             return 110
@@ -2562,10 +2562,17 @@ function ActionsTab({
     }
 
     // Row renderer for virtualized list
-    const renderRow = ({ index, key, style }: ListRowProps): JSX.Element => {
+    const renderRow = ({
+        index,
+        style,
+    }: {
+        ariaAttributes: Record<string, unknown>
+        index: number
+        style: CSSProperties
+    }): JSX.Element => {
         const action = filtered[index]
         if (!action) {
-            return <div key={key} style={style} />
+            return <div style={style} />
         }
 
         const isOpen = expanded.has(action.id)
@@ -2574,7 +2581,6 @@ function ActionsTab({
 
         return (
             <div
-                key={key}
                 style={{
                     ...style,
                     display: 'flex',
@@ -2689,11 +2695,11 @@ function ActionsTab({
     }
 
     // Create a ref for the List to trigger re-render when expanded state changes
-    const listRef = useRef<List>(null)
+    const listRef = useListRef()
 
-    // Force re-render of list when expanded state changes
+    // Force re-render of list when expanded state changes - not needed in v2 since rowHeight is recalculated
     useEffect(() => {
-        listRef.current?.recomputeRowHeights()
+        // In v2, the list re-renders when rowHeight function returns different values
     }, [expanded, filtered])
 
     return (
@@ -2793,19 +2799,21 @@ function ActionsTab({
                     {filtered.length === 0 ? (
                         <div style={{ padding: 12, color: 'rgba(0,0,0,0.6)' }}>No actions yet.</div>
                     ) : (
-                        <AutoSizer>
-                            {({ height, width }) => (
-                                <List
-                                    ref={listRef}
-                                    width={width}
-                                    height={height}
-                                    rowCount={filtered.length}
-                                    rowHeight={getRowHeight}
-                                    rowRenderer={renderRow}
-                                    overscanRowCount={10}
-                                />
-                            )}
-                        </AutoSizer>
+                        <AutoSizer
+                            renderProp={({ height, width }) =>
+                                height && width ? (
+                                    <List
+                                        listRef={listRef}
+                                        style={{ width, height }}
+                                        rowCount={filtered.length}
+                                        rowHeight={getRowHeight}
+                                        overscanCount={10}
+                                        rowComponent={renderRow}
+                                        rowProps={{}}
+                                    />
+                                ) : null
+                            }
+                        />
                     )}
                 </div>
             </div>

--- a/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
+++ b/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { CSSProperties } from 'react'
-import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
-import { List, ListRowProps, ListRowRenderer } from 'react-virtualized/dist/es/List'
+import { CSSProperties, useEffect } from 'react'
+import { AutoSizer } from 'react-virtualized-auto-sizer'
+import { List, useListRef } from 'react-window'
 
 import { IconHome } from '@posthog/icons'
 
@@ -92,6 +92,41 @@ interface SaveToDashboardModalProps {
     canEditInsight: boolean
 }
 
+interface DashboardRowProps {
+    orderedDashboards: DashboardBasicType[]
+    currentDashboards: DashboardBasicType[]
+    insightProps: InsightLogicProps
+    canEditInsight: boolean
+    scrollIndex: number
+}
+
+const DashboardRow = ({
+    index,
+    style,
+    orderedDashboards,
+    currentDashboards,
+    insightProps,
+    canEditInsight,
+    scrollIndex,
+}: {
+    ariaAttributes: Record<string, unknown>
+    index: number
+    style: CSSProperties
+} & DashboardRowProps): JSX.Element => {
+    return (
+        <DashboardRelationRow
+            dashboard={orderedDashboards[index]}
+            insightProps={insightProps}
+            canEditInsight={canEditInsight}
+            isHighlighted={index === scrollIndex}
+            isAlreadyOnDashboard={currentDashboards.some(
+                (currentDashboard) => currentDashboard.id === orderedDashboards[index].id
+            )}
+            style={style}
+        />
+    )
+}
+
 export function AddToDashboardModal({
     isOpen,
     closeModal,
@@ -102,21 +137,20 @@ export function AddToDashboardModal({
 
     const { searchQuery, currentDashboards, orderedDashboards, scrollIndex } = useValues(logic)
     const { setSearchQuery, addNewDashboard } = useActions(logic)
+    const listRef = useListRef()
 
-    const renderItem: ListRowRenderer = ({ index: rowIndex, style }: ListRowProps): JSX.Element | null => {
-        return (
-            <DashboardRelationRow
-                key={rowIndex}
-                dashboard={orderedDashboards[rowIndex]}
-                insightProps={insightProps}
-                canEditInsight={canEditInsight}
-                isHighlighted={rowIndex === scrollIndex}
-                isAlreadyOnDashboard={currentDashboards.some(
-                    (currentDashboard) => currentDashboard.id === orderedDashboards[rowIndex].id
-                )}
-                style={style}
-            />
-        )
+    useEffect(() => {
+        if (scrollIndex >= 0 && listRef.current) {
+            listRef.current.scrollToRow({ index: scrollIndex, align: 'smart' })
+        }
+    }, [scrollIndex])
+
+    const rowProps: DashboardRowProps = {
+        orderedDashboards,
+        currentDashboards,
+        insightProps,
+        canEditInsight,
+        scrollIndex,
     }
 
     return (
@@ -163,19 +197,21 @@ export function AddToDashboardModal({
                     {pluralize(currentDashboards.length, 'dashboard', 'dashboards', false)}
                 </div>
                 <div className="min-h-[420px]">
-                    <AutoSizer>
-                        {({ height, width }) => (
-                            <List
-                                width={width}
-                                height={height}
-                                rowCount={orderedDashboards.length}
-                                overscanRowCount={100}
-                                rowHeight={40}
-                                rowRenderer={renderItem}
-                                scrollToIndex={scrollIndex}
-                            />
-                        )}
-                    </AutoSizer>
+                    <AutoSizer
+                        renderProp={({ height, width }) =>
+                            height && width ? (
+                                <List
+                                    listRef={listRef}
+                                    style={{ width, height }}
+                                    rowCount={orderedDashboards.length}
+                                    overscanCount={100}
+                                    rowHeight={40}
+                                    rowComponent={DashboardRow}
+                                    rowProps={rowProps}
+                                />
+                            ) : null
+                        }
+                    />
                 </div>
             </div>
         </LemonModal>

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -3,9 +3,9 @@ import './InfiniteList.scss'
 
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
-import { useState } from 'react'
-import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
-import { List, ListRowProps, ListRowRenderer } from 'react-virtualized/dist/es/List'
+import { CSSProperties, useCallback, useEffect, useState } from 'react'
+import { AutoSizer } from 'react-virtualized-auto-sizer'
+import { List, useListRef } from 'react-window'
 
 import { IconArchive, IconCheck, IconPlus } from '@posthog/icons'
 import { LemonTag } from '@posthog/lemon-ui'
@@ -253,145 +253,192 @@ export function InfiniteList({ popupAnchorElement }: InfiniteListProps): JSX.Ele
     const showEmptyState =
         totalListCount === 0 && !isLoading && (!!searchQuery || !hasRemoteDataSource) && !showNonCapturedEventOption
 
-    const renderItem: ListRowRenderer = ({ index: rowIndex, style }: ListRowProps): JSX.Element | null => {
-        const item = results[rowIndex]
-        const itemGroup = getItemGroup(item, taxonomicGroups, group)
-        const itemValue = item ? itemGroup?.getValue?.(item) : null
+    const listRef = useListRef()
 
-        // Normalize value to match itemValue type before comparison
-        const normalizedValue = typeof itemValue === 'number' && typeof value === 'string' ? Number(value) : value
+    useEffect(() => {
+        if (index >= 0 && listRef.current) {
+            listRef.current.scrollToRow({ index, align: 'smart' })
+        }
+    }, [index])
 
-        const isSelected = listGroupType === groupType && itemValue === normalizedValue
+    const renderItem = useCallback(
+        ({
+            index: rowIndex,
+            style,
+        }: {
+            ariaAttributes: Record<string, unknown>
+            index: number
+            style: CSSProperties
+        }): JSX.Element | null => {
+            const item = results[rowIndex]
+            const itemGroup = getItemGroup(item, taxonomicGroups, group)
+            const itemValue = item ? itemGroup?.getValue?.(item) : null
 
-        const isHighlighted = rowIndex === index && isActiveTab
+            // Normalize value to match itemValue type before comparison
+            const normalizedValue = typeof itemValue === 'number' && typeof value === 'string' ? Number(value) : value
 
-        const isActive = itemValue ? !!selectedProperties[listGroupType]?.includes(itemValue) : false
+            const isSelected = listGroupType === groupType && itemValue === normalizedValue
 
-        // Show create custom event option when there are no results
-        if (showNonCapturedEventOption && rowIndex === 0) {
-            const selectNonCapturedEvent = (): void => {
-                selectItem(
-                    itemGroup,
-                    trimmedSearchQuery,
-                    { name: trimmedSearchQuery, isNonCaptured: true },
-                    trimmedSearchQuery
+            const isHighlighted = rowIndex === index && isActiveTab
+
+            const isActive = itemValue ? !!selectedProperties[listGroupType]?.includes(itemValue) : false
+
+            // Show create custom event option when there are no results
+            if (showNonCapturedEventOption && rowIndex === 0) {
+                const selectNonCapturedEvent = (): void => {
+                    selectItem(
+                        itemGroup,
+                        trimmedSearchQuery,
+                        { name: trimmedSearchQuery, isNonCaptured: true },
+                        trimmedSearchQuery
+                    )
+                }
+
+                return (
+                    <LemonRow
+                        key={`item_${rowIndex}`}
+                        fullWidth
+                        className={clsx(
+                            'taxonomic-list-row',
+                            'border border-dashed border-secondary rounded min-h-9 justify-center'
+                        )}
+                        outlined={false}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                                selectNonCapturedEvent()
+                            }
+                        }}
+                        onClick={selectNonCapturedEvent}
+                        onMouseEnter={() => mouseInteractionsEnabled && setIndex(rowIndex)}
+                        icon={<IconPlus className="text-muted size-4" />}
+                        data-attr="prop-filter-event-option-custom"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={style}
+                    >
+                        <div className="flex items-center gap-2">
+                            <span className="text-muted">Select event:</span>
+                            <span className="font-medium">{trimmedSearchQuery}</span>
+                            <LemonTag type="caution" size="small">
+                                Not seen yet
+                            </LemonTag>
+                        </div>
+                    </LemonRow>
                 )
             }
 
-            return (
-                <LemonRow
-                    key={`item_${rowIndex}`}
-                    fullWidth
-                    className={clsx(
-                        'taxonomic-list-row',
-                        'border border-dashed border-secondary rounded min-h-9 justify-center'
-                    )}
-                    outlined={false}
-                    onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                            selectNonCapturedEvent()
-                        }
-                    }}
-                    onClick={selectNonCapturedEvent}
-                    onMouseEnter={() => mouseInteractionsEnabled && setIndex(rowIndex)}
-                    icon={<IconPlus className="text-muted size-4" />}
-                    data-attr="prop-filter-event-option-custom"
-                >
-                    <div className="flex items-center gap-2">
-                        <span className="text-muted">Select event:</span>
-                        <span className="font-medium">{trimmedSearchQuery}</span>
-                        <LemonTag type="caution" size="small">
-                            Not seen yet
-                        </LemonTag>
+            const commonDivProps: React.HTMLProps<HTMLDivElement> = {
+                key: `item_${rowIndex}`,
+                className: clsx(
+                    'taxonomic-list-row',
+                    rowIndex === index && mouseInteractionsEnabled && 'hover',
+                    isActive && 'active',
+                    isSelected && 'selected'
+                ),
+                onMouseOver: () => (mouseInteractionsEnabled ? setIndex(rowIndex) : setIndex(NO_ITEM_SELECTED)),
+                // if the popover is not enabled then don't leave the row selected when the mouse leaves it
+                onMouseLeave: () => (mouseInteractionsEnabled && !showPopover ? setIndex(NO_ITEM_SELECTED) : null),
+                style: style,
+                ref: isHighlighted
+                    ? (element) => {
+                          setHighlightedItemElement(element && popupAnchorElement ? popupAnchorElement : element)
+                      }
+                    : null,
+            }
+
+            // If there's an item to render
+            if (item && itemGroup) {
+                return (
+                    <div
+                        {...commonDivProps}
+                        data-attr={`prop-filter-${listGroupType}-${rowIndex}`}
+                        onClick={() => {
+                            return (
+                                canSelectItem(listGroupType, dataWarehousePopoverFields) &&
+                                selectItem(itemGroup, itemValue ?? null, item, items.originalQuery)
+                            )
+                        }}
+                    >
+                        {renderItemContents({
+                            item,
+                            listGroupType,
+                            itemGroup,
+                            eventNames,
+                            isActive,
+                        })}
                     </div>
-                </LemonRow>
-            )
-        }
+                )
+            }
 
-        const commonDivProps: React.HTMLProps<HTMLDivElement> = {
-            key: `item_${rowIndex}`,
-            className: clsx(
-                'taxonomic-list-row',
-                rowIndex === index && mouseInteractionsEnabled && 'hover',
-                isActive && 'active',
-                isSelected && 'selected'
-            ),
-            onMouseOver: () => (mouseInteractionsEnabled ? setIndex(rowIndex) : setIndex(NO_ITEM_SELECTED)),
-            // if the popover is not enabled then don't leave the row selected when the mouse leaves it
-            onMouseLeave: () => (mouseInteractionsEnabled && !showPopover ? setIndex(NO_ITEM_SELECTED) : null),
-            style: style,
-            ref: isHighlighted
-                ? (element) => {
-                      setHighlightedItemElement(element && popupAnchorElement ? popupAnchorElement : element)
-                  }
-                : null,
-        }
+            // Check if this row should be the "show more" expand row:
+            // - !item: No actual item data exists at this index
+            // - rowIndex === totalListCount - 1: This is the last row in the visible list
+            // - isExpandable: There are more items available to load/show
+            // - !isLoading: We're not currently in the middle of loading data
+            const isExpandRow = !item && rowIndex === totalListCount - 1 && isExpandable && !isLoading
+            if (isExpandRow) {
+                return (
+                    <div
+                        {...commonDivProps}
+                        className={clsx(commonDivProps.className, 'expand-row')}
+                        data-attr={`expand-list-${listGroupType}`}
+                        onClick={expand}
+                    >
+                        {group.expandLabel?.({ count: totalResultCount, expandedCount }) ??
+                            `See ${expandedCount - totalResultCount} more ${pluralize(
+                                expandedCount - totalResultCount,
+                                'row',
+                                'rows',
+                                false
+                            )}`}
+                    </div>
+                )
+            }
 
-        // If there's an item to render
-        if (item && itemGroup) {
+            // Otherwise show a skeleton loader
             return (
                 <div
                     {...commonDivProps}
-                    data-attr={`prop-filter-${listGroupType}-${rowIndex}`}
-                    onClick={() => {
-                        return (
-                            canSelectItem(listGroupType, dataWarehousePopoverFields) &&
-                            selectItem(itemGroup, itemValue ?? null, item, items.originalQuery)
-                        )
-                    }}
+                    className={clsx(commonDivProps.className, 'skeleton-row')}
+                    data-attr={`prop-skeleton-${listGroupType}-${rowIndex}`}
                 >
-                    {renderItemContents({
-                        item,
-                        listGroupType,
-                        itemGroup,
-                        eventNames,
-                        isActive,
-                    })}
-                </div>
-            )
-        }
-
-        // Check if this row should be the "show more" expand row:
-        // - !item: No actual item data exists at this index
-        // - rowIndex === totalListCount - 1: This is the last row in the visible list
-        // - isExpandable: There are more items available to load/show
-        // - !isLoading: We're not currently in the middle of loading data
-        const isExpandRow = !item && rowIndex === totalListCount - 1 && isExpandable && !isLoading
-        if (isExpandRow) {
-            return (
-                <div
-                    {...commonDivProps}
-                    className={clsx(commonDivProps.className, 'expand-row')}
-                    data-attr={`expand-list-${listGroupType}`}
-                    onClick={expand}
-                >
-                    {group.expandLabel?.({ count: totalResultCount, expandedCount }) ??
-                        `See ${expandedCount - totalResultCount} more ${pluralize(
-                            expandedCount - totalResultCount,
-                            'row',
-                            'rows',
-                            false
-                        )}`}
-                </div>
-            )
-        }
-
-        // Otherwise show a skeleton loader
-        return (
-            <div
-                {...commonDivProps}
-                className={clsx(commonDivProps.className, 'skeleton-row')}
-                data-attr={`prop-skeleton-${listGroupType}-${rowIndex}`}
-            >
-                <div className="taxonomic-list-row-contents">
-                    <div className="taxonomic-list-row-contents-icon">
-                        <Spinner className="h-4 w-4" speed="0.8s" />
+                    <div className="taxonomic-list-row-contents">
+                        <div className="taxonomic-list-row-contents-icon">
+                            <Spinner className="h-4 w-4" speed="0.8s" />
+                        </div>
+                        <LemonSkeleton className="h-4 flex-1" />
                     </div>
-                    <LemonSkeleton className="h-4 flex-1" />
                 </div>
-            </div>
-        )
-    }
+            )
+        },
+        [
+            results,
+            taxonomicGroups,
+            group,
+            value,
+            listGroupType,
+            groupType,
+            index,
+            isActiveTab,
+            selectedProperties,
+            showNonCapturedEventOption,
+            trimmedSearchQuery,
+            selectItem,
+            mouseInteractionsEnabled,
+            setIndex,
+            showPopover,
+            popupAnchorElement,
+            setHighlightedItemElement,
+            dataWarehousePopoverFields,
+            items.originalQuery,
+            eventNames,
+            totalListCount,
+            isExpandable,
+            isLoading,
+            expand,
+            totalResultCount,
+            expandedCount,
+        ]
+    )
 
     const selectedItemGroup = getItemGroup(selectedItem, taxonomicGroups, group)
 
@@ -415,24 +462,26 @@ export function InfiniteList({ popupAnchorElement }: InfiniteListProps): JSX.Ele
                     <Spinner className="text-3xl" />
                 </div>
             ) : (
-                <AutoSizer>
-                    {({ height, width }) => (
-                        <List
-                            width={width}
-                            height={height}
-                            rowCount={
-                                showNonCapturedEventOption
-                                    ? 1
-                                    : Math.max(results.length || (isLoading ? 7 : 0), totalListCount || 0)
-                            }
-                            overscanRowCount={100}
-                            rowHeight={36} // LemonRow heights
-                            rowRenderer={renderItem}
-                            onRowsRendered={onRowsRendered}
-                            scrollToIndex={index}
-                        />
-                    )}
-                </AutoSizer>
+                <AutoSizer
+                    renderProp={({ height, width }) =>
+                        height && width ? (
+                            <List
+                                listRef={listRef}
+                                style={{ width, height }}
+                                rowCount={
+                                    showNonCapturedEventOption
+                                        ? 1
+                                        : Math.max(results.length || (isLoading ? 7 : 0), totalListCount || 0)
+                                }
+                                overscanCount={100}
+                                rowHeight={36}
+                                rowComponent={renderItem}
+                                rowProps={{}}
+                                onRowsRendered={onRowsRendered}
+                            />
+                        ) : null
+                    }
+                />
             )}
             {isActiveTab &&
             selectedItemHasPopover(selectedItem, listGroupType, selectedItemGroup) &&

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -204,23 +204,13 @@ describe('infiniteListLogic', () => {
                 })
 
                 await expectLogic(logic, () =>
-                    logic.actions.onRowsRendered({
-                        startIndex: 30,
-                        stopIndex: 40,
-                        overscanStartIndex: 20,
-                        overscanStopIndex: 60,
-                    })
+                    logic.actions.onRowsRendered({ startIndex: 30, stopIndex: 40 }, { startIndex: 20, stopIndex: 60 })
                 )
                     .toDispatchActions(['onRowsRendered'])
                     .toNotHaveDispatchedActions(['loadRemoteItems'])
 
                 await expectLogic(logic, () =>
-                    logic.actions.onRowsRendered({
-                        startIndex: 80,
-                        stopIndex: 100,
-                        overscanStartIndex: 70,
-                        overscanStopIndex: 120,
-                    })
+                    logic.actions.onRowsRendered({ startIndex: 80, stopIndex: 100 }, { startIndex: 70, stopIndex: 120 })
                 )
                     .toDispatchActions(['onRowsRendered', 'loadRemoteItems', 'loadRemoteItemsSuccess'])
                     .toMatchValues({

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -5,9 +5,9 @@ import { SortableContext, arrayMove, rectSortingStrategy, useSortable } from '@d
 import { CSS } from '@dnd-kit/utilities'
 import clsx from 'clsx'
 import Fuse from 'fuse.js'
-import { MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
-import { List } from 'react-virtualized/dist/es/List'
+import { CSSProperties, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { AutoSizer } from 'react-virtualized-auto-sizer'
+import { List } from 'react-window'
 
 import { IconCheck, IconPencil, IconX } from '@posthog/icons'
 import { LemonCheckbox, Tooltip } from '@posthog/lemon-ui'
@@ -31,6 +31,90 @@ const NON_ESCAPED_COMMA_REGEX = /(?<!\\),/
 const VIRTUALIZED_SELECT_OPTION_HEIGHT = 33
 
 const VIRTUALIZED_MAX_DROPDOWN_HEIGHT = 420
+
+interface VirtualizedOptionRowProps {
+    visibleOptions: LemonInputSelectOption[]
+    selectedIndex: number
+    stringKeys: string[]
+    wasLimitReached: boolean
+    limit?: number
+    _onActionItem: (key: string, e?: MouseEvent<HTMLButtonElement>) => void
+    setSelectedIndex: (index: number) => void
+    allowCustomValues?: boolean
+    disableEditing?: boolean
+    setInputValue: (value: string) => void
+    inputRef: React.RefObject<HTMLInputElement | null>
+    _onFocus: () => void
+    getInputLabel: (option: LemonInputSelectOption) => React.ReactNode
+    getOptionIcon: (option: LemonInputSelectOption, isSelected: boolean) => JSX.Element | undefined
+}
+
+const VirtualizedOptionRow = ({
+    index,
+    style,
+    visibleOptions,
+    selectedIndex,
+    stringKeys,
+    wasLimitReached,
+    limit,
+    _onActionItem,
+    setSelectedIndex,
+    allowCustomValues,
+    disableEditing,
+    setInputValue,
+    inputRef,
+    _onFocus,
+    getInputLabel,
+    getOptionIcon,
+}: {
+    ariaAttributes: Record<string, unknown>
+    index: number
+    style: CSSProperties
+} & VirtualizedOptionRowProps): JSX.Element => {
+    const option = visibleOptions[index]
+    const isFocused = index === selectedIndex
+    const isSelected = stringKeys.includes(option.key)
+    const isDisabled = wasLimitReached && !isSelected
+    return (
+        <LemonButton
+            style={style}
+            key={option.key}
+            type="tertiary"
+            size="small"
+            fullWidth
+            active={isFocused}
+            onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
+            onMouseEnter={() => setSelectedIndex(index)}
+            disabledReason={isDisabled ? `Limit of ${limit} options reached` : undefined}
+            tooltip={option.tooltip}
+            icon={getOptionIcon(option, isSelected)}
+            sideAction={
+                !option.__isInput && allowCustomValues && !disableEditing
+                    ? {
+                          icon: <IconPencil className={!isFocused ? 'invisible' : undefined} />,
+                          tooltip: (
+                              <>
+                                  Edit this value
+                                  <KeyboardShortcut option enter />
+                              </>
+                          ),
+                          onClick: () => {
+                              setInputValue(option.key)
+                              inputRef.current?.focus()
+                              _onFocus()
+                          },
+                      }
+                    : undefined
+            }
+        >
+            <span className="whitespace-nowrap ph-no-capture truncate">
+                {!option.__isInput && !option.__isCustomValue
+                    ? (option.labelComponent ?? option.label)
+                    : getInputLabel(option)}
+            </span>
+        </LemonButton>
+    )
+}
 
 export interface LemonInputSelectOption<T = string> {
     key: string
@@ -755,74 +839,35 @@ export function LemonInputSelect<T = string>({
                     {visibleOptions.length > 0 ? (
                         virtualized ? (
                             <div>
-                                <AutoSizer disableHeight>
-                                    {({ width }) => (
-                                        <List
-                                            width={width}
-                                            height={virtualizedListHeight}
-                                            rowCount={visibleOptions.length}
-                                            overscanRowCount={100}
-                                            rowHeight={VIRTUALIZED_SELECT_OPTION_HEIGHT}
-                                            rowRenderer={({ index, style }) => {
-                                                const option = visibleOptions[index]
-                                                const isFocused = index === selectedIndex
-                                                const isSelected = stringKeys.includes(option.key)
-                                                const isDisabled = wasLimitReached && !isSelected
-                                                return (
-                                                    <LemonButton
-                                                        style={style}
-                                                        key={option.key}
-                                                        type="tertiary"
-                                                        size="small"
-                                                        fullWidth
-                                                        active={isFocused}
-                                                        onClick={(e) => !isDisabled && _onActionItem(option.key, e)}
-                                                        onMouseEnter={() => setSelectedIndex(index)}
-                                                        disabledReason={
-                                                            isDisabled ? `Limit of ${limit} options reached` : undefined
-                                                        }
-                                                        tooltip={option.tooltip}
-                                                        icon={getOptionIcon(option, isSelected)}
-                                                        sideAction={
-                                                            !option.__isInput && allowCustomValues && !disableEditing
-                                                                ? {
-                                                                      // To reduce visual clutter we only show the icon on focus or hover,
-                                                                      // but we do want it present to make sure the layout is stable
-                                                                      icon: (
-                                                                          <IconPencil
-                                                                              className={
-                                                                                  !isFocused ? 'invisible' : undefined
-                                                                              }
-                                                                          />
-                                                                      ),
-                                                                      tooltip: (
-                                                                          <>
-                                                                              Edit this value
-                                                                              <KeyboardShortcut option enter />
-                                                                          </>
-                                                                      ),
-                                                                      onClick: () => {
-                                                                          setInputValue(option.key)
-                                                                          inputRef.current?.focus()
-                                                                          _onFocus()
-                                                                      },
-                                                                  }
-                                                                : undefined
-                                                        }
-                                                    >
-                                                        <span className="whitespace-nowrap ph-no-capture truncate">
-                                                            {
-                                                                !option.__isInput && !option.__isCustomValue
-                                                                    ? (option.labelComponent ?? option.label) // Regular option
-                                                                    : getInputLabel(option) // Input-based option
-                                                            }
-                                                        </span>
-                                                    </LemonButton>
-                                                )
-                                            }}
-                                        />
-                                    )}
-                                </AutoSizer>
+                                <AutoSizer
+                                    renderProp={({ width }) =>
+                                        width ? (
+                                            <List
+                                                style={{ width, height: virtualizedListHeight }}
+                                                rowCount={visibleOptions.length}
+                                                overscanCount={100}
+                                                rowHeight={VIRTUALIZED_SELECT_OPTION_HEIGHT}
+                                                rowComponent={VirtualizedOptionRow}
+                                                rowProps={{
+                                                    visibleOptions,
+                                                    selectedIndex,
+                                                    stringKeys,
+                                                    wasLimitReached,
+                                                    limit,
+                                                    _onActionItem,
+                                                    setSelectedIndex,
+                                                    allowCustomValues,
+                                                    disableEditing,
+                                                    setInputValue,
+                                                    inputRef,
+                                                    _onFocus,
+                                                    getInputLabel,
+                                                    getOptionIcon,
+                                                }}
+                                            />
+                                        ) : null
+                                    }
+                                />
                             </div>
                         ) : (
                             visibleOptions.map((option, index) => {

--- a/frontend/src/lib/monaco/CodeEditorResizable.tsx
+++ b/frontend/src/lib/monaco/CodeEditorResizable.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { useEffect, useRef, useState } from 'react'
-import AutoSizer from 'react-virtualized/dist/es/AutoSizer'
+import { AutoSizer } from 'react-virtualized-auto-sizer'
 
 import { IconCheck, IconX } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
@@ -57,16 +57,18 @@ export function CodeEditorResizeable({
                 height: manualHeight ?? height,
             }}
         >
-            <AutoSizer disableWidth>
-                {({ height }) => (
-                    <CodeEditor
-                        {...props}
-                        className={editorClassName}
-                        height={height - 2} // Account for border
-                        originalValue={originalValue}
-                    />
-                )}
-            </AutoSizer>
+            <AutoSizer
+                renderProp={({ height }) =>
+                    height ? (
+                        <CodeEditor
+                            {...props}
+                            className={editorClassName}
+                            height={height - 2} // Account for border
+                            originalValue={originalValue}
+                        />
+                    ) : null
+                }
+            />
 
             {showDiffActions && (
                 <div className="flex absolute top-2 right-2 z-20 gap-1 p-1 bg-white rounded-lg border shadow-sm">

--- a/frontend/src/queries/QueryEditor/QueryEditor.tsx
+++ b/frontend/src/queries/QueryEditor/QueryEditor.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
-import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
+import { AutoSizer } from 'react-virtualized-auto-sizer'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
@@ -45,18 +45,20 @@ export function QueryEditor(props: QueryEditorProps): JSX.Element {
                 )}
             >
                 <div className="flex-1">
-                    <AutoSizer disableWidth>
-                        {({ height }) => (
-                            <CodeEditor
-                                className="border"
-                                language="json"
-                                value={queryInput}
-                                onChange={(v) => setQueryInput(v ?? '')}
-                                height={height}
-                                schema={schema}
-                            />
-                        )}
-                    </AutoSizer>
+                    <AutoSizer
+                        renderProp={({ height }) =>
+                            height ? (
+                                <CodeEditor
+                                    className="border"
+                                    language="json"
+                                    value={queryInput}
+                                    onChange={(v) => setQueryInput(v ?? '')}
+                                    height={height}
+                                    schema={schema}
+                                />
+                            ) : null
+                        }
+                    />
                 </div>
                 {error ? (
                     <div className="bg-danger text-white p-2">

--- a/frontend/src/queries/nodes/DataNode/DataNode.tsx
+++ b/frontend/src/queries/nodes/DataNode/DataNode.tsx
@@ -1,6 +1,6 @@
 import { BuiltLogic, LogicWrapper, useValues } from 'kea'
 import { useState } from 'react'
-import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
+import { AutoSizer } from 'react-virtualized-auto-sizer'
 
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
@@ -40,16 +40,18 @@ export function DataNode(props: DataNodeProps): JSX.Element {
                     <Spinner />
                 </div>
             ) : (
-                <AutoSizer disableWidth>
-                    {({ height }) => (
-                        <CodeEditor
-                            className="border"
-                            language="json"
-                            value={JSON.stringify(response ?? responseErrorObject, null, 2)}
-                            height={Math.max(height, 300)}
-                        />
-                    )}
-                </AutoSizer>
+                <AutoSizer
+                    renderProp={({ height }) =>
+                        height ? (
+                            <CodeEditor
+                                className="border"
+                                language="json"
+                                value={JSON.stringify(response ?? responseErrorObject, null, 2)}
+                                height={Math.max(height, 300)}
+                            />
+                        ) : null
+                    }
+                />
             )}
         </div>
     )

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -6,7 +6,7 @@ import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-
 import { CSS } from '@dnd-kit/utilities'
 import { BindLogic, useActions, useValues } from 'kea'
 import { useState } from 'react'
-import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
+import { AutoSizer } from 'react-virtualized-auto-sizer'
 
 import { IconPencil, IconX } from '@posthog/icons'
 
@@ -214,28 +214,30 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                     <div className="HalfColumn">
                         <h4 className="secondary uppercase text-secondary">Available columns</h4>
                         <div className="h-[min(480px,60vh)]">
-                            <AutoSizer>
-                                {({ height, width }: { height: number; width: number }) => (
-                                    <TaxonomicFilter
-                                        height={height}
-                                        width={width}
-                                        taxonomicGroupTypes={taxonomicGroupTypes}
-                                        value={undefined}
-                                        onChange={(group, value) => {
-                                            const column = isGroupsQuery(query.source)
-                                                ? taxonomicGroupFilterToHogQL(group.type, value)
-                                                : isActorsQuery(query.source)
-                                                  ? taxonomicPersonFilterToHogQL(group.type, value)
-                                                  : taxonomicEventFilterToHogQL(group.type, value)
-                                            if (column !== null) {
-                                                selectColumn(column)
-                                            }
-                                        }}
-                                        popoverEnabled={false}
-                                        selectFirstItem={false}
-                                    />
-                                )}
-                            </AutoSizer>
+                            <AutoSizer
+                                renderProp={({ height, width }) =>
+                                    height && width ? (
+                                        <TaxonomicFilter
+                                            height={height}
+                                            width={width}
+                                            taxonomicGroupTypes={taxonomicGroupTypes}
+                                            value={undefined}
+                                            onChange={(group, value) => {
+                                                const column = isGroupsQuery(query.source)
+                                                    ? taxonomicGroupFilterToHogQL(group.type, value)
+                                                    : isActorsQuery(query.source)
+                                                      ? taxonomicPersonFilterToHogQL(group.type, value)
+                                                      : taxonomicEventFilterToHogQL(group.type, value)
+                                                if (column !== null) {
+                                                    selectColumn(column)
+                                                }
+                                            }}
+                                            popoverEnabled={false}
+                                            selectFirstItem={false}
+                                        />
+                                    ) : null
+                                }
+                            />
                         </div>
                     </div>
                 </div>

--- a/frontend/src/scenes/data-pipelines/legacy-plugins/PipelinePluginConfiguration.tsx
+++ b/frontend/src/scenes/data-pipelines/legacy-plugins/PipelinePluginConfiguration.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import React, { useState } from 'react'
-import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
+import { AutoSizer } from 'react-virtualized-auto-sizer'
 
 import { IconLock, IconPencil } from '@posthog/icons'
 import {
@@ -314,21 +314,24 @@ function JsonConfigField(props: {
     value: any
 }): JSX.Element {
     return (
-        <AutoSizer disableWidth className="min-h-60">
-            {({ height }) => (
-                <CodeEditor
-                    className="border"
-                    language="json"
-                    value={props.value}
-                    onChange={(v) => props.onChange?.(v ?? '')}
-                    height={height}
-                    options={{
-                        minimap: {
-                            enabled: false,
-                        },
-                    }}
-                />
-            )}
-        </AutoSizer>
+        <AutoSizer
+            className="min-h-60"
+            renderProp={({ height }) =>
+                height ? (
+                    <CodeEditor
+                        className="border"
+                        language="json"
+                        value={props.value}
+                        onChange={(v) => props.onChange?.(v ?? '')}
+                        height={height}
+                        options={{
+                            minimap: {
+                                enabled: false,
+                            },
+                        }}
+                    />
+                ) : null
+            }
+        />
     )
 }

--- a/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
+import { AutoSizer } from 'react-virtualized-auto-sizer'
 
 import { IconCheck, IconX } from '@posthog/icons'
 
@@ -45,33 +45,34 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
             >
                 <div className="relative flex flex-col w-full">
                     <div className="flex-1" data-attr="hogql-query-editor">
-                        <AutoSizer>
-                            {({ height, width }) => (
-                                <CodeEditor
-                                    language="hogQL"
-                                    value={props.queryInput}
-                                    sourceQuery={props.sourceQuery}
-                                    height={height}
-                                    width={width}
-                                    originalValue={props.originalValue}
-                                    {...props.codeEditorProps}
-                                    options={{
-                                        minimap: {
-                                            enabled: false,
-                                        },
-                                        wordWrap: 'on',
-                                        // Overscroll needed when Accept/Reject buttons are shown, so that they don't obscure the query
-                                        scrollBeyondLastLine: !!props.originalValue,
-                                        automaticLayout: true,
-                                        fixedOverflowWidgets: true,
-                                        suggest: {
-                                            showInlineDetails: true,
-                                        },
-                                        quickSuggestionsDelay: 300,
-                                    }}
-                                />
-                            )}
-                        </AutoSizer>
+                        <AutoSizer
+                            renderProp={({ height, width }) =>
+                                height && width ? (
+                                    <CodeEditor
+                                        language="hogQL"
+                                        value={props.queryInput}
+                                        sourceQuery={props.sourceQuery}
+                                        height={height}
+                                        width={width}
+                                        originalValue={props.originalValue}
+                                        {...props.codeEditorProps}
+                                        options={{
+                                            minimap: {
+                                                enabled: false,
+                                            },
+                                            wordWrap: 'on',
+                                            scrollBeyondLastLine: !!props.originalValue,
+                                            automaticLayout: true,
+                                            fixedOverflowWidgets: true,
+                                            suggest: {
+                                                showInlineDetails: true,
+                                            },
+                                            quickSuggestionsDelay: 300,
+                                        }}
+                                    />
+                                ) : null
+                            }
+                        />
                     </div>
                     <div className="absolute bottom-6 right-4">
                         <MaxTool

--- a/frontend/src/types/react-virtualized-auto-sizer.d.ts
+++ b/frontend/src/types/react-virtualized-auto-sizer.d.ts
@@ -1,0 +1,30 @@
+declare module 'react-virtualized-auto-sizer' {
+    import type { CSSProperties, ReactNode } from 'react'
+
+    export interface Size {
+        height: number
+        width: number
+    }
+
+    export interface AutoSizerChildProps {
+        height: number | undefined
+        width: number | undefined
+    }
+
+    export interface AutoSizerProps {
+        box?: 'border-box' | 'content-box' | 'device-pixel-content-box'
+        className?: string
+        'data-testid'?: string
+        id?: string | number
+        nonce?: string
+        onResize?: (size: Size) => void
+        style?: CSSProperties
+        tagName?: string
+        renderProp?: (params: AutoSizerChildProps) => ReactNode
+        ChildComponent?: React.ComponentType<AutoSizerChildProps>
+        Child?: React.ComponentType<AutoSizerChildProps>
+    }
+
+    export function AutoSizer(props: AutoSizerProps): JSX.Element
+    export { AutoSizerChildProps as SizeProps }
+}

--- a/frontend/src/types/react-window.d.ts
+++ b/frontend/src/types/react-window.d.ts
@@ -1,0 +1,60 @@
+declare module 'react-window' {
+    import type {
+        CSSProperties,
+        HTMLAttributes,
+        ReactElement,
+        ReactNode,
+        MutableRefObject,
+        Dispatch,
+        SetStateAction,
+    } from 'react'
+
+    export interface ListImperativeAPI {
+        readonly element: HTMLDivElement | null
+        scrollToRow(config: {
+            align?: 'auto' | 'center' | 'end' | 'smart' | 'start'
+            behavior?: 'auto' | 'instant' | 'smooth'
+            index: number
+        }): void
+    }
+
+    export interface DynamicRowHeight {
+        getAverageRowHeight(): number
+        getRowHeight(index: number): number | undefined
+        setRowHeight(index: number, size: number): void
+        observeRowElements: (elements: Element[] | NodeListOf<Element>) => () => void
+    }
+
+    export interface ListProps<RowProps extends object = object>
+        extends Omit<HTMLAttributes<HTMLDivElement>, 'onResize'> {
+        children?: ReactNode
+        className?: string
+        defaultHeight?: number
+        listRef?: MutableRefObject<ListImperativeAPI | undefined>
+        onResize?: (size: { height: number; width: number }, prevSize: { height: number; width: number }) => void
+        onRowsRendered?: (
+            visibleRows: { startIndex: number; stopIndex: number },
+            allRows: { startIndex: number; stopIndex: number }
+        ) => void
+        overscanCount?: number
+        rowComponent: (
+            props: {
+                ariaAttributes: Record<string, unknown>
+                index: number
+                style: CSSProperties
+            } & RowProps
+        ) => ReactElement | null
+        rowCount: number
+        rowHeight: number | string | ((index: number, cellProps: RowProps) => number) | DynamicRowHeight
+        rowProps: RowProps
+        style?: CSSProperties
+        tagName?: keyof JSX.IntrinsicElements
+    }
+
+    export function List<RowProps extends object = object>(props: ListProps<RowProps>): ReactElement
+
+    export function useListRef(): MutableRefObject<ListImperativeAPI | undefined>
+    export function useListCallbackRef(): [ListImperativeAPI | null, Dispatch<SetStateAction<ListImperativeAPI | null>>]
+
+    export function useDynamicRowHeight(config: { defaultRowHeight: number; key?: string | number }): DynamicRowHeight
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1170,6 +1170,12 @@ importers:
       process:
         specifier: ^0.11.10
         version: 0.11.10
+      react-virtualized-auto-sizer:
+        specifier: ^2.0.2
+        version: 2.0.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-window:
+        specifier: ^2.2.5
+        version: 2.2.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       redis:
         specifier: ^4.6.13
         version: 4.6.13
@@ -2068,7 +2074,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: '*'
-        version: 30.0.5(@types/node@22.15.17)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       kea:
         specifier: ^3.1.7
         version: 3.1.7(react@18.2.0)
@@ -2153,7 +2159,7 @@ importers:
         version: 3.1.3
       jest:
         specifier: '*'
-        version: 29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
+        version: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
       kea:
         specifier: ^3.1.7
         version: 3.1.7(react@18.2.0)
@@ -10891,6 +10897,7 @@ packages:
   aws-sdk@2.1366.0:
     resolution: {integrity: sha512-tS7y18KHH0eq43I8WJsxVBpwOMY45FSsu6a+A/6k0bMrE4zhd1fzhPN+5coNIODaGxnqVvgw9guLg3AOe4SpaA==}
     engines: {node: '>= 10.0.0'}
+    deprecated: The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil
 
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
@@ -17924,11 +17931,23 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
 
+  react-virtualized-auto-sizer@2.0.2:
+    resolution: {integrity: sha512-FvnVDed3nn7Xt2m2ioo+O1VBpP1uMIl8ygtpkzfhYoRb1e06on6hp2DEBg9AquCXqtP1bhgVT4lS+xpBwrXq7Q==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
   react-virtualized@9.22.5:
     resolution: {integrity: sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==}
     peerDependencies:
       react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
       react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
+
+  react-window@2.2.5:
+    resolution: {integrity: sha512-6viWvPSZvVuMIe9hrl4IIZoVfO/npiqOb03m4Z9w+VihmVzBbiudUrtUqDpsWdKvd/Ai31TCR25CBcFFAUm28w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -19710,8 +19729,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.358.0:
-    resolution: {integrity: sha512-bclc48QXfc98QaMrt9t+attTSiVyCWBB7EegUo03TdrRKpLjZnww7PVwApmwza5qf9lGzWCGbBLlNzdEIJuPrQ==}
+  unlayer-types@1.360.0:
+    resolution: {integrity: sha512-RntBPW7369s621/gs4QNKco1KtJyG9umwsgYR2rEaAGFLVqJtI+bPTo31CI0y7e8nEg7uFFEzaTt8qZGLF2IDA==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -24350,41 +24369,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.18.8
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@30.0.5(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))':
     dependencies:
       '@jest/console': 30.0.5
@@ -24401,6 +24385,42 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
       jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest-haste-map: 30.0.5
+      jest-message-util: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.5
+      jest-resolve-dependencies: 30.0.5
+      jest-runner: 30.0.5
+      jest-runtime: 30.0.5
+      jest-snapshot: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      jest-watcher: 30.0.5
+      micromatch: 4.0.8
+      pretty-format: 30.0.5
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  '@jest/core@30.0.5(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))':
+    dependencies:
+      '@jest/console': 30.0.5
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.0.5
+      '@jest/test-result': 30.0.5
+      '@jest/transform': 30.0.5
+      '@jest/types': 30.0.5
+      '@types/node': 22.18.8
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.0.5
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -29470,7 +29490,7 @@ snapshots:
       commander: 9.4.1
       expect-playwright: 0.8.0
       glob: 10.4.5
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -32727,21 +32747,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-require@1.1.1: {}
 
   crelt@1.0.5: {}
@@ -35879,25 +35884,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0:
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
@@ -35917,25 +35903,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@30.0.5(@types/node@22.15.17)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2)):
     dependencies:
       '@jest/core': 30.0.5(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
@@ -35945,6 +35912,25 @@ snapshots:
       exit-x: 0.2.2
       import-local: 3.2.0
       jest-config: 30.0.5(@types/node@22.15.17)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-cli@30.0.5(@types/node@22.18.8)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2)):
+    dependencies:
+      '@jest/core': 30.0.5(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
+      '@jest/test-result': 30.0.5
+      '@jest/types': 30.0.5
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -36017,68 +36003,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2)):
-    dependencies:
-      '@babel/core': 7.28.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.0)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.18.8
-      ts-node: 10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2)):
-    dependencies:
-      '@babel/core': 7.28.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.0)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.0.6
-      ts-node: 10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
   jest-config@30.0.5(@types/node@22.15.17)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2)):
     dependencies:
       '@babel/core': 7.28.0
@@ -36143,6 +36067,40 @@ snapshots:
       '@types/node': 22.18.8
       esbuild-register: 3.5.0(esbuild@0.27.2)
       ts-node: 10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2)):
+    dependencies:
+      '@babel/core': 7.28.0
+      '@jest/get-type': 30.0.1
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.0.5
+      '@jest/types': 30.0.5
+      babel-jest: 30.0.5(@babel/core@7.28.0)
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      deepmerge: 4.3.1
+      glob: 10.4.5
+      graceful-fs: 4.2.11
+      jest-circus: 30.0.5
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.5
+      jest-runner: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.0.5
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.18.8
+      esbuild-register: 3.5.0(esbuild@0.27.2)
+      ts-node: 10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -36335,7 +36293,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -36615,7 +36573,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.4.1
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -36665,18 +36623,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0:
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest@29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
@@ -36689,24 +36635,25 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@25.0.6)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest@30.0.5(@types/node@22.15.17)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2)):
     dependencies:
       '@jest/core': 30.0.5(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
       '@jest/types': 30.0.5
       import-local: 3.2.0
       jest-cli: 30.0.5(@types/node@22.15.17)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.0.5(@types/node@22.18.8)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2)):
+    dependencies:
+      '@jest/core': 30.0.5(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
+      '@jest/types': 30.0.5
+      import-local: 3.2.0
+      jest-cli: 30.0.5(@types/node@22.18.8)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -40531,7 +40478,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.2.0):
     dependencies:
       react: 18.2.0
-      unlayer-types: 1.358.0
+      unlayer-types: 1.360.0
 
   react-error-overlay@6.0.9: {}
 
@@ -40705,6 +40652,11 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
+  react-virtualized-auto-sizer@2.0.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
   react-virtualized@9.22.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.28.4
@@ -40715,6 +40667,11 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-lifecycles-compat: 3.0.4
+
+  react-window@2.2.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   react@18.2.0:
     dependencies:
@@ -42357,14 +42314,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.11.4(@swc/helpers@0.5.15)
 
-  ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.6)(typescript@5.2.2):
+  ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 25.0.6
+      '@types/node': 22.18.8
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -42758,7 +42715,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.358.0: {}
+  unlayer-types@1.360.0: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
react-virtualized seems abandoned no commits for ~1yr

the same author has newer active libraries

let's start switching to those

why? 

* the existing is dead
* it has a component that is keeping detached elements alive and contributing to memory leak

![CleanShot 2026-01-23 at 21.30.01@2x.png](https://app.graphite.com/user-attachments/assets/ab9072b8-aa32-4676-8728-dc30d0262289.png)

Related to #32479
