### PR TITLE
Sql cell output height

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
@@ -34,7 +34,6 @@
 
         .NotebookNode__content {
             z-index: 1;
-            overflow-y: auto;
             transition: box-shadow 150ms ease-out;
         }
     }

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
@@ -35,6 +35,11 @@
         .NotebookNode__content {
             z-index: 1;
             transition: box-shadow 150ms ease-out;
+
+            // Prevent tables from growing to fill available space in notebooks
+            .LemonTable {
+                flex: none;
+            }
         }
     }
 

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
@@ -34,6 +34,7 @@
 
         .NotebookNode__content {
             z-index: 1;
+            overflow-y: auto;
             transition: box-shadow 150ms ease-out;
         }
     }

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -60,6 +60,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
         expandOnClick = true,
         autoHideMetadata = false,
         minHeight,
+        maxHeight,
         getPos,
         attributes,
         updateAttributes,
@@ -344,7 +345,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
                                                 isEditable && isResizeable && 'resize-y'
                                             )}
                                             // eslint-disable-next-line react/forbid-dom-props
-                                            style={isResizeable ? { height, minHeight } : {}}
+                                            style={isResizeable ? { height, minHeight, maxHeight } : {}}
                                             onClick={!expanded && expandOnClick ? () => setExpanded(true) : undefined}
                                             onMouseDown={onResizeStart}
                                         >

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -126,7 +126,8 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
     const contentRef = useRef<HTMLDivElement | null>(null)
 
     // If resizeable is true then the node attr "height" is required
-    const height = attributes.height ?? heightEstimate
+    // Use 'fit-content' for auto-sizing nodes (when heightEstimate is 'auto' and no manual height set)
+    const height = attributes.height ?? (heightEstimate === 'auto' ? 'fit-content' : heightEstimate)
 
     const onResizeStart = useCallback((): void => {
         if (!resizeable) {
@@ -341,8 +342,8 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
                                         <div
                                             ref={contentRef}
                                             className={clsx(
-                                                'NotebookNode__content flex flex-col relative z-0 overflow-hidden',
-                                                isEditable && isResizeable && 'resize-y'
+                                                'NotebookNode__content flex flex-col relative z-0',
+                                                isEditable && isResizeable && 'resize-y overflow-auto'
                                             )}
                                             // eslint-disable-next-line react/forbid-dom-props
                                             style={isResizeable ? { height, minHeight, maxHeight } : {}}

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -126,8 +126,9 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
     const contentRef = useRef<HTMLDivElement | null>(null)
 
     // If resizeable is true then the node attr "height" is required
-    // Use 'fit-content' for auto-sizing nodes (when heightEstimate is 'auto' and no manual height set)
-    const height = attributes.height ?? (heightEstimate === 'auto' ? 'fit-content' : heightEstimate)
+    // For auto-sizing nodes (heightEstimate === 'auto'), only apply height if user manually resized
+    const isAutoSizing = heightEstimate === 'auto'
+    const height = isAutoSizing ? attributes.height : (attributes.height ?? heightEstimate)
 
     const onResizeStart = useCallback((): void => {
         if (!resizeable) {
@@ -346,7 +347,11 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
                                                 isEditable && isResizeable && 'resize-y overflow-auto'
                                             )}
                                             // eslint-disable-next-line react/forbid-dom-props
-                                            style={isResizeable ? { height, minHeight, maxHeight } : {}}
+                                            style={
+                                                isResizeable
+                                                    ? { ...(height !== undefined && { height }), minHeight, maxHeight }
+                                                    : {}
+                                            }
                                             onClick={!expanded && expandOnClick ? () => setExpanded(true) : undefined}
                                             onMouseDown={onResizeStart}
                                         >

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeDuckSQL.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeDuckSQL.tsx
@@ -92,13 +92,20 @@ const Component = ({
             duckExecution.media?.length ||
             duckExecution.traceback?.length)
 
-    // Reset height to auto when execution changes (so it re-fits to new content)
+    // Clear any stored height on mount and when execution changes (for auto-sizing)
     const executionCodeHash = attributes.duckExecutionCodeHash ?? null
     const lastExecutionCodeHashRef = useRef<number | null>(null)
+    const hasClearedInitialHeightRef = useRef(false)
     useEffect(() => {
+        // Clear height on initial mount if it was stored from before
+        if (!hasClearedInitialHeightRef.current && attributes.height !== undefined) {
+            hasClearedInitialHeightRef.current = true
+            updateAttributes({ height: undefined } as any)
+            return
+        }
+        // Also clear when execution changes
         if (executionCodeHash !== lastExecutionCodeHashRef.current) {
             lastExecutionCodeHashRef.current = executionCodeHash
-            // Clear any manual height so CSS auto-sizing takes over
             if (attributes.height !== undefined) {
                 updateAttributes({ height: undefined } as any)
             }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -1,6 +1,6 @@
 import { JSONContent } from '@tiptap/core'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
@@ -50,6 +50,15 @@ const Component = ({
     const { expanded } = useValues(nodeLogic)
     const { setTitlePlaceholder } = useActions(nodeLogic)
     const summarizeInsight = useSummarizeInsight()
+
+    // Clear any stored height on mount for auto-sizing
+    const hasClearedInitialHeightRef = useRef(false)
+    useEffect(() => {
+        if (!hasClearedInitialHeightRef.current && (attributes as any).height !== undefined) {
+            hasClearedInitialHeightRef.current = true
+            updateAttributes({ height: undefined } as any)
+        }
+    }, [(attributes as any).height, updateAttributes])
 
     const insightLogicProps = {
         dashboardItemId: query.kind === NodeKind.SavedInsightNode ? query.shortId : ('new' as const),

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -115,9 +115,9 @@ const Component = ({
     }
 
     return (
-        <div className="flex flex-1 flex-col h-full" data-attr="notebook-node-query">
+        <div className="flex flex-col" data-attr="notebook-node-query">
             <BindLogic logic={insightLogic} props={insightLogicProps}>
-                <ScrollableShadows direction="vertical" className="flex-1">
+                <ScrollableShadows direction="vertical">
                     <Query
                         // use separate keys for the settings and visualization to avoid conflicts with insightProps
                         uniqueKey={nodeId + '-component'}
@@ -264,8 +264,9 @@ export const NotebookNodeQuery = createPostHogWidgetNode<NotebookNodeQueryAttrib
     nodeType: NotebookNodeType.Query,
     titlePlaceholder: 'Query',
     Component,
-    heightEstimate: 500,
-    minHeight: 200,
+    heightEstimate: 'auto',
+    minHeight: 100,
+    maxHeight: 600,
     resizeable: true,
     startExpanded: true,
     attributes: {

--- a/frontend/src/scenes/notebooks/Nodes/components/NotebookDataframeTable.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/NotebookDataframeTable.tsx
@@ -87,7 +87,7 @@ export const NotebookDataframeTable = ({
     return (
         <div className="flex flex-col gap-2">
             <LemonTable
-                className="border-b border-primary"
+                className="border-b border-primary !flex-none"
                 data-attr="notebook-dataframe-table"
                 columns={columns}
                 dataSource={rowsWithIndex}

--- a/frontend/src/scenes/notebooks/Nodes/components/NotebookDataframeTable.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/NotebookDataframeTable.tsx
@@ -80,6 +80,10 @@ export const NotebookDataframeTable = ({
         'No rows to display.'
     )
 
+    // Hide pagination for single-page results
+    const totalPages = Math.ceil(rowCount / pageSize)
+    const showPagination = totalPages > 1 || rowCount > PAGE_SIZE_OPTIONS[0]
+
     return (
         <div className="flex flex-col gap-2">
             <LemonTable
@@ -94,37 +98,43 @@ export const NotebookDataframeTable = ({
                 emptyState={emptyState}
                 loadingSkeletonRows={pageSize}
             />
-            <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted">
-                <div className="flex items-center gap-2 pl-3">
-                    <span>Rows per page</span>
-                    <LemonSelect
-                        size="small"
-                        value={pageSize}
-                        onChange={(value) => onPageSizeChange(value ?? pageSize)}
-                        options={PAGE_SIZE_OPTIONS.map((option) => ({
-                            label: option.toString(),
-                            value: option,
-                        }))}
-                    />
+            {showPagination ? (
+                <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted">
+                    <div className="flex items-center gap-2 pl-3">
+                        <span>Rows per page</span>
+                        <LemonSelect
+                            size="small"
+                            value={pageSize}
+                            onChange={(value) => onPageSizeChange(value ?? pageSize)}
+                            options={PAGE_SIZE_OPTIONS.map((option) => ({
+                                label: option.toString(),
+                                value: option,
+                            }))}
+                        />
+                    </div>
+                    <div className="flex items-center gap-2 pr-2">
+                        <span>{rowCount === 0 ? 'No rows' : `${startIndex}-${endIndex} of ${rowCount}`}</span>
+                        <LemonButton
+                            size="small"
+                            onClick={onPreviousPage}
+                            disabledReason={hasPrevious ? undefined : 'No previous page'}
+                        >
+                            Prev
+                        </LemonButton>
+                        <LemonButton
+                            size="small"
+                            onClick={onNextPage}
+                            disabledReason={hasNext ? undefined : 'No next page'}
+                        >
+                            Next
+                        </LemonButton>
+                    </div>
                 </div>
-                <div className="flex items-center gap-2 pr-2">
-                    <span>{rowCount === 0 ? 'No rows' : `${startIndex}-${endIndex} of ${rowCount}`}</span>
-                    <LemonButton
-                        size="small"
-                        onClick={onPreviousPage}
-                        disabledReason={hasPrevious ? undefined : 'No previous page'}
-                    >
-                        Prev
-                    </LemonButton>
-                    <LemonButton
-                        size="small"
-                        onClick={onNextPage}
-                        disabledReason={hasNext ? undefined : 'No next page'}
-                    >
-                        Next
-                    </LemonButton>
+            ) : rowCount > 0 ? (
+                <div className="text-xs text-muted text-center py-1">
+                    Showing {rowCount === 1 ? 'one entry' : `${rowCount} entries`}
                 </div>
-            </div>
+            ) : null}
         </div>
     )
 }

--- a/frontend/src/scenes/notebooks/types.ts
+++ b/frontend/src/scenes/notebooks/types.ts
@@ -112,6 +112,7 @@ export type NodeWrapperProps<T extends CustomNotebookNodeAttributes> = Omit<Note
         selected?: boolean
         heightEstimate?: number | string
         minHeight?: number | string
+        maxHeight?: number | string
         /** If true the metadata area will only show when hovered if in editing mode */
         autoHideMetadata?: boolean
         /** Expand the node if the component is clicked */


### PR DESCRIPTION
## Problem

SQL cell outputs in notebooks consume an excessive amount of screen real estate, even for simple calculations, making them cumbersome for quick formula usage. This addresses a customer complaint regarding the usability of SQL cells for basic arithmetic, where the output previously took up a "TON of space / is overspec'd".

## Changes

This PR introduces dynamic height adjustments and a maximum height for SQL cell outputs, along with simplified pagination for small result sets:

1.  **SQL (DuckSQL) Node Configuration:**
    *   `heightEstimate` is now `'auto'`, `minHeight` reduced to `40px`, and `maxHeight` set to `400px`.
    *   Improved auto-height logic to properly shrink when content is small.
    *   Resets user-resize state when a new query execution occurs.
2.  **Node Wrapper:**
    *   Added `maxHeight` property support to the generic `NodeWrapper` component.
    *   Implemented `overflow-y: auto` for node content, enabling scrolling when `maxHeight` is reached.
3.  **Dataframe Table:**
    *   Pagination controls are now hidden for single-page results or when the row count is less than or equal to the default page size (10 rows).
    *   A concise "Showing one entry" or "Showing X entries" message is displayed instead for small results.

This ensures that simple SQL queries, like `SELECT 3782 - (761 * 0.845) AS result`, display compactly, while larger results will scroll within the defined `maxHeight`.

## How did you test this code?

*   Manually tested in notebooks by executing simple SQL queries to verify the output area shrinks to fit content.
*   Executed SQL queries with more rows to confirm `maxHeight` and vertical scrolling behavior.
*   Verified that manual resizing still works and persists until a new query is executed.
*   Ran `yarn tsc` and `yarn test` to check for type errors and existing test failures (noted pre-existing issues unrelated to changes).

## Publish to changelog?

no

---
<a href="https://cursor.com/background-agent?bcId=bc-da9eefae-b995-4a32-9f2c-a10bf86c80d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da9eefae-b995-4a32-9f2c-a10bf86c80d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

