### PR TITLE
chore(livestream): Add ingestion lag metrics for the livestream service

### DIFF
--- a/livestream/events/kafka.go
+++ b/livestream/events/kafka.go
@@ -220,9 +220,9 @@ func parse(geolocator geo.GeoLocator, kafkaMessage []byte) PostHogEvent {
 
 	if wrapperMessage.Timestamp != "" {
 		if eventTime, err := time.Parse(time.RFC3339Nano, wrapperMessage.Timestamp); err == nil {
-			lagSeconds := time.Since(eventTime).Seconds()
-			metrics.EventLagGauge.Set(lagSeconds)
-			metrics.EventLagHistogram.Observe(lagSeconds)
+			if lag := time.Since(eventTime).Seconds(); lag >= 0 {
+				metrics.EventLagHistogram.Observe(lag)
+			}
 		}
 	}
 

--- a/livestream/events/kafka.go
+++ b/livestream/events/kafka.go
@@ -218,6 +218,14 @@ func parse(geolocator geo.GeoLocator, kafkaMessage []byte) PostHogEvent {
 		log.Printf("Error decoding JSON %s: %v", err, string(kafkaMessage))
 	}
 
+	if wrapperMessage.Timestamp != "" {
+		if eventTime, err := time.Parse(time.RFC3339Nano, wrapperMessage.Timestamp); err == nil {
+			lagSeconds := time.Since(eventTime).Seconds()
+			metrics.EventLagGauge.Set(lagSeconds)
+			metrics.EventLagHistogram.Observe(lagSeconds)
+		}
+	}
+
 	phEvent := PostHogEvent{
 		Timestamp:  wrapperMessage.Timestamp,
 		Token:      "",

--- a/livestream/metrics/metrics.go
+++ b/livestream/metrics/metrics.go
@@ -99,4 +99,14 @@ var (
 		Name: "livestream_session_recording_token_count",
 		Help: "Number of unique tokens being tracked",
 	})
+
+	EventLagGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "livestream_event_lag_seconds",
+		Help: "Time difference between event timestamp and when it was consumed",
+	})
+	EventLagHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "livestream_event_lag_seconds_histogram",
+		Help:    "Distribution of event lag in seconds",
+		Buckets: []float64{1, 2, 5, 10, 30, 60, 120, 300, 600, 900, 1800, 3600},
+	})
 )

--- a/livestream/metrics/metrics.go
+++ b/livestream/metrics/metrics.go
@@ -100,12 +100,8 @@ var (
 		Help: "Number of unique tokens being tracked",
 	})
 
-	EventLagGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "livestream_event_lag_seconds",
-		Help: "Time difference between event timestamp and when it was consumed",
-	})
 	EventLagHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "livestream_event_lag_seconds_histogram",
+		Name:    "livestream_event_lag_seconds",
 		Help:    "Distribution of event lag in seconds",
 		Buckets: []float64{1, 2, 5, 10, 30, 60, 120, 300, 600, 900, 1800, 3600},
 	})


### PR DESCRIPTION
## Problem
We are consistently seeing old events emitted from the Livestream service and have no way to track that. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds some basic metrics to track how far behind we are when processing messages

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
