### PR TITLE
fix(data-warehouse): handle PostgreSQL dates beyond Python's year 9999 limit

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -5,6 +5,7 @@ import time
 import collections
 from collections.abc import Callable, Iterator
 from contextlib import _GeneratorContextManager
+from datetime import date
 from typing import Any, Literal, LiteralString, Optional, cast
 
 import psycopg
@@ -176,6 +177,43 @@ class RangeAsStringLoader(Loader):
         if data is None:
             return None
         return bytes(data).decode("utf-8")
+
+
+class SafeDateLoader(Loader):
+    """Load PostgreSQL dates, handling edge cases beyond Python's date range.
+
+    PostgreSQL can store dates beyond Python's datetime.date limits (year 1 to
+    year 9999). This includes 'infinity', '-infinity', and dates in years > 9999.
+    When encountering such dates, we clamp to Python's date limits rather than
+    raising an error.
+    """
+
+    def load(self, data) -> date | None:
+        if data is None:
+            return None
+
+        s = bytes(data).decode("utf-8")
+
+        if s in ("infinity", "-infinity"):
+            return date.max if s == "infinity" else date.min
+
+        try:
+            parts = s.split("-")
+            if len(parts) >= 3:
+                year = int(parts[0])
+                month = int(parts[1])
+                day = int(parts[2])
+
+                if year > 9999:
+                    return date.max
+                if year < 1:
+                    return date.min
+
+                return date(year, month, day)
+        except (ValueError, IndexError):
+            pass
+
+        return date.max
 
 
 def _build_query(
@@ -747,6 +785,7 @@ def postgres_source(
                 connection.adapters.register_loader("tsrange", RangeAsStringLoader)
                 connection.adapters.register_loader("tstzrange", RangeAsStringLoader)
                 connection.adapters.register_loader("daterange", RangeAsStringLoader)
+                connection.adapters.register_loader("date", SafeDateLoader)
                 return connection
 
             def offset_chunking(offset: int, chunk_size: int):

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -197,9 +197,13 @@ class SafeDateLoader(Loader):
         if s in ("infinity", "-infinity"):
             return date.max if s == "infinity" else date.min
 
+        # Handle negative years (BC dates)
+        if s.startswith("-") or "bc" in s.lower():
+            return date.min
+
         try:
             parts = s.split("-")
-            if len(parts) >= 3:
+            if len(parts) == 3:
                 year = int(parts[0])
                 month = int(parts[1])
                 day = int(parts[2])
@@ -213,6 +217,7 @@ class SafeDateLoader(Loader):
         except (ValueError, IndexError):
             pass
 
+        # Fallback: clamp to max for unparseable dates
         return date.max
 
 

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1,0 +1,32 @@
+from datetime import date
+
+import pytest
+
+from posthog.temporal.data_imports.sources.postgres.postgres import SafeDateLoader
+
+
+class TestSafeDateLoader:
+    @pytest.fixture
+    def loader(self):
+        return SafeDateLoader(oid=1082)  # 1082 is the PostgreSQL OID for date type
+
+    @pytest.mark.parametrize(
+        "input_data,expected",
+        [
+            (b"2024-01-15", date(2024, 1, 15)),
+            (b"1999-12-31", date(1999, 12, 31)),
+            (b"0001-01-01", date(1, 1, 1)),
+            (b"9999-12-31", date(9999, 12, 31)),
+            # Edge cases: dates beyond Python's date range should clamp
+            (b"48113-11-21", date.max),
+            (b"10000-01-01", date.max),
+            (b"99999-12-31", date.max),
+            # Infinity values
+            (b"infinity", date.max),
+            (b"-infinity", date.min),
+            # None should return None
+            (None, None),
+        ],
+    )
+    def test_load_dates(self, loader, input_data, expected):
+        assert loader.load(input_data) == expected

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -24,6 +24,11 @@ class TestSafeDateLoader:
             # Infinity values
             (b"infinity", date.max),
             (b"-infinity", date.min),
+            # Negative years / BC dates should clamp to date.min
+            (b"-0001-01-01", date.min),
+            (b"-0044-03-15", date.min),
+            (b"0000-01-01", date.min),
+            (b"0044-03-15 BC", date.min),
             # None should return None
             (None, None),
         ],


### PR DESCRIPTION
## Problem

When importing data from PostgreSQL, the data import fails with `DataError: date too large (after year 10K): '48113-11-21'` if the source database contains date values beyond Python's `datetime.date` limits (year 1 to year 9999).

PostgreSQL can store dates including `infinity`, `-infinity`, and dates with years > 9999. Python's `datetime.date` type cannot represent these values, causing psycopg's built-in `DateLoader` to raise an error and fail the entire data import.

Closes https://us.posthog.com/error_tracking/0199e7bf-09c9-7972-b877-adb1620550b2

## Changes

- Added a `SafeDateLoader` class that handles PostgreSQL dates beyond Python's date range by clamping them to `date.min` or `date.max` instead of raising an error
- Registered the loader for the `date` type on PostgreSQL connections during data imports
- Added tests covering normal dates, infinity values, and out-of-range dates

## How did you test this code?

- Added parameterized unit tests that verify:
  - Normal date values parse correctly
  - The specific problematic date (`48113-11-21`) returns `date.max`
  - Dates at year 10000+ return `date.max`
  - PostgreSQL `infinity` returns `date.max`
  - PostgreSQL `-infinity` returns `date.min`
  - `None` values are handled correctly

```
pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py -v
# 10 passed
```

## Publish to changelog?

No