### PR TITLE
fix(llma): eval timeout alignment

### DIFF
--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -16,6 +16,7 @@ from posthog.models.event.util import create_event
 from posthog.models.team import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.heartbeat_sync import HeartbeaterSync
 from posthog.temporal.llm_analytics.message_utils import extract_text_from_messages
 
 from products.llm_analytics.backend.llm import Client, CompletionRequest
@@ -34,6 +35,14 @@ logger = structlog.get_logger(__name__)
 
 # Default model for LLM judge
 DEFAULT_JUDGE_MODEL = "gpt-5-mini"
+
+# Retry policy for LLM judge activity with exponential backoff to prevent amplifying load during outages
+LLM_JUDGE_RETRY_POLICY = RetryPolicy(
+    maximum_attempts=3,
+    initial_interval=timedelta(seconds=10),
+    maximum_interval=timedelta(seconds=60),
+    backoff_coefficient=2.0,
+)
 
 
 class BooleanEvalResult(BaseModel):
@@ -335,18 +344,17 @@ Output: {output_data}"""
     )
 
     try:
-        # Signal that we're about to make a potentially long-running LLM call
-        if temporalio.activity.in_activity():
-            temporalio.activity.heartbeat("starting LLM judge call")
-        response = client.complete(
-            CompletionRequest(
-                model=model,
-                system=system_prompt,
-                messages=[{"role": "user", "content": user_prompt}],
-                provider=provider,
-                response_format=response_format,
+        # HeartbeaterSync sends periodic heartbeats during the potentially long-running LLM call
+        with HeartbeaterSync(details=("llm_judge", evaluation["id"])):
+            response = client.complete(
+                CompletionRequest(
+                    model=model,
+                    system=system_prompt,
+                    messages=[{"role": "user", "content": user_prompt}],
+                    provider=provider,
+                    response_format=response_format,
+                )
             )
-        )
     except AuthenticationError:
         if is_byok:
             raise ApplicationError(
@@ -542,8 +550,9 @@ class RunEvaluationWorkflow(PostHogWorkflow):
             result = await temporalio.workflow.execute_activity(
                 execute_llm_judge_activity,
                 args=[evaluation, inputs.event_data],
-                schedule_to_close_timeout=timedelta(minutes=2),
-                retry_policy=RetryPolicy(maximum_attempts=3),
+                schedule_to_close_timeout=timedelta(minutes=6),  # > SDK timeout (300s) to allow graceful handling
+                heartbeat_timeout=timedelta(seconds=60),
+                retry_policy=LLM_JUDGE_RETRY_POLICY,
             )
         except temporalio.exceptions.ActivityError as e:
             if isinstance(e.cause, ApplicationError) and e.cause.details:

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -112,8 +112,18 @@ class TestRunEvaluationWorkflow:
             },
         )
 
+        mock_heartbeater = MagicMock()
+        mock_heartbeater.__enter__ = MagicMock(return_value=mock_heartbeater)
+        mock_heartbeater.__exit__ = MagicMock(return_value=False)
+
         # Mock unified Client response
-        with patch("posthog.temporal.llm_analytics.run_evaluation.Client") as mock_client_class:
+        with (
+            patch(
+                "posthog.temporal.llm_analytics.run_evaluation.HeartbeaterSync",
+                MagicMock(return_value=mock_heartbeater),
+            ),
+            patch("posthog.temporal.llm_analytics.run_evaluation.Client") as mock_client_class,
+        ):
             mock_client = MagicMock()
             mock_client_class.return_value = mock_client
 
@@ -196,7 +206,17 @@ class TestRunEvaluationWorkflow:
             },
         )
 
-        with patch("posthog.temporal.llm_analytics.run_evaluation.Client") as mock_client_class:
+        mock_heartbeater = MagicMock()
+        mock_heartbeater.__enter__ = MagicMock(return_value=mock_heartbeater)
+        mock_heartbeater.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(
+                "posthog.temporal.llm_analytics.run_evaluation.HeartbeaterSync",
+                MagicMock(return_value=mock_heartbeater),
+            ),
+            patch("posthog.temporal.llm_analytics.run_evaluation.Client") as mock_client_class,
+        ):
             mock_client = MagicMock()
             mock_client_class.return_value = mock_client
 
@@ -239,7 +259,17 @@ class TestRunEvaluationWorkflow:
             },
         )
 
-        with patch("posthog.temporal.llm_analytics.run_evaluation.Client") as mock_client_class:
+        mock_heartbeater = MagicMock()
+        mock_heartbeater.__enter__ = MagicMock(return_value=mock_heartbeater)
+        mock_heartbeater.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(
+                "posthog.temporal.llm_analytics.run_evaluation.HeartbeaterSync",
+                MagicMock(return_value=mock_heartbeater),
+            ),
+            patch("posthog.temporal.llm_analytics.run_evaluation.Client") as mock_client_class,
+        ):
             mock_client = MagicMock()
             mock_client_class.return_value = mock_client
 
@@ -373,7 +403,17 @@ class TestRunEvaluationWorkflow:
             },
         )
 
-        with patch("posthog.temporal.llm_analytics.run_evaluation.Client") as mock_client_class:
+        mock_heartbeater = MagicMock()
+        mock_heartbeater.__enter__ = MagicMock(return_value=mock_heartbeater)
+        mock_heartbeater.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(
+                "posthog.temporal.llm_analytics.run_evaluation.HeartbeaterSync",
+                MagicMock(return_value=mock_heartbeater),
+            ),
+            patch("posthog.temporal.llm_analytics.run_evaluation.Client") as mock_client_class,
+        ):
             mock_client = MagicMock()
             mock_client_class.return_value = mock_client
 

--- a/products/llm_analytics/backend/llm/providers/openai.py
+++ b/products/llm_analytics/backend/llm/providers/openai.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 class OpenAIConfig:
     REASONING_EFFORT: ReasoningEffort = "medium"
     TEMPERATURE: float = 0
+    TIMEOUT: float = 300.0
 
     SUPPORTED_MODELS: list[str] = [
         "gpt-4.1",
@@ -85,9 +86,14 @@ class OpenAIAdapter:
                 api_key=effective_api_key,
                 posthog_client=posthog_client,
                 base_url=settings.OPENAI_BASE_URL,
+                timeout=OpenAIConfig.TIMEOUT,
             )
         else:
-            client = openai.OpenAI(api_key=effective_api_key, base_url=settings.OPENAI_BASE_URL)
+            client = openai.OpenAI(
+                api_key=effective_api_key,
+                base_url=settings.OPENAI_BASE_URL,
+                timeout=OpenAIConfig.TIMEOUT,
+            )
 
         messages: Any = self._build_messages(request)
 
@@ -210,9 +216,14 @@ Return ONLY the JSON object, no other text or markdown formatting."""
                 api_key=effective_api_key,
                 posthog_client=posthog_client,
                 base_url=settings.OPENAI_BASE_URL,
+                timeout=OpenAIConfig.TIMEOUT,
             )
         else:
-            client = openai.OpenAI(api_key=effective_api_key, base_url=settings.OPENAI_BASE_URL)
+            client = openai.OpenAI(
+                api_key=effective_api_key,
+                base_url=settings.OPENAI_BASE_URL,
+                timeout=OpenAIConfig.TIMEOUT,
+            )
 
         supports_reasoning = model_id in OpenAIConfig.SUPPORTED_MODELS_WITH_THINKING
         reasoning_on = supports_reasoning and (request.thinking or bool(request.reasoning_level))
@@ -302,7 +313,7 @@ Return ONLY the JSON object, no other text or markdown formatting."""
         if not api_key.startswith(("sk-", "sk-proj-")):
             return (LLMProviderKey.State.INVALID, "Invalid key format (should start with 'sk-' or 'sk-proj-')")
         try:
-            client = openai.OpenAI(api_key=api_key)
+            client = openai.OpenAI(api_key=api_key, timeout=OpenAIConfig.TIMEOUT)
             client.models.list()
             return (LLMProviderKey.State.OK, None)
         except openai.AuthenticationError:
@@ -320,7 +331,7 @@ Return ONLY the JSON object, no other text or markdown formatting."""
         """List available OpenAI models."""
         if api_key:
             try:
-                client = openai.OpenAI(api_key=api_key)
+                client = openai.OpenAI(api_key=api_key, timeout=OpenAIConfig.TIMEOUT)
                 all_models = [m.id for m in client.models.list()]
                 return [
                     m

--- a/products/llm_analytics/backend/providers/test/test_openai.py
+++ b/products/llm_analytics/backend/providers/test/test_openai.py
@@ -11,6 +11,12 @@ class TestOpenAIConfig(SimpleTestCase):
     def test_default_temperature(self):
         assert OpenAIConfig.TEMPERATURE == 0
 
+    def test_timeout_below_activity_timeout(self):
+        # SDK timeout (300s) must be less than activity timeout (360s) to allow graceful error handling
+        activity_timeout_seconds = 360
+        assert OpenAIConfig.TIMEOUT < activity_timeout_seconds
+        assert OpenAIConfig.TIMEOUT == 300.0
+
     def test_supported_models_include_expected(self):
         expected_models = [
             "gpt-4o",


### PR DESCRIPTION
Ensures that Temporal jobs for evals time out in applicaiton code before they time out in Temporal code (i.e. aligns timeout values for LLM SDKs and the Temporal SDK).