### PR TITLE
fix(llma): always load dashboard without feature flag check

### DIFF
--- a/products/llm_analytics/frontend/tabs/llmAnalyticsDashboardLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsDashboardLogic.ts
@@ -3,9 +3,7 @@ import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { urls } from 'scenes/urls'
 
@@ -52,12 +50,7 @@ function getDayDateRange(day: string): { date_from: string; date_to: string } {
 export const llmAnalyticsDashboardLogic = kea<llmAnalyticsDashboardLogicType>([
     path(['products', 'llm_analytics', 'frontend', 'tabs', 'llmAnalyticsDashboardLogic']),
     connect({
-        values: [
-            llmAnalyticsSharedLogic,
-            ['dashboardDateFilter', 'shouldFilterTestAccounts', 'propertyFilters'],
-            featureFlagLogic,
-            ['featureFlags'],
-        ],
+        values: [llmAnalyticsSharedLogic, ['dashboardDateFilter', 'shouldFilterTestAccounts', 'propertyFilters']],
     }),
 
     actions({
@@ -583,9 +576,7 @@ export const llmAnalyticsDashboardLogic = kea<llmAnalyticsDashboardLogicType>([
         ],
     }),
 
-    afterMount(({ actions, values }) => {
-        if (values.featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]) {
-            actions.loadLLMDashboards()
-        }
+    afterMount(({ actions }) => {
+        actions.loadLLMDashboards()
     }),
 ])


### PR DESCRIPTION


## Problem

The dashboard tab was showing "Dashboard not found" for users without the LLM_ANALYTICS_EARLY_ADOPTERS feature flag.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No.
