### PR TITLE
fix: Widen impersonation notice

### DIFF
--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
@@ -1,6 +1,6 @@
 .ImpersonationNotice {
     display: flex;
-    width: 320px;
+    width: 26rem;
     background-color: var(--color-bg-surface-primary);
     border: 1px solid var(--border);
     border-radius: var(--radius);
@@ -129,7 +129,6 @@
         color: var(--text-primary);
         text-transform: uppercase;
         letter-spacing: 0.025em;
-        white-space: nowrap;
     }
 
     &__content {


### PR DESCRIPTION
Stop the expand icon from overflowing the container by making it wider (it's now the same width as other toasts).