### PR TITLE
feat(approvals): extend approvals with bypass roles and org lvl

### DIFF
--- a/frontend/src/scenes/approvals/ApprovalDetail.tsx
+++ b/frontend/src/scenes/approvals/ApprovalDetail.tsx
@@ -352,6 +352,8 @@ interface PolicySnapshot {
     users?: number[]
     roles?: string[]
     allow_self_approve?: boolean
+    bypass_org_membership_levels?: string[]
+    bypass_roles?: string[]
     conditions?: {
         type?: string
         field?: string

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -674,6 +674,27 @@ export const SETTINGS_MAP: SettingSection[] = [
     },
     {
         level: 'environment',
+        id: 'environment-approvals',
+        title: 'Approvals',
+        flag: 'APPROVALS',
+        minimumAccessLevel: OrganizationMembershipLevel.Admin,
+        settings: [
+            {
+                id: 'approval-policies',
+                title: 'Policies',
+                description: 'Configure which actions require approval before being applied',
+                component: <ApprovalPolicies />,
+            },
+            {
+                id: 'change-requests',
+                title: 'Change requests',
+                description: 'Review and approve pending change requests',
+                component: <ChangeRequestsList />,
+            },
+        ],
+    },
+    {
+        level: 'environment',
         id: 'environment-discussions',
         title: 'Discussions',
         settings: [
@@ -878,27 +899,6 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'organization-security',
                 title: 'Security settings',
                 component: <OrganizationSecuritySettings />,
-            },
-        ],
-    },
-    {
-        level: 'organization',
-        id: 'organization-approvals',
-        title: 'Approvals',
-        flag: 'APPROVALS',
-        minimumAccessLevel: OrganizationMembershipLevel.Admin,
-        settings: [
-            {
-                id: 'approval-policies',
-                title: 'Policies',
-                description: 'Configure which actions require approval before being applied',
-                component: <ApprovalPolicies />,
-            },
-            {
-                id: 'change-requests',
-                title: 'Change requests',
-                description: 'Review and approve pending change requests',
-                component: <ChangeRequestsList />,
             },
         ],
     },

--- a/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
@@ -261,6 +261,8 @@ function ApprovalPolicyModal({ policy, onClose }: { policy?: ApprovalPolicy; onC
             },
             allow_self_approve: allowSelfApprove,
             conditions,
+            bypass_org_membership_levels: [],
+            bypass_roles: [],
             enabled: true,
         }
 

--- a/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
@@ -187,6 +187,10 @@ function ApprovalPolicyModal({ policy, onClose }: { policy?: ApprovalPolicy; onC
     const [allowSelfApprove, setAllowSelfApprove] = useState(policy?.allow_self_approve || false)
     const [approverUserIds, setApproverUserIds] = useState<number[]>(policy?.approver_config?.users || [])
     const [approverRoleIds, setApproverRoleIds] = useState<string[]>(policy?.approver_config?.roles || [])
+    const [bypassAdminsOwners, setBypassAdminsOwners] = useState(
+        (policy?.bypass_org_membership_levels?.length ?? 0) > 0
+    )
+    const [bypassRoleIds, setBypassRoleIds] = useState<string[]>(policy?.bypass_roles || [])
 
     // Parse existing conditions into rules
     const parseExistingConditions = (): ConditionRule[] => {
@@ -261,8 +265,8 @@ function ApprovalPolicyModal({ policy, onClose }: { policy?: ApprovalPolicy; onC
             },
             allow_self_approve: allowSelfApprove,
             conditions,
-            bypass_org_membership_levels: [],
-            bypass_roles: [],
+            bypass_org_membership_levels: bypassAdminsOwners ? ['8', '15'] : [],
+            bypass_roles: bypassRoleIds,
             enabled: true,
         }
 
@@ -426,6 +430,42 @@ function ApprovalPolicyModal({ policy, onClose }: { policy?: ApprovalPolicy; onC
                             </div>
                         }
                     />
+                </div>
+
+                <div className="border-t pt-4 mt-4">
+                    <label className="block text-sm font-medium mb-2">Bypass options</label>
+                    <p className="text-xs text-secondary mb-3">
+                        Users matching these criteria can skip the approval flow entirely
+                    </p>
+
+                    <div className="space-y-3">
+                        <LemonSwitch
+                            checked={bypassAdminsOwners}
+                            onChange={setBypassAdminsOwners}
+                            label={
+                                <div className="flex items-center gap-2">
+                                    <span>Allow org admins and owners to bypass</span>
+                                    <Tooltip title="Organization admins and owners can perform this action without requiring approval">
+                                        <IconInfo className="text-muted-alt w-4 h-4" />
+                                    </Tooltip>
+                                </div>
+                            }
+                        />
+
+                        <div>
+                            <label className="block text-sm font-medium mb-1">Bypass roles</label>
+                            <LemonInputSelect
+                                mode="multiple"
+                                value={bypassRoleIds}
+                                onChange={setBypassRoleIds}
+                                options={roleOptions}
+                                placeholder="Select roles that can bypass approval"
+                            />
+                            <p className="text-xs text-secondary mt-1">
+                                Users with any of these roles can skip the approval flow
+                            </p>
+                        </div>
+                    </div>
                 </div>
             </div>
         </LemonModal>

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -50,7 +50,7 @@ export type SettingSectionId =
     | 'organization-authentication'
     | 'organization-proxy'
     | 'organization-security'
-    | 'organization-approvals'
+    | 'environment-approvals'
     | 'organization-danger-zone'
     | 'organization-billing'
     | 'organization-startup-program'

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -218,7 +218,7 @@ export const urls = {
     productTour: (id: string, params?: string): string =>
         `/product_tours/${id}${params ? `?${params.startsWith('?') ? params.slice(1) : params}` : ''}`,
     organizationDeactivated: (): string => '/organization-deactivated',
-    approvals: (): string => '/settings/organization-approvals#change-requests',
+    approvals: (): string => '/settings/environment-approvals#change-requests',
     approval: (id: string): string => `/approvals/${id}`,
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6681,6 +6681,8 @@ export interface ApprovalPolicy {
     conditions: Record<string, any>
     approver_config: Record<string, any>
     allow_self_approve: boolean
+    bypass_org_membership_levels: string[]
+    bypass_roles: string[]
     expires_after: string
     enabled: boolean
     created_by: UserBasicType

--- a/posthog/approvals/models.py
+++ b/posthog/approvals/models.py
@@ -5,7 +5,11 @@ from django.db import models
 
 from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDModel
 
-from ee.models.rbac.role import Role, RoleMembership
+try:
+    from ee.models.rbac.role import Role, RoleMembership
+except ImportError:
+    Role = None  # type: ignore
+    RoleMembership = None  # type: ignore
 
 if TYPE_CHECKING:
     from posthog.approvals.actions.base import BaseAction

--- a/posthog/approvals/policies.py
+++ b/posthog/approvals/policies.py
@@ -293,13 +293,13 @@ class PolicyEngine:
 
         # Check bypass_roles (RBAC roles)
         if bypass_role_ids:
-            user_role_ids = set(
+            user_role_ids = {
                 str(rid)
                 for rid in RoleMembership.objects.filter(
                     user=actor,
                     role__organization=org,
                 ).values_list("role_id", flat=True)
-            )
+            }
             if user_role_ids & set(bypass_role_ids):
                 return True
 

--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -3,7 +3,10 @@ from rest_framework import serializers
 from posthog.api.shared import UserBasicSerializer
 from posthog.approvals.models import Approval, ApprovalPolicy, ChangeRequest
 
-from ee.models.rbac.role import Role
+try:
+    from ee.models.rbac.role import Role
+except ImportError:
+    Role = None  # type: ignore
 
 
 class ChangeRequestSerializer(serializers.ModelSerializer):

--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from posthog.api.shared import UserBasicSerializer
 from posthog.approvals.models import Approval, ApprovalPolicy, ChangeRequest
 
-from ee.models.rbac.role import Role, RoleMembership
+from ee.models.rbac.role import Role
 
 
 class ChangeRequestSerializer(serializers.ModelSerializer):

--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -3,6 +3,8 @@ from rest_framework import serializers
 from posthog.api.shared import UserBasicSerializer
 from posthog.approvals.models import Approval, ApprovalPolicy, ChangeRequest
 
+from ee.models.rbac.role import Role, RoleMembership
+
 
 class ChangeRequestSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
@@ -156,8 +158,16 @@ class ApprovalSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "created_by", "created_at"]
 
 
+class BypassRolesField(serializers.ListField):
+    child = serializers.UUIDField()
+
+    def to_representation(self, value):
+        return [str(role.id) for role in value.all()]
+
+
 class ApprovalPolicySerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
+    bypass_roles = BypassRolesField(required=False, default=list)
 
     class Meta:
         model = ApprovalPolicy
@@ -167,6 +177,8 @@ class ApprovalPolicySerializer(serializers.ModelSerializer):
             "conditions",
             "approver_config",
             "allow_self_approve",
+            "bypass_org_membership_levels",
+            "bypass_roles",
             "expires_after",
             "enabled",
             "created_by",
@@ -174,3 +186,45 @@ class ApprovalPolicySerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = ["id", "created_by", "created_at", "updated_at"]
+
+    def validate_bypass_roles(self, value):
+        if not value:
+            return value
+
+        if self.instance:
+            # Update: get organization from existing policy
+            organization_id = self.instance.organization_id
+        else:
+            # Create: get organization from view
+            organization_id = self.context["view"].organization.id
+
+        roles = Role.objects.filter(id__in=value)
+
+        # Check all submitted IDs exist
+        found_ids = {str(r.id) for r in roles}
+        submitted_ids = {str(v) for v in value}
+        missing_ids = submitted_ids - found_ids
+        if missing_ids:
+            raise serializers.ValidationError(f"Roles do not exist: {', '.join(missing_ids)}")
+
+        # Check all roles belong to the correct organization
+        invalid_roles = [r for r in roles if r.organization_id != organization_id]
+        if invalid_roles:
+            invalid_names = [r.name for r in invalid_roles]
+            raise serializers.ValidationError(f"Roles must belong to the same organization: {', '.join(invalid_names)}")
+
+        return value
+
+    def create(self, validated_data):
+        bypass_role_ids = validated_data.pop("bypass_roles", [])
+        instance = super().create(validated_data)
+        if bypass_role_ids:
+            instance.set_bypass_roles([str(rid) for rid in bypass_role_ids])
+        return instance
+
+    def update(self, instance, validated_data):
+        bypass_role_ids = validated_data.pop("bypass_roles", None)
+        instance = super().update(instance, validated_data)
+        if bypass_role_ids is not None:
+            instance.set_bypass_roles([str(rid) for rid in bypass_role_ids])
+        return instance

--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -3,11 +3,6 @@ from rest_framework import serializers
 from posthog.api.shared import UserBasicSerializer
 from posthog.approvals.models import Approval, ApprovalPolicy, ChangeRequest
 
-try:
-    from ee.models.rbac.role import Role
-except ImportError:
-    Role = None  # type: ignore
-
 
 class ChangeRequestSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
@@ -193,6 +188,11 @@ class ApprovalPolicySerializer(serializers.ModelSerializer):
     def validate_bypass_roles(self, value):
         if not value:
             return value
+
+        try:
+            from ee.models.rbac.role import Role
+        except ImportError:
+            raise serializers.ValidationError("RBAC roles are not available")
 
         if self.instance:
             # Update: get organization from existing policy

--- a/posthog/approvals/tests/test_policy_engine.py
+++ b/posthog/approvals/tests/test_policy_engine.py
@@ -1,0 +1,344 @@
+from posthog.test.base import APIBaseTest
+
+from parameterized import parameterized
+
+from posthog.approvals.models import ApprovalPolicy
+from posthog.approvals.policies import PolicyEngine
+from posthog.models.organization import OrganizationMembership
+
+
+class TestPolicyEngineBypass(APIBaseTest):
+    def _create_policy(
+        self,
+        bypass_org_membership_levels: list[str] | None = None,
+        bypass_role_ids: list[str] | None = None,
+    ) -> ApprovalPolicy:
+        policy = ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=self.team,
+            action_key="feature_flag.update",
+            conditions={},
+            approver_config={"quorum": 1, "users": [self.user.id]},
+            bypass_org_membership_levels=bypass_org_membership_levels or [],
+            created_by=self.user,
+        )
+        if bypass_role_ids:
+            policy.set_bypass_roles(bypass_role_ids)
+        return policy
+
+    @parameterized.expand(
+        [
+            (OrganizationMembership.Level.ADMIN, ["8", "15"], True),
+            (OrganizationMembership.Level.OWNER, ["8", "15"], True),
+            (OrganizationMembership.Level.MEMBER, ["8", "15"], False),
+            (OrganizationMembership.Level.ADMIN, ["15"], False),
+            (OrganizationMembership.Level.OWNER, ["15"], True),
+            (OrganizationMembership.Level.ADMIN, [], False),
+        ]
+    )
+    def test_bypass_org_membership_levels(
+        self,
+        user_level: int,
+        bypass_levels: list[str],
+        expected_bypass: bool,
+    ):
+        self.organization_membership.level = user_level
+        self.organization_membership.save()
+
+        policy = self._create_policy(bypass_org_membership_levels=bypass_levels)
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        bypass_role_ids = [str(r.id) for r in policy.bypass_roles.all()]
+
+        result = engine._has_bypass(self.user, policy, bypass_role_ids, context)
+
+        assert result is expected_bypass
+
+    def test_bypass_rbac_role(self):
+        from ee.models.rbac.role import Role, RoleMembership
+
+        role = Role.objects.create(
+            organization=self.organization,
+            name="Approver Role",
+        )
+        RoleMembership.objects.create(user=self.user, role=role)
+
+        policy = self._create_policy(bypass_role_ids=[str(role.id)])
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        bypass_role_ids = [str(r.id) for r in policy.bypass_roles.all()]
+
+        result = engine._has_bypass(self.user, policy, bypass_role_ids, context)
+
+        assert result is True
+
+    def test_bypass_rbac_role_user_not_in_role(self):
+        from ee.models.rbac.role import Role
+
+        role = Role.objects.create(
+            organization=self.organization,
+            name="Approver Role",
+        )
+
+        policy = self._create_policy(bypass_role_ids=[str(role.id)])
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        bypass_role_ids = [str(r.id) for r in policy.bypass_roles.all()]
+
+        result = engine._has_bypass(self.user, policy, bypass_role_ids, context)
+
+        assert result is False
+
+    def test_bypass_rbac_role_user_has_other_org_role_but_not_bypass_role(self):
+        from posthog.models.organization import Organization
+
+        from ee.models.rbac.role import Role, RoleMembership
+
+        other_org = Organization.objects.create(name="Other Org")
+        other_role = Role.objects.create(
+            organization=other_org,
+            name="Other Org Role",
+        )
+        RoleMembership.objects.create(user=self.user, role=other_role)
+
+        bypass_role = Role.objects.create(
+            organization=self.organization,
+            name="Bypass Role",
+        )
+
+        policy = self._create_policy(bypass_role_ids=[str(bypass_role.id)])
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        bypass_role_ids = [str(r.id) for r in policy.bypass_roles.all()]
+
+        result = engine._has_bypass(self.user, policy, bypass_role_ids, context)
+
+        assert result is False
+
+    def test_no_bypass_when_both_empty(self):
+        policy = self._create_policy(bypass_org_membership_levels=[], bypass_role_ids=[])
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        bypass_role_ids = [str(r.id) for r in policy.bypass_roles.all()]
+
+        result = engine._has_bypass(self.user, policy, bypass_role_ids, context)
+
+        assert result is False
+
+    def test_no_bypass_without_organization_context(self):
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        policy = self._create_policy(bypass_org_membership_levels=["8", "15"])
+        engine = PolicyEngine()
+        context: dict[str, object] = {}
+        bypass_role_ids = [str(r.id) for r in policy.bypass_roles.all()]
+
+        result = engine._has_bypass(self.user, policy, bypass_role_ids, context)
+
+        assert result is False
+
+
+class TestPolicyEngineEvaluateBypass(APIBaseTest):
+    def _create_policy(
+        self,
+        bypass_org_membership_levels: list[str] | None = None,
+        bypass_role_ids: list[str] | None = None,
+    ) -> ApprovalPolicy:
+        policy = ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=self.team,
+            action_key="feature_flag.update",
+            conditions={},
+            approver_config={"quorum": 1, "users": [self.user.id]},
+            bypass_org_membership_levels=bypass_org_membership_levels or [],
+            created_by=self.user,
+        )
+        if bypass_role_ids:
+            policy.set_bypass_roles(bypass_role_ids)
+        return policy
+
+    def test_evaluate_returns_allow_when_org_level_bypass(self):
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        policy = self._create_policy(bypass_org_membership_levels=["8", "15"])
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        intent = {"gated_changes": {"rollout_percentage": [{"path": "groups[0]", "value": 80}]}}
+
+        decision = engine.evaluate(policy, self.user, intent, context)
+
+        assert decision.result == "ALLOW"
+        assert "bypass" in decision.reason.lower()
+
+    def test_evaluate_returns_allow_when_rbac_role_bypass(self):
+        from ee.models.rbac.role import Role, RoleMembership
+
+        role = Role.objects.create(
+            organization=self.organization,
+            name="Bypass Role",
+        )
+        RoleMembership.objects.create(user=self.user, role=role)
+
+        policy = self._create_policy(bypass_role_ids=[str(role.id)])
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        intent = {"gated_changes": {"rollout_percentage": [{"path": "groups[0]", "value": 80}]}}
+
+        decision = engine.evaluate(policy, self.user, intent, context)
+
+        assert decision.result == "ALLOW"
+        assert "bypass" in decision.reason.lower()
+
+    def test_evaluate_returns_require_approval_when_no_bypass(self):
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        policy = self._create_policy(bypass_org_membership_levels=["8", "15"])
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        intent = {"gated_changes": {"rollout_percentage": [{"path": "groups[0]", "value": 80}]}}
+
+        decision = engine.evaluate(policy, self.user, intent, context)
+
+        assert decision.result == "REQUIRE_APPROVAL"
+
+
+class TestPolicySnapshotBypassFields(APIBaseTest):
+    def _create_policy(
+        self,
+        bypass_org_membership_levels: list[str] | None = None,
+        bypass_role_ids: list[str] | None = None,
+    ) -> ApprovalPolicy:
+        policy = ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=self.team,
+            action_key="feature_flag.update",
+            conditions={},
+            approver_config={"quorum": 1, "users": [self.user.id]},
+            bypass_org_membership_levels=bypass_org_membership_levels or [],
+            created_by=self.user,
+        )
+        if bypass_role_ids:
+            policy.set_bypass_roles(bypass_role_ids)
+        return policy
+
+    def test_policy_snapshot_includes_bypass_org_membership_levels(self):
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        policy = self._create_policy(bypass_org_membership_levels=["8", "15"])
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        intent = {"gated_changes": {"rollout_percentage": [{"path": "groups[0]", "value": 80}]}}
+
+        decision = engine.evaluate(policy, self.user, intent, context)
+
+        assert "bypass_org_membership_levels" in decision.policy_snapshot
+        assert decision.policy_snapshot["bypass_org_membership_levels"] == ["8", "15"]
+
+    def test_policy_snapshot_includes_bypass_roles(self):
+        from ee.models.rbac.role import Role
+
+        role = Role.objects.create(
+            organization=self.organization,
+            name="Bypass Role",
+        )
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        policy = self._create_policy(bypass_role_ids=[str(role.id)])
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        intent = {"gated_changes": {"rollout_percentage": [{"path": "groups[0]", "value": 80}]}}
+
+        decision = engine.evaluate(policy, self.user, intent, context)
+
+        assert "bypass_roles" in decision.policy_snapshot
+        assert decision.policy_snapshot["bypass_roles"] == [str(role.id)]
+
+    def test_policy_snapshot_includes_empty_bypass_fields(self):
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        policy = self._create_policy()
+        engine = PolicyEngine()
+        context = {"organization": self.organization}
+        intent = {"gated_changes": {"rollout_percentage": [{"path": "groups[0]", "value": 80}]}}
+
+        decision = engine.evaluate(policy, self.user, intent, context)
+
+        assert decision.policy_snapshot["bypass_org_membership_levels"] == []
+        assert decision.policy_snapshot["bypass_roles"] == []
+
+
+class TestBypassRolesValidation(APIBaseTest):
+    def test_set_bypass_roles_validates_organization(self):
+        from posthog.models.organization import Organization
+
+        from ee.models.rbac.role import Role
+
+        other_org = Organization.objects.create(name="Other Org")
+        role = Role.objects.create(
+            organization=other_org,
+            name="Other Org Role",
+        )
+
+        policy = ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=self.team,
+            action_key="feature_flag.update",
+            conditions={},
+            approver_config={"quorum": 1, "users": [self.user.id]},
+            created_by=self.user,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            policy.set_bypass_roles([str(role.id)])
+
+        assert "same organization" in str(context.exception)
+
+    def test_set_bypass_roles_accepts_valid_roles(self):
+        from ee.models.rbac.role import Role
+
+        role = Role.objects.create(
+            organization=self.organization,
+            name="Valid Role",
+        )
+
+        policy = ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=self.team,
+            action_key="feature_flag.update",
+            conditions={},
+            approver_config={"quorum": 1, "users": [self.user.id]},
+            created_by=self.user,
+        )
+
+        policy.set_bypass_roles([str(role.id)])
+
+        assert list(policy.bypass_roles.values_list("id", flat=True)) == [role.id]
+
+    def test_set_bypass_roles_clears_when_empty(self):
+        from ee.models.rbac.role import Role
+
+        role = Role.objects.create(
+            organization=self.organization,
+            name="Valid Role",
+        )
+
+        policy = ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=self.team,
+            action_key="feature_flag.update",
+            conditions={},
+            approver_config={"quorum": 1, "users": [self.user.id]},
+            created_by=self.user,
+        )
+        policy.bypass_roles.add(role)
+
+        policy.set_bypass_roles([])
+
+        assert policy.bypass_roles.count() == 0

--- a/posthog/migrations/0993_approvalpolicy_bypass_options.py
+++ b/posthog/migrations/0993_approvalpolicy_bypass_options.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "0992_drop_approvalpolicy_bypass_roles_column"),
+        ("ee", "0025_role_members"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="approvalpolicy",
+            name="bypass_org_membership_levels",
+            field=models.JSONField(default=list),
+        ),
+        migrations.AddField(
+            model_name="approvalpolicy",
+            name="bypass_roles",
+            field=models.ManyToManyField(blank=True, related_name="bypass_policies", to="ee.role"),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0992_drop_approvalpolicy_bypass_roles_column
+0993_approvalpolicy_bypass_options


### PR DESCRIPTION
## Problem                                                                                                                                                                               
                                                                                                                                                                                           
  Approval policies currently don't support bypass options for trusted users. Org admins and users with specific roles should be able to skip the approval flow when needed.          
                                                                                                                                                                                           
  Also, the Approvals settings were in the Organization section but make more sense in the Project section since policies are scoped to teams.                                  
                                                                                                                                                                                           
  ## Changes

<img width="711" height="708" alt="image" src="https://github.com/user-attachments/assets/51c32845-7045-44cd-86c5-d914520da76d" />                                                                                                                                                                               
                                                                                                                                                                                           
- Move Approvals to Project settings                                                                                                                                                                                                                                              
- Add bypass options to approval policies                                                                                                                                              
                                                                                                                                                                                
  ## How did you test this code?                                                                                                                                                           
                                                                                                                                                                                           
  - Added 20 tests covering:                                                                                                                                                               
    - Org membership level bypass (admin, owner, member combinations)                                                                                                                      
    - RBAC role bypass                                                                                                                                                                     
    - Organization validation for bypass roles                                                                                                                                             
    - Policy snapshot includes bypass fields                                                                                                                                               
                                                                                                                                              
                                                                                                                                                                                           
  ## Publish to changelog?                                                                                                                                                                 
                                                                                                                                                                                           
  no                          
