### PR TITLE
fix: Fix input key being set on focus for lemon dropdowns

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -254,8 +254,14 @@ export function LemonInputSelect<T = string>({
                 // We don't want to show the input-based option again. The check for __isInput covers the case the user types something that is already an option, but we want to keep the original option
                 continue
             }
-            if (mode === 'single' && values.length > 0 && option.key === getStringKey(values[0])) {
+            if (
+                mode === 'single' &&
+                values.length > 0 &&
+                option.key === getStringKey(values[0]) &&
+                (!inputValue || stringKeys.includes(inputValue))
+            ) {
                 // In single-select mode, we've already added the selected value to the top earlier
+                // (only skip if we actually added it - which happens when there's no inputValue or inputValue matches a selected key)
                 continue
             }
             ret.push(option)
@@ -422,10 +428,8 @@ export function LemonInputSelect<T = string>({
     }
 
     const _onFocus = (): void => {
-        // In single mode, when focusing with a selected value, enter edit mode right away
-        if (mode === 'single' && values.length > 0 && !inputValue) {
-            setInputValue(getStringKey(values[0]))
-        }
+        // In single mode, just show the dropdown - the selected value is shown via valuesPrefix
+        // User can start typing to search/filter options
         onFocus?.()
         setShowPopover(true)
         popoverFocusRef.current = true
@@ -604,6 +608,7 @@ export function LemonInputSelect<T = string>({
         sortable,
         handleDragEnd,
         size,
+        onChange,
     ])
 
     // Positioned like a placeholder but rendered via the suffix since the actual placeholder has to be a string


### PR DESCRIPTION
## Problem

The dropdown was showing the numeric ID ("2028") in the input field when focused because _onFocus was setting inputValue to the key instead of the label

## Changes

frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx:
  - Removed the code in _onFocus that pre-filled the input with the key (ID) when clicking the dropdown in single-select mode
  - Now when you click the dropdown, all options are shown immediately and the selected value is displayed via the prefix (which shows the proper
  label)
  - You can start typing to filter options

## How did you test this code?

manually