### PR TITLE
feat(personhog): support for db routing based on client request

### DIFF
--- a/proto/personhog/replica/v1/replica.proto
+++ b/proto/personhog/replica/v1/replica.proto
@@ -24,9 +24,10 @@ service PersonHogReplica {
   rpc GetDistinctIdsForPerson(personhog.types.v1.GetDistinctIdsForPersonRequest) returns (personhog.types.v1.GetDistinctIdsForPersonResponse);
   rpc GetDistinctIdsForPersons(personhog.types.v1.GetDistinctIdsForPersonsRequest) returns (personhog.types.v1.GetDistinctIdsForPersonsResponse);
 
-  // Feature flag support
-  rpc GetPersonIdsAndHashKeyOverrides(personhog.types.v1.GetPersonIdsAndHashKeyOverridesRequest) returns (personhog.types.v1.GetPersonIdsAndHashKeyOverridesResponse);
-  rpc GetExistingPersonIdsWithOverrideKeys(personhog.types.v1.GetExistingPersonIdsWithOverrideKeysRequest) returns (personhog.types.v1.GetExistingPersonIdsWithOverrideKeysResponse);
+  // Feature flag hash key override support
+  rpc GetHashKeyOverrideContext(personhog.types.v1.GetHashKeyOverrideContextRequest) returns (personhog.types.v1.GetHashKeyOverrideContextResponse);
+  rpc UpsertHashKeyOverrides(personhog.types.v1.UpsertHashKeyOverridesRequest) returns (personhog.types.v1.UpsertHashKeyOverridesResponse);
+  rpc DeleteHashKeyOverridesByTeams(personhog.types.v1.DeleteHashKeyOverridesByTeamsRequest) returns (personhog.types.v1.DeleteHashKeyOverridesByTeamsResponse);
 
   // Cohort membership
   rpc CheckCohortMembership(personhog.types.v1.CheckCohortMembershipRequest) returns (personhog.types.v1.CohortMembershipResponse);

--- a/proto/personhog/types/v1/cohort.proto
+++ b/proto/personhog/types/v1/cohort.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package personhog.types.v1;
 
+import "personhog/types/v1/common.proto";
+
 // CohortMembership indicates whether a person belongs to a cohort
 message CohortMembership {
   int64 cohort_id = 1;
@@ -10,6 +12,7 @@ message CohortMembership {
 message CheckCohortMembershipRequest {
   int64 person_id = 1;
   repeated int64 cohort_ids = 2;
+  ReadOptions read_options = 3;
 }
 
 message CohortMembershipResponse {

--- a/proto/personhog/types/v1/common.proto
+++ b/proto/personhog/types/v1/common.proto
@@ -1,6 +1,20 @@
 syntax = "proto3";
 package personhog.types.v1;
 
+// ConsistencyLevel specifies the consistency guarantee for read operations.
+// EVENTUAL: Read from replica (may have replication lag)
+// STRONG: Read from primary (guaranteed latest data)
+enum ConsistencyLevel {
+  CONSISTENCY_LEVEL_UNSPECIFIED = 0;
+  CONSISTENCY_LEVEL_EVENTUAL = 1;
+  CONSISTENCY_LEVEL_STRONG = 2;
+}
+
+// ReadOptions configures read operation behavior.
+message ReadOptions {
+  ConsistencyLevel consistency = 1;
+}
+
 // TeamDistinctId is a cross-team lookup key for person resolution
 message TeamDistinctId {
   int64 team_id = 1;

--- a/proto/personhog/types/v1/feature_flag.proto
+++ b/proto/personhog/types/v1/feature_flag.proto
@@ -1,39 +1,69 @@
 syntax = "proto3";
 package personhog.types.v1;
 
+import "personhog/types/v1/common.proto";
+
 // HashKeyOverride represents a feature flag hash key override for a person
 message HashKeyOverride {
   string feature_flag_key = 1;
   string hash_key = 2;
 }
 
-// PersonIdWithOverrides pairs a person with their hash key overrides
-message PersonIdWithOverrides {
+// HashKeyOverrideContext contains the context needed for hash key override decisions.
+// This includes the resolved person ID, existing overrides, and which flags already
+// have overrides (to avoid duplicate writes).
+message HashKeyOverrideContext {
   int64 person_id = 1;
   string distinct_id = 2;
+  // The actual hash key override values for this person
   repeated HashKeyOverride overrides = 3;
+  // Feature flag keys that already have overrides (useful for upsert logic)
+  repeated string existing_feature_flag_keys = 4;
 }
 
-// PersonIdWithOverrideKeys lists existing override keys for a person
-message PersonIdWithOverrideKeys {
+// GetHashKeyOverrideContextRequest fetches the context needed for hash key override
+// decisions. This resolves distinct IDs to person IDs and returns existing override
+// information.
+message GetHashKeyOverrideContextRequest {
+  int64 team_id = 1;
+  repeated string distinct_ids = 2;
+  // When true, only returns results for persons that exist in posthog_person table
+  bool check_person_exists = 3;
+  ReadOptions read_options = 4;
+}
+
+message GetHashKeyOverrideContextResponse {
+  repeated HashKeyOverrideContext results = 1;
+}
+
+// HashKeyOverrideInput represents a single override to upsert.
+// The hash_key is specified at the request level since all overrides
+// in a batch share the same hash key (for experience continuity).
+message HashKeyOverrideInput {
   int64 person_id = 1;
-  repeated string existing_feature_flag_keys = 2;
+  string feature_flag_key = 2;
 }
 
-message GetPersonIdsAndHashKeyOverridesRequest {
+// UpsertHashKeyOverridesRequest batch upserts hash key overrides.
+// All overrides in a batch share the same hash_key, which is used for
+// experience continuity - ensuring consistent flag values when a user
+// logs in with a new distinct_id.
+message UpsertHashKeyOverridesRequest {
   int64 team_id = 1;
-  repeated string distinct_ids = 2;
+  repeated HashKeyOverrideInput overrides = 2;
+  // The hash key to use for all overrides (typically the $anon_distinct_id)
+  string hash_key = 3;
 }
 
-message GetPersonIdsAndHashKeyOverridesResponse {
-  repeated PersonIdWithOverrides results = 1;
+message UpsertHashKeyOverridesResponse {
+  int64 inserted_count = 1;
 }
 
-message GetExistingPersonIdsWithOverrideKeysRequest {
-  int64 team_id = 1;
-  repeated string distinct_ids = 2;
+// DeleteHashKeyOverridesByTeamsRequest deletes all hash key overrides for the specified teams
+message DeleteHashKeyOverridesByTeamsRequest {
+  repeated int64 team_ids = 1;
 }
 
-message GetExistingPersonIdsWithOverrideKeysResponse {
-  repeated PersonIdWithOverrideKeys results = 1;
+message DeleteHashKeyOverridesByTeamsResponse {
+  int64 deleted_count = 1;
 }

--- a/proto/personhog/types/v1/group.proto
+++ b/proto/personhog/types/v1/group.proto
@@ -46,6 +46,7 @@ message GetGroupRequest {
   int64 team_id = 1;
   int32 group_type_index = 2;
   string group_key = 3;
+  ReadOptions read_options = 4;
 }
 
 message GetGroupResponse {
@@ -55,6 +56,7 @@ message GetGroupResponse {
 message GetGroupsRequest {
   int64 team_id = 1;
   repeated GroupIdentifier group_identifiers = 2;
+  ReadOptions read_options = 3;
 }
 
 message GroupsResponse {
@@ -64,6 +66,7 @@ message GroupsResponse {
 
 message GetGroupsBatchRequest {
   repeated GroupKey keys = 1;
+  ReadOptions read_options = 2;
 }
 
 message GetGroupsBatchResponse {
@@ -72,18 +75,22 @@ message GetGroupsBatchResponse {
 
 message GetGroupTypeMappingsByTeamIdRequest {
   int64 team_id = 1;
+  ReadOptions read_options = 2;
 }
 
 message GetGroupTypeMappingsByTeamIdsRequest {
   repeated int64 team_ids = 1;
+  ReadOptions read_options = 2;
 }
 
 message GetGroupTypeMappingsByProjectIdRequest {
   int64 project_id = 1;
+  ReadOptions read_options = 2;
 }
 
 message GetGroupTypeMappingsByProjectIdsRequest {
   repeated int64 project_ids = 1;
+  ReadOptions read_options = 2;
 }
 
 message GroupTypeMappingsResponse {

--- a/proto/personhog/types/v1/person.proto
+++ b/proto/personhog/types/v1/person.proto
@@ -44,6 +44,7 @@ message PersonWithTeamDistinctId {
 message GetPersonRequest {
   int64 team_id = 1;
   int64 person_id = 2;
+  ReadOptions read_options = 3;
 }
 
 message GetPersonResponse {
@@ -53,6 +54,7 @@ message GetPersonResponse {
 message GetPersonsRequest {
   int64 team_id = 1;
   repeated int64 person_ids = 2;
+  ReadOptions read_options = 3;
 }
 
 message PersonsResponse {
@@ -63,21 +65,25 @@ message PersonsResponse {
 message GetPersonByUuidRequest {
   int64 team_id = 1;
   string uuid = 2;
+  ReadOptions read_options = 3;
 }
 
 message GetPersonsByUuidsRequest {
   int64 team_id = 1;
   repeated string uuids = 2;
+  ReadOptions read_options = 3;
 }
 
 message GetPersonByDistinctIdRequest {
   int64 team_id = 1;
   string distinct_id = 2;
+  ReadOptions read_options = 3;
 }
 
 message GetPersonsByDistinctIdsInTeamRequest {
   int64 team_id = 1;
   repeated string distinct_ids = 2;
+  ReadOptions read_options = 3;
 }
 
 message PersonsByDistinctIdsInTeamResponse {
@@ -86,6 +92,7 @@ message PersonsByDistinctIdsInTeamResponse {
 
 message GetPersonsByDistinctIdsRequest {
   repeated TeamDistinctId team_distinct_ids = 1;
+  ReadOptions read_options = 2;
 }
 
 message PersonsByDistinctIdsResponse {
@@ -95,6 +102,7 @@ message PersonsByDistinctIdsResponse {
 message GetDistinctIdsForPersonRequest {
   int64 team_id = 1;
   int64 person_id = 2;
+  ReadOptions read_options = 3;
 }
 
 message GetDistinctIdsForPersonResponse {
@@ -104,6 +112,7 @@ message GetDistinctIdsForPersonResponse {
 message GetDistinctIdsForPersonsRequest {
   int64 team_id = 1;
   repeated int64 person_ids = 2;
+  ReadOptions read_options = 3;
 }
 
 message GetDistinctIdsForPersonsResponse {

--- a/rust/personhog-replica/src/config.rs
+++ b/rust/personhog-replica/src/config.rs
@@ -11,8 +11,14 @@ pub struct Config {
     #[envconfig(default = "postgres")]
     pub storage_backend: String,
 
+    /// Primary database URL (for writes and strong consistency reads)
     #[envconfig(default = "postgres://posthog:posthog@localhost:5432/posthog")]
-    pub database_url: String,
+    pub primary_database_url: String,
+
+    /// Replica database URL (for eventual consistency reads)
+    /// If not set, falls back to primary_database_url
+    #[envconfig(default = "")]
+    pub replica_database_url: String,
 
     #[envconfig(default = "10")]
     pub max_pg_connections: u32,
@@ -51,6 +57,15 @@ impl Config {
             None
         } else {
             Some(self.statement_timeout_ms)
+        }
+    }
+
+    /// Returns the replica database URL, falling back to primary if not set
+    pub fn replica_database_url(&self) -> &str {
+        if self.replica_database_url.is_empty() {
+            &self.primary_database_url
+        } else {
+            &self.replica_database_url
         }
     }
 }

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -47,12 +47,27 @@ async fn create_storage(config: &Config) -> Arc<PostgresStorage> {
                 statement_timeout_ms: config.statement_timeout(),
             };
 
-            let pool = get_pool_with_config(&config.database_url, pool_config)
-                .await
-                .expect("Failed to create database pool");
+            // Create primary pool
+            let primary_pool =
+                get_pool_with_config(&config.primary_database_url, pool_config.clone())
+                    .await
+                    .expect("Failed to create primary database pool");
+            tracing::info!("Created primary database pool");
 
-            tracing::info!("Created Postgres storage backend");
-            Arc::new(PostgresStorage::new(pool))
+            // Create replica pool (uses primary URL if replica URL not configured)
+            let replica_url = config.replica_database_url();
+            let replica_pool = if replica_url == config.primary_database_url {
+                tracing::info!("Replica URL not configured, using primary pool for both");
+                primary_pool.clone()
+            } else {
+                let pool = get_pool_with_config(replica_url, pool_config)
+                    .await
+                    .expect("Failed to create replica database pool");
+                tracing::info!("Created separate replica database pool");
+                pool
+            };
+
+            Arc::new(PostgresStorage::new(primary_pool, replica_pool))
         }
         other => {
             panic!("Unknown storage backend: {other}. Supported: postgres");

--- a/rust/personhog-replica/src/storage/mod.rs
+++ b/rust/personhog-replica/src/storage/mod.rs
@@ -7,7 +7,7 @@ pub use error::{StorageError, StorageResult};
 
 pub use types::{
     CohortMembership, DistinctIdMapping, DistinctIdWithVersion, Group, GroupIdentifier, GroupKey,
-    GroupTypeMapping, HashKeyOverride, Person, PersonIdWithOverrideKeys, PersonIdWithOverrides,
+    GroupTypeMapping, HashKeyOverride, HashKeyOverrideContext, HashKeyOverrideInput, Person,
 };
 
 pub use traits::{CohortStorage, DistinctIdLookup, FeatureFlagStorage, GroupStorage, PersonLookup};

--- a/rust/personhog-replica/src/storage/postgres/distinct_id.rs
+++ b/rust/personhog-replica/src/storage/postgres/distinct_id.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use sqlx::FromRow;
 
-use super::{PostgresStorage, DB_QUERY_DURATION};
+use super::{ConsistencyLevel, PostgresStorage, DB_QUERY_DURATION};
 use crate::storage::error::StorageResult;
 use crate::storage::traits::DistinctIdLookup;
 use crate::storage::types::{DistinctIdMapping, DistinctIdWithVersion};
@@ -24,12 +24,15 @@ impl DistinctIdLookup for PostgresStorage {
         &self,
         team_id: i64,
         person_id: i64,
+        consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<DistinctIdWithVersion>> {
         let labels = [(
             "operation".to_string(),
             "get_distinct_ids_for_person".to_string(),
         )];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
+
+        let pool = self.pool_for_consistency(consistency);
 
         let rows = sqlx::query_as::<_, DistinctIdWithVersionRow>(
             r#"
@@ -40,7 +43,7 @@ impl DistinctIdLookup for PostgresStorage {
         )
         .bind(team_id)
         .bind(person_id)
-        .fetch_all(&self.pool)
+        .fetch_all(pool)
         .await?;
 
         Ok(rows
@@ -56,6 +59,7 @@ impl DistinctIdLookup for PostgresStorage {
         &self,
         team_id: i64,
         person_ids: &[i64],
+        consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<DistinctIdMapping>> {
         if person_ids.is_empty() {
             return Ok(Vec::new());
@@ -67,6 +71,8 @@ impl DistinctIdLookup for PostgresStorage {
         )];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
+        let pool = self.pool_for_consistency(consistency);
+
         let rows = sqlx::query_as::<_, DistinctIdRow>(
             r#"
             SELECT person_id, distinct_id
@@ -76,7 +82,7 @@ impl DistinctIdLookup for PostgresStorage {
         )
         .bind(team_id)
         .bind(person_ids)
-        .fetch_all(&self.pool)
+        .fetch_all(pool)
         .await?;
 
         Ok(rows

--- a/rust/personhog-replica/src/storage/postgres/feature_flag.rs
+++ b/rust/personhog-replica/src/storage/postgres/feature_flag.rs
@@ -3,130 +3,175 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use sqlx::FromRow;
 
-use super::{PostgresStorage, DB_QUERY_DURATION};
+use super::{ConsistencyLevel, PostgresStorage, DB_QUERY_DURATION};
 use crate::storage::error::StorageResult;
 use crate::storage::traits::FeatureFlagStorage;
-use crate::storage::types::{HashKeyOverride, PersonIdWithOverrideKeys, PersonIdWithOverrides};
+use crate::storage::types::{HashKeyOverride, HashKeyOverrideContext, HashKeyOverrideInput};
 
 #[derive(Debug, Clone, FromRow)]
-struct PersonIdAndHashKeyOverrideRow {
+struct HashKeyOverrideContextRow {
     person_id: i64,
     distinct_id: String,
     feature_flag_key: Option<String>,
     hash_key: Option<String>,
 }
 
-#[derive(Debug, Clone, FromRow)]
-struct PersonIdWithOverrideKeyRow {
-    person_id: i64,
-    feature_flag_key: Option<String>,
-}
-
 #[async_trait]
 impl FeatureFlagStorage for PostgresStorage {
-    async fn get_person_ids_and_hash_key_overrides(
+    async fn get_hash_key_override_context(
         &self,
         team_id: i64,
         distinct_ids: &[String],
-    ) -> StorageResult<Vec<PersonIdWithOverrides>> {
+        check_person_exists: bool,
+        consistency: ConsistencyLevel,
+    ) -> StorageResult<Vec<HashKeyOverrideContext>> {
         if distinct_ids.is_empty() {
             return Ok(Vec::new());
         }
 
         let labels = [(
             "operation".to_string(),
-            "get_person_ids_and_hash_key_overrides".to_string(),
+            "get_hash_key_override_context".to_string(),
         )];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
-        let rows = sqlx::query_as::<_, PersonIdAndHashKeyOverrideRow>(
-            r#"
-            SELECT ppd.person_id, ppd.distinct_id, fhko.feature_flag_key, fhko.hash_key
-            FROM posthog_persondistinctid ppd
-            LEFT JOIN posthog_featureflaghashkeyoverride fhko
-                ON fhko.person_id = ppd.person_id AND fhko.team_id = ppd.team_id
-            WHERE ppd.team_id = $1 AND ppd.distinct_id = ANY($2)
-            "#,
-        )
-        .bind(team_id)
-        .bind(distinct_ids)
-        .fetch_all(&self.pool)
-        .await?;
+        // Select the appropriate pool based on consistency requirements.
+        //
+        // Strong consistency is used when the caller needs read-after-write guarantees,
+        // such as immediately after writing hash key overrides.
+        //
+        // Note: This queries the primary database directly for strong consistency.
+        // When personhog-leader is implemented, person table reads will be served from
+        // the leader's cache, and strong consistency will require routing to the leader
+        // service instead. Before the personhog-leader is implemented, we can serve consistent read after writes
+        // for person data from this service
+        let pool = self.pool_for_consistency(consistency);
 
-        // Group by (person_id, distinct_id) and collect overrides
-        let mut result_map: HashMap<(i64, String), Vec<HashKeyOverride>> = HashMap::new();
+        let rows = if check_person_exists {
+            // Query with person existence check
+            sqlx::query_as::<_, HashKeyOverrideContextRow>(
+                r#"
+                SELECT DISTINCT p.person_id, p.distinct_id, existing.feature_flag_key, existing.hash_key
+                FROM posthog_persondistinctid p
+                LEFT JOIN posthog_featureflaghashkeyoverride existing
+                    ON existing.person_id = p.person_id AND existing.team_id = p.team_id
+                WHERE p.team_id = $1 AND p.distinct_id = ANY($2)
+                    AND EXISTS (SELECT 1 FROM posthog_person WHERE id = p.person_id AND team_id = p.team_id)
+                "#,
+            )
+            .bind(team_id)
+            .bind(distinct_ids)
+            .fetch_all(pool)
+            .await?
+        } else {
+            // Query without person existence check
+            sqlx::query_as::<_, HashKeyOverrideContextRow>(
+                r#"
+                SELECT ppd.person_id, ppd.distinct_id, fhko.feature_flag_key, fhko.hash_key
+                FROM posthog_persondistinctid ppd
+                LEFT JOIN posthog_featureflaghashkeyoverride fhko
+                    ON fhko.person_id = ppd.person_id AND fhko.team_id = ppd.team_id
+                WHERE ppd.team_id = $1 AND ppd.distinct_id = ANY($2)
+                "#,
+            )
+            .bind(team_id)
+            .bind(distinct_ids)
+            .fetch_all(pool)
+            .await?
+        };
+
+        // Group by (person_id, distinct_id) and collect overrides + existing keys
+        let mut result_map: HashMap<(i64, String), HashKeyOverrideContext> = HashMap::new();
         for row in rows {
             let key = (row.person_id, row.distinct_id.clone());
-            if let (Some(flag_key), Some(hash_key)) = (row.feature_flag_key, row.hash_key) {
-                result_map.entry(key).or_default().push(HashKeyOverride {
-                    feature_flag_key: flag_key,
-                    hash_key,
+            let entry = result_map
+                .entry(key)
+                .or_insert_with(|| HashKeyOverrideContext {
+                    person_id: row.person_id,
+                    distinct_id: row.distinct_id.clone(),
+                    overrides: Vec::new(),
+                    existing_feature_flag_keys: Vec::new(),
                 });
-            } else {
-                // Ensure the key exists even if there are no overrides
-                result_map.entry(key).or_default();
+
+            if let Some(flag_key) = row.feature_flag_key {
+                // Add to existing_feature_flag_keys if not already present
+                if !entry.existing_feature_flag_keys.contains(&flag_key) {
+                    entry.existing_feature_flag_keys.push(flag_key.clone());
+                }
+                // Add to overrides if we have the hash_key
+                if let Some(hash_key) = row.hash_key {
+                    entry.overrides.push(HashKeyOverride {
+                        feature_flag_key: flag_key,
+                        hash_key,
+                    });
+                }
             }
         }
 
-        Ok(result_map
-            .into_iter()
-            .map(
-                |((person_id, distinct_id), overrides)| PersonIdWithOverrides {
-                    person_id,
-                    distinct_id,
-                    overrides,
-                },
-            )
-            .collect())
+        Ok(result_map.into_values().collect())
     }
 
-    async fn get_existing_person_ids_with_override_keys(
+    async fn upsert_hash_key_overrides(
         &self,
         team_id: i64,
-        distinct_ids: &[String],
-    ) -> StorageResult<Vec<PersonIdWithOverrideKeys>> {
-        if distinct_ids.is_empty() {
-            return Ok(Vec::new());
+        overrides: &[HashKeyOverrideInput],
+        hash_key: &str,
+    ) -> StorageResult<i64> {
+        if overrides.is_empty() {
+            return Ok(0);
         }
 
         let labels = [(
             "operation".to_string(),
-            "get_existing_person_ids_with_override_keys".to_string(),
+            "upsert_hash_key_overrides".to_string(),
         )];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
-        let rows = sqlx::query_as::<_, PersonIdWithOverrideKeyRow>(
+        let person_ids: Vec<i64> = overrides.iter().map(|o| o.person_id).collect();
+        let flag_keys: Vec<&str> = overrides
+            .iter()
+            .map(|o| o.feature_flag_key.as_str())
+            .collect();
+
+        let result = sqlx::query(
             r#"
-            SELECT DISTINCT p.person_id, existing.feature_flag_key
-            FROM posthog_persondistinctid p
-            LEFT JOIN posthog_featureflaghashkeyoverride existing
-                ON existing.person_id = p.person_id AND existing.team_id = p.team_id
-            WHERE p.team_id = $1 AND p.distinct_id = ANY($2)
-                AND EXISTS (SELECT 1 FROM posthog_person WHERE id = p.person_id AND team_id = p.team_id)
+            INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
+            SELECT $1, person_id, flag_key, $2
+            FROM UNNEST($3::bigint[], $4::text[]) AS t(person_id, flag_key)
+            ON CONFLICT DO NOTHING
             "#,
         )
         .bind(team_id)
-        .bind(distinct_ids)
-        .fetch_all(&self.pool)
+        .bind(hash_key)
+        .bind(&person_ids)
+        .bind(&flag_keys)
+        .execute(&self.primary_pool)
         .await?;
 
-        let mut result_map: HashMap<i64, Vec<String>> = HashMap::new();
-        for row in rows {
-            if let Some(flag_key) = row.feature_flag_key {
-                result_map.entry(row.person_id).or_default().push(flag_key);
-            } else {
-                result_map.entry(row.person_id).or_default();
-            }
+        Ok(result.rows_affected() as i64)
+    }
+
+    async fn delete_hash_key_overrides_by_teams(&self, team_ids: &[i64]) -> StorageResult<i64> {
+        if team_ids.is_empty() {
+            return Ok(0);
         }
 
-        Ok(result_map
-            .into_iter()
-            .map(
-                |(person_id, existing_feature_flag_keys)| PersonIdWithOverrideKeys {
-                    person_id,
-                    existing_feature_flag_keys,
-                },
-            )
-            .collect())
+        let labels = [(
+            "operation".to_string(),
+            "delete_hash_key_overrides_by_teams".to_string(),
+        )];
+        let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
+
+        let result = sqlx::query(
+            r#"
+            DELETE FROM posthog_featureflaghashkeyoverride
+            WHERE team_id = ANY($1)
+            "#,
+        )
+        .bind(team_ids)
+        .execute(&self.primary_pool)
+        .await?;
+
+        Ok(result.rows_affected() as i64)
     }
 }

--- a/rust/personhog-replica/src/storage/postgres/mod.rs
+++ b/rust/personhog-replica/src/storage/postgres/mod.rs
@@ -10,14 +10,63 @@ use super::error::StorageError;
 
 pub(crate) const DB_QUERY_DURATION: &str = "personhog_replica_db_query_duration_ms";
 
-/// Postgres implementation of storage traits
+/// Consistency level for read operations
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ConsistencyLevel {
+    /// Read from replica (may have replication lag)
+    #[default]
+    Eventual,
+    /// Read from primary (guaranteed latest data)
+    Strong,
+}
+
+/// Postgres implementation of storage traits with dual-pool support
+/// for primary (strong consistency) and replica (eventual consistency) databases.
 pub struct PostgresStorage {
-    pub(crate) pool: PgPool,
+    /// Connection pool for the primary database (writes + strong consistency reads)
+    pub(crate) primary_pool: PgPool,
+    /// Connection pool for the replica database (eventual consistency reads)
+    pub(crate) replica_pool: PgPool,
 }
 
 impl PostgresStorage {
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    /// Create a new PostgresStorage with separate primary and replica pools.
+    /// For single-database setups, pass the same pool for both.
+    pub fn new(primary_pool: PgPool, replica_pool: PgPool) -> Self {
+        Self {
+            primary_pool,
+            replica_pool,
+        }
+    }
+
+    /// Create a new PostgresStorage with a single pool used for both primary and replica.
+    pub fn new_single_pool(pool: PgPool) -> Self {
+        Self {
+            primary_pool: pool.clone(),
+            replica_pool: pool,
+        }
+    }
+
+    /// Get the appropriate pool based on consistency level.
+    /// Strong consistency always uses the primary pool.
+    /// Eventual consistency uses the replica pool.
+    pub(crate) fn pool_for_consistency(&self, consistency: ConsistencyLevel) -> &PgPool {
+        match consistency {
+            ConsistencyLevel::Strong => &self.primary_pool,
+            ConsistencyLevel::Eventual => &self.replica_pool,
+        }
+    }
+
+    /// Get the primary pool (for writes).
+    #[allow(dead_code)]
+    pub(crate) fn primary_pool(&self) -> &PgPool {
+        &self.primary_pool
+    }
+
+    /// Get the replica pool (for eventual consistency reads).
+    #[allow(dead_code)]
+    pub(crate) fn replica_pool(&self) -> &PgPool {
+        &self.replica_pool
     }
 }
 

--- a/rust/personhog-replica/src/storage/postgres/person.rs
+++ b/rust/personhog-replica/src/storage/postgres/person.rs
@@ -75,7 +75,7 @@ impl PersonLookup for PostgresStorage {
         )
         .bind(team_id)
         .bind(person_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&self.replica_pool)
         .await?;
 
         Ok(row.map(Person::from))
@@ -95,7 +95,7 @@ impl PersonLookup for PostgresStorage {
         )
         .bind(team_id)
         .bind(uuid)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&self.replica_pool)
         .await?;
 
         Ok(row.map(Person::from))
@@ -123,7 +123,7 @@ impl PersonLookup for PostgresStorage {
         )
         .bind(team_id)
         .bind(person_ids)
-        .fetch_all(&self.pool)
+        .fetch_all(&self.replica_pool)
         .await?;
 
         Ok(rows.into_iter().map(Person::from).collect())
@@ -151,7 +151,7 @@ impl PersonLookup for PostgresStorage {
         )
         .bind(team_id)
         .bind(uuids)
-        .fetch_all(&self.pool)
+        .fetch_all(&self.replica_pool)
         .await?;
 
         Ok(rows.into_iter().map(Person::from).collect())
@@ -180,7 +180,7 @@ impl PersonLookup for PostgresStorage {
         )
         .bind(team_id)
         .bind(distinct_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&self.replica_pool)
         .await?;
 
         Ok(row.map(Person::from))
@@ -213,7 +213,7 @@ impl PersonLookup for PostgresStorage {
         )
         .bind(team_id)
         .bind(distinct_ids)
-        .fetch_all(&self.pool)
+        .fetch_all(&self.replica_pool)
         .await?;
 
         let found: HashMap<String, Person> = rows
@@ -273,7 +273,7 @@ impl PersonLookup for PostgresStorage {
         )
         .bind(&team_ids)
         .bind(&distinct_ids)
-        .fetch_all(&self.pool)
+        .fetch_all(&self.replica_pool)
         .await?;
 
         let found: HashMap<(i64, String), Person> = rows

--- a/rust/personhog-replica/src/storage/traits/cohort.rs
+++ b/rust/personhog-replica/src/storage/traits/cohort.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use crate::storage::error::StorageResult;
+use crate::storage::postgres::ConsistencyLevel;
 use crate::storage::types::CohortMembership;
 
 /// Cohort membership operations
@@ -10,5 +11,6 @@ pub trait CohortStorage: Send + Sync {
         &self,
         person_id: i64,
         cohort_ids: &[i64],
+        consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<CohortMembership>>;
 }

--- a/rust/personhog-replica/src/storage/traits/distinct_id.rs
+++ b/rust/personhog-replica/src/storage/traits/distinct_id.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use crate::storage::error::StorageResult;
+use crate::storage::postgres::ConsistencyLevel;
 use crate::storage::types::{DistinctIdMapping, DistinctIdWithVersion};
 
 /// Distinct ID operations - fetching distinct IDs for persons
@@ -10,11 +11,13 @@ pub trait DistinctIdLookup: Send + Sync {
         &self,
         team_id: i64,
         person_id: i64,
+        consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<DistinctIdWithVersion>>;
 
     async fn get_distinct_ids_for_persons(
         &self,
         team_id: i64,
         person_ids: &[i64],
+        consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<DistinctIdMapping>>;
 }

--- a/rust/personhog-replica/src/storage/traits/feature_flag.rs
+++ b/rust/personhog-replica/src/storage/traits/feature_flag.rs
@@ -1,20 +1,53 @@
 use async_trait::async_trait;
 
 use crate::storage::error::StorageResult;
-use crate::storage::types::{PersonIdWithOverrideKeys, PersonIdWithOverrides};
+use crate::storage::postgres::ConsistencyLevel;
+use crate::storage::types::{HashKeyOverrideContext, HashKeyOverrideInput};
 
 /// Feature flag hash key override operations
 #[async_trait]
 pub trait FeatureFlagStorage: Send + Sync {
-    async fn get_person_ids_and_hash_key_overrides(
+    /// Gets the context needed for hash key override decisions.
+    ///
+    /// This resolves distinct IDs to person IDs and returns existing hash key
+    /// override information for each person.
+    ///
+    /// When `check_person_exists` is true, only returns results for persons that
+    /// exist in the posthog_person table. This uses an EXISTS subquery against
+    /// the person table.
+    ///
+    /// ## Consistency
+    ///
+    /// The `consistency` parameter controls which database pool is used:
+    /// - `Strong`: Uses the primary database, guaranteeing read-after-write consistency.
+    ///   This is important when the caller has just written hash key overrides and needs
+    ///   to read them back immediately.
+    /// - `Eventual`: Uses the replica database, which may have replication lag.
+    ///
+    /// Note: When the personhog-leader service is implemented, the person table will be
+    /// cached on the leader pods. At that point, strong consistency for person data will
+    /// require routing to the leader service, not the primary database. The current
+    /// implementation queries the primary database directly as a temporary solution.
+    async fn get_hash_key_override_context(
         &self,
         team_id: i64,
         distinct_ids: &[String],
-    ) -> StorageResult<Vec<PersonIdWithOverrides>>;
+        check_person_exists: bool,
+        consistency: ConsistencyLevel,
+    ) -> StorageResult<Vec<HashKeyOverrideContext>>;
 
-    async fn get_existing_person_ids_with_override_keys(
+    /// Batch upsert hash key overrides. Returns the number of inserted records.
+    ///
+    /// All overrides in a batch share the same `hash_key`, which is used for
+    /// experience continuity - ensuring consistent flag values when a user
+    /// logs in with a new distinct_id.
+    async fn upsert_hash_key_overrides(
         &self,
         team_id: i64,
-        distinct_ids: &[String],
-    ) -> StorageResult<Vec<PersonIdWithOverrideKeys>>;
+        overrides: &[HashKeyOverrideInput],
+        hash_key: &str,
+    ) -> StorageResult<i64>;
+
+    /// Delete all hash key overrides for the specified teams. Returns the number of deleted records.
+    async fn delete_hash_key_overrides_by_teams(&self, team_ids: &[i64]) -> StorageResult<i64>;
 }

--- a/rust/personhog-replica/src/storage/traits/group.rs
+++ b/rust/personhog-replica/src/storage/traits/group.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use crate::storage::error::StorageResult;
+use crate::storage::postgres::ConsistencyLevel;
 use crate::storage::types::{Group, GroupIdentifier, GroupKey, GroupTypeMapping};
 
 /// Group and group type mapping operations
@@ -13,35 +14,45 @@ pub trait GroupStorage: Send + Sync {
         team_id: i64,
         group_type_index: i32,
         group_key: &str,
+        consistency: ConsistencyLevel,
     ) -> StorageResult<Option<Group>>;
 
     async fn get_groups(
         &self,
         team_id: i64,
         identifiers: &[GroupIdentifier],
+        consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<Group>>;
 
-    async fn get_groups_batch(&self, keys: &[GroupKey]) -> StorageResult<Vec<(GroupKey, Group)>>;
+    async fn get_groups_batch(
+        &self,
+        keys: &[GroupKey],
+        consistency: ConsistencyLevel,
+    ) -> StorageResult<Vec<(GroupKey, Group)>>;
 
     // Group type mappings
 
     async fn get_group_type_mappings_by_team_id(
         &self,
         team_id: i64,
+        consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<GroupTypeMapping>>;
 
     async fn get_group_type_mappings_by_team_ids(
         &self,
         team_ids: &[i64],
+        consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<GroupTypeMapping>>;
 
     async fn get_group_type_mappings_by_project_id(
         &self,
         project_id: i64,
+        consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<GroupTypeMapping>>;
 
     async fn get_group_type_mappings_by_project_ids(
         &self,
         project_ids: &[i64],
+        consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<GroupTypeMapping>>;
 }

--- a/rust/personhog-replica/src/storage/types/feature_flag.rs
+++ b/rust/personhog-replica/src/storage/types/feature_flag.rs
@@ -4,15 +4,21 @@ pub struct HashKeyOverride {
     pub hash_key: String,
 }
 
+/// Input for upserting a hash key override.
+/// The hash_key is specified separately at the batch level since all overrides
+/// share the same hash key (for experience continuity).
 #[derive(Debug, Clone)]
-pub struct PersonIdWithOverrides {
+pub struct HashKeyOverrideInput {
+    pub person_id: i64,
+    pub feature_flag_key: String,
+}
+
+/// Context for hash key override decisions. Contains the resolved person ID,
+/// existing overrides, and which flags already have overrides.
+#[derive(Debug, Clone)]
+pub struct HashKeyOverrideContext {
     pub person_id: i64,
     pub distinct_id: String,
     pub overrides: Vec<HashKeyOverride>,
-}
-
-#[derive(Debug, Clone)]
-pub struct PersonIdWithOverrideKeys {
-    pub person_id: i64,
     pub existing_feature_flag_keys: Vec<String>,
 }

--- a/rust/personhog-replica/tests/common/mod.rs
+++ b/rust/personhog-replica/tests/common/mod.rs
@@ -28,7 +28,8 @@ impl TestContext {
         let pool = PgPool::connect(&database_url)
             .await
             .expect("Failed to connect to test database");
-        let storage = Arc::new(PostgresStorage::new(pool.clone()));
+        // In tests, use the same pool for both primary and replica
+        let storage = Arc::new(PostgresStorage::new(pool.clone(), pool.clone()));
         let team_id = random_team_id();
 
         Self {

--- a/rust/personhog-replica/tests/grpc_transport.rs
+++ b/rust/personhog-replica/tests/grpc_transport.rs
@@ -84,7 +84,11 @@ async fn test_grpc_get_person_roundtrip() {
 
     let response = ctx
         .client
-        .get_person(GetPersonRequest { team_id, person_id })
+        .get_person(GetPersonRequest {
+            team_id,
+            person_id,
+            read_options: None,
+        })
         .await
         .expect("gRPC call failed");
 
@@ -114,6 +118,7 @@ async fn test_grpc_batch_lookup_roundtrip() {
                 "grpc_batch_2".to_string(),
                 "grpc_batch_missing".to_string(),
             ],
+            read_options: None,
         })
         .await
         .expect("gRPC call failed");
@@ -142,6 +147,7 @@ async fn test_grpc_invalid_uuid_returns_error() {
         .get_person_by_uuid(GetPersonByUuidRequest {
             team_id,
             uuid: "not-a-valid-uuid".to_string(),
+            read_options: None,
         })
         .await;
 


### PR DESCRIPTION
## Problem

Simple person's database access patterns that come from non-ingestion clients like feature flags should not be coupled to the stateful personhog implementation.

That means we need the personhog-replica service to support connecting to the primary database and accepting "ConsistencyLevel" messages in its requests, in order to decide which database it should read from to properly service a request.

We also need to support connecting to the primary from this service in order to service non-ingestion writes that don't touch the persons table.

## Changes

- Adds a new field to the proto definitions for the replica service that accept a "consistency level" specifier, allowing a client to decide what consistency their read queries will result in
- Adds a new storage pool to connect to the primary database, with routing logic that decides which database to request from based on teh client request
- Adds the write endpoints that fully support the feature flag client
- NOTE: there is a feature flag read path that requires us to read data from the persons table on the primary database from the personhog-replica service. We will have to re-evaluate the lack of strong consistency once the leader is implemented to understand if this query needs to move to the other service
- NOTE: I expect the proto breaking changes lint to break here, the service is not deployed/still in flux we can change the proto definitions at will

## How did you test this code?

Integration and unit tests written for the new behaviour.
