### PR TITLE
fix: unpin the MCP inspector version

### DIFF
--- a/services/mcp/typescript/package.json
+++ b/services/mcp/typescript/package.json
@@ -33,7 +33,7 @@
         "dev:local-resources": "wrangler dev --var POSTHOG_MCP_LOCAL_SKILLS_URL:http://localhost:8765/skills-mcp-resources.zip",
         "deploy": "wrangler deploy",
         "cf-typegen": "wrangler types",
-        "inspector": "npx @modelcontextprotocol/inspector@0.15.0 npx -y mcp-remote@latest http://localhost:8787/mcp",
+        "inspector": "npx @modelcontextprotocol/inspector npx -y mcp-remote@latest http://localhost:8787/mcp",
         "test": "vitest",
         "test:integration": "vitest run --config vitest.integration.config.mts",
         "test:watch": "vitest watch",


### PR DESCRIPTION
## Problem

MCP inspector was pinned to v`0.15` and they're always updating that tool with new features.

## Changes

Unpin the version

## How did you test this code?

locally 

## Publish to changelog?

no