### PR TITLE
fix(data-warehouse): order run history from left to right (oldest to …

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
@@ -47,8 +47,8 @@ function RunHistoryDisplay({
         return <span className="text-muted">-</span>
     }
 
-    // Show up to 5 most recent runs
-    const displayRuns = runHistory.slice(0, 5)
+    // Show up to 5 most recent runs, reversed so the most recent is on the right
+    const displayRuns = runHistory.slice(0, 5).reverse()
 
     return (
         <div className="flex gap-1">


### PR DESCRIPTION
## Problem
- https://posthog.slack.com/archives/C0A9BSVSE72/p1769466479842299

## Changes
- Change the order of the mat view run history order 
