### PR TITLE
fix: await client warnings as side effects

### DIFF
--- a/nodejs/src/worker/ingestion/utils.ts
+++ b/nodejs/src/worker/ingestion/utils.ts
@@ -90,8 +90,7 @@ export async function captureIngestionWarning(
     ingestionWarningCounter.inc({ type, emitted: shouldEmit.toString() })
 
     if (shouldEmit) {
-        // TODO: Either here or in follow up change this to an await as we do care.
-        void kafkaProducer
+        return kafkaProducer
             .queueMessages({
                 topic: KAFKA_INGESTION_WARNINGS,
                 messages: [
@@ -106,6 +105,7 @@ export async function captureIngestionWarning(
                     },
                 ],
             })
+            .then(() => true)
             .catch((error) => {
                 logger.warn('⚠️', 'Failed to produce ingestion warning', {
                     error,
@@ -113,7 +113,8 @@ export async function captureIngestionWarning(
                     type,
                     details,
                 })
+                return false
             })
     }
-    return Promise.resolve(shouldEmit)
+    return Promise.resolve(false)
 }


### PR DESCRIPTION
## Problem

We're discarding the client warning Kafka promise instead of returning it to be handled as a side effect.

## Changes

Passes the Kafka producer client ingestion warning promise as a side effect to the pipeline.

## How did you test this code?

Fixes the flaky test.