### PR TITLE
feat: Zen mode deeplink

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -346,6 +346,14 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
         },
     })),
     selectors({
+        zenModeFromUrl: [
+            () => [router.selectors.searchParams],
+            (searchParams): boolean => {
+                // Enable zen mode via ?zen or ?zen=true or ?zen=1
+                const zenParam = searchParams?.zen
+                return zenParam !== undefined && zenParam !== 'false' && zenParam !== '0'
+            },
+        ],
         mode: [
             (s) => [s.sceneConfig, s.isCurrentOrganizationUnavailable, s.zenMode],
             (sceneConfig, isCurrentOrganizationUnavailable, zenMode): Navigation3000Mode => {
@@ -774,6 +782,13 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                 item.ref?.current?.focus()
             } else {
                 props.inputElement?.focus()
+            }
+        },
+        zenModeFromUrl: (zenModeFromUrl: boolean) => {
+            // Enable zen mode when URL parameter is present (e.g., ?zen or ?zen=true)
+            // Only enable, never disable from URL - user can manually disable
+            if (zenModeFromUrl && !values.zenMode) {
+                actions.setZenMode(true)
             }
         },
     })),


### PR DESCRIPTION
## Problem

Users need a way to share or directly access pages with Zen Mode automatically enabled for a focused, distraction-free experience. This improves shareability and direct access to a more focused view of any page.

## Changes

This PR introduces a deeplink for Zen Mode. Appending `?zen` (or `?zen=true`, `?zen=1`) to any URL will automatically activate Zen Mode upon page load.

The implementation in `frontend/src/layout/navigation-3000/navigationLogic.tsx` includes:
- A `zenModeFromUrl` selector to detect the URL parameter.
- A subscription that enables Zen Mode if the parameter is present and Zen Mode is not already active.
- The URL parameter only enables Zen Mode; it does not disable it, allowing users to manually toggle it off.

**Usage examples:**
- `https://app.posthog.com/dashboards?zen`
- `https://app.posthog.com/insights?zen=true`
- `https://app.posthog.com/replay?zen=1`

## How did you test this code?

Manually tested by navigating to various PostHog pages with `?zen` appended to the URL, confirming Zen Mode activates. Verified that `?zen=false` or `?zen=0` does not activate it, and that Zen Mode can be manually disabled after being activated by the URL.

## Publish to changelog?

Yes

---
[Slack Thread](https://posthog.slack.com/archives/C043VJ93L3B/p1769438677970749?thread_ts=1769438677.970749&cid=C043VJ93L3B)

<a href="https://cursor.com/background-agent?bcId=bc-b017e508-d561-4c87-a231-cf368e6a0a2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b017e508-d561-4c87-a231-cf368e6a0a2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

