### PR TITLE
fix: escape problematic linear stuff

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/linear/linear.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/linear/linear.template.ts
@@ -23,10 +23,7 @@ export const template: HogFunctionTemplate = {
     })
 }
 
-let escaped_title := replaceAll(replaceAll(inputs.title, '"', '\\\\"'), '\n', ' ');
-let escaped_description := replaceAll(replaceAll(inputs.description, '"', '\\\\"'), '\n', ' ');
-
-let issue_mutation := f'mutation IssueCreate \\{ issueCreate(input: \\{ title: "{escaped_title}" description: "{escaped_description}" teamId: "{inputs.team}" }) \\{ success issue \\{ identifier } } }';
+let issue_mutation := f'mutation IssueCreate \\{ issueCreate(input: \\{ title: {jsonStringify(inputs.title)} description: {jsonStringify(inputs.description)} teamId: "{inputs.team}" }) \\{ success issue \\{ identifier } } }';
 
 let issue_response := query(issue_mutation);
 

--- a/nodejs/src/cdp/templates/_destinations/linear/linear.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/linear/linear.template.ts
@@ -23,7 +23,10 @@ export const template: HogFunctionTemplate = {
     })
 }
 
-let issue_mutation := f'mutation IssueCreate \\{ issueCreate(input: \\{ title: "{inputs.title}" description: "{inputs.description}" teamId: "{inputs.team}" }) \\{ success issue \\{ identifier } } }';
+let escaped_title := replaceAll(replaceAll(inputs.title, '"', '\\\\"'), '\n', ' ');
+let escaped_description := replaceAll(replaceAll(inputs.description, '"', '\\\\"'), '\n', ' ');
+
+let issue_mutation := f'mutation IssueCreate \\{ issueCreate(input: \\{ title: "{escaped_title}" description: "{escaped_description}" teamId: "{inputs.team}" }) \\{ success issue \\{ identifier } } }';
 
 let issue_response := query(issue_mutation);
 


### PR DESCRIPTION
- \\" was causing problems in a graphql mutation,
- \n is not accepted by linears graphql

This PR fixes that 