### PR TITLE
fix(experiments): handle memory limit errors more gracefully.

### DIFF
--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -1,9 +1,9 @@
 import posthog from 'posthog-js'
 
-import { ApiError } from 'lib/api'
+import api, { ApiError } from 'lib/api'
 
 import { useMocks } from '~/mocks/jest'
-import { performQuery, queryExportContext } from '~/queries/query'
+import { performQuery, pollForResults, queryExportContext } from '~/queries/query'
 import { EventsQuery, HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { PropertyFilterType, PropertyOperator } from '~/types'
@@ -125,5 +125,78 @@ describe('query', () => {
         const queryFailedCalls = captureSpy.mock.calls.filter((call) => call[0] === 'query failed')
         expect(queryFailedCalls).toHaveLength(1)
         expect(queryFailedCalls[0][1]).toMatchObject({ query: q, duration: expect.any(Number) })
+    })
+
+    describe('pollForResults error message parsing', () => {
+        it('parses ErrorDetail list format and extracts message and code', async () => {
+            jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce({
+                data: {
+                    query_status: {
+                        error_message:
+                            "[ErrorDetail(string='Query exceeded memory limit', code='memory_limit_exceeded')]",
+                    },
+                },
+            })
+
+            await expect(pollForResults('test-query-id')).rejects.toMatchObject({
+                detail: 'Query exceeded memory limit',
+                code: 'memory_limit_exceeded',
+            })
+        })
+
+        it('parses ErrorDetail single format and extracts message and code', async () => {
+            jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce({
+                data: {
+                    query_status: {
+                        error_message: "ErrorDetail(string='Database connection failed', code='db_error')",
+                    },
+                },
+            })
+
+            await expect(pollForResults('test-query-id')).rejects.toMatchObject({
+                detail: 'Database connection failed',
+                code: 'db_error',
+            })
+        })
+
+        it('preserves original message when not in ErrorDetail format', async () => {
+            jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce({
+                data: {
+                    query_status: {
+                        error_message: 'Simple error message',
+                    },
+                },
+            })
+
+            await expect(pollForResults('test-query-id')).rejects.toMatchObject({
+                detail: 'Simple error message',
+            })
+        })
+
+        it('handles undefined error message', async () => {
+            jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce({
+                data: {
+                    query_status: {},
+                },
+            })
+
+            await expect(pollForResults('test-query-id')).rejects.toMatchObject({
+                detail: '',
+            })
+        })
+
+        it('handles non-string error message', async () => {
+            jest.spyOn(api.queryStatus, 'get').mockRejectedValueOnce({
+                data: {
+                    query_status: {
+                        error_message: { nested: 'object' },
+                    },
+                },
+            })
+
+            await expect(pollForResults('test-query-id')).rejects.toMatchObject({
+                detail: { nested: 'object' },
+            })
+        })
     })
 })

--- a/posthog/hogql_queries/experiments/test/test_error_handling.py
+++ b/posthog/hogql_queries/experiments/test/test_error_handling.py
@@ -1,0 +1,125 @@
+"""Tests for experiment error handling decorator and error message mapping."""
+
+from typing import cast
+
+from posthog.test.base import BaseTest
+from unittest.mock import Mock, patch
+
+from rest_framework.exceptions import ErrorDetail, ValidationError
+
+from posthog.exceptions import ClickHouseQueryMemoryLimitExceeded
+from posthog.hogql_queries.experiments.error_handling import (
+    ERROR_TYPE_TO_CODE,
+    experiment_error_handler,
+    get_user_friendly_message,
+)
+
+
+class TestExperimentErrorHandling(BaseTest):
+    def test_get_user_friendly_message_for_memory_limit_exceeded(self):
+        """Test that ClickHouseQueryMemoryLimitExceeded gets a user-friendly message."""
+        error = ClickHouseQueryMemoryLimitExceeded()
+        message = get_user_friendly_message(error)
+
+        self.assertIsNotNone(message)
+        self.assertEqual(
+            message,
+            "This experiment query is using too much memory. Try viewing a shorter time period or contact support for help.",
+        )
+
+    def test_get_user_friendly_message_for_unmapped_error(self):
+        """Test that unmapped errors return None."""
+        error = RuntimeError("Some unexpected error")
+        message = get_user_friendly_message(error)
+
+        self.assertIsNone(message)
+
+    @patch("posthog.hogql_queries.experiments.error_handling.capture_exception")
+    def test_decorator_converts_memory_limit_exception(self, mock_capture):
+        """Test that the decorator converts ClickHouseQueryMemoryLimitExceeded to ValidationError."""
+
+        @experiment_error_handler
+        def failing_method(self):
+            raise ClickHouseQueryMemoryLimitExceeded()
+
+        mock_self = Mock()
+        mock_self.experiment_id = None  # Ensure this is None so the fallback to experiment.id is used
+        mock_experiment = Mock()
+        mock_experiment.id = 123
+        mock_self.experiment = mock_experiment
+        mock_self.metric = None
+        mock_self.user_facing = True
+
+        with self.assertRaises(ValidationError) as context:
+            failing_method(mock_self)
+
+        # ValidationError.detail can be a list or dict, check it's a list first
+        self.assertIsInstance(context.exception.detail, list)
+
+        # Cast to list for type checker
+        detail_list = cast(list[ErrorDetail], context.exception.detail)
+
+        self.assertEqual(
+            str(detail_list[0]),
+            "This experiment query is using too much memory. Try viewing a shorter time period or contact support for help.",
+        )
+        # Verify error code is set correctly
+        # In DRF, the code is stored in the ErrorDetail object, not directly on the exception
+        self.assertIsInstance(detail_list[0], ErrorDetail)
+        self.assertEqual(detail_list[0].code, "memory_limit_exceeded")
+
+        # Verify exception was captured with correct properties
+        mock_capture.assert_called_once()
+        call_args = mock_capture.call_args
+        self.assertIsInstance(call_args[0][0], ClickHouseQueryMemoryLimitExceeded)
+        self.assertEqual(call_args[1]["additional_properties"]["experiment_id"], 123)
+        self.assertEqual(call_args[1]["additional_properties"]["query_runner"], "Mock")
+
+    @patch("posthog.hogql_queries.experiments.error_handling.capture_exception")
+    def test_decorator_captures_query_runner_name(self, mock_capture):
+        """Test that the decorator captures the query runner class name."""
+
+        @experiment_error_handler
+        def failing_method(self):
+            raise ClickHouseQueryMemoryLimitExceeded()
+
+        class ExperimentExposuresQueryRunner:
+            def __init__(self):
+                self.experiment = Mock(id=456)
+                self.metric = None
+                self.user_facing = True
+
+        runner = ExperimentExposuresQueryRunner()
+
+        with self.assertRaises(ValidationError):
+            failing_method(runner)
+
+        mock_capture.assert_called_once()
+        additional_props = mock_capture.call_args[1]["additional_properties"]
+        self.assertEqual(additional_props["query_runner"], "ExperimentExposuresQueryRunner")
+        self.assertEqual(additional_props["experiment_id"], 456)
+
+    @patch("posthog.hogql_queries.experiments.error_handling.capture_exception")
+    def test_decorator_does_not_convert_for_non_user_facing(self, mock_capture):
+        """Test that the decorator doesn't convert exceptions when user_facing=False."""
+
+        @experiment_error_handler
+        def failing_method(self):
+            raise ClickHouseQueryMemoryLimitExceeded()
+
+        mock_self = Mock()
+        mock_self.experiment = Mock(id=123)
+        mock_self.metric = None
+        mock_self.user_facing = False
+
+        # Should re-raise the original exception
+        with self.assertRaises(ClickHouseQueryMemoryLimitExceeded):
+            failing_method(mock_self)
+
+        # Should still capture for internal tracking
+        mock_capture.assert_called_once()
+
+    def test_error_type_to_code_mapping(self):
+        """Test that ClickHouseQueryMemoryLimitExceeded has a code mapping."""
+        self.assertIn(ClickHouseQueryMemoryLimitExceeded, ERROR_TYPE_TO_CODE)
+        self.assertEqual(ERROR_TYPE_TO_CODE[ClickHouseQueryMemoryLimitExceeded], "memory_limit_exceeded")


### PR DESCRIPTION
## Problem

When a query fails due to out-of-memory, we return a standard error message to the client. This message is generic to all HogQL queries and provides misleading information to users in the context of experiments. The recommended follow-up actions can't be performed by the user, and the help link doesn't provide any meaningful help.

| query memory error on the experiments page | a better error message |
| - | - |
| <img width="820" height="382" alt="image" src="https://github.com/user-attachments/assets/1262238c-ed1d-42a1-b289-aaa9926cb1de" /> | <img width="456" height="170" alt="image" src="https://github.com/user-attachments/assets/76a2e0e1-a94e-430f-88b4-4ced547d5f41" /> |


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

The exposures query runner wasn't using the `@experiment_error_handler` decorator, so we added it to the `_calculate` method, and extended the decorator to support `ClickHouseQueryMemoryLimitExceeded`.

On the frontend, we needed to modify the `pollForResults` function to parse the error message from the backend before showing it to the user.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest queries/query.test
hogli test:python posthog/hogql_queries/experiments/test/test_error_handling.py
```

![cat-type](https://github.com/user-attachments/assets/920930c8-941a-41d7-b726-87be3d4c2440)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
