### PR TITLE
chore(dev): limit cargo parallel jobs in mprocs

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -27,6 +27,8 @@ rustfmt = { pkg-path = "rustfmt", pkg-group = "rust-toolchain" }
 rust-lib-src = { pkg-path = "rustPlatform.rustLibSrc", pkg-group = "rust-toolchain" }
 libiconv = { pkg-path = "libiconv", systems = ["aarch64-darwin"], pkg-group = "rust-toolchain" }
 rust-analyzer = { pkg-path = "rust-analyzer", pkg-group = "rust-analyzer" } # rust-analyzer should be isolated in its own group, details in cookbook example
+lld = { pkg-path = "lld", systems = ["aarch64-darwin"] } # Faster linker for Rust dev builds on macOS
+sccache = { pkg-path = "sccache" } # Compilation cache for Rust (also used in CI)
 # Go
 go = { pkg-path = "go", version = "1.24", pkg-group = "go" }
 golangci-lint = { pkg-path = "golangci-lint", pkg-group = "go" }

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -40,6 +40,7 @@ postgresql = { pkg-path = "postgresql_14" } # psql
 ffmpeg.pkg-path = "ffmpeg"
 gh = { pkg-path = "gh" }
 protobuf = { pkg-path = "protobuf" } # protoc compiler for gRPC code generation
+watchman = { pkg-path = "watchman" } # Fast file watching for Django/Celery autoreload (uses pywatchman)
 
 # Set environment variables in the `[vars]` section. These variables may not
 # reference one another, and are added to the environment without first

--- a/bin/start
+++ b/bin/start
@@ -18,6 +18,10 @@ export SESSION_RECORDING_V2_S3_ENDPOINT=${SESSION_RECORDING_V2_S3_ENDPOINT:-http
 export DEBUG=${DEBUG:-1}
 export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
 
+# Limit Rust parallel compilation jobs to reduce CPU contention when multiple
+# services start simultaneously via mprocs (they share a build lock anyway)
+export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}"
+
 export BILLING_SERVICE_URL=${BILLING_SERVICE_URL:-https://billing.dev.posthog.dev}
 export API_QUERIES_PER_TEAM='{"1": 100}'
 

--- a/bin/start
+++ b/bin/start
@@ -22,6 +22,9 @@ export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
 # services start simultaneously via mprocs (they share a build lock anyway)
 export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}"
 
+# Use sccache for Rust compilation caching (requires sccache in PATH via flox)
+export RUSTC_WRAPPER="${RUSTC_WRAPPER:-sccache}"
+
 export BILLING_SERVICE_URL=${BILLING_SERVICE_URL:-https://billing.dev.posthog.dev}
 export API_QUERIES_PER_TEAM='{"1": 100}'
 

--- a/bin/start
+++ b/bin/start
@@ -22,8 +22,15 @@ export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
 # services start simultaneously via mprocs (they share a build lock anyway)
 export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}"
 
-# Use sccache for Rust compilation caching (requires sccache in PATH via flox)
-export RUSTC_WRAPPER="${RUSTC_WRAPPER:-sccache}"
+# Use sccache for Rust compilation caching (if available via flox or homebrew)
+if [[ -z "${RUSTC_WRAPPER:-}" ]] && command -v sccache &>/dev/null; then
+    export RUSTC_WRAPPER="sccache"
+fi
+
+# Use lld linker on macOS for faster Rust linking (if available via flox or homebrew)
+if [[ "$(uname -s)" == "Darwin" ]] && [[ -z "${CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS:-}" ]] && command -v lld &>/dev/null; then
+    export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-fuse-ld=lld"
+fi
 
 export BILLING_SERVICE_URL=${BILLING_SERVICE_URL:-https://billing.dev.posthog.dev}
 export API_QUERIES_PER_TEAM='{"1": 100}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,6 +262,7 @@ dev = [
     "types-requests==2.31.0.6",
     "types-retry==0.9.9.4",
     "types-tzlocal~=5.1.0.1",
+    "pywatchman>=2.0.0",
     "watchdog==5.0.3",
 ]
 

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -2,3 +2,8 @@
 # Force SQLX to run in offline mode for CI. Devs can change this if they want, to live code against the DB,
 # but we use it at the workspace level here to allow use of sqlx macros across all crates
 SQLX_OFFLINE = "true"
+
+# Use lld linker on macOS for faster linking (2-4x speedup)
+# Only affects local dev; CI runs on Linux and ignores this
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -2,8 +2,3 @@
 # Force SQLX to run in offline mode for CI. Devs can change this if they want, to live code against the DB,
 # but we use it at the workspace level here to allow use of sqlx macros across all crates
 SQLX_OFFLINE = "true"
-
-# Use lld linker on macOS for faster linking (2-4x speedup)
-# Only affects local dev; CI runs on Linux and ignores this
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/uv.lock
+++ b/uv.lock
@@ -4619,6 +4619,7 @@ dev = [
     { name = "pytest-watch" },
     { name = "pytest-xdist" },
     { name = "python-dateutil" },
+    { name = "pywatchman" },
     { name = "requests-mock" },
     { name = "responses" },
     { name = "ruff" },
@@ -4874,6 +4875,7 @@ dev = [
     { name = "pytest-watch", specifier = "==4.2.0" },
     { name = "pytest-xdist", specifier = "~=3.8.0" },
     { name = "python-dateutil", specifier = "~=2.9.0" },
+    { name = "pywatchman", specifier = ">=2.0.0" },
     { name = "requests-mock", specifier = "~=1.12.1" },
     { name = "responses", specifier = "==0.23.1" },
     { name = "ruff", specifier = "~=0.14.11" },
@@ -5707,6 +5709,16 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/32/12032aa8c673ee16707a9b6cdda2b09c0089131f35af55d443b6a9c69c1d/pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588", size = 317095, upload-time = "2023-03-29T04:23:28.655Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/99/ad6bd37e748257dd70d6f85d916cafe79c0b0f5e2e95b11f7fbc82bf3110/pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb", size = 502345, upload-time = "2023-03-29T04:23:25.307Z" },
+]
+
+[[package]]
+name = "pywatchman"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/6b/f1df266103d33014ea7492222d12652f3341978c21d13f0b297cb7fd7e1f/pywatchman-3.0.0.tar.gz", hash = "sha256:efd32a17391a5872118c55041da71a20960e46ba4b73440c24efac287eea911e", size = 40717, upload-time = "2025-05-30T00:36:18.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/8e/431e68fca61344c68ac1ad294bc6fa352d68e48a0f6a1fbeb538216bb1d7/pywatchman-3.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4f69c49a72e81f1d24733ff5c9dda451404c542edb1efafdb77fd43c7c1a8df9", size = 60136, upload-time = "2025-05-30T00:36:13.45Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/721898f989cab2c0fe8bb3805b2f847c94c46ce7c88af3bd0cb9e0a6b2eb/pywatchman-3.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c15484b7d20c007f5b3c7781dddf5acb2c8a8f6440925e3e512b7e194b05dda9", size = 52448, upload-time = "2025-05-30T00:36:14.287Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Problem**

When `bin/start` launches mprocs, lots of things start already and among them multiple Rust services start simultaneously via `cargo run`. They share a workspace build lock, so only one can compile at a time while others wait. With default parallelism (all CPU cores), the compiling service maxes out CPU while waiting services spin on the lock — system becomes unresponsive.

**Fix**

Set `CARGO_BUILD_JOBS=1` by default. Trades slower Rust builds for usable system during startup. Override with `CARGO_BUILD_JOBS=4 bin/start` if faster builds are preferred.