### PR TITLE
fix: transaction on commit

### DIFF
--- a/products/conversations/backend/api/tests/test_signals.py
+++ b/products/conversations/backend/api/tests/test_signals.py
@@ -3,11 +3,19 @@ import uuid
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.db import transaction
+
 from posthog.models.comment import Comment
 
 from products.conversations.backend.models import Ticket
 
 
+# Patch on_commit to execute immediately in tests
+def immediate_on_commit(func):
+    func()
+
+
+@patch.object(transaction, "on_commit", side_effect=immediate_on_commit)
 class TestTicketMessageSignals(BaseTest):
     """Tests for signal handlers that maintain denormalized ticket stats."""
 
@@ -40,7 +48,7 @@ class TestTicketMessageSignals(BaseTest):
             item_context={"author_type": "team", "is_private": False},
         )
 
-    def test_customer_message_updates_stats(self):
+    def test_customer_message_updates_stats(self, mock_on_commit):
         comment = self._create_customer_message("Hello from customer")
 
         self.ticket.refresh_from_db()
@@ -49,7 +57,7 @@ class TestTicketMessageSignals(BaseTest):
         assert self.ticket.last_message_text == "Hello from customer"
         assert self.ticket.unread_customer_count == 0  # Customer messages don't increment this
 
-    def test_team_message_updates_stats_and_unread(self):
+    def test_team_message_updates_stats_and_unread(self, mock_on_commit):
         comment = self._create_team_message("Response from team")
 
         self.ticket.refresh_from_db()
@@ -58,7 +66,7 @@ class TestTicketMessageSignals(BaseTest):
         assert self.ticket.last_message_text == "Response from team"
         assert self.ticket.unread_customer_count == 1  # Team messages increment this
 
-    def test_multiple_messages_accumulate(self):
+    def test_multiple_messages_accumulate(self, mock_on_commit):
         self._create_customer_message("First")
         self._create_team_message("Second")
         last = self._create_customer_message("Third")
@@ -69,7 +77,7 @@ class TestTicketMessageSignals(BaseTest):
         assert self.ticket.last_message_text == "Third"
         assert self.ticket.unread_customer_count == 1  # Only 1 team message
 
-    def test_long_message_truncated_to_500_chars(self):
+    def test_long_message_truncated_to_500_chars(self, mock_on_commit):
         long_content = "x" * 600
         self._create_customer_message(long_content)
 
@@ -77,7 +85,7 @@ class TestTicketMessageSignals(BaseTest):
         assert len(self.ticket.last_message_text) == 500
         assert self.ticket.last_message_text == "x" * 500
 
-    def test_soft_delete_decrements_count(self):
+    def test_soft_delete_decrements_count(self, mock_on_commit):
         comment = self._create_customer_message("To be deleted")
         self.ticket.refresh_from_db()
         assert self.ticket.message_count == 1
@@ -88,7 +96,7 @@ class TestTicketMessageSignals(BaseTest):
         self.ticket.refresh_from_db()
         assert self.ticket.message_count == 0
 
-    def test_soft_delete_recalculates_last_message(self):
+    def test_soft_delete_recalculates_last_message(self, mock_on_commit):
         first = self._create_customer_message("First message")
         second = self._create_customer_message("Second message")
 
@@ -103,7 +111,7 @@ class TestTicketMessageSignals(BaseTest):
         assert self.ticket.last_message_at == first.created_at
         assert self.ticket.last_message_text == "First message"
 
-    def test_soft_delete_last_message_clears_last_message_fields(self):
+    def test_soft_delete_last_message_clears_last_message_fields(self, mock_on_commit):
         comment = self._create_customer_message("Only message")
         self.ticket.refresh_from_db()
         assert self.ticket.last_message_text == "Only message"
@@ -116,7 +124,7 @@ class TestTicketMessageSignals(BaseTest):
         assert self.ticket.last_message_at is None
         assert self.ticket.last_message_text is None
 
-    def test_soft_delete_team_message_decrements_unread(self):
+    def test_soft_delete_team_message_decrements_unread(self, mock_on_commit):
         comment = self._create_team_message("Team response")
         self.ticket.refresh_from_db()
         assert self.ticket.unread_customer_count == 1
@@ -127,7 +135,7 @@ class TestTicketMessageSignals(BaseTest):
         self.ticket.refresh_from_db()
         assert self.ticket.unread_customer_count == 0
 
-    def test_soft_delete_prevents_negative_counts(self):
+    def test_soft_delete_prevents_negative_counts(self, mock_on_commit):
         # Manually set count to 0 to simulate race condition / data inconsistency
         Ticket.objects.filter(id=self.ticket.id).update(message_count=0, unread_customer_count=0)
 
@@ -142,7 +150,7 @@ class TestTicketMessageSignals(BaseTest):
         assert self.ticket.message_count == 0  # Not -1
         assert self.ticket.unread_customer_count == 0  # Not -1
 
-    def test_non_conversations_comment_ignored(self):
+    def test_non_conversations_comment_ignored(self, mock_on_commit):
         # Comment for a different scope (e.g., recordings)
         Comment.objects.create(
             team=self.team,
@@ -154,7 +162,7 @@ class TestTicketMessageSignals(BaseTest):
         self.ticket.refresh_from_db()
         assert self.ticket.message_count == 0  # Unchanged
 
-    def test_comment_without_item_id_ignored(self):
+    def test_comment_without_item_id_ignored(self, mock_on_commit):
         Comment.objects.create(
             team=self.team,
             scope="conversations_ticket",
@@ -166,6 +174,7 @@ class TestTicketMessageSignals(BaseTest):
         assert self.ticket.message_count == 0  # Unchanged
 
 
+@patch.object(transaction, "on_commit", side_effect=immediate_on_commit)
 class TestCacheInvalidation(BaseTest):
     """Tests that cache invalidation is called at the right times."""
 
@@ -181,7 +190,7 @@ class TestCacheInvalidation(BaseTest):
 
     @patch("products.conversations.backend.signals.invalidate_messages_cache")
     @patch("products.conversations.backend.signals.invalidate_tickets_cache")
-    def test_message_create_invalidates_cache(self, mock_tickets_cache, mock_messages_cache):
+    def test_message_create_invalidates_cache(self, mock_tickets_cache, mock_messages_cache, mock_on_commit):
         Comment.objects.create(
             team=self.team,
             scope="conversations_ticket",
@@ -195,7 +204,7 @@ class TestCacheInvalidation(BaseTest):
 
     @patch("products.conversations.backend.signals.invalidate_messages_cache")
     @patch("products.conversations.backend.signals.invalidate_tickets_cache")
-    def test_soft_delete_invalidates_cache(self, mock_tickets_cache, mock_messages_cache):
+    def test_soft_delete_invalidates_cache(self, mock_tickets_cache, mock_messages_cache, mock_on_commit):
         comment = Comment.objects.create(
             team=self.team,
             scope="conversations_ticket",
@@ -213,7 +222,7 @@ class TestCacheInvalidation(BaseTest):
         mock_tickets_cache.assert_called_once_with(self.team.id, self.widget_session_id)
 
     @patch("products.conversations.backend.signals.invalidate_messages_cache")
-    def test_non_conversations_comment_no_cache_invalidation(self, mock_cache):
+    def test_non_conversations_comment_no_cache_invalidation(self, mock_cache, mock_on_commit):
         Comment.objects.create(
             team=self.team,
             scope="recordings",

--- a/products/conversations/backend/cache.py
+++ b/products/conversations/backend/cache.py
@@ -59,8 +59,9 @@ def invalidate_messages_cache(team_id: int, ticket_id: str) -> None:
         if hasattr(cache, "delete_pattern"):
             cache.delete_pattern(pattern)
         else:
-            # Fallback: delete initial key. Other variations expire via TTL.
+            # Fallback: delete initial key. Other variations expire via TTL (15s).
             cache.delete(get_messages_cache_key(team_id, ticket_id, None))
+            logger.info("conversations_cache_pattern_delete_unavailable", pattern=pattern)
     except Exception:
         logger.warning("conversations_cache_invalidate_error", pattern=pattern, exc_info=True)
 

--- a/products/conversations/backend/signals.py
+++ b/products/conversations/backend/signals.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.db.models import F
 from django.db.models.functions import Greatest
 from django.db.models.signals import post_save, pre_save
@@ -16,11 +17,12 @@ logger = structlog.get_logger(__name__)
 @receiver(post_save, sender=Comment)
 def update_ticket_on_message(sender, instance: Comment, created: bool, **kwargs):
     """
-    Update ticket stats when a message is created or soft-deleted.
-    - Increment message_count, update last_message_at/text on create
+    Update ticket stats when a new message is created.
+    - Increment message_count, update last_message_at/text
     - Increment unread_customer_count for team messages
-    - Handle soft-delete by decrementing count and recalculating last_message
     - Invalidate widget cache for polling endpoints
+
+    Uses transaction.on_commit() to defer work and avoid blocking the request.
     """
     if instance.scope != "conversations_ticket":
         return
@@ -28,35 +30,48 @@ def update_ticket_on_message(sender, instance: Comment, created: bool, **kwargs)
     if not instance.item_id:
         return
 
-    if created:
+    if not created:
+        return
+
+    # Capture values for closure (avoid referencing instance in deferred callback)
+    team_id = instance.team_id
+    item_id = instance.item_id
+    created_at = instance.created_at
+    content = instance.content
+    item_context = instance.item_context
+    created_by_id = instance.created_by_id
+
+    def do_update():
         # New message: update denormalized stats
-        author_type = instance.item_context.get("author_type") if isinstance(instance.item_context, dict) else None
-        is_team_message = instance.created_by and author_type != "customer"
+        author_type = item_context.get("author_type") if isinstance(item_context, dict) else None
+        is_team_message = created_by_id and author_type != "customer"
 
         update_fields = {
             "message_count": F("message_count") + 1,
-            "last_message_at": instance.created_at,
-            "last_message_text": (instance.content or "")[:500],  # Truncate to 500 chars
+            "last_message_at": created_at,
+            "last_message_text": (content or "")[:500],  # Truncate to 500 chars
         }
 
         if is_team_message:
             update_fields["unread_customer_count"] = F("unread_customer_count") + 1
 
-        Ticket.objects.filter(id=instance.item_id, team=instance.team).update(**update_fields)
+        Ticket.objects.filter(id=item_id, team_id=team_id).update(**update_fields)
 
         # Invalidate widget cache so polling sees new messages
-        invalidate_messages_cache(instance.team_id, instance.item_id)
+        invalidate_messages_cache(team_id, item_id)
         # Also invalidate tickets list cache (last_message changed)
         try:
-            ticket = Ticket.objects.filter(id=instance.item_id, team=instance.team).values("widget_session_id").first()
+            ticket = Ticket.objects.filter(id=item_id, team_id=team_id).values("widget_session_id").first()
             if ticket:
-                invalidate_tickets_cache(instance.team_id, ticket["widget_session_id"])
+                invalidate_tickets_cache(team_id, ticket["widget_session_id"])
         except Exception:
             logger.warning(
                 "conversations_ticket_cache_invalidate_failed",
-                ticket_id=instance.item_id,
+                ticket_id=item_id,
                 exc_info=True,
             )
+
+    transaction.on_commit(do_update)
 
 
 @receiver(pre_save, sender=Comment)
@@ -64,6 +79,8 @@ def handle_comment_soft_delete(sender, instance: Comment, **kwargs):
     """
     When a comment is soft-deleted, update the ticket's message stats.
     We use pre_save to detect the change from deleted=False to deleted=True.
+
+    Uses transaction.on_commit() to defer work and avoid blocking the request.
     """
     if instance.scope != "conversations_ticket":
         return
@@ -81,49 +98,59 @@ def handle_comment_soft_delete(sender, instance: Comment, **kwargs):
 
     # Detect soft-delete: was not deleted, now is deleted
     if not old_instance.deleted and instance.deleted:
-        author_type = instance.item_context.get("author_type") if isinstance(instance.item_context, dict) else None
-        is_team_message = instance.created_by and author_type != "customer"
+        # Capture values for closure (avoid referencing instance in deferred callback)
+        team_id = instance.team_id
+        item_id = instance.item_id
+        comment_pk = instance.pk
+        item_context = instance.item_context
+        created_by_id = instance.created_by_id
 
-        # Use Greatest to prevent negative counts from race conditions or data inconsistencies
-        update_fields = {"message_count": Greatest(F("message_count") - 1, 0)}
-        if is_team_message:
-            update_fields["unread_customer_count"] = Greatest(F("unread_customer_count") - 1, 0)
+        def do_soft_delete_update():
+            author_type = item_context.get("author_type") if isinstance(item_context, dict) else None
+            is_team_message = created_by_id and author_type != "customer"
 
-        Ticket.objects.filter(id=instance.item_id, team=instance.team).update(**update_fields)
+            # Use Greatest to prevent negative counts from race conditions or data inconsistencies
+            update_fields = {"message_count": Greatest(F("message_count") - 1, 0)}
+            if is_team_message:
+                update_fields["unread_customer_count"] = Greatest(F("unread_customer_count") - 1, 0)
 
-        # Recalculate last_message from remaining messages
-        last_comment = (
-            Comment.objects.filter(
-                team=instance.team,
-                scope="conversations_ticket",
-                item_id=instance.item_id,
-                deleted=False,
-            )
-            .exclude(pk=instance.pk)  # Exclude the one being deleted
-            .order_by("-created_at")
-            .first()
-        )
+            Ticket.objects.filter(id=item_id, team_id=team_id).update(**update_fields)
 
-        if last_comment:
-            Ticket.objects.filter(id=instance.item_id, team=instance.team).update(
-                last_message_at=last_comment.created_at,
-                last_message_text=(last_comment.content or "")[:500],
-            )
-        else:
-            Ticket.objects.filter(id=instance.item_id, team=instance.team).update(
-                last_message_at=None,
-                last_message_text=None,
+            # Recalculate last_message from remaining messages
+            last_comment = (
+                Comment.objects.filter(
+                    team_id=team_id,
+                    scope="conversations_ticket",
+                    item_id=item_id,
+                    deleted=False,
+                )
+                .exclude(pk=comment_pk)  # Exclude the one being deleted
+                .order_by("-created_at")
+                .first()
             )
 
-        # Invalidate widget cache
-        invalidate_messages_cache(instance.team_id, instance.item_id)
-        try:
-            ticket = Ticket.objects.filter(id=instance.item_id, team=instance.team).values("widget_session_id").first()
-            if ticket:
-                invalidate_tickets_cache(instance.team_id, ticket["widget_session_id"])
-        except Exception:
-            logger.warning(
-                "conversations_ticket_cache_invalidate_failed",
-                ticket_id=instance.item_id,
-                exc_info=True,
-            )
+            if last_comment:
+                Ticket.objects.filter(id=item_id, team_id=team_id).update(
+                    last_message_at=last_comment.created_at,
+                    last_message_text=(last_comment.content or "")[:500],
+                )
+            else:
+                Ticket.objects.filter(id=item_id, team_id=team_id).update(
+                    last_message_at=None,
+                    last_message_text=None,
+                )
+
+            # Invalidate widget cache
+            invalidate_messages_cache(team_id, item_id)
+            try:
+                ticket = Ticket.objects.filter(id=item_id, team_id=team_id).values("widget_session_id").first()
+                if ticket:
+                    invalidate_tickets_cache(team_id, ticket["widget_session_id"])
+            except Exception:
+                logger.warning(
+                    "conversations_ticket_cache_invalidate_failed",
+                    ticket_id=item_id,
+                    exc_info=True,
+                )
+
+        transaction.on_commit(do_soft_delete_update)


### PR DESCRIPTION
## Problem

When sending a message (from PostHog or widget), the request was timing out. The message was saved to the database, but the response never came back.
Root cause: The post_save signal on Comment was running synchronously during the request. If the ticket update or cache invalidation was slow (Redis slow/unreachable, DB contention), it blocked the entire response.

## Changes

Changed from synchronous execution to deferred execution using transaction.on_commit().
