### PR TITLE
fix: Add optional chaining to event

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -239,10 +239,10 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                                                     )}{' '}
                                                     <span className="text-muted">performed</span>{' '}
                                                     <span className="space-y-1 font-semibold text-md">
-                                                        {sampleGlobals?.event.event}
+                                                        {sampleGlobals?.event?.event}
                                                     </span>{' '}
-                                                    {sampleGlobals?.event.timestamp && (
-                                                        <TZLabel time={sampleGlobals.event.timestamp} />
+                                                    {sampleGlobals?.event?.timestamp && (
+                                                        <TZLabel time={sampleGlobals?.event?.timestamp} />
                                                     )}
                                                 </div>
                                                 {shouldLoadSampleGlobals ? (


### PR DESCRIPTION
## Problem

https://us.posthog.com/project/2/error_tracking/019af8bb-735b-7621-be48-d71967288e86?94790c2dce985c32955e0e4f0296a2eb58f0336f76977196bde5aea998ba65f1834d217c8f32937d6c33d1526f40ef0446246b1b984b481959f4b486f007eae6&timestamp=2026-01-23%2016%3A13%3A47.813000-08%3A00

https://posthoghelp.zendesk.com/agent/tickets/48196 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/51097)

## Changes

Add optional chaining to event - prevents UI crash but the test will still fail to run without a valid event.

## How did you test this code?

Tested locally