### PR TITLE
fix(docker): wait for clickhouse to be up before flushing system tables

### DIFF
--- a/docker/clickhouse/docker-entrypoint-initdb.d/init-db.sh
+++ b/docker/clickhouse/docker-entrypoint-initdb.d/init-db.sh
@@ -11,5 +11,11 @@ fi
 
 cp -r /idl/* /var/lib/clickhouse/format_schemas/
 
-# flush all log tables to ensure they are created
-clickhouse client --query "system flush logs"
+# Wait for ClickHouse to be ready to accept queries, then flush log tables to ensure
+# system log tables (e.g., system.crash_log) are created. Use timeout to avoid hanging.
+for i in {1..30}; do
+    if clickhouse client --query "select 1" > /dev/null 2>&1; then
+        clickhouse client --query "system flush logs" && break
+    fi
+    sleep 1
+done

--- a/docker/clickhouse/docker-entrypoint-initdb.d/init-db.sh
+++ b/docker/clickhouse/docker-entrypoint-initdb.d/init-db.sh
@@ -13,9 +13,17 @@ cp -r /idl/* /var/lib/clickhouse/format_schemas/
 
 # Wait for ClickHouse to be ready to accept queries, then flush log tables to ensure
 # system log tables (e.g., system.crash_log) are created. Use timeout to avoid hanging.
+READY=false
 for i in {1..30}; do
     if clickhouse client --query "select 1" > /dev/null 2>&1; then
-        clickhouse client --query "system flush logs" && break
+        clickhouse client --query "system flush logs"
+        READY=true
+        break
     fi
     sleep 1
 done
+
+if [ "$READY" = false ]; then
+    echo "ClickHouse failed to become ready after 30 seconds" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Problem

Clickhouse was hanging in local dev (i think because it wasn't waiting on clickhouse to be up before flushing logs). this could be resolved by restarting the container but then migration would fail because the log tables weren't created from the flush.

## Changes

order these ops properly

## How did you test this code?

local dev works from a scratch workspace now.

## Publish to changelog?
no