### PR TITLE
feat(dagster): add _inserted_at column to ducklake backfill

### DIFF
--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -129,7 +129,8 @@ EVENTS_COLUMNS = """
     group3_created_at,
     group4_created_at,
     person_mode,
-    historical_migration
+    historical_migration,
+    NOW() as _inserted_at
 """
 
 # Expected columns in the DuckLake events table (for schema validation)
@@ -158,6 +159,7 @@ EXPECTED_DUCKLAKE_COLUMNS = {
     "group4_created_at",
     "person_mode",
     "historical_migration",
+    "_inserted_at",
 }
 
 

--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -372,7 +372,7 @@ def export_events_to_s3(
         {EVENTS_COLUMNS}
     FROM events
     WHERE {chunk_where}
-    SETTINGS s3_truncate_on_insert=1
+    SETTINGS s3_truncate_on_insert=1, use_hive_partitioning=0
     """
 
     chunk_info = f"{team_id_chunk + 1}/{total_chunks}"
@@ -385,7 +385,7 @@ def export_events_to_s3(
         {EVENTS_COLUMNS}
     FROM events
     WHERE {chunk_where}
-    SETTINGS s3_truncate_on_insert=1
+    SETTINGS s3_truncate_on_insert=1, use_hive_partitioning=0
     """
         context.log.info(f"[DRY RUN] Would export chunk {chunk_info} with SQL: {safe_sql[:800]}...")
         return []

--- a/posthog/dags/tests/test_events_backfill_to_ducklake.py
+++ b/posthog/dags/tests/test_events_backfill_to_ducklake.py
@@ -184,5 +184,6 @@ class TestEventsColumnsSchema:
             "group4_created_at",
             "person_mode",
             "historical_migration",
+            "_inserted_at",
         }
         assert EXPECTED_DUCKLAKE_COLUMNS == export_columns


### PR DESCRIPTION
## Summary

This PR fixes two issues with the DuckLake backfill job:

1. Adds the `_inserted_at` system column to maintain schema consistency with Kafka Connect
2. Disables Hive partitioning to prevent ClickHouse errors

## Context

### `_inserted_at` column

The DuckLake Kafka Connect ingestor was recently updated to include a `_inserted_at` TIMESTAMP column that tracks when data was inserted into DuckLake (see [ducklake-kafka-connect commits 56db5e7 and 4cb184b](https://github.com/PostHog/ducklake-kafka-connect/commits)).

The backfill job needs to export this same column to maintain schema consistency between:
- Real-time events ingested via Kafka Connect
- Historical events backfilled from ClickHouse

### Hive partitioning issue

ClickHouse was auto-detecting Hive partitioning from the S3 path pattern (`/year=YYYY/month=MM/day=DD/`) and expecting `year`, `month`, and `day` columns in the SELECT statement. This caused the error:

```
All hive partitioning columns must be present in the schema. Missing column: day.
```

Since we use the path structure purely for file organization (not for storing partition columns in the data), we need to explicitly disable Hive partitioning.

## Changes

1. Added `NOW() as _inserted_at` to the `EVENTS_COLUMNS` SELECT list
2. Added `_inserted_at` to the `EXPECTED_DUCKLAKE_COLUMNS` validation set
3. Added `use_hive_partitioning=0` to the S3 INSERT settings

The `_inserted_at` column is populated with `NOW()` to represent when the backfill ran, which is semantically correct - it tracks insertion time into DuckLake, not the original event timestamp (which is captured in the `timestamp` column).

## Test plan

- Verify the backfill job runs without the Hive partitioning error
- Confirm that backfilled Parquet files include the `_inserted_at` column
- Check that DuckLake ingestion successfully loads backfilled data with the new column
- Verify schema validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)