### PR TITLE
fix(cyclotron): add already applied migration

### DIFF
--- a/.github/workflows/ci-migrations-service-separation-check.yml
+++ b/.github/workflows/ci-migrations-service-separation-check.yml
@@ -30,6 +30,17 @@ jobs:
                           - 'rust/cyclotron-core/migrations/*.sql'
                       nodejs:
                           - 'nodejs/**'
+
+            # Separate step with predicate-quantifier: 'every' so that the
+            # negative patterns actually exclude migration directories.
+            # The default quantifier is 'some' (OR logic), which means a file
+            # matching ANY pattern (including the positive rust/**) passes the
+            # filter — the ! patterns are silently ignored.
+            - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+              id: rust-filter
+              with:
+                  predicate-quantifier: 'every'
+                  filters: |
                       rust_services:
                           - 'rust/**'
                           - '!rust/persons_migrations/**'
@@ -55,7 +66,7 @@ jobs:
                   fi
 
                   # Check rust services + sqlx migrations
-                  if [ "${{ steps.filter.outputs.sqlx_migrations }}" == "true" ] && [ "${{ steps.filter.outputs.rust_services }}" == "true" ]; then
+                  if [ "${{ steps.filter.outputs.sqlx_migrations }}" == "true" ] && [ "${{ steps.rust-filter.outputs.rust_services }}" == "true" ]; then
                       error_messages="${error_messages}❌ Found both sqlx migration and rust service changes\n"
                       has_error=true
                   fi

--- a/rust/cyclotron-core/migrations/20260115221204_add_parent_run_id_column.sql
+++ b/rust/cyclotron-core/migrations/20260115221204_add_parent_run_id_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cyclotron_jobs ADD COLUMN parent_run_id TEXT;


### PR DESCRIPTION
## Problem

We can't run any new migrations as it seems `20260115221204_add_parent_run_id_column.sql` was already applied from this PR (https://github.com/PostHog/posthog/pull/45080/changes#diff-045fb85abe618a58641dd3e029bd4b9c7e03ef2f087aa585dcc8698f385c99c5) but then the PR got reverted but the revert did not revert the applied migration.

## Changes

- re-add migration
