### PR TITLE
feat(logs): part-1 add column logic management functionality

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -11,6 +11,7 @@ import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { LogsFilterBar } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar'
 import { LogsFilterBar as LogsFilterBarV2 } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar'
+import { logsViewerColumnLogic } from 'products/logs/frontend/components/LogsViewer/columns/logsViewerColumnLogic'
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 import { VirtualizedLogsList } from 'products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList'
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
@@ -65,23 +66,25 @@ export function LogsViewer({
 }: LogsViewerProps): JSX.Element {
     return (
         <BindLogic logic={logsViewerConfigLogic} props={{ id: tabId }}>
-            <BindLogic logic={logDetailsModalLogic} props={{ tabId }}>
-                <BindLogic logic={logsViewerLogic} props={{ tabId, logs, orderBy, onAddFilter }}>
-                    <LogsViewerContent
-                        loading={loading}
-                        totalLogsCount={totalLogsCount}
-                        hasMoreLogsToLoad={hasMoreLogsToLoad}
-                        orderBy={orderBy}
-                        onChangeOrderBy={onChangeOrderBy}
-                        onRefresh={onRefresh}
-                        onLoadMore={onLoadMore}
-                        sparklineData={sparklineData}
-                        sparklineLoading={sparklineLoading}
-                        onDateRangeChange={onDateRangeChange}
-                        sparklineBreakdownBy={sparklineBreakdownBy}
-                        onSparklineBreakdownByChange={onSparklineBreakdownByChange}
-                        onExpandTimeRange={onExpandTimeRange}
-                    />
+            <BindLogic logic={logsViewerColumnLogic} props={{ id: tabId }}>
+                <BindLogic logic={logDetailsModalLogic} props={{ tabId }}>
+                    <BindLogic logic={logsViewerLogic} props={{ tabId, logs, orderBy, onAddFilter }}>
+                        <LogsViewerContent
+                            loading={loading}
+                            totalLogsCount={totalLogsCount}
+                            hasMoreLogsToLoad={hasMoreLogsToLoad}
+                            orderBy={orderBy}
+                            onChangeOrderBy={onChangeOrderBy}
+                            onRefresh={onRefresh}
+                            onLoadMore={onLoadMore}
+                            sparklineData={sparklineData}
+                            sparklineLoading={sparklineLoading}
+                            onDateRangeChange={onDateRangeChange}
+                            sparklineBreakdownBy={sparklineBreakdownBy}
+                            onSparklineBreakdownByChange={onSparklineBreakdownByChange}
+                            onExpandTimeRange={onExpandTimeRange}
+                        />
+                    </BindLogic>
                 </BindLogic>
             </BindLogic>
         </BindLogic>

--- a/products/logs/frontend/components/LogsViewer/columns/constants.ts
+++ b/products/logs/frontend/components/LogsViewer/columns/constants.ts
@@ -1,0 +1,84 @@
+import {
+    BuiltInConfigurableColumn,
+    ConfigurableColumn,
+    FixedColumn,
+} from 'products/logs/frontend/components/LogsViewer/columns/types'
+
+export const SEVERITY_COLOR_COLUMN: FixedColumn = {
+    id: 'severityColorColumn',
+    type: 'severityColor',
+    order: 0,
+    width: 8,
+    label: '',
+}
+
+export const SELECT_CHECKBOX_COLUMN: FixedColumn = {
+    id: 'selectCheckboxColumn',
+    type: 'selectCheckbox',
+    order: 1,
+    width: 28,
+    label: '',
+}
+
+export const EXPAND_ROW_BUTTON_COLUMN: FixedColumn = {
+    id: 'expandRowButtonColumn',
+    type: 'expandRowButton',
+    order: 2,
+    width: 28,
+    label: '',
+}
+
+export const FIXED_COLUMNS_BY_ID: Record<string, FixedColumn> = {
+    severityColorColumn: SEVERITY_COLOR_COLUMN,
+    selectCheckboxColumn: SELECT_CHECKBOX_COLUMN,
+    expandRowButtonColumn: EXPAND_ROW_BUTTON_COLUMN,
+}
+
+export const TIMESTAMP_COLUMN: BuiltInConfigurableColumn = {
+    id: 'timestampColumn',
+    type: 'timestamp',
+    order: 3,
+    width: 180,
+    label: 'Timestamp',
+}
+
+export const BODY_COLUMN: BuiltInConfigurableColumn = {
+    id: 'bodyColumn',
+    type: 'body',
+    order: 4,
+    width: 120,
+    label: 'Body',
+}
+
+export const DATE_COLUMN: BuiltInConfigurableColumn = {
+    id: 'dateColumn',
+    type: 'date',
+    width: 120,
+    label: 'Date',
+}
+
+export const TIME_COLUMN: BuiltInConfigurableColumn = {
+    id: 'timeColumn',
+    type: 'time',
+    width: 120,
+    label: 'Time',
+}
+
+export const DISTINCT_ID_COLUMN: BuiltInConfigurableColumn = {
+    id: 'distinctIdColumn',
+    type: 'distinctId',
+    width: 120,
+    label: 'Distinct ID',
+}
+
+export const SESSION_ID_COLUMN: BuiltInConfigurableColumn = {
+    id: 'sessionIdColumn',
+    type: 'sessionId',
+    width: 120,
+    label: 'Session ID',
+}
+
+export const DEFAULT_CONFIGURABLE_COLUMNS_BY_ID: Record<string, ConfigurableColumn> = {
+    timestampColumn: TIMESTAMP_COLUMN,
+    bodyColumn: BODY_COLUMN,
+}

--- a/products/logs/frontend/components/LogsViewer/columns/logsViewerColumnLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/columns/logsViewerColumnLogic.test.ts
@@ -1,0 +1,373 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { ParsedLogMessage } from '../../../types'
+import { BODY_COLUMN, DEFAULT_CONFIGURABLE_COLUMNS_BY_ID, FIXED_COLUMNS_BY_ID, TIMESTAMP_COLUMN } from './constants'
+import { logsViewerColumnLogic } from './logsViewerColumnLogic'
+import { AttributeColumn, ConfigurableColumn, ExpressionColumn } from './types'
+
+describe('logsViewerColumnLogic', () => {
+    let logic: ReturnType<typeof logsViewerColumnLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = logsViewerColumnLogic({ id: 'test-tab' })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    describe('initial state', () => {
+        it('has default configurable columns', () => {
+            expect(logic.values.configurableColumnsById).toEqual(DEFAULT_CONFIGURABLE_COLUMNS_BY_ID)
+        })
+
+        it('merges fixed and configurable columns in columnsById', () => {
+            expect(logic.values.columnsById).toEqual({
+                ...FIXED_COLUMNS_BY_ID,
+                ...DEFAULT_CONFIGURABLE_COLUMNS_BY_ID,
+            })
+        })
+    })
+
+    describe('setConfigurableColumns', () => {
+        it('replaces all configurable columns', async () => {
+            const newColumns: Record<string, ConfigurableColumn> = {
+                timestampColumn: { ...TIMESTAMP_COLUMN, width: 200 },
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.setConfigurableColumns(newColumns)
+            }).toMatchValues({
+                configurableColumnsById: newColumns,
+            })
+        })
+    })
+
+    describe('setColumnWidth', () => {
+        it('updates width for existing column', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setColumnWidth('timestampColumn', 250)
+            }).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById.timestampColumn.width).toBe(250)
+        })
+
+        it('ignores non-existent column', async () => {
+            const before = { ...logic.values.configurableColumnsById }
+
+            await expectLogic(logic, () => {
+                logic.actions.setColumnWidth('nonExistentColumn', 100)
+            }).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById).toEqual(before)
+        })
+    })
+
+    describe('addAttributeColumn', () => {
+        it('adds new attribute column with correct properties', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.addAttributeColumn('service.name')
+            }).toFinishAllListeners()
+
+            const column = logic.values.configurableColumnsById['attribute-service.name'] as AttributeColumn
+            expect(column).toBeTruthy()
+            expect(column.type).toBe('attribute')
+            expect(column.attributeKey).toBe('service.name')
+            expect(column.label).toBe('service.name')
+            expect(column.id).toBe('attribute-service.name')
+        })
+
+        it('assigns order after existing columns', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.addAttributeColumn('first.attr')
+            }).toFinishAllListeners()
+
+            const firstOrder = logic.values.configurableColumnsById['attribute-first.attr'].order
+
+            await expectLogic(logic, () => {
+                logic.actions.addAttributeColumn('second.attr')
+            }).toFinishAllListeners()
+
+            const secondOrder = logic.values.configurableColumnsById['attribute-second.attr'].order
+            expect(secondOrder).toBeGreaterThan(firstOrder!)
+        })
+    })
+
+    describe('removeColumn', () => {
+        it('removes existing column', async () => {
+            logic.actions.addAttributeColumn('to.remove')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById['attribute-to.remove']).toBeTruthy()
+
+            await expectLogic(logic, () => {
+                logic.actions.removeColumn('attribute-to.remove')
+            }).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById['attribute-to.remove']).toBeUndefined()
+        })
+
+        it('handles removing non-existent column gracefully', async () => {
+            const before = { ...logic.values.configurableColumnsById }
+
+            await expectLogic(logic, () => {
+                logic.actions.removeColumn('nonExistent')
+            }).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById).toEqual(before)
+        })
+    })
+
+    describe('moveColumn', () => {
+        beforeEach(async () => {
+            logic.actions.setConfigurableColumns({
+                col1: { id: 'col1', type: 'timestamp', order: 3, width: 100, label: 'Col 1' },
+                col2: { id: 'col2', type: 'date', order: 4, width: 100, label: 'Col 2' },
+                col3: { id: 'col3', type: 'time', order: 5, width: 100, label: 'Col 3' },
+                bodyColumn: BODY_COLUMN,
+            })
+            await expectLogic(logic).toFinishAllListeners()
+        })
+
+        it('moves column left by swapping orders', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.moveColumn('col2', 'left')
+            }).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById.col1.order).toBe(4)
+            expect(logic.values.configurableColumnsById.col2.order).toBe(3)
+        })
+
+        it('moves column right by swapping orders', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.moveColumn('col2', 'right')
+            }).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById.col2.order).toBe(5)
+            expect(logic.values.configurableColumnsById.col3.order).toBe(4)
+        })
+
+        it('does nothing when moving first column left', async () => {
+            const orderBefore = logic.values.configurableColumnsById.col1.order
+
+            await expectLogic(logic, () => {
+                logic.actions.moveColumn('col1', 'left')
+            }).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById.col1.order).toBe(orderBefore)
+        })
+
+        it('does nothing when moving last non-body column right', async () => {
+            const orderBefore = logic.values.configurableColumnsById.col3.order
+
+            await expectLogic(logic, () => {
+                logic.actions.moveColumn('col3', 'right')
+            }).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById.col3.order).toBe(orderBefore)
+        })
+
+        it('does nothing for non-existent column', async () => {
+            const before = { ...logic.values.configurableColumnsById }
+
+            await expectLogic(logic, () => {
+                logic.actions.moveColumn('nonExistent', 'left')
+            }).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById).toEqual(before)
+        })
+    })
+
+    describe('columns selector', () => {
+        it('sorts columns by order with body column always last', async () => {
+            logic.actions.setConfigurableColumns({
+                bodyColumn: { ...BODY_COLUMN, order: 1 },
+                timestampColumn: { ...TIMESTAMP_COLUMN, order: 10 },
+            })
+            await expectLogic(logic).toFinishAllListeners()
+
+            const columns = logic.values.columns
+            const bodyIndex = columns.findIndex((c) => c.type === 'body')
+            expect(bodyIndex).toBe(columns.length - 1)
+        })
+
+        it('includes both fixed and configurable columns', () => {
+            const columnIds = logic.values.columns.map((c) => c.id)
+            expect(columnIds).toContain('severityColorColumn')
+            expect(columnIds).toContain('selectCheckboxColumn')
+            expect(columnIds).toContain('timestampColumn')
+            expect(columnIds).toContain('bodyColumn')
+        })
+    })
+
+    describe('getColumnById', () => {
+        it.each([
+            ['fixed column', 'severityColorColumn'],
+            ['configurable column', 'timestampColumn'],
+        ])('returns %s by id', (_, columnId) => {
+            const column = logic.values.getColumnById(columnId)
+            expect(column).toBeTruthy()
+            expect(column?.id).toBe(columnId)
+        })
+
+        it('returns undefined for non-existent column', () => {
+            expect(logic.values.getColumnById('nonExistent')).toBeUndefined()
+        })
+    })
+
+    describe('isAttributeColumn', () => {
+        it('returns false when attribute column does not exist', () => {
+            expect(logic.values.isAttributeColumn('some.attr')).toBe(false)
+        })
+
+        it('returns true when attribute column exists', async () => {
+            logic.actions.addAttributeColumn('some.attr')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.isAttributeColumn('some.attr')).toBe(true)
+        })
+    })
+
+    describe('sortedConfigurableColumns', () => {
+        it('excludes body column from sorted list', () => {
+            const sorted = logic.values.sortedConfigurableColumns
+            expect(sorted.find((c) => c.type === 'body')).toBeUndefined()
+        })
+
+        it('returns columns sorted by order', async () => {
+            logic.actions.setConfigurableColumns({
+                col1: { id: 'col1', type: 'timestamp', order: 5, width: 100, label: 'Col 1' },
+                col2: { id: 'col2', type: 'date', order: 3, width: 100, label: 'Col 2' },
+                bodyColumn: BODY_COLUMN,
+            })
+            await expectLogic(logic).toFinishAllListeners()
+
+            const sorted = logic.values.sortedConfigurableColumns
+            expect(sorted[0].id).toBe('col2')
+            expect(sorted[1].id).toBe('col1')
+        })
+    })
+
+    describe('isFirstConfigurableColumn / isLastConfigurableColumn', () => {
+        beforeEach(async () => {
+            logic.actions.setConfigurableColumns({
+                col1: { id: 'col1', type: 'timestamp', order: 3, width: 100, label: 'Col 1' },
+                col2: { id: 'col2', type: 'date', order: 4, width: 100, label: 'Col 2' },
+                bodyColumn: BODY_COLUMN,
+            })
+            await expectLogic(logic).toFinishAllListeners()
+        })
+
+        it('identifies first column correctly', () => {
+            expect(logic.values.isFirstConfigurableColumn('col1')).toBe(true)
+            expect(logic.values.isFirstConfigurableColumn('col2')).toBe(false)
+        })
+
+        it('identifies last column correctly', () => {
+            expect(logic.values.isLastConfigurableColumn('col2')).toBe(true)
+            expect(logic.values.isLastConfigurableColumn('col1')).toBe(false)
+        })
+    })
+
+    describe('compiledPaths', () => {
+        it('compiles expression paths for expression columns', async () => {
+            const expressionColumn: ExpressionColumn = {
+                id: 'expr1',
+                type: 'expression',
+                expression: 'attributes.http.status',
+                width: 100,
+            }
+            logic.actions.setConfigurableColumns({
+                expr1: expressionColumn,
+                timestampColumn: TIMESTAMP_COLUMN,
+            })
+            await expectLogic(logic).toFinishAllListeners()
+
+            const paths = logic.values.compiledPaths
+            expect(paths.get('attributes.http.status')).toEqual(['attributes', 'http', 'status'])
+        })
+
+        it('ignores non-expression columns', async () => {
+            logic.actions.setConfigurableColumns({
+                timestampColumn: TIMESTAMP_COLUMN,
+            })
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.compiledPaths.size).toBe(0)
+        })
+    })
+
+    describe('evaluateExpression', () => {
+        const mockLog = {
+            attributes: {
+                http: {
+                    status: 200,
+                },
+            },
+            nested: {
+                value: 'test',
+            },
+        } as unknown as ParsedLogMessage
+
+        it.each([
+            ['attributes.http.status', 200],
+            ['nested.value', 'test'],
+            ['nonexistent.path', undefined],
+            ['attributes.http.nonexistent', undefined],
+        ])('evaluates expression "%s" to %s', (expression, expected) => {
+            expect(logic.values.evaluateExpression(mockLog, expression)).toBe(expected)
+        })
+
+        it('handles null values in path', () => {
+            const logWithNull = { attributes: null } as unknown as ParsedLogMessage
+            expect(logic.values.evaluateExpression(logWithNull, 'attributes.foo')).toBeUndefined()
+        })
+    })
+
+    describe('toggleAttributeColumn listener', () => {
+        it('adds column when it does not exist', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.toggleAttributeColumn('new.attr')
+            }).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById['attribute-new.attr']).toBeTruthy()
+        })
+
+        it('removes column when it exists', async () => {
+            logic.actions.addAttributeColumn('existing.attr')
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.toggleAttributeColumn('existing.attr')
+            }).toFinishAllListeners()
+
+            expect(logic.values.configurableColumnsById['attribute-existing.attr']).toBeUndefined()
+        })
+    })
+
+    describe('keyed instances', () => {
+        it('maintains separate state for different keys', async () => {
+            const logic1 = logsViewerColumnLogic({ id: 'tab-1' })
+            const logic2 = logsViewerColumnLogic({ id: 'tab-2' })
+            logic1.mount()
+            logic2.mount()
+
+            logic1.actions.addAttributeColumn('attr1')
+            logic2.actions.addAttributeColumn('attr2')
+            await expectLogic(logic1).toFinishAllListeners()
+            await expectLogic(logic2).toFinishAllListeners()
+
+            expect(logic1.values.configurableColumnsById['attribute-attr1']).toBeTruthy()
+            expect(logic1.values.configurableColumnsById['attribute-attr2']).toBeUndefined()
+            expect(logic2.values.configurableColumnsById['attribute-attr2']).toBeTruthy()
+            expect(logic2.values.configurableColumnsById['attribute-attr1']).toBeUndefined()
+
+            logic1.unmount()
+            logic2.unmount()
+        })
+    })
+})

--- a/products/logs/frontend/components/LogsViewer/columns/logsViewerColumnLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/columns/logsViewerColumnLogic.ts
@@ -1,0 +1,200 @@
+import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+
+import {
+    DEFAULT_CONFIGURABLE_COLUMNS_BY_ID,
+    FIXED_COLUMNS_BY_ID,
+} from 'products/logs/frontend/components/LogsViewer/columns/constants'
+import { DEFAULT_ATTRIBUTE_COLUMN_WIDTH } from 'products/logs/frontend/components/VirtualizedLogsList/layoutUtils'
+
+import type { ParsedLogMessage } from '../../../types'
+import type { logsViewerColumnLogicType } from './logsViewerColumnLogicType'
+import type { Column, ConfigurableColumn } from './types'
+
+export interface LogsViewerColumnLogicProps {
+    id: string
+}
+
+const getNextAvailableColumnOrderPosition = (columnsById: Record<string, ConfigurableColumn>): number => {
+    const fixedMaxOrder = Math.max(...Object.values(FIXED_COLUMNS_BY_ID).map((c) => c.order ?? 0))
+    const configurableOrders = Object.values(columnsById).map((c) => c.order ?? 0)
+    const maxOrder = configurableOrders.length > 0 ? Math.max(fixedMaxOrder, ...configurableOrders) : fixedMaxOrder
+    return maxOrder + 1
+}
+
+export const logsViewerColumnLogic = kea<logsViewerColumnLogicType>([
+    path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'columns', 'logsViewerColumnLogic']),
+    props({ id: 'default' } as LogsViewerColumnLogicProps),
+    key((props) => props.id),
+
+    actions({
+        setConfigurableColumns: (columns: Record<string, ConfigurableColumn>) => ({ columns }),
+        setColumnWidth: (columnId: string, width: number) => ({ columnId, width }),
+        addAttributeColumn: (attributeKey: string) => ({ attributeKey }),
+        toggleAttributeColumn: (attributeKey: string) => ({ attributeKey }),
+        removeColumn: (columnId: string) => ({ columnId }),
+        moveColumn: (columnId: string, direction: 'left' | 'right') => ({ columnId, direction }),
+    }),
+
+    reducers({
+        configurableColumnsById: [
+            DEFAULT_CONFIGURABLE_COLUMNS_BY_ID as Record<string, ConfigurableColumn>,
+            { persist: true },
+            {
+                setConfigurableColumns: (_, { columns }) => columns,
+                setColumnWidth: (state, { columnId, width }) =>
+                    state[columnId] ? { ...state, [columnId]: { ...state[columnId], width } } : state,
+                addAttributeColumn: (state, { attributeKey }) => {
+                    const id = `attribute-${attributeKey}` as const
+                    return {
+                        ...state,
+                        [id]: {
+                            id,
+                            type: 'attribute' as const,
+                            order: getNextAvailableColumnOrderPosition(state),
+                            label: attributeKey,
+                            attributeKey,
+                            width: DEFAULT_ATTRIBUTE_COLUMN_WIDTH,
+                        },
+                    }
+                },
+                removeColumn: (state, { columnId }) => {
+                    const { [columnId]: _, ...rest } = state
+                    return rest
+                },
+                moveColumn: (state, { columnId, direction }) => {
+                    const column = state[columnId]
+                    if (!column) {
+                        return state
+                    }
+
+                    // Get all configurable columns sorted by order (excluding body which is always last)
+                    const sortedColumns = Object.values(state)
+                        .filter((c) => c.type !== 'body')
+                        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+
+                    const currentIndex = sortedColumns.findIndex((c) => c.id === columnId)
+                    const targetIndex = direction === 'left' ? currentIndex - 1 : currentIndex + 1
+
+                    if (targetIndex < 0 || targetIndex >= sortedColumns.length) {
+                        return state
+                    }
+
+                    const targetColumn = sortedColumns[targetIndex]
+                    if (!targetColumn) {
+                        return state
+                    }
+
+                    // Swap orders
+                    return {
+                        ...state,
+                        [columnId]: { ...column, order: targetColumn.order },
+                        [targetColumn.id]: { ...targetColumn, order: column.order },
+                    }
+                },
+            },
+        ],
+    }),
+
+    selectors({
+        columnsById: [
+            (s) => [s.configurableColumnsById],
+            (configurableColumnsById): Record<string, Column> => ({
+                ...FIXED_COLUMNS_BY_ID,
+                ...configurableColumnsById,
+            }),
+        ],
+        columns: [
+            (s) => [s.columnsById],
+            (columnsById: Record<string, Column>): Column[] =>
+                Object.values(columnsById).sort((a: Column, b: Column) => {
+                    // Body column always last
+                    if (a.type === 'body') {
+                        return 1
+                    }
+                    if (b.type === 'body') {
+                        return -1
+                    }
+                    return (a.order ?? 0) - (b.order ?? 0)
+                }),
+        ],
+        compiledPaths: [
+            (s) => [s.columns],
+            (columns): Map<string, string[]> => {
+                const paths = new Map<string, string[]>()
+                for (const col of columns) {
+                    if (col.type === 'expression') {
+                        paths.set(col.expression, col.expression.split('.'))
+                    }
+                }
+                return paths
+            },
+        ],
+        getColumnById: [
+            (s) => [s.columnsById],
+            (columnsById: Record<string, Column>) =>
+                (columnId: string): Column | undefined => {
+                    return columnsById[columnId]
+                },
+        ],
+        isAttributeColumn: [
+            (s) => [s.configurableColumnsById],
+            (configurableColumnsById: Record<string, ConfigurableColumn>) =>
+                (attributeKey: string): boolean => {
+                    const id = `attribute-${attributeKey}`
+                    const col = configurableColumnsById[id]
+                    return col?.type === 'attribute'
+                },
+        ],
+        sortedConfigurableColumns: [
+            (s) => [s.configurableColumnsById],
+            (configurableColumnsById: Record<string, ConfigurableColumn>): ConfigurableColumn[] =>
+                Object.values(configurableColumnsById)
+                    .filter((c) => c.type !== 'body')
+                    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+        ],
+        isFirstConfigurableColumn: [
+            (s) => [s.sortedConfigurableColumns],
+            (sortedColumns: ConfigurableColumn[]) =>
+                (columnId: string): boolean => {
+                    return sortedColumns.length > 0 && sortedColumns[0]?.id === columnId
+                },
+        ],
+        isLastConfigurableColumn: [
+            (s) => [s.sortedConfigurableColumns],
+            (sortedColumns: ConfigurableColumn[]) =>
+                (columnId: string): boolean => {
+                    return sortedColumns.length > 0 && sortedColumns[sortedColumns.length - 1]?.id === columnId
+                },
+        ],
+        evaluateExpression: [
+            (s) => [s.compiledPaths],
+            (compiledPaths) =>
+                (log: ParsedLogMessage, expression: string): unknown => {
+                    let path = compiledPaths.get(expression)
+                    if (!path) {
+                        path = expression.split('.')
+                    }
+
+                    let value: unknown = log
+                    for (const key of path) {
+                        if (value == null || typeof value !== 'object') {
+                            return undefined
+                        }
+                        value = (value as Record<string, unknown>)[key]
+                    }
+                    return value
+                },
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        toggleAttributeColumn: ({ attributeKey }) => {
+            const columnId = `attribute-${attributeKey}`
+            if (values.isAttributeColumn(attributeKey)) {
+                actions.removeColumn(columnId)
+            } else {
+                actions.addAttributeColumn(attributeKey)
+            }
+        },
+    })),
+])

--- a/products/logs/frontend/components/LogsViewer/columns/types.ts
+++ b/products/logs/frontend/components/LogsViewer/columns/types.ts
@@ -1,0 +1,49 @@
+// Fixed UI columns - always present, not user-configurable
+export const FIXED_COLUMN_TYPES = ['severityColor', 'selectCheckbox', 'expandRowButton'] as const
+export type FixedColumnType = (typeof FIXED_COLUMN_TYPES)[number]
+
+// User-configurable column types
+export const CONFIGURABLE_COLUMN_TYPES = [
+    'timestamp',
+    'date',
+    'time',
+    'body',
+    'distinctId',
+    'sessionId',
+    'attribute',
+    'expression',
+] as const
+export type ConfigurableColumnType = (typeof CONFIGURABLE_COLUMN_TYPES)[number]
+
+export const COLUMN_TYPES = [...FIXED_COLUMN_TYPES, ...CONFIGURABLE_COLUMN_TYPES] as const
+export type ColumnType = (typeof COLUMN_TYPES)[number]
+
+interface BaseColumn {
+    id: string
+    label?: string
+    order?: number
+    width: number
+}
+
+export interface FixedColumn extends BaseColumn {
+    type: FixedColumnType
+}
+
+export interface BuiltInConfigurableColumn extends BaseColumn {
+    type: 'timestamp' | 'date' | 'time' | 'body' | 'distinctId' | 'sessionId'
+}
+
+export interface AttributeColumn extends BaseColumn {
+    id: `attribute-${string}`
+    type: 'attribute'
+    attributeKey: string
+}
+
+export interface ExpressionColumn extends BaseColumn {
+    type: 'expression'
+    expression: string
+}
+
+export type ConfigurableColumn = BuiltInConfigurableColumn | AttributeColumn | ExpressionColumn
+
+export type Column = FixedColumn | ConfigurableColumn

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
@@ -1,21 +1,26 @@
-import { actions, kea, key, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, path, props, reducers, selectors } from 'kea'
 
 import { FilterLogicalOperator } from '~/types'
 
-import { LogsViewerConfig, LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
+import { logsViewerColumnLogic } from 'products/logs/frontend/components/LogsViewer/columns/logsViewerColumnLogic'
+import { Column } from 'products/logs/frontend/components/LogsViewer/columns/types'
+import {
+    LogsViewerConfig,
+    LogsViewerConfigVersion,
+    LogsViewerFilters,
+} from 'products/logs/frontend/components/LogsViewer/config/types'
 import { LogsOrderBy } from 'products/logs/frontend/types'
 
 import type { logsViewerConfigLogicType } from './logsViewerConfigLogicType'
 
-export const DEFAULT_LOGS_VIEWER_CONFIG: LogsViewerConfig = {
-    filters: {
-        dateRange: { date_from: '-1h', date_to: null },
-        searchTerm: '',
-        severityLevels: [],
-        serviceNames: [],
-        filterGroup: { type: FilterLogicalOperator.And, values: [] },
-    },
-    orderBy: 'latest',
+const CONFIG_VERSION: LogsViewerConfigVersion = 1
+
+const DEFAULT_FILTERS: LogsViewerFilters = {
+    dateRange: { date_from: '-1h', date_to: null },
+    searchTerm: '',
+    severityLevels: [],
+    serviceNames: [],
+    filterGroup: { type: FilterLogicalOperator.And, values: [] },
 }
 
 const DEFAULT_ORDER_BY: LogsOrderBy = 'latest'
@@ -28,6 +33,9 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
     path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'config', 'logsViewerConfigLogic']),
     props({ id: 'default' } as LogsViewerConfigProps),
     key((props) => props.id),
+    connect(({ id }: LogsViewerConfigProps) => ({
+        values: [logsViewerColumnLogic({ id }), ['columns']],
+    })),
 
     actions({
         setOrderBy: (orderBy: LogsOrderBy, source: 'header' | 'toolbar' = 'toolbar') => ({ orderBy, source }),
@@ -40,7 +48,7 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
 
     reducers({
         filters: [
-            DEFAULT_LOGS_VIEWER_CONFIG.filters,
+            DEFAULT_FILTERS,
             {
                 setFilters: (_, { filters }) => filters,
                 setFilter: (state, { filter, value }) => ({
@@ -58,6 +66,14 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
     }),
 
     selectors({
-        config: [(s) => [s.filters], (filters: LogsViewerFilters): LogsViewerConfig => ({ filters })],
+        config: [
+            (s) => [s.filters, s.columns, s.orderBy],
+            (filters: LogsViewerFilters, columns: Record<string, Column>, orderBy: LogsOrderBy): LogsViewerConfig => ({
+                filters,
+                columns,
+                orderBy,
+                version: CONFIG_VERSION,
+            }),
+        ],
     }),
 ])

--- a/products/logs/frontend/components/LogsViewer/config/types.ts
+++ b/products/logs/frontend/components/LogsViewer/config/types.ts
@@ -1,6 +1,8 @@
 import { DateRange, LogsQuery } from '~/queries/schema/schema-general'
 import { UniversalFiltersGroup } from '~/types'
 
+import { Column } from 'products/logs/frontend/components/LogsViewer/columns/types'
+
 export interface LogsViewerFilters {
     dateRange: DateRange
     searchTerm: LogsQuery['searchTerm']
@@ -9,7 +11,11 @@ export interface LogsViewerFilters {
     filterGroup: UniversalFiltersGroup
 }
 
+export type LogsViewerConfigVersion = 1
+
 export interface LogsViewerConfig {
+    version: LogsViewerConfigVersion
     filters: LogsViewerFilters
     orderBy: LogsQuery['orderBy']
+    columns: Record<string, Column>
 }

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -10,6 +10,8 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
+import { logsViewerColumnLogic } from 'products/logs/frontend/components/LogsViewer/columns/logsViewerColumnLogic'
+
 import { AttributeColumnConfig, LogsOrderBy, ParsedLogMessage } from '../../types'
 import { logDetailsModalLogic } from './LogDetailsModal/logDetailsModalLogic'
 import type { logsViewerLogicType } from './logsViewerLogicType'
@@ -39,7 +41,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
     path((tabId) => ['products', 'logs', 'frontend', 'components', 'LogsViewer', 'logsViewerLogic', tabId]),
     props({} as LogsViewerLogicProps),
     key((props) => props.tabId),
-    connect(() => ({
+    connect((props: LogsViewerLogicProps) => ({
         values: [
             logsViewerSettingsLogic,
             ['timezone', 'wrapBody', 'prettifyJson'],
@@ -51,6 +53,13 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
             ['setTimezone', 'setWrapBody', 'setPrettifyJson'],
             logDetailsModalLogic,
             ['openLogDetails', 'closeLogDetails'],
+            logsViewerColumnLogic({ id: props.tabId }),
+            [
+                'setColumnWidth as logsViewerColumnLogicSetColumnWidth',
+                'addAttributeColumn as logsViewerColumnLogicAddAttributeColumn',
+                'removeColumn as logsViewerColumnLogicRemoveColumn',
+                'moveColumn as logsViewerColumnLogicMoveColumn',
+            ],
         ],
     })),
 
@@ -384,7 +393,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
 
     listeners(({ actions, values, props }) => ({
         recomputeRowHeights: async ({ logIds }, breakpoint) => {
-            await breakpoint(30) // Debounce 30ms
+            await breakpoint(10)
             actions.debouncedRecomputeRowHeights(logIds)
         },
         setLogs: ({ logs }) => {
@@ -571,6 +580,18 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
             if (attributeKey in values.attributeColumnsConfig) {
                 posthog.capture('logs column added', { attribute_key: attributeKey })
             }
+        },
+        logsViewerColumnLogicSetColumnWidth: () => {
+            actions.recomputeRowHeights()
+        },
+        logsViewerColumnLogicAddAttributeColumn: () => {
+            actions.recomputeRowHeights()
+        },
+        logsViewerColumnLogicRemoveColumn: () => {
+            actions.recomputeRowHeights()
+        },
+        logsViewerColumnLogicMoveColumn: () => {
+            actions.recomputeRowHeights()
         },
     })),
 


### PR DESCRIPTION
## Problem

We need to be able to save columns as part of 'view presets' - currently we don't have data driven columns and the logic is tightly coupled.

## Changes

- Added `logsViewerColumnLogic` to manage column configuration for the logs viewer
- Created column types and constants to define the structure of different column types
- Added support for fixed columns (severity color, select checkbox, expand row button)
- Added ability to add, remove, resize, and reorder columns
- Connected column changes to row height recalculation for proper rendering

## How did you test this code?

- new unit tests

## Publish to changelog?

No