### PR TITLE
chore: align evals metrics with batch_exports conventions

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -14,6 +14,7 @@ from posthog.temporal.common.combined_metrics_server import CombinedMetricsServe
 from posthog.temporal.common.liveness_tracker import LivenessInterceptor
 from posthog.temporal.common.logger import get_write_only_logger
 from posthog.temporal.common.posthog_client import PostHogClientInterceptor
+from posthog.temporal.llm_analytics.metrics import EvalsMetricsInterceptor
 
 from products.batch_exports.backend.temporal.metrics import BatchExportsMetricsInterceptor
 
@@ -36,6 +37,24 @@ BATCH_EXPORTS_LATENCY_HISTOGRAM_BUCKETS = [
     21_600_000.0,  # 6 hours
     43_200_000.0,  # 12 hours
     86_400_000.0,  # 24 hours
+]
+
+EVALS_LATENCY_HISTOGRAM_METRICS = (
+    "llma_eval_activity_execution_latency",
+    "llma_eval_workflow_execution_latency",
+    "llma_eval_activity_schedule_to_start_latency",
+)
+EVALS_LATENCY_HISTOGRAM_BUCKETS = [
+    100.0,  # 100ms
+    500.0,  # 500ms
+    1_000.0,  # 1 second
+    2_000.0,  # 2 seconds
+    5_000.0,  # 5 seconds
+    10_000.0,  # 10 seconds
+    30_000.0,  # 30 seconds
+    60_000.0,  # 1 minute
+    120_000.0,  # 2 minutes
+    300_000.0,  # 5 minutes
 ]
 
 
@@ -148,6 +167,12 @@ async def create_worker(
                         itertools.repeat(BATCH_EXPORTS_LATENCY_HISTOGRAM_BUCKETS),
                     )
                 )
+                | dict(
+                    zip(
+                        EVALS_LATENCY_HISTOGRAM_METRICS,
+                        itertools.repeat(EVALS_LATENCY_HISTOGRAM_BUCKETS),
+                    )
+                )
                 | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0, 100.0]},
             ),
         )
@@ -171,7 +196,12 @@ async def create_worker(
             activities=activities,
             workflow_runner=UnsandboxedWorkflowRunner(),
             graceful_shutdown_timeout=graceful_shutdown_timeout or dt.timedelta(minutes=5),
-            interceptors=[LivenessInterceptor(), PostHogClientInterceptor(), BatchExportsMetricsInterceptor()],
+            interceptors=[
+                LivenessInterceptor(),
+                PostHogClientInterceptor(),
+                BatchExportsMetricsInterceptor(),
+                EvalsMetricsInterceptor(),
+            ],
             activity_executor=ThreadPoolExecutor(max_workers=max_concurrent_activities or 50),
             tuner=WorkerTuner.create_resource_based(
                 target_memory_usage=target_memory_usage,
@@ -191,7 +221,12 @@ async def create_worker(
             activities=activities,
             workflow_runner=UnsandboxedWorkflowRunner(),
             graceful_shutdown_timeout=graceful_shutdown_timeout or dt.timedelta(minutes=5),
-            interceptors=[LivenessInterceptor(), PostHogClientInterceptor(), BatchExportsMetricsInterceptor()],
+            interceptors=[
+                LivenessInterceptor(),
+                PostHogClientInterceptor(),
+                BatchExportsMetricsInterceptor(),
+                EvalsMetricsInterceptor(),
+            ],
             activity_executor=ThreadPoolExecutor(max_workers=max_concurrent_activities or 50),
             max_concurrent_activities=max_concurrent_activities or 50,
             max_concurrent_workflow_tasks=max_concurrent_workflow_tasks or 50,

--- a/posthog/temporal/llm_analytics/__init__.py
+++ b/posthog/temporal/llm_analytics/__init__.py
@@ -1,3 +1,4 @@
+from posthog.temporal.llm_analytics.metrics import EvalsMetricsInterceptor  # noqa: F401
 from posthog.temporal.llm_analytics.run_evaluation import (
     RunEvaluationWorkflow,
     disable_evaluation_activity,

--- a/posthog/temporal/llm_analytics/metrics.py
+++ b/posthog/temporal/llm_analytics/metrics.py
@@ -1,0 +1,246 @@
+import time
+import typing
+import datetime as dt
+
+from temporalio import activity, workflow
+from temporalio.common import MetricMeter
+from temporalio.worker import (
+    ActivityInboundInterceptor,
+    ExecuteActivityInput,
+    ExecuteWorkflowInput,
+    Interceptor,
+    WorkflowInboundInterceptor,
+    WorkflowInterceptorClassInput,
+)
+
+from posthog.temporal.common.logger import get_write_only_logger
+
+LOGGER = get_write_only_logger(__name__)
+
+EVAL_ACTIVITY_TYPES = {
+    "fetch_evaluation_activity",
+    "execute_llm_judge_activity",
+    "emit_evaluation_event_activity",
+    "emit_internal_telemetry_activity",
+    "increment_trial_eval_count_activity",
+    "update_key_state_activity",
+}
+
+EVAL_WORKFLOW_TYPES = {
+    "run-evaluation",
+}
+
+Attributes = dict[str, str | int | float | bool]
+
+
+def get_metric_meter(additional_attributes: Attributes | None = None) -> MetricMeter:
+    """Return a meter depending on in which context we are."""
+    if activity.in_activity():
+        meter = activity.metric_meter()
+    elif workflow.in_workflow():
+        meter = workflow.metric_meter()
+    else:
+        raise RuntimeError("Not within workflow or activity context")
+
+    if additional_attributes:
+        meter = meter.with_additional_attributes(additional_attributes)
+
+    return meter
+
+
+def increment_workflow_started() -> None:
+    """Track workflow starts."""
+    meter = get_metric_meter()
+    counter = meter.create_counter("llma_eval_workflow_started", "Number of eval workflows started")
+    counter.add(1)
+
+
+def increment_workflow_finished(status: str) -> None:
+    """Track workflow completions by outcome (completed/failed/skipped)."""
+    meter = get_metric_meter({"status": status})
+    counter = meter.create_counter("llma_eval_workflow_finished", "Number of eval workflows finished")
+    counter.add(1)
+
+
+def increment_verdict(verdict: str) -> None:
+    """Track verdict distribution (true/false/na/error)."""
+    meter = get_metric_meter({"verdict": verdict})
+    counter = meter.create_counter("llma_eval_verdict", "Verdict distribution")
+    counter.add(1)
+
+
+def increment_key_type(key_type: str) -> None:
+    """Track BYOK vs PostHog trial usage."""
+    meter = get_metric_meter({"key_type": key_type})
+    counter = meter.create_counter("llma_eval_key_type", "API key type usage")
+    counter.add(1)
+
+
+def increment_provider_model(provider: str, model: str) -> None:
+    """Track provider/model breakdown."""
+    meter = get_metric_meter({"provider": provider, "model": model})
+    counter = meter.create_counter("llma_eval_provider_model", "Provider and model usage")
+    counter.add(1)
+
+
+def increment_errors(error_type: str) -> None:
+    """Track error categorization."""
+    meter = get_metric_meter({"error_type": error_type})
+    counter = meter.create_counter("llma_eval_errors", "Error counts by type")
+    counter.add(1)
+
+
+def increment_tokens(token_type: str, count: int) -> None:
+    """Track token usage (input/output/total)."""
+    meter = get_metric_meter({"token_type": token_type})
+    counter = meter.create_counter("llma_eval_tokens", "Token usage")
+    counter.add(count)
+
+
+def record_schedule_to_start_latency(activity_type: str, latency_ms: int) -> None:
+    """Record queue depth indicator for alerting."""
+    meter = get_metric_meter({"activity_type": activity_type})
+    hist = meter.create_histogram_timedelta(
+        name="llma_eval_activity_schedule_to_start_latency",
+        description="Time between activity scheduling and start (queue depth indicator)",
+        unit="ms",
+    )
+    hist.record(dt.timedelta(milliseconds=latency_ms))
+
+
+class ExecutionTimeRecorder:
+    """Context manager to record execution time to a histogram metric."""
+
+    def __init__(
+        self,
+        histogram_name: str,
+        /,
+        description: str | None = None,
+        histogram_attributes: Attributes | None = None,
+        log: bool = False,
+    ) -> None:
+        self.histogram_name = histogram_name
+        self.description = description
+        self.histogram_attributes = histogram_attributes or {}
+        self.log = log
+        self._start_counter: float | None = None
+
+    def __enter__(self) -> typing.Self:
+        self._start_counter = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback) -> None:
+        if not self._start_counter:
+            raise RuntimeError("Start counter not initialized, did you call `__enter__`?")
+
+        end_counter = time.perf_counter()
+        delta_milli_seconds = int((end_counter - self._start_counter) * 1000)
+        delta = dt.timedelta(milliseconds=delta_milli_seconds)
+
+        attributes = dict(self.histogram_attributes)
+
+        if exc_value is not None:
+            attributes["status"] = "FAILED"
+            attributes["exception"] = str(exc_value)
+        else:
+            attributes["status"] = "COMPLETED"
+            attributes["exception"] = ""
+
+        meter = get_metric_meter(attributes)
+        hist = meter.create_histogram_timedelta(name=self.histogram_name, description=self.description, unit="ms")
+        try:
+            hist.record(value=delta)
+        except Exception:
+            LOGGER.exception("Failed to record execution time to histogram '%s'", self.histogram_name)
+
+        if self.log:
+            LOGGER.info(
+                "Finished %s with status '%s' in %dms",
+                self.histogram_name,
+                attributes["status"],
+                delta_milli_seconds,
+            )
+
+        self._start_counter = None
+
+
+class EvalsMetricsInterceptor(Interceptor):
+    """Interceptor to emit Prometheus metrics for evals workflows."""
+
+    def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
+        return _EvalsMetricsActivityInboundInterceptor(super().intercept_activity(next))
+
+    def workflow_interceptor_class(
+        self, input: WorkflowInterceptorClassInput
+    ) -> type[WorkflowInboundInterceptor] | None:
+        return _EvalsMetricsWorkflowInterceptor
+
+
+class _EvalsMetricsActivityInboundInterceptor(ActivityInboundInterceptor):
+    async def execute_activity(self, input: ExecuteActivityInput) -> typing.Any:
+        activity_info = activity.info()
+        activity_type = activity_info.activity_type
+
+        if activity_type not in EVAL_ACTIVITY_TYPES:
+            return await super().execute_activity(input)
+
+        # Record schedule-to-start latency (queue depth indicator)
+        scheduled_time = activity_info.scheduled_time
+        started_time = activity_info.started_time
+        if scheduled_time and started_time:
+            schedule_to_start_ms = int((started_time - scheduled_time).total_seconds() * 1000)
+            record_schedule_to_start_latency(activity_type, schedule_to_start_ms)
+
+        histogram_attributes: Attributes = {"activity_type": activity_type}
+
+        with ExecutionTimeRecorder(
+            "llma_eval_activity_execution_latency",
+            description="Execution latency for eval activities",
+            histogram_attributes=histogram_attributes,
+        ):
+            return await super().execute_activity(input)
+
+
+class _EvalsMetricsWorkflowInterceptor(WorkflowInboundInterceptor):
+    async def execute_workflow(self, input: ExecuteWorkflowInput) -> typing.Any:
+        workflow_info = workflow.info()
+        workflow_type = workflow_info.workflow_type
+
+        if workflow_type not in EVAL_WORKFLOW_TYPES:
+            return await super().execute_workflow(input)
+
+        increment_workflow_started()
+
+        with ExecutionTimeRecorder(
+            "llma_eval_workflow_execution_latency",
+            description="End-to-end workflow execution latency",
+        ):
+            status = "COMPLETED"
+            try:
+                result = await super().execute_workflow(input)
+
+                # Check if workflow was skipped
+                if isinstance(result, dict) and result.get("skipped"):
+                    status = "SKIPPED"
+                    increment_workflow_finished(status)
+                    return result
+
+                # Record verdict
+                if isinstance(result, dict):
+                    verdict = result.get("verdict")
+                    if verdict is True:
+                        increment_verdict("true")
+                    elif verdict is False:
+                        increment_verdict("false")
+                    elif verdict is None:
+                        # N/A case (applicable=false)
+                        increment_verdict("na")
+
+                increment_workflow_finished(status)
+                return result
+
+            except Exception:
+                status = "FAILED"
+                increment_workflow_finished(status)
+                increment_errors("workflow_exception")
+                raise

--- a/posthog/temporal/llm_analytics/metrics.py
+++ b/posthog/temporal/llm_analytics/metrics.py
@@ -146,12 +146,12 @@ class ExecutionTimeRecorder:
 
         attributes = dict(self.histogram_attributes)
 
-        if self._status_override is not None:
-            attributes["status"] = self._status_override
-            attributes["exception"] = ""
-        elif exc_value is not None:
+        if exc_value is not None:
             attributes["status"] = "FAILED"
             attributes["exception"] = str(exc_value)
+        elif self._status_override is not None:
+            attributes["status"] = self._status_override
+            attributes["exception"] = ""
         else:
             attributes["status"] = "COMPLETED"
             attributes["exception"] = ""

--- a/posthog/temporal/llm_analytics/metrics.py
+++ b/posthog/temporal/llm_analytics/metrics.py
@@ -84,7 +84,9 @@ def increment_provider_model(provider: str, model: str) -> None:
 
 
 def increment_errors(error_type: str) -> None:
-    """Track error categorization."""
+    """Track error categorization. Safe to call outside Temporal context (no-ops)."""
+    if not activity.in_activity() and not workflow.in_workflow():
+        return
     meter = get_metric_meter({"error_type": error_type})
     counter = meter.create_counter("llma_eval_errors", "Error counts by type")
     counter.add(1)

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -399,6 +399,9 @@ Output: {output_data}"""
             f"Model '{model}' not found.",
             non_retryable=True,
         )
+    except Exception:
+        increment_errors("unknown_error")
+        raise
 
     # Parse structured output
     result = response.parsed

--- a/posthog/temporal/llm_analytics/test_metrics.py
+++ b/posthog/temporal/llm_analytics/test_metrics.py
@@ -1,0 +1,96 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.temporal.llm_analytics.metrics import (
+    EVAL_ACTIVITY_TYPES,
+    EVAL_WORKFLOW_TYPES,
+    EvalsMetricsInterceptor,
+    ExecutionTimeRecorder,
+)
+
+
+class TestExecutionTimeRecorder:
+    def test_records_completed_status_on_success(self):
+        """Test that ExecutionTimeRecorder records completed status when no exception"""
+        mock_meter = MagicMock()
+        mock_hist = MagicMock()
+        mock_meter.create_histogram_timedelta.return_value = mock_hist
+
+        with patch("posthog.temporal.llm_analytics.metrics.get_metric_meter", return_value=mock_meter) as mock_get:
+            with ExecutionTimeRecorder("test_histogram"):
+                pass
+
+            call_args = mock_get.call_args[0][0]
+            assert call_args["status"] == "COMPLETED"
+            assert call_args["exception"] == ""
+
+    def test_records_failed_status_on_exception(self):
+        """Test that ExecutionTimeRecorder records failed status when exception raised"""
+        mock_meter = MagicMock()
+        mock_hist = MagicMock()
+        mock_meter.create_histogram_timedelta.return_value = mock_hist
+
+        with patch("posthog.temporal.llm_analytics.metrics.get_metric_meter", return_value=mock_meter) as mock_get:
+            with pytest.raises(ValueError):
+                with ExecutionTimeRecorder("test_histogram"):
+                    raise ValueError("test error")
+
+            call_args = mock_get.call_args[0][0]
+            assert call_args["status"] == "FAILED"
+            assert call_args["exception"] == "test error"
+
+    def test_raises_if_not_entered(self):
+        """Test that __exit__ raises if __enter__ was not called"""
+        recorder = ExecutionTimeRecorder("test_histogram")
+        with pytest.raises(RuntimeError, match="Start counter not initialized"):
+            recorder.__exit__(None, None, None)
+
+    def test_includes_histogram_attributes(self):
+        """Test that additional histogram attributes are included"""
+        mock_meter = MagicMock()
+        mock_hist = MagicMock()
+        mock_meter.create_histogram_timedelta.return_value = mock_hist
+
+        with patch("posthog.temporal.llm_analytics.metrics.get_metric_meter", return_value=mock_meter) as mock_get:
+            with ExecutionTimeRecorder("test_histogram", histogram_attributes={"activity_type": "test_activity"}):
+                pass
+
+            call_args = mock_get.call_args[0][0]
+            assert call_args["activity_type"] == "test_activity"
+            assert call_args["status"] == "COMPLETED"
+            assert call_args["exception"] == ""
+
+
+class TestEvalsMetricsInterceptor:
+    def test_interceptor_creates_activity_interceptor(self):
+        """Test that the interceptor creates an activity interceptor"""
+        interceptor = EvalsMetricsInterceptor()
+        mock_next = MagicMock()
+        result = interceptor.intercept_activity(mock_next)
+        assert result is not None
+
+    def test_interceptor_returns_workflow_interceptor_class(self):
+        """Test that the interceptor returns a workflow interceptor class"""
+        interceptor = EvalsMetricsInterceptor()
+        mock_input = MagicMock()
+        result = interceptor.workflow_interceptor_class(mock_input)
+        assert result is not None
+
+
+class TestActivityTypes:
+    def test_eval_activity_types_contains_expected_activities(self):
+        """Test that EVAL_ACTIVITY_TYPES contains the expected activities"""
+        expected = {
+            "fetch_evaluation_activity",
+            "execute_llm_judge_activity",
+            "emit_evaluation_event_activity",
+            "emit_internal_telemetry_activity",
+            "increment_trial_eval_count_activity",
+            "update_key_state_activity",
+        }
+        assert EVAL_ACTIVITY_TYPES == expected
+
+    def test_eval_workflow_types_contains_expected_workflows(self):
+        """Test that EVAL_WORKFLOW_TYPES contains the expected workflows"""
+        expected = {"run-evaluation"}
+        assert EVAL_WORKFLOW_TYPES == expected

--- a/posthog/temporal/llm_analytics/test_metrics.py
+++ b/posthog/temporal/llm_analytics/test_metrics.py
@@ -60,6 +60,20 @@ class TestExecutionTimeRecorder:
             assert call_args["status"] == "COMPLETED"
             assert call_args["exception"] == ""
 
+    def test_set_status_overrides_default(self):
+        """Test that set_status overrides the default COMPLETED status"""
+        mock_meter = MagicMock()
+        mock_hist = MagicMock()
+        mock_meter.create_histogram_timedelta.return_value = mock_hist
+
+        with patch("posthog.temporal.llm_analytics.metrics.get_metric_meter", return_value=mock_meter) as mock_get:
+            with ExecutionTimeRecorder("test_histogram") as recorder:
+                recorder.set_status("SKIPPED")
+
+            call_args = mock_get.call_args[0][0]
+            assert call_args["status"] == "SKIPPED"
+            assert call_args["exception"] == ""
+
 
 class TestEvalsMetricsInterceptor:
     def test_interceptor_creates_activity_interceptor(self):


### PR DESCRIPTION
Improves observability over evals executions. Follows the same patterns as other temporal jobs. 