### PR TITLE
fix: Hotfix onboarding

### DIFF
--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1098,6 +1098,7 @@ export const sceneLogic = kea<sceneLogicType>([
                         teamLogic.values.currentTeam &&
                         !teamLogic.values.currentTeam.is_demo &&
                         !teamLogic.values.hasOnboardedAnyProduct &&
+                        !teamLogic.values.currentTeam?.ingested_event &&
                         !pathPrefixesOnboardingNotRequiredFor.some((path) =>
                             removeProjectIdIfPresent(location.pathname).startsWith(path)
                         )


### PR DESCRIPTION
Some accounts are falling on the onboarding flow even though they've been using posthog for a long time. This happens if they've never completed the onboarding process. In the past it was very easy to just drop onboarding, it's much harder now, so they were being forced to do it. Let's make it easy again, sorry.