### PR TITLE
fix: Validate experiment metrics + update MCP schema

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -242,8 +242,8 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
         for i, metric in enumerate(metrics):
             try:
                 ExperimentMetric.model_validate(metric)
-            except Exception as e:
-                raise ValidationError(f"Invalid metric at index {i}: {e}")
+            except Exception:
+                raise ValidationError(f"Invalid metric at index {i}")
 
         return metrics
 

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -240,6 +240,8 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
             raise ValidationError("Metrics must be a list")
 
         for i, metric in enumerate(metrics):
+            if not isinstance(metric, dict) or metric.get("kind") != "ExperimentMetric":
+                continue
             try:
                 ExperimentMetric.model_validate(metric)
             except Exception:

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -13,7 +13,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from posthog.schema import ActionsNode, ExperimentEventExposureConfig
+from posthog.schema import ActionsNode, ExperimentEventExposureConfig, ExperimentMetric
 
 from posthog.api.cohort import CohortSerializer
 from posthog.api.feature_flag import FeatureFlagSerializer, MinimalFeatureFlagSerializer
@@ -231,6 +231,27 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
                 raise ValidationError("Invalid exposure criteria")
 
         return exposure_criteria
+
+    def _validate_metrics_list(self, metrics: list | None) -> list | None:
+        if metrics is None:
+            return metrics
+
+        if not isinstance(metrics, list):
+            raise ValidationError("Metrics must be a list")
+
+        for i, metric in enumerate(metrics):
+            try:
+                ExperimentMetric.model_validate(metric)
+            except Exception as e:
+                raise ValidationError(f"Invalid metric at index {i}: {e}")
+
+        return metrics
+
+    def validate_metrics(self, value):
+        return self._validate_metrics_list(value)
+
+    def validate_metrics_secondary(self, value):
+        return self._validate_metrics_list(value)
 
     def create(self, validated_data: dict, *args: Any, **kwargs: Any) -> Experiment:
         is_draft = "start_date" not in validated_data or validated_data["start_date"] is None

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -895,6 +895,107 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["detail"], "This field may not be null.")
 
+    def test_rejects_metrics_with_dict_properties_on_create(self):
+        dict_properties_metric = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {
+                "kind": "EventsNode",
+                "event": "$pageview",
+                "properties": {
+                    "$current_url": {
+                        "value": "/start",
+                        "operator": "icontains",
+                    }
+                },
+            },
+        }
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Bad metrics experiment",
+                "feature_flag_key": "bad-metrics-flag",
+                "parameters": {},
+                "filters": {},
+                "metrics": [dict_properties_metric],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["attr"], "metrics")
+
+    def test_rejects_metrics_with_dict_properties_on_update(self):
+        create_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Good experiment",
+                "feature_flag_key": "update-metrics-flag",
+                "parameters": {},
+                "filters": {},
+            },
+            format="json",
+        )
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+        experiment_id = create_response.json()["id"]
+
+        dict_properties_metric = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {
+                "kind": "EventsNode",
+                "event": "$pageview",
+                "properties": {
+                    "$current_url": {
+                        "value": "/start",
+                        "operator": "icontains",
+                    }
+                },
+            },
+        }
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/",
+            {"metrics": [dict_properties_metric]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["attr"], "metrics")
+
+    def test_accepts_metrics_with_array_properties(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Good metrics experiment",
+                "feature_flag_key": "good-metrics-flag",
+                "parameters": {},
+                "filters": {},
+                "metrics": [
+                    {
+                        "kind": "ExperimentMetric",
+                        "metric_type": "mean",
+                        "source": {
+                            "kind": "EventsNode",
+                            "event": "$pageview",
+                            "properties": [
+                                {
+                                    "key": "$current_url",
+                                    "value": "/start",
+                                    "operator": "icontains",
+                                    "type": "event",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
     def test_experiment_date_validation(self):
         ff_key = "a-b-tests"
 

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -12,7 +12,7 @@ import { ErrorDetailsSchema, ListErrorsSchema } from './errors'
 import { FilterGroupsSchema, UpdateFeatureFlagInputSchema } from './flags'
 import { CreateInsightInputSchema, ListInsightsSchema, UpdateInsightInputSchema } from './insights'
 import { LogsListAttributeValuesInputSchema, LogsListAttributesInputSchema, LogsQueryInputSchema } from './logs'
-import { InsightQuerySchema } from './query'
+import { InsightQuerySchema, PropertyFilter } from './query'
 import {
     CreateSurveyInputSchema,
     GetSurveySpecificStatsInputSchema,
@@ -102,7 +102,7 @@ export const ExperimentUpdateInputSchema = z.object({
                     .array(z.string())
                     .optional()
                     .describe('For funnel metrics only: Array of event names for each funnel step'),
-                properties: z.record(z.any()).optional().describe('Event properties to filter on'),
+                properties: z.array(PropertyFilter).optional().describe('Event property filters as an array, e.g. [{ key: "$browser", value: "Chrome", operator: "exact", type: "event" }]'),
                 description: z.string().optional().describe('What this metric measures'),
             })
         )
@@ -116,7 +116,7 @@ export const ExperimentUpdateInputSchema = z.object({
                 metric_type: z.enum(['mean', 'funnel', 'ratio']).describe('Metric type'),
                 event_name: z.string().describe('PostHog event name'),
                 funnel_steps: z.array(z.string()).optional().describe('For funnel metrics only: Array of event names'),
-                properties: z.record(z.any()).optional().describe('Event properties to filter on'),
+                properties: z.array(PropertyFilter).optional().describe('Event property filters as an array, e.g. [{ key: "$browser", value: "Chrome", operator: "exact", type: "event" }]'),
                 description: z.string().optional().describe('What this metric measures'),
             })
         )
@@ -187,7 +187,7 @@ export const ExperimentCreateSchema = z.object({
                     .describe(
                         "For funnel metrics only: Array of event names for each funnel step (e.g., ['product_view', 'add_to_cart', 'checkout', 'purchase'])"
                     ),
-                properties: z.record(z.any()).optional().describe('Event properties to filter on'),
+                properties: z.array(PropertyFilter).optional().describe('Event property filters as an array, e.g. [{ key: "$browser", value: "Chrome", operator: "exact", type: "event" }]'),
                 description: z
                     .string()
                     .optional()
@@ -214,7 +214,7 @@ export const ExperimentCreateSchema = z.object({
                     .array(z.string())
                     .optional()
                     .describe('For funnel metrics only: Array of event names for each funnel step'),
-                properties: z.record(z.any()).optional().describe('Event properties to filter on'),
+                properties: z.array(PropertyFilter).optional().describe('Event property filters as an array, e.g. [{ key: "$browser", value: "Chrome", operator: "exact", type: "event" }]'),
                 description: z.string().optional().describe('What this secondary metric measures'),
             })
         )

--- a/services/mcp/tests/api/client.integration.test.ts
+++ b/services/mcp/tests/api/client.integration.test.ts
@@ -1126,7 +1126,7 @@ describe('API Client Integration Tests', { concurrent: false }, () => {
                           metric_type: metric.metric_type,
                           event_name: metric.event_name || '$pageview',
                           funnel_steps: metric.funnel_steps,
-                          properties: metric.properties || {},
+                          properties: metric.properties,
                           description: metric.description,
                       }))
                     : undefined,
@@ -1518,7 +1518,6 @@ describe('API Client Integration Tests', { concurrent: false }, () => {
                         metric_type: 'funnel' as const,
                         event_name: 'landing',
                         funnel_steps: ['landing', 'signup', 'activation'],
-                        properties: {},
                     },
                 ],
                 variants: [

--- a/services/mcp/tests/tools/experiments.integration.test.ts
+++ b/services/mcp/tests/tools/experiments.integration.test.ts
@@ -145,7 +145,7 @@ describe('Experiments', { concurrent: false }, () => {
                         name: 'Average Page Load Time',
                         metric_type: 'mean' as const,
                         event_name: '$pageview',
-                        properties: { page: '/checkout' },
+                        properties: [{ key: 'page', value: '/checkout', operator: 'exact', type: 'event' }],
                         description: 'Measure average page load time for checkout page',
                     },
                 ],


### PR DESCRIPTION
## Problem

A [customer used](https://posthoghelp.zendesk.com/agent/tickets/48010) the MCP to create an experiment, but it resulted in one of their primary metrics having the wrong shape,

```
"properties": {
    "$current_url": {
        "value": "/start",
        "operator": "icontains"
    }
}
```

instead of

```
"properties": [
  {
    "key": "$current_url",
    "value": "/start",
    "operator": "icontains",
    "type": "event"
  }
]
```

It was ultimately causing [this crash](https://us.posthog.com/project/2/error_tracking/019ad062-063d-7072-b74c-3d91c677b0c5?7bfaa375f7d15454a84ce8d56d83f65efdb6df00daab39669b17cc32ef6d6469722f6dd97c68f8b9957fc4806567ac345062ddd62cf58b6d9a53771d76c69019&timestamp=2026-01-22%2011%3A54%3A52.693000-08%3A00), and this fix doesn't avoid it but prevents metrics from getting into the same state.

## Changes

- Update the MCP schema to try and avoid this
- Add validation to the API to prevent primary/secondary metrics from being created with the wrong shape

## How did you test this code?

Added unit tests