### PR TITLE
fix(docs): remove unused CalloutBox import in openai-agents

### DIFF
--- a/docs/onboarding/llm-analytics/openai-agents.tsx
+++ b/docs/onboarding/llm-analytics/openai-agents.tsx
@@ -5,7 +5,6 @@ export const OpenAIAgentsInstallation = (): JSX.Element => {
         Steps,
         Step,
         CodeBlock,
-        CalloutBox,
         ProductScreenshot,
         OSButton,
         Markdown,


### PR DESCRIPTION
## Summary
- Removes unused `CalloutBox` destructuring from `docs/onboarding/llm-analytics/openai-agents.tsx`, fixing the `TS6133` error in the TypeScript check

## Test plan
- [ ] `pnpm --filter=@posthog/frontend typescript:check` passes