### PR TITLE
feat(llma): migrate translation to use LLM gateway

### DIFF
--- a/posthog/llm/gateway_client.py
+++ b/posthog/llm/gateway_client.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from openai import OpenAI
 
 Product = Literal[
-    "llm_gateway", "twig", "wizard", "django", "growth"
+    "llm_gateway", "twig", "wizard", "django", "growth", "llma_translation"
 ]  # If you add a product here, make sure it's also in services/llm-gateway/src/llm_gateway/products/config.py
 
 

--- a/products/llm_analytics/backend/api/translate.py
+++ b/products/llm_analytics/backend/api/translate.py
@@ -89,7 +89,8 @@ class LLMAnalyticsTranslateViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
                 text_length=len(text),
             )
             start_time = time.time()
-            translation = translate_text(text, target_language, user_distinct_id=request.user.distinct_id)
+            user = cast(User, request.user)
+            translation = translate_text(text, target_language, user_distinct_id=user.distinct_id)
             duration_seconds = time.time() - start_time
             logger.info(
                 "translation_completed",
@@ -98,7 +99,7 @@ class LLMAnalyticsTranslateViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
             )
 
             report_user_action(
-                cast(User, request.user),
+                user,
                 "llma translation generated",
                 {
                     "target_language": target_language,

--- a/products/llm_analytics/backend/api/translate.py
+++ b/products/llm_analytics/backend/api/translate.py
@@ -8,8 +8,6 @@ Endpoint:
 import time
 from typing import cast
 
-from django.conf import settings
-
 import structlog
 from rest_framework import exceptions, serializers, status, viewsets
 from rest_framework.request import Request
@@ -84,12 +82,6 @@ class LLMAnalyticsTranslateViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
         text = serializer.validated_data["text"]
         target_language = serializer.validated_data.get("target_language", DEFAULT_TARGET_LANGUAGE)
 
-        if not getattr(settings, "OPENAI_API_KEY", None):
-            raise exceptions.APIException(
-                detail="Translation service is not configured. OPENAI_API_KEY is required.",
-                code="translation_not_configured",
-            )
-
         try:
             logger.info(
                 "translation_requested",
@@ -97,7 +89,7 @@ class LLMAnalyticsTranslateViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
                 text_length=len(text),
             )
             start_time = time.time()
-            translation = translate_text(text, target_language)
+            translation = translate_text(text, target_language, user_distinct_id=request.user.distinct_id)
             duration_seconds = time.time() - start_time
             logger.info(
                 "translation_completed",

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -55,6 +55,11 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allowed_models=None,
         allow_api_keys=True,
     ),
+    "llma_translation": ProductConfig(
+        allowed_application_ids=None,
+        allowed_models=frozenset({"gpt-4.1-mini"}),
+        allow_api_keys=True,
+    ),
 }
 
 

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -49,6 +49,10 @@ class TestCheckProductAccess:
             ("django", "personal_api_key", None, "gpt-4.1-mini", True, None),
             ("django", "personal_api_key", None, "claude-3-opus", True, None),
             ("django", "oauth_access_token", "any-app-id", "gpt-4.1-mini", True, None),
+            # llma_translation allows API keys but only gpt-4.1-mini
+            ("llma_translation", "personal_api_key", None, "gpt-4.1-mini", True, None),
+            ("llma_translation", "personal_api_key", None, "claude-3-opus", False, "not allowed"),
+            ("llma_translation", "oauth_access_token", "any-app-id", "gpt-4.1-mini", True, None),
             # unknown product
             ("unknown", "personal_api_key", None, None, False, "Unknown product"),
         ],


### PR DESCRIPTION
## Problem

The LLMA translation feature calls OpenAI directly, bypassing the centralized LLM gateway. This means no automatic `$ai_generation` event tracking, no cost/token tracking, and no gateway-level rate limiting.

## Changes

- Replace direct `openai.OpenAI(api_key=settings.OPENAI_API_KEY)` with `get_llm_client("llma_translation")` in the translation module
- Register `llma_translation` as a gateway product (restricted to `gpt-4.1-mini`)
- Add `llma_translation` to the Django gateway client `Product` type
- Remove `OPENAI_API_KEY` check from the translate view (gateway manages provider keys)
- Pass user `distinct_id` through for proper analytics attribution
- Update all tests to mock the gateway client instead of `openai.OpenAI`

## How did you test this code?

- All unit tests updated and passing (23/23 translation, 14/14 gateway client, 38/38 gateway product config, 13/13 API integration)
- Manual test: translation works end-to-end via local gateway with `ai_product=llma_translation` tracking

## Publish to changelog?

No