### PR TITLE
chore(deduplicator): clean up comments

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/import.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/import.rs
@@ -136,7 +136,7 @@ impl CheckpointImporter {
                         checkpoint = attempt_tag,
                         local_attempt_path = local_path_tag,
                         error = e.to_string(),
-                        "Failed to import checkpoint files "
+                        "Failed to import checkpoint files"
                     );
                     if local_attempt_path.exists() {
                         match tokio::fs::remove_dir_all(&local_attempt_path).await {

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -363,7 +363,7 @@ impl CheckpointManager {
                 } // end tokio::select! block
             } // end 'outer loop
 
-            info!("Checkpoint manager: submit loop shutting down");
+            info!("Checkpoint manager: exiting submit loop");
             checkpoint_health_reporter.store(false, Ordering::SeqCst);
         });
         self.checkpoint_task = Some(checkpoint_task_handle);

--- a/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
@@ -129,7 +129,7 @@ where
                             let partition_count = partitions.count();
                             info!(
                                 partition_count = partition_count,
-                                "Received resume command for partitions after checkpoint import"
+                                "Received resume command for partitions after store setup"
                             );
                             if let Err(e) = consumer.resume(&partitions) {
                                 error!(

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -167,11 +167,11 @@ impl StoreManager {
             warn!(
                 topic = topic,
                 partition = partition,
-                "No store registered for partition - message will be dropped (partition likely revoked)"
+                "No store registered for partition - message will be dropped (partition may have been revoked or not yet assigned)"
             );
             metrics::counter!(crate::metrics_const::MESSAGES_DROPPED_NO_STORE).increment(1);
             anyhow::anyhow!(
-                "No store registered for partition {}:{} - partition was likely revoked",
+                "No store registered for partition {}:{} - partition may have been revoked or not yet assigned",
                 topic,
                 partition
             )
@@ -709,7 +709,6 @@ impl StoreManager {
 
                         // Then check if we need capacity-based cleanup
                         if manager.needs_cleanup() {
-                            info!("Global capacity exceeded, triggering cleanup");
                             match manager.cleanup_old_entries_if_needed() {
                                 Ok(0) => {
                                     debug!("Cleanup skipped (may be already running or no data to clean)");
@@ -777,7 +776,7 @@ impl StoreManager {
                 std::fs::create_dir_all(parent).with_context(|| {
                     format!("Failed to create parent directory: {}", parent.display())
                 })?;
-                info!("Created parent directory: {}", parent.display());
+                debug!("Created parent directory: {}", parent.display());
             }
         }
 


### PR DESCRIPTION
## Problem
Tidy up some log levels and stale comments in the `kafka-deduplicator` project
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Comments, linter pass
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
