### PR TITLE
chore(hogql): increase json parser comparison sampling rate

### DIFF
--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -102,7 +102,7 @@ def _compare_with_cpp_json(
     placeholders: dict[str, ast.Expr] | None = None,
 ) -> None:
     # Only compare a fraction of queries to avoid performance overhead
-    if random.random() > 0.1:
+    if random.random() > 0.25:
         return
 
     if backend == "cpp-json":


### PR DESCRIPTION
## Problem

We want to make sure the cpp-json backend is solid before fully committing to it

## Changes

Increase the sampling rate for comparisons from 0.1 to 0.25

## How did you test this code?

Running it

## Publish to changelog?

No