### PR TITLE
feat(logs): set kafka headers in log ingestion based on settings

### DIFF
--- a/nodejs/src/logs-ingestion/__snapshots__/logs-ingestion-consumer.test.ts.snap
+++ b/nodejs/src/logs-ingestion/__snapshots__/logs-ingestion-consumer.test.ts.snap
@@ -4,6 +4,8 @@ exports[`LogsIngestionConsumer general should process a valid log message 1`] = 
 [
   {
     "headers": {
+      "json-parse": "true",
+      "retention-days": "15",
       "team_id": "2",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
     },
@@ -23,6 +25,8 @@ exports[`LogsIngestionConsumer general should process multiple log messages 1`] 
 [
   {
     "headers": {
+      "json-parse": "true",
+      "retention-days": "15",
       "team_id": "2",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
     },
@@ -37,6 +41,8 @@ exports[`LogsIngestionConsumer general should process multiple log messages 1`] 
   },
   {
     "headers": {
+      "json-parse": "true",
+      "retention-days": "15",
       "team_id": "2",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
     },
@@ -51,6 +57,8 @@ exports[`LogsIngestionConsumer general should process multiple log messages 1`] 
   },
   {
     "headers": {
+      "json-parse": "true",
+      "retention-days": "15",
       "team_id": "2",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
     },
@@ -70,6 +78,8 @@ exports[`LogsIngestionConsumer message parsing and validation should overwrite e
 [
   {
     "headers": {
+      "json-parse": "true",
+      "retention-days": "15",
       "team_id": "2",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
     },
@@ -89,7 +99,9 @@ exports[`LogsIngestionConsumer message parsing and validation should preserve ka
 [
   {
     "headers": {
+      "json-parse": "true",
       "myHeader": "hello",
+      "retention-days": "15",
       "team_id": "2",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
     },

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -308,7 +308,7 @@ describe('LogsIngestionConsumer', () => {
             )
 
             // Clear team cache to ensure fresh data
-            await hub.teamManager.clearCache(team.id)
+            hub.teamManager['lazyLoader'].markForRefresh(String(team.id))
 
             const logData = createLogMessage()
             const messages = createKafkaMessages([logData], {

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -9,6 +9,7 @@ import { createTeam, getFirstTeam, getTeam, resetTestDatabase } from '~/tests/he
 
 import { Hub, Team } from '../../src/types'
 import { closeHub, createHub } from '../../src/utils/db/hub'
+import { PostgresUse } from '../../src/utils/db/postgres'
 import { KAFKA_APP_METRICS_2 } from '../config/kafka-topics'
 import { parseJSON } from '../utils/json-parse'
 import {
@@ -299,7 +300,8 @@ describe('LogsIngestionConsumer', () => {
 
         it('should use custom logs_settings when set', async () => {
             // Update team with custom logs settings
-            await hub.db.postgres.query(
+            await hub.postgres.query(
+                PostgresUse.COMMON_WRITE,
                 `UPDATE posthog_team
                  SET logs_settings = $1
                  WHERE id = $2`,

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -622,6 +622,13 @@ export interface RawOrganization {
 export type OrganizationAvailableFeature = 'group_analytics' | 'data_pipelines' | 'zapier'
 
 /** Usable Team model. */
+export interface LogsSettings {
+    capture_console_logs?: boolean
+    json_parse_logs?: boolean
+    retention_days?: number
+    retention_last_updated?: string
+}
+
 export interface Team {
     id: number
     project_id: ProjectId
@@ -644,6 +651,7 @@ export interface Team {
     // This is parsed as a join from the org table
     available_features: OrganizationAvailableFeature[]
     drop_events_older_than_seconds: number | null
+    logs_settings: LogsSettings | null
 }
 
 /** Properties shared by RawEventMessage and EventMessage. */

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -651,7 +651,7 @@ export interface Team {
     // This is parsed as a join from the org table
     available_features: OrganizationAvailableFeature[]
     drop_events_older_than_seconds: number | null
-    logs_settings: LogsSettings | null
+    logs_settings?: LogsSettings | null
 }
 
 /** Properties shared by RawEventMessage and EventMessage. */

--- a/nodejs/src/utils/team-manager.test.ts
+++ b/nodejs/src/utils/team-manager.test.ts
@@ -57,6 +57,7 @@ describe('TeamManager()', () => {
                   "heatmaps_opt_in": null,
                   "id": 2,
                   "ingested_event": true,
+                  "logs_settings": null,
                   "name": "TEST PROJECT",
                   "organization_id": "<REPLACED-UUID-1>",
                   "person_display_name_properties": [],

--- a/nodejs/src/utils/team-manager.ts
+++ b/nodejs/src/utils/team-manager.ts
@@ -126,6 +126,7 @@ export class TeamManager {
                 t.person_display_name_properties,
                 t.cookieless_server_hash_mode,
                 t.timezone,
+                t.logs_settings,
                 extract('epoch' from t.drop_events_older_than) as drop_events_older_than_seconds,
                 o.available_product_features
             FROM posthog_team t


### PR DESCRIPTION
## Problem

We want to allow certain things to be configured via project settings - for now it's automatic JSON parsing and changing retention settings

At the moment we do not "unwrap" the message body (which is an AVRO file) in log ingestion so for now let's not do any of the work in ingestion, we simply fetch the settings and forward them via kafka message headers. We will update the clickhouse ingestion to use those headers to e.g. set expiry times or parse json bodies

## Changes

read team logs_settings and forward as necessary to the clickhouse ingestion topic as kafka message headers
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
