### PR TITLE
fix(exporter): Classify more unknown exceptions

### DIFF
--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -157,6 +157,10 @@ class CHQueryErrorUnsupportedMethod(InternalCHQueryError):
     pass
 
 
+class CHQueryErrorInvalidJoinOnExpression(ExposedCHQueryError):
+    pass
+
+
 def get_specific_clickhouse_error(meta_name: str, original_message: str, code: int) -> InternalCHQueryError | None:
     lookup: dict[str, InternalCHQueryError] = {
         # Infrastructure errors - custom messages to hide internals
@@ -186,6 +190,9 @@ def get_specific_clickhouse_error(meta_name: str, original_message: str, code: i
         "CANNOT_PARSE_UUID": CHQueryErrorCannotParseUuid(original_message, code=code, code_name="cannot_parse_uuid"),
         "UNSUPPORTED_METHOD": CHQueryErrorUnsupportedMethod(
             original_message, code=code, code_name="unsupported_method"
+        ),
+        "INVALID_JOIN_ON_EXPRESSION": CHQueryErrorInvalidJoinOnExpression(
+            original_message, code=code, code_name="invalid_join_on_expression"
         ),
     }
     return lookup.get(meta_name)

--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -157,7 +157,7 @@ class CHQueryErrorUnsupportedMethod(InternalCHQueryError):
     pass
 
 
-class CHQueryErrorInvalidJoinOnExpression(ExposedCHQueryError):
+class CHQueryErrorInvalidJoinOnExpression(InternalCHQueryError):
     pass
 
 

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -91,10 +91,7 @@ class ExcelWriter(TabularWriter):
             self._worksheet.append(columns)
         except ValueError as e:
             if "Invalid column index" in str(e):
-                raise ExcelColumnLimitExceeded(
-                    "Export exceeds Excel's maximum of 18,278 columns. "
-                    "Try exporting fewer columns or use CSV format instead."
-                ) from e
+                raise ExcelColumnLimitExceeded() from e
             raise
 
     def write_row(self, row: dict) -> None:
@@ -108,10 +105,7 @@ class ExcelWriter(TabularWriter):
             self._worksheet.append(values)
         except ValueError as e:
             if "Invalid column index" in str(e):
-                raise ExcelColumnLimitExceeded(
-                    "Export exceeds Excel's maximum of 18,278 columns. "
-                    "Try exporting fewer columns or use CSV format instead."
-                ) from e
+                raise ExcelColumnLimitExceeded() from e
             raise
 
     def finish(self) -> str:
@@ -218,12 +212,11 @@ def _get_breakdown_info(
 
 
 def _format_breakdown_value(breakdown_value: Any) -> str:
-    """Format breakdown_value for CSV export, handling various data types."""
+    """Format breakdown_value for CSV export in a type safe way."""
     if breakdown_value is None:
         return ""
-    if isinstance(breakdown_value, list):
-        return "::".join(str(v) for v in breakdown_value)
-    return str(breakdown_value)
+
+    return "::".join(breakdown_value)
 
 
 def _convert_response_to_csv_data(data: Any, breakdown_filter: Optional[dict] = None) -> Generator[Any, None, None]:

--- a/posthog/tasks/exports/failure_handler.py
+++ b/posthog/tasks/exports/failure_handler.py
@@ -63,12 +63,12 @@ class ExportCancelled(Exception):
 
 
 class ExcelColumnLimitExceeded(Exception):
-    """Raised when export data exceeds Excel's 16,384 column limit (XFD)."""
+    """Raised when export data exceeds openpyxl's 18,278 column limit (ZZZ)."""
 
     def __init__(self, message: str | None = None):
         super().__init__(
             message
-            or "Export exceeds Excel's maximum of 16,384 columns. Try exporting fewer columns or use CSV format instead."
+            or "Export exceeds the maximum of 18,278 columns. Try exporting fewer columns or use CSV format instead."
         )
 
 

--- a/posthog/tasks/exports/failure_handler.py
+++ b/posthog/tasks/exports/failure_handler.py
@@ -63,9 +63,13 @@ class ExportCancelled(Exception):
 
 
 class ExcelColumnLimitExceeded(Exception):
-    """Raised when export data exceeds Excel's 18,278 column limit (ZZZ)."""
+    """Raised when export data exceeds Excel's 16,384 column limit (XFD)."""
 
-    pass
+    def __init__(self, message: str | None = None):
+        super().__init__(
+            message
+            or "Export exceeds Excel's maximum of 16,384 columns. Try exporting fewer columns or use CSV format instead."
+        )
 
 
 EXCEPTIONS_TO_RETRY = (
@@ -99,8 +103,8 @@ USER_QUERY_ERRORS = (
     QuerySizeExceeded,
     CHQueryErrorUnsupportedMethod,
     ResolutionError,
-    CHQueryErrorInvalidJoinOnExpression,  # Invalid JOIN ON clause in HogQL query
-    ExcelColumnLimitExceeded,  # Export exceeds Excel's column limit
+    CHQueryErrorInvalidJoinOnExpression,
+    ExcelColumnLimitExceeded,
 )
 
 TIMEOUT_ERRORS = (

--- a/posthog/tasks/exports/failure_handler.py
+++ b/posthog/tasks/exports/failure_handler.py
@@ -5,7 +5,7 @@ from django.db import OperationalError
 from billiard.exceptions import SoftTimeLimitExceeded
 from clickhouse_driver.errors import SocketTimeoutError
 from selenium.common import TimeoutException
-from urllib3.exceptions import MaxRetryError, ProtocolError
+from urllib3.exceptions import MaxRetryError, ProtocolError, ReadTimeoutError
 
 from posthog.hogql.errors import (
     QueryError,
@@ -18,6 +18,7 @@ from posthog.errors import (
     CHQueryErrorCannotParseUuid,
     CHQueryErrorIllegalAggregation,
     CHQueryErrorIllegalTypeOfArgument,
+    CHQueryErrorInvalidJoinOnExpression,
     CHQueryErrorNoCommonType,
     CHQueryErrorNotAnAggregate,
     CHQueryErrorNumberOfArgumentsDoesntMatch,
@@ -61,6 +62,12 @@ class ExportCancelled(Exception):
     pass
 
 
+class ExcelColumnLimitExceeded(Exception):
+    """Raised when export data exceeds Excel's 18,278 column limit (ZZZ)."""
+
+    pass
+
+
 EXCEPTIONS_TO_RETRY = (
     CHQueryErrorS3Error,
     CHQueryErrorTooManySimultaneousQueries,
@@ -68,6 +75,7 @@ EXCEPTIONS_TO_RETRY = (
     ProtocolError,
     ConcurrencyLimitExceeded,
     MaxRetryError,  # This is from urllib, e.g. HTTP retries instead of "job retries"
+    ReadTimeoutError,  # Network timeout from urllib3
     ClickHouseAtCapacity,
     SocketTimeoutError,
     SSLError,
@@ -91,6 +99,8 @@ USER_QUERY_ERRORS = (
     QuerySizeExceeded,
     CHQueryErrorUnsupportedMethod,
     ResolutionError,
+    CHQueryErrorInvalidJoinOnExpression,  # Invalid JOIN ON clause in HogQL query
+    ExcelColumnLimitExceeded,  # Export exceeds Excel's column limit
 )
 
 TIMEOUT_ERRORS = (

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -1521,7 +1521,7 @@ class TestCSVExporter(APIBaseTest):
                 assert "[31mred[0mafter" in str(data_row)  # ANSI: ESC stripped, rest preserved
 
     def test_format_breakdown_value(self) -> None:
-        """Test _format_breakdown_value handles None (the actual incident case)."""
+        """Test _format_breakdown_value handles None."""
         # None was causing TypeError: can only join an iterable
         assert _format_breakdown_value(None) == ""
 
@@ -1532,13 +1532,13 @@ class TestCSVExporter(APIBaseTest):
 
     def test_excel_writer_raises_column_limit_exceeded(self) -> None:
         writer = ExcelWriter()
-        # Create more columns than Excel supports
+        # Create more columns than openpyxl supports (18,278 max)
         columns = [f"col_{i}" for i in range(18300)]
 
         with pytest.raises(ExcelColumnLimitExceeded) as exc_info:
             writer.write_header(columns)
 
-        assert "16,384 columns" in str(exc_info.value)
+        assert "18,278 columns" in str(exc_info.value)
         assert "CSV format" in str(exc_info.value)
 
     def test_excel_writer_normal_column_count_works(self) -> None:

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -1533,6 +1533,7 @@ class TestCSVExporter(APIBaseTest):
     def test_excel_writer_raises_column_limit_exceeded(self) -> None:
         writer = ExcelWriter()
         # Create more columns than openpyxl supports (18,278 max)
+        # See: https://foss.heptapod.net/openpyxl/openpyxl/-/blob/a345f3975f06450193646a53a5caaf081730e9ea/openpyxl/utils/cell.py#L93
         columns = [f"col_{i}" for i in range(18300)]
 
         with pytest.raises(ExcelColumnLimitExceeded) as exc_info:

--- a/posthog/tasks/exports/test/test_failure_handler.py
+++ b/posthog/tasks/exports/test/test_failure_handler.py
@@ -26,6 +26,8 @@ class TestIsUserQueryErrorType(TestCase):
             ("CHQueryErrorUnknownFunction", True),
             ("ClickHouseQueryTimeOut", True),
             ("ClickHouseQueryMemoryLimitExceeded", True),
+            ("CHQueryErrorInvalidJoinOnExpression", True),
+            ("ExcelColumnLimitExceeded", True),
             # Non-user errors - should return False
             ("TimeoutError", False),
             ("ValueError", False),
@@ -33,6 +35,7 @@ class TestIsUserQueryErrorType(TestCase):
             ("CHQueryErrorTooManySimultaneousQueries", False),
             ("ClickHouseAtCapacity", False),
             ("ConcurrencyLimitExceeded", False),
+            ("ReadTimeoutError", False),
             (None, False),
             ("", False),
         ]
@@ -53,11 +56,14 @@ class TestClassifyFailureType(TestCase):
             ("CHQueryErrorIllegalAggregation", FAILURE_TYPE_USER),
             ("ClickHouseQueryTimeOut", FAILURE_TYPE_USER),
             ("ClickHouseQueryMemoryLimitExceeded", FAILURE_TYPE_USER),
+            ("CHQueryErrorInvalidJoinOnExpression", FAILURE_TYPE_USER),
+            ("ExcelColumnLimitExceeded", FAILURE_TYPE_USER),
             # System errors (from EXCEPTIONS_TO_RETRY)
             ("CHQueryErrorS3Error", FAILURE_TYPE_SYSTEM),
             ("CHQueryErrorTooManySimultaneousQueries", FAILURE_TYPE_SYSTEM),
             ("OperationalError", FAILURE_TYPE_SYSTEM),
             ("ClickHouseAtCapacity", FAILURE_TYPE_SYSTEM),
+            ("ReadTimeoutError", FAILURE_TYPE_SYSTEM),
             # Unknown errors
             ("ValueError", FAILURE_TYPE_UNKNOWN),
             ("RuntimeError", FAILURE_TYPE_UNKNOWN),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

This PR classifies four additional export failure errors that were previously reported as "unknown" ([metabase US link](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjozNCwidHlwZSI6Im5hdGl2ZSIsIm5hdGl2ZSI6eyJ0ZW1wbGF0ZS10YWdzIjp7fSwicXVlcnkiOiIgIFNFTEVDVFxuICAgICAgZXhjZXB0aW9uLFxuICAgICAgZXhjZXB0aW9uX3R5cGUsXG4gICAgICBDT1VOVCgqKSBBUyBvY2N1cnJlbmNlX2NvdW50LFxuICAgICAgTUlOKGNyZWF0ZWRfYXQpIEFTIGZpcnN0X3NlZW4sXG4gICAgICBNQVgoY3JlYXRlZF9hdCkgQVMgbGFzdF9zZWVuLFxuICAgICAgU1RSSU5HX0FHRyhESVNUSU5DVCB0ZWFtX2lkOjp0ZXh0LCAnLCAnIE9SREVSIEJZIHRlYW1faWQ6OnRleHQpIEFTIHRlYW1faWRzLFxuICAgICAgQ09VTlQoRElTVElOQ1QgdGVhbV9pZCkgQVMgdW5pcXVlX3RlYW1zXG4gIEZST00gcG9zdGhvZ19leHBvcnRlZGFzc2V0XG4gIFdIRVJFIGZhaWx1cmVfdHlwZSA9ICd1bmtub3duJ1xuICAgICAgQU5EIGNyZWF0ZWRfYXQgPj0gTk9XKCkgLSBJTlRFUlZBTCAnMyBkYXlzJ1xuICBHUk9VUCBCWSBleGNlcHRpb24sIGV4Y2VwdGlvbl90eXBlXG4gIE9SREVSIEJZIG9jY3VycmVuY2VfY291bnQgREVTQzsifX0sImRpc3BsYXkiOiJ0YWJsZSIsImRpc3BsYXlJc0xvY2tlZCI6dHJ1ZSwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsidGFibGUucGl2b3RfY29sdW1uIjoidW5pcXVlX3RlYW1zIiwidGFibGUuY2VsbF9jb2x1bW4iOiJvY2N1cnJlbmNlX2NvdW50In0sIm9yaWdpbmFsX2NhcmRfaWQiOjE4Mzh9) and [metabase EU link](https://metabase.prod-eu.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjozNCwidHlwZSI6Im5hdGl2ZSIsIm5hdGl2ZSI6eyJ0ZW1wbGF0ZS10YWdzIjp7fSwicXVlcnkiOiIgIFNFTEVDVFxuICAgICAgZXhjZXB0aW9uLFxuICAgICAgZXhjZXB0aW9uX3R5cGUsXG4gICAgICBDT1VOVCgqKSBBUyBvY2N1cnJlbmNlX2NvdW50LFxuICAgICAgTUlOKGNyZWF0ZWRfYXQpIEFTIGZpcnN0X3NlZW4sXG4gICAgICBNQVgoY3JlYXRlZF9hdCkgQVMgbGFzdF9zZWVuLFxuICAgICAgU1RSSU5HX0FHRyhESVNUSU5DVCB0ZWFtX2lkOjp0ZXh0LCAnLCAnIE9SREVSIEJZIHRlYW1faWQ6OnRleHQpIEFTIHRlYW1faWRzLFxuICAgICAgQ09VTlQoRElTVElOQ1QgdGVhbV9pZCkgQVMgdW5pcXVlX3RlYW1zXG4gIEZST00gcG9zdGhvZ19leHBvcnRlZGFzc2V0XG4gIFdIRVJFIGZhaWx1cmVfdHlwZSA9ICd1bmtub3duJ1xuICAgICAgQU5EIGNyZWF0ZWRfYXQgPj0gTk9XKCkgLSBJTlRFUlZBTCAnMyBkYXlzJ1xuICBHUk9VUCBCWSBleGNlcHRpb24sIGV4Y2VwdGlvbl90eXBlXG4gIE9SREVSIEJZIG9jY3VycmVuY2VfY291bnQgREVTQzsifX0sImRpc3BsYXkiOiJ0YWJsZSIsImRpc3BsYXlJc0xvY2tlZCI6dHJ1ZSwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsidGFibGUucGl2b3RfY29sdW1uIjoidW5pcXVlX3RlYW1zIiwidGFibGUuY2VsbF9jb2x1bW4iOiJvY2N1cnJlbmNlX2NvdW50In0sIm9yaWdpbmFsX2NhcmRfaWQiOjU2NX0=)):

| Error | Classification | User Action |
|-------|----------------|-------------|
| `CHQueryErrorInvalidJoinOnExpression` | User | Fix the invalid JOIN ON clause in query |
| `ExcelColumnLimitExceeded` | User | Reduce columns or use CSV format instead (raising this to inform the user about this as well) |
| `TypeError: can only join an iterable` | N/A | Fixed underlying bug ([logs](https://us.posthog.com/project/2/logs?dateRange=%7B%22date_from%22%3A%222026-01-26T03%3A00%3A00.000Z%22%2C%22date_to%22%3A%222026-01-26T09%3A00%3A00.000Z%22%7D&filterGroup=%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22key%22%3A%22message%22%2C%22value%22%3A%22can%20only%20join%20an%20iterable%22%2C%22operator%22%3A%22icontains%22%2C%22type%22%3A%22log%22%7D%5D%7D%5D%7D)) |
| `ReadTimeoutError` | System | Retryable network timeout |

This to further improve our overview / insights into the causes for failing exports.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Either classified the errors accordingly (as per the table above) or fix the underlying issue causing the exception (e.g. in the case of the `TypeError`).


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

✅ The new tests are passing in the CI (alongisde the existing tests)

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

N/A

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
