### PR TITLE
feat(temporal): switch llm-analytics schedules to dedicated queue

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -445,6 +445,32 @@ jobs:
                         "timestamp": "${{ github.event.head_commit.timestamp }}"
                       }
 
+            - name: Check for changes that affect llm analytics temporal worker
+              id: check_changes_llm_analytics_temporal_worker
+              run: |
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/llm_analytics|^products/llm_analytics|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+
+            - name: Trigger LLM Analytics Temporal Worker Cloud deployment
+              if: steps.check_changes_llm_analytics_temporal_worker.outputs.changed == 'true'
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repository: PostHog/charts
+                  event-type: commit_state_update
+                  client-payload: |
+                      {
+                        "values": {
+                          "image": {
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
+                          }
+                        },
+                        "release": "temporal-worker-llm-analytics",
+                        "commit": ${{ toJson(github.event.head_commit) }},
+                        "repository": ${{ toJson(github.repository) }},
+                        "labels": ${{ steps.labels.outputs.labels }},
+                        "timestamp": "${{ github.event.head_commit.timestamp }}"
+                      }
+
             - name: Trigger Messaging Temporal Worker Cloud deployment
               if: steps.check_changes_messaging_temporal_worker.outputs.changed == 'true'
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -243,6 +243,11 @@ _task_queue_specs = [
         LLM_ANALYTICS_EVAL_WORKFLOWS,
         LLM_ANALYTICS_EVAL_ACTIVITIES,
     ),
+    (
+        settings.LLMA_TASK_QUEUE,
+        LLM_ANALYTICS_WORKFLOWS,
+        LLM_ANALYTICS_ACTIVITIES,
+    ),
 ]
 
 # Note: When running locally, many task queues resolve to the same queue name.

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -76,3 +76,4 @@ ANALYTICS_PLATFORM_TASK_QUEUE = _set_temporal_task_queue("analytics-platform-tas
 SESSION_REPLAY_TASK_QUEUE = _set_temporal_task_queue("session-replay-task-queue")
 WEEKLY_DIGEST_TASK_QUEUE = _set_temporal_task_queue("weekly-digest-task-queue")
 LLMA_EVALS_TASK_QUEUE = _set_temporal_task_queue("llm-analytics-evals-task-queue")
+LLMA_TASK_QUEUE = _set_temporal_task_queue("llm-analytics-task-queue")

--- a/posthog/temporal/llm_analytics/trace_clustering/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/schedule.py
@@ -37,7 +37,7 @@ async def create_trace_clustering_coordinator_schedule(client: Client):
                 max_k=DEFAULT_MAX_K,
             ),
             id=COORDINATOR_SCHEDULE_ID,
-            task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
+            task_queue=settings.LLMA_TASK_QUEUE,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(days=1))]),
     )
@@ -82,7 +82,7 @@ async def create_generation_clustering_coordinator_schedule(client: Client):
                 max_k=DEFAULT_MAX_K,
             ),
             id=GENERATION_COORDINATOR_SCHEDULE_ID,
-            task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
+            task_queue=settings.LLMA_TASK_QUEUE,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(days=1))]),
     )

--- a/posthog/temporal/llm_analytics/trace_summarization/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/schedule.py
@@ -37,7 +37,7 @@ async def create_batch_trace_summarization_schedule(client: Client):
                 window_minutes=DEFAULT_WINDOW_MINUTES,
             ),
             id=COORDINATOR_SCHEDULE_ID,
-            task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
+            task_queue=settings.LLMA_TASK_QUEUE,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(hours=SCHEDULE_INTERVAL_HOURS))]),
     )
@@ -71,7 +71,7 @@ async def create_batch_generation_summarization_schedule(client: Client):
                 window_minutes=DEFAULT_WINDOW_MINUTES,
             ),
             id=GENERATION_COORDINATOR_SCHEDULE_ID,
-            task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
+            task_queue=settings.LLMA_TASK_QUEUE,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(hours=SCHEDULE_INTERVAL_HOURS))]),
     )


### PR DESCRIPTION
## Problem

LLM Analytics workflows need to be switched from the general-purpose queue to the dedicated llm-analytics-task-queue.

Depends on #46149

## Changes

- Update trace summarization schedule to use `LLMA_TASK_QUEUE`
- Update trace clustering schedule to use `LLMA_TASK_QUEUE`

## How did you test this code?

This is a configuration change. Verification:
1. Confirm workers from #46149 are deployed and healthy
2. Check Temporal Cloud for workflows on `llm-analytics-task-queue`
3. Monitor for any increase in general-purpose queue latency

## Pre-merge checklist

- [x] PR #46149 merged and deployed
- [x] Charts PR PostHog/charts#8088 merged and synced
- [ ] Workers verified healthy in dev environment
- [ ] Workers verified healthy in prod-us and prod-eu

## Publish to changelog?

No