### PR TITLE
fix(web-analytics): handle malformed URLs in domain selector

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -213,15 +213,20 @@ const WebAnalyticsDomainSelector = (): JSX.Element => {
                               ]
                             : []),
                         ...authorizedDomains.map((domain) => {
-                            const url = new URL(domain)
+                            let hostname: string | null = null
+                            try {
+                                hostname = new URL(domain).hostname
+                            } catch {
+                                // skip favicon for malformed URLs
+                            }
                             return {
                                 label: domain,
                                 value: domain,
-                                ...(featureFlags[FEATURE_FLAGS.SHOW_REFERRER_FAVICON]
+                                ...(hostname && featureFlags[FEATURE_FLAGS.SHOW_REFERRER_FAVICON]
                                     ? {
                                           icon: (
                                               <img
-                                                  src={faviconUrl(url.hostname)}
+                                                  src={faviconUrl(hostname)}
                                                   width={16}
                                                   height={16}
                                                   alt={`${domain} favicon`}


### PR DESCRIPTION
## Problem

`new URL(domain)` in the web analytics domain selector throws an error for malformed URLs, crashing the component. This is expected because people can use different protocols, local domains and other options on this dropdown, they just won't have favicons at this time.

https://posthoghelp.zendesk.com/agent/tickets/48520 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50720)

## Changes

- Wrap URL parsing in try/catch in `WebAnalyticsDomainSelector`
- Skip favicon when the domain string can't be parsed as a valid URL

## How did you test this code?

- Verified the domain selector renders correctly with valid domains
- Confirmed malformed domain strings no longer crash the component (favicon is gracefully skipped)