### PR TITLE
fix(ci): broaden chunk exclusion pattern in bundle size check

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -140,7 +140,7 @@ jobs:
                   # Exclude source maps and chunk files (chunk hashes change every build)
                   exclude: |
                       frontend/dist/*.js.map
-                      frontend/dist/chunk-*.js
+                      frontend/dist/chunk*.js
                   # Only show large changes
                   minimum-change-threshold: 1000
                   order-by: 'Size:desc'


### PR DESCRIPTION
Change the exclusion pattern from `chunk-*.js` to `chunk*.js` to ensure all chunk files are excluded from bundle size comparison since chunk hashes change every build.

Slack thread: https://posthog.slack.com/archives/C03P7NL6RMW/p1769589790474779?thread_ts=1769552918.170619&cid=C03P7NL6RMW

https://claude.ai/code/session_01TifiqMPVhq1uq8zq6gME9F

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
