### PR TITLE
fix(cohorts): optimize ClickHouse email lookup using materialized columns

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -560,7 +560,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
             # Use materialized email column for optimal performance
             query = """
             SELECT DISTINCT person.id
-            FROM person
+            FROM person FINAL
             WHERE person.team_id = %(team_id)s
               AND person.pmat_email IN %(emails)s
               AND person.is_deleted = 0

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -557,12 +557,12 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
             return []
 
         try:
-            # Use direct ClickHouse SQL for fast person lookup
+            # Use materialized email column for optimal performance
             query = """
             SELECT DISTINCT person.id
-            FROM person FINAL
+            FROM person
             WHERE person.team_id = %(team_id)s
-              AND JSONExtractString(person.properties, 'email') IN %(emails)s
+              AND person.pmat_email IN %(emails)s
               AND person.is_deleted = 0
             """
 

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -559,10 +559,10 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         try:
             # Use optimized ClickHouse query with GROUP BY HAVING
             query = """
-            SELECT DISTINCT person.id
+            SELECT person.id
             FROM person
             WHERE person.team_id = %(team_id)s
-              AND has(%(emails)s, person.pmat_email)
+              AND person.pmat_email IN %(emails)s
             GROUP BY person.id
             HAVING argMax(person.is_deleted, person.version) = 0
             SETTINGS optimize_aggregation_in_order = 1

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -557,7 +557,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
             return []
 
         try:
-            # Use optimized ClickHouse query with GROUP BY (same pattern as person API)
+            # Use optimized ClickHouse query with GROUP BY HAVING
             query = """
             SELECT DISTINCT person.id
             FROM person

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -557,7 +557,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
             return []
 
         try:
-            # Use materialized email column for optimal performance
+            # Use direct ClickHouse SQL for fast person lookup
             query = """
             SELECT DISTINCT person.id
             FROM person FINAL

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -557,13 +557,15 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
             return []
 
         try:
-            # Use direct ClickHouse SQL for fast person lookup
+            # Use optimized ClickHouse query with GROUP BY (same pattern as person API)
             query = """
             SELECT DISTINCT person.id
-            FROM person FINAL
+            FROM person
             WHERE person.team_id = %(team_id)s
-              AND person.pmat_email IN %(emails)s
-              AND person.is_deleted = 0
+              AND has(%(emails)s, person.pmat_email)
+            GROUP BY person.id
+            HAVING argMax(person.is_deleted, person.version) = 0
+            SETTINGS optimize_aggregation_in_order = 1
             """
 
             result = sync_execute(query, {"team_id": team_id, "emails": emails})


### PR DESCRIPTION
## Problem

Follow-up to #46034 - the ClickHouse email lookup was still timing out in production after 300 seconds due to inefficient JSON extraction using `JSONExtractString(person.properties, 'email')`.

## Changes

- Use `person.pmat_email` materialized column for optimal performance instead of JSON extraction
- Simplified query structure by removing unnecessary complexity