### PR TITLE
feat(llm-analytics): use gpt-4.1-nano for temporal summarization workflows

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/README.md
+++ b/posthog/temporal/llm_analytics/trace_summarization/README.md
@@ -107,15 +107,16 @@ Edit `ALLOWED_TEAM_IDS` in `constants.py`. Empty list = coordinator skips all te
 
 Key constants in `constants.py`:
 
-| Constant                             | Default    | Description                 |
-| ------------------------------------ | ---------- | --------------------------- |
-| `DEFAULT_MAX_TRACES_PER_WINDOW`      | 100        | Max traces per window       |
-| `DEFAULT_BATCH_SIZE`                 | 3          | Concurrent trace processing |
-| `DEFAULT_MODE`                       | "detailed" | Summary detail level        |
-| `DEFAULT_WINDOW_MINUTES`             | 60         | Time window to query        |
-| `WORKFLOW_EXECUTION_TIMEOUT_MINUTES` | 120        | Max workflow duration       |
-| `SAMPLE_TIMEOUT_SECONDS`             | 300        | Sampling activity timeout   |
-| `GENERATE_SUMMARY_TIMEOUT_SECONDS`   | 300        | Summary activity timeout    |
+| Constant                             | Default        | Description                 |
+| ------------------------------------ | -------------- | --------------------------- |
+| `DEFAULT_MAX_TRACES_PER_WINDOW`      | 100            | Max traces per window       |
+| `DEFAULT_BATCH_SIZE`                 | 3              | Concurrent trace processing |
+| `DEFAULT_MODE`                       | "detailed"     | Summary detail level        |
+| `DEFAULT_MODEL`                      | "gpt-4.1-nano" | LLM model for summarization |
+| `DEFAULT_WINDOW_MINUTES`             | 60             | Time window to query        |
+| `WORKFLOW_EXECUTION_TIMEOUT_MINUTES` | 120            | Max workflow duration       |
+| `SAMPLE_TIMEOUT_SECONDS`             | 300            | Sampling activity timeout   |
+| `GENERATE_SUMMARY_TIMEOUT_SECONDS`   | 300            | Summary activity timeout    |
 
 Retry policies: `SAMPLE_RETRY_POLICY` (3 attempts), `SUMMARIZE_RETRY_POLICY` (2 attempts), `COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY` (2 attempts).
 

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -12,12 +12,12 @@ DEFAULT_BATCH_SIZE = 3  # Number of traces to process in parallel (reduced to av
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)
 DEFAULT_PROVIDER = SummarizationProvider.OPENAI
-DEFAULT_MODEL = OpenAIModel.GPT_4_1_MINI
+DEFAULT_MODEL = OpenAIModel.GPT_4_1_NANO
 
 # Max text representation length by provider (in characters)
 # Gemini models have ~1M token context. At typical 2.5:1 char/token ratio,
 # 1.5M chars = ~600K tokens, leaving room for system prompt and output.
-# OpenAI GPT-4.1-mini has 1M token context with better token efficiency,
+# OpenAI GPT-4.1-nano has 1M token context with better token efficiency,
 # so 2M chars = ~800K tokens is safe.
 MAX_LENGTH_BY_PROVIDER: dict[SummarizationProvider, int] = {
     SummarizationProvider.GEMINI: 1_500_000,

--- a/products/llm_analytics/backend/summarization/models.py
+++ b/products/llm_analytics/backend/summarization/models.py
@@ -13,6 +13,7 @@ class SummarizationProvider(StrEnum):
 class OpenAIModel(StrEnum):
     """Supported OpenAI models for summarization."""
 
+    GPT_4_1_NANO = "gpt-4.1-nano"
     GPT_4_1_MINI = "gpt-4.1-mini"
     GPT_4O_MINI = "gpt-4o-mini"
     GPT_4O = "gpt-4o"


### PR DESCRIPTION
## Problem

Batch trace summarization using gpt-4.1-mini is expensive at scale (~$0.40/1M input tokens).

## Changes

- Add `GPT_4_1_NANO` to `OpenAIModel` enum
- Set `gpt-4.1-nano` as default for Temporal summarization workflows
- Update README with model configuration

gpt-4.1-nano is 75% cheaper ($0.10/1M input) with the same 1M token context.

On-demand summarization keeps gpt-4.1-mini as default.

## Does this work well for self-hosted?

N/A - internal LLM analytics feature

## How did you test this code?

- Existing coordinator tests pass

Relates to #45868