### PR TITLE
fix(groups): show specific error messages instead of generic failure

### DIFF
--- a/frontend/src/queries/nodes/DataTable/queryFeatures.test.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.test.ts
@@ -1,0 +1,34 @@
+import { NodeKind } from '~/queries/schema/schema-general'
+
+import { QueryFeature, getQueryFeatures } from './queryFeatures'
+
+describe('getQueryFeatures', () => {
+    describe('displayResponseError', () => {
+        it.each([
+            [NodeKind.GroupsQuery, { kind: NodeKind.GroupsQuery, group_type_index: 0 }],
+            [NodeKind.ActorsQuery, { kind: NodeKind.ActorsQuery }],
+            [NodeKind.TracesQuery, { kind: NodeKind.TracesQuery }],
+            [NodeKind.EventsQuery, { kind: NodeKind.EventsQuery, select: ['*'] }],
+            [NodeKind.SessionsQuery, { kind: NodeKind.SessionsQuery }],
+            [NodeKind.HogQLQuery, { kind: NodeKind.HogQLQuery, query: 'SELECT 1' }],
+        ])('%s should have displayResponseError enabled', (_, query) => {
+            const features = getQueryFeatures(query)
+            expect(features.has(QueryFeature.displayResponseError)).toBe(true)
+        })
+    })
+
+    describe('columnConfigurator with displayResponseError', () => {
+        it.each([
+            [NodeKind.GroupsQuery, { kind: NodeKind.GroupsQuery, group_type_index: 0 }],
+            [NodeKind.ActorsQuery, { kind: NodeKind.ActorsQuery }],
+            [NodeKind.TracesQuery, { kind: NodeKind.TracesQuery }],
+            [NodeKind.EventsQuery, { kind: NodeKind.EventsQuery, select: ['*'] }],
+            [NodeKind.SessionsQuery, { kind: NodeKind.SessionsQuery }],
+        ])('%s with columnConfigurator should also have displayResponseError', (_, query) => {
+            const features = getQueryFeatures(query)
+            if (features.has(QueryFeature.columnConfigurator)) {
+                expect(features.has(QueryFeature.displayResponseError)).toBe(true)
+            }
+        })
+    })
+})

--- a/frontend/src/queries/nodes/DataTable/queryFeatures.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.ts
@@ -112,6 +112,7 @@ export function getQueryFeatures(query: Node): Set<QueryFeature> {
         features.add(QueryFeature.columnConfigurator)
         features.add(QueryFeature.linkDataButton)
         features.add(QueryFeature.showCount)
+        features.add(QueryFeature.displayResponseError)
     }
 
     if (

--- a/frontend/src/queries/nodes/DataTable/queryFeatures.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.ts
@@ -100,6 +100,7 @@ export function getQueryFeatures(query: Node): Set<QueryFeature> {
             features.add(QueryFeature.columnsInResponse)
             features.add(QueryFeature.resultIsArrayOfArrays)
             features.add(QueryFeature.showCount)
+            features.add(QueryFeature.displayResponseError)
         }
     }
 
@@ -149,6 +150,7 @@ export function getQueryFeatures(query: Node): Set<QueryFeature> {
         features.add(QueryFeature.testAccountFilters)
         features.add(QueryFeature.supportTracesFilters)
         features.add(QueryFeature.columnConfigurator)
+        features.add(QueryFeature.displayResponseError)
     }
 
     if (isEndpointsUsageTableQuery(query)) {


### PR DESCRIPTION
## Problem

When query errors occur on the Groups, Persons, or LLM Traces pages, users see a generic message "There was a problem completing this query" instead of the actual error. This makes debugging difficult because users don't know what went wrong.

For example, if a user tries to query a non-existent field, they should see "Unable to resolve field: field name" rather than a generic failure message.

## Changes

Enable `displayResponseError` feature for DataTable queries that have `columnConfigurator` but were missing this feature:
- **GroupsQuery** - Groups page (`/groups/`)
- **ActorsQuery** - Persons page (`/persons/`)
- **TracesQuery** - LLM traces page

This aligns these query types with others like EventsQuery and SessionsQuery which already show specific error messages.

Added tests to ensure queries with `columnConfigurator` also have `displayResponseError` enabled, preventing regression.

## How did you test this code?

1. Traced the error handling code path from the original error stack trace
2. Verified the fix matches the pattern used for other query types (EventsQuery, SessionsQuery, etc.)
3. Added unit tests for `getQueryFeatures()` that verify all queries with `columnConfigurator` also have `displayResponseError`

```bash
pnpm --filter=@posthog/frontend jest frontend/src/queries/nodes/DataTable/queryFeatures.test.ts
# 11 tests passing
```

## Publish to changelog?

no