### PR TITLE
fix: add new items to new search

### DIFF
--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -168,9 +168,16 @@ const getIconForItem = (item: SearchItem): ReactNode => {
         itemType = 'workflows'
     }
     if (itemType) {
+        // Handle iconColor which may be a single-element array or tuple
+        const rawColor = item.record?.iconColor as string[] | undefined
+        const colorOverride: [string, string] | undefined = rawColor
+            ? rawColor.length === 1
+                ? [rawColor[0], rawColor[0]]
+                : [rawColor[0], rawColor[1]]
+            : undefined
         return (
-            <ProductIconWrapper type={itemType as string}>
-                {iconForType(itemType as FileSystemIconType)}
+            <ProductIconWrapper type={itemType as string} colorOverride={colorOverride}>
+                {iconForType(itemType as FileSystemIconType, colorOverride)}
             </ProductIconWrapper>
         )
     }
@@ -332,8 +339,8 @@ function SearchRoot({
             loadingByCategory.set(cat.key, cat.isLoading ?? false)
         }
 
-        // Fixed order: recents first, then apps, then everything else
-        const orderedCategories = ['recents', 'apps']
+        // Fixed order: recents first, then apps, then create, then everything else
+        const orderedCategories = ['recents', 'apps', 'create']
         const hasSearchValue = searchValue.trim().length > 0
 
         for (const category of orderedCategories) {
@@ -342,9 +349,10 @@ function SearchRoot({
 
             // When searching: hide empty groups (unless still loading)
             // When not searching: always show recents/apps (with skeleton if loading)
+            // "create" is only shown when searching
             const shouldShow = hasSearchValue
                 ? items.length > 0 || isLoading
-                : category === 'recents' || category === 'apps' || items.length > 0
+                : category === 'recents' || category === 'apps'
 
             if (shouldShow) {
                 groups.push({ category, items, isLoading })

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -715,7 +715,12 @@ export const searchLogic = kea<searchLogicType>([
 
                         // Every chunk must match either "new"/"create" or be found in the item name/type/id
                         return searchChunks.every((chunk) => {
-                            if (chunk.includes('new') || chunk.includes('create')) {
+                            if (
+                                chunk === 'new' ||
+                                chunk === 'create' ||
+                                chunk.startsWith('new') ||
+                                chunk.startsWith('create')
+                            ) {
                                 return true
                             }
                             if (nameLower.includes(chunk)) {

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -715,7 +715,7 @@ export const searchLogic = kea<searchLogicType>([
 
                         // Every chunk must match either "new"/"create" or be found in the item name/type/id
                         return searchChunks.every((chunk) => {
-                            if ('new'.includes(chunk) || 'create'.includes(chunk)) {
+                            if (chunk.includes('new') || chunk.includes('create')) {
                                 return true
                             }
                             if (nameLower.includes(chunk)) {

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -11,7 +11,7 @@ import { urls } from 'scenes/urls'
 
 import { splitPath, unescapePath } from '~/layout/panel-layout/ProjectTree/utils'
 import { groupsModel } from '~/models/groupsModel'
-import { getTreeItemsMetadata, getTreeItemsProducts } from '~/products'
+import { getTreeItemsMetadata, getTreeItemsNew, getTreeItemsProducts } from '~/products'
 import { FileSystemEntry, FileSystemViewLogEntry, GroupsQueryResponse } from '~/queries/schema/schema-general'
 import { ActivityTab, Group, GroupTypeIndex, PersonType, SearchResponse } from '~/types'
 
@@ -405,6 +405,55 @@ export const searchLogic = kea<searchLogicType>([
                 })
             },
         ],
+        newItems: [
+            (s) => [s.featureFlags, s.isDev],
+            (featureFlags, isDev): SearchItem[] => {
+                const allNewItems = getTreeItemsNew()
+                const filteredItems = allNewItems.filter((item) => {
+                    if (!isDev && item.category === 'Unreleased') {
+                        return false
+                    }
+                    if (item.flag && !(featureFlags as Record<string, boolean>)[item.flag]) {
+                        return false
+                    }
+                    return true
+                })
+
+                return filteredItems.map((item) => {
+                    // Format display name:
+                    // "Insight/Lifecycle" -> "New Lifecycle insight"
+                    // "Data/Destination" -> "New Destination" (no suffix for Data)
+                    const pathParts = item.path.split('/')
+                    let displayName: string
+                    if (pathParts.length > 1) {
+                        const suffix = pathParts[0].toLowerCase()
+                        // Don't append "data" suffix for data pipeline items
+                        displayName =
+                            suffix === 'data'
+                                ? `New ${pathParts.slice(1).join(' ')}`
+                                : `New ${pathParts.slice(1).join(' ')} ${suffix}`
+                    } else {
+                        displayName = `New ${item.path}`
+                    }
+
+                    return {
+                        id: `new-${item.path}`,
+                        name: displayName,
+                        displayName,
+                        category: 'create',
+                        productCategory: item.category || null,
+                        href: item.href || '#',
+                        itemType: item.iconType || item.type || null,
+                        tags: item.tags,
+                        record: {
+                            type: item.type || item.iconType,
+                            iconType: item.iconType,
+                            iconColor: item.iconColor,
+                        },
+                    }
+                })
+            },
+        ],
         groupItems: [
             (s) => [s.groupSearchResults, s.aggregationLabel],
             (groupSearchResults, aggregationLabel): SearchItem[] => {
@@ -565,36 +614,36 @@ export const searchLogic = kea<searchLogicType>([
                 s.recentItems,
                 s.appsItems,
                 s.dataManagementItems,
+                s.newItems,
                 s.personItems,
                 s.groupItems,
                 s.playlistItems,
                 s.unifiedSearchItems,
+                s.unifiedSearchResults,
                 s.recentsLoading,
                 s.recentsHasLoaded,
                 s.sceneLogViewsLoading,
                 s.sceneLogViewsHasLoaded,
                 s.personSearchResultsLoading,
                 s.groupSearchResultsLoading,
-                s.playlistSearchResultsLoading,
-                s.unifiedSearchResultsLoading,
                 s.search,
             ],
             (
                 recentItems,
                 appsItems,
                 dataManagementItems,
+                newItems,
                 personItems,
                 groupItems,
                 playlistItems,
                 unifiedSearchItems,
+                unifiedSearchResults,
                 recentsLoading,
                 recentsHasLoaded,
                 sceneLogViewsLoading,
                 sceneLogViewsHasLoaded,
                 personSearchResultsLoading,
                 groupSearchResultsLoading,
-                playlistSearchResultsLoading,
-                unifiedSearchResultsLoading,
                 search
             ): SearchCategory[] => {
                 const categories: SearchCategory[] = []
@@ -646,9 +695,49 @@ export const searchLogic = kea<searchLogicType>([
                     })
                 }
 
+                // Show "create" category only when searching and matching "new" or relevant keywords
+                if (hasSearch) {
+                    const searchLower = search.toLowerCase()
+                    const searchChunks = searchLower.split(' ').filter((s) => s)
+
+                    // Filter new items - ALL search chunks must match
+                    const filteredNewItems = newItems.filter((item) => {
+                        const nameLower = (item.displayName || item.name || '').toLowerCase()
+                        const typeLower = (item.itemType || '').toLowerCase()
+                        // Also search against the original path (stored in id as "new-{path}")
+                        const idLower = item.id.toLowerCase()
+
+                        // Every chunk must match either "new"/"create" or be found in the item name/type/id
+                        return searchChunks.every((chunk) => {
+                            if ('new'.includes(chunk) || 'create'.includes(chunk)) {
+                                return true
+                            }
+                            if (nameLower.includes(chunk)) {
+                                return true
+                            }
+                            if (typeLower.includes(chunk)) {
+                                return true
+                            }
+                            if (idLower.includes(chunk)) {
+                                return true
+                            }
+                            return false
+                        })
+                    })
+
+                    if (filteredNewItems.length > 0) {
+                        categories.push({
+                            key: 'create',
+                            items: filteredNewItems,
+                            isLoading: false,
+                        })
+                    }
+                }
+
                 // Only show unified search results when searching
                 if (hasSearch) {
-                    const unifiedLoading = unifiedSearchResultsLoading
+                    // unifiedSearchResults is null when still loading (initial state)
+                    const unifiedLoading = unifiedSearchResults === null
 
                     // Add unified search categories
                     const categoryOrder = [
@@ -678,11 +767,11 @@ export const searchLogic = kea<searchLogicType>([
                     }
 
                     // Add session recording playlists
-                    if (playlistItems.length > 0 || playlistSearchResultsLoading) {
+                    if (playlistItems.length > 0) {
                         categories.push({
                             key: 'session_recording_playlist',
                             items: playlistItems,
-                            isLoading: playlistSearchResultsLoading,
+                            isLoading: false,
                         })
                     }
 

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -232,6 +232,13 @@ export const searchLogic = kea<searchLogicType>([
                 loadSceneLogViewsFailure: () => true,
             },
         ],
+        isAppsLoading: [
+            true,
+            {
+                loadSceneLogViewsSuccess: () => false,
+                loadSceneLogViewsFailure: () => false,
+            },
+        ],
     }),
     selectors({
         sceneLogViewsByRef: [
@@ -619,13 +626,13 @@ export const searchLogic = kea<searchLogicType>([
                 s.groupItems,
                 s.playlistItems,
                 s.unifiedSearchItems,
-                s.unifiedSearchResults,
+                s.unifiedSearchResultsLoading,
                 s.recentsLoading,
                 s.recentsHasLoaded,
-                s.sceneLogViewsLoading,
-                s.sceneLogViewsHasLoaded,
+                s.isAppsLoading,
                 s.personSearchResultsLoading,
                 s.groupSearchResultsLoading,
+                s.playlistSearchResultsLoading,
                 s.search,
             ],
             (
@@ -637,13 +644,13 @@ export const searchLogic = kea<searchLogicType>([
                 groupItems,
                 playlistItems,
                 unifiedSearchItems,
-                unifiedSearchResults,
+                unifiedSearchResultsLoading,
                 recentsLoading,
                 recentsHasLoaded,
-                sceneLogViewsLoading,
-                sceneLogViewsHasLoaded,
+                isAppsLoading,
                 personSearchResultsLoading,
                 groupSearchResultsLoading,
+                playlistSearchResultsLoading,
                 search
             ): SearchCategory[] => {
                 const categories: SearchCategory[] = []
@@ -673,7 +680,6 @@ export const searchLogic = kea<searchLogicType>([
                 })
 
                 // Filter apps and data management by search
-                const isAppsLoading = sceneLogViewsLoading || !sceneLogViewsHasLoaded
                 const filteredApps = filterBySearch(appsItems)
                 const filteredDataManagement = filterBySearch(dataManagementItems)
 
@@ -736,8 +742,7 @@ export const searchLogic = kea<searchLogicType>([
 
                 // Only show unified search results when searching
                 if (hasSearch) {
-                    // unifiedSearchResults is null when still loading (initial state)
-                    const unifiedLoading = unifiedSearchResults === null
+                    const unifiedLoading = unifiedSearchResultsLoading
 
                     // Add unified search categories
                     const categoryOrder = [
@@ -767,11 +772,11 @@ export const searchLogic = kea<searchLogicType>([
                     }
 
                     // Add session recording playlists
-                    if (playlistItems.length > 0) {
+                    if (playlistItems.length > 0 || playlistSearchResultsLoading) {
                         categories.push({
                             key: 'session_recording_playlist',
                             items: playlistItems,
-                            isLoading: false,
+                            isLoading: playlistSearchResultsLoading,
                         })
                     }
 

--- a/frontend/src/lib/components/Search/utils.ts
+++ b/frontend/src/lib/components/Search/utils.ts
@@ -3,6 +3,7 @@ import { pluralize } from 'lib/utils'
 
 export const getCategoryDisplayName = (category: string): string => {
     const displayNames: Record<string, string> = {
+        create: 'Create new',
         'create-new': 'Create new',
         apps: 'Apps',
         'data-management': 'Data management',

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -811,7 +811,7 @@ export const fileSystemTypes = {
         filterKey: 'revenue',
     },
     session_recording_playlist: {
-        name: 'Replay playlist',
+        name: 'Replay saved filter',
         iconType: 'session_replay',
         href: (ref: string) => urls.replayPlaylist(ref),
         iconColor: ['var(--color-product-session-replay-light)', 'var(--color-product-session-replay-dark)'],

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -811,7 +811,7 @@ export const fileSystemTypes = {
         filterKey: 'revenue',
     },
     session_recording_playlist: {
-        name: 'Replay saved filter',
+        name: 'Replay playlist',
         iconType: 'session_replay',
         href: (ref: string) => urls.replayPlaylist(ref),
         iconColor: ['var(--color-product-session-replay-light)', 'var(--color-product-session-replay-dark)'],


### PR DESCRIPTION
## Problem
Users are used to the old search ux typing "new" and having items show up to create new things (like insights, surveys etc)

## Changes
* Add in new items into `searchLogic` 

![2026-01-26 14 18 35](https://github.com/user-attachments/assets/c8a170cb-8942-4c48-9c8c-5ed8a86f8e9e)


## How did you test this code?
Locally

## Publish to changelog?
No