### PR TITLE
Add Bearer token authentication for internal API routes

### DIFF
--- a/nodejs/src/api/middleware/api-auth.ts
+++ b/nodejs/src/api/middleware/api-auth.ts
@@ -1,0 +1,31 @@
+import { NextFunction, Request, Response } from 'ultimate-express'
+
+import { logger } from '~/utils/logger'
+
+/**
+ * Creates middleware that validates a Bearer token on /api/ routes.
+ * When the token is empty, auth is disabled (for local dev / backwards compat).
+ */
+export function createApiAuthMiddleware(token: string) {
+    return (req: Request, res: Response, next: NextFunction): void => {
+        if (!token) {
+            next()
+            return
+        }
+
+        // Only enforce auth on /api/ routes
+        if (!req.path.startsWith('/api/')) {
+            next()
+            return
+        }
+
+        const authHeader = req.headers['authorization']
+        if (!authHeader || authHeader !== `Bearer ${token}`) {
+            logger.warn('Unauthorized API request', { path: req.path })
+            res.status(401).json({ error: 'Unauthorized' })
+            return
+        }
+
+        next()
+    }
+}

--- a/nodejs/src/api/router.ts
+++ b/nodejs/src/api/router.ts
@@ -1,8 +1,9 @@
 import * as prometheus from 'prom-client'
 import express, { Request, Response } from 'ultimate-express'
 
+import { createApiAuthMiddleware } from '~/api/middleware/api-auth'
 import { corsMiddleware } from '~/api/middleware/cors'
-import { HealthCheckResultError, PluginServerService } from '~/types'
+import { HealthCheckResultError, PluginsServerConfig, PluginServerService } from '~/types'
 import { logger } from '~/utils/logger'
 
 prometheus.collectDefaultMetrics()
@@ -19,11 +20,13 @@ export function setupCommonRoutes(
     return app
 }
 
-export function setupExpressApp(): express.Application {
+export function setupExpressApp(config?: Pick<PluginsServerConfig, 'PLUGIN_SERVER_API_TOKEN'>): express.Application {
     const app = express()
 
     // Add CORS middleware before other middleware
     app.use(corsMiddleware)
+
+    app.use(createApiAuthMiddleware(config?.PLUGIN_SERVER_API_TOKEN ?? ''))
 
     app.use(
         express.json({

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -327,6 +327,9 @@ export function getDefaultConfig(): PluginsServerConfig {
         POD_TERMINATION_BASE_TIMEOUT_MINUTES: 30, // Default: 30 minutes
         POD_TERMINATION_JITTER_MINUTES: 45, // Default: 45 hour, so timeout is between 30 minutes and 1h15m
 
+        // Internal API auth
+        PLUGIN_SERVER_API_TOKEN: '',
+
         // Logs ingestion
         LOGS_INGESTION_CONSUMER_GROUP_ID: 'ingestion-logs',
         LOGS_INGESTION_CONSUMER_CONSUME_TOPIC: KAFKA_LOGS_INGESTION,

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -66,7 +66,7 @@ export class PluginServer {
             ...config,
         }
 
-        this.expressApp = setupExpressApp()
+        this.expressApp = setupExpressApp(this.config)
         this.nodeInstrumentation = new NodeInstrumentation(this.config)
         this.setupContinuousProfiling()
     }

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -484,6 +484,9 @@ export interface PluginsServerConfig
     POD_TERMINATION_ENABLED: boolean
     POD_TERMINATION_BASE_TIMEOUT_MINUTES: number
     POD_TERMINATION_JITTER_MINUTES: number
+
+    // Internal API auth
+    PLUGIN_SERVER_API_TOKEN: string
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/posthog/plugins/plugin_server_api.py
+++ b/posthog/plugins/plugin_server_api.py
@@ -6,11 +6,17 @@ import structlog
 
 from posthog.models.utils import UUIDT
 from posthog.redis import get_client
-from posthog.settings import CDP_API_URL, PLUGINS_RELOAD_REDIS_URL
+from posthog.settings import CDP_API_URL, PLUGIN_SERVER_API_TOKEN, PLUGINS_RELOAD_REDIS_URL
 
 logger = structlog.get_logger(__name__)
 
 # NOTE: Any message publishing to the workers should be done here so that it is easy to find and update if needed
+
+
+def _api_headers() -> dict[str, str]:
+    if PLUGIN_SERVER_API_TOKEN:
+        return {"Authorization": f"Bearer {PLUGIN_SERVER_API_TOKEN}"}
+    return {}
 
 
 def publish_message(channel: str, payload: Union[dict, str]):
@@ -68,6 +74,7 @@ def create_hog_invocation_test(team_id: int, hog_function_id: str, payload: dict
     return requests.post(
         CDP_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/invocations",
         json=payload,
+        headers=_api_headers(),
     )
 
 
@@ -76,41 +83,44 @@ def create_hog_flow_invocation_test(team_id: int, hog_flow_id: str, payload: dic
     return requests.post(
         CDP_API_URL + f"/api/projects/{team_id}/hog_flows/{hog_flow_id}/invocations",
         json=payload,
+        headers=_api_headers(),
     )
 
 
 def get_hog_function_status(team_id: int, hog_function_id: UUIDT) -> requests.Response:
-    return requests.get(CDP_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/status")
+    return requests.get(CDP_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/status", headers=_api_headers())
 
 
 def patch_hog_function_status(team_id: int, hog_function_id: UUIDT, state: int) -> requests.Response:
     return requests.patch(
         CDP_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/status",
         json={"state": state},
+        headers=_api_headers(),
     )
 
 
 def generate_messaging_preferences_token(team_id: int, identifier: str) -> str:
     payload = {"team_id": team_id, "identifier": identifier}
-    response = requests.post(CDP_API_URL + "/api/messaging/generate_preferences_token", json=payload)
+    response = requests.post(CDP_API_URL + "/api/messaging/generate_preferences_token", json=payload, headers=_api_headers())
     if response.status_code == 200:
         return response.json().get("token")
     return ""
 
 
 def validate_messaging_preferences_token(token: str) -> requests.Response:
-    return requests.get(CDP_API_URL + f"/api/messaging/validate_preferences_token/{token}")
+    return requests.get(CDP_API_URL + f"/api/messaging/validate_preferences_token/{token}", headers=_api_headers())
 
 
 def get_hog_function_templates() -> requests.Response:
-    return requests.get(CDP_API_URL + f"/api/hog_function_templates")
+    return requests.get(CDP_API_URL + f"/api/hog_function_templates", headers=_api_headers())
 
 
 def create_batch_hog_flow_job_invocation(team_id: int, hog_flow_id: UUIDT, batch_job_id: UUIDT) -> requests.Response:
     return requests.post(
         CDP_API_URL + f"/api/projects/{team_id}/hog_flows/{hog_flow_id}/batch_invocations/{batch_job_id}",
+        headers=_api_headers(),
     )
 
 
 def get_plugin_server_status() -> requests.Response:
-    return requests.get(CDP_API_URL + f"/_health")
+    return requests.get(CDP_API_URL + f"/_health", headers=_api_headers())

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -420,6 +420,8 @@ CDP_API_URL = get_from_env("CDP_API_URL", "")
 if not CDP_API_URL:
     CDP_API_URL = "http://localhost:6738" if DEBUG else "http://ingestion-cdp-api.posthog.svc.cluster.local"
 
+PLUGIN_SERVER_API_TOKEN = os.getenv("PLUGIN_SERVER_API_TOKEN", "")
+
 EMBEDDING_API_URL = get_from_env("EMBEDDING_API_URL", "")
 
 # Used to generate embeddings on the fly, for use with the document embeddings table


### PR DESCRIPTION
## Problem

The plugin server's internal API routes (`/api/*`) need to be protected with authentication to prevent unauthorized access. Currently, there is no authentication mechanism in place.

## Changes

- **New middleware**: Created `api-auth.ts` middleware that validates Bearer tokens on `/api/` routes
  - Authentication is optional and disabled when `PLUGIN_SERVER_API_TOKEN` is empty (for local dev and backwards compatibility)
  - Returns 401 Unauthorized for invalid or missing tokens on protected routes
  - Logs unauthorized attempts for monitoring

- **Configuration**: 
  - Added `PLUGIN_SERVER_API_TOKEN` config option to `PluginsServerConfig` type
  - Added default empty value in `getDefaultConfig()`
  - Added environment variable support in Django settings

- **Integration**:
  - Integrated auth middleware into Express app setup in `router.ts`
  - Updated `PluginServer` to pass config to `setupExpressApp()`
  - Updated all Python API client calls in `plugin_server_api.py` to include Bearer token in request headers when configured

## How did you test this code?

- Verified middleware logic: token validation, path matching, and header checking
- Confirmed backwards compatibility: empty token disables auth
- Verified all API client calls in Python now include auth headers when token is configured
- Tested that non-API routes are not affected by the middleware

## Publish to changelog?

Yes - this adds a new security feature for protecting internal API endpoints.

https://claude.ai/code/session_01D4bFvzSQWym22atPhk5TNt