### PR TITLE
fix(devex): set COMPOSE_PROJECT_NAME for worktree support

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -58,6 +58,7 @@ OPENSSL_INCLUDE_DIR = "$FLOX_ENV/include"
 LDFLAGS="-L$FLOX_ENV/lib"
 CPPFLAGS="-I$FLOX_ENV/include"
 UV_PROJECT_ENVIRONMENT = "$FLOX_ENV_CACHE/venv"
+COMPOSE_PROJECT_NAME = "posthog" # Ensure consistent Docker Compose project name across worktrees
 
 # The `hook.on-activate` script is run by the *bash* shell immediately upon
 # activating an environment, and will not be invoked if Flox detects that the


### PR DESCRIPTION
Hardcodes `COMPOSE_PROJECT_NAME=posthog` in flox vars to ensure all worktrees share the same Docker containers.

Without this, Docker Compose uses the directory name as the project name, causing worktrees to create duplicate containers or conflict with the main checkout.

Simpler approach than #40634 — just set it in flox instead of computing it in bin/start.