### PR TITLE
fix(gateway): remove dummy PostHog token from mprocs config

### DIFF
--- a/bin/mprocs-with-logging.yaml
+++ b/bin/mprocs-with-logging.yaml
@@ -104,8 +104,6 @@ procs:
         env:
             LLM_GATEWAY_DEBUG: 'true'
             LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS: '{"1": 10}'
-            LLM_GATEWAY_POSTHOG_PROJECT_TOKEN: 'phc_localposthogprojecttoken'
-            LLM_GATEWAY_POSTHOG_HOST: 'http://localhost:8010'
 
     mcp:
         shell: 'bin/start-mcp-server 2>&1 | tee /tmp/posthog-mcp.log'

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -104,8 +104,6 @@ procs:
         env:
             LLM_GATEWAY_DEBUG: 'true'
             LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS: '{"1": 10}'
-            LLM_GATEWAY_POSTHOG_PROJECT_TOKEN: 'phc_localposthogprojecttoken'
-            LLM_GATEWAY_POSTHOG_HOST: 'http://localhost:8010'
 
     mcp:
         shell: 'bin/start-mcp-server'


### PR DESCRIPTION
## Problem

The mprocs config hardcodes `LLM_GATEWAY_POSTHOG_PROJECT_TOKEN: 'phc_localposthogprojecttoken'` (added in #45272 as a placeholder). No local team actually has this token, so the gateway's PostHog callback sends `$ai_generation` events that get silently dropped by the capture endpoint. This means LLM analytics tracking never works locally via mprocs.

## Changes

Removes the hardcoded `LLM_GATEWAY_POSTHOG_PROJECT_TOKEN` and `LLM_GATEWAY_POSTHOG_HOST` from both `mprocs.yaml` and `mprocs-with-logging.yaml`. Developers who want local LLM analytics tracking can set these in their `.env` file with their real team's project token. When unset, the gateway gracefully skips registering the PostHog callback.

## How did you test this code?

Confirmed the gateway picks up the token from `.env` when the mprocs override is removed. Verified `$ai_generation` events land in ClickHouse with the correct team token. Verified the gateway starts cleanly without the token set (callback is simply not registered).

## Publish to changelog?

No