### PR TITLE
feat(llma): add dedicated llm-analytics task queue

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -445,6 +445,32 @@ jobs:
                         "timestamp": "${{ github.event.head_commit.timestamp }}"
                       }
 
+            - name: Check for changes that affect llm analytics temporal worker
+              id: check_changes_llm_analytics_temporal_worker
+              run: |
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/llm_analytics|^products/llm_analytics|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+
+            - name: Trigger LLM Analytics Temporal Worker Cloud deployment
+              if: steps.check_changes_llm_analytics_temporal_worker.outputs.changed == 'true'
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repository: PostHog/charts
+                  event-type: commit_state_update
+                  client-payload: |
+                      {
+                        "values": {
+                          "image": {
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
+                          }
+                        },
+                        "release": "temporal-worker-llm-analytics",
+                        "commit": ${{ toJson(github.event.head_commit) }},
+                        "repository": ${{ toJson(github.repository) }},
+                        "labels": ${{ steps.labels.outputs.labels }},
+                        "timestamp": "${{ github.event.head_commit.timestamp }}"
+                      }
+
             - name: Trigger Messaging Temporal Worker Cloud deployment
               if: steps.check_changes_messaging_temporal_worker.outputs.changed == 'true'
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -243,6 +243,11 @@ _task_queue_specs = [
         LLM_ANALYTICS_EVAL_WORKFLOWS,
         LLM_ANALYTICS_EVAL_ACTIVITIES,
     ),
+    (
+        settings.LLMA_TASK_QUEUE,
+        LLM_ANALYTICS_WORKFLOWS,
+        LLM_ANALYTICS_ACTIVITIES,
+    ),
 ]
 
 # Note: When running locally, many task queues resolve to the same queue name.

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -76,3 +76,4 @@ ANALYTICS_PLATFORM_TASK_QUEUE = _set_temporal_task_queue("analytics-platform-tas
 SESSION_REPLAY_TASK_QUEUE = _set_temporal_task_queue("session-replay-task-queue")
 WEEKLY_DIGEST_TASK_QUEUE = _set_temporal_task_queue("weekly-digest-task-queue")
 LLMA_EVALS_TASK_QUEUE = _set_temporal_task_queue("llm-analytics-evals-task-queue")
+LLMA_TASK_QUEUE = _set_temporal_task_queue("llm-analytics-task-queue")


### PR DESCRIPTION
## Problem

LLM Analytics summarization and clustering workflows run on the general-purpose Temporal queue, making it difficult to scale and monitor independently.

## Changes

- Add `LLMA_TASK_QUEUE` setting for the new `llm-analytics-task-queue`
- Register the new queue in `start_temporal_worker.py` with LLM Analytics workflows/activities
- Add CD workflow trigger to deploy the new worker

Note: Schedules remain on general-purpose queue. Switch traffic in #46151 after workers are verified healthy.

## How did you test this code?

- Verified queue definition resolves correctly in settings
- Code review of worker registration matches existing patterns
- Local worker can be started with: `DEBUG=1 python ./manage.py start_temporal_worker --task-queue "llm-analytics-task-queue"`

## Publish to changelog?

No