### PR TITLE
fix(devenv): add migrate-persons-db to always_required in dev:setup

### DIFF
--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -188,5 +188,3 @@ always_required:
     - capture
     - feature-flags
     - property-defs-rs
-    # Migrations
-    - migrate-persons-db

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -176,6 +176,11 @@ always_required:
     - frontend
     - typegen
     - docker-compose
+    # Migrations (DBs created by postgres init scripts, run for everyone)
+    - migrate-postgres
+    - migrate-clickhouse
+    - migrate-persons-db
+    - migrate-behavioral-cohorts
     # Core services
     - celery-worker
     - celery-beat

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -183,3 +183,5 @@ always_required:
     - capture
     - feature-flags
     - property-defs-rs
+    # Migrations
+    - migrate-persons-db


### PR DESCRIPTION
## Problem

The persons migration was not being run by default, causing generate-demo-data to fail with missing table errors like posthog_grouptypemapping.

https://claude.ai/code/session_013ybTmGJ3tCJrRxCK1ULg7v

## Changes

add it to intents

## How did you test this code?

ran locally

## Publish to changelog?
no