### PR TITLE
fix(experiments): Restrict metric chart to avoid one large chart squeezing all others

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
@@ -64,9 +64,15 @@ export function ChartCell({
     const viewBoxHeight = CHART_CELL_VIEW_BOX_HEIGHT
     const barHeightPercent = CHART_CELL_BAR_HEIGHT_PERCENT
     const y = (viewBoxHeight - barHeightPercent) / 2 // Center the bar vertically
-    const x1 = scale(lower)
-    const x2 = scale(upper)
-    const deltaX = scale(delta)
+
+    // Cap positions to valid SVG range so bars extending beyond ±MAX_AXIS_RANGE are cut off at edges
+    const minX = SVG_EDGE_MARGIN
+    const maxX = VIEW_BOX_WIDTH - SVG_EDGE_MARGIN
+    const capToChartBounds = (value: number): number => Math.max(minX, Math.min(maxX, value))
+
+    const x1 = capToChartBounds(scale(lower))
+    const x2 = capToChartBounds(scale(upper))
+    const deltaX = capToChartBounds(scale(delta))
 
     const isClickable = !!onTimeseriesClick
 

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -12,6 +12,7 @@ import { experimentLogic } from '../../experimentLogic'
 import { type ExperimentVariantResult, getVariantInterval } from '../shared/utils'
 import { MetricRowGroup } from './MetricRowGroup'
 import { TableHeader } from './TableHeader'
+import { MAX_AXIS_RANGE } from './constants'
 
 interface MetricsTableProps {
     metrics: ExperimentMetric[]
@@ -46,7 +47,7 @@ export function MetricsTable({
     )
 
     const axisMargin = Math.max(maxAbsValue * 0.05, 0.1)
-    const axisRange = maxAbsValue + axisMargin
+    const axisRange = Math.min(maxAbsValue + axisMargin, MAX_AXIS_RANGE)
 
     if (metrics.length === 0) {
         return (

--- a/frontend/src/scenes/experiments/MetricsView/new/constants.ts
+++ b/frontend/src/scenes/experiments/MetricsView/new/constants.ts
@@ -14,6 +14,7 @@ export const GRID_LINES_OPACITY = 0.8
 // Axis
 export const TICK_PANEL_HEIGHT = 20
 export const TICK_FONT_SIZE = 9
+export const MAX_AXIS_RANGE = 1.5 // Cap at ±150% to prevent outliers from squishing other charts
 
 // New temporary values until the new table have been fully rolled out
 export const BAR_HEIGHT_NEW = 12


### PR DESCRIPTION
## Problem

The experiment page shows charts for each of the metrics in one column. If one chart is an outlier, it did squeeze all other charts.

## Changes

- Apply capping logic to limit the interval to -150% and +150%

| before | after |
| - | - |
|  <img width="1123" height="570" alt="before" src="https://github.com/user-attachments/assets/610499a5-6563-409b-a849-d598aab74c20" /> | <img width="1119" height="561" alt="after" src="https://github.com/user-attachments/assets/d199360e-86ec-42e9-8b23-f8aabef13d2c" /> |

Fyi, if the interval does lower values than 150%, the scale does dynamically scale as it did before, so the 150% is not static now but only applied when needed:

<img width="1119" height="559" alt="normal" src="https://github.com/user-attachments/assets/18e1ae47-bc8f-4da0-a8bc-dc3035f122bf" />



## How did you test this code?

Manually

## Publish to changelog?

No