### PR TITLE
feat(llma): add generation-level summarization workflow

### DIFF
--- a/posthog/temporal/llm_analytics/__init__.py
+++ b/posthog/temporal/llm_analytics/__init__.py
@@ -17,8 +17,9 @@ from posthog.temporal.llm_analytics.trace_clustering import (
 from posthog.temporal.llm_analytics.trace_summarization import (
     BatchTraceSummarizationCoordinatorWorkflow,
     BatchTraceSummarizationWorkflow,
+    generate_and_save_generation_summary_activity,
     generate_and_save_summary_activity,
-    query_traces_in_window_activity,
+    sample_items_in_window_activity,
 )
 
 EVAL_WORKFLOWS = [
@@ -44,8 +45,9 @@ WORKFLOWS = [
 ]
 
 ACTIVITIES = [
-    query_traces_in_window_activity,
+    sample_items_in_window_activity,
     generate_and_save_summary_activity,
+    generate_and_save_generation_summary_activity,
     # Clustering activities
     perform_clustering_compute_activity,
     generate_cluster_labels_activity,

--- a/posthog/temporal/llm_analytics/trace_summarization/README.md
+++ b/posthog/temporal/llm_analytics/trace_summarization/README.md
@@ -34,7 +34,7 @@ Spawns child workflows for teams in `ALLOWED_TEAM_IDS` (configured in `constants
 
 **Inputs** (`BatchTraceSummarizationCoordinatorInputs`): `max_traces`, `batch_size`, `mode`, `window_minutes`, `model` - all optional with sensible defaults.
 
-**Returns** `CoordinatorResult`: `teams_processed`, `teams_failed`, `failed_team_ids`, `total_traces`, `total_summaries`
+**Returns** `CoordinatorResult`: `teams_processed`, `teams_failed`, `failed_team_ids`, `total_items`, `total_summaries`
 
 ### Per-Team: `llma-trace-summarization`
 
@@ -45,7 +45,7 @@ Spawns child workflows for teams in `ALLOWED_TEAM_IDS` (configured in `constants
 - `window_start`, `window_end` - optional explicit window (RFC3339)
 - `model` - optional LLM model override
 
-**Returns** `BatchSummarizationResult`: `batch_run_id`, `metrics` (traces_queried, summaries_generated/skipped/failed, embedding_requests_succeeded/failed, duration_seconds)
+**Returns** `BatchSummarizationResult`: `batch_run_id`, `metrics` (items_queried, summaries_generated/skipped/failed, embedding_requests_succeeded/failed, duration_seconds)
 
 ## Output Events
 
@@ -109,7 +109,7 @@ Key constants in `constants.py`:
 
 | Constant                             | Default        | Description                 |
 | ------------------------------------ | -------------- | --------------------------- |
-| `DEFAULT_MAX_TRACES_PER_WINDOW`      | 100            | Max traces per window       |
+| `DEFAULT_MAX_ITEMS_PER_WINDOW`       | 10             | Max items per window        |
 | `DEFAULT_BATCH_SIZE`                 | 3              | Concurrent trace processing |
 | `DEFAULT_MODE`                       | "detailed"     | Summary detail level        |
 | `DEFAULT_MODEL`                      | "gpt-4.1-nano" | LLM model for summarization |

--- a/posthog/temporal/llm_analytics/trace_summarization/__init__.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/__init__.py
@@ -1,11 +1,10 @@
 """Trace summarization workflows and activities for batch processing."""
 
-# Export activities
 # Export constants
 from posthog.temporal.llm_analytics.trace_summarization.constants import (
     COORDINATOR_WORKFLOW_NAME,
     DEFAULT_BATCH_SIZE,
-    DEFAULT_MAX_TRACES_PER_WINDOW,
+    DEFAULT_MAX_ITEMS_PER_WINDOW,
     DEFAULT_MODE,
     DEFAULT_WINDOW_MINUTES,
     EVENT_NAME_TRACE_SUMMARY,
@@ -15,10 +14,13 @@ from posthog.temporal.llm_analytics.trace_summarization.coordinator import (
     BatchTraceSummarizationCoordinatorInputs,
     BatchTraceSummarizationCoordinatorWorkflow,
 )
+from posthog.temporal.llm_analytics.trace_summarization.generation_summarization import (
+    generate_and_save_generation_summary_activity,
+)
 
 # Export models
-from posthog.temporal.llm_analytics.trace_summarization.models import BatchSummarizationInputs
-from posthog.temporal.llm_analytics.trace_summarization.sampling import query_traces_in_window_activity
+from posthog.temporal.llm_analytics.trace_summarization.models import BatchSummarizationInputs, SampledItem
+from posthog.temporal.llm_analytics.trace_summarization.sampling import sample_items_in_window_activity
 from posthog.temporal.llm_analytics.trace_summarization.schedule import create_batch_trace_summarization_schedule
 from posthog.temporal.llm_analytics.trace_summarization.summarization import generate_and_save_summary_activity
 
@@ -28,11 +30,12 @@ from posthog.temporal.llm_analytics.trace_summarization.workflow import BatchTra
 __all__ = [
     # Activities
     "generate_and_save_summary_activity",
-    "query_traces_in_window_activity",
+    "generate_and_save_generation_summary_activity",
+    "sample_items_in_window_activity",
     # Constants
     "COORDINATOR_WORKFLOW_NAME",
     "DEFAULT_BATCH_SIZE",
-    "DEFAULT_MAX_TRACES_PER_WINDOW",
+    "DEFAULT_MAX_ITEMS_PER_WINDOW",
     "DEFAULT_MODE",
     "DEFAULT_WINDOW_MINUTES",
     "EVENT_NAME_TRACE_SUMMARY",
@@ -40,6 +43,7 @@ __all__ = [
     # Models
     "BatchSummarizationInputs",
     "BatchTraceSummarizationCoordinatorInputs",
+    "SampledItem",
     # Workflows
     "BatchTraceSummarizationWorkflow",
     "BatchTraceSummarizationCoordinatorWorkflow",

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -7,7 +7,7 @@ from temporalio.common import RetryPolicy
 from products.llm_analytics.backend.summarization.models import OpenAIModel, SummarizationMode, SummarizationProvider
 
 # Window processing configuration
-DEFAULT_MAX_TRACES_PER_WINDOW = 10  # Max traces to process per window (conservative for worst-case 30s/trace)
+DEFAULT_MAX_ITEMS_PER_WINDOW = 10  # Max items to process per window (conservative for worst-case 30s/item)
 DEFAULT_BATCH_SIZE = 3  # Number of traces to process in parallel (reduced to avoid rate limits)
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)
@@ -48,6 +48,13 @@ COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY = RetryPolicy(maximum_attempts=2)
 
 # Event schema
 EVENT_NAME_TRACE_SUMMARY = "$ai_trace_summary"
+EVENT_NAME_GENERATION_SUMMARY = "$ai_generation_summary"  # For generation-level summarization
+
+# Document types for embeddings
+GENERATION_DOCUMENT_TYPE = "llm-generation-summary-detailed"  # For generation-level embeddings
+
+# Generation-level configuration
+DEFAULT_MAX_GENERATIONS_PER_WINDOW = 50  # Higher than traces - generations are simpler units
 
 # Team allowlist - only these teams will be processed by the coordinator
 # Empty list means no teams will be processed (coordinator skips)
@@ -67,3 +74,6 @@ WORKFLOW_NAME = "llma-trace-summarization"
 COORDINATOR_WORKFLOW_NAME = "llma-trace-summarization-coordinator"
 COORDINATOR_SCHEDULE_ID = "llma-trace-summarization-coordinator-schedule"
 CHILD_WORKFLOW_ID_PREFIX = "llma-trace-summarization-team"
+
+# Generation-level schedule configuration (reuses same coordinator workflow with different inputs)
+GENERATION_COORDINATOR_SCHEDULE_ID = "llma-generation-summarization-coordinator-schedule"

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -22,14 +22,18 @@ from posthog.temporal.llm_analytics.trace_summarization.constants import (
     CHILD_WORKFLOW_ID_PREFIX,
     COORDINATOR_WORKFLOW_NAME,
     DEFAULT_BATCH_SIZE,
-    DEFAULT_MAX_TRACES_PER_WINDOW,
+    DEFAULT_MAX_ITEMS_PER_WINDOW,
     DEFAULT_MODE,
     DEFAULT_MODEL,
     DEFAULT_PROVIDER,
     DEFAULT_WINDOW_MINUTES,
     WORKFLOW_EXECUTION_TIMEOUT_MINUTES,
 )
-from posthog.temporal.llm_analytics.trace_summarization.models import BatchSummarizationInputs, CoordinatorResult
+from posthog.temporal.llm_analytics.trace_summarization.models import (
+    AnalysisLevel,
+    BatchSummarizationInputs,
+    CoordinatorResult,
+)
 from posthog.temporal.llm_analytics.trace_summarization.workflow import BatchTraceSummarizationWorkflow
 
 from products.llm_analytics.backend.summarization.models import SummarizationMode, SummarizationProvider
@@ -41,7 +45,8 @@ logger = structlog.get_logger(__name__)
 class BatchTraceSummarizationCoordinatorInputs:
     """Inputs for the coordinator workflow."""
 
-    max_traces: int = DEFAULT_MAX_TRACES_PER_WINDOW
+    analysis_level: AnalysisLevel = "trace"  # "trace" or "generation"
+    max_items: int = DEFAULT_MAX_ITEMS_PER_WINDOW
     batch_size: int = DEFAULT_BATCH_SIZE
     mode: SummarizationMode = DEFAULT_MODE
     window_minutes: int = DEFAULT_WINDOW_MINUTES
@@ -76,12 +81,13 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
     def parse_inputs(inputs: list[str]) -> BatchTraceSummarizationCoordinatorInputs:
         """Parse workflow inputs from string list."""
         return BatchTraceSummarizationCoordinatorInputs(
-            max_traces=int(inputs[0]) if len(inputs) > 0 else DEFAULT_MAX_TRACES_PER_WINDOW,
-            batch_size=int(inputs[1]) if len(inputs) > 1 else DEFAULT_BATCH_SIZE,
-            mode=SummarizationMode(inputs[2]) if len(inputs) > 2 else DEFAULT_MODE,
-            window_minutes=int(inputs[3]) if len(inputs) > 3 else DEFAULT_WINDOW_MINUTES,
-            provider=SummarizationProvider(inputs[4]) if len(inputs) > 4 else DEFAULT_PROVIDER,
-            model=inputs[5] if len(inputs) > 5 else DEFAULT_MODEL,
+            analysis_level="generation" if len(inputs) > 0 and inputs[0] == "generation" else "trace",
+            max_items=int(inputs[1]) if len(inputs) > 1 else DEFAULT_MAX_ITEMS_PER_WINDOW,
+            batch_size=int(inputs[2]) if len(inputs) > 2 else DEFAULT_BATCH_SIZE,
+            mode=SummarizationMode(inputs[3]) if len(inputs) > 3 else DEFAULT_MODE,
+            window_minutes=int(inputs[4]) if len(inputs) > 4 else DEFAULT_WINDOW_MINUTES,
+            provider=SummarizationProvider(inputs[5]) if len(inputs) > 5 else DEFAULT_PROVIDER,
+            model=inputs[6] if len(inputs) > 6 else DEFAULT_MODEL,
         )
 
     @temporalio.workflow.run
@@ -89,7 +95,8 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
         """Execute coordinator workflow."""
         logger.info(
             "Starting batch trace summarization coordinator",
-            max_traces=inputs.max_traces,
+            analysis_level=inputs.analysis_level,
+            max_items=inputs.max_items,
             window_minutes=inputs.window_minutes,
         )
 
@@ -102,14 +109,14 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
                 teams_processed=0,
                 teams_failed=0,
                 failed_team_ids=[],
-                total_traces=0,
+                total_items=0,
                 total_summaries=0,
             )
 
         logger.info("Processing teams from allowlist", team_count=len(team_ids), team_ids=team_ids)
 
         # Spawn child workflows for each team
-        total_traces = 0
+        total_items = 0
         total_summaries = 0
         failed_teams = []
 
@@ -119,7 +126,8 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
                     BatchTraceSummarizationWorkflow.run,
                     BatchSummarizationInputs(
                         team_id=team_id,
-                        max_traces=inputs.max_traces,
+                        analysis_level=inputs.analysis_level,
+                        max_items=inputs.max_items,
                         batch_size=inputs.batch_size,
                         mode=inputs.mode,
                         window_minutes=inputs.window_minutes,
@@ -131,7 +139,7 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
                     retry_policy=constants.COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY,
                 )
 
-                total_traces += workflow_result.metrics.traces_queried
+                total_items += workflow_result.metrics.items_queried
                 total_summaries += workflow_result.metrics.summaries_generated
 
             except Exception as e:
@@ -143,6 +151,6 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
             teams_processed=len(team_ids),
             teams_failed=len(failed_teams),
             failed_team_ids=failed_teams,
-            total_traces=total_traces,
+            total_items=total_items,
             total_summaries=total_summaries,
         )

--- a/posthog/temporal/llm_analytics/trace_summarization/generation_summarization.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/generation_summarization.py
@@ -1,0 +1,307 @@
+"""Activity for generating summaries of individual $ai_generation events using LLM."""
+
+from uuid import uuid4
+
+import structlog
+import temporalio
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.models.event.util import create_event
+from posthog.models.team import Team
+from posthog.sync import database_sync_to_async
+from posthog.temporal.llm_analytics.trace_summarization import constants
+from posthog.temporal.llm_analytics.trace_summarization.models import SummarizationActivityResult
+from posthog.temporal.llm_analytics.trace_summarization.utils import format_datetime_for_clickhouse
+
+from products.llm_analytics.backend.summarization.llm import summarize
+from products.llm_analytics.backend.summarization.llm.schema import SummarizationResponse
+from products.llm_analytics.backend.summarization.models import (
+    GeminiModel,
+    OpenAIModel,
+    SummarizationMode,
+    SummarizationProvider,
+)
+
+from ee.hogai.llm_traces_summaries.tools.embed_summaries import LLMTracesSummarizerEmbedder
+
+logger = structlog.get_logger(__name__)
+
+
+def _format_generation_text_repr(generation_data: dict) -> str:
+    """Format a generation event into a text representation for LLM summarization."""
+    parts = []
+
+    # Header
+    parts.append("=== LLM Generation Event ===")
+    parts.append("")
+
+    # Model and provider info
+    if generation_data.get("model"):
+        parts.append(f"Model: {generation_data['model']}")
+    if generation_data.get("provider"):
+        parts.append(f"Provider: {generation_data['provider']}")
+
+    # Token usage
+    input_tokens = generation_data.get("input_tokens")
+    output_tokens = generation_data.get("output_tokens")
+    if input_tokens is not None or output_tokens is not None:
+        tokens_str = []
+        if input_tokens is not None:
+            tokens_str.append(f"input={input_tokens}")
+        if output_tokens is not None:
+            tokens_str.append(f"output={output_tokens}")
+        parts.append(f"Tokens: {', '.join(tokens_str)}")
+
+    # Latency
+    latency = generation_data.get("latency")
+    if latency is not None:
+        parts.append(f"Latency: {latency:.2f}s")
+
+    parts.append("")
+
+    # Input/prompt
+    input_content = generation_data.get("input")
+    if input_content:
+        parts.append("--- Input ---")
+        if isinstance(input_content, list):
+            for msg in input_content:
+                role = msg.get("role", "unknown")
+                content = msg.get("content", "")
+                parts.append(f"[{role}]: {content}")
+        else:
+            parts.append(str(input_content))
+        parts.append("")
+
+    # Output/response
+    output_content = generation_data.get("output")
+    if output_content:
+        parts.append("--- Output ---")
+        if isinstance(output_content, list):
+            for msg in output_content:
+                role = msg.get("role", "unknown")
+                content = msg.get("content", "")
+                parts.append(f"[{role}]: {content}")
+        else:
+            parts.append(str(output_content))
+
+    return "\n".join(parts)
+
+
+@temporalio.activity.defn
+async def generate_and_save_generation_summary_activity(
+    generation_id: str,
+    trace_id: str,
+    trace_first_timestamp: str,
+    team_id: int,
+    window_start: str,
+    window_end: str,
+    mode: str,
+    batch_run_id: str,
+    provider: str,
+    model: str | None = None,
+    max_length: int | None = None,
+) -> SummarizationActivityResult:
+    """
+    Generate summary for a single $ai_generation event and save it to ClickHouse.
+
+    Fetches generation data, generates LLM summary, and saves it as an event.
+    Saves directly to avoid passing large objects through workflow history.
+
+    Args:
+        trace_first_timestamp: The first event timestamp of the parent trace,
+            used for navigation in the cluster scatter plot.
+    """
+
+    def _fetch_generation_data(
+        generation_id: str, team_id: int, window_start: str, window_end: str
+    ) -> tuple[dict, Team] | None:
+        """Fetch generation event data.
+
+        Returns tuple of (generation_dict, team) or None if not found.
+        """
+        team = Team.objects.get(id=team_id)
+
+        # Convert ISO format to ClickHouse-compatible format
+        start_dt_str = format_datetime_for_clickhouse(window_start)
+        end_dt_str = format_datetime_for_clickhouse(window_end)
+
+        query = parse_select(
+            """
+            SELECT
+                properties.$ai_model as model,
+                properties.$ai_provider as provider,
+                properties.$ai_input as input,
+                properties.$ai_output as output,
+                properties.$ai_input_tokens as input_tokens,
+                properties.$ai_output_tokens as output_tokens,
+                properties.$ai_latency as latency
+            FROM events
+            WHERE event = '$ai_generation'
+                AND timestamp >= toDateTime({start_dt}, 'UTC')
+                AND timestamp < toDateTime({end_dt}, 'UTC')
+                AND uuid = {generation_id}
+            LIMIT 1
+            """
+        )
+
+        result = execute_hogql_query(
+            query_type="GenerationForSummarization",
+            query=query,
+            placeholders={
+                "start_dt": ast.Constant(value=start_dt_str),
+                "end_dt": ast.Constant(value=end_dt_str),
+                "generation_id": ast.Constant(value=generation_id),
+            },
+            team=team,
+        )
+
+        if not result.results:
+            return None
+
+        row = result.results[0]
+        generation_dict = {
+            "model": row[0],
+            "provider": row[1],
+            "input": row[2],
+            "output": row[3],
+            "input_tokens": row[4],
+            "output_tokens": row[5],
+            "latency": row[6],
+        }
+
+        return generation_dict, team
+
+    def _save_summary_event(
+        summary_result: SummarizationResponse,
+        text_repr: str,
+        team: Team,
+    ) -> None:
+        """Save summary as $ai_generation_summary event to ClickHouse."""
+
+        event_uuid = uuid4()
+
+        summary_bullets_json = [bullet.model_dump() for bullet in summary_result.summary_bullets]
+        summary_notes_json = [note.model_dump() for note in summary_result.interesting_notes]
+
+        properties = {
+            "$ai_generation_id": generation_id,
+            "$ai_trace_id": trace_id,
+            "$ai_batch_run_id": batch_run_id,
+            "$ai_summary_mode": mode,
+            "$ai_summary_title": summary_result.title,
+            "$ai_summary_flow_diagram": summary_result.flow_diagram,
+            "$ai_summary_bullets": summary_bullets_json,
+            "$ai_summary_interesting_notes": summary_notes_json,
+            "$ai_text_repr_length": len(text_repr),
+            "trace_timestamp": trace_first_timestamp,
+        }
+
+        create_event(
+            event_uuid=event_uuid,
+            event=constants.EVENT_NAME_GENERATION_SUMMARY,
+            team=team,
+            distinct_id=f"generation_summary_{team_id}",
+            properties=properties,
+        )
+
+    def _embed_summary(summary_result: SummarizationResponse, team: Team) -> None:
+        """Generate embedding for the summary and send to Kafka."""
+        parts = []
+        if summary_result.title:
+            parts.append(f"Title: {summary_result.title}")
+        if summary_result.flow_diagram:
+            parts.append(f"\nFlow:\n{summary_result.flow_diagram}")
+        if summary_result.summary_bullets:
+            bullets_text = "\n".join(f"- {b.text}" for b in summary_result.summary_bullets)
+            parts.append(f"\nSummary:\n{bullets_text}")
+        if summary_result.interesting_notes:
+            notes_text = "\n".join(f"- {n.text}" for n in summary_result.interesting_notes)
+            parts.append(f"\nInteresting Notes:\n{notes_text}")
+
+        summary_text = "\n".join(parts)
+
+        embedder = LLMTracesSummarizerEmbedder(team=team)
+        embedder._embed_document(
+            content=summary_text,
+            document_id=generation_id,
+            document_type=constants.GENERATION_DOCUMENT_TYPE,
+            rendering=batch_run_id,
+            product="llm-analytics",
+        )
+
+    # Fetch generation data
+    result = await database_sync_to_async(_fetch_generation_data, thread_sensitive=False)(
+        generation_id, team_id, window_start, window_end
+    )
+
+    if result is None:
+        logger.warning(
+            "Skipping generation - not found in time window",
+            generation_id=generation_id,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        return SummarizationActivityResult(
+            trace_id=trace_id,
+            success=False,
+            generation_id=generation_id,
+            skipped=True,
+            skip_reason="generation_not_found",
+        )
+
+    generation_dict, team = result
+
+    # Format text representation
+    text_repr = _format_generation_text_repr(generation_dict)
+
+    # Apply max_length truncation if needed
+    if max_length and len(text_repr) > max_length:
+        text_repr = text_repr[:max_length] + "\n... [truncated]"
+
+    # Generate summary using LLM
+    mode_enum = SummarizationMode(mode)
+    provider_enum = SummarizationProvider(provider)
+    model_enum: OpenAIModel | GeminiModel | None = None
+    if model:
+        if provider_enum == SummarizationProvider.GEMINI:
+            model_enum = GeminiModel(model)
+        else:
+            model_enum = OpenAIModel(model)
+
+    summary_result = await summarize(
+        text_repr=text_repr,
+        team_id=team_id,
+        mode=mode_enum,
+        provider=provider_enum,
+        model=model_enum,
+    )
+
+    # Save event to ClickHouse
+    await database_sync_to_async(_save_summary_event, thread_sensitive=False)(summary_result, text_repr, team)
+
+    # Request embedding
+    embedding_requested = False
+    embedding_request_error = None
+    try:
+        await database_sync_to_async(_embed_summary, thread_sensitive=False)(summary_result, team)
+        embedding_requested = True
+    except Exception as e:
+        embedding_request_error = str(e)
+        logger.exception(
+            "Failed to request embedding for generation summary",
+            generation_id=generation_id,
+            error=embedding_request_error,
+        )
+
+    return SummarizationActivityResult(
+        trace_id=trace_id,
+        success=True,
+        generation_id=generation_id,
+        text_repr_length=len(text_repr),
+        event_count=1,  # Single generation event
+        embedding_requested=embedding_requested,
+        embedding_request_error=embedding_request_error,
+    )

--- a/posthog/temporal/llm_analytics/trace_summarization/models.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/models.py
@@ -1,13 +1,13 @@
 """Data models for batch trace summarization."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
 from posthog.temporal.llm_analytics.trace_summarization.constants import (
     DEFAULT_BATCH_SIZE,
-    DEFAULT_MAX_TRACES_PER_WINDOW,
+    DEFAULT_MAX_ITEMS_PER_WINDOW,
     DEFAULT_MODE,
     DEFAULT_MODEL,
     DEFAULT_PROVIDER,
@@ -16,6 +16,9 @@ from posthog.temporal.llm_analytics.trace_summarization.constants import (
 
 from products.llm_analytics.backend.summarization.llm.schema import SummarizationResponse
 from products.llm_analytics.backend.summarization.models import SummarizationMode, SummarizationProvider
+
+# Analysis level determines whether we summarize traces or individual generations
+AnalysisLevel = Literal["trace", "generation"]
 
 
 class TraceSummary(BaseModel):
@@ -31,13 +34,14 @@ class TraceSummary(BaseModel):
 class BatchSummarizationInputs:
     """Inputs for batch trace summarization workflow.
 
-    The workflow processes traces from a time window (last N minutes) up to a maximum count.
-    This makes it suitable for scheduled execution where each run processes recent traces.
+    The workflow processes traces/generations from a time window (last N minutes) up to a maximum count.
+    This makes it suitable for scheduled execution where each run processes recent items.
     """
 
     team_id: int
-    max_traces: int = DEFAULT_MAX_TRACES_PER_WINDOW  # Hard limit on traces to process
-    batch_size: int = DEFAULT_BATCH_SIZE  # Number of traces per batch
+    analysis_level: AnalysisLevel = "trace"  # "trace" or "generation"
+    max_items: int = DEFAULT_MAX_ITEMS_PER_WINDOW  # Hard limit on items to process
+    batch_size: int = DEFAULT_BATCH_SIZE  # Number of items per batch
     mode: SummarizationMode = DEFAULT_MODE
     window_minutes: int = DEFAULT_WINDOW_MINUTES  # Time window to query (defaults to 60 min)
     provider: SummarizationProvider = DEFAULT_PROVIDER
@@ -48,11 +52,25 @@ class BatchSummarizationInputs:
 
 
 @dataclass
+class SampledItem:
+    """A sampled item for summarization.
+
+    Used by both trace-level and generation-level sampling to provide
+    consistent data structure with trace context.
+    """
+
+    trace_id: str  # The trace ID
+    trace_first_timestamp: str  # First event timestamp of the trace (for navigation)
+    generation_id: str | None = None  # Generation UUID (None for trace-level, set for generation-level)
+
+
+@dataclass
 class SummarizationActivityResult:
     """Result from generate_and_save_summary_activity."""
 
-    trace_id: str
+    trace_id: str  # Always set - the trace ID (or parent trace for generations)
     success: bool
+    generation_id: str | None = None  # Only set for generation-level summarization
     text_repr_length: int = 0
     event_count: int = 0
     skipped: bool = False
@@ -63,9 +81,9 @@ class SummarizationActivityResult:
 
 @dataclass
 class BatchSummarizationMetrics:
-    """Metrics from batch trace summarization workflow."""
+    """Metrics from batch summarization workflow."""
 
-    traces_queried: int = 0
+    items_queried: int = 0  # traces or generations depending on analysis_level
     summaries_skipped: int = 0
     summaries_failed: int = 0
     summaries_generated: int = 0
@@ -89,5 +107,5 @@ class CoordinatorResult:
     teams_processed: int
     teams_failed: int
     failed_team_ids: list[int]
-    total_traces: int
+    total_items: int  # traces or generations depending on analysis_level
     total_summaries: int

--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -1,25 +1,44 @@
-"""Activity for querying trace IDs from a time window."""
+"""Activity for sampling traces/generations from a time window.
+
+Uses TracesQueryRunner for both trace-level and generation-level sampling.
+For generation-level, samples traces first then queries for the last generation
+per trace - this ensures each generation has its parent trace's first_timestamp
+for navigation.
+"""
 
 import structlog
 import temporalio
 
 from posthog.schema import DateRange, TracesQuery
 
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+
 from posthog.hogql_queries.ai.traces_query_runner import TracesQueryRunner
 from posthog.models.team import Team
 from posthog.sync import database_sync_to_async
-from posthog.temporal.llm_analytics.trace_summarization.models import BatchSummarizationInputs
+from posthog.temporal.llm_analytics.trace_summarization.models import BatchSummarizationInputs, SampledItem
+from posthog.temporal.llm_analytics.trace_summarization.utils import format_datetime_for_clickhouse
 
 logger = structlog.get_logger(__name__)
 
 
 @temporalio.activity.defn
-async def query_traces_in_window_activity(inputs: BatchSummarizationInputs) -> list[str]:
+async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> list[SampledItem]:
     """
-    Query trace IDs from a time window using TracesQueryRunner.
+    Sample traces or generations from a time window using TracesQueryRunner.
 
-    Queries up to max_traces from the specified time window.
-    Returns a list of trace IDs in random order for sampling.
+    For trace-level (analysis_level="trace"):
+        Returns one SampledItem per trace with generation_id=None.
+
+    For generation-level (analysis_level="generation"):
+        Samples traces first to get trace context (id, first_timestamp), then
+        queries for the last $ai_generation event per trace.
+        Returns one SampledItem per generation with the parent trace's context.
+
+    This unified approach ensures both levels have access to the trace's
+    first_timestamp, which is needed for navigation in the cluster scatter plot.
 
     Requires window_start and window_end to be set on inputs (computed by workflow
     using deterministic workflow time to avoid race conditions between runs).
@@ -27,25 +46,116 @@ async def query_traces_in_window_activity(inputs: BatchSummarizationInputs) -> l
     if not inputs.window_start or not inputs.window_end:
         raise ValueError("window_start and window_end must be provided by the workflow")
 
-    def _execute_traces_query(team_id: int, window_start: str, window_end: str, max_traces: int) -> list[str]:
+    def _sample_items(
+        team_id: int, window_start: str, window_end: str, max_items: int, analysis_level: str
+    ) -> list[SampledItem]:
         team = Team.objects.get(id=team_id)
 
+        # Step 1: Sample traces using TracesQueryRunner
         query = TracesQuery(
             dateRange=DateRange(date_from=window_start, date_to=window_end),
-            limit=max_traces,
+            limit=max_items,
             randomOrder=True,
         )
 
         runner = TracesQueryRunner(team=team, query=query)
         response = runner.calculate()
 
-        return [trace.id for trace in response.results]
+        logger.debug(
+            "traces_query_runner_result",
+            num_traces=len(response.results),
+            analysis_level=analysis_level,
+            window_start=window_start,
+            window_end=window_end,
+            team_id=team_id,
+        )
 
-    trace_ids = await database_sync_to_async(_execute_traces_query, thread_sensitive=False)(
+        if analysis_level == "generation":
+            # Step 2: For generation-level, query for last generation per trace
+            trace_context = {trace.id: trace.createdAt for trace in response.results}
+
+            if not trace_context:
+                return []
+
+            # Query last generation per trace (with timestamp bounds for efficiency)
+            trace_ids_tuple = ast.Tuple(exprs=[ast.Constant(value=tid) for tid in trace_context.keys()])
+
+            # Convert ISO format to ClickHouse-compatible format
+            start_dt_str = format_datetime_for_clickhouse(window_start)
+            end_dt_str = format_datetime_for_clickhouse(window_end)
+
+            generations_query = parse_select(
+                """
+                SELECT
+                    properties.$ai_trace_id as trace_id,
+                    argMax(uuid, timestamp) as last_generation_id
+                FROM events
+                WHERE event = '$ai_generation'
+                    AND timestamp >= toDateTime({start_ts}, 'UTC')
+                    AND timestamp <= toDateTime({end_ts}, 'UTC')
+                    AND properties.$ai_trace_id IN {trace_ids}
+                GROUP BY trace_id
+                """
+            )
+
+            result = execute_hogql_query(
+                query_type="GenerationsForSampling",
+                query=generations_query,
+                placeholders={
+                    "trace_ids": trace_ids_tuple,
+                    "start_ts": ast.Constant(value=start_dt_str),
+                    "end_ts": ast.Constant(value=end_dt_str),
+                },
+                team=team,
+            )
+
+            logger.debug(
+                "generation_query_result",
+                num_generations=len(result.results or []),
+                num_trace_ids_queried=len(trace_context),
+                start_ts=start_dt_str,
+                end_ts=end_dt_str,
+                team_id=team_id,
+            )
+
+            items: list[SampledItem] = []
+            for row in result.results or []:
+                trace_id = row[0]
+                generation_id = row[1]
+                if trace_id in trace_context:
+                    items.append(
+                        SampledItem(
+                            trace_id=trace_id,
+                            trace_first_timestamp=trace_context[trace_id],
+                            generation_id=str(generation_id),
+                        )
+                    )
+
+            return items
+        else:
+            # Trace-level: one item per trace
+            return [
+                SampledItem(
+                    trace_id=trace.id,
+                    trace_first_timestamp=trace.createdAt,
+                    generation_id=None,
+                )
+                for trace in response.results
+            ]
+
+    items = await database_sync_to_async(_sample_items, thread_sensitive=False)(
         inputs.team_id,
         inputs.window_start,
         inputs.window_end,
-        inputs.max_traces,
+        inputs.max_items,
+        inputs.analysis_level,
     )
 
-    return trace_ids
+    logger.debug(
+        "sample_items_in_window_result",
+        num_items=len(items),
+        analysis_level=inputs.analysis_level,
+        team_id=inputs.team_id,
+    )
+
+    return items

--- a/posthog/temporal/llm_analytics/trace_summarization/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/schedule.py
@@ -11,9 +11,11 @@ from posthog.temporal.llm_analytics.trace_summarization.constants import (
     COORDINATOR_SCHEDULE_ID,
     COORDINATOR_WORKFLOW_NAME,
     DEFAULT_BATCH_SIZE,
-    DEFAULT_MAX_TRACES_PER_WINDOW,
+    DEFAULT_MAX_GENERATIONS_PER_WINDOW,
+    DEFAULT_MAX_ITEMS_PER_WINDOW,
     DEFAULT_MODE,
     DEFAULT_WINDOW_MINUTES,
+    GENERATION_COORDINATOR_SCHEDULE_ID,
     SCHEDULE_INTERVAL_HOURS,
 )
 from posthog.temporal.llm_analytics.trace_summarization.coordinator import BatchTraceSummarizationCoordinatorInputs
@@ -29,7 +31,7 @@ async def create_batch_trace_summarization_schedule(client: Client):
         action=ScheduleActionStartWorkflow(
             COORDINATOR_WORKFLOW_NAME,
             BatchTraceSummarizationCoordinatorInputs(
-                max_traces=DEFAULT_MAX_TRACES_PER_WINDOW,
+                max_items=DEFAULT_MAX_ITEMS_PER_WINDOW,
                 batch_size=DEFAULT_BATCH_SIZE,
                 mode=DEFAULT_MODE,
                 window_minutes=DEFAULT_WINDOW_MINUTES,
@@ -47,5 +49,39 @@ async def create_batch_trace_summarization_schedule(client: Client):
             client,
             COORDINATOR_SCHEDULE_ID,
             batch_trace_summarization_schedule,
+            trigger_immediately=False,
+        )
+
+
+async def create_batch_generation_summarization_schedule(client: Client):
+    """Create or update the schedule for the batch generation summarization coordinator workflow.
+
+    This schedule runs hourly and automatically processes generations (individual LLM calls)
+    for all teams with recent LLM activity. Uses the same coordinator workflow as trace
+    summarization but with analysis_level="generation".
+    """
+    batch_generation_summarization_schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            COORDINATOR_WORKFLOW_NAME,
+            BatchTraceSummarizationCoordinatorInputs(
+                analysis_level="generation",
+                max_items=DEFAULT_MAX_GENERATIONS_PER_WINDOW,
+                batch_size=DEFAULT_BATCH_SIZE,
+                mode=DEFAULT_MODE,
+                window_minutes=DEFAULT_WINDOW_MINUTES,
+            ),
+            id=GENERATION_COORDINATOR_SCHEDULE_ID,
+            task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
+        ),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(hours=SCHEDULE_INTERVAL_HOURS))]),
+    )
+
+    if await a_schedule_exists(client, GENERATION_COORDINATOR_SCHEDULE_ID):
+        await a_update_schedule(client, GENERATION_COORDINATOR_SCHEDULE_ID, batch_generation_summarization_schedule)
+    else:
+        await a_create_schedule(
+            client,
+            GENERATION_COORDINATOR_SCHEDULE_ID,
+            batch_generation_summarization_schedule,
             trigger_immediately=False,
         )

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_coordinator.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from posthog.temporal.llm_analytics.trace_summarization.constants import (
     ALLOWED_TEAM_IDS,
     DEFAULT_BATCH_SIZE,
-    DEFAULT_MAX_TRACES_PER_WINDOW,
+    DEFAULT_MAX_ITEMS_PER_WINDOW,
     DEFAULT_MODE,
     DEFAULT_MODEL,
     DEFAULT_PROVIDER,
@@ -49,7 +49,8 @@ class TestBatchTraceSummarizationCoordinatorWorkflow:
             pytest.param(
                 [],
                 BatchTraceSummarizationCoordinatorInputs(
-                    max_traces=DEFAULT_MAX_TRACES_PER_WINDOW,
+                    analysis_level="trace",
+                    max_items=DEFAULT_MAX_ITEMS_PER_WINDOW,
                     batch_size=DEFAULT_BATCH_SIZE,
                     mode=DEFAULT_MODE,
                     window_minutes=DEFAULT_WINDOW_MINUTES,
@@ -59,21 +60,36 @@ class TestBatchTraceSummarizationCoordinatorWorkflow:
                 id="empty_inputs_uses_defaults",
             ),
             pytest.param(
-                ["200"],
+                ["trace", "200"],
                 BatchTraceSummarizationCoordinatorInputs(
-                    max_traces=200,
+                    analysis_level="trace",
+                    max_items=200,
                     batch_size=DEFAULT_BATCH_SIZE,
                     mode=DEFAULT_MODE,
                     window_minutes=DEFAULT_WINDOW_MINUTES,
                     provider=DEFAULT_PROVIDER,
                     model=DEFAULT_MODEL,
                 ),
-                id="single_input_sets_max_traces",
+                id="trace_level_with_max_traces",
             ),
             pytest.param(
-                ["200", "20", "detailed", "30", "openai", "gpt-4.1-mini"],
+                ["generation", "200"],
                 BatchTraceSummarizationCoordinatorInputs(
-                    max_traces=200,
+                    analysis_level="generation",
+                    max_items=200,
+                    batch_size=DEFAULT_BATCH_SIZE,
+                    mode=DEFAULT_MODE,
+                    window_minutes=DEFAULT_WINDOW_MINUTES,
+                    provider=DEFAULT_PROVIDER,
+                    model=DEFAULT_MODEL,
+                ),
+                id="generation_level_with_max_traces",
+            ),
+            pytest.param(
+                ["trace", "200", "20", "detailed", "30", "openai", "gpt-4.1-mini"],
+                BatchTraceSummarizationCoordinatorInputs(
+                    analysis_level="trace",
+                    max_items=200,
                     batch_size=20,
                     mode=SummarizationMode.DETAILED,
                     window_minutes=30,
@@ -88,7 +104,8 @@ class TestBatchTraceSummarizationCoordinatorWorkflow:
         """Test parsing of workflow inputs."""
         result = BatchTraceSummarizationCoordinatorWorkflow.parse_inputs(inputs)
 
-        assert result.max_traces == expected.max_traces
+        assert result.analysis_level == expected.analysis_level
+        assert result.max_items == expected.max_items
         assert result.batch_size == expected.batch_size
         assert result.mode == expected.mode
         assert result.window_minutes == expected.window_minutes

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_generation_summarization.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_generation_summarization.py
@@ -1,0 +1,209 @@
+"""Tests for generation summarization activity."""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from unittest.mock import patch
+
+from posthog.temporal.llm_analytics.trace_summarization.generation_summarization import (
+    _format_generation_text_repr,
+    generate_and_save_generation_summary_activity,
+)
+
+
+class TestFormatGenerationTextRepr:
+    """Tests for _format_generation_text_repr helper."""
+
+    def test_format_with_all_fields(self):
+        """Test formatting with all fields populated."""
+        generation_data = {
+            "model": "gpt-4",
+            "provider": "openai",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "latency": 1.5,
+            "input": [{"role": "user", "content": "Hello"}],
+            "output": [{"role": "assistant", "content": "Hi there!"}],
+        }
+
+        result = _format_generation_text_repr(generation_data)
+
+        assert "Model: gpt-4" in result
+        assert "Provider: openai" in result
+        assert "input=100" in result
+        assert "output=50" in result
+        assert "Latency: 1.50s" in result
+        assert "[user]: Hello" in result
+        assert "[assistant]: Hi there!" in result
+
+    def test_format_with_minimal_fields(self):
+        """Test formatting with minimal fields."""
+        generation_data = {"model": "gpt-4"}
+
+        result = _format_generation_text_repr(generation_data)
+
+        assert "Model: gpt-4" in result
+        assert "Provider:" not in result
+        assert "Tokens:" not in result
+
+    def test_format_with_string_input_output(self):
+        """Test formatting when input/output are strings instead of lists."""
+        generation_data = {
+            "input": "What is 2+2?",
+            "output": "4",
+        }
+
+        result = _format_generation_text_repr(generation_data)
+
+        assert "What is 2+2?" in result
+        assert "4" in result
+
+
+class TestGenerateAndSaveGenerationSummaryActivity:
+    """Tests for generate_and_save_generation_summary_activity."""
+
+    @pytest.fixture
+    def mock_team(self, db):
+        """Create a test team."""
+        from posthog.models.organization import Organization
+        from posthog.models.team import Team
+
+        organization = Organization.objects.create(name="Test Org")
+        team = Team.objects.create(organization=organization, name="Test Team")
+        return team
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
+    async def test_generation_not_found_returns_skipped(self, mock_team):
+        """Test that missing generation returns skipped result."""
+        with patch(
+            "posthog.temporal.llm_analytics.trace_summarization.generation_summarization.execute_hogql_query"
+        ) as mock_query:
+            mock_query.return_value.results = []
+
+            result = await generate_and_save_generation_summary_activity(
+                generation_id=str(uuid.uuid4()),
+                trace_id=str(uuid.uuid4()),
+                trace_first_timestamp=datetime.now(UTC).isoformat(),
+                team_id=mock_team.id,
+                window_start="2025-01-01T00:00:00Z",
+                window_end="2025-01-01T01:00:00Z",
+                mode="minimal",
+                batch_run_id="test_batch",
+                provider="openai",
+            )
+
+            assert result.success is False
+            assert result.skipped is True
+            assert result.skip_reason == "generation_not_found"
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
+    async def test_successful_summary_generation(self, mock_team):
+        """Test successful summary generation and saving."""
+        from products.llm_analytics.backend.summarization.llm.schema import SummarizationResponse
+
+        generation_id = str(uuid.uuid4())
+        trace_id = str(uuid.uuid4())
+
+        mock_summary = SummarizationResponse(
+            title="Test Generation Summary",
+            flow_diagram="A -> B",
+            summary_bullets=[],
+            interesting_notes=[],
+        )
+
+        with (
+            patch(
+                "posthog.temporal.llm_analytics.trace_summarization.generation_summarization.execute_hogql_query"
+            ) as mock_query,
+            patch(
+                "posthog.temporal.llm_analytics.trace_summarization.generation_summarization.summarize"
+            ) as mock_summarize,
+            patch(
+                "posthog.temporal.llm_analytics.trace_summarization.generation_summarization.create_event"
+            ) as mock_create_event,
+            patch(
+                "posthog.temporal.llm_analytics.trace_summarization.generation_summarization.LLMTracesSummarizerEmbedder"
+            ),
+        ):
+            mock_query.return_value.results = [
+                (
+                    "gpt-4",
+                    "openai",
+                    [{"role": "user", "content": "Hi"}],
+                    [{"role": "assistant", "content": "Hello"}],
+                    10,
+                    5,
+                    0.5,
+                )
+            ]
+            mock_summarize.return_value = mock_summary
+
+            result = await generate_and_save_generation_summary_activity(
+                generation_id=generation_id,
+                trace_id=trace_id,
+                trace_first_timestamp=datetime.now(UTC).isoformat(),
+                team_id=mock_team.id,
+                window_start="2025-01-01T00:00:00Z",
+                window_end="2025-01-01T01:00:00Z",
+                mode="minimal",
+                batch_run_id="test_batch",
+                provider="openai",
+            )
+
+            assert result.success is True
+            assert result.trace_id == trace_id
+            assert result.generation_id == generation_id
+            assert result.text_repr_length > 0
+
+            mock_create_event.assert_called_once()
+            call_kwargs = mock_create_event.call_args.kwargs
+            assert call_kwargs["properties"]["$ai_generation_id"] == generation_id
+            assert call_kwargs["properties"]["$ai_trace_id"] == trace_id
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
+    async def test_embedding_failure_captured(self, mock_team):
+        """Test that embedding failures are captured but don't fail the activity."""
+        from products.llm_analytics.backend.summarization.llm.schema import SummarizationResponse
+
+        mock_summary = SummarizationResponse(
+            title="Test",
+            flow_diagram="",
+            summary_bullets=[],
+            interesting_notes=[],
+        )
+
+        with (
+            patch(
+                "posthog.temporal.llm_analytics.trace_summarization.generation_summarization.execute_hogql_query"
+            ) as mock_query,
+            patch(
+                "posthog.temporal.llm_analytics.trace_summarization.generation_summarization.summarize"
+            ) as mock_summarize,
+            patch("posthog.temporal.llm_analytics.trace_summarization.generation_summarization.create_event"),
+            patch(
+                "posthog.temporal.llm_analytics.trace_summarization.generation_summarization.LLMTracesSummarizerEmbedder"
+            ) as mock_embedder_class,
+        ):
+            mock_query.return_value.results = [("gpt-4", "openai", "input", "output", 10, 5, 0.5)]
+            mock_summarize.return_value = mock_summary
+            mock_embedder_class.return_value._embed_document.side_effect = Exception("Embedding failed")
+
+            result = await generate_and_save_generation_summary_activity(
+                generation_id=str(uuid.uuid4()),
+                trace_id=str(uuid.uuid4()),
+                trace_first_timestamp=datetime.now(UTC).isoformat(),
+                team_id=mock_team.id,
+                window_start="2025-01-01T00:00:00Z",
+                window_end="2025-01-01T01:00:00Z",
+                mode="minimal",
+                batch_run_id="test_batch",
+                provider="openai",
+            )
+
+            assert result.success is True
+            assert result.embedding_requested is False
+            assert result.embedding_request_error == "Embedding failed"

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -333,8 +333,23 @@ class TestBatchTraceSummarizationWorkflow:
         assert inputs.mode == "detailed"
         assert inputs.window_minutes == 60
 
-    def test_parse_inputs_full(self):
-        """Test parsing full inputs."""
+    def test_parse_inputs_full_trace_level(self):
+        """Test parsing full inputs for trace-level analysis."""
+        inputs = BatchTraceSummarizationWorkflow.parse_inputs(
+            ["123", "trace", "200", "20", "detailed", "30", "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z"]
+        )
+
+        assert inputs.team_id == 123
+        assert inputs.analysis_level == "trace"
+        assert inputs.max_items == 200
+        assert inputs.batch_size == 20
+        assert inputs.mode == "detailed"
+        assert inputs.window_minutes == 30
+        assert inputs.window_start == "2025-01-01T00:00:00Z"
+        assert inputs.window_end == "2025-01-02T00:00:00Z"
+
+    def test_parse_inputs_full_generation_level(self):
+        """Test parsing full inputs for generation-level analysis."""
         inputs = BatchTraceSummarizationWorkflow.parse_inputs(
             ["123", "generation", "200", "20", "detailed", "30", "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z"]
         )

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -6,8 +6,8 @@ from datetime import UTC, datetime
 import pytest
 from unittest.mock import patch
 
-from posthog.temporal.llm_analytics.trace_summarization.models import BatchSummarizationInputs
-from posthog.temporal.llm_analytics.trace_summarization.sampling import query_traces_in_window_activity
+from posthog.temporal.llm_analytics.trace_summarization.models import BatchSummarizationInputs, SampledItem
+from posthog.temporal.llm_analytics.trace_summarization.sampling import sample_items_in_window_activity
 from posthog.temporal.llm_analytics.trace_summarization.summarization import generate_and_save_summary_activity
 from posthog.temporal.llm_analytics.trace_summarization.workflow import BatchTraceSummarizationWorkflow
 
@@ -70,16 +70,16 @@ def sample_trace_hierarchy(sample_trace_data):
     }
 
 
-class TestQueryTracesInWindowActivity:
-    """Tests for query_traces_in_window_activity."""
+class TestSampleItemsInWindowActivity:
+    """Tests for sample_items_in_window_activity."""
 
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.asyncio
-    async def test_query_traces_success(self, mock_team):
-        """Test successful trace querying from window."""
+    async def test_sample_items_success(self, mock_team):
+        """Test successful item sampling from window."""
         inputs = BatchSummarizationInputs(
             team_id=mock_team.id,
-            max_traces=100,
+            max_items=100,
             window_minutes=60,
             window_start="2025-01-15T11:00:00",
             window_end="2025-01-15T12:00:00",
@@ -104,19 +104,20 @@ class TestQueryTracesInWindowActivity:
             ]
             mock_runner.calculate.return_value.results = mock_traces
 
-            result = await query_traces_in_window_activity(inputs)
+            result = await sample_items_in_window_activity(inputs)
 
             assert len(result) == 50
-            assert result[0] == "trace_0"
-            assert result[49] == "trace_49"
+            assert isinstance(result[0], SampledItem)
+            assert result[0].trace_id == "trace_0"
+            assert result[49].trace_id == "trace_49"
 
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.asyncio
-    async def test_query_traces_empty(self, mock_team):
-        """Test querying when no traces found in window."""
+    async def test_sample_items_empty(self, mock_team):
+        """Test sampling when no traces found in window."""
         inputs = BatchSummarizationInputs(
             team_id=mock_team.id,
-            max_traces=100,
+            max_items=100,
             window_minutes=60,
             window_start="2025-01-15T11:00:00",
             window_end="2025-01-15T12:00:00",
@@ -128,7 +129,7 @@ class TestQueryTracesInWindowActivity:
             mock_runner = mock_runner_class.return_value
             mock_runner.calculate.return_value.results = []
 
-            result = await query_traces_in_window_activity(inputs)
+            result = await sample_items_in_window_activity(inputs)
 
             assert len(result) == 0
 
@@ -189,6 +190,7 @@ class TestGenerateSummaryActivity:
 
             result = await generate_and_save_summary_activity(
                 sample_trace_data["trace_id"],
+                sample_trace_data["trace_timestamp"],
                 mock_team.id,
                 "2025-01-01T00:00:00Z",  # window_start
                 "2025-01-01T01:00:00Z",  # window_end
@@ -248,6 +250,7 @@ class TestGenerateSummaryActivity:
 
             result = await generate_and_save_summary_activity(
                 sample_trace_data["trace_id"],
+                sample_trace_data["trace_timestamp"],
                 mock_team.id,
                 "2025-01-01T00:00:00Z",
                 "2025-01-01T01:00:00Z",
@@ -302,6 +305,7 @@ class TestGenerateSummaryActivity:
 
             result = await generate_and_save_summary_activity(
                 sample_trace_data["trace_id"],
+                sample_trace_data["trace_timestamp"],
                 mock_team.id,
                 "2025-01-01T00:00:00Z",
                 "2025-01-01T01:00:00Z",
@@ -323,7 +327,8 @@ class TestBatchTraceSummarizationWorkflow:
         inputs = BatchTraceSummarizationWorkflow.parse_inputs(["123"])
 
         assert inputs.team_id == 123
-        assert inputs.max_traces == 10
+        assert inputs.analysis_level == "trace"
+        assert inputs.max_items == 10
         assert inputs.batch_size == 3
         assert inputs.mode == "detailed"
         assert inputs.window_minutes == 60
@@ -331,11 +336,12 @@ class TestBatchTraceSummarizationWorkflow:
     def test_parse_inputs_full(self):
         """Test parsing full inputs."""
         inputs = BatchTraceSummarizationWorkflow.parse_inputs(
-            ["123", "200", "20", "detailed", "30", "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z"]
+            ["123", "generation", "200", "20", "detailed", "30", "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z"]
         )
 
         assert inputs.team_id == 123
-        assert inputs.max_traces == 200
+        assert inputs.analysis_level == "generation"
+        assert inputs.max_items == 200
         assert inputs.batch_size == 20
         assert inputs.mode == "detailed"
         assert inputs.window_minutes == 30

--- a/posthog/temporal/llm_analytics/trace_summarization/utils.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/utils.py
@@ -1,0 +1,9 @@
+"""Utility functions for trace summarization."""
+
+from datetime import datetime
+
+
+def format_datetime_for_clickhouse(iso_string: str) -> str:
+    """Convert ISO format datetime string to ClickHouse-compatible format."""
+    dt = datetime.fromisoformat(iso_string)
+    return dt.strftime("%Y-%m-%d %H:%M:%S")

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -28,7 +28,10 @@ from posthog.temporal.ducklake.compaction_types import DucklakeCompactionInput
 from posthog.temporal.enforce_max_replay_retention.types import EnforceMaxReplayRetentionInput
 from posthog.temporal.experiments.schedule import create_experiment_regular_metrics_schedules
 from posthog.temporal.llm_analytics.trace_clustering.schedule import create_trace_clustering_coordinator_schedule
-from posthog.temporal.llm_analytics.trace_summarization.schedule import create_batch_trace_summarization_schedule
+from posthog.temporal.llm_analytics.trace_summarization.schedule import (
+    create_batch_generation_summarization_schedule,
+    create_batch_trace_summarization_schedule,
+)
 from posthog.temporal.product_analytics.upgrade_queries_workflow import UpgradeQueriesWorkflowInputs
 from posthog.temporal.quota_limiting.run_quota_limiting import RunQuotaLimitingInputs
 from posthog.temporal.salesforce_enrichment.workflow import SalesforceEnrichmentInputs
@@ -304,6 +307,7 @@ schedules = [
     create_enforce_max_replay_retention_schedule,
     create_weekly_digest_schedule,
     create_batch_trace_summarization_schedule,
+    create_batch_generation_summarization_schedule,
     create_trace_clustering_coordinator_schedule,
     create_ducklake_compaction_schedule,
     create_delete_recording_metadata_schedule,


### PR DESCRIPTION
## Problem

LLM analytics clustering only supports trace-level analysis. Users need generation-level clustering to analyze patterns in individual LLM calls.

Part 1 of 3 in stack (see also #45916, #45917). Supersedes #45805. Tracked in #45918.

## Changes

- New `generate_and_save_generation_summary_activity` for generation summaries
- `SampledItem` model with optional `generation_id` field
- Unified sampling that handles both trace and generation levels
- `AnalysisLevel` type parameter throughout the workflow
- New scheduled workflow for generation-level summarization
- Renamed `query_traces_in_window_activity` to `sample_items_in_window_activity`

## How did you test this code?

```bash
pytest posthog/temporal/llm_analytics/trace_summarization/tests/ -v
```

## Publish to changelog?

No - part of larger feature, will publish with final PR.