### PR TITLE
[#41785]:  join team id filter to subquery for RIGHT JOIN

### DIFF
--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -893,12 +893,7 @@ class ClickHousePrinter(HogQLPrinter):
         ):
             return team_id_guard_for_table(node_type, self.context)
 
-    def _print_table_ref(
-        self,
-        table_type: ast.TableType | ast.LazyTableType,
-        node: ast.JoinExpr,
-        team_id_filter: ast.Expr | None = None,
-    ) -> str:
+    def _print_table_ref(self, table_type: ast.TableType | ast.LazyTableType, node: ast.JoinExpr) -> str:
         sql = table_type.table.to_printed_clickhouse(self.context)
 
         # Edge case. If we are joining an s3 table, we must wrap it in a subquery for the join to work
@@ -906,13 +901,6 @@ class ClickHousePrinter(HogQLPrinter):
             node.next_join or node.join_type == "JOIN" or (node.join_type and node.join_type.startswith("GLOBAL "))
         ):
             sql = f"(SELECT * FROM {sql})"
-        # For joined tables with a team_id filter, wrap the table in a subquery with the filter.
-        # This ensures ClickHouse applies the team_id filter BEFORE building the hash table for JOINs,
-        # preventing memory exhaustion when large tables like events are on the right side of a JOIN.
-        # See: https://github.com/PostHog/posthog/issues/41785
-        elif team_id_filter is not None:
-            team_id_sql = self.visit(team_id_filter)
-            sql = f"(SELECT * FROM {sql} WHERE {team_id_sql})"
 
         return sql
 

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -1356,11 +1356,11 @@ class TestPrinter(BaseTest):
         # See: https://github.com/PostHog/posthog/issues/41785
         self.assertEqual(
             self._select("select 1 from events cross join raw_groups"),
-            f"SELECT 1 FROM events CROSS JOIN (SELECT * FROM groups WHERE equals(team_id, {self.team.pk})) AS groups WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+            f"SELECT 1 FROM events CROSS JOIN (SELECT * FROM groups WHERE equals(team_id, {self.team.pk})) AS `groups` WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
         self.assertEqual(
             self._select("select 1 from events, raw_groups"),
-            f"SELECT 1 FROM events CROSS JOIN (SELECT * FROM groups WHERE equals(team_id, {self.team.pk})) AS groups WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+            f"SELECT 1 FROM events CROSS JOIN (SELECT * FROM groups WHERE equals(team_id, {self.team.pk})) AS `groups` WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
 
     def test_left_join_team_id_in_on_clause(self):
@@ -1443,7 +1443,7 @@ class TestPrinter(BaseTest):
 
         # The JOINed table (e2) should be wrapped in a subquery with team_id filter
         # This ensures ClickHouse applies the filter BEFORE building the hash table
-        self.assertIn(f"(SELECT * FROM events WHERE equals(team_id, {self.team.pk})) AS e2", result)
+        self.assertIn(f"(SELECT * FROM events WHERE equals(team_id, {self.team.pk})) AS `e2`", result)
 
     def test_events_on_right_side_of_join_issue_41785(self):
         """
@@ -1470,7 +1470,7 @@ class TestPrinter(BaseTest):
 
         # The events table should be wrapped in a subquery with team_id filter
         # This ensures the filter is applied BEFORE building the hash table
-        self.assertIn(f"(SELECT * FROM events WHERE equals(team_id, {self.team.pk})) AS e", result)
+        self.assertIn(f"(SELECT * FROM events WHERE equals(team_id, {self.team.pk})) AS `e`", result)
 
         # The team_id filter should NOT be in the global WHERE clause for the joined events table
         # (it's already in the subquery)


### PR DESCRIPTION
## Problem

When the `events` table (or other large tables) is on the right side of a JOIN, ClickHouse builds a hash table from ALL rows before applying WHERE filters. This causes queries to timeout or run out of memory because ClickHouse tries to load billions of rows into memory, even though only a single team's data is needed.

The ClickHouse team confirmed this is expected behavior: the `team_id` filter must be applied BEFORE the hash table is built, not in the global WHERE clause.

Closes #41785

## Changes

Modified the HogQL printer to wrap joined tables (right side of non-LEFT JOINs) in a subquery with the `team_id` filter:

**Before:**
```sql
SELECT * FROM scope AS s 
JOIN events AS e ON e.distinct_id = s.distinct_id 
WHERE e.team_id = 123  -- Too late! Hash table already built
```

**After:**
```sql
SELECT * FROM scope AS s 
JOIN (SELECT * FROM events WHERE team_id = 123) AS `e` ON e.distinct_id = s.distinct_id
-- Filter applied BEFORE hash table construction
```

- LEFT JOINs unchanged (team_id stays in ON clause to preserve NULL rows)
- FROM table unchanged (team_id stays in WHERE clause)
- Only affects joined tables on right side of INNER/CROSS/etc. JOINs

## How did you test this code?

- Updated existing unit tests (`test_select_cross_join`, `test_inner_join_team_id_in_subquery`)
- Added regression test `test_events_on_right_side_of_join_issue_41785` that reproduces the exact query pattern from the issue
- Verified LEFT JOIN behavior unchanged in `test_left_join_team_id_in_on_clause`

## Publish to changelog?

No