### PR TITLE
fix(deduplicator): early return bug where resume cmd is not sent to coordinator

### DIFF
--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -123,6 +123,11 @@ pub const REBALANCE_RESUME_PARTITIONS_FILTERED: &str = "rebalance_resume_partiti
 /// Counter for Resume commands skipped entirely (all partitions were revoked)
 pub const REBALANCE_RESUME_SKIPPED_ALL_REVOKED: &str = "rebalance_resume_skipped_all_revoked_total";
 
+/// Counter for partitions resumed after rebalance was cancelled
+/// This happens when a new rebalance starts before async setup completes,
+/// but some partitions are still owned and need to be resumed
+pub const REBALANCE_RESUME_AFTER_CANCELLATION: &str = "rebalance_resume_after_cancellation_total";
+
 // ==== Partition Batch Processing Diagnostics ====
 /// Histogram for partition batch processing duration (in milliseconds)
 pub const PARTITION_BATCH_PROCESSING_DURATION_MS: &str = "partition_batch_processing_duration_ms";


### PR DESCRIPTION
## Problem
Found a bug where we're not sending a `Resume` command to the `RebalanceCoordinator` 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Fix early return bug
* Validate behavior with updated + new test cases
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
