### PR TITLE
fix: failed to load conversation history before auth

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -1,6 +1,6 @@
 import './Navigation.scss'
 
-import { useActions, useValues } from 'kea'
+import { useActions, useMountedLogic, useValues } from 'kea'
 import { ReactNode, useEffect, useRef } from 'react'
 
 import { BillingAlertsV2 } from 'lib/components/BillingAlertsV2'
@@ -8,6 +8,7 @@ import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableSh
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { cn } from 'lib/utils/css-classes'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { SceneConfig } from 'scenes/sceneTypes'
 
@@ -34,6 +35,7 @@ export function Navigation({
     children: ReactNode
     sceneConfig: SceneConfig | null
 }): JSX.Element {
+    useMountedLogic(maxGlobalLogic)
     const { isDev } = useValues(preflightLogic)
     const { theme } = useValues(themeLogic)
     const { mobileLayout } = useValues(navigationLogic)

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -12,7 +12,6 @@ import { eventIngestionRestrictionLogic } from 'lib/logic/eventIngestionRestrict
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { appLogic } from 'scenes/appLogic'
 import { appScenes } from 'scenes/appScenes'
-import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { userLogic } from 'scenes/userLogic'
 
@@ -33,7 +32,6 @@ export function App(): JSX.Element | null {
     useMountedLogic(sceneLogic({ scenes: appScenes }))
     useMountedLogic(apiStatusLogic)
     useMountedLogic(eventIngestionRestrictionLogic)
-    useMountedLogic(maxGlobalLogic)
     useThemedHtml()
 
     if (showApp) {

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -10,7 +10,6 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
-import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
@@ -84,17 +83,8 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
             ['featureFlags'],
             sidePanelStateLogic,
             ['sidePanelOpen', 'selectedTab'],
-            teamLogic,
-            ['currentTeamId'],
         ],
-        actions: [
-            router,
-            ['locationChanged'],
-            sidePanelStateLogic,
-            ['openSidePanel'],
-            teamLogic,
-            ['loadCurrentTeamSuccess'],
-        ],
+        actions: [router, ['locationChanged'], sidePanelStateLogic, ['openSidePanel']],
     })),
     actions({
         openSidePanelMax: (conversationId?: string) => ({ conversationId }),
@@ -210,22 +200,9 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
         loadConversationHistoryFailure: ({ errorObject }) => {
             lemonToast.error(errorObject?.data?.detail || 'Failed to load conversation history.')
         },
-        loadCurrentTeamSuccess: ({ currentTeam }) => {
-            // Load conversation history when team becomes available (e.g., after login)
-            if (
-                currentTeam &&
-                values.featureFlags[FEATURE_FLAGS.AI_FIRST] &&
-                values.conversationHistory.length === 0 &&
-                !values.conversationHistoryLoading
-            ) {
-                actions.loadConversationHistory()
-            }
-        },
     })),
     afterMount(({ actions, values }) => {
-        // Only load conversation history if we have a valid team (i.e., user is authenticated)
-        // During auth/verification flows, currentTeamId will be null
-        if (values.featureFlags[FEATURE_FLAGS.AI_FIRST] && values.currentTeamId) {
+        if (values.featureFlags[FEATURE_FLAGS.AI_FIRST]) {
             actions.loadConversationHistory()
         }
     }),

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -10,6 +10,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
@@ -83,8 +84,17 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
             ['featureFlags'],
             sidePanelStateLogic,
             ['sidePanelOpen', 'selectedTab'],
+            teamLogic,
+            ['currentTeamId'],
         ],
-        actions: [router, ['locationChanged'], sidePanelStateLogic, ['openSidePanel']],
+        actions: [
+            router,
+            ['locationChanged'],
+            sidePanelStateLogic,
+            ['openSidePanel'],
+            teamLogic,
+            ['loadCurrentTeamSuccess'],
+        ],
     })),
     actions({
         openSidePanelMax: (conversationId?: string) => ({ conversationId }),
@@ -200,9 +210,22 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
         loadConversationHistoryFailure: ({ errorObject }) => {
             lemonToast.error(errorObject?.data?.detail || 'Failed to load conversation history.')
         },
+        loadCurrentTeamSuccess: ({ currentTeam }) => {
+            // Load conversation history when team becomes available (e.g., after login)
+            if (
+                currentTeam &&
+                values.featureFlags[FEATURE_FLAGS.AI_FIRST] &&
+                values.conversationHistory.length === 0 &&
+                !values.conversationHistoryLoading
+            ) {
+                actions.loadConversationHistory()
+            }
+        },
     })),
     afterMount(({ actions, values }) => {
-        if (values.featureFlags[FEATURE_FLAGS.AI_FIRST]) {
+        // Only load conversation history if we have a valid team (i.e., user is authenticated)
+        // During auth/verification flows, currentTeamId will be null
+        if (values.featureFlags[FEATURE_FLAGS.AI_FIRST] && values.currentTeamId) {
             actions.loadConversationHistory()
         }
     }),


### PR DESCRIPTION
## Problem

The "Failed to load conversation history" error appears on logout and during the email verification step after signup. This occurs because `maxGlobalLogic` attempts to load conversation history in its `afterMount` hook even when the user is not fully authenticated and `currentTeamId` is not yet available. `ApiConfig.getCurrentTeamId()` throws an error in this case. 

<img width="1428" height="1071" alt="Screenshot 2026-01-26 at 14 34 40" src="https://github.com/user-attachments/assets/d0dff678-30ac-4d11-897c-894f62a5701f" />

## Changes

Moved `useMountedLogic(maxGlobalLogic)` from `App` to `Navigation`. Since it's actually used there and it only renders for authenticated users. 

Note: I initially tried to check in the afterMount if `currentTeamId` exists before loading. That works too, but is less clean imo (the logic would still mount on pages where PosthogAI is never used anyway). ter authentication.

## How did you test this code?

Manually tested by:
1. Logging out and verifying the error no longer appears.
2. Signing up for a new account and verifying the error does not appear during the email verification step.
3. Confirming that conversation history loads correctly after a successful login.