### PR TITLE
feat: batch step 3 CH query in windowed person reconciliation job

### DIFF
--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -605,9 +605,8 @@ def compare_raw_updates_with_person_state(
     if not raw_updates:
         return []
 
-    # Build lookup from person_id to raw_update for efficient access
-    raw_updates_by_person: dict[str, RawPersonPropertyUpdates] = {u.person_id: u for u in raw_updates}
-    person_ids = list(raw_updates_by_person.keys())
+    # Extract person_ids for batching
+    person_ids = [u.person_id for u in raw_updates]
 
     # Query person properties and versions in batches to avoid "Query size exceeded"
     person_data: dict[str, tuple[dict, int]] = {}

--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -559,6 +559,12 @@ def merge_raw_person_property_updates(
                 existing.unset_updates[key] = new_pv
 
 
+# Max number of person_ids per batch when querying person state.
+# Prevents "Query size exceeded" errors when IN clause becomes too large.
+# 10K UUIDs × ~40 chars ≈ 400KB query text, under typical max_query_size limits.
+PERSON_STATE_BATCH_SIZE = 10000
+
+
 def compare_raw_updates_with_person_state(
     team_id: int,
     raw_updates: list[RawPersonPropertyUpdates],
@@ -584,6 +590,11 @@ def compare_raw_updates_with_person_state(
         preferable for reconciliation as it avoids unnecessary updates when
         values are semantically equivalent.
 
+    Note on batching:
+        For high-volume teams with many affected persons, we batch the person
+        state queries to avoid "Query size exceeded" errors from overly large
+        IN clauses. Each batch queries up to PERSON_STATE_BATCH_SIZE persons.
+
     Args:
         team_id: Team ID
         raw_updates: Merged raw updates from all time windows
@@ -594,37 +605,42 @@ def compare_raw_updates_with_person_state(
     if not raw_updates:
         return []
 
-    person_ids = [u.person_id for u in raw_updates]
+    # Build lookup from person_id to raw_update for efficient access
+    raw_updates_by_person: dict[str, RawPersonPropertyUpdates] = {u.person_id: u for u in raw_updates}
+    person_ids = list(raw_updates_by_person.keys())
 
-    # Query person properties and versions
-    query = """
-    SELECT
-        id,
-        argMax(properties, version) as properties,
-        argMax(version, version) as person_version
-    FROM person
-    WHERE team_id = %(team_id)s
-      AND id IN %(person_ids)s
-    GROUP BY id
-    HAVING argMax(is_deleted, version) = 0
-    """
-
-    params = {
-        "team_id": team_id,
-        "person_ids": tuple(person_ids),
-    }
-
-    rows = sync_execute(query, params)
-
-    # Build person lookup
+    # Query person properties and versions in batches to avoid "Query size exceeded"
     person_data: dict[str, tuple[dict, int]] = {}
-    for row in rows:
-        person_id, properties_str, version = row
-        if properties_str:
-            properties = json.loads(properties_str) if isinstance(properties_str, str) else properties_str
-        else:
-            properties = {}
-        person_data[str(person_id)] = (properties, int(version))
+
+    for batch_start in range(0, len(person_ids), PERSON_STATE_BATCH_SIZE):
+        batch_person_ids = person_ids[batch_start : batch_start + PERSON_STATE_BATCH_SIZE]
+
+        query = """
+        SELECT
+            id,
+            argMax(properties, version) as properties,
+            argMax(version, version) as person_version
+        FROM person
+        WHERE team_id = %(team_id)s
+          AND id IN %(person_ids)s
+        GROUP BY id
+        HAVING argMax(is_deleted, version) = 0
+        """
+
+        params = {
+            "team_id": team_id,
+            "person_ids": tuple(batch_person_ids),
+        }
+
+        rows = sync_execute(query, params)
+
+        for row in rows:
+            person_id, properties_str, version = row
+            if properties_str:
+                properties = json.loads(properties_str) if isinstance(properties_str, str) else properties_str
+            else:
+                properties = {}
+            person_data[str(person_id)] = (properties, int(version))
 
     results: list[PersonPropertyDiffs] = []
 
@@ -688,6 +704,7 @@ def get_person_property_updates_windowed(
     team_id: int,
     bug_window_start: str,
     window_seconds: int,
+    logger: Any = None,
 ) -> list[PersonPropertyDiffs]:
     """
     Fetch person property updates, optionally in time windows.
@@ -703,17 +720,25 @@ def get_person_property_updates_windowed(
         team_id: Team ID to query
         bug_window_start: Start of time window (ClickHouse format: "YYYY-MM-DD HH:MM:SS")
         window_seconds: Size of each query window in seconds. If <= 0, single query is used.
+        logger: Optional logger for progress tracking
 
     Returns:
         List of PersonPropertyDiffs with merged results across all windows
     """
     if window_seconds <= 0:
+        if logger:
+            logger.info(f"Using single-query mode for team_id={team_id}")
         return get_person_property_updates_from_clickhouse(team_id, bug_window_start)
 
     # Step 1 & 2: Query raw updates per window and merge
     accumulated: dict[str, RawPersonPropertyUpdates] = {}
     current_start = parse_ch_timestamp(bug_window_start)
     now = datetime.now(UTC)
+    window_count = 0
+    total_windows = int((now - current_start).total_seconds() / window_seconds) + 1
+
+    if logger:
+        logger.info(f"Starting windowed query: team_id={team_id}, ~{total_windows} windows of {window_seconds}s each")
 
     while current_start < now:
         current_end = min(current_start + timedelta(seconds=window_seconds), now)
@@ -723,9 +748,25 @@ def get_person_property_updates_windowed(
             format_ch_timestamp(current_end),
         )
         merge_raw_person_property_updates(accumulated, window_updates)
+        window_count += 1
+
+        if logger and window_count % 10 == 0:
+            logger.info(
+                f"Processed window {window_count}/{total_windows} for team_id={team_id}, "
+                f"accumulated {len(accumulated)} unique persons"
+            )
+
         current_start = current_end
 
+    if logger:
+        logger.info(
+            f"Completed all {window_count} windows for team_id={team_id}, total unique persons: {len(accumulated)}"
+        )
+
     # Step 3: Compare merged raw updates against person state
+    if logger:
+        logger.info(f"Comparing {len(accumulated)} persons against current state for team_id={team_id}")
+
     return compare_raw_updates_with_person_state(team_id, list(accumulated.values()))
 
 
@@ -1521,11 +1562,17 @@ def reconcile_single_team(
     This function does not catch exceptions - the caller is responsible for error handling.
     """
     # Query ClickHouse for all persons with property updates in this team
+    logger.info(
+        f"Querying ClickHouse for property updates: team_id={team_id}, "
+        f"bug_window_start={bug_window_start}, window_seconds={team_ch_props_fetch_window_seconds}"
+    )
     person_property_diffs = get_person_property_updates_windowed(
         team_id=team_id,
         bug_window_start=bug_window_start,
         window_seconds=team_ch_props_fetch_window_seconds,
+        logger=logger,
     )
+    logger.info(f"Found {len(person_property_diffs)} persons with property diffs for team_id={team_id}")
 
     # Filter conflicting set/unset operations
     person_property_diffs = filter_event_person_properties(person_property_diffs)


### PR DESCRIPTION
## Problem
A test run using the new windowed-query codepath hit a syntax error due to too large submitted query input from a naive oversized IN clause.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Batch the "step 3" query during event property by-person collection and deduplication, prior to building write diffs for Postgres
* Update and expand test suite to cover this change
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI - smoke test run after change is landed ✅ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
