### PR TITLE
fix(migrations): add tls support for sqlx

### DIFF
--- a/rust/Dockerfile.sqlx-migrate
+++ b/rust/Dockerfile.sqlx-migrate
@@ -2,7 +2,7 @@
 # Supports persons, behavioral cohorts, cyclotron migrations
 FROM rust:1.91-bookworm AS builder
 
-RUN cargo install sqlx-cli --version 0.8.0 --features postgres --no-default-features --locked
+RUN cargo install sqlx-cli --version 0.8.0 --features native-tls,postgres --no-default-features --locked
 
 FROM debian:bookworm-slim
 
@@ -11,6 +11,7 @@ RUN apt-get update && \
     ca-certificates \
     libpq5 \
     postgresql-client \
+    libssl3 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

We want to run sqlx migrations against a database that requires a TLS connection
Right now this fails with
```
error occurred while attempting to establish a TLS connection: TLS upgrade required by connect options but SQLx was built without TLS support enabled
```

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- enable native-tls as mentioned in [their docs](https://github.com/launchbadge/sqlx/tree/main/sqlx-cli)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
