### PR TITLE
revert(mendral): mount latest UDF config for ClickHouse in dev environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -142,7 +142,7 @@ services:
             - ./docker/clickhouse/config.d/default.xml:/etc/clickhouse-server/config.d/default.xml
             - ./docker/clickhouse/config.d/dev-memory.xml:/etc/clickhouse-server/config.d/dev-memory.xml
             - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
-            - ./posthog/user_scripts/latest_user_defined_function.xml:/etc/clickhouse-server/user_defined_function.xml
+            - ./docker/clickhouse/user_defined_function.xml:/etc/clickhouse-server/user_defined_function.xml
             - ./posthog/user_scripts:/var/lib/clickhouse/user_scripts
         extra_hosts:
             - 'host.docker.internal:host-gateway'


### PR DESCRIPTION
Reverts PostHog/posthog#45394

Funnel insights in local dev fails, as they are looking for the versioned udf with this change. I'll revert an see where this affects AI evals.