### PR TITLE
feat: add 'View' option to insight card

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -246,6 +246,18 @@ export function InsightMeta({
             moreButtons={
                 <>
                     {/* Insight related */}
+                    <LemonButton
+                        to={urls.insightView(
+                            short_id,
+                            dashboardId,
+                            variablesOverride,
+                            filtersOverride,
+                            tile?.filters_overrides
+                        )}
+                        fullWidth
+                    >
+                        View
+                    </LemonButton>
                     {canEditInsight && (
                         <>
                             <LemonButton

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -246,18 +246,20 @@ export function InsightMeta({
             moreButtons={
                 <>
                     {/* Insight related */}
-                    <LemonButton
-                        to={urls.insightView(
-                            short_id,
-                            dashboardId,
-                            variablesOverride,
-                            filtersOverride,
-                            tile?.filters_overrides
-                        )}
-                        fullWidth
-                    >
-                        View
-                    </LemonButton>
+                    {canViewInsight && (
+                        <LemonButton
+                            to={urls.insightView(
+                                short_id,
+                                dashboardId,
+                                variablesOverride,
+                                filtersOverride,
+                                tile?.filters_overrides
+                            )}
+                            fullWidth
+                        >
+                            View
+                        </LemonButton>
+                    )}
                     {canEditInsight && (
                         <>
                             <LemonButton


### PR DESCRIPTION
## Problem

Every time I go to a dashboard I intuitively click on the dropdown to view the insight, because it is not obvious that clicking on the insight title will take you to view the insight. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Added a new `View` option to the insight card which takes you to the same place as the card title link. This way there are now 2 paths to get here, and it is easier to intuitively discover this.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="1108" height="540" alt="Screenshot 2026-01-26 at 12 57 53 PM" src="https://github.com/user-attachments/assets/fa75899a-c3b2-4d13-8f82-81c686c2c509" />

## How did you test this code?

Manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
