### PR TITLE
fix(persons): Split person modal wouldn't close

### DIFF
--- a/frontend/src/scenes/persons/MergeSplitPerson.tsx
+++ b/frontend/src/scenes/persons/MergeSplitPerson.tsx
@@ -8,9 +8,11 @@ import { pluralize } from 'lib/utils'
 import { PersonType } from '~/types'
 
 import { mergeSplitPersonLogic } from './mergeSplitPersonLogic'
+import { personsLogic } from './personsLogic'
 
 export function MergeSplitPerson({ person }: { person: PersonType }): JSX.Element {
-    const logicProps = { person }
+    const { urlId } = useValues(personsLogic)
+    const logicProps = { person, urlId: urlId ?? '' }
     const { executedLoading } = useValues(mergeSplitPersonLogic(logicProps))
     const { execute, cancel } = useActions(mergeSplitPersonLogic(logicProps))
 

--- a/frontend/src/scenes/persons/mergeSplitPersonLogic.test.ts
+++ b/frontend/src/scenes/persons/mergeSplitPersonLogic.test.ts
@@ -1,0 +1,108 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { mergeSplitPersonLogic } from './mergeSplitPersonLogic'
+import { personsLogic } from './personsLogic'
+
+const URL_DISTINCT_ID = 'user@example.com'
+
+const MOCK_PERSON = {
+    id: '123',
+    uuid: 'abc-123',
+    distinct_ids: [URL_DISTINCT_ID, 'user-456'],
+    properties: { email: 'user@example.com' },
+    created_at: '2024-01-01T00:00:00Z',
+}
+
+describe('mergeSplitPersonLogic', () => {
+    let logic: ReturnType<typeof mergeSplitPersonLogic.build>
+    let personsLogicInstance: ReturnType<typeof personsLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/persons/': { results: [MOCK_PERSON], count: 1 },
+            },
+            post: {
+                '/api/person/123/split/': { success: true },
+            },
+        })
+        initKeaTests()
+
+        personsLogicInstance = personsLogic({ syncWithUrl: true, urlId: URL_DISTINCT_ID })
+        personsLogicInstance.mount()
+
+        logic = mergeSplitPersonLogic({ person: MOCK_PERSON, urlId: URL_DISTINCT_ID })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        personsLogicInstance.unmount()
+    })
+
+    describe('cancel', () => {
+        it('closes the modal by dispatching setSplitMergeModalShown(false) on the correct personsLogic instance', async () => {
+            personsLogicInstance.actions.setSplitMergeModalShown(true)
+
+            await expectLogic(personsLogicInstance).toMatchValues({
+                splitMergeModalShown: true,
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.cancel()
+            })
+                .toDispatchActions([personsLogicInstance.actionTypes.setSplitMergeModalShown])
+                .toFinishListeners()
+
+            await expectLogic(personsLogicInstance).toMatchValues({
+                splitMergeModalShown: false,
+            })
+        })
+
+        it('does not close the modal while execute is loading', async () => {
+            personsLogicInstance.actions.setSplitMergeModalShown(true)
+
+            logic.actions.execute()
+            logic.actions.cancel()
+
+            await expectLogic(personsLogicInstance).toMatchValues({
+                splitMergeModalShown: true,
+            })
+        })
+    })
+
+    describe('execute', () => {
+        it('closes the modal on successful split', async () => {
+            personsLogicInstance.actions.setSplitMergeModalShown(true)
+
+            await expectLogic(logic, () => {
+                logic.actions.execute()
+            })
+                .toDispatchActions(['execute', 'executeSuccess'])
+                .toFinishListeners()
+
+            await expectLogic(personsLogicInstance).toMatchValues({
+                splitMergeModalShown: false,
+            })
+        })
+    })
+
+    describe('urlId matching', () => {
+        it('connects to the correct personsLogic instance based on urlId', async () => {
+            const differentPersonsLogic = personsLogic({ syncWithUrl: true, urlId: 'different-user' })
+            differentPersonsLogic.mount()
+            differentPersonsLogic.actions.setSplitMergeModalShown(true)
+
+            logic.actions.cancel()
+
+            await expectLogic(differentPersonsLogic).toMatchValues({
+                splitMergeModalShown: true,
+            })
+
+            differentPersonsLogic.unmount()
+        })
+    })
+})

--- a/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
+++ b/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
@@ -13,6 +13,7 @@ import { personsLogic } from './personsLogic'
 
 export interface SplitPersonLogicProps {
     person: PersonType
+    urlId: string
 }
 
 export type PersonUuids = NonNullable<PersonType['uuid']>[]
@@ -21,12 +22,12 @@ export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>([
     props({} as SplitPersonLogicProps),
     key((props) => props.person.id ?? 'new'),
     path((key) => ['scenes', 'persons', 'mergeSplitPersonLogic', key]),
-    connect(() => ({
+    connect((props: SplitPersonLogicProps) => ({
         actions: [
-            personsLogic({ syncWithUrl: true }),
+            personsLogic({ syncWithUrl: true, urlId: props.urlId }),
             ['setListFilters', 'loadPersons', 'setPerson', 'setSplitMergeModalShown'],
         ],
-        values: [personsLogic({ syncWithUrl: true }), ['persons']],
+        values: [personsLogic({ syncWithUrl: true, urlId: props.urlId }), ['persons']],
     })),
     actions({
         setSelectedPersonToAssignSplit: (id: string) => ({ id }),


### PR DESCRIPTION
## Problem
Closes #40420

## Changes
We pass urlId to `mergeSplitPersonLogic` so it connects to the correct personsLogic instance, allowing the modal to close. 


https://github.com/user-attachments/assets/e35d758f-0f02-4729-be95-4a58b702022f


## How did you test this code?
- Go to persons
- Click split IDs in top right
- Modal should be closable

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
