### PR TITLE
fix(dashboards): fix go back link when dashboard name isn't loaded

### DIFF
--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -247,8 +247,9 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                 s.sceneSource,
             ],
             (insightLogicRef, insight, insightQuery, dashboardId, dashboardName, tabId, sceneSource): Breadcrumb[] => {
+                const dashboardLabel = dashboardName ?? 'Dashboard'
                 return [
-                    ...(dashboardId !== null && dashboardName
+                    ...(dashboardId !== null
                         ? [
                               {
                                   key: Scene.Dashboards,
@@ -258,7 +259,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                               },
                               {
                                   key: Scene.Dashboard,
-                                  name: dashboardName,
+                                  name: dashboardLabel,
                                   path: urls.dashboard(dashboardId),
                                   iconType: 'dashboard' as FileSystemIconType,
                               },


### PR DESCRIPTION
## Problem

When visiting an insight with a dashboard id, without having opened the dashboard in the same session (i.e. when opening a link with a dashboard id), we would display a "Go back to Product analytics" link on the insight.

## Changes

Fixes this by displaying a link with a generic "Dashboard" name.

## How did you test this code?

Manually