### PR TITLE
feat(llma): (2/2) add evaluation summary frontend UI

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -291,6 +291,7 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_TRACE_NAVIGATION: 'llm-analytics-trace-navigation', // owner: #team-llm-analytics
     LLM_ANALYTICS_EVALUATIONS_CUSTOM_MODELS: 'llm-analytics-evaluations-custom-models', // owner: #team-llm-analytics
     LLM_ANALYTICS_EVALUATIONS_ONBOARDING_EXPERIMENT: 'llm-analytics-evaluations-onboarding-experiment', // owner: #team-llm-analytics, multivariate=control,test-b,test-c
+    LLM_ANALYTICS_EVALUATIONS_SUMMARY: 'llm-analytics-evaluations-summary', // owner: #team-llm-analytics
     LLM_ANALYTICS_SESSION_SUMMARIZATION: 'llm-analytics-session-summarization', // owner: #team-llm-analytics
     LLM_ANALYTICS_CLUSTERS_TAB: 'llm-analytics-clusters-tab', // owner: #team-llm-analytics
     LLM_ANALYTICS_CLUSTERING_ADMIN: 'llm-analytics-clustering-admin', // owner: #team-llm-analytics

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
@@ -9,10 +9,16 @@ import { urls } from 'scenes/urls'
 
 import { llmEvaluationLogic } from '../llmEvaluationLogic'
 import { EvaluationRun } from '../types'
+import { EvaluationSummaryControls, EvaluationSummaryPanel } from './EvaluationSummaryPanel'
 
 export function EvaluationRunsTable(): JSX.Element {
     const { evaluationRuns, evaluationRunsLoading } = useValues(llmEvaluationLogic)
     const { refreshEvaluationRuns } = useActions(llmEvaluationLogic)
+
+    const runsLookup: Record<string, EvaluationRun> = {}
+    for (const run of evaluationRuns) {
+        runsLookup[run.generation_id] = run
+    }
 
     const columns: LemonTableColumns<EvaluationRun> = [
         {
@@ -49,7 +55,6 @@ export function EvaluationRunsTable(): JSX.Element {
                 if (run.status === 'running') {
                     return <LemonTag type="primary">Running...</LemonTag>
                 }
-                // Handle N/A case (result is null when not applicable)
                 if (run.result === null) {
                     return (
                         <LemonTag type="muted" icon={<IconMinus />}>
@@ -75,7 +80,6 @@ export function EvaluationRunsTable(): JSX.Element {
                 if (a.status !== 'completed' || b.status !== 'completed') {
                     return a.status.localeCompare(b.status)
                 }
-                // N/A (null) sorts between pass (1) and fail (0)
                 const valA = a.result === null ? 0.5 : Number(a.result)
                 const valB = b.result === null ? 0.5 : Number(b.result)
                 return valB - valA
@@ -109,17 +113,21 @@ export function EvaluationRunsTable(): JSX.Element {
 
     return (
         <div className="space-y-4">
-            <div className="flex justify-end">
+            <div className="flex justify-between items-center">
+                <EvaluationSummaryControls />
                 <LemonButton
                     type="secondary"
                     icon={<IconRefresh />}
                     onClick={refreshEvaluationRuns}
                     loading={evaluationRunsLoading}
                     size="small"
+                    data-attr="llma-evaluation-refresh-runs"
                 >
                     Refresh
                 </LemonButton>
             </div>
+
+            <EvaluationSummaryPanel runsLookup={runsLookup} />
 
             <LemonTable
                 columns={columns}

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
@@ -8,6 +8,7 @@ import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { urls } from 'scenes/urls'
 
 import { llmEvaluationLogic } from '../llmEvaluationLogic'
+import { EvaluationRun } from '../types'
 import { EvaluationSummaryControls, EvaluationSummaryPanel } from './EvaluationSummaryPanel'
 
 export function EvaluationRunsTable(): JSX.Element {

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
@@ -8,17 +8,11 @@ import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { urls } from 'scenes/urls'
 
 import { llmEvaluationLogic } from '../llmEvaluationLogic'
-import { EvaluationRun } from '../types'
 import { EvaluationSummaryControls, EvaluationSummaryPanel } from './EvaluationSummaryPanel'
 
 export function EvaluationRunsTable(): JSX.Element {
-    const { evaluationRuns, evaluationRunsLoading } = useValues(llmEvaluationLogic)
+    const { evaluationRuns, evaluationRunsLoading, runsLookup } = useValues(llmEvaluationLogic)
     const { refreshEvaluationRuns } = useActions(llmEvaluationLogic)
-
-    const runsLookup: Record<string, EvaluationRun> = {}
-    for (const run of evaluationRuns) {
-        runsLookup[run.generation_id] = run
-    }
 
     const columns: LemonTableColumns<EvaluationRun> = [
         {

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -1,0 +1,346 @@
+import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
+
+import { IconCheck, IconChevronDown, IconMinus, IconX } from '@posthog/icons'
+import { LemonButton, LemonSegmentedButton, Spinner, Tooltip } from '@posthog/lemon-ui'
+
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+
+import { llmEvaluationLogic } from '../llmEvaluationLogic'
+import { EvaluationPattern, EvaluationRun, EvaluationSummary, EvaluationSummaryFilter } from '../types'
+import { PatternCard } from './PatternCard'
+
+export function EvaluationSummaryControls(): JSX.Element | null {
+    const {
+        evaluation,
+        runsSummary,
+        runsToSummarizeCount,
+        evaluationSummary,
+        evaluationSummaryLoading,
+        evaluationSummaryFilter,
+    } = useValues(llmEvaluationLogic)
+    const { generateEvaluationSummary, regenerateEvaluationSummary, setEvaluationSummaryFilter } =
+        useActions(llmEvaluationLogic)
+    const showSummaryFeature = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
+
+    if (!showSummaryFeature || !runsSummary || runsSummary.total === 0) {
+        return null
+    }
+
+    return (
+        <div className="flex items-center gap-2">
+            <Tooltip
+                title={
+                    runsToSummarizeCount === 0
+                        ? 'No runs match the current filter'
+                        : evaluationSummary
+                          ? `Regenerate AI summary for ${runsToSummarizeCount} ${
+                                evaluationSummaryFilter === 'all'
+                                    ? ''
+                                    : evaluationSummaryFilter === 'pass'
+                                      ? 'passing '
+                                      : evaluationSummaryFilter === 'fail'
+                                        ? 'failing '
+                                        : 'N/A '
+                            }evaluation results`
+                          : `Use AI to analyze patterns in ${runsToSummarizeCount} ${
+                                evaluationSummaryFilter === 'all'
+                                    ? ''
+                                    : evaluationSummaryFilter === 'pass'
+                                      ? 'passing '
+                                      : evaluationSummaryFilter === 'fail'
+                                        ? 'failing '
+                                        : 'N/A '
+                            }evaluation results`
+                }
+            >
+                <LemonButton
+                    type="secondary"
+                    onClick={() => {
+                        posthog.capture(
+                            evaluationSummary
+                                ? 'llma evaluation regenerate clicked'
+                                : 'llma evaluation summarize clicked',
+                            {
+                                filter: evaluationSummaryFilter,
+                                runs_to_summarize: runsToSummarizeCount,
+                            }
+                        )
+                        if (evaluationSummary) {
+                            regenerateEvaluationSummary()
+                        } else {
+                            generateEvaluationSummary({})
+                        }
+                    }}
+                    size="small"
+                    disabled={runsToSummarizeCount === 0}
+                    loading={evaluationSummaryLoading}
+                    data-attr="llma-evaluation-summarize"
+                >
+                    {evaluationSummary ? 'Regenerate' : 'Summarize'}
+                </LemonButton>
+            </Tooltip>
+            <LemonSegmentedButton
+                value={evaluationSummaryFilter}
+                onChange={(value) => {
+                    posthog.capture('llma evaluation summary filter changed', {
+                        filter: value,
+                        previous_filter: evaluationSummaryFilter,
+                    })
+                    setEvaluationSummaryFilter(value as EvaluationSummaryFilter)
+                }}
+                options={[
+                    { value: 'all', label: 'All' },
+                    { value: 'pass', label: 'Passing' },
+                    { value: 'fail', label: 'Failing' },
+                    ...(evaluation?.output_config?.allows_na ? [{ value: 'na', label: 'N/A' }] : []),
+                ]}
+                size="small"
+                data-attr="llma-evaluation-summary-filter"
+            />
+        </div>
+    )
+}
+
+interface EvaluationSummaryPanelProps {
+    runsLookup: Record<string, EvaluationRun>
+}
+
+export function EvaluationSummaryPanel({ runsLookup }: EvaluationSummaryPanelProps): JSX.Element | null {
+    const {
+        runsToSummarizeCount,
+        evaluationSummary,
+        evaluationSummaryLoading,
+        evaluationSummaryFilter,
+        summaryExpanded,
+    } = useValues(llmEvaluationLogic)
+    const { toggleSummaryExpanded } = useActions(llmEvaluationLogic)
+    const showSummaryFeature = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
+
+    if (!showSummaryFeature) {
+        return null
+    }
+
+    if (evaluationSummaryLoading) {
+        return (
+            <div className="flex items-center justify-center py-6 border rounded-lg bg-bg-light">
+                <Spinner className="text-primary" />
+                <span className="ml-2 text-muted">Analyzing {runsToSummarizeCount} evaluation results...</span>
+            </div>
+        )
+    }
+
+    if (!evaluationSummary) {
+        return null
+    }
+
+    return (
+        <div className="border rounded-lg bg-bg-light">
+            <button
+                className="w-full flex items-center justify-between p-3 hover:bg-border-light transition-colors cursor-pointer"
+                onClick={() => {
+                    posthog.capture('llma evaluation summary toggled', {
+                        expanded: !summaryExpanded,
+                        filter: evaluationSummaryFilter,
+                    })
+                    toggleSummaryExpanded()
+                }}
+                data-attr="llma-evaluation-summary-toggle"
+            >
+                <div className="text-left">
+                    <span className="font-semibold text-sm">AI Summary</span>
+                    <span className="text-xs text-muted ml-2">
+                        {evaluationSummary.statistics.total_analyzed} runs analyzed
+                    </span>
+                </div>
+                <IconChevronDown className={`text-muted transition-transform ${summaryExpanded ? '' : '-rotate-90'}`} />
+            </button>
+
+            {summaryExpanded && (
+                <div className="p-4 pt-0 space-y-4">
+                    <div>
+                        <p className="text-sm">{evaluationSummary.overall_assessment}</p>
+                        <SummaryStatistics filter={evaluationSummaryFilter} statistics={evaluationSummary.statistics} />
+                    </div>
+
+                    {evaluationSummaryFilter === 'all' && (
+                        <AllPatternsGrid evaluationSummary={evaluationSummary} runsLookup={runsLookup} />
+                    )}
+
+                    <FilteredPatternSection
+                        filter={evaluationSummaryFilter}
+                        evaluationSummary={evaluationSummary}
+                        runsLookup={runsLookup}
+                    />
+
+                    {evaluationSummary.recommendations.length > 0 && (
+                        <div>
+                            <h4 className="font-semibold mb-2 text-sm">Recommendations</h4>
+                            <ul className="list-disc list-inside space-y-1 text-sm">
+                                {evaluationSummary.recommendations.map((rec, i) => (
+                                    <li key={i}>{rec}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}
+
+function SummaryStatistics({
+    filter,
+    statistics,
+}: {
+    filter: EvaluationSummaryFilter
+    statistics: EvaluationSummary['statistics']
+}): JSX.Element {
+    return (
+        <div className="mt-1 text-xs text-muted">
+            {filter === 'all' && (
+                <>
+                    {statistics.pass_count} passed, {statistics.fail_count} failed
+                    {statistics.na_count > 0 && <>, {statistics.na_count} N/A</>}
+                </>
+            )}
+            {filter === 'pass' && <>{statistics.pass_count} passing runs analyzed</>}
+            {filter === 'fail' && <>{statistics.fail_count} failing runs analyzed</>}
+            {filter === 'na' && <>{statistics.na_count} N/A runs analyzed</>}
+        </div>
+    )
+}
+
+function AllPatternsGrid({
+    evaluationSummary,
+    runsLookup,
+}: {
+    evaluationSummary: EvaluationSummary
+    runsLookup: Record<string, EvaluationRun>
+}): JSX.Element | null {
+    const hasPass = evaluationSummary.pass_patterns.length > 0
+    const hasFail = evaluationSummary.fail_patterns.length > 0
+
+    if (!hasPass && !hasFail) {
+        return null
+    }
+
+    return (
+        <div className={`grid gap-4 ${hasPass && hasFail ? 'grid-cols-2' : 'grid-cols-1'}`}>
+            {hasPass && (
+                <PatternList
+                    patterns={evaluationSummary.pass_patterns}
+                    type="pass"
+                    label="Passing patterns"
+                    icon={<IconCheck className="text-success" />}
+                    runsLookup={runsLookup}
+                />
+            )}
+            {hasFail && (
+                <PatternList
+                    patterns={evaluationSummary.fail_patterns}
+                    type="fail"
+                    label="Failing patterns"
+                    icon={<IconX className="text-danger" />}
+                    runsLookup={runsLookup}
+                />
+            )}
+        </div>
+    )
+}
+
+function PatternList({
+    patterns,
+    type,
+    label,
+    icon,
+    runsLookup,
+}: {
+    patterns: EvaluationPattern[]
+    type: 'pass' | 'fail' | 'na'
+    label: string
+    icon: JSX.Element
+    runsLookup: Record<string, EvaluationRun>
+}): JSX.Element {
+    return (
+        <div>
+            <h4 className="font-semibold mb-2 flex items-center gap-2 text-sm">
+                {icon}
+                {label}
+            </h4>
+            <div className="space-y-2">
+                {patterns.map((pattern, i) => (
+                    <PatternCard key={i} pattern={pattern} type={type} runsLookup={runsLookup} />
+                ))}
+            </div>
+        </div>
+    )
+}
+
+const FILTER_CONFIG: Record<
+    string,
+    {
+        patternsKey: 'pass_patterns' | 'fail_patterns' | 'na_patterns'
+        icon: JSX.Element
+        label: string
+        type: 'pass' | 'fail' | 'na'
+        emptyText: string
+    }
+> = {
+    pass: {
+        patternsKey: 'pass_patterns',
+        icon: <IconCheck className="text-success" />,
+        label: 'Passing patterns',
+        type: 'pass',
+        emptyText: 'No passing patterns identified',
+    },
+    fail: {
+        patternsKey: 'fail_patterns',
+        icon: <IconX className="text-danger" />,
+        label: 'Failing patterns',
+        type: 'fail',
+        emptyText: 'No failing patterns identified',
+    },
+    na: {
+        patternsKey: 'na_patterns',
+        icon: <IconMinus className="text-muted" />,
+        label: 'N/A patterns',
+        type: 'na',
+        emptyText: 'No N/A patterns identified',
+    },
+}
+
+function FilteredPatternSection({
+    filter,
+    evaluationSummary,
+    runsLookup,
+}: {
+    filter: EvaluationSummaryFilter
+    evaluationSummary: EvaluationSummary
+    runsLookup: Record<string, EvaluationRun>
+}): JSX.Element | null {
+    const section = FILTER_CONFIG[filter]
+    if (!section) {
+        return null
+    }
+
+    const patterns = evaluationSummary[section.patternsKey]
+
+    return (
+        <div>
+            <h4 className="font-semibold mb-2 flex items-center gap-2 text-sm">
+                {section.icon}
+                {section.label}
+            </h4>
+            <div className="space-y-2">
+                {patterns.length > 0 ? (
+                    patterns.map((pattern, i) => (
+                        <PatternCard key={i} pattern={pattern} type={section.type} runsLookup={runsLookup} />
+                    ))
+                ) : (
+                    <p className="text-sm text-muted">{section.emptyText}</p>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -145,8 +145,8 @@ export function EvaluationSummaryPanel({ runsLookup }: EvaluationSummaryPanelPro
 
     return (
         <div className="border rounded-lg bg-bg-light">
-            <button
-                className="w-full flex items-center justify-between p-3 hover:bg-border-light transition-colors cursor-pointer"
+            <LemonButton
+                fullWidth
                 onClick={() => {
                     posthog.capture('llma evaluation summary toggled', {
                         expanded: !summaryExpanded,
@@ -155,15 +155,19 @@ export function EvaluationSummaryPanel({ runsLookup }: EvaluationSummaryPanelPro
                     toggleSummaryExpanded()
                 }}
                 data-attr="llma-evaluation-summary-toggle"
+                sideIcon={
+                    <IconChevronDown
+                        className={`text-muted transition-transform ${summaryExpanded ? '' : '-rotate-90'}`}
+                    />
+                }
             >
-                <div className="text-left">
+                <div className="flex items-center gap-2">
                     <span className="font-semibold text-sm">AI Summary</span>
-                    <span className="text-xs text-muted ml-2">
+                    <span className="text-xs text-muted">
                         {evaluationSummary.statistics.total_analyzed} runs analyzed
                     </span>
                 </div>
-                <IconChevronDown className={`text-muted transition-transform ${summaryExpanded ? '' : '-rotate-90'}`} />
-            </button>
+            </LemonButton>
 
             {summaryExpanded && (
                 <div className="p-4 pt-0 space-y-4">

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -10,6 +10,25 @@ import { llmEvaluationLogic } from '../llmEvaluationLogic'
 import { EvaluationPattern, EvaluationRun, EvaluationSummary, EvaluationSummaryFilter } from '../types'
 import { PatternCard } from './PatternCard'
 
+const FILTER_LABELS: Record<Exclude<EvaluationSummaryFilter, 'all'>, string> = {
+    pass: 'passing ',
+    fail: 'failing ',
+    na: 'N/A ',
+}
+
+function getFilterLabel(filter: EvaluationSummaryFilter): string {
+    return filter === 'all' ? '' : FILTER_LABELS[filter]
+}
+
+function getSummarizeTooltip(runsCount: number, filter: EvaluationSummaryFilter, hasSummary: boolean): string {
+    if (runsCount === 0) {
+        return 'No runs match the current filter'
+    }
+    const filterLabel = getFilterLabel(filter)
+    const action = hasSummary ? 'Regenerate AI summary for' : 'Use AI to analyze patterns in'
+    return `${action} ${runsCount} ${filterLabel}evaluation results`
+}
+
 export function EvaluationSummaryControls(): JSX.Element | null {
     const {
         evaluation,
@@ -29,31 +48,7 @@ export function EvaluationSummaryControls(): JSX.Element | null {
 
     return (
         <div className="flex items-center gap-2">
-            <Tooltip
-                title={
-                    runsToSummarizeCount === 0
-                        ? 'No runs match the current filter'
-                        : evaluationSummary
-                          ? `Regenerate AI summary for ${runsToSummarizeCount} ${
-                                evaluationSummaryFilter === 'all'
-                                    ? ''
-                                    : evaluationSummaryFilter === 'pass'
-                                      ? 'passing '
-                                      : evaluationSummaryFilter === 'fail'
-                                        ? 'failing '
-                                        : 'N/A '
-                            }evaluation results`
-                          : `Use AI to analyze patterns in ${runsToSummarizeCount} ${
-                                evaluationSummaryFilter === 'all'
-                                    ? ''
-                                    : evaluationSummaryFilter === 'pass'
-                                      ? 'passing '
-                                      : evaluationSummaryFilter === 'fail'
-                                        ? 'failing '
-                                        : 'N/A '
-                            }evaluation results`
-                }
-            >
+            <Tooltip title={getSummarizeTooltip(runsToSummarizeCount, evaluationSummaryFilter, !!evaluationSummary)}>
                 <LemonButton
                     type="secondary"
                     onClick={() => {

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -111,6 +111,7 @@ export function EvaluationSummaryPanel({ runsLookup }: EvaluationSummaryPanelPro
         runsToSummarizeCount,
         evaluationSummary,
         evaluationSummaryLoading,
+        evaluationSummaryError,
         evaluationSummaryFilter,
         summaryExpanded,
     } = useValues(llmEvaluationLogic)
@@ -126,6 +127,14 @@ export function EvaluationSummaryPanel({ runsLookup }: EvaluationSummaryPanelPro
             <div className="flex items-center justify-center py-6 border rounded-lg bg-bg-light">
                 <Spinner className="text-primary" />
                 <span className="ml-2 text-muted">Analyzing {runsToSummarizeCount} evaluation results...</span>
+            </div>
+        )
+    }
+
+    if (evaluationSummaryError) {
+        return (
+            <div className="flex items-center justify-center py-6 border rounded-lg bg-bg-light">
+                <span className="text-muted text-sm">Failed to generate summary. Try again.</span>
             </div>
         )
     }

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -28,6 +28,19 @@ function getSummarizeTooltip(runsCount: number, filter: EvaluationSummaryFilter,
     return `${action} ${runsCount} ${filterLabel}evaluation results`
 }
 
+interface FilterOption {
+    value: EvaluationSummaryFilter
+    label: string
+}
+
+const BASE_FILTER_OPTIONS: FilterOption[] = [
+    { value: 'all', label: 'All' },
+    { value: 'pass', label: 'Passing' },
+    { value: 'fail', label: 'Failing' },
+]
+
+const NA_FILTER_OPTION: FilterOption = { value: 'na', label: 'N/A' }
+
 export function EvaluationSummaryControls(): JSX.Element | null {
     const {
         evaluation,
@@ -75,12 +88,7 @@ export function EvaluationSummaryControls(): JSX.Element | null {
                 onChange={(value) => {
                     setEvaluationSummaryFilter(value as EvaluationSummaryFilter, evaluationSummaryFilter)
                 }}
-                options={[
-                    { value: 'all', label: 'All' },
-                    { value: 'pass', label: 'Passing' },
-                    { value: 'fail', label: 'Failing' },
-                    ...(evaluation?.output_config?.allows_na ? [{ value: 'na', label: 'N/A' }] : []),
-                ]}
+                options={[...BASE_FILTER_OPTIONS, ...(evaluation?.output_config?.allows_na ? [NA_FILTER_OPTION] : [])]}
                 size="small"
                 data-attr="llma-evaluation-summary-filter"
             />

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -335,7 +335,7 @@ function FilteredPatternSection({
             </h4>
             <div className="space-y-2">
                 {patterns.length > 0 ? (
-                    patterns.map((pattern, i) => (
+                    patterns.map((pattern: EvaluationPattern, i: number) => (
                         <PatternCard key={i} pattern={pattern} type={section.type} runsLookup={runsLookup} />
                     ))
                 ) : (

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -271,7 +271,7 @@ function PatternList({
 }
 
 const FILTER_CONFIG: Record<
-    string,
+    Exclude<EvaluationSummaryFilter, 'all'>,
     {
         patternsKey: 'pass_patterns' | 'fail_patterns' | 'na_patterns'
         icon: JSX.Element

--- a/products/llm_analytics/frontend/evaluations/components/PatternCard.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/PatternCard.tsx
@@ -1,0 +1,65 @@
+import posthog from 'posthog-js'
+
+import { IconCheck, IconMinus, IconX } from '@posthog/icons'
+import { Link } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { EvaluationPattern, EvaluationRun } from '../types'
+
+export interface PatternCardProps {
+    pattern: EvaluationPattern
+    type: 'pass' | 'fail' | 'na'
+    runsLookup: Record<string, EvaluationRun>
+}
+
+export function PatternCard({ pattern, type, runsLookup }: PatternCardProps): JSX.Element {
+    const borderClass = type === 'pass' ? 'border-success' : type === 'fail' ? 'border-danger' : 'border-muted'
+    const iconClass = type === 'pass' ? 'text-success' : type === 'fail' ? 'text-danger' : 'text-muted'
+    const Icon = type === 'pass' ? IconCheck : type === 'fail' ? IconX : IconMinus
+
+    return (
+        <div className={`border rounded-lg p-3 ${borderClass}`}>
+            <div className="flex items-center gap-2 mb-2">
+                <Icon className={iconClass} />
+                <span className="font-semibold">{pattern.title}</span>
+                <span className="text-xs text-muted bg-bg-light px-2 py-0.5 rounded">{pattern.frequency}</span>
+            </div>
+            <p className="text-sm text-default mb-2">{pattern.description}</p>
+            <div className="text-xs text-muted bg-bg-light p-2 rounded">
+                <strong>Example:</strong> {pattern.example_reasoning}
+            </div>
+            {pattern.example_generation_ids.length > 0 && (
+                <div className="mt-2 flex items-center gap-2 flex-wrap">
+                    <span className="text-xs text-muted">Generations:</span>
+                    {pattern.example_generation_ids.map((genId) => {
+                        const run = runsLookup[genId]
+                        if (run) {
+                            return (
+                                <Link
+                                    key={genId}
+                                    to={urls.llmAnalyticsTrace(run.trace_id, { event: genId, tab: 'evals' })}
+                                    className="text-xs font-mono text-primary hover:underline"
+                                    data-attr="llma-evaluation-summary-example-link"
+                                    onClick={() => {
+                                        posthog.capture('llma evaluation summary example clicked', {
+                                            pattern_type: type,
+                                            pattern_title: pattern.title,
+                                        })
+                                    }}
+                                >
+                                    {genId.slice(0, 8)}...
+                                </Link>
+                            )
+                        }
+                        return (
+                            <span key={genId} className="text-xs font-mono text-muted">
+                                {genId.slice(0, 8)}...
+                            </span>
+                        )
+                    })}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/evaluations/components/PatternCard.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/PatternCard.tsx
@@ -30,7 +30,7 @@ export function PatternCard({ pattern, type, runsLookup }: PatternCardProps): JS
                 <strong>Example:</strong> {pattern.example_reasoning}
             </div>
             {pattern.example_generation_ids.length > 0 && (
-                <div className="mt-2 flex items-center gap-2 flex-wrap">
+                <div className="mt-2 flex items-baseline gap-1.5 flex-wrap">
                     <span className="text-xs text-muted">Generations:</span>
                     {pattern.example_generation_ids.map((genId) => {
                         const run = runsLookup[genId]

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
@@ -375,6 +375,156 @@ describe('llmEvaluationLogic', () => {
         })
     })
 
+    describe('evaluation summary', () => {
+        beforeEach(() => {
+            logic = llmEvaluationLogic({ evaluationId: 'eval-123' })
+            logic.mount()
+        })
+
+        describe('evaluationSummaryFilter', () => {
+            it('defaults to all', async () => {
+                expect(logic.values.evaluationSummaryFilter).toBe('all')
+            })
+
+            it('updates when setEvaluationSummaryFilter is called', async () => {
+                logic.actions.setEvaluationSummaryFilter('pass', 'all')
+
+                await expectLogic(logic).toMatchValues({
+                    evaluationSummaryFilter: 'pass',
+                })
+            })
+
+            it('clears evaluationSummary when filter changes', async () => {
+                // Simulate having a summary
+                logic.actions.generateEvaluationSummarySuccess({
+                    overall_assessment: 'Test',
+                    pass_patterns: [],
+                    fail_patterns: [],
+                    na_patterns: [],
+                    recommendations: [],
+                    statistics: { total_analyzed: 10, pass_count: 5, fail_count: 3, na_count: 2 },
+                })
+
+                await expectLogic(logic).toMatchValues({
+                    evaluationSummary: expect.objectContaining({ overall_assessment: 'Test' }),
+                })
+
+                logic.actions.setEvaluationSummaryFilter('fail', 'all')
+
+                await expectLogic(logic).toMatchValues({
+                    evaluationSummary: null,
+                })
+            })
+        })
+
+        describe('runsToSummarizeCount', () => {
+            it('returns 0 when no runs', async () => {
+                expect(logic.values.runsToSummarizeCount).toBe(0)
+            })
+
+            it('counts all completed runs when filter is all', async () => {
+                logic.actions.loadEvaluationRunsSuccess(mockRuns)
+
+                await expectLogic(logic).toMatchValues({
+                    runsToSummarizeCount: 3,
+                })
+            })
+
+            it('counts only passing runs when filter is pass', async () => {
+                logic.actions.loadEvaluationRunsSuccess(mockRuns)
+                logic.actions.setEvaluationSummaryFilter('pass', 'all')
+
+                await expectLogic(logic).toMatchValues({
+                    runsToSummarizeCount: 1,
+                })
+            })
+
+            it('counts only failing runs when filter is fail', async () => {
+                logic.actions.loadEvaluationRunsSuccess(mockRuns)
+                logic.actions.setEvaluationSummaryFilter('fail', 'all')
+
+                await expectLogic(logic).toMatchValues({
+                    runsToSummarizeCount: 1,
+                })
+            })
+
+            it('counts only N/A runs when filter is na', async () => {
+                logic.actions.loadEvaluationRunsSuccess(mockRuns)
+                logic.actions.setEvaluationSummaryFilter('na', 'all')
+
+                await expectLogic(logic).toMatchValues({
+                    runsToSummarizeCount: 1,
+                })
+            })
+
+            it('caps count at 100', async () => {
+                const manyRuns = Array.from({ length: 150 }, (_, i) => ({
+                    ...mockRuns[0],
+                    id: `run-${i}`,
+                    generation_id: `gen-${i}`,
+                }))
+                logic.actions.loadEvaluationRunsSuccess(manyRuns)
+
+                await expectLogic(logic).toMatchValues({
+                    runsToSummarizeCount: 100,
+                })
+            })
+        })
+
+        describe('summaryExpanded', () => {
+            it('defaults to true', async () => {
+                expect(logic.values.summaryExpanded).toBe(true)
+            })
+
+            it('toggles on toggleSummaryExpanded', async () => {
+                logic.actions.toggleSummaryExpanded()
+
+                await expectLogic(logic).toMatchValues({
+                    summaryExpanded: false,
+                })
+
+                logic.actions.toggleSummaryExpanded()
+
+                await expectLogic(logic).toMatchValues({
+                    summaryExpanded: true,
+                })
+            })
+
+            it('expands on generateEvaluationSummarySuccess', async () => {
+                logic.actions.toggleSummaryExpanded() // collapse
+
+                await expectLogic(logic).toMatchValues({ summaryExpanded: false })
+
+                logic.actions.generateEvaluationSummarySuccess({
+                    overall_assessment: 'Test',
+                    pass_patterns: [],
+                    fail_patterns: [],
+                    na_patterns: [],
+                    recommendations: [],
+                    statistics: { total_analyzed: 10, pass_count: 5, fail_count: 3, na_count: 2 },
+                })
+
+                await expectLogic(logic).toMatchValues({
+                    summaryExpanded: true,
+                })
+            })
+        })
+
+        describe('runsLookup', () => {
+            it('creates lookup by generation_id', async () => {
+                logic.actions.loadEvaluationRunsSuccess(mockRuns)
+
+                await expectLogic(logic).toMatchValues({
+                    runsLookup: {
+                        'gen-1': expect.objectContaining({ id: 'run-1' }),
+                        'gen-2': expect.objectContaining({ id: 'run-2' }),
+                        'gen-3': expect.objectContaining({ id: 'run-3' }),
+                    },
+                })
+            })
+        })
+    })
+
     describe('provider selection', () => {
         beforeEach(() => {
             logic = llmEvaluationLogic({ evaluationId: 'new' })

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -122,12 +122,19 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                         return null
                     }
 
+                    const requestFilter = values.evaluationSummaryFilter
+
                     // Backend fetches data server-side by ID - we just pass the filter
                     const response = await api.create(`/api/environments/${teamId}/llm_analytics/evaluation_summary/`, {
                         evaluation_id: props.evaluationId,
-                        filter: values.evaluationSummaryFilter,
+                        filter: requestFilter,
                         force_refresh: forceRefresh,
                     })
+
+                    // Discard if the user changed the filter while the request was in flight
+                    if (values.evaluationSummaryFilter !== requestFilter) {
+                        return null
+                    }
 
                     return response as EvaluationSummary
                 },
@@ -228,6 +235,15 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
         evaluationSummary: {
             setEvaluationSummaryFilter: () => null,
         },
+        evaluationSummaryError: [
+            false,
+            {
+                generateEvaluationSummary: () => false,
+                generateEvaluationSummarySuccess: () => false,
+                generateEvaluationSummaryFailure: () => true,
+                setEvaluationSummaryFilter: () => false,
+            },
+        ],
         summaryExpanded: [
             true,
             {

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -488,6 +488,17 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 providerKeysByProvider[selectedProvider] || [],
         ],
 
+        runsLookup: [
+            (s) => [s.evaluationRuns],
+            (runs): Record<string, EvaluationRun> => {
+                const lookup: Record<string, EvaluationRun> = {}
+                for (const run of runs) {
+                    lookup[run.generation_id] = run
+                }
+                return lookup
+            },
+        ],
+
         runsSummary: [
             (s) => [s.evaluationRuns],
             (runs) => {

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -116,7 +116,8 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
         evaluationSummary: [
             null as EvaluationSummary | null,
             {
-                generateEvaluationSummary: async ({ forceRefresh = false }: { forceRefresh?: boolean } = {}) => {
+                generateEvaluationSummary: async ({ forceRefresh }: { forceRefresh?: boolean }) => {
+                    const shouldRefresh = forceRefresh ?? false
                     const teamId = teamLogic.values.currentTeamId
                     if (!teamId || !props.evaluationId || props.evaluationId === 'new') {
                         return null
@@ -128,7 +129,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                     const response = await api.create(`/api/environments/${teamId}/llm_analytics/evaluation_summary/`, {
                         evaluation_id: props.evaluationId,
                         filter: requestFilter,
-                        force_refresh: forceRefresh,
+                        force_refresh: shouldRefresh,
                     })
 
                     // Discard if the user changed the filter while the request was in flight

--- a/products/llm_analytics/frontend/evaluations/types.ts
+++ b/products/llm_analytics/frontend/evaluations/types.ts
@@ -53,3 +53,29 @@ export interface EvaluationRun {
     reasoning: string
     status: 'completed' | 'failed' | 'running'
 }
+
+export type EvaluationSummaryFilter = 'all' | 'pass' | 'fail' | 'na'
+
+export interface EvaluationPattern {
+    title: string
+    description: string
+    frequency: string
+    example_reasoning: string
+    example_generation_ids: string[]
+}
+
+export interface EvaluationSummaryStatistics {
+    total_analyzed: number
+    pass_count: number
+    fail_count: number
+    na_count: number
+}
+
+export interface EvaluationSummary {
+    overall_assessment: string
+    pass_patterns: EvaluationPattern[]
+    fail_patterns: EvaluationPattern[]
+    na_patterns: EvaluationPattern[]
+    recommendations: string[]
+    statistics: EvaluationSummaryStatistics
+}


### PR DESCRIPTION
## Problem

Users need a frontend UI to trigger and view AI-powered evaluation summaries. This builds on the backend endpoint from PR #46023.

This is PR 2 of 2 in a stack (depends on #46023).

## Changes

- Add `LLM_ANALYTICS_EVALUATIONS_SUMMARY` feature flag constant
- Add TypeScript types: `EvaluationSummaryFilter`, `EvaluationPattern`, `EvaluationSummaryStatistics`, `EvaluationSummary`
- Extend kea logic with summary loader, filter reducer, expand toggle, and `runsToSummarizeCount` selector
- Add `EvaluationSummaryPanel` component with collapsible summary display, statistics, pattern grids, and recommendations
- Add `PatternCard` component for individual pattern rendering with generation ID links
- Integrate summary controls and panel into `EvaluationRunsTable`
- Feature flag gated behind `LLM_ANALYTICS_EVALUATIONS_SUMMARY`

## How did you test this code?

- TypeScript check: `pnpm --filter=@posthog/frontend typescript:check`
- Prettier formatting verified
- Manual testing: enable feature flag, navigate to an evaluation with runs, generate summary, toggle filters

## Publish to changelog?

No