### PR TITLE
chore(product tours): sidebar element selection bugfixes

### DIFF
--- a/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
@@ -19,7 +19,7 @@ import {
 } from '~/types'
 
 import { ProductTourPreview } from '../components/ProductTourPreview'
-import { STEP_TYPE_ICONS, STEP_TYPE_LABELS, createDefaultStep } from '../stepUtils'
+import { STEP_TYPE_ICONS, STEP_TYPE_LABELS, createDefaultStep, getStepTitle } from '../stepUtils'
 import { StepButtonsEditor } from './StepButtonsEditor'
 import { StepContentEditor } from './StepContentEditor'
 import { StepLayoutSettings } from './StepLayoutSettings'
@@ -30,18 +30,6 @@ export interface ProductTourStepsEditorProps {
     steps: ProductTourStep[]
     appearance?: ProductTourAppearance
     onChange: (steps: ProductTourStep[]) => void
-}
-
-function getStepTitle(step: ProductTourStep, index: number): string {
-    if (step.content && typeof step.content === 'object') {
-        const doc = step.content as JSONContent
-        const firstContent = doc.content?.[0]
-        if (firstContent?.content?.[0]?.text) {
-            const text = firstContent.content[0].text
-            return text.length > 30 ? text.slice(0, 30) + '...' : text
-        }
-    }
-    return `Step ${index + 1}`
 }
 
 export function getWidthValue(maxWidth: ProductTourStep['maxWidth']): number {

--- a/frontend/src/scenes/product-tours/stepUtils.tsx
+++ b/frontend/src/scenes/product-tours/stepUtils.tsx
@@ -55,6 +55,25 @@ export function getDefaultSurveyContent(type: ProductTourSurveyQuestionType): Pr
     }
 }
 
+export function getStepTitle(step: ProductTourStep, index: number): string {
+    if (step.type === 'survey' && step.survey?.questionText) {
+        const text = step.survey.questionText
+        return text.length > 30 ? text.slice(0, 30) + '...' : text
+    }
+
+    if (step.content && typeof step.content === 'object') {
+        const doc = step.content as { content?: Array<{ content?: Array<{ text?: string }> }> }
+        const firstContent = doc.content?.[0]
+        if (firstContent?.content?.[0]?.text) {
+            const text = firstContent.content[0].text
+            return text.length > 30 ? text.slice(0, 30) + '...' : text
+        }
+    }
+
+    const typeLabel = STEP_TYPE_LABELS[step.type] ?? step.type
+    return `${typeLabel} step ${index + 1}`
+}
+
 export function createDefaultStep(type: ProductTourStepType): ProductTourStep {
     const baseStep: ProductTourStep = {
         id: uuid(),

--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -33,7 +33,11 @@ export function Elements(): JSX.Element {
     const { setHoverElement, selectElement } = useActions(elementsLogic)
     const { highestClickCount } = useValues(heatmapToolbarMenuLogic)
     const { refreshClickmap } = useActions(heatmapToolbarMenuLogic)
-    const { isSelecting: productToursSelecting, hoverElementRect: productToursHoverRect } = useValues(productToursLogic)
+    const {
+        isSelecting: productToursSelecting,
+        hoverElementRect: productToursHoverRect,
+        expandedStepRect: productToursSelectedStepRect,
+    } = useValues(productToursLogic)
 
     const shiftPressed = useShiftKeyPressed(refreshClickmap)
     const heatmapPointerEvents = shiftPressed ? 'none' : 'all'
@@ -68,6 +72,7 @@ export function Elements(): JSX.Element {
                 {activeToolbarMode === 'heatmap' && <HeatmapCanvas context="toolbar" />}
                 {highlightElementMeta?.rect ? <FocusRect rect={highlightElementMeta.rect} /> : null}
                 {productToursSelecting && productToursHoverRect && <ElementHighlight rect={productToursHoverRect} />}
+                {productToursSelectedStepRect && <ElementHighlight rect={productToursSelectedStepRect} isSelected />}
 
                 {elementsToDisplay.map(({ rect, element, apparentZIndex }, index) => {
                     return (

--- a/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
+++ b/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
@@ -13,6 +13,7 @@ import {
     PRODUCT_TOURS_MIN_JS_VERSION,
     TourStep,
     hasMinProductToursVersion,
+    hasValidSelector,
     productToursLogic,
 } from './productToursLogic'
 import { PRODUCT_TOURS_SIDEBAR_TRANSITION_MS } from './utils'
@@ -80,6 +81,11 @@ export function ProductToursSidebar(): JSX.Element | null {
         if (tourFormErrors?.name) {
             return 'Enter a tour name'
         }
+
+        const hasInvalidSteps = steps.some((step) => !hasValidSelector(step))
+        if (hasInvalidSteps) {
+            return 'Some steps are missing element selection'
+        }
     }
 
     const getPreviewDisabledReason = (): string | undefined => {
@@ -93,6 +99,11 @@ export function ProductToursSidebar(): JSX.Element | null {
 
         if (stepCount === 0) {
             return 'Add at least one step'
+        }
+
+        const hasInvalidSteps = steps.some((step) => !hasValidSelector(step))
+        if (hasInvalidSteps) {
+            return 'Some steps are missing element selection'
         }
     }
 

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -77,6 +77,19 @@ function isToolbarElement(element: HTMLElement): boolean {
     return toolbar?.contains(element) ?? false
 }
 
+export function hasValidSelector(step: TourStep): boolean {
+    if (step.type !== 'element') {
+        return true
+    }
+    if (step.useManualSelector && !step.selector) {
+        return false
+    }
+    if (!step.useManualSelector && !step.inferenceData) {
+        return false
+    }
+    return true
+}
+
 /** Get the DOM element for a step, checking cached ref is still valid */
 export function getStepElement(step: TourStep): HTMLElement | null {
     if (step.element && document.body.contains(step.element)) {
@@ -89,11 +102,22 @@ export function getStepElement(step: TourStep): HTMLElement | null {
         if (!step.selector) {
             return null
         }
-        return document.querySelector(step.selector) as HTMLElement | null
+        try {
+            return document.querySelector(step.selector) as HTMLElement | null
+        } catch {
+            return null
+        }
     }
 
     if (!step.inferenceData) {
-        return step.selector ? (document.querySelector(step.selector) as HTMLElement | null) : null
+        if (!step.selector) {
+            return null
+        }
+        try {
+            return document.querySelector(step.selector) as HTMLElement | null
+        } catch {
+            return null
+        }
     }
 
     return findElement(step.inferenceData)
@@ -288,7 +312,7 @@ export const productToursLogic = kea<productToursLogicType>([
     forms(({ values, actions }) => ({
         tourForm: {
             defaults: { name: '', steps: [] } as TourForm,
-            errors: ({ name, id }) => {
+            errors: ({ name, id, steps }) => {
                 if (!name || !name.length) {
                     return { name: 'Must name this tour' }
                 }
@@ -299,6 +323,12 @@ export const productToursLogic = kea<productToursLogicType>([
                 if (isDuplicate) {
                     return { name: 'A tour with this name already exists' }
                 }
+
+                const stepErrors = steps.map((s) => (hasValidSelector(s) ? {} : { selector: 'Missing selector' }))
+                if (stepErrors.some((e) => Object.keys(e).length > 0)) {
+                    return { steps: stepErrors }
+                }
+
                 return {}
             },
             submit: async (formValues) => {
@@ -408,6 +438,23 @@ export const productToursLogic = kea<productToursLogicType>([
             },
         ],
         stepCount: [(s) => [s.tourForm], (tourForm) => tourForm?.steps?.length ?? 0],
+        expandedStepRect: [
+            (s) => [s.expandedStepIndex, s.tourForm, s.rectUpdateCounter, s.editorState],
+            (expandedStepIndex, tourForm, _, editorState): ElementRect | null => {
+                if (editorState.mode === 'selecting') {
+                    return null
+                }
+                if (expandedStepIndex === null || !tourForm?.steps) {
+                    return null
+                }
+                const step = tourForm.steps[expandedStepIndex]
+                if (!step || step.type !== 'element') {
+                    return null
+                }
+                const element = getStepElement(step)
+                return element ? getRectForElement(element) : null
+            },
+        ],
     }),
 
     subscriptions(({ actions }) => ({
@@ -513,6 +560,7 @@ export const productToursLogic = kea<productToursLogicType>([
                     useManualSelector: true,
                     inferenceData: undefined,
                     screenshotMediaId: undefined,
+                    element: undefined,
                 }
             } else {
                 // switching from manual -> auto: wipe selector data, prompt for re-selection
@@ -522,6 +570,7 @@ export const productToursLogic = kea<productToursLogicType>([
                     selector: undefined,
                     inferenceData: undefined,
                     screenshotMediaId: undefined,
+                    element: undefined,
                 }
                 actions.setEditorState({ mode: 'selecting', stepIndex: index })
             }
@@ -536,7 +585,7 @@ export const productToursLogic = kea<productToursLogicType>([
             if (!step || step.type !== 'element') {
                 return
             }
-            steps[index] = { ...step, selector }
+            steps[index] = { ...step, selector, element: undefined }
             actions.setTourFormValue('steps', steps)
         },
         updateStepProgressionTrigger: ({ index, trigger }) => {


### PR DESCRIPTION
## Problem

product tours sidebar needs some bug fixes, particularly re: element selection

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- adds error handling to querySelector (typing just `#` was throwing an error and closing the sidebar)
- adds inferred step titles everywhere, so the sidebar does not just say "element step" over and over
- highlights the target element (if found on the page) when the step is expanded
- smoother UX / error handling on element selection data (inference or manual css selector), particularly during the transition between auto<>manual selection modes
- updates screenshot image URLs (for fetch, not upload) to use `uiHost` instead of `apiHost`

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->