### PR TITLE
feat(deduplicator): extend rebalance cancellation to individual file import attempts

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/import.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/import.rs
@@ -3,7 +3,8 @@ use std::path::{Path, PathBuf};
 use super::{CheckpointDownloader, CheckpointMetadata};
 
 use anyhow::{Context, Result};
-use tracing::{error, info};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
 
 #[derive(Debug)]
 pub struct CheckpointImporter {
@@ -40,6 +41,18 @@ impl CheckpointImporter {
         topic: &str,
         partition_number: i32,
     ) -> Result<PathBuf> {
+        self.import_checkpoint_for_topic_partition_cancellable(topic, partition_number, None)
+            .await
+    }
+
+    /// Import checkpoint files with optional cancellation support.
+    /// If cancel_token is provided and cancelled during download, returns an error early.
+    pub async fn import_checkpoint_for_topic_partition_cancellable(
+        &self,
+        topic: &str,
+        partition_number: i32,
+        cancel_token: Option<&CancellationToken>,
+    ) -> Result<PathBuf> {
         let mut checkpoint_metadata = self
             .fetch_checkpoint_metadata(topic, partition_number)
             .await?;
@@ -59,6 +72,18 @@ impl CheckpointImporter {
 
         // checkpoints iterated in order of recency; we keep the first good one we fetch
         for attempt in checkpoint_metadata {
+            // Check cancellation before each attempt
+            if let Some(token) = cancel_token {
+                if token.is_cancelled() {
+                    warn!(
+                        topic = topic,
+                        partition = partition_number,
+                        "Checkpoint import cancelled before attempt"
+                    );
+                    return Err(anyhow::anyhow!("Checkpoint import cancelled"));
+                }
+            }
+
             let local_attempt_path = attempt.get_store_path(&self.store_base_path);
             let local_path_tag = local_attempt_path.to_string_lossy().to_string();
             let attempt_tag = attempt.get_attempt_path();
@@ -95,7 +120,7 @@ impl CheckpointImporter {
                 })?;
 
             match self
-                .fetch_checkpoint_files(&attempt, &local_attempt_path)
+                .fetch_checkpoint_files_cancellable(&attempt, &local_attempt_path, cancel_token)
                 .await
             {
                 Ok(_) => {
@@ -183,6 +208,16 @@ impl CheckpointImporter {
         checkpoint_metadata: &CheckpointMetadata,
         local_attempt_path: &Path,
     ) -> Result<()> {
+        self.fetch_checkpoint_files_cancellable(checkpoint_metadata, local_attempt_path, None)
+            .await
+    }
+
+    pub async fn fetch_checkpoint_files_cancellable(
+        &self,
+        checkpoint_metadata: &CheckpointMetadata,
+        local_attempt_path: &Path,
+        cancel_token: Option<&CancellationToken>,
+    ) -> Result<()> {
         let target_files = checkpoint_metadata
             .files
             .iter()
@@ -197,7 +232,7 @@ impl CheckpointImporter {
 
         match self
             .downloader
-            .download_files(&target_files, local_attempt_path)
+            .download_files_cancellable(&target_files, local_attempt_path, cancel_token)
             .await
         {
             Ok(_) => {
@@ -226,6 +261,7 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::time::Duration;
     use tempfile::TempDir;
 
     /// Mock downloader for testing checkpoint import behavior
@@ -259,25 +295,33 @@ mod tests {
             Ok(json.into_bytes())
         }
 
-        async fn download_and_store_file(
+        async fn download_and_store_file_cancellable(
             &self,
             _remote_key: &str,
             local_filepath: &Path,
+            cancel_token: Option<&CancellationToken>,
         ) -> Result<()> {
+            if let Some(token) = cancel_token {
+                if token.is_cancelled() {
+                    return Err(anyhow::anyhow!("Download cancelled"));
+                }
+            }
             tokio::fs::write(local_filepath, b"mock file content").await?;
             Ok(())
         }
 
-        async fn download_files(
+        async fn download_files_cancellable(
             &self,
             remote_keys: &[String],
             local_base_path: &Path,
+            cancel_token: Option<&CancellationToken>,
         ) -> Result<()> {
             self.download_count.fetch_add(1, Ordering::SeqCst);
             for key in remote_keys {
                 let filename = key.rsplit('/').next().unwrap_or(key);
                 let local_path = local_base_path.join(filename);
-                self.download_and_store_file(key, &local_path).await?;
+                self.download_and_store_file_cancellable(key, &local_path, cancel_token)
+                    .await?;
             }
             Ok(())
         }
@@ -285,6 +329,259 @@ mod tests {
         async fn is_available(&self) -> bool {
             true
         }
+    }
+
+    /// Mock downloader that can simulate failures and delays for cancellation testing
+    #[derive(Debug)]
+    struct CancellationTestDownloader {
+        /// Checkpoints to return from list_recent_checkpoints (multiple for multi-attempt tests)
+        checkpoints: Vec<CheckpointMetadata>,
+        /// Number of attempts that should fail before succeeding (for multi-attempt tests)
+        fail_count: AtomicUsize,
+        /// Delay to add during download (to simulate slow downloads)
+        download_delay: Option<Duration>,
+    }
+
+    impl CancellationTestDownloader {
+        fn new(checkpoints: Vec<CheckpointMetadata>) -> Self {
+            Self {
+                checkpoints,
+                fail_count: AtomicUsize::new(0),
+                download_delay: None,
+            }
+        }
+
+        fn with_fail_count(mut self, count: usize) -> Self {
+            self.fail_count = AtomicUsize::new(count);
+            self
+        }
+
+        fn with_download_delay(mut self, delay: Duration) -> Self {
+            self.download_delay = Some(delay);
+            self
+        }
+    }
+
+    #[async_trait]
+    impl CheckpointDownloader for CancellationTestDownloader {
+        async fn list_recent_checkpoints(
+            &self,
+            _topic: &str,
+            _partition_number: i32,
+        ) -> Result<Vec<String>> {
+            Ok(self
+                .checkpoints
+                .iter()
+                .map(|m| m.get_metadata_filepath())
+                .collect())
+        }
+
+        async fn download_file(&self, remote_key: &str) -> Result<Vec<u8>> {
+            // Find the matching checkpoint metadata
+            for checkpoint in &self.checkpoints {
+                if checkpoint.get_metadata_filepath() == remote_key {
+                    return Ok(checkpoint.to_json()?.into_bytes());
+                }
+            }
+            Err(anyhow::anyhow!("Metadata not found: {remote_key}"))
+        }
+
+        async fn download_and_store_file_cancellable(
+            &self,
+            _remote_key: &str,
+            local_filepath: &Path,
+            cancel_token: Option<&CancellationToken>,
+        ) -> Result<()> {
+            // Check cancellation before starting
+            if let Some(token) = cancel_token {
+                if token.is_cancelled() {
+                    return Err(anyhow::anyhow!("Download cancelled"));
+                }
+            }
+
+            // Simulate slow download if configured
+            if let Some(delay) = self.download_delay {
+                tokio::time::sleep(delay).await;
+            }
+
+            // Check cancellation after delay (simulates mid-stream cancellation)
+            if let Some(token) = cancel_token {
+                if token.is_cancelled() {
+                    return Err(anyhow::anyhow!("Download cancelled mid-stream"));
+                }
+            }
+
+            tokio::fs::write(local_filepath, b"mock file content").await?;
+            Ok(())
+        }
+
+        async fn download_files_cancellable(
+            &self,
+            remote_keys: &[String],
+            local_base_path: &Path,
+            cancel_token: Option<&CancellationToken>,
+        ) -> Result<()> {
+            // Apply delay first (simulates slow network/S3 response)
+            if let Some(delay) = self.download_delay {
+                tokio::time::sleep(delay).await;
+            }
+
+            // Check cancellation after delay
+            if let Some(token) = cancel_token {
+                if token.is_cancelled() {
+                    return Err(anyhow::anyhow!("Download cancelled"));
+                }
+            }
+
+            // Check if this attempt should fail
+            let remaining_fails = self.fail_count.load(Ordering::SeqCst);
+            if remaining_fails > 0 {
+                self.fail_count.fetch_sub(1, Ordering::SeqCst);
+                return Err(anyhow::anyhow!("Simulated download failure"));
+            }
+
+            for key in remote_keys {
+                let filename = key.rsplit('/').next().unwrap_or(key);
+                let local_path = local_base_path.join(filename);
+                self.download_and_store_file_cancellable(key, &local_path, cancel_token)
+                    .await?;
+            }
+            Ok(())
+        }
+
+        async fn is_available(&self) -> bool {
+            true
+        }
+    }
+
+    fn create_test_metadata(topic: &str, partition: i32, hour: u32) -> CheckpointMetadata {
+        let timestamp = Utc.with_ymd_and_hms(2025, 6, 15, hour, 0, 0).unwrap();
+        let mut metadata =
+            CheckpointMetadata::new(topic.to_string(), partition, timestamp, 12345, 100, 50);
+        metadata.track_file(
+            format!("checkpoints/{topic}/{partition}/2025-06-15T{hour:02}-00-00Z/000001.sst",),
+            "checksum1".to_string(),
+        );
+        metadata
+    }
+
+    #[tokio::test]
+    async fn test_download_files_cancellable_returns_early_when_pre_cancelled() {
+        let tmp_dir = TempDir::new().unwrap();
+        let metadata = create_test_metadata("test-topic", 0, 12);
+        let downloader = CancellationTestDownloader::new(vec![metadata]);
+
+        // Create a pre-cancelled token
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let result = downloader
+            .download_files_cancellable(
+                &["checkpoints/test-topic/0/file.sst".to_string()],
+                tmp_dir.path(),
+                Some(&token),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("cancelled"),
+            "Error should mention cancellation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_import_checkpoint_cancellable_returns_early_when_pre_cancelled() {
+        let tmp_dir = TempDir::new().unwrap();
+        let metadata = create_test_metadata("test-topic", 0, 12);
+        let downloader = CancellationTestDownloader::new(vec![metadata]);
+        let importer =
+            CheckpointImporter::new(Box::new(downloader), tmp_dir.path().to_path_buf(), 3);
+
+        // Create a pre-cancelled token
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let result = importer
+            .import_checkpoint_for_topic_partition_cancellable("test-topic", 0, Some(&token))
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("cancelled"),
+            "Error should mention cancellation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_import_checkpoint_cancelled_between_attempts() {
+        let tmp_dir = TempDir::new().unwrap();
+
+        // Create two checkpoint attempts
+        let metadata1 = create_test_metadata("test-topic", 0, 14); // Most recent
+        let metadata2 = create_test_metadata("test-topic", 0, 12); // Older
+
+        // First attempt will fail after 50ms delay, second would succeed
+        let downloader = CancellationTestDownloader::new(vec![metadata1, metadata2])
+            .with_fail_count(1) // First attempt fails
+            .with_download_delay(Duration::from_millis(50)); // Delay before failure
+
+        let importer =
+            CheckpointImporter::new(Box::new(downloader), tmp_dir.path().to_path_buf(), 3);
+
+        let token = CancellationToken::new();
+
+        // Cancel after 20ms - during first attempt's delay, before failure check
+        let token_clone = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            token_clone.cancel();
+        });
+
+        let result = importer
+            .import_checkpoint_for_topic_partition_cancellable("test-topic", 0, Some(&token))
+            .await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        // Cancellation should be detected during the download delay
+        assert!(
+            err_msg.contains("cancelled"),
+            "Error should mention cancellation, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_download_cancelled_mid_stream() {
+        let tmp_dir = TempDir::new().unwrap();
+        let metadata = create_test_metadata("test-topic", 0, 12);
+
+        // Add a delay to simulate slow download
+        let downloader = CancellationTestDownloader::new(vec![metadata])
+            .with_download_delay(Duration::from_millis(100));
+
+        let token = CancellationToken::new();
+
+        // Cancel after 20ms (before the 100ms download completes)
+        let token_clone = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            token_clone.cancel();
+        });
+
+        let result = downloader
+            .download_files_cancellable(
+                &["checkpoints/test-topic/0/file.sst".to_string()],
+                tmp_dir.path(),
+                Some(&token),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("cancelled"),
+            "Error should mention cancellation"
+        );
     }
 
     #[tokio::test]

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -125,6 +125,10 @@ pub struct Config {
     #[envconfig(default = "102400")] // 100MB max bytes to prefetch (value is in KB)
     pub kafka_consumer_queued_max_messages_kbytes: u32,
 
+    #[envconfig(default = "300000")]
+    // 5 minutes - max time between poll() calls before consumer leaves group
+    pub kafka_max_poll_interval_ms: u32,
+
     // Partition worker channel buffer size for pipeline parallelism
     #[envconfig(default = "10")]
     pub partition_worker_channel_buffer_size: usize,

--- a/rust/kafka-deduplicator/src/kafka/config.rs
+++ b/rust/kafka-deduplicator/src/kafka/config.rs
@@ -97,6 +97,12 @@ impl ConsumerConfigBuilder {
         self
     }
 
+    /// Set maximum time between poll() calls before consumer leaves group
+    pub fn with_max_poll_interval_ms(mut self, ms: u32) -> Self {
+        self.config.set("max.poll.interval.ms", ms.to_string());
+        self
+    }
+
     /// Enable sticky partition assignments based on the kafka client ID supplied.
     /// Always uses cooperative-sticky strategy for consistent behavior across all pods.
     /// When client_id is provided, also enables static membership for truly sticky assignments.

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -355,6 +355,8 @@ impl KafkaDeduplicatorService {
                 .with_queued_max_messages_kbytes(
                     self.config.kafka_consumer_queued_max_messages_kbytes,
                 )
+                // Consumer group membership settings
+                .with_max_poll_interval_ms(self.config.kafka_max_poll_interval_ms)
                 .build();
 
         // Create shutdown channel


### PR DESCRIPTION
## Problem
During checkpoint import and store manager setup, we only cancel the high level import attempts when another rebalance is triggered while one is in flight. This can leave long-running S3 `GetObject` and other calls running async until completion, competing with the new rebalance's import attempts, only to drop the results.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Eval rebalance cancellation token at individual file-import level for fast reset during overlap
* Related test and metric updates
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally + CI; smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
