### PR TITLE
fix: Give more color to persons in data table

### DIFF
--- a/frontend/src/scenes/persons/PersonDisplay.tsx
+++ b/frontend/src/scenes/persons/PersonDisplay.tsx
@@ -50,12 +50,9 @@ export function PersonIcon({
         return typeof possibleEmail === 'string' ? possibleEmail : undefined
     }, [person?.properties?.email])
 
-    // Generate a stable color index from the person's distinct_id if not explicitly provided
-    //
-    // Don't depend on `person` for the memoization since this is only used to get an accurate color
-    // and person is a complex object that could change.
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
-    const colorIndex = useMemo(() => index ?? getPersonColorIndex(person), [index])
+    // Generate a stable color index from the person's distinct_id (or display name) if not explicitly provided
+    const identifier = person?.distinct_id || person?.distinct_ids?.[0] || displayName
+    const colorIndex = useMemo(() => index ?? getPersonColorIndex(identifier), [index, identifier])
 
     return (
         <ProfilePicture

--- a/frontend/src/scenes/persons/person-utils.test.ts
+++ b/frontend/src/scenes/persons/person-utils.test.ts
@@ -150,56 +150,35 @@ describe('the person header', () => {
     })
 
     describe('color index', () => {
-        it('returns undefined for null/undefined person', () => {
+        it('returns undefined for null/undefined identifier', () => {
             expect(getPersonColorIndex(null)).toBeUndefined()
             expect(getPersonColorIndex(undefined)).toBeUndefined()
         })
 
-        it('returns undefined for person without distinct_id', () => {
-            expect(getPersonColorIndex({ properties: { email: 'test@example.com' } })).toBeUndefined()
-        })
-
-        it('returns a number between 0 and 15 for person with distinct_id', () => {
+        it('returns a number between 0 and 15', () => {
             for (let i = 0; i < 26; i++) {
                 const letter = String.fromCharCode(97 + i) // a-z
-                const idx = getPersonColorIndex({ distinct_id: `user-1234${letter}` })
+                const idx = getPersonColorIndex(`user-1234${letter}`)
                 expect(idx).toBeGreaterThanOrEqual(0)
                 expect(idx).toBeLessThanOrEqual(15)
             }
         })
 
-        it('returns consistent index for the same distinct_id', () => {
-            const person = { distinct_id: 'user-abc-123' }
-            const index1 = getPersonColorIndex(person)
-            const index2 = getPersonColorIndex(person)
+        it('returns consistent index for the same identifier', () => {
+            const index1 = getPersonColorIndex('user-abc-123')
+            const index2 = getPersonColorIndex('user-abc-123')
             expect(index1).toEqual(index2)
         })
 
-        it('returns different indices for IDs starting with the same character', () => {
-            // This is the key test: IDs starting with same char should get different colors
-            const index1 = getPersonColorIndex({ distinct_id: '0abc123' })
-            const index2 = getPersonColorIndex({ distinct_id: '0xyz789' })
-            const index3 = getPersonColorIndex({ distinct_id: '0different' })
+        it('returns different indices for identifiers starting with the same character', () => {
+            // This is the key test: identifiers starting with same char should get different colors
+            const index1 = getPersonColorIndex('0abc123')
+            const index2 = getPersonColorIndex('0xyz789')
+            const index3 = getPersonColorIndex('0different')
 
             // At least two of these should be different (with good hash distribution)
             const uniqueIndices = new Set([index1, index2, index3])
-            expect(uniqueIndices.size).toBeGreaterThan(1)
-        })
-
-        it('uses first distinct_id from distinct_ids array', () => {
-            const index1 = getPersonColorIndex({ distinct_ids: ['user-abc'] })
-            const index2 = getPersonColorIndex({ distinct_id: 'user-abc' })
-            expect(index1).toEqual(index2)
-        })
-
-        it('prefers distinct_id over distinct_ids', () => {
-            const index = getPersonColorIndex({
-                id: 'person-uuid',
-                distinct_id: 'primary-id',
-                distinct_ids: ['secondary-id'],
-            })
-            const expected = getPersonColorIndex({ distinct_id: 'primary-id' })
-            expect(index).toEqual(expected)
+            expect(uniqueIndices.size).toBe(3)
         })
     })
 })

--- a/frontend/src/scenes/persons/person-utils.ts
+++ b/frontend/src/scenes/persons/person-utils.ts
@@ -13,27 +13,16 @@ import { HogQLQueryString, hogql } from '~/queries/utils'
  * Generates a stable color index from a string using djb2 hash.
  * Used for consistent avatar colors based on person identifiers.
  */
-function hashStringToColorIndex(str: string): number {
-    let hash = 5381
-    for (let i = 0; i < str.length; i++) {
-        hash = (hash * 33) ^ str.charCodeAt(i)
-    }
-    return Math.abs(hash) % NUM_LETTERMARK_STYLES
-}
-
-/**
- * Returns a stable color index for a person based on their identifier.
- * Uses distinct_id (or first of distinct_ids) to generate consistent colors.
- */
-export function getPersonColorIndex(person: PersonPropType | null | undefined): number | undefined {
-    if (!person) {
-        return undefined
-    }
-    const identifier = person.distinct_id || person.distinct_ids?.[0]
+export function getPersonColorIndex(identifier: string | null | undefined): number | undefined {
     if (!identifier) {
         return undefined
     }
-    return hashStringToColorIndex(identifier)
+
+    let hash = 5381
+    for (let i = 0; i < identifier.length; i++) {
+        hash = (hash * 33) ^ identifier.charCodeAt(i)
+    }
+    return Math.abs(hash) % NUM_LETTERMARK_STYLES
 }
 
 export type PersonPropType =


### PR DESCRIPTION
We don't get `distinct_id` in here, but rather the `display_name` as a property. So, inside `PersonDisplay` fallback to `displayName` to make this work as expected



Confirmed it works locally

![image.png](https://app.graphite.com/user-attachments/assets/14aca535-fba6-43f2-b954-7ad49e066631.png)

