### PR TITLE
feat(endpoints): add limit support to endpoint execution

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11857,6 +11857,10 @@
                     "$ref": "#/definitions/DashboardFilter",
                     "description": "A map for overriding insight query filters.\n\nTip: Use to get data for a specific customer or user."
                 },
+                "limit": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Maximum number of results to return. If not provided, returns all results."
+                },
                 "query_override": {
                     "description": "Map of Insight query keys to be overridden at execution time. For example:   Assuming query = {\"kind\": \"TrendsQuery\", \"series\": [{\"kind\": \"EventsNode\",\"name\": \"$pageview\",\"event\": \"$pageview\",\"math\": \"total\"}]}   If query_override = {\"series\": [{\"kind\": \"EventsNode\",\"name\": \"$identify\",\"event\": \"$identify\",\"math\": \"total\"}]}   The query executed will return the count of $identify events, instead of $pageview's",
                     "type": "object"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1766,6 +1766,8 @@ export interface EndpointRunRequest {
      * @default false
      */
     debug?: boolean
+    /** Maximum number of results to return. If not provided, returns all results. */
+    limit?: integer
 }
 
 export interface EndpointLastExecutionTimesRequest {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -10310,6 +10310,10 @@ class EndpointRunRequest(BaseModel):
             "A map for overriding insight query filters.\n\nTip: Use to get data for a specific customer or user."
         ),
     )
+    limit: int | None = Field(
+        default=None,
+        description=("Maximum number of results to return. If not provided, returns all results."),
+    )
     query_override: dict[str, Any] | None = Field(
         default=None,
         description=(

--- a/products/endpoints/backend/tests/test_endpoint.py
+++ b/products/endpoints/backend/tests/test_endpoint.py
@@ -1086,6 +1086,151 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response_data)
         self.assertEqual(len(response_data["results"]), expected_result_count)
 
+    def test_execute_endpoint_with_limit_query_param(self):
+        """Test executing an endpoint with limit via query parameter."""
+        create_endpoint_with_version(
+            name="limit_query_param_test",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT event FROM events"},
+            created_by=self.user,
+            is_active=True,
+        )
+        distinct_id = str(uuid4())
+
+        for _ in range(0, 10):
+            _create_event(
+                distinct_id=distinct_id,
+                team=self.team,
+                event="$event1",
+                properties={"$lib": "$web"},
+                timestamp=datetime(2025, 9, 10),
+            )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/limit_query_param_test/run/?limit=3")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(len(response_data["results"]), 3)
+
+    def test_execute_endpoint_with_limit_body(self):
+        """Test executing an endpoint with limit via request body."""
+        create_endpoint_with_version(
+            name="limit_body_test",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT event FROM events"},
+            created_by=self.user,
+            is_active=True,
+        )
+        distinct_id = str(uuid4())
+
+        for _ in range(0, 10):
+            _create_event(
+                distinct_id=distinct_id,
+                team=self.team,
+                event="$event1",
+                properties={"$lib": "$web"},
+                timestamp=datetime(2025, 9, 10),
+            )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/limit_body_test/run/",
+            {"limit": 5},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(len(response_data["results"]), 5)
+
+    def test_execute_endpoint_limit_body_precedence(self):
+        """Test that limit from request body takes precedence over query param."""
+        create_endpoint_with_version(
+            name="limit_precedence_test",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT event FROM events"},
+            created_by=self.user,
+            is_active=True,
+        )
+        distinct_id = str(uuid4())
+
+        for _ in range(0, 10):
+            _create_event(
+                distinct_id=distinct_id,
+                team=self.team,
+                event="$event1",
+                properties={"$lib": "$web"},
+                timestamp=datetime(2025, 9, 10),
+            )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/limit_precedence_test/run/?limit=8",
+            {"limit": 2},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(len(response_data["results"]), 2)
+
+    @parameterized.expand(
+        [
+            ("negative", "-5"),
+            ("zero", "0"),
+            ("non_integer", "abc"),
+            ("float", "3.5"),
+        ]
+    )
+    def test_execute_endpoint_invalid_limit(self, _name, limit_value):
+        """Test that invalid limit values return 400."""
+        create_endpoint_with_version(
+            name="invalid_limit_test",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/endpoints/invalid_limit_test/run/?limit={limit_value}"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", response.json())
+
+    def test_execute_endpoint_limit_respects_existing_query_limit(self):
+        """Test that API limit takes minimum with existing query limit."""
+        create_endpoint_with_version(
+            name="limit_min_test",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT event FROM events LIMIT 5"},
+            created_by=self.user,
+            is_active=True,
+        )
+        distinct_id = str(uuid4())
+
+        for _ in range(0, 10):
+            _create_event(
+                distinct_id=distinct_id,
+                team=self.team,
+                event="$event1",
+                properties={"$lib": "$web"},
+                timestamp=datetime(2025, 9, 10),
+            )
+
+        # Request limit of 10, but query has limit of 5 - should use min (5)
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/limit_min_test/run/?limit=10")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(len(response_data["results"]), 5)
+
+        # Request limit of 3, query has limit of 5 - should return 3
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/limit_min_test/run/?limit=3")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(len(response_data["results"]), 3)
+
 
 class TestEndpointOpenAPISpec(ClickhouseTestMixin, APIBaseTest):
     """Tests for the OpenAPI specification generation endpoint."""


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
i saw a user try hard to pass a limit to the endpoint execution.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- allow adding `limit` to the endpoint execution for hogql queries

## How did you test this code?
- ran it locally and unit tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
not really