### PR TITLE
feat: add team id to db metric labels

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -246,9 +246,11 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
         .map(|p| (Some(p.id), Some(p.properties)))
         .unwrap_or((None, None));
     person_query_timer.fin();
-    with_canonical_log(|log| log.person_queries += 1);
-
     let person_query_duration = person_query_start.elapsed();
+    with_canonical_log(|log| {
+        log.person_queries += 1;
+        log.person_query_time_ms += person_query_duration.as_millis() as u64;
+    });
 
     if person_query_duration.as_millis() > 500 {
         warn!(
@@ -294,9 +296,11 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
                 .fetch_all(&mut *conn)
                 .await?;
             cohort_timer.fin();
-            with_canonical_log(|log| log.static_cohort_queries += 1);
-
             let cohort_query_duration = cohort_query_start.elapsed();
+            with_canonical_log(|log| {
+                log.static_cohort_queries += 1;
+                log.cohort_query_time_ms += cohort_query_duration.as_millis() as u64;
+            });
 
             if cohort_query_duration.as_millis() > 200 {
                 warn!(
@@ -385,9 +389,11 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             .fetch_all(&mut *conn)
             .await?;
         group_query_timer.fin();
-        with_canonical_log(|log| log.group_queries += 1);
-
         let group_query_duration = group_query_start.elapsed();
+        with_canonical_log(|log| {
+            log.group_queries += 1;
+            log.group_query_time_ms += group_query_duration.as_millis() as u64;
+        });
 
         if group_query_duration.as_millis() > 300 {
             warn!(

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -226,7 +226,10 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
         }
     };
 
-    let query_labels = [("pool".to_string(), "persons_reader".to_string())];
+    let query_labels = [
+        ("pool".to_string(), "persons_reader".to_string()),
+        ("team_id".to_string(), team_id.to_string()),
+    ];
 
     // First query: Get person data from the distinct_id (person_id and person_properties)
     // TRICKY: sometimes we don't have a person_id ingested by the time we get a `/flags` request for a given
@@ -880,6 +883,7 @@ async fn try_set_feature_flag_hash_key_overrides(
                 "set_hash_key_overrides".to_string(),
             ),
             ("pool".to_string(), "persons_writer".to_string()),
+            ("team_id".to_string(), team_id.to_string()),
         ];
         let person_query_start = Instant::now();
         let person_query_timer =
@@ -954,6 +958,7 @@ async fn try_set_feature_flag_hash_key_overrides(
                 "set_hash_key_overrides".to_string(),
             ),
             ("pool".to_string(), "non_persons_reader".to_string()),
+            ("team_id".to_string(), team_id.to_string()),
         ];
         let flags_query_start = Instant::now();
         let flags_query_timer =
@@ -1018,6 +1023,7 @@ async fn try_set_feature_flag_hash_key_overrides(
                 "set_hash_key_overrides".to_string(),
             ),
             ("pool".to_string(), "persons_writer".to_string()),
+            ("team_id".to_string(), team_id.to_string()),
         ];
         let insert_start = Instant::now();
         let insert_timer = common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &insert_labels);
@@ -1216,6 +1222,7 @@ async fn try_should_write_hash_key_override(
             ),
             ("operation".to_string(), "should_write_check".to_string()),
             ("pool".to_string(), "persons_reader".to_string()),
+            ("team_id".to_string(), team_id.to_string()),
         ];
         let person_query_timer =
             common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &person_query_labels);
@@ -1298,6 +1305,7 @@ async fn try_should_write_hash_key_override(
             ),
             ("operation".to_string(), "should_write_check".to_string()),
             ("pool".to_string(), "non_persons_reader".to_string()),
+            ("team_id".to_string(), team_id.to_string()),
         ];
         let flags_query_timer =
             common_metrics::timing_guard(FLAG_DEFINITION_QUERY_TIME, &flags_labels);

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -109,6 +109,12 @@ pub struct FlagsCanonicalLogLine {
     pub group_queries: usize,
     /// Number of static cohort membership queries made to the database.
     pub static_cohort_queries: usize,
+    /// Time spent on person property queries in milliseconds.
+    pub person_query_time_ms: u64,
+    /// Time spent on group property queries in milliseconds.
+    pub group_query_time_ms: u64,
+    /// Time spent on static cohort membership queries in milliseconds.
+    pub cohort_query_time_ms: u64,
     pub property_cache_hits: usize,
     pub property_cache_misses: usize,
     /// True if person properties were not found in evaluation state cache.
@@ -167,6 +173,9 @@ impl Default for FlagsCanonicalLogLine {
             person_queries: 0,
             group_queries: 0,
             static_cohort_queries: 0,
+            person_query_time_ms: 0,
+            group_query_time_ms: 0,
+            cohort_query_time_ms: 0,
             property_cache_hits: 0,
             property_cache_misses: 0,
             person_properties_not_cached: false,
@@ -223,6 +232,9 @@ impl FlagsCanonicalLogLine {
             person_queries = self.person_queries,
             group_queries = self.group_queries,
             static_cohort_queries = self.static_cohort_queries,
+            person_query_time_ms = self.person_query_time_ms,
+            group_query_time_ms = self.group_query_time_ms,
+            cohort_query_time_ms = self.cohort_query_time_ms,
             property_cache_hits = self.property_cache_hits,
             property_cache_misses = self.property_cache_misses,
             person_properties_not_cached = self.person_properties_not_cached,


### PR DESCRIPTION
## Problem

During incident investigation, we couldn't attribute slow DB queries to specific teams because query timing metrics lacked team_id labels. This made root cause analysis unnecessarily difficult and time-consuming.

## Changes

Added team_id label to all query timing metrics in the feature flags service:

  - `flags_person_query_time`
  - `flags_cohort_query_time`
  - `flags_group_query_time`
  - `flags_definition_query_time`

The existing `team_id_label_filter` handles cardinality by filtering team_ids based on configuration (only tracked teams get their actual ID, others become "unknown").

After deployment, teams can be identified in Grafana with queries like:
`histogram_quantile(0.99, sum by (team_id) (rate(flags_person_query_time_bucket[5m])))`

## How did you test this code?

- All 812 unit tests pass


## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
