### PR TITLE
fix(data-table): display back to source button for event query

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -873,11 +873,13 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         backToSourceQuery: [
             (s) => [s.query],
             (query): InsightVizNode | null => {
-                if (isActorsQuery(query) && isInsightActorsQuery(query.source) && !!query.source.source) {
-                    const insightQuery = query.source.source
+                const insightSource =
+                    (isActorsQuery(query) && isInsightActorsQuery(query.source) ? query.source.source : null) ??
+                    (isEventsQuery(query) && isInsightActorsQuery(query.source) ? query.source.source : null)
+                if (insightSource) {
                     const insightVizNode: InsightVizNode = {
                         kind: NodeKind.InsightVizNode,
-                        source: insightQuery,
+                        source: insightSource,
                         full: true,
                     }
                     return insightVizNode

--- a/frontend/src/queries/nodes/DataTable/BackToSource.tsx
+++ b/frontend/src/queries/nodes/DataTable/BackToSource.tsx
@@ -1,6 +1,8 @@
 import { useValues } from 'kea'
 import { router } from 'kea-router'
 
+import { IconArrowLeft } from '@posthog/icons'
+
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { summarizeInsightQuery } from 'scenes/insights/summarizeInsight'
 import { mathsLogic } from 'scenes/trends/mathsLogic'
@@ -21,19 +23,22 @@ export function BackToSource(): JSX.Element | null {
         return null
     }
 
-    const summary = summarizeInsightQuery(backToSourceQuery.source, {
+    const insightSummary = summarizeInsightQuery(backToSourceQuery.source, {
         aggregationLabel,
         cohortsById,
         mathDefinitions,
     })
+    const summary = `Viewing actors query based on insight: ${insightSummary}`
 
     return (
         <LemonButton
             tooltip={summary}
-            type="secondary"
+            type="primary"
             onClick={() => router.actions.push(urls.insightNew({ query: backToSourceQuery }))}
+            size="small"
+            className="mr-2"
         >
-            &laquo; Back to {backToSourceQuery.source.kind?.replace('Query', '') ?? 'Insight'}
+            <IconArrowLeft aria-hidden="true" className="size-3 text-tertiary mr-1" /> View source insight
         </LemonButton>
     )
 }


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/45271

https://posthog.slack.com/archives/C045L1VEG87/p1768324008219379

## Changes


![Screenshot 2026-01-26 at 14.51.52.png](https://app.graphite.com/user-attachments/assets/4b2407b1-8b7d-450f-aae1-55db9e7b4521.png)

## How did you test this code?

Manually