### PR TITLE
feat(cyclotron): add shadow service

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -26,6 +26,14 @@ if [ -d "$SCRIPT_DIR/../rust/bin" ]; then
         fi
     fi
 
+    if run_scope "cyclotron-shadow"; then
+        bash $SCRIPT_DIR/../rust/bin/migrate-cyclotron-shadow
+        if [ $? -ne 0 ]; then
+            echo "Error in rust/bin/migrate-cyclotron-shadow, exiting."
+            exit 1
+        fi
+    fi
+
     if run_scope "persons"; then
         echo "Running persons migrations via external non-django migrator..."
         bash $SCRIPT_DIR/../rust/bin/migrate-persons

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -71,6 +71,17 @@ procs:
             bin/start-rust-service cyclotron-janitor
         capability: cyclotron
 
+    cyclotron-janitor-shadow:
+        shell: |-
+            bin/check_postgres_up cyclotron_shadow && \
+            bin/check_kafka_clickhouse_up && \
+            DATABASE_URL=postgres://posthog:posthog@localhost:5432/cyclotron_shadow \
+            BIND_PORT=3304 \
+            JANITOR_ID=shadow-janitor \
+            SHARD_ID=shadow \
+            bin/start-rust-service cyclotron-janitor
+        capability: cyclotron
+
     cymbal:
         shell: |-
             bin/check_postgres_up && \

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -80,7 +80,7 @@ procs:
             JANITOR_ID=shadow-janitor \
             SHARD_ID=shadow \
             bin/start-rust-service cyclotron-janitor
-        capability: cyclotron_shadow
+        capability: cyclotron
 
     cymbal:
         shell: |-
@@ -175,7 +175,7 @@ procs:
 
     migrate-cyclotron-shadow:
         shell: 'bin/check_postgres_up cyclotron_shadow && bin/migrate --scope=cyclotron-shadow'
-        capability: cyclotron_shadow
+        capability: cyclotron
 
     migrate-persons-db:
         shell: 'bin/check_postgres_up posthog_persons && bin/migrate --scope=persons'

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -80,7 +80,7 @@ procs:
             JANITOR_ID=shadow-janitor \
             SHARD_ID=shadow \
             bin/start-rust-service cyclotron-janitor
-        capability: cyclotron
+        capability: cyclotron_shadow
 
     cymbal:
         shell: |-
@@ -175,7 +175,7 @@ procs:
 
     migrate-cyclotron-shadow:
         shell: 'bin/check_postgres_up cyclotron_shadow && bin/migrate --scope=cyclotron-shadow'
-        capability: cyclotron
+        capability: cyclotron_shadow
 
     migrate-persons-db:
         shell: 'bin/check_postgres_up posthog_persons && bin/migrate --scope=persons'

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -169,6 +169,14 @@ procs:
         shell: 'bin/check_kafka_clickhouse_up && bin/check_ducklake_up && bin/migrate --scope=clickhouse'
         capability: core_infra
 
+    migrate-cyclotron:
+        shell: 'bin/check_postgres_up cyclotron && bin/migrate --scope=cyclotron'
+        capability: cyclotron
+
+    migrate-cyclotron-shadow:
+        shell: 'bin/check_postgres_up cyclotron_shadow && bin/migrate --scope=cyclotron-shadow'
+        capability: cyclotron
+
     migrate-persons-db:
         shell: 'bin/check_postgres_up posthog_persons && bin/migrate --scope=persons'
         # no capability - optional migration

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -116,7 +116,7 @@ case "$RS_SVC" in
     export RUST_BACKTRACE=1
     export KAFKA_HOSTS=localhost:9092
     export KAFKA_TOPIC=clickhouse_app_metrics2
-    export DATABASE_URL=postgres://posthog:posthog@localhost:5432/cyclotron
+    export DATABASE_URL=${DATABASE_URL:-postgres://posthog:posthog@localhost:5432/cyclotron}
     export DEBUG=1
     export ALLOW_INTERNAL_IPS=${ALLOW_INTERNAL_IPS:-true}
     ;;

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -84,12 +84,7 @@ capabilities:
         docker_profiles: []
 
     cyclotron:
-        description: 'Cyclotron janitor service'
-        requires: [core_infra]
-        docker_profiles: []
-
-    cyclotron_shadow:
-        description: 'Shadow Cyclotron worker and janitor for testing Postgres-backed job queue'
+        description: 'Cyclotron job queue infrastructure (includes shadow for testing)'
         requires: [core_infra]
         docker_profiles: []
 
@@ -189,15 +184,7 @@ intents:
     pipelines:
         description: 'Data pipeline transformations and destinations'
         capabilities:
-            [
-                event_ingestion,
-                property_definitions,
-                celery_workers,
-                temporal_workflows,
-                nodejs_cdp_workflows,
-                cyclotron,
-                cyclotron_shadow,
-            ]
+            [event_ingestion, property_definitions, celery_workers, temporal_workflows, nodejs_cdp_workflows, cyclotron]
 
     ai_features:
         description: 'AI features'
@@ -209,15 +196,7 @@ intents:
 
     workflows:
         description: 'Workflow automation and orchestration'
-        capabilities:
-            [
-                event_ingestion,
-                property_definitions,
-                temporal_workflows,
-                nodejs_cdp_workflows,
-                cyclotron,
-                cyclotron_shadow,
-            ]
+        capabilities: [event_ingestion, property_definitions, temporal_workflows, nodejs_cdp_workflows, cyclotron]
 
     tracing:
         description: 'OpenTelemetry tracing with Jaeger UI'

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -88,6 +88,11 @@ capabilities:
         requires: [core_infra]
         docker_profiles: []
 
+    cyclotron_shadow:
+        description: 'Shadow Cyclotron worker and janitor for testing Postgres-backed job queue'
+        requires: [core_infra]
+        docker_profiles: []
+
     # Node.js capability groups - control which consumers run to reduce event loop contention
     nodejs_cdp:
         description: 'Node.js CDP - destinations, webhooks, and realtime alerts'
@@ -183,7 +188,16 @@ intents:
 
     pipelines:
         description: 'Data pipeline transformations and destinations'
-        capabilities: [event_ingestion, property_definitions, celery_workers, temporal_workflows, nodejs_cdp_workflows]
+        capabilities:
+            [
+                event_ingestion,
+                property_definitions,
+                celery_workers,
+                temporal_workflows,
+                nodejs_cdp_workflows,
+                cyclotron,
+                cyclotron_shadow,
+            ]
 
     ai_features:
         description: 'AI features'
@@ -195,7 +209,15 @@ intents:
 
     workflows:
         description: 'Workflow automation and orchestration'
-        capabilities: [event_ingestion, property_definitions, temporal_workflows, nodejs_cdp_workflows]
+        capabilities:
+            [
+                event_ingestion,
+                property_definitions,
+                temporal_workflows,
+                nodejs_cdp_workflows,
+                cyclotron,
+                cyclotron_shadow,
+            ]
 
     tracing:
         description: 'OpenTelemetry tracing with Jaeger UI'

--- a/docker/postgres-init-scripts/create-cyclotron-shadow-db.sh
+++ b/docker/postgres-init-scripts/create-cyclotron-shadow-db.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -u
+
+echo "Checking if database 'cyclotron_shadow' exists..."
+DB_EXISTS=$(psql -U "$POSTGRES_USER" -tAc "SELECT 1 FROM pg_database WHERE datname='cyclotron_shadow'")
+
+if [ -z "$DB_EXISTS" ]; then
+    echo "Creating database 'cyclotron_shadow'..."
+    psql -U "$POSTGRES_USER" -c "CREATE DATABASE cyclotron_shadow;"
+    psql -U "$POSTGRES_USER" -c "GRANT ALL PRIVILEGES ON DATABASE cyclotron_shadow TO $POSTGRES_USER;"
+    echo "Database 'cyclotron_shadow' created successfully"
+else
+    echo "Database 'cyclotron_shadow' already exists"
+fi

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -27,7 +27,7 @@
         "prepublishOnly": "pnpm build",
         "setup:dev:clickhouse": "cd .. && DEBUG=1 python manage.py migrate_clickhouse",
         "setup:test": "cd .. && TEST=1 python manage.py setup_test_environment && cd nodejs && pnpm run setup:test:rust",
-        "setup:test:rust": "CYCLOTRON_DATABASE_NAME=test_cyclotron PERSONS_DATABASE_NAME=test_persons BEHAVIORAL_COHORTS_DATABASE_NAME=test_behavioral_cohorts ../rust/bin/migrate-entry all --fresh",
+        "setup:test:rust": "CYCLOTRON_DATABASE_NAME=test_cyclotron CYCLOTRON_SHADOW_DATABASE_NAME=test_cyclotron_shadow PERSONS_DATABASE_NAME=test_persons BEHAVIORAL_COHORTS_DATABASE_NAME=test_behavioral_cohorts ../rust/bin/migrate-entry all --fresh",
         "migrate:persons": "../rust/bin/migrate-persons",
         "migrate:cyclotron": "../rust/bin/migrate-cyclotron",
         "migrate:behavioral-cohorts": "../rust/bin/migrate-behavioral-cohorts",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -30,6 +30,7 @@
         "setup:test:rust": "CYCLOTRON_DATABASE_NAME=test_cyclotron CYCLOTRON_SHADOW_DATABASE_NAME=test_cyclotron_shadow PERSONS_DATABASE_NAME=test_persons BEHAVIORAL_COHORTS_DATABASE_NAME=test_behavioral_cohorts ../rust/bin/migrate-entry all --fresh",
         "migrate:persons": "../rust/bin/migrate-persons",
         "migrate:cyclotron": "../rust/bin/migrate-cyclotron",
+        "migrate:cyclotron-shadow": "../rust/bin/migrate-cyclotron-shadow",
         "migrate:behavioral-cohorts": "../rust/bin/migrate-behavioral-cohorts",
         "migrate:rust": "../rust/bin/migrate-entry all",
         "services:start": "cd .. && docker compose -f docker-compose.dev.yml up",

--- a/nodejs/src/capabilities.ts
+++ b/nodejs/src/capabilities.ts
@@ -198,5 +198,9 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
             return {
                 cdpDataWarehouseEvents: true,
             }
+        case PluginServerMode.cdp_cyclotron_shadow_worker:
+            return {
+                cdpCyclotronShadowWorker: true,
+            }
     }
 }

--- a/nodejs/src/capabilities.ts
+++ b/nodejs/src/capabilities.ts
@@ -11,6 +11,7 @@ export const CAPABILITIES_CDP: PluginServerCapabilities = {
     cdpPersonUpdates: true,
     cdpInternalEvents: true,
     cdpCyclotronWorker: true,
+    cdpCyclotronShadowWorker: true,
     cdpApi: true,
     appManagementSingleton: true,
     cdpDataWarehouseEvents: false, // Not yet fully developed - enable when ready

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-shadow-worker.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-shadow-worker.consumer.test.ts
@@ -91,4 +91,24 @@ describe('CdpCyclotronShadowWorker', () => {
             expect.stringContaining('Function completed in'),
         ])
     })
+
+    it('should skip Kafka monitoring in processBatch', async () => {
+        const monitoringSpy = jest.spyOn(processor['hogFunctionMonitoringService'], 'queueInvocationResults')
+        const flushSpy = jest.spyOn(processor['hogFunctionMonitoringService'], 'flush')
+        processor['queueInvocationResults'] = jest.fn().mockResolvedValue(undefined)
+
+        await processor.processBatch([invocation])
+
+        expect(monitoringSpy).not.toHaveBeenCalled()
+        expect(flushSpy).not.toHaveBeenCalled()
+    })
+
+    it('should skip watcher in processBatch', async () => {
+        const watcherSpy = jest.spyOn(processor['hogWatcher'], 'observeResults')
+        processor['queueInvocationResults'] = jest.fn().mockResolvedValue(undefined)
+
+        await processor.processBatch([invocation])
+
+        expect(watcherSpy).not.toHaveBeenCalled()
+    })
 })

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-shadow-worker.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-shadow-worker.consumer.test.ts
@@ -1,0 +1,94 @@
+import { mockFetch } from '~/tests/helpers/mocks/request.mock'
+
+import { DateTime } from 'luxon'
+
+import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
+
+import { Hub, Team } from '../../types'
+import { closeHub, createHub } from '../../utils/db/hub'
+import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '../_tests/examples'
+import {
+    createExampleInvocation,
+    createHogExecutionGlobals,
+    createHogFunction,
+    insertHogFunction,
+} from '../_tests/fixtures'
+import { CyclotronJobInvocationHogFunction, HogFunctionInvocationGlobalsWithInputs, HogFunctionType } from '../types'
+import { CdpCyclotronShadowWorker } from './cdp-cyclotron-shadow-worker.consumer'
+
+jest.setTimeout(1000)
+
+describe('CdpCyclotronShadowWorker', () => {
+    let processor: CdpCyclotronShadowWorker
+    let hub: Hub
+    let team: Team
+    let fn: HogFunctionType
+    let globals: HogFunctionInvocationGlobalsWithInputs
+    let invocation: CyclotronJobInvocationHogFunction
+
+    beforeEach(async () => {
+        const fixedTime = DateTime.fromObject({ year: 2025, month: 1, day: 1 }, { zone: 'UTC' })
+        jest.spyOn(Date, 'now').mockReturnValue(fixedTime.toMillis())
+
+        await resetTestDatabase()
+        hub = await createHub()
+        team = await getFirstTeam(hub)
+        hub.CYCLOTRON_SHADOW_DATABASE_URL = 'postgres://posthog:posthog@localhost:5432/test_cyclotron_shadow'
+
+        processor = new CdpCyclotronShadowWorker(hub)
+
+        fn = await insertHogFunction(
+            hub.postgres,
+            team.id,
+            createHogFunction({
+                ...HOG_EXAMPLES.simple_fetch,
+                ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                ...HOG_FILTERS_EXAMPLES.pageview_or_autocapture_filter,
+                template_id: 'template-webhook',
+            })
+        )
+
+        globals = {
+            ...createHogExecutionGlobals({}),
+            inputs: {
+                url: 'https://posthog.com',
+            },
+        }
+
+        invocation = createExampleInvocation(fn, globals)
+        invocation.queueSource = 'postgres'
+
+        mockFetch.mockClear()
+        mockFetch.mockResolvedValue({
+            status: 200,
+            json: () => Promise.resolve({}),
+            text: () => Promise.resolve(JSON.stringify({})),
+            headers: {},
+        } as any)
+    })
+
+    afterEach(async () => {
+        jest.setTimeout(10000)
+        await closeHub(hub)
+    })
+
+    it('should process invocations with no-op fetch (mockFetch not called)', async () => {
+        const results = await processor.processInvocations([invocation])
+        const result = results[0]
+
+        expect(result.finished).toBe(true)
+        expect(result.error).toBe(undefined)
+        expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('should still execute bytecode and produce logs', async () => {
+        const results = await processor.processInvocations([invocation])
+        const result = results[0]
+
+        expect(result.finished).toBe(true)
+        expect(result.logs.map((x) => x.message)).toEqual([
+            'Fetch response:, {"status":200,"body":""}',
+            expect.stringContaining('Function completed in'),
+        ])
+    })
+})

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-shadow-worker.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-shadow-worker.consumer.ts
@@ -27,7 +27,6 @@ export class CdpCyclotronShadowWorker extends CdpCyclotronWorker {
             CYCLOTRON_DATABASE_URL: hub.CYCLOTRON_SHADOW_DATABASE_URL,
             CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: 'postgres',
             CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING: '*:postgres',
-            CDP_CYCLOTRON_SHADOW_WRITE_ENABLED: false,
         }
         super(shadowHub)
     }

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-shadow-worker.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-shadow-worker.consumer.ts
@@ -1,0 +1,30 @@
+import { CyclotronJobInvocation, CyclotronJobInvocationResult } from '../types'
+import { createInvocationResult } from '../utils/invocation-utils'
+import { CdpCyclotronWorker, CdpCyclotronWorkerHub } from './cdp-cyclotron-worker.consumer'
+
+/**
+ * Shadow worker that consumes from the shadow Cyclotron database.
+ * Loads hog functions and produces mock successful results without making real HTTP calls.
+ * This exercises the full queue infrastructure (dual-write, dequeue, result handling)
+ * without side effects.
+ */
+export class CdpCyclotronShadowWorker extends CdpCyclotronWorker {
+    protected name = 'CdpCyclotronShadowWorker'
+
+    constructor(hub: CdpCyclotronWorkerHub) {
+        const shadowHub: CdpCyclotronWorkerHub = {
+            ...hub,
+            CYCLOTRON_DATABASE_URL: hub.CYCLOTRON_SHADOW_DATABASE_URL,
+            CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: 'postgres',
+            CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING: '*:postgres',
+            CDP_CYCLOTRON_SHADOW_WRITE_ENABLED: false,
+        }
+        super(shadowHub)
+    }
+
+    public async processInvocations(invocations: CyclotronJobInvocation[]): Promise<CyclotronJobInvocationResult[]> {
+        const loadedInvocations = await this.loadHogFunctions(invocations)
+
+        return loadedInvocations.map((invocation) => createInvocationResult(invocation, {}, { finished: true }))
+    }
+}

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -1,5 +1,6 @@
 import { pickBy } from 'lodash'
 import { DateTime } from 'luxon'
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { Counter, Histogram } from 'prom-client'
 
 import { ExecResult, convertHogToJS } from '@posthog/hogvm'
@@ -57,6 +58,8 @@ const cdpHttpRequestTiming = new Histogram({
     buckets: [0, 10, 20, 50, 100, 200, 500, 1000, 2000, 3000, 5000, 10000],
 })
 
+export const shadowFetchContext = new AsyncLocalStorage<boolean>()
+
 export async function cdpTrackedFetch({
     url,
     fetchParams,
@@ -66,6 +69,14 @@ export async function cdpTrackedFetch({
     fetchParams: FetchOptions
     templateId: string
 }): Promise<{ fetchError: Error | null; fetchResponse: FetchResponse | null; fetchDuration: number }> {
+    if (shadowFetchContext.getStore()) {
+        return {
+            fetchError: null,
+            fetchResponse: { status: 200, headers: {} } as unknown as FetchResponse,
+            fetchDuration: 0,
+        }
+    }
+
     const start = performance.now()
     const [fetchError, fetchResponse] = await tryCatch(async () => await fetch(url, fetchParams))
     const fetchDuration = performance.now() - start

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -72,7 +72,13 @@ export async function cdpTrackedFetch({
     if (shadowFetchContext.getStore()) {
         return {
             fetchError: null,
-            fetchResponse: { status: 200, headers: {} } as unknown as FetchResponse,
+            fetchResponse: {
+                status: 200,
+                headers: {},
+                text: () => Promise.resolve(''),
+                json: () => Promise.resolve(null),
+                dump: () => Promise.resolve(),
+            },
             fetchDuration: 0,
         }
     }

--- a/nodejs/src/cdp/services/job-queue/job-queue.test.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.test.ts
@@ -218,6 +218,27 @@ describe('CyclotronJobQueue', () => {
             expect(queue['shadowPostgres']!.queueInvocations).toHaveBeenCalledWith(invocations)
         })
 
+        it('should not shadow write hogflow invocations', async () => {
+            const queue = buildQueue(true)
+            await queue.startAsProducer()
+
+            const invocations = [
+                {
+                    ...createInvocation(
+                        {
+                            ...createHogExecutionGlobals(),
+                            inputs: {},
+                        },
+                        exampleHogFunction
+                    ),
+                    queue: 'hogflow' as const,
+                },
+            ]
+            await queue.queueInvocations(invocations)
+
+            expect(queue['shadowPostgres']!.queueInvocations).not.toHaveBeenCalled()
+        })
+
         it('should not block on shadow write failure', async () => {
             const queue = buildQueue(true)
             await queue.startAsProducer()

--- a/nodejs/src/cdp/services/job-queue/job-queue.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.ts
@@ -249,8 +249,12 @@ export class CyclotronJobQueue {
         ])
 
         if (this.shadowPostgres && Date.now() >= this.shadowCircuitOpenUntil) {
+            const hogInvocations = invocations.filter((x) => x.queue === 'hog')
+            if (!hogInvocations.length) {
+                return
+            }
             void this.shadowPostgres
-                .queueInvocations(invocations)
+                .queueInvocations(hogInvocations)
                 .then(() => {
                     this.shadowFailures = 0
                 })

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -235,6 +235,10 @@ export function getDefaultConfig(): PluginsServerConfig {
             : 'postgres://posthog:posthog@localhost:5432/cyclotron',
 
         CYCLOTRON_SHARD_DEPTH_LIMIT: 1000000,
+        CYCLOTRON_SHADOW_DATABASE_URL: isTestEnv()
+            ? 'postgres://posthog:posthog@localhost:5432/test_cyclotron_shadow'
+            : 'postgres://posthog:posthog@localhost:5432/cyclotron_shadow',
+        CDP_CYCLOTRON_SHADOW_WRITE_ENABLED: false,
 
         // New IngestionConsumer config
         INGESTION_CONSUMER_GROUP_ID: 'events-ingestion-consumer',

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -9,6 +9,7 @@ import { getPluginServerCapabilities } from './capabilities'
 import { CdpApi } from './cdp/cdp-api'
 import { CdpBatchHogFlowRequestsConsumer } from './cdp/consumers/cdp-batch-hogflow.consumer'
 import { CdpCohortMembershipConsumer } from './cdp/consumers/cdp-cohort-membership.consumer'
+import { CdpCyclotronShadowWorker } from './cdp/consumers/cdp-cyclotron-shadow-worker.consumer'
 import { CdpCyclotronWorkerHogFlow } from './cdp/consumers/cdp-cyclotron-worker-hogflow.consumer'
 import { CdpCyclotronWorker } from './cdp/consumers/cdp-cyclotron-worker.consumer'
 import { CdpDatawarehouseEventsConsumer } from './cdp/consumers/cdp-data-warehouse-events.consumer'
@@ -234,6 +235,14 @@ export class PluginServer {
             if (capabilities.cdpCyclotronWorker) {
                 serviceLoaders.push(async () => {
                     const worker = new CdpCyclotronWorker(hub)
+                    await worker.start()
+                    return worker.service
+                })
+            }
+
+            if (capabilities.cdpCyclotronShadowWorker) {
+                serviceLoaders.push(async () => {
+                    const worker = new CdpCyclotronShadowWorker(hub)
                     await worker.start()
                     return worker.service
                 })

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -59,6 +59,7 @@ export enum PluginServerMode {
     evaluation_scheduler = 'evaluation-scheduler',
     ingestion_logs = 'ingestion-logs',
     cdp_batch_hogflow_requests = 'cdp-batch-hogflow-requests',
+    cdp_cyclotron_shadow_worker = 'cdp-cyclotron-shadow-worker',
 }
 
 export const stringToPluginServerMode = Object.fromEntries(
@@ -188,6 +189,8 @@ export type CdpConfig = {
     // Cyclotron (CDP job queue)
     CYCLOTRON_DATABASE_URL: string
     CYCLOTRON_SHARD_DEPTH_LIMIT: number
+    CYCLOTRON_SHADOW_DATABASE_URL: string
+    CDP_CYCLOTRON_SHADOW_WRITE_ENABLED: boolean
 
     // SES (Workflows email sending)
     SES_ENDPOINT: string
@@ -544,6 +547,7 @@ export interface PluginServerCapabilities {
     cdpApi?: boolean
     appManagementSingleton?: boolean
     evaluationScheduler?: boolean
+    cdpCyclotronShadowWorker?: boolean
 }
 
 export type TeamId = Team['id']

--- a/rust/bin/migrate-cyclotron-shadow
+++ b/rust/bin/migrate-cyclotron-shadow
@@ -1,0 +1,12 @@
+#!/bin/sh
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+
+CYCLOTRON_SHADOW_DATABASE_NAME=${CYCLOTRON_SHADOW_DATABASE_NAME:-cyclotron_shadow}
+CYCLOTRON_SHADOW_DATABASE_URL=${CYCLOTRON_SHADOW_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/$CYCLOTRON_SHADOW_DATABASE_NAME}
+
+echo "Performing cyclotron shadow migrations for $CYCLOTRON_SHADOW_DATABASE_URL (DATABASE_NAME=$CYCLOTRON_SHADOW_DATABASE_NAME)"
+
+cd $SCRIPT_DIR/..
+
+sqlx database create -D "$CYCLOTRON_SHADOW_DATABASE_URL"
+sqlx migrate run -D "$CYCLOTRON_SHADOW_DATABASE_URL" --source cyclotron-core/migrations/

--- a/rust/bin/migrate-entry
+++ b/rust/bin/migrate-entry
@@ -23,10 +23,11 @@ parse_args() {
 }
 
 show_usage() {
-    echo "Usage: $0 <all|persons|cyclotron|behavioral-cohorts> [--fresh]"
+    echo "Usage: $0 <all|persons|cyclotron|cyclotron-shadow|behavioral-cohorts> [--fresh]"
     echo "  all                - Run all migrations"
     echo "  persons            - Run only persons migrations"
     echo "  cyclotron          - Run only cyclotron migrations"
+    echo "  cyclotron-shadow   - Run only cyclotron shadow migrations"
     echo "  behavioral-cohorts - Run only behavioral cohorts migrations"
     echo ""
     echo "Options:"
@@ -118,6 +119,25 @@ run_cyclotron_migrations() {
     fi
 }
 
+run_cyclotron_shadow_migrations() {
+    local db_type="cyclotron-shadow"
+    CYCLOTRON_SHADOW_DATABASE_NAME=${CYCLOTRON_SHADOW_DATABASE_NAME:-cyclotron_shadow}
+    CYCLOTRON_SHADOW_DATABASE_URL=${CYCLOTRON_SHADOW_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/$CYCLOTRON_SHADOW_DATABASE_NAME}
+
+    log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$CYCLOTRON_SHADOW_DATABASE_NAME\",\"fresh_mode\":$FRESH_MODE"
+
+    if [ "$FRESH_MODE" = true ]; then
+        sqlx database reset -y -D "$CYCLOTRON_SHADOW_DATABASE_URL" --source "$MIGRATIONS_BASE/cyclotron-core/migrations/"
+        log_json "info" "Database reset and migrations completed" "completed" "$db_type"
+    else
+        sqlx database create -D "$CYCLOTRON_SHADOW_DATABASE_URL"
+        log_json "info" "Database created or already exists" "running" "$db_type"
+
+        sqlx migrate run -D "$CYCLOTRON_SHADOW_DATABASE_URL" --source "$MIGRATIONS_BASE/cyclotron-core/migrations/"
+        log_json "info" "Migrations completed successfully" "completed" "$db_type"
+    fi
+}
+
 run_behavioral_cohorts_migrations() {
     local db_type="behavioral-cohorts"
     BEHAVIORAL_COHORTS_DATABASE_NAME=${BEHAVIORAL_COHORTS_DATABASE_NAME:-behavioral_cohorts}
@@ -150,12 +170,16 @@ case "$MIGRATION_TYPE" in
     cyclotron)
         run_cyclotron_migrations
         ;;
+    cyclotron-shadow)
+        run_cyclotron_shadow_migrations
+        ;;
     behavioral-cohorts)
         run_behavioral_cohorts_migrations
         ;;
     all)
         run_persons_migrations
         run_cyclotron_migrations
+        run_cyclotron_shadow_migrations
         run_behavioral_cohorts_migrations
         ;;
     *)


### PR DESCRIPTION
 ## What we are doing                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                           
  Adds a shadow Cyclotron system: a second Postgres database that receives a fire-and-forget copy of every CDP `hog` job, consumed by a dedicated shadow worker that executes the full bytecode pipeline but with no-op HTTP fetches.                      
                                                                                                                                                                                                                                                           
  ### Infrastructure                                                                                                                                                                                                                                       
  - Docker init script and migration scripts for `cyclotron_shadow` database                                                                                                                                                                               
  - `bin/migrate --scope=cyclotron-shadow` support                                                                                                                                                                                                         
                                                                                                                                                                                                                                                           
  ### Dual-write with circuit breaker                                                                                                                                                                                                                      
  - `CyclotronJobQueue` creates an optional shadow postgres producer when `CDP_CYCLOTRON_SHADOW_WRITE_ENABLED=true`                                                                                                                                        
  - Every `queueInvocations` call fire-and-forgets a copy of `hog` queue invocations to the shadow DB (hogflow and other queue types are excluded)                                                                                                         
  - Failures are logged but never block the main path                                                                                                                                                                                                      
  - Circuit breaker opens after 5 consecutive failures, skips shadow writes for 60s to prevent resource accumulation                                                                                                                                       
  - If shadow DB is unreachable at startup, shadow writes are disabled gracefully (main system starts normally)                                                                                                                                            
                                                                                                                                                                                                                                                           
  ### Shadow worker                                                                                                                                                                                                                                        
  - New `CdpCyclotronShadowWorker` class that consumes from the shadow DB and executes bytecode with no-op HTTP fetches                                                                                                                                    
  - Skips Kafka log/metric production to avoid shadow data mixing with real data                                                                                                                                                                           
  - Skips watcher (cost tracking / rate limiting) calls                                                                                                                                                                                                    
  - Exposes Prometheus counter `cdp_shadow_invocations_processed` with outcome labels (`completed`, `error`, `continuing`)                                                                                                                                 
  - New `PluginServerMode.cdp_cyclotron_shadow_worker`                                                                                                                                                                                                     
  - Auto-starts with `bin/start` locally (added to default capabilities)                                                                                                                                                                                   
                                                                                                                                                                                                                                                           
  ### Config                                                                                                                                                                                                                                               
  - `CYCLOTRON_SHADOW_DATABASE_URL` — shadow DB connection string                                                                                                                                                                                          
  - `CDP_CYCLOTRON_SHADOW_WRITE_ENABLED` — toggle dual-write (default: false)                                                                                                                                                                              
                                                                                                                                                                                                                                                           
  ### Mocking Fetch                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                           
  The shadow worker needs to run the full execution pipeline (bytecode, retries, etc.) but skip real HTTP requests.                                                                                                                                        
                                                                                                                                                                                                                                                           
  `AsyncLocalStorage` solves this by letting us tag a specific execution context. When the shadow worker processes a batch, it wraps the call in `shadowFetchContext.run(true, ...)`. Any code running within that async context — no matter how deep in   
  the stack — can check `shadowFetchContext.getStore()` and see `true`. Meanwhile, code running from a regular worker in the same process sees `undefined` because it's in a different context.                                                            
                                                                                                                                                                                                                                                           
  In `cdpTrackedFetch` (the single function all 4 executor services use for HTTP), we check: are we inside a shadow context? If yes, return a fake 200 response. If no, make the real request.                                                             
                                                                                                                                                                                                                                                           
  ### Comparison: Real vs Shadow Worker                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                           
  | Aspect | Real worker | Shadow worker |                                                                                                                                                                                                                 
  |--------|-------------|---------------|                                                                                                                                                                                                                 
  | **Database** | Main cyclotron DB | Shadow cyclotron DB |                                                                                                                                                                                               
  | **Bytecode execution** | Full execution | Full execution (same) |                                                                                                                                                                                      
  | **HTTP fetches** | Real requests via `cdpTrackedFetch` | No-op (returns `{status: 200, body: ""}`) |                                                                                                                                                   
  | **Re-queuing** (multi-step functions) | Back to main DB (postgres/kafka) | Back to shadow DB (postgres only) |                                                                                                                                         
  | **Logs to Kafka** | Yes, via `hogFunctionMonitoringService` | Skipped |                                                                                                                                                                                
  | **Metrics to Kafka** | Yes, via `hogFunctionMonitoringService` | Skipped |                                                                                                                                                                             
  | **Watcher** (cost tracking / rate limiting) | Yes, via `hogWatcher.observeResults` | Skipped |                                                                                                                                                         
  | **Shadow dual-write** | Writes to shadow DB if enabled | Disabled (no recursion) |                                                                                                                                                                     
  | **Consumer mode** | Configurable (postgres/kafka) | Always postgres |                                                                                                                                                                                  
  | **Observability** | Kafka topics + Prometheus | Prometheus only |                                                                                                                                                                                      
  | **Process isolation** | Own deployment | Own deployment |                                                                                                                                                                                              
                                                                                                                                                                                                                                                           
  ### Fault tolerance                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                           
  | Failure mode | Mitigation | Effect |                                                                                                                                                                                                                   
  |---|---|---|                                                                                                                                                                                                                                            
  | Shadow DB unreachable at startup | `startAsProducer()` wrapped in `.catch()`, sets `shadowPostgres = null` | Shadow writes disabled for process lifetime, main system starts normally |                                                                
  | Shadow DB down at runtime | Fire-and-forget write with `.catch()`, never awaited | Main path completes unaffected, error logged |                                                                                                                      
  | Shadow DB slow / unresponsive | Circuit breaker opens after 5 consecutive failures, skips writes for 60s | Prevents promise/connection accumulation in the producer process |                                                                          
  | Shadow worker crashes or OOMs | Runs as a separate process | No shared state with real workers, crash has zero production impact |                                                                                                                     
  | Shadow worker falls behind on queue | Jobs accumulate in shadow DB only | No backpressure on the dual-write side, real pipeline unaffected |                 