### PR TITLE
chore(livestream): Don't send messages to unsubscibed clients in the livestream service

### DIFF
--- a/livestream/events/counter.go
+++ b/livestream/events/counter.go
@@ -1,0 +1,67 @@
+package events
+
+import (
+	"sync"
+)
+
+// Counter is a thread-safe reference-counted set of strings.
+// Each key tracks how many times it has been added. A key is only
+// removed from the set when its count reaches zero.
+//
+// This is useful for tracking registrations where multiple consumers
+// may register interest in the same key, and the key should only be
+// considered "inactive" when all consumers have unregistered.
+type Counter struct {
+	keys map[string]int
+	mu   sync.RWMutex
+}
+
+// NewCounter creates a new empty Counter.
+func NewCounter() *Counter {
+	return &Counter{
+		keys: make(map[string]int),
+	}
+}
+
+// Add increments the count for the given key.
+// Empty strings are ignored.
+func (c *Counter) Add(key string) {
+	if key == "" {
+		return
+	}
+	c.mu.Lock()
+	c.keys[key]++
+	c.mu.Unlock()
+}
+
+// Remove decrements the count for the given key.
+// If the count reaches zero, the key is removed from the set.
+// Empty strings are ignored.
+func (c *Counter) Remove(key string) {
+	if key == "" {
+		return
+	}
+	c.mu.Lock()
+	if c.keys[key] > 1 {
+		c.keys[key]--
+	} else {
+		delete(c.keys, key)
+	}
+	c.mu.Unlock()
+}
+
+// Has returns true if the key exists in the set (count > 0).
+func (c *Counter) Has(key string) bool {
+	c.mu.RLock()
+	_, exists := c.keys[key]
+	c.mu.RUnlock()
+	return exists
+}
+
+// HasAny returns true if the set is non-empty.
+func (c *Counter) HasAny() bool {
+	c.mu.RLock()
+	hasAny := len(c.keys) > 0
+	c.mu.RUnlock()
+	return hasAny
+}

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -67,7 +67,8 @@ func main() {
 	go stats.KeepStats(statsChan)
 	go sessionStats.KeepStats(ctx, sessionStatsChan)
 
-	consumer, err := events.NewPostHogKafkaConsumer(config.Kafka, geolocator, phEventChan, statsChan, config.Parallelism)
+	filter := events.NewFilter(subChan, unSubChan, phEventChan)
+	consumer, err := events.NewPostHogKafkaConsumer(config.Kafka, geolocator, phEventChan, statsChan, config.Parallelism, filter.ActiveTokens())
 	if err != nil {
 		log.Fatalf("Failed to create Kafka consumer: %v", err)
 	}
@@ -107,7 +108,6 @@ func main() {
 		}
 	}()
 
-	filter := events.NewFilter(subChan, unSubChan, phEventChan)
 	go filter.Run()
 
 	// Echo instance

--- a/livestream/metrics/metrics.go
+++ b/livestream/metrics/metrics.go
@@ -57,6 +57,17 @@ var (
 		},
 		[]string{"channel"},
 	)
+	MsgSkippedNoSubscribers = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "livestream_kafka_skipped_no_subscribers_total",
+		Help: "Messages skipped because no active subscribers exist",
+	})
+	TokenSource = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "livestream_token_source_total",
+			Help: "Source of the token in parsed events",
+		},
+		[]string{"source"},
+	)
 
 	SessionRecordingMsgConsumed = promauto.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
## Problem
The Livestream service currently sends messages regardless if the user is actually subscribed to the SSE stream to receive it.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
  - Skip geo-lookup processing when there are no active subscribers
  - Skip sending messages to the outgoing channel when there are no active subscribers
  - Add `Counter` type to track active subscriptions
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
