### PR TITLE
feat(logs): add debounced row height computation

### DIFF
--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -102,6 +102,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
 
         // Row height recomputation (triggered by child components when content changes)
         recomputeRowHeights: (logIds?: string[]) => ({ logIds }),
+        debouncedRecomputeRowHeights: (logIds?: string[]) => ({ logIds }),
 
         // Multi-select
         toggleSelectLog: (logId: string) => ({ logId }),
@@ -245,7 +246,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         recomputeRowHeightsRequest: [
             null as { logIds?: string[]; timestamp: number } | null,
             {
-                recomputeRowHeights: (_, { logIds }) => ({ logIds, timestamp: Date.now() }),
+                debouncedRecomputeRowHeights: (_, { logIds }) => ({ logIds, timestamp: Date.now() }),
             },
         ],
 
@@ -382,6 +383,10 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
     }),
 
     listeners(({ actions, values, props }) => ({
+        recomputeRowHeights: async ({ logIds }, breakpoint) => {
+            await breakpoint(30) // Debounce 30ms
+            actions.debouncedRecomputeRowHeights(logIds)
+        },
         setLogs: ({ logs }) => {
             if (logs.length === 0) {
                 actions.resetCursor()


### PR DESCRIPTION
## Problem

Row height computation caused a bit of lag when firing from precise events such as column resizing.

## Changes

Added debouncing to row height recomputation in the logs viewer to improve performance. The implementation adds a 30ms debounce to prevent excessive recalculations when multiple events trigger in quick succession.

## How did you test this code?

Tested by resizing columns in the logs viewer and verifying that the UI remains responsive without visual lag.

## Publish to changelog?

No