### PR TITLE
feat: pre-fill signup email from signin email

### DIFF
--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -280,7 +280,7 @@ export function Login(): JSX.Element {
                 {!isEmailVerificationSent && preflight?.cloud && (
                     <div className="text-center mt-4">
                         Don't have an account?{' '}
-                        <Link to={signupUrl} data-attr="signup" className="font-bold">
+                        <Link to={[signupUrl, { email: login.email }]} data-attr="signup" className="font-bold">
                             Create an account
                         </Link>
                     </div>


### PR DESCRIPTION
## Problem

I think I have a posthog account so I try to sign in. I realize I don't have a posthog account so I click signup. It is kinda annoying I have to re-enter my email.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Prefil the email field on the signup page based on the email that is entered on the login page.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
