### PR TITLE
fix(data-warehouse): use stable row key for syncs table expansion

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -73,6 +73,7 @@ export const Syncs = ({ id }: SyncsProps): JSX.Element => {
             <LemonTable
                 hideScrollbar
                 dataSource={filteredJobs}
+                rowKey="id"
                 loading={jobsLoading}
                 disableTableWhileLoading={false}
                 columns={[


### PR DESCRIPTION
## Problem

When viewing the Syncs table in data warehouse settings, expanding a row to see job details and then having new jobs added (e.g., from a sync completing) causes the wrong row to be expanded. The expanded row "moves up" because the expansion state was tied to the array index rather than the actual job.

## Changes

Added `rowKey="id"` to the LemonTable in Syncs.tsx so that row expansion state is keyed by the job's unique ID instead of its position in the array.

## How did you test this code?

Manual testing: Expand a row in the syncs table, verify that when the data source updates with new items, the same row remains expanded.

## Publish to changelog?

no