### PR TITLE
chore(cyclotron): remove migration responsibility from janitor

### DIFF
--- a/rust/cyclotron-core/src/janitor.rs
+++ b/rust/cyclotron-core/src/janitor.rs
@@ -5,7 +5,7 @@ use sqlx::PgPool;
 use crate::{
     ops::{
         janitor::{delete_completed_and_failed_jobs, detect_poison_pills, reset_stalled_jobs},
-        meta::{count_total_waiting_jobs, dead_letter, run_migrations},
+        meta::{count_total_waiting_jobs, dead_letter},
     },
     types::AggregatedDelete,
     PoolConfig, QueueError,
@@ -24,10 +24,6 @@ impl Janitor {
 
     pub fn from_pool(pool: PgPool) -> Self {
         Self { pool }
-    }
-
-    pub async fn run_migrations(&self) {
-        run_migrations(&self.pool).await;
     }
 
     pub async fn delete_completed_and_failed_jobs(

--- a/rust/cyclotron-core/src/ops/meta.rs
+++ b/rust/cyclotron-core/src/ops/meta.rs
@@ -1,4 +1,4 @@
-use sqlx::{postgres::PgQueryResult, PgPool};
+use sqlx::postgres::PgQueryResult;
 use uuid::Uuid;
 
 use crate::{
@@ -35,14 +35,6 @@ pub fn throw_if_no_rows(res: PgQueryResult, job: Uuid, lock: Uuid) -> Result<(),
     } else {
         Ok(())
     }
-}
-
-/// Run the latest cyclotron migrations. Panics if the migrations can't be run - failure to run migrations is purposefully fatal.
-pub async fn run_migrations(pool: &PgPool) {
-    sqlx::migrate!("./migrations")
-        .run(pool)
-        .await
-        .expect("Failed to run migrations");
 }
 
 /// Move a job into the dead letter queue, also updating the metadata table. Note that this operation does not

--- a/rust/cyclotron-core/src/worker.rs
+++ b/rust/cyclotron-core/src/worker.rs
@@ -17,7 +17,7 @@ use crate::{
     config::WorkerConfig,
     error::JobError,
     ops::{
-        meta::{dead_letter, run_migrations},
+        meta::dead_letter,
         worker::{dequeue_jobs, dequeue_with_vm_state, flush_job, get_vm_state, set_heartbeat},
     },
     types::Bytes,
@@ -82,11 +82,6 @@ impl Worker {
         ));
 
         worker
-    }
-
-    /// Run the latest cyclotron migrations. Panics if the migrations can't be run - failure to run migrations is purposefully fatal.
-    pub async fn run_migrations(&self) {
-        run_migrations(&self.pool).await;
     }
 
     /// Dequeues jobs from the queue, and returns them. Job sorting happens at the queue level,

--- a/rust/cyclotron-janitor/src/janitor.rs
+++ b/rust/cyclotron-janitor/src/janitor.rs
@@ -61,10 +61,6 @@ impl Janitor {
         })
     }
 
-    pub async fn run_migrations(&self) {
-        self.inner.run_migrations().await;
-    }
-
     pub async fn run_once(&self) -> Result<CleanupResult, QueueError> {
         info!("Running janitor loop");
         let _loop_start = common_metrics::timing_guard(RUN_TIME, &self.metrics_labels);

--- a/rust/cyclotron-janitor/src/main.rs
+++ b/rust/cyclotron-janitor/src/main.rs
@@ -78,8 +78,6 @@ async fn main() {
         .await
         .expect("failed to create janitor");
 
-    janitor.run_migrations().await;
-
     let janitor_liveness = liveness
         .register(
             "janitor".to_string(),


### PR DESCRIPTION
 Summary                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                           
  - Remove run_migrations() from the cyclotron janitor and worker startup paths. Migrations are now handled by a dedicated migrator service (rust/bin/migrate-entry).                
  - Remove the now-unused run_migrations function from cyclotron-core::ops::meta and its wrapper methods on Worker and Janitor.                                                                                                                            
                                                                                                                                                                                                                                                          