### PR TITLE
feat(deduplicator): refactor partition state tracking for more robust rebalance handling

### DIFF
--- a/rust/kafka-deduplicator/src/kafka/rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/kafka/rebalance_handler.rs
@@ -48,15 +48,15 @@ use crate::kafka::batch_context::ConsumerCommandSender;
 ///
 /// ```text
 /// pre_rebalance(Revoke partition 0)
-///     └─► setup_revoked_partitions()   - adds partition 0 to pending_cleanup set
+///     └─► setup_revoked_partitions()   - removes partition 0 from owned_partitions
 ///
 /// post_rebalance(Assign partition 0)
-///     └─► setup_assigned_partitions()  - REMOVES partition 0 from pending_cleanup
+///     └─► setup_assigned_partitions()  - adds partition 0 back to owned_partitions
 ///                                       - reuses existing worker if present
 ///
 /// Async worker processes RebalanceEvent::Revoke:
-///     └─► cleanup_revoked_partitions() - checks pending_cleanup set
-///                                       - partition 0 NOT in set → SKIPS cleanup!
+///     └─► cleanup_revoked_partitions() - checks owned_partitions via coordinator
+///                                       - partition 0 IS owned → SKIPS cleanup!
 ///                                       - worker and store are preserved
 /// ```
 ///

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -112,21 +112,39 @@ pub const ACTIVE_STORE_COUNT: &str = "active_store_count";
 /// Value > 0 means rebalance async work is ongoing; used to block orphan cleanup
 pub const REBALANCING_COUNT: &str = "rebalancing_count";
 
+// ==== Partition Ownership Tracking ====
+
+/// Gauge for currently owned partition count
+/// Updated on every ownership change for real-time visibility
+pub const OWNED_PARTITIONS_COUNT: &str = "owned_partitions_count";
+
+/// Counter for partitions added to ownership (ASSIGN callback)
+pub const PARTITION_OWNERSHIP_ADDED: &str = "partition_ownership_added_total";
+
+/// Counter for partitions removed from ownership (REVOKE callback)
+pub const PARTITION_OWNERSHIP_REMOVED: &str = "partition_ownership_removed_total";
+
+/// Counter for async setup cancellations
+/// Incremented when a new rebalance starts before async setup completes
+pub const REBALANCE_ASYNC_SETUP_CANCELLED: &str = "rebalance_async_setup_cancelled_total";
+
+/// Counter for partitions skipped during store creation (no longer owned)
+/// Labels: reason (not_owned, cancelled)
+pub const PARTITION_STORE_SETUP_SKIPPED: &str = "partition_store_setup_skipped_total";
+
+/// Counter for partitions where checkpoint import failed and we fell back to empty store
+/// Labels: checkpoint_failure_reason (import, restore)
+/// This is an important metric for alerting - indicates degraded deduplication quality
+pub const PARTITION_STORE_FALLBACK_EMPTY: &str = "partition_store_fallback_empty_total";
+
 /// Counter for messages dropped because no store was registered for the partition
 /// This indicates the partition was likely revoked during a rebalance
 pub const MESSAGES_DROPPED_NO_STORE: &str = "messages_dropped_no_store_total";
 
-// ==== Rebalance Resume Filtering ====
-/// Counter for partitions filtered from Resume commands (revoked during async setup)
-pub const REBALANCE_RESUME_PARTITIONS_FILTERED: &str = "rebalance_resume_partitions_filtered_total";
+// ==== Rebalance Resume ====
 
-/// Counter for Resume commands skipped entirely (all partitions were revoked)
-pub const REBALANCE_RESUME_SKIPPED_ALL_REVOKED: &str = "rebalance_resume_skipped_all_revoked_total";
-
-/// Counter for partitions resumed after rebalance was cancelled
-/// This happens when a new rebalance starts before async setup completes,
-/// but some partitions are still owned and need to be resumed
-pub const REBALANCE_RESUME_AFTER_CANCELLATION: &str = "rebalance_resume_after_cancellation_total";
+/// Counter for Resume commands skipped entirely (no owned partitions)
+pub const REBALANCE_RESUME_SKIPPED_NO_OWNED: &str = "rebalance_resume_skipped_no_owned_total";
 
 // ==== Partition Batch Processing Diagnostics ====
 /// Histogram for partition batch processing duration (in milliseconds)

--- a/rust/kafka-deduplicator/src/rebalance_coordinator.rs
+++ b/rust/kafka-deduplicator/src/rebalance_coordinator.rs
@@ -30,25 +30,39 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+
+use dashmap::DashSet;
 use tracing::{info, warn};
 
-use crate::metrics_const::REBALANCING_COUNT;
+use crate::kafka::types::Partition;
+use crate::metrics_const::{
+    OWNED_PARTITIONS_COUNT, PARTITION_OWNERSHIP_ADDED, PARTITION_OWNERSHIP_REMOVED,
+    REBALANCING_COUNT,
+};
 
 /// Coordinates rebalance state across multiple components.
 ///
-/// This is a lightweight struct (~8 bytes) that can be cheaply cloned via `Arc`.
-/// It provides the single source of truth for whether a rebalance is in progress.
+/// This is a lightweight struct that can be cheaply cloned via `Arc`.
+/// It provides the single source of truth for:
+/// - Whether a rebalance is in progress (counter-based for overlapping rebalances)
+/// - Which partitions are currently owned by this consumer
 pub struct RebalanceCoordinator {
     /// Counter tracking the number of in-progress rebalances.
     /// Using a counter (not bool) correctly handles overlapping rebalances.
     rebalancing_count: AtomicUsize,
+
+    /// Set of partitions currently owned by this consumer.
+    /// Updated synchronously in ASSIGN (add) and REVOKE (remove) callbacks.
+    /// Used to determine which partitions to resume and which to cleanup.
+    owned_partitions: DashSet<Partition>,
 }
 
 impl RebalanceCoordinator {
-    /// Create a new coordinator with the counter initialized to 0.
+    /// Create a new coordinator with the counter initialized to 0 and no owned partitions.
     pub fn new() -> Self {
         Self {
             rebalancing_count: AtomicUsize::new(0),
+            owned_partitions: DashSet::new(),
         }
     }
 
@@ -119,6 +133,103 @@ impl RebalanceCoordinator {
         }
     }
 
+    // ============================================
+    // PARTITION OWNERSHIP TRACKING
+    // ============================================
+
+    /// Add partitions to the owned set. Called from ASSIGN callback.
+    ///
+    /// This is called synchronously in the rdkafka callback to update ownership
+    /// before async work is queued. Idempotent - adding a partition that's already
+    /// owned is a no-op.
+    pub fn add_owned_partitions(&self, partitions: &[Partition]) {
+        if partitions.is_empty() {
+            return;
+        }
+
+        let mut added_count = 0;
+        for partition in partitions {
+            if self.owned_partitions.insert(partition.clone()) {
+                added_count += 1;
+            }
+        }
+
+        let total_owned = self.owned_partitions.len();
+        metrics::gauge!(OWNED_PARTITIONS_COUNT).set(total_owned as f64);
+        metrics::counter!(PARTITION_OWNERSHIP_ADDED).increment(added_count as u64);
+
+        if added_count > 0 {
+            info!(
+                added_count = added_count,
+                total_owned = total_owned,
+                "Partitions added to ownership"
+            );
+        }
+    }
+
+    /// Remove partitions from the owned set. Called from REVOKE callback.
+    ///
+    /// This is called synchronously in the rdkafka callback to update ownership
+    /// before async work is queued. Idempotent - removing a partition that's not
+    /// owned is a no-op.
+    pub fn remove_owned_partitions(&self, partitions: &[Partition]) {
+        if partitions.is_empty() {
+            return;
+        }
+
+        let mut removed_count = 0;
+        for partition in partitions {
+            if self.owned_partitions.remove(partition).is_some() {
+                removed_count += 1;
+            }
+        }
+
+        let total_owned = self.owned_partitions.len();
+        metrics::gauge!(OWNED_PARTITIONS_COUNT).set(total_owned as f64);
+        metrics::counter!(PARTITION_OWNERSHIP_REMOVED).increment(removed_count as u64);
+
+        if removed_count > 0 {
+            info!(
+                removed_count = removed_count,
+                total_owned = total_owned,
+                "Partitions removed from ownership"
+            );
+        }
+    }
+
+    /// Get a snapshot of all currently owned partitions.
+    ///
+    /// Returns a Vec copy of all owned partitions. Use this to determine
+    /// which partitions to resume after async setup completes.
+    pub fn get_owned_partitions(&self) -> Vec<Partition> {
+        self.owned_partitions.iter().map(|p| p.clone()).collect()
+    }
+
+    /// Check if a specific partition is currently owned.
+    ///
+    /// Use this to skip work for partitions that were revoked during async setup.
+    pub fn is_partition_owned(&self, partition: &Partition) -> bool {
+        self.owned_partitions.contains(partition)
+    }
+
+    /// Get partitions from the input list that are NOT currently owned.
+    ///
+    /// Use this in cleanup to determine which partitions should be cleaned up
+    /// (those that are still not owned after rapid revoke→assign).
+    pub fn get_unowned_partitions(&self, partitions: &[Partition]) -> Vec<Partition> {
+        partitions
+            .iter()
+            .filter(|p| !self.owned_partitions.contains(*p))
+            .cloned()
+            .collect()
+    }
+
+    /// Get the count of owned partitions (for testing/debugging).
+    #[cfg(test)]
+    pub fn owned_partition_count(&self) -> usize {
+        self.owned_partitions.len()
+    }
+
     /// Get the current rebalancing count (for testing/debugging).
     #[cfg(test)]
     pub fn rebalancing_count(&self) -> usize {
@@ -149,6 +260,7 @@ impl Drop for RebalancingGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::kafka::types::Partition;
 
     #[test]
     fn test_new_coordinator_not_rebalancing() {
@@ -237,5 +349,111 @@ mod tests {
     fn test_default_impl() {
         let coordinator = RebalanceCoordinator::default();
         assert!(!coordinator.is_rebalancing());
+    }
+
+    // ============================================
+    // PARTITION OWNERSHIP TESTS
+    // ============================================
+
+    #[test]
+    fn test_owned_partitions_initially_empty() {
+        let coordinator = RebalanceCoordinator::new();
+        assert!(coordinator.get_owned_partitions().is_empty());
+        assert_eq!(coordinator.owned_partition_count(), 0);
+    }
+
+    #[test]
+    fn test_add_and_remove_owned_partitions() {
+        let coordinator = RebalanceCoordinator::new();
+        let p0 = Partition::new("topic".to_string(), 0);
+        let p1 = Partition::new("topic".to_string(), 1);
+
+        // Add partitions
+        coordinator.add_owned_partitions(&[p0.clone(), p1.clone()]);
+        assert_eq!(coordinator.owned_partition_count(), 2);
+        assert!(coordinator.is_partition_owned(&p0));
+        assert!(coordinator.is_partition_owned(&p1));
+
+        // Remove one partition
+        coordinator.remove_owned_partitions(std::slice::from_ref(&p1));
+        assert_eq!(coordinator.owned_partition_count(), 1);
+        assert!(coordinator.is_partition_owned(&p0));
+        assert!(!coordinator.is_partition_owned(&p1));
+
+        // Remove the other
+        coordinator.remove_owned_partitions(std::slice::from_ref(&p0));
+        assert_eq!(coordinator.owned_partition_count(), 0);
+        assert!(!coordinator.is_partition_owned(&p0));
+    }
+
+    #[test]
+    fn test_get_unowned_partitions() {
+        let coordinator = RebalanceCoordinator::new();
+        let p0 = Partition::new("topic".to_string(), 0);
+        let p1 = Partition::new("topic".to_string(), 1);
+        let p2 = Partition::new("topic".to_string(), 2);
+
+        // Add p0 only
+        coordinator.add_owned_partitions(std::slice::from_ref(&p0));
+
+        // Query for unowned among [p0, p1, p2]
+        let unowned = coordinator.get_unowned_partitions(&[p0.clone(), p1.clone(), p2.clone()]);
+        assert_eq!(unowned.len(), 2);
+        assert!(!unowned.contains(&p0));
+        assert!(unowned.contains(&p1));
+        assert!(unowned.contains(&p2));
+    }
+
+    #[test]
+    fn test_idempotent_add_remove() {
+        let coordinator = RebalanceCoordinator::new();
+        let p0 = Partition::new("topic".to_string(), 0);
+
+        // Adding twice should be idempotent
+        coordinator.add_owned_partitions(std::slice::from_ref(&p0));
+        coordinator.add_owned_partitions(std::slice::from_ref(&p0));
+        assert_eq!(coordinator.owned_partition_count(), 1);
+
+        // Removing twice should be idempotent
+        coordinator.remove_owned_partitions(std::slice::from_ref(&p0));
+        coordinator.remove_owned_partitions(std::slice::from_ref(&p0));
+        assert!(coordinator.get_owned_partitions().is_empty());
+    }
+
+    #[test]
+    fn test_rapid_revoke_assign_ownership() {
+        // Simulates rapid revoke -> assign scenario
+        let coordinator = RebalanceCoordinator::new();
+        let p0 = Partition::new("topic".to_string(), 0);
+
+        // Initial assignment
+        coordinator.add_owned_partitions(std::slice::from_ref(&p0));
+        assert!(coordinator.is_partition_owned(&p0));
+
+        // Revoke
+        coordinator.remove_owned_partitions(std::slice::from_ref(&p0));
+        assert!(!coordinator.is_partition_owned(&p0));
+
+        // Immediate re-assign
+        coordinator.add_owned_partitions(std::slice::from_ref(&p0));
+        assert!(coordinator.is_partition_owned(&p0));
+
+        // Partition should be owned and NOT in unowned list
+        let unowned = coordinator.get_unowned_partitions(std::slice::from_ref(&p0));
+        assert!(unowned.is_empty());
+    }
+
+    #[test]
+    fn test_empty_operations() {
+        let coordinator = RebalanceCoordinator::new();
+
+        // Empty add/remove should be no-ops
+        coordinator.add_owned_partitions(&[]);
+        coordinator.remove_owned_partitions(&[]);
+        assert_eq!(coordinator.owned_partition_count(), 0);
+
+        // Empty unowned query
+        let unowned = coordinator.get_unowned_partitions(&[]);
+        assert!(unowned.is_empty());
     }
 }


### PR DESCRIPTION
## Problem
Current partition state tracking has some gaps wrt coordination of overlapping async rebalance handlers
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Refactor partition assignment state tracking into coordinator
* Updates and additions to test suite
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
