### PR TITLE
fix(surveys): reset wizard state on unmount and improve title editing UX

### DIFF
--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -93,7 +93,7 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
                     return WIZARD_STEPS[Math.max(currentIndex - 1, 0)]
                 },
                 resetWizard: () => (props.id === 'new' ? 'template' : 'questions'),
-                selectTemplate: () => 'questions', // Move to questions after selecting template
+                selectTemplate: () => 'questions',
             },
         ],
         selectedTemplate: [
@@ -145,14 +145,7 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
                 return defaultSurveyTemplates.filter((t) => !CORE_TEMPLATE_TYPES.includes(t.templateType))
             },
         ],
-        stepNumber: [
-            (s) => [s.currentStep],
-            (currentStep: WizardStep): number => {
-                const index = WIZARD_STEPS.indexOf(currentStep)
-                // Template step is step 0, so questions is step 1
-                return index
-            },
-        ],
+        stepNumber: [(s) => [s.currentStep], (currentStep: WizardStep): number => WIZARD_STEPS.indexOf(currentStep)],
         stepValidationErrors: [
             (s) => [s.survey],
             (survey: Survey): Record<WizardStep, string[]> => {
@@ -216,8 +209,13 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
 
     listeners(({ actions, values, props }) => ({
         selectTemplate: ({ template }) => {
-            // Initialize survey with selected template
-            const timestamp = new Date().toISOString().slice(0, 16).replace('T', ' ')
+            const timestamp = new Date().toLocaleString('sv-SE', {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+            })
             actions.setSurveyValue('name', `${template.templateType} (${timestamp})`)
             actions.setSurveyValue('description', template.description || '')
             actions.setSurveyValue('type', template.type || SurveyType.Popover)
@@ -250,26 +248,14 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
                 ...cleanTemplateBehavior,
             })
 
-            // Set frequency based on template type, but preserve other conditions from template
             const frequencyToDays: Record<string, number | undefined> = {
                 once: undefined,
                 yearly: 365,
                 quarterly: 90,
                 monthly: 30,
             }
-            const templateType = template.templateType
-            let frequencyValue = 'monthly'
-            if (templateType.includes('NPS') || templateType.includes('PMF')) {
-                frequencyValue = 'quarterly'
-            } else if (templateType.includes('CSAT') || templateType.includes('CES')) {
-                frequencyValue = 'monthly'
-            } else if (templateType.includes('Onboarding') || templateType.includes('Attribution')) {
-                frequencyValue = 'once'
-            }
-
-            const isOnce = frequencyValue === 'once'
-            actions.setSurveyValue('schedule', isOnce ? SurveySchedule.Once : SurveySchedule.Always)
-            // Preserve existing template conditions (e.g. event triggers) and only update frequency
+            const { value: frequencyValue } = values.recommendedFrequency
+            actions.setSurveyValue('schedule', frequencyValue === 'once' ? SurveySchedule.Once : SurveySchedule.Always)
             actions.setSurveyValue('conditions', {
                 ...template.conditions,
                 seenSurveyWaitPeriodInDays: frequencyToDays[frequencyValue],
@@ -319,11 +305,7 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
         },
         saveDraft: async () => {
             try {
-                const surveyData = {
-                    ...values.survey,
-                    // Don't set start_date - keep as draft
-                }
-                const createdSurvey = await api.surveys.create(surveyData)
+                const createdSurvey = await api.surveys.create(values.survey)
                 actions.saveDraftSuccess(createdSurvey)
             } catch (e) {
                 actions.saveDraftFailure(String(e))
@@ -346,8 +328,7 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
         },
         updateSurvey: async () => {
             try {
-                const surveyData = values.survey
-                const updatedSurvey = await api.surveys.update(props.id, surveyData)
+                const updatedSurvey = await api.surveys.update(props.id, values.survey)
                 actions.updateSurveySuccess(updatedSurvey)
             } catch (e) {
                 actions.updateSurveyFailure(String(e))
@@ -364,24 +345,23 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
 
     afterMount(({ actions, props, values }) => {
         if (props.id === 'new') {
-            // Check if survey already has a template selected (from SurveyTemplates page)
             // Templates set both name AND questions, while default NEW_SURVEY has empty name
             const hasTemplateSelected = values.survey?.name && values.survey?.questions?.length > 0
             if (hasTemplateSelected) {
-                // Skip template step, go directly to questions
                 actions.setStep('questions')
             } else {
-                // Reset wizard and survey state for new survey
                 actions.resetWizard()
                 actions.resetSurvey()
             }
         } else {
-            // Load existing survey data
             actions.loadSurvey()
         }
 
         return () => {
             actions.resetWizard()
+            if (props.id === 'new') {
+                actions.resetSurvey()
+            }
         }
     }),
 ])

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -4,6 +4,7 @@ import { router } from 'kea-router'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -209,13 +210,7 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
 
     listeners(({ actions, values, props }) => ({
         selectTemplate: ({ template }) => {
-            const timestamp = new Date().toLocaleString('sv-SE', {
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-                hour: '2-digit',
-                minute: '2-digit',
-            })
+            const timestamp = dayjs().format('YYYY-MM-DD HH:mm')
             actions.setSurveyValue('name', `${template.templateType} (${timestamp})`)
             actions.setSurveyValue('description', template.description || '')
             actions.setSurveyValue('type', template.type || SurveyType.Popover)


### PR DESCRIPTION
## Summary

- **Fix stale state on re-creation**: the survey wizard wasn't resetting form state (name, questions, etc.) when unmounting for new surveys, so creating another survey would carry over the previous survey's data. Now calls `resetSurvey()` on unmount when `id === 'new'`.
- **Inline-editable survey title**: replaced the static template name next to the back button with an `EditableField` rendered as a page-level title, with an accessible `<label>` for screen readers.

![CleanShot 2026-01-27 at 17 36 13@2x](https://github.com/user-attachments/assets/70a69729-67aa-460d-9f10-2fe59a805bdf)


## Test plan

- [ ] Create a new survey via the wizard, launch or save it, then click "New survey" again — form should be fully reset (empty name, template step)
- [ ] Verify the survey name appears as a large editable title below the back button with a "Survey name" label
- [ ] Click the survey name to edit it inline, confirm it saves on blur
- [ ] Check the auto-generated timestamp in the survey name matches local time, not UTC