### PR TITLE
feat(infra): make nginx unit request limit configurable

### DIFF
--- a/bin/docker-server-unit
+++ b/bin/docker-server-unit
@@ -58,6 +58,7 @@ else
 
     export NGINX_UNIT_PYTHON_PROTOCOL=${NGINX_UNIT_PYTHON_PROTOCOL:-wsgi}
     export NGINX_UNIT_APP_PROCESSES=${NGINX_UNIT_APP_PROCESSES:-4}
+    export NGINX_UNIT_REQUEST_LIMIT=${NGINX_UNIT_REQUEST_LIMIT:-7500}
     envsubst < /docker-entrypoint.d/unit.json.tpl > /docker-entrypoint.d/unit.json
 
     # We need to run as root so that nginx unit can proxy the control socket for stats

--- a/unit.json.tpl
+++ b/unit.json.tpl
@@ -47,7 +47,7 @@
             "protocol": "$NGINX_UNIT_PYTHON_PROTOCOL",
             "user": "nobody",
             "limits": {
-                "requests": 7500
+                "requests": $NGINX_UNIT_REQUEST_LIMIT
             }
         },
         "metrics": {


### PR DESCRIPTION
## Problem

looking into query related memory pressure, we found that Unit workers hold onto memory after processing large query results

The `limits.requests: 7500` setting from #21649 was tuned for web. query now deals with much bigger result sets and hits memory limits well before workers get a chance to recycle.

Making this configurable lets us tune it per-deployment without affecting existing behavior.

## Changes

- Add `NGINX_UNIT_REQUEST_LIMIT` env var (defaults to 7500)
- Use it in `unit.json.tpl` instead of hardcoded value

## How did you test this code?

Locally verified envsubst works and default is unchanged. Will test with lower value on query in dev.

## Publish to changelog?

no
