### PR TITLE
fix: index passed to react-window must always be positive integer

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
@@ -67,7 +67,7 @@ export function PlayerInspectorList(): JSX.Element {
             )
             markerRef.current.style.transform = `translateY(${offset}px)`
 
-            if (!syncScrollPaused) {
+            if (!syncScrollPaused && playbackIndicatorIndex >= 0) {
                 scrolledByJsFlag.current = true
                 listRef.current.scrollToRow({ index: playbackIndicatorIndex })
             }


### PR DESCRIPTION
when using scroll within react-window it is on us to make sure we only pass a positive index