### PR TITLE
fix(surveys): exclude archived responses from summaries and visualizations

### DIFF
--- a/frontend/src/scenes/surveys/components/question-visualizations/RatingQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/RatingQuestionViz.tsx
@@ -150,7 +150,8 @@ function NPSBreakdownViz({ npsBreakdown }: { npsBreakdown: NPSBreakdown }): JSX.
 }
 
 function NPSRatingOverTime({ questionIndex, questionId }: { questionIndex: number; questionId: string }): JSX.Element {
-    const { dateRange, interval, compareFilter, defaultInterval, survey } = useValues(surveyLogic)
+    const { dateRange, interval, compareFilter, defaultInterval, survey, archivedResponsesPropertyFilter } =
+        useValues(surveyLogic)
     const { setDateRange, setInterval, setCompareFilter } = useActions(surveyLogic)
 
     return (
@@ -225,6 +226,7 @@ function NPSRatingOverTime({ questionIndex, questionId }: { questionIndex: numbe
                                                     operator: PropertyOperator.Exact,
                                                     value: survey.id,
                                                 },
+                                                ...archivedResponsesPropertyFilter,
                                             ],
                                             trendsFilter: {
                                                 formula: '(A / (A+B+C) * 100) - (C / (A+B+C) * 100)',
@@ -262,7 +264,8 @@ function RatingScoreOverTime({
     questionId: string
     scale: 3 | 5 | 7
 }): JSX.Element {
-    const { dateRange, interval, compareFilter, defaultInterval, survey } = useValues(surveyLogic)
+    const { dateRange, interval, compareFilter, defaultInterval, survey, archivedResponsesPropertyFilter } =
+        useValues(surveyLogic)
     const { setDateRange, setInterval, setCompareFilter } = useActions(surveyLogic)
 
     // Array to hold the event series - one series for each possible rating value
@@ -362,6 +365,7 @@ function RatingScoreOverTime({
                                                     operator: PropertyOperator.Exact,
                                                     value: survey.id,
                                                 },
+                                                ...archivedResponsesPropertyFilter,
                                             ],
                                             trendsFilter: {
                                                 formula: formula,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1349,17 +1349,37 @@ export const surveyLogic = kea<surveyLogicType>([
         archivedResponsesFilter: [
             (s) => [s.showArchivedResponses, s.archivedResponseUuids],
             (showArchivedResponses: boolean, archivedUuids: Set<string>): string => {
-                if (showArchivedResponses) {
-                    return ''
-                }
-                if (!archivedUuids || archivedUuids.size === 0) {
+                if (showArchivedResponses || !archivedUuids || archivedUuids.size === 0) {
                     return ''
                 }
 
+                // UUIDs are pre-validated by Django's UUIDField when stored in SurveyResponseArchive
                 const uuidList = Array.from(archivedUuids)
                     .map((uuid) => `'${uuid}'`)
                     .join(', ')
                 return `AND uuid NOT IN (${uuidList})`
+            },
+        ],
+        archivedResponsesPropertyFilter: [
+            (s) => [s.showArchivedResponses, s.archivedResponseUuids],
+            (
+                showArchivedResponses: boolean,
+                archivedUuids: Set<string>
+            ): Array<{ type: PropertyFilterType.HogQL; key: string }> => {
+                if (showArchivedResponses || !archivedUuids || archivedUuids.size === 0) {
+                    return []
+                }
+
+                // UUIDs are pre-validated by Django's UUIDField when stored in SurveyResponseArchive
+                const uuidList = Array.from(archivedUuids)
+                    .map((uuid) => `'${uuid}'`)
+                    .join(', ')
+                return [
+                    {
+                        type: PropertyFilterType.HogQL,
+                        key: `uuid NOT IN (${uuidList})`,
+                    },
+                ]
             },
         ],
         isAdaptiveLimitFFEnabled: [

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -1556,6 +1556,9 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
         if question_text is None:
             raise exceptions.ValidationError("the text of the question is required")
 
+        # Get archived response UUIDs to exclude
+        archived_uuids = get_archived_response_uuids(survey_id, self.team.pk)
+
         # Fetch responses using the new module
         # For choice questions, exclude predefined choices to only get open-ended "Other" responses
         responses = fetch_responses(
@@ -1566,6 +1569,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
             end_date=end_date,
             team=self.team,
             exclude_values=question_choices,
+            exclude_uuids=archived_uuids,
         )
         response_count = len(responses)
 

--- a/products/surveys/backend/summarization/fetch.py
+++ b/products/surveys/backend/summarization/fetch.py
@@ -19,6 +19,7 @@ def fetch_responses(
     team: Team,
     limit: int = 100,
     exclude_values: list[str] | None = None,
+    exclude_uuids: set[str] | None = None,
 ) -> list[str]:
     """
     Fetch survey responses for a specific question.
@@ -32,13 +33,15 @@ def fetch_responses(
         team: The team to query
         limit: Maximum number of responses to fetch
         exclude_values: List of values to exclude (e.g., predefined choices for choice questions)
+        exclude_uuids: Set of response UUIDs to exclude (e.g., archived responses)
 
     Returns:
         List of response strings
     """
     paginator = HogQLHasMorePaginator(limit=limit, offset=0)
-    q = parse_select(
-        """
+
+    # Build the base query
+    base_query = """
         SELECT getSurveyResponse({question_index}, {question_id})
         FROM events
         WHERE event == 'survey sent'
@@ -46,15 +49,25 @@ def fetch_responses(
             AND trim(getSurveyResponse({question_index}, {question_id})) != ''
             AND timestamp >= {start_date}
             AND timestamp <= {end_date}
-        """,
-        {
-            "survey_id": ast.Constant(value=survey_id),
-            "start_date": ast.Constant(value=start_date),
-            "end_date": ast.Constant(value=end_date),
-            "question_index": ast.Constant(value=question_index),
-            "question_id": ast.Constant(value=question_id),
-        },
-    )
+    """
+
+    # Add archived response filter if there are UUIDs to exclude
+    # UUIDs are pre-validated by Django's UUIDField when stored in SurveyResponseArchive
+    if exclude_uuids:
+        base_query += " AND uuid NOT IN {exclude_uuids}"
+
+    placeholders: dict[str, ast.Expr] = {
+        "survey_id": ast.Constant(value=survey_id),
+        "start_date": ast.Constant(value=start_date),
+        "end_date": ast.Constant(value=end_date),
+        "question_index": ast.Constant(value=question_index),
+        "question_id": ast.Constant(value=question_id),
+    }
+
+    if exclude_uuids:
+        placeholders["exclude_uuids"] = ast.Tuple(exprs=[ast.Constant(value=uuid) for uuid in exclude_uuids])
+
+    q = parse_select(base_query, placeholders)
 
     query_response = paginator.execute_hogql_query(
         team=team,


### PR DESCRIPTION
## Summary
- Archived responses were being included in AI summaries and trend visualizations
- Now properly excluded using the existing `SurveyResponseArchive` UUIDs

## Changes
- **Backend**: `fetch_responses()` and `generate_survey_headline()` now filter out archived UUIDs
- **Frontend**: Added `archivedResponsesPropertyFilter` selector for trend charts (NPS over time, rating trends)

## Test plan
- [ ] Archive a survey response
- [ ] Verify it no longer appears in quick summaries
- [ ] Verify it no longer appears in headline summaries
- [ ] Verify trend visualizations exclude it
- [ ] Toggle "Show archived" and verify it reappears in data table only