### PR TITLE
chore: set stricter timeouts for experiments jobs

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -66,11 +66,13 @@ class ExperimentQueryRunner(QueryRunner):
         *args,
         override_end_date: Optional[datetime] = None,
         user_facing: bool = True,
+        max_execution_time: Optional[int] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.override_end_date = override_end_date
         self.user_facing = user_facing
+        self.max_execution_time = max_execution_time if max_execution_time is not None else MAX_EXECUTION_TIME
 
         if not self.query.experiment_id:
             raise ValidationError("experiment_id is required")
@@ -192,7 +194,7 @@ class ExperimentQueryRunner(QueryRunner):
             timings=self.timings,
             modifiers=create_default_modifiers_for_team(self.team),
             settings=HogQLGlobalSettings(
-                max_execution_time=MAX_EXECUTION_TIME,
+                max_execution_time=self.max_execution_time,
                 allow_experimental_analyzer=True,
                 max_bytes_before_external_group_by=MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
             ),

--- a/products/experiments/dags/experiment_timeseries_recalculation.py
+++ b/products/experiments/dags/experiment_timeseries_recalculation.py
@@ -23,6 +23,8 @@ from posthog.models.experiment import ExperimentMetricResult, ExperimentTimeseri
 
 from products.experiments.dags.utils import remove_step_sessions_from_experiment_result
 
+JOB_TIMEOUT_SECONDS = 15 * 60  # 15 minutes
+
 experiment_timeseries_recalculation_partitions_def = dagster.DynamicPartitionsDefinition(
     name="experiment_recalculations"
 )
@@ -213,7 +215,10 @@ def experiment_timeseries_recalculation(context: AssetExecutionContext) -> dict[
 experiment_timeseries_recalculation_job = dagster.define_asset_job(
     name="experiment_timeseries_recalculation_job",
     selection=[experiment_timeseries_recalculation],
-    tags={"owner": JobOwners.TEAM_EXPERIMENTS.value},
+    tags={
+        "owner": JobOwners.TEAM_EXPERIMENTS.value,
+        "dagster/max_runtime": str(JOB_TIMEOUT_SECONDS),
+    },
     executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 4}),
 )
 


### PR DESCRIPTION
## Problem

Some jobs are hanging for days in Dagster, consuming resources and slots in the queue to run new jobs.

## Changes

Set timeouts for regular and saved metric jobs.
Also, max query execution time to 2 minutes for them as they should be pretty quick to finish based on how long successful jobs take (which is usually less than 1 minute).

## How did you test this code?

Unit tests.