### PR TITLE
chore(batch-exports): add disclaimer about data types

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
@@ -44,6 +44,8 @@ export function BatchExportConfiguration(): JSX.Element {
         batchExportConfig,
         selectedModel,
         runningStep,
+        isDatabaseDestination,
+        service,
     } = useValues(batchExportConfigurationLogic)
     const { setSelectedModel, setConfigurationValue, runBatchExportConfigTestStep } =
         useActions(batchExportConfigurationLogic)
@@ -233,6 +235,19 @@ export function BatchExportConfiguration(): JSX.Element {
                                         header: 'View model schema',
                                         content: (
                                             <div className="flex-1">
+                                                {/* TODO: display the data types that will be used in the destination */}
+                                                {isDatabaseDestination && (
+                                                    <LemonBanner type="info" className="mb-4">
+                                                        This schema is just for reference and does not reflect the
+                                                        actual data types that will be used in {service}.
+                                                        <br />
+                                                        <br />
+                                                        <b>
+                                                            It is recommended to allow the batch export to create the
+                                                            destination table automatically.
+                                                        </b>
+                                                    </LemonBanner>
+                                                )}
                                                 <DatabaseTable
                                                     table={selectedModel ? selectedModel : 'events'}
                                                     tables={tables}

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
@@ -968,6 +968,11 @@ export const batchExportConfigurationLogic = kea<batchExportConfigurationLogicTy
             (batchExportConfigLoading, batchExportConfigTestLoading) =>
                 batchExportConfigLoading || batchExportConfigTestLoading,
         ],
+        isDatabaseDestination: [
+            (s) => [s.service],
+            (service): boolean =>
+                !!service && ['Postgres', 'Redshift', 'Snowflake', 'Databricks', 'BigQuery'].includes(service),
+        ],
         requiredFields: [
             (s) => [s.service, s.isNew, s.configuration],
             (service, isNew, config): string[] => {


### PR DESCRIPTION
## Problem

In the batch export configuration UI we display the schema for the model being exported. However, this uses internal data types, rather than those data types used by the particular destination (BigQuery, Snowflake, etc), which is confusing and can lead to users creating tables with the incorrect data types.

## Changes

Add a note to inform the user that we recommend they allow batch exports to create the table for them and that these data types don't reflect the ones used in their particular destination.

(In future, we should display the actual data types that will be used in the destination.)

<img width="805" height="544" alt="image" src="https://github.com/user-attachments/assets/efc92ce7-43d2-495b-9d34-44487064dd88" />


## How did you test this code?

Local testing.

## Publish to changelog?

No.