### PR TITLE
refactor(logs): migrate filters to use logsViewerConfigLogic

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/DateRangeFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/DateRangeFilter.tsx
@@ -9,8 +9,6 @@ import { DateMappingOption } from '~/types'
 
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 
-import { logsSceneLogic } from '../../../logsSceneLogic'
-
 const dateMapping: DateMappingOption[] = [
     { key: CUSTOM_OPTION_KEY, values: [] },
     {
@@ -56,8 +54,9 @@ const dateMapping: DateMappingOption[] = [
 ]
 
 export const DateRangeFilter = (): JSX.Element => {
-    const { dateRange } = useValues(logsSceneLogic)
-    const { setDateRange } = useActions(logsSceneLogic)
+    const {
+        filters: { dateRange },
+    } = useValues(logsViewerConfigLogic)
     const { setFilter } = useActions(logsViewerConfigLogic)
 
     return (
@@ -67,7 +66,6 @@ export const DateRangeFilter = (): JSX.Element => {
             dateTo={dateRange.date_to}
             dateOptions={dateMapping}
             onChange={(changedDateFrom, changedDateTo) => {
-                setDateRange({ date_from: changedDateFrom, date_to: changedDateTo })
                 setFilter('dateRange', { date_from: changedDateFrom, date_to: changedDateTo })
             }}
             allowTimePrecision

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -45,8 +45,12 @@ const taxonomicGroupTypes = [
 
 export const LogsFilterBar = (): JSX.Element => {
     const newLogsDateRangePicker = useFeatureFlag('NEW_LOGS_DATE_RANGE_PICKER')
-    const { logsLoading, liveTailRunning, liveTailDisabledReason, dateRange } = useValues(logsSceneLogic)
-    const { runQuery, zoomDateRange, setLiveTailRunning, setDateRange } = useActions(logsSceneLogic)
+    const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsSceneLogic)
+    const { runQuery, zoomDateRange, setLiveTailRunning } = useActions(logsSceneLogic)
+    const {
+        filters: { dateRange },
+    } = useValues(logsViewerConfigLogic)
+    const { setFilter } = useActions(logsViewerConfigLogic)
 
     return (
         <LogsFilterGroup>
@@ -76,7 +80,10 @@ export const LogsFilterBar = (): JSX.Element => {
 
                         {!newLogsDateRangePicker && <DateRangeFilter />}
                         {newLogsDateRangePicker && (
-                            <LogsDateRangePicker dateRange={dateRange} setDateRange={setDateRange} />
+                            <LogsDateRangePicker
+                                dateRange={dateRange}
+                                setDateRange={(newDateRange) => setFilter('dateRange', newDateRange)}
+                            />
                         )}
 
                         <LemonButton
@@ -113,14 +120,16 @@ export const LogsFilterBar = (): JSX.Element => {
 }
 
 const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Element => {
-    const { filterGroup, tabId, utcDateRange, serviceNames, filterGroup: logsFilterGroup } = useValues(logsSceneLogic)
-    const { setFilterGroup } = useActions(logsSceneLogic)
+    const { tabId, utcDateRange } = useValues(logsSceneLogic)
+    const {
+        filters: { filterGroup, serviceNames },
+    } = useValues(logsViewerConfigLogic)
     const { setFilter } = useActions(logsViewerConfigLogic)
 
     const endpointFilters = {
         dateRange: { ...utcDateRange, date_to: utcDateRange.date_to ?? dayjs().toISOString() },
-        filterGroup: logsFilterGroup,
-        serviceNames: serviceNames,
+        filterGroup,
+        serviceNames,
     }
 
     return (
@@ -131,7 +140,6 @@ const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Eleme
             endpointFilters={endpointFilters}
             onChange={(group) => {
                 const newFilterGroup = { type: FilterLogicalOperator.And, values: [group] }
-                setFilterGroup(newFilterGroup)
                 setFilter('filterGroup', newFilterGroup)
             }}
         >
@@ -142,7 +150,10 @@ const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Eleme
 
 const LogsFilterSearch = (): JSX.Element => {
     const [visible, setVisible] = useState<boolean>(false)
-    const { utcDateRange, serviceNames, filterGroup: logsFilterGroup } = useValues(logsSceneLogic)
+    const { utcDateRange } = useValues(logsSceneLogic)
+    const {
+        filters: { filterGroup: logsFilterGroup, serviceNames },
+    } = useValues(logsViewerConfigLogic)
     const { addGroupFilter, setGroupValues } = useActions(universalFiltersLogic)
     const { filterGroup } = useValues(universalFiltersLogic)
 

--- a/products/logs/frontend/components/LogsViewer/Filters/SearchTermFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SearchTermFilter.tsx
@@ -4,11 +4,10 @@ import { LemonInput } from '@posthog/lemon-ui'
 
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 
-import { logsSceneLogic } from '../../../logsSceneLogic'
-
 export const SearchTermFilter = (): JSX.Element => {
-    const { searchTerm } = useValues(logsSceneLogic)
-    const { setSearchTerm } = useActions(logsSceneLogic)
+    const {
+        filters: { searchTerm },
+    } = useValues(logsViewerConfigLogic)
     const { setFilter } = useActions(logsViewerConfigLogic)
 
     return (
@@ -16,7 +15,6 @@ export const SearchTermFilter = (): JSX.Element => {
             size="small"
             value={searchTerm}
             onChange={(value) => {
-                setSearchTerm(value)
                 setFilter('searchTerm', value)
             }}
             placeholder="Search logs..."

--- a/products/logs/frontend/components/LogsViewer/Filters/ServiceFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/ServiceFilter.tsx
@@ -9,12 +9,11 @@ import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 
-import { logsSceneLogic } from '../../../logsSceneLogic'
-
 export const ServiceFilter = (): JSX.Element => {
-    const { serviceNames, dateRange } = useValues(logsSceneLogic)
+    const {
+        filters: { serviceNames, dateRange },
+    } = useValues(logsViewerConfigLogic)
     const { currentProjectId } = useValues(projectLogic)
-    const { setServiceNames } = useActions(logsSceneLogic)
     const { setFilter } = useActions(logsViewerConfigLogic)
 
     const endpoint = combineUrl(`api/environments/${currentProjectId}/logs/values`, {
@@ -33,7 +32,6 @@ export const ServiceFilter = (): JSX.Element => {
                 type={PropertyFilterType.Log}
                 value={serviceNames}
                 onSet={(value: LogsQuery['serviceNames']) => {
-                    setServiceNames(value)
                     setFilter('serviceNames', value)
                 }}
                 placeholder="Service name"

--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
@@ -22,9 +22,7 @@ const ALL_LOG_LEVELS = Object.values(options) as LogMessage['severity_text'][]
 
 export const SeverityLevelsFilter = (): JSX.Element => {
     const {
-        config: {
-            filters: { severityLevels },
-        },
+        filters: { severityLevels },
     } = useValues(logsViewerConfigLogic)
     const { setFilter } = useActions(logsViewerConfigLogic)
 


### PR DESCRIPTION
## Problem

Phase 2a established the controlled component pattern for `LogsViewer` with bidirectional communication. Filter components were still using dual-write (writing to both `logsSceneLogic` and `logsViewerConfigLogic`), with only `SeverityLevelsFilter` migrated as a proof of concept.

## Changes

Migrate all remaining filter components to read/write only from `logsViewerConfigLogic`:

- `DateRangeFilter` - removed `logsSceneLogic` dependency
- `SearchTermFilter` - removed `logsSceneLogic` dependency
- `ServiceFilter` - removed `logsSceneLogic` dependency
- `LogsFilterBar` / `LogsFilterGroup` / `LogsFilterSearch` - read filter state from `logsViewerConfigLogic`

Components still use `logsSceneLogic` for:
- UI state: `logsLoading`, `liveTailRunning`, `liveTailDisabledReason`, `tabId`
- UI actions: `runQuery`, `zoomDateRange`, `setLiveTailRunning`
- Derived value: `utcDateRange`

Also updated all components to subscribe to `filters` directly instead of `config.filters` for efficiency.

## How did you test this code?

- All 8 unit tests pass
- TypeScript check passes

## Publish to changelog?

No
