### PR TITLE
chore: Remove node dependencies from posthog image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,16 +167,7 @@ ENV PYTHONUNBUFFERED 1
 
 # Install OS runtime dependencies.
 # Note: please add in this stage runtime dependences only!
-# Add Confluent's client repository for librdkafka runtime
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    "wget" \
-    "gnupg" \
-    && \
-    mkdir -p /etc/apt/keyrings && \
-    wget -qO - https://packages.confluent.io/clients/deb/archive.key | gpg --dearmor -o /etc/apt/keyrings/confluent-clients.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/confluent-clients.gpg] https://packages.confluent.io/clients/deb/ bookworm main" > /etc/apt/sources.list.d/confluent-clients.list && \
-    apt-get update && \
     apt-get install -y --no-install-recommends --allow-downgrades \
     "chromium" \
     "chromium-driver" \
@@ -185,8 +176,6 @@ RUN apt-get update && \
     "libxmlsec1-dev=1.2.37-2" \
     "libxml2" \
     "ffmpeg=7:5.1.8-0+deb12u1" \
-    "librdkafka1=2.10.1-1.cflt~deb12" \
-    "librdkafka++1=2.10.1-1.cflt~deb12" \
     "libssl-dev=3.0.17-1~deb12u2" \
     "libssl3=3.0.17-1~deb12u2" \
     "libjemalloc2" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends --allow-downgrades \
     "chromium" \
     "chromium-driver" \
+    "gettext-base" \
     "libpq-dev" \
     "libxmlsec1=1.2.37-2" \
     "libxmlsec1-dev=1.2.37-2" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@
 #
 # - frontend-build: build the frontend (static assets)
 # - sourcemap-upload: upload sourcemaps to PostHog (isolated, no artifacts)
-# - nodejs-build: build nodejs (Node.js app) & fetch its runtime dependencies
 # - posthog-build: fetch PostHog (Django app) dependencies & build Django collectstatic
 # - fetch-geoip-db: fetch the GeoIP database
+#
+# Node.js services are built separately using Dockerfile.node.
 #
 # In the last stage, we import the artifacts from the previous
 # stages, add some runtime dependencies and build the final image.
@@ -76,73 +77,6 @@ RUN --mount=type=secret,id=posthog_upload_sourcemaps_cli_api_key \
     ) || true && \
     touch /tmp/.sourcemaps-processed
 
-
-#
-# ---------------------------------------------------------
-#
-FROM ghcr.io/posthog/rust-node-container:bookworm_rust_1.91-node_24.13.0 AS nodejs-build
-
-# Compile and install system dependencies
-# Add Confluent's client repository for librdkafka 2.10.1
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    "wget" \
-    "gnupg" \
-    && \
-    mkdir -p /etc/apt/keyrings && \
-    wget -qO - https://packages.confluent.io/clients/deb/archive.key | gpg --dearmor -o /etc/apt/keyrings/confluent-clients.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/confluent-clients.gpg] https://packages.confluent.io/clients/deb/ bookworm main" > /etc/apt/sources.list.d/confluent-clients.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends --allow-downgrades \
-    "make" \
-    "g++" \
-    "gcc" \
-    "python3" \
-    "librdkafka1=2.10.1-1.cflt~deb12" \
-    "librdkafka++1=2.10.1-1.cflt~deb12" \
-    "librdkafka-dev=2.10.1-1.cflt~deb12" \
-    "libssl-dev=3.0.17-1~deb12u2" \
-    "libssl3=3.0.17-1~deb12u2" \
-    "zlib1g-dev" \
-    && \
-    rm -rf /var/lib/apt/lists/*
-
-WORKDIR /code
-COPY turbo.json package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
-COPY ./bin/turbo ./bin/turbo
-COPY ./patches ./patches
-COPY ./rust ./rust
-COPY ./common/esbuilder/ ./common/esbuilder/
-COPY ./common/plugin_transpiler/ ./common/plugin_transpiler/
-COPY ./common/hogvm/typescript/ ./common/hogvm/typescript/
-COPY ./nodejs/package.json ./nodejs/tsconfig.json ./nodejs/
-SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
-
-# Use system librdkafka from Confluent (2.10.1) instead of bundled version
-ENV BUILD_LIBRDKAFKA=0
-
-# Compile and install Node.js dependencies.
-# NOTE: we don't actually use the plugin-transpiler with the nodejs, it's just here for the build.
-RUN --mount=type=cache,id=pnpm,target=/tmp/pnpm-store-v24 \
-    corepack enable && \
-    NODE_OPTIONS="--max-old-space-size=16384" CI=1 pnpm --filter=@posthog/nodejs... install --frozen-lockfile --store-dir /tmp/pnpm-store-v24 && \
-    NODE_OPTIONS="--max-old-space-size=16384" CI=1 pnpm --filter=@posthog/plugin-transpiler... install --frozen-lockfile --store-dir /tmp/pnpm-store-v24 && \
-    NODE_OPTIONS="--max-old-space-size=16384" bin/turbo --filter=@posthog/plugin-transpiler build
-
-# Build the nodejs services.
-#
-# Note: we run the build as a separate action to increase
-# the cache hit ratio of the layers above.
-COPY ./nodejs/src/ ./nodejs/src/
-COPY ./nodejs/tests/ ./nodejs/tests/
-COPY ./nodejs/assets/ ./nodejs/assets/
-COPY ./nodejs/bin/ ./nodejs/bin/
-
-# Build cyclotron first
-RUN NODE_OPTIONS="--max-old-space-size=16384" bin/turbo --filter=@posthog/cyclotron build
-
-# Then build the nodejs services
-RUN NODE_OPTIONS="--max-old-space-size=16384" bin/turbo --filter=@posthog/nodejs build
 
 #
 # ---------------------------------------------------------
@@ -250,7 +184,6 @@ RUN apt-get update && \
     "libxmlsec1=1.2.37-2" \
     "libxmlsec1-dev=1.2.37-2" \
     "libxml2" \
-    "gettext-base" \
     "ffmpeg=7:5.1.8-0+deb12u1" \
     "librdkafka1=2.10.1-1.cflt~deb12" \
     "librdkafka++1=2.10.1-1.cflt~deb12" \
@@ -267,48 +200,6 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/truste
     ACCEPT_EULA=Y apt-get install -y msodbcsql18 && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 24.13.0 with architecture detection and verification
-ENV NODE_VERSION 24.13.0
-
-RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-    amd64) ARCH='x64';; \
-    ppc64el) ARCH='ppc64le';; \
-    s390x) ARCH='s390x';; \
-    arm64) ARCH='arm64';; \
-    armhf) ARCH='armv7l';; \
-    i386) ARCH='x86';; \
-    *) echo "unsupported architecture"; exit 1 ;; \
-    esac \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && set -ex \
-    && for key in \
-    5BE8A3F6C8A5C01D106C0AD820B1A390B168D356 \
-    C0D6248439F1D5604AAFFB4021D900FFDB233756 \
-    DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 \
-    CC68F5A3106FF448322E48ED27F5E38D5B0A215F \
-    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-    890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
-    C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
-    108F52B48DB57BB0CC439B2997B01419BD92F80A \
-    A363A499291CBBC940DD62E41F10027AF002F8B0 \
-    ; do \
-    { gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" && gpg --batch --fingerprint "$key"; } || \
-    { gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" && gpg --batch --fingerprint "$key"; } ; \
-    done \
-    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
-    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-    && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-    && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-    && node --version \
-    && npm --version \
-    && rm -rf /tmp/*
-
 # Install and use a non-root user.
 RUN groupadd -g 1000 posthog && \
     useradd -r -g posthog posthog && \
@@ -318,22 +209,6 @@ USER posthog
 # Add the commit hash
 ARG COMMIT_HASH
 RUN echo $COMMIT_HASH > /code/commit.txt
-
-# Add in the compiled nodejs & its runtime dependencies from the nodejs-build stage.
-COPY --from=nodejs-build --chown=posthog:posthog /code/rust/cyclotron-node/dist /code/rust/cyclotron-node/dist
-COPY --from=nodejs-build --chown=posthog:posthog /code/rust/cyclotron-node/package.json /code/rust/cyclotron-node/package.json
-COPY --from=nodejs-build --chown=posthog:posthog /code/rust/cyclotron-node/index.node /code/rust/cyclotron-node/index.node
-COPY --from=nodejs-build --chown=posthog:posthog /code/common/plugin_transpiler/dist /code/common/plugin_transpiler/dist
-COPY --from=nodejs-build --chown=posthog:posthog /code/common/plugin_transpiler/node_modules /code/common/plugin_transpiler/node_modules
-COPY --from=nodejs-build --chown=posthog:posthog /code/common/plugin_transpiler/package.json /code/common/plugin_transpiler/package.json
-COPY --from=nodejs-build --chown=posthog:posthog /code/common/hogvm/typescript/dist /code/common/hogvm/typescript/dist
-COPY --from=nodejs-build --chown=posthog:posthog /code/common/hogvm/typescript/node_modules /code/common/hogvm/typescript/node_modules
-COPY --from=nodejs-build --chown=posthog:posthog /code/nodejs/dist /code/nodejs/dist
-COPY --from=nodejs-build --chown=posthog:posthog /code/node_modules /code/node_modules
-COPY --from=nodejs-build --chown=posthog:posthog /code/nodejs/node_modules /code/nodejs/node_modules
-COPY --from=nodejs-build --chown=posthog:posthog /code/nodejs/package.json /code/nodejs/package.json
-COPY --from=nodejs-build --chown=posthog:posthog /code/nodejs/assets /code/nodejs/assets
-COPY --from=nodejs-build --chown=posthog:posthog /code/nodejs/bin /code/nodejs/bin
 
 # Copy the Python dependencies and Django staticfiles from the posthog-build stage.
 COPY --from=posthog-build --chown=posthog:posthog /code/staticfiles /code/staticfiles
@@ -381,11 +256,9 @@ COPY --chown=posthog:posthog common/migration_utils common/migration_utils/
 COPY --chown=posthog:posthog products products/
 
 # Setup ENV.
-ENV NODE_ENV=production \
-    CHROME_BIN=/usr/bin/chromium \
+ENV CHROME_BIN=/usr/bin/chromium \
     CHROME_PATH=/usr/lib/chromium/ \
     CHROMEDRIVER_BIN=/usr/bin/chromedriver \
-    BUILD_LIBRDKAFKA=0 \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 # Expose container port and run entry point script.

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -368,7 +368,7 @@ services:
             COOKIELESS_REDIS_PORT: 6379
 
     plugins:
-        command: ./bin/posthog-node --no-restart-loop
+        command: node nodejs/dist/index.js
         restart: on-failure
         environment:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -167,7 +167,9 @@ services:
         extends:
             file: docker-compose.base.yml
             service: plugins
-        build: .
+        build:
+            context: .
+            dockerfile: Dockerfile.node
         volumes:
             - .:/app/posthog
         environment:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -133,7 +133,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: plugins
-        image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        image: ${REGISTRY_URL}-node:${POSTHOG_APP_TAG}
         environment:
             SITE_URL: https://$DOMAIN
             SECRET_KEY: $POSTHOG_SECRET


### PR DESCRIPTION
## Problem

Since we moved all node services to the new node image, we no longer need to have any node dependencies on the posthog image.

## Changes

- Remove the `nodejs-build` stage, Node.js 24.13.0 runtime installation from `Dockerfile`
- Remove `gettext-base`, `NODE_ENV`, and `BUILD_LIBRDKAFKA` env vars that were only needed for Node.js
- Update `docker-compose.hobby.yml` plugins image from `$REGISTRY_URL:$POSTHOG_APP_TAG` to `${REGISTRY_URL}-node:${POSTHOG_APP_TAG}`
- Update `docker-compose.dev-full.yml` plugins build to use `Dockerfile.node`

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
