### PR TITLE
fix(llma): register generation clustering coordinator schedule

### DIFF
--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -30,7 +30,10 @@ from posthog.temporal.experiments.schedule import (
     create_experiment_regular_metrics_schedules,
     create_experiment_saved_metrics_schedules,
 )
-from posthog.temporal.llm_analytics.trace_clustering.schedule import create_trace_clustering_coordinator_schedule
+from posthog.temporal.llm_analytics.trace_clustering.schedule import (
+    create_generation_clustering_coordinator_schedule,
+    create_trace_clustering_coordinator_schedule,
+)
 from posthog.temporal.llm_analytics.trace_summarization.schedule import (
     create_batch_generation_summarization_schedule,
     create_batch_trace_summarization_schedule,
@@ -312,6 +315,7 @@ schedules = [
     create_batch_trace_summarization_schedule,
     create_batch_generation_summarization_schedule,
     create_trace_clustering_coordinator_schedule,
+    create_generation_clustering_coordinator_schedule,
     create_ducklake_compaction_schedule,
     create_delete_recording_metadata_schedule,
     create_experiment_regular_metrics_schedules,


### PR DESCRIPTION
## Problem

The `create_generation_clustering_coordinator_schedule` function was added for generation-level clustering but was not imported or added to the `schedules` list in `posthog/temporal/schedule.py`. This means the schedule is never registered with Temporal.

## Changes

- Import `create_generation_clustering_coordinator_schedule` from the trace clustering schedule module
- Add it to the `schedules` list so it gets registered on worker startup

## How did you test this code?

Code inspection. After merge, will run `python manage.py schedule_temporal_workflows` in both US and EU clusters to register the schedule.