### PR TITLE
chore(product tours): add min version warning on tour preview

### DIFF
--- a/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
+++ b/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
@@ -9,13 +9,18 @@ import { STEP_TYPE_ICONS, STEP_TYPE_LABELS } from 'scenes/product-tours/stepUtil
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 
 import { StepCard } from './StepCard'
-import { TourStep, productToursLogic } from './productToursLogic'
+import {
+    PRODUCT_TOURS_MIN_JS_VERSION,
+    TourStep,
+    hasMinProductToursVersion,
+    productToursLogic,
+} from './productToursLogic'
 import { PRODUCT_TOURS_SIDEBAR_TRANSITION_MS } from './utils'
 
 const SIDEBAR_WIDTH = 320
 
 export function ProductToursSidebar(): JSX.Element | null {
-    const { userIntent } = useValues(toolbarConfigLogic)
+    const { userIntent, posthog } = useValues(toolbarConfigLogic)
     const {
         selectedTourId,
         tourForm,
@@ -78,6 +83,10 @@ export function ProductToursSidebar(): JSX.Element | null {
     }
 
     const getPreviewDisabledReason = (): string | undefined => {
+        if (posthog?.version && !hasMinProductToursVersion(posthog.version)) {
+            return `Requires posthog-js ${PRODUCT_TOURS_MIN_JS_VERSION}+`
+        }
+
         if (isPreviewing) {
             return 'Preview in progress'
         }

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -47,6 +47,13 @@ export interface TourForm {
     steps: TourStep[]
 }
 
+export const PRODUCT_TOURS_MIN_JS_VERSION = '1.324.0'
+
+export function hasMinProductToursVersion(version: string): boolean {
+    const [major, minor] = version.split('.').map(Number)
+    return major > 1 || (major === 1 && minor >= 324)
+}
+
 function newTour(): TourForm {
     return {
         name: '',
@@ -560,6 +567,11 @@ export const productToursLogic = kea<productToursLogicType>([
         },
         previewTour: () => {
             const { tourForm, posthog, selectedTourId, tours } = values
+            if (posthog?.version && !hasMinProductToursVersion(posthog.version)) {
+                lemonToast.error(`Requires posthog-js ${PRODUCT_TOURS_MIN_JS_VERSION}+`)
+                return
+            }
+
             if (!tourForm || !posthog?.productTours) {
                 lemonToast.error('Unable to preview tour')
                 return


### PR DESCRIPTION
## Problem

users are confused about why product tour previews do not work

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

add explicit error messaging if customer `posthog-js` version is too low

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->