### PR TITLE
fix(dagster): remove person reconciliation job sensor run_key

### DIFF
--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -2013,14 +2013,12 @@ def person_property_reconciliation_scheduler(context: dagster.SensorEvaluationCo
                 team_ids=chunk_team_ids,
             )
 
-            run_key = f"reconcile_team_ids_{next_team_index}_{chunk_end_index - 1}"
             context.log.info(
                 f"Scheduling run for team_ids[{next_team_index}:{chunk_end_index}] ({len(chunk_team_ids)} teams)"
             )
 
             run_requests.append(
                 dagster.RunRequest(
-                    run_key=run_key,
                     run_config=run_config,
                     tags={
                         "reconciliation_team_ids_range": f"{next_team_index}-{chunk_end_index - 1}",
@@ -2055,12 +2053,10 @@ def person_property_reconciliation_scheduler(context: dagster.SensorEvaluationCo
                 max_team_id=chunk_end,
             )
 
-            run_key = f"reconcile_teams_{current_start}_{chunk_end}"
             context.log.info(f"Scheduling run for teams {current_start}-{chunk_end}")
 
             run_requests.append(
                 dagster.RunRequest(
-                    run_key=run_key,
                     run_config=run_config,
                     tags={
                         "reconciliation_range": f"{current_start}-{chunk_end}",

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -6424,8 +6424,8 @@ class TestReconciliationSchedulerSensor:
         assert isinstance(result, SensorResult)
         assert result.run_requests is not None
         assert len(result.run_requests) == 2
-        assert result.run_requests[0].run_key == "reconcile_teams_1_1000"
-        assert result.run_requests[1].run_key == "reconcile_teams_1001_2000"
+        assert result.run_requests[0].tags["reconciliation_range"] == "1-1000"
+        assert result.run_requests[1].tags["reconciliation_range"] == "1001-2000"
 
         assert result.cursor is not None
         new_cursor = json.loads(result.cursor)
@@ -6458,7 +6458,7 @@ class TestReconciliationSchedulerSensor:
         assert isinstance(result, SensorResult)
         assert result.run_requests is not None
         assert len(result.run_requests) == 1
-        assert result.run_requests[0].run_key == "reconcile_teams_1001_1500"
+        assert result.run_requests[0].tags["reconciliation_range"] == "1001-1500"
 
         assert result.cursor is not None
         new_cursor = json.loads(result.cursor)
@@ -6721,10 +6721,10 @@ class TestReconciliationSchedulerSensor:
         assert isinstance(result, SensorResult)
         assert result.run_requests is not None
         assert len(result.run_requests) == 4  # 10 teams / 3 per chunk = 4 chunks (3+3+3+1)
-        assert result.run_requests[0].run_key == "reconcile_team_ids_0_2"
-        assert result.run_requests[1].run_key == "reconcile_team_ids_3_5"
-        assert result.run_requests[2].run_key == "reconcile_team_ids_6_8"
-        assert result.run_requests[3].run_key == "reconcile_team_ids_9_9"
+        assert result.run_requests[0].tags["reconciliation_team_ids_range"] == "0-2"
+        assert result.run_requests[1].tags["reconciliation_team_ids_range"] == "3-5"
+        assert result.run_requests[2].tags["reconciliation_team_ids_range"] == "6-8"
+        assert result.run_requests[3].tags["reconciliation_team_ids_range"] == "9-9"
 
         # Verify first run config has correct team_ids chunk
         first_run_config = result.run_requests[0].run_config


### PR DESCRIPTION
## Problem
The `run_key` pattern is preventing us from running the backfill job over the same window using the sensor to coordinate and rate limit chunked job launches.

This pattern is useful for event-triggered or scheduled idempotent runs, but is a bad match for our use case, which is using the sensor to coordinate incident-driven one-off backfills where repeat dry run testing and/or manual triggers over the same team ID ranges will frequently be our goal.

The `run_key` is not used to coordinate paused/resumed sensor state or log/tag which jobs are running which chunks, so this won't remove observability or cause every sensor enablement to start the run fresh. It should be a no-op for our purposes 👍 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Remove the `run_key` from sensor-launched child jobs/tasks
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI + Dagster Cloud
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
