### PR TITLE
feat(web-analytics): Allow users to update their preset filters

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilterPresets.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilterPresets.tsx
@@ -5,6 +5,7 @@ import {
     IconBookmark,
     IconBookmarkSolid,
     IconCheck,
+    IconPencil,
     IconPin,
     IconPinFilled,
     IconPlus,
@@ -21,16 +22,34 @@ import {
     Popover,
 } from '@posthog/lemon-ui'
 
+import { IconSync } from 'lib/lemon-ui/icons'
+
 import { WebAnalyticsFilterPresetType } from '~/types'
 
 import { webAnalyticsFilterPresetsLogic } from './webAnalyticsFilterPresetsLogic'
 
 export const FilterPresetsDropdown = (): JSX.Element => {
     const [dropdownOpen, setDropdownOpen] = useState(false)
-    const { pinnedPresets, recentPresets, presetsLoading, activePreset, hasPresets, presetToDelete } =
-        useValues(webAnalyticsFilterPresetsLogic)
-    const { applyPreset, deletePreset, updatePreset, openSaveModal, clearPreset, openDeleteModal, closeDeleteModal } =
-        useActions(webAnalyticsFilterPresetsLogic)
+    const {
+        pinnedPresets,
+        recentPresets,
+        presetsLoading,
+        activePreset,
+        hasPresets,
+        presetToDelete,
+        hasUnsavedChanges,
+    } = useValues(webAnalyticsFilterPresetsLogic)
+    const {
+        applyPreset,
+        deletePreset,
+        updatePreset,
+        openSaveModal,
+        clearPreset,
+        openDeleteModal,
+        closeDeleteModal,
+        openEditModal,
+        updateAppliedPresetFilters,
+    } = useActions(webAnalyticsFilterPresetsLogic)
 
     const handleTogglePin = (preset: WebAnalyticsFilterPresetType, e: React.MouseEvent): void => {
         e.stopPropagation()
@@ -41,6 +60,12 @@ export const FilterPresetsDropdown = (): JSX.Element => {
         e.stopPropagation()
         setDropdownOpen(false)
         openDeleteModal(preset)
+    }
+
+    const handleEdit = (preset: WebAnalyticsFilterPresetType, e: React.MouseEvent): void => {
+        e.stopPropagation()
+        setDropdownOpen(false)
+        openEditModal(preset)
     }
 
     const renderPresetItem = (preset: WebAnalyticsFilterPresetType): JSX.Element => {
@@ -71,6 +96,12 @@ export const FilterPresetsDropdown = (): JSX.Element => {
                     />
                     <LemonButton
                         size="xsmall"
+                        icon={<IconPencil />}
+                        onClick={(e) => handleEdit(preset, e)}
+                        tooltip="Edit"
+                    />
+                    <LemonButton
+                        size="xsmall"
                         icon={<IconTrash />}
                         onClick={(e) => handleDelete(preset, e)}
                         tooltip="Delete"
@@ -83,18 +114,48 @@ export const FilterPresetsDropdown = (): JSX.Element => {
 
     const dropdownContent = (
         <div className="w-72 max-h-96 overflow-y-auto">
-            <div className="p-2">
-                <LemonButton
-                    fullWidth
-                    size="small"
-                    icon={<IconPlus />}
-                    onClick={() => {
-                        setDropdownOpen(false)
-                        openSaveModal()
-                    }}
-                >
-                    Save current filters
-                </LemonButton>
+            <div className="px-2 pt-2 pb-1 ">
+                {activePreset && hasUnsavedChanges ? (
+                    <>
+                        <LemonButton
+                            fullWidth
+                            size="small"
+                            type="primary"
+                            icon={<IconSync />}
+                            onClick={() => {
+                                setDropdownOpen(false)
+                                updateAppliedPresetFilters()
+                            }}
+                        >
+                            Update "{activePreset.name}"
+                        </LemonButton>
+                        <LemonDivider className="mt-2 mb-2" />
+                        <LemonButton
+                            fullWidth
+                            size="small"
+                            type="tertiary"
+                            icon={<IconPlus />}
+                            onClick={() => {
+                                setDropdownOpen(false)
+                                openSaveModal()
+                            }}
+                        >
+                            Save as new preset
+                        </LemonButton>
+                    </>
+                ) : (
+                    <LemonButton
+                        fullWidth
+                        size="small"
+                        icon={<IconPlus />}
+                        onClick={() => {
+                            setDropdownOpen(false)
+                            openSaveModal()
+                        }}
+                    >
+                        Save current filters
+                    </LemonButton>
+                )}
             </div>
 
             {presetsLoading ? (
@@ -164,7 +225,14 @@ export const FilterPresetsDropdown = (): JSX.Element => {
                             : undefined
                     }
                 >
-                    {activePreset ? <span className="max-w-32 truncate">{activePreset.name}</span> : 'Presets'}
+                    {activePreset ? (
+                        <span className="max-w-32 truncate">
+                            {activePreset.name}
+                            {hasUnsavedChanges && <span className="text-warning ml-1">(modified)</span>}
+                        </span>
+                    ) : (
+                        'Presets'
+                    )}
                 </LemonButton>
             </Popover>
             <SaveFilterPresetModal />
@@ -178,22 +246,38 @@ export const FilterPresetsDropdown = (): JSX.Element => {
 }
 
 const SaveFilterPresetModal = (): JSX.Element | null => {
-    const { saveModalOpen, savedPresetLoading, presetFormName, presetFormDescription, canSavePreset } =
-        useValues(webAnalyticsFilterPresetsLogic)
-    const { closeSaveModal, saveCurrentFiltersAsPreset, setPresetFormName, setPresetFormDescription } =
+    const {
+        saveModalOpen,
+        savedPresetLoading,
+        presetFormName,
+        presetFormDescription,
+        canSavePreset,
+        isEditMode,
+        editingPreset,
+    } = useValues(webAnalyticsFilterPresetsLogic)
+    const { closeSaveModal, saveCurrentFiltersAsPreset, setPresetFormName, setPresetFormDescription, updatePreset } =
         useActions(webAnalyticsFilterPresetsLogic)
 
     const handleSave = (): void => {
         if (canSavePreset) {
-            saveCurrentFiltersAsPreset(presetFormName.trim(), presetFormDescription.trim() || undefined)
+            if (isEditMode && editingPreset) {
+                updatePreset(editingPreset.short_id, {
+                    name: presetFormName.trim(),
+                    description: presetFormDescription.trim() || undefined,
+                })
+            } else {
+                saveCurrentFiltersAsPreset(presetFormName.trim(), presetFormDescription.trim() || undefined)
+            }
         }
     }
 
+    const isOpen = saveModalOpen || isEditMode
+
     return (
         <LemonModal
-            isOpen={saveModalOpen}
+            isOpen={isOpen}
             onClose={closeSaveModal}
-            title="Save filter preset"
+            title={isEditMode ? `Edit "${editingPreset?.name}"` : 'Save filter preset'}
             footer={
                 <>
                     <LemonButton type="secondary" onClick={closeSaveModal}>
@@ -205,7 +289,7 @@ const SaveFilterPresetModal = (): JSX.Element | null => {
                         loading={savedPresetLoading}
                         disabledReason={!canSavePreset ? 'Name is required' : undefined}
                     >
-                        Save preset
+                        {isEditMode ? 'Update preset' : 'Save preset'}
                     </LemonButton>
                 </>
             }

--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilterPresets.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilterPresets.tsx
@@ -226,9 +226,9 @@ export const FilterPresetsDropdown = (): JSX.Element => {
                     }
                 >
                     {activePreset ? (
-                        <span className="max-w-32 truncate">
-                            {activePreset.name}
-                            {hasUnsavedChanges && <span className="text-warning ml-1">(modified)</span>}
+                        <span className="flex items-center gap-1">
+                            <span className="max-w-32 truncate">{activePreset.name}</span>
+                            {hasUnsavedChanges && <span className="text-warning shrink-0">(modified)</span>}
                         </span>
                     ) : (
                         'Presets'

--- a/frontend/src/scenes/web-analytics/webAnalyticsFilterPresetsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsFilterPresetsLogic.ts
@@ -173,6 +173,7 @@ export const webAnalyticsFilterPresetsLogic = kea<webAnalyticsFilterPresetsLogic
                 if (values.appliedPreset?.short_id === savedPreset.short_id) {
                     actions.setAppliedPreset(savedPreset)
                 }
+                actions.resetPresetForm()
             }
         },
         saveCurrentFiltersAsPresetSuccess: ({ savedPreset }) => {

--- a/frontend/src/scenes/web-analytics/webAnalyticsFilterPresetsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsFilterPresetsLogic.ts
@@ -4,7 +4,7 @@ import { router } from 'kea-router'
 
 import api, { PaginatedResponse } from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { toParams } from 'lib/utils'
+import { objectsEqual, toParams } from 'lib/utils'
 
 import { WebAnalyticsFilterPresetType } from '~/types'
 
@@ -39,6 +39,8 @@ export const webAnalyticsFilterPresetsLogic = kea<webAnalyticsFilterPresetsLogic
         resetPresetForm: true,
         openDeleteModal: (preset: WebAnalyticsFilterPresetType) => ({ preset }),
         closeDeleteModal: true,
+        openEditModal: (preset: WebAnalyticsFilterPresetType) => ({ preset }),
+        updateAppliedPresetFilters: true,
     }),
     reducers({
         appliedPreset: [
@@ -79,6 +81,15 @@ export const webAnalyticsFilterPresetsLogic = kea<webAnalyticsFilterPresetsLogic
                 openDeleteModal: (_, { preset }) => preset,
                 closeDeleteModal: () => null,
                 deletePreset: () => null,
+            },
+        ],
+        editingPreset: [
+            null as WebAnalyticsFilterPresetType | null,
+            {
+                openEditModal: (_, { preset }) => preset,
+                openSaveModal: () => null,
+                closeSaveModal: () => null,
+                updatePresetSuccess: () => null,
             },
         ],
     }),
@@ -145,6 +156,25 @@ export const webAnalyticsFilterPresetsLogic = kea<webAnalyticsFilterPresetsLogic
         closeSaveModal: () => {
             actions.resetPresetForm()
         },
+        openEditModal: ({ preset }) => {
+            actions.setPresetFormName(preset.name)
+            actions.setPresetFormDescription(preset.description || '')
+        },
+        updateAppliedPresetFilters: () => {
+            if (values.appliedPreset) {
+                actions.updatePreset(values.appliedPreset.short_id, {
+                    filters: values.currentFiltersConfig,
+                })
+            }
+        },
+        updatePresetSuccess: ({ savedPreset }) => {
+            if (savedPreset) {
+                lemonToast.success(`Preset "${savedPreset.name}" updated`)
+                if (values.appliedPreset?.short_id === savedPreset.short_id) {
+                    actions.setAppliedPreset(savedPreset)
+                }
+            }
+        },
         saveCurrentFiltersAsPresetSuccess: ({ savedPreset }) => {
             lemonToast.success(`Preset "${savedPreset.name}" saved`)
             actions.setAppliedPreset(savedPreset)
@@ -197,6 +227,16 @@ export const webAnalyticsFilterPresetsLogic = kea<webAnalyticsFilterPresetsLogic
                 return appliedPreset
             },
         ],
+        hasUnsavedChanges: [
+            (s) => [s.appliedPreset, s.currentFiltersConfig],
+            (appliedPreset, currentFiltersConfig): boolean => {
+                if (!appliedPreset) {
+                    return false
+                }
+                return !objectsEqual(appliedPreset.filters, currentFiltersConfig)
+            },
+        ],
+        isEditMode: [(s) => [s.editingPreset], (editingPreset): boolean => !!editingPreset],
     }),
     afterMount(({ actions }) => {
         actions.loadPresets()


### PR DESCRIPTION
## Problem
Users who wanted to update their Web Analytics filter presets needed to create a new one every time.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Allow editing and updating presets when an active filter is modified. 
<img width="1443" height="313" alt="image" src="https://github.com/user-attachments/assets/0d592c5c-bdac-416e-ad62-78361b26df67" />
<img width="1443" height="313" alt="image" src="https://github.com/user-attachments/assets/55c557bc-00ba-408d-a7cb-17a66e53a4f1" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
