### PR TITLE
fix(heatmaps): wait for canvas data to load in storybook test

### DIFF
--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.stories.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.stories.tsx
@@ -78,8 +78,7 @@ export const IframeExample: Story = {
     parameters: {
         pageUrl: urls.heatmap('hm_iframe'),
         testOptions: {
-            waitForSelector: '#heatmap-iframe',
-            skipIframeWait: true,
+            waitForSelector: ['#heatmap-iframe', '.heatmaps-ready'],
         },
     },
     decorators: [


### PR DESCRIPTION
## Summary
- The `IframeExample` visual regression test was flapping because it only waited for `#heatmap-iframe` to exist, not for the heatmap canvas overlay to finish loading
- Now waits for both `#heatmap-iframe` and `.heatmaps-ready` selectors before taking the snapshot
- Removed `skipIframeWait: true` to re-enable iframe load tracking and stabilization

## Test plan
- [ ] CI storybook visual tests pass without flakiness
- [ ] The `scenes-app-heatmap--iframe-example--light.png` snapshot is captured correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)