### PR TITLE
chore: added team_id to counter for better alert descriptions

### DIFF
--- a/nodejs/src/session-recording/sessions/metrics.ts
+++ b/nodejs/src/session-recording/sessions/metrics.ts
@@ -172,7 +172,7 @@ export class SessionBatchMetrics {
     }
 
     public static incrementNewSessionsRateLimited(teamId: number, count: number = 1): void {
-        this.newSessionsRateLimited.labels({ team_id: String(teamId) }).inc(count)
+        this.newSessionsRateLimited.labels({ team_id: teamId }).inc(count)
     }
 
     public static incrementSessionTrackerCacheHit(count: number = 1): void {

--- a/nodejs/src/session-recording/sessions/metrics.ts
+++ b/nodejs/src/session-recording/sessions/metrics.ts
@@ -76,6 +76,7 @@ export class SessionBatchMetrics {
     private static readonly newSessionsRateLimited = new Counter({
         name: 'recording_blob_ingestion_v2_new_sessions_rate_limited_total',
         help: 'Number of new sessions that were rate limited',
+        labelNames: ['team_id'],
     })
 
     private static readonly sessionTrackerCacheHit = new Counter({
@@ -170,8 +171,8 @@ export class SessionBatchMetrics {
         this.newSessionsDetected.inc(count)
     }
 
-    public static incrementNewSessionsRateLimited(count: number = 1): void {
-        this.newSessionsRateLimited.inc(count)
+    public static incrementNewSessionsRateLimited(teamId: number, count: number = 1): void {
+        this.newSessionsRateLimited.labels({ team_id: String(teamId) }).inc(count)
     }
 
     public static incrementSessionTrackerCacheHit(count: number = 1): void {

--- a/nodejs/src/session-recording/sessions/session-filter.test.ts
+++ b/nodejs/src/session-recording/sessions/session-filter.test.ts
@@ -304,7 +304,7 @@ describe('SessionFilter', () => {
             await sessionFilter.handleNewSession(1, 'session-123')
 
             expect(mockRedis.set).toHaveBeenCalled()
-            expect(SessionBatchMetrics.incrementNewSessionsRateLimited).toHaveBeenCalled()
+            expect(SessionBatchMetrics.incrementNewSessionsRateLimited).toHaveBeenCalledWith(1)
             expect(SessionBatchMetrics.incrementSessionsBlocked).toHaveBeenCalled()
         })
 
@@ -322,7 +322,7 @@ describe('SessionFilter', () => {
             await disabledFilter.handleNewSession(1, 'session-123')
 
             expect(mockRedis.set).not.toHaveBeenCalled()
-            expect(SessionBatchMetrics.incrementNewSessionsRateLimited).toHaveBeenCalled()
+            expect(SessionBatchMetrics.incrementNewSessionsRateLimited).toHaveBeenCalledWith(1)
         })
 
         it('should skip all Redis calls when filter is disabled', async () => {

--- a/nodejs/src/session-recording/sessions/session-filter.ts
+++ b/nodejs/src/session-recording/sessions/session-filter.ts
@@ -172,7 +172,7 @@ export class SessionFilter {
                 sessionId,
                 blockingEnabled: this.blockingEnabled,
             })
-            SessionBatchMetrics.incrementNewSessionsRateLimited()
+            SessionBatchMetrics.incrementNewSessionsRateLimited(teamId)
 
             if (this.blockingEnabled && this.filterEnabled) {
                 await this.blockSession(teamId, sessionId)


### PR DESCRIPTION
Added alerts whenever the new-session rate limiter is triggered. But needed to include the team_id to make the alert easier to react to.