### PR TITLE
fix(gateway): exact match instead of prefix match for allowed models

### DIFF
--- a/services/llm-gateway/src/llm_gateway/services/model_registry.py
+++ b/services/llm-gateway/src/llm_gateway/services/model_registry.py
@@ -46,9 +46,8 @@ def _is_chat_model(cost_data: ModelCost) -> bool:
 
 
 def _model_matches_allowlist(model_id: str, allowed_models: frozenset[str]) -> bool:
-    """Check if model matches allowlist using prefix matching (consistent with check_product_access)."""
-    model_lower = model_id.lower()
-    return any(model_lower.startswith(allowed) for allowed in allowed_models)
+    """Check if model matches allowlist using exact matching for /models endpoint listing."""
+    return model_id.lower() in allowed_models
 
 
 class ModelRegistryService:

--- a/services/llm-gateway/tests/test_models_api.py
+++ b/services/llm-gateway/tests/test_models_api.py
@@ -156,7 +156,8 @@ class TestListModelsForProductEndpoint:
         assert response.status_code == 200
         data = response.json()
         model_ids = {m["id"] for m in data["data"]}
-        assert "claude-sonnet-4-5-20260101" in model_ids
+        assert "claude-sonnet-4-5" in model_ids
+        assert "claude-sonnet-4-5-20260101" not in model_ids
         assert "gpt-4o" not in model_ids
         assert "o1" not in model_ids
         assert "claude-3-5-sonnet-20241022" not in model_ids
@@ -166,7 +167,7 @@ class TestListModelsForProductEndpoint:
         assert response.status_code == 200
         data = response.json()
         model_ids = {m["id"] for m in data["data"]}
-        assert "claude-sonnet-4-5-20260101" in model_ids
+        assert "claude-sonnet-4-5" in model_ids
         assert "gpt-4o" not in model_ids
 
     def test_returns_error_for_invalid_product(self, client: TestClient):


### PR DESCRIPTION
## Problem

we were matching by prefix instead of exact match in our per product model list in the gateway. this'll mean for `claude-sonnet-4-5` we'll also return `claude-sonnet-4-5-latest` which is not what we want. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

made this an exact match instead of prefix match
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually and updated tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
