### PR TITLE
chore(livestream): Skip hot reloading the livestream service if air doesn't exist

### DIFF
--- a/bin/start-go-service
+++ b/bin/start-go-service
@@ -58,11 +58,24 @@ case "$GO_SVC" in
     ;;
 esac
 
+# check if air is available for hot reloading
+if command -v air &>/dev/null; then
+  USE_AIR=true
+else
+  USE_AIR=false
+  echo -e "\n\033[33mWarning: 'air' not found. Running without hot reload.\033[0m"
+  echo -e "Install air for hot reloading: go install github.com/air-verse/air@latest\n"
+fi
+
 # ensure the service restarts if it crashes in dev
 sleep 1
 while true; do
   if ! ps -p ${GO_PID:-} &>/dev/null; then
-    air &
+    if [ "$USE_AIR" = true ]; then
+      air &
+    else
+      go run . &
+    fi
     export GO_PID=$!
     echo -e "\n\033[47m>>\033[0m Restarted '$GO_SVC' with PID $GO_PID\n"
   fi


### PR DESCRIPTION
## Problem
The Livestream service will not run for uses who don't have the air package installed. Instead of letting the service fail to start, we should run without hot-reloading.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Run livestream without hot reloading when air doesn't exist.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
