### PR TITLE
fix(dagster): convert UUID columns to strings for parquet export

### DIFF
--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -106,7 +106,7 @@ DEFAULT_CLICKHOUSE_SETTINGS = {
 # Note: We use toInt64(team_id) as project_id since they're equivalent in PostHog.
 # Materialized columns (dmat_*) are ClickHouse-specific and not present in DuckLake.
 EVENTS_COLUMNS = """
-    uuid,
+    toString(uuid) as uuid,
     event,
     properties,
     timestamp,
@@ -115,7 +115,7 @@ EVENTS_COLUMNS = """
     distinct_id,
     elements_chain,
     created_at,
-    person_id,
+    toString(person_id) as person_id,
     person_created_at,
     person_properties,
     group0_properties,

--- a/posthog/dags/tests/test_events_backfill_to_ducklake.py
+++ b/posthog/dags/tests/test_events_backfill_to_ducklake.py
@@ -141,11 +141,17 @@ class TestGetPartitionWhereClause:
 
 class TestEventsColumnsSchema:
     def test_events_columns_has_expected_columns(self):
-        columns_in_sql = {
-            col.strip().split()[0].rstrip(",") for col in EVENTS_COLUMNS.strip().split("\n") if col.strip()
-        }
-        columns_in_sql.discard("toInt64(team_id)")
-        columns_in_sql.add("project_id")
+        columns_in_sql = set()
+        for col in EVENTS_COLUMNS.strip().split("\n"):
+            if col.strip():
+                # Handle columns with 'AS' alias (e.g., "toString(uuid) as uuid")
+                if " as " in col.lower():
+                    # Extract the alias after 'as'
+                    alias = col.lower().split(" as ")[1].split(",")[0].strip()
+                    columns_in_sql.add(alias)
+                else:
+                    # No alias, use the column name directly
+                    columns_in_sql.add(col.strip().split()[0].rstrip(","))
 
         assert "uuid" in columns_in_sql
         assert "event" in columns_in_sql


### PR DESCRIPTION
## Summary

This PR fixes a Parquet export error in the DuckLake backfill job by converting UUID columns to strings.

## Problem

The backfill job was failing with:
```
DB::Exception: Internal type 'UUID' of column 'uuid' is not supported for conversion into Parquet data format
```

ClickHouse's native UUID type cannot be directly serialized to Parquet format. The affected columns are:
- `uuid` - the event UUID
- `person_id` - the person UUID

## Solution

Convert both UUID columns to strings using ClickHouse's `toString()` function:
```sql
toString(uuid) as uuid,
toString(person_id) as person_id,
```

This preserves the UUID values as strings in the exported Parquet files, which is compatible with:
- Parquet format specification
- DuckDB UUID type (can cast from string)
- PostgreSQL UUID type (can cast from string)

## Changes

Updated `EVENTS_COLUMNS` in `posthog/dags/events_backfill_to_ducklake.py`:
- Line 109: `uuid,` → `toString(uuid) as uuid,`
- Line 118: `person_id,` → `toString(person_id) as person_id,`

## Test plan

- Verify the backfill job runs without the UUID conversion error
- Confirm that exported Parquet files contain UUID values as strings
- Verify DuckLake ingestion can successfully load the UUID columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)