### PR TITLE
feat(twig): restrict available models for twig

### DIFF
--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -29,7 +29,15 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
     ),
     "array": ProductConfig(
         allowed_application_ids=frozenset({ARRAY_US_APP_ID, ARRAY_EU_APP_ID}),
-        allowed_models=None,
+        allowed_models=frozenset(
+            {
+                "claude-opus-4-5",
+                "claude-sonnet-4-5",
+                "claude-haiku-4-5",
+                "gpt-5.2",
+                "gpt-5-mini",
+            }
+        ),
         allow_api_keys=False,
     ),
     "wizard": ProductConfig(

--- a/services/llm-gateway/tests/test_model_registry.py
+++ b/services/llm-gateway/tests/test_model_registry.py
@@ -26,6 +26,18 @@ MOCK_COST_DATA: dict[str, ModelCost] = {
         "supports_vision": True,
         "mode": "chat",
     },
+    "gpt-5.2": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "gpt-5-mini": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
     "o1": {
         "litellm_provider": "openai",
         "max_input_tokens": 200000,
@@ -39,6 +51,24 @@ MOCK_COST_DATA: dict[str, ModelCost] = {
         "mode": "chat",
     },
     "claude-3-5-haiku-20241022": {
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "claude-opus-4-5": {
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "claude-sonnet-4-5": {
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "claude-haiku-4-5": {
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "supports_vision": True,
@@ -209,9 +239,14 @@ class TestIsModelAvailable:
         "model_id,product,expected",
         [
             ("gpt-4o", "llm_gateway", True),
-            ("gpt-4o", "array", True),
+            ("gpt-4o", "array", False),
             ("o1", "llm_gateway", True),
-            ("o1", "array", True),
+            ("o1", "array", False),
+            ("gpt-5.2", "array", True),
+            ("gpt-5-mini", "array", True),
+            ("claude-opus-4-5", "array", True),
+            ("claude-sonnet-4-5", "array", True),
+            ("claude-haiku-4-5", "array", True),
             ("unknown-model", "llm_gateway", False),
         ],
     )

--- a/services/llm-gateway/tests/test_models_api.py
+++ b/services/llm-gateway/tests/test_models_api.py
@@ -19,6 +19,18 @@ MOCK_COST_DATA: dict[str, ModelCost] = {
         "supports_vision": True,
         "mode": "chat",
     },
+    "gpt-5.2": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "gpt-5-mini": {
+        "litellm_provider": "openai",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
     "o1": {
         "litellm_provider": "openai",
         "max_input_tokens": 200000,
@@ -26,6 +38,24 @@ MOCK_COST_DATA: dict[str, ModelCost] = {
         "mode": "chat",
     },
     "claude-3-5-sonnet-20241022": {
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "claude-opus-4-5": {
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "claude-sonnet-4-5": {
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "claude-haiku-4-5": {
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "supports_vision": True,
@@ -115,15 +145,20 @@ class TestListModelsForProductEndpoint:
         assert "gpt-4o" in model_ids
         assert "o1" in model_ids
 
-    def test_array_returns_all_models_from_configured_providers(self, client: TestClient):
+    def test_array_returns_only_restricted_models(self, client: TestClient):
         response = client.get("/array/v1/models")
         assert response.status_code == 200
         data = response.json()
         model_ids = {m["id"] for m in data["data"]}
-        assert "gpt-4o" in model_ids
-        assert "o1" in model_ids
-        assert "claude-3-5-sonnet-20241022" in model_ids
-        assert "gemini-2.0-flash" in model_ids
+        assert "claude-opus-4-5" in model_ids
+        assert "claude-sonnet-4-5" in model_ids
+        assert "claude-haiku-4-5" in model_ids
+        assert "gpt-5.2" in model_ids
+        assert "gpt-5-mini" in model_ids
+        assert "gpt-4o" not in model_ids
+        assert "o1" not in model_ids
+        assert "claude-3-5-sonnet-20241022" not in model_ids
+        assert "gemini-2.0-flash" not in model_ids
 
     def test_returns_error_for_invalid_product(self, client: TestClient):
         response = client.get("/invalid_product/v1/models")

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -69,17 +69,33 @@ class TestCheckProductAccess:
     @pytest.mark.parametrize(
         "model",
         [
-            "claude-3-5-haiku-20241022",
-            "gpt-4o-mini",
+            "claude-opus-4-5",
+            "claude-sonnet-4-5",
+            "claude-haiku-4-5",
+            "gpt-5.2",
+            "gpt-5-mini",
+        ],
+    )
+    def test_array_allows_restricted_models_with_valid_app_id(self, model: str):
+        allowed, error = check_product_access("array", "oauth_access_token", ARRAY_US_APP_ID, model)
+        assert allowed is True
+        assert error is None
+
+    @pytest.mark.parametrize(
+        "model",
+        [
             "gpt-4o",
+            "gpt-4o-mini",
+            "claude-3-5-haiku-20241022",
             "claude-3-opus",
             "o1",
         ],
     )
-    def test_array_allows_all_models_with_valid_app_id(self, model: str):
+    def test_array_rejects_non_allowed_models(self, model: str):
         allowed, error = check_product_access("array", "oauth_access_token", ARRAY_US_APP_ID, model)
-        assert allowed is True
-        assert error is None
+        assert allowed is False
+        assert error is not None
+        assert "not allowed" in error
 
 
 class TestValidateProduct:


### PR DESCRIPTION
## Problem

We were still exposing all available gateway models for Twig. We want the gateway product to be the source of truth for available models in the app. <!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Restrict the available list of models to just the latest Anthropic and OpenAI models.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
