### PR TITLE
fix(sql-editor): expand when searching

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -1172,10 +1172,17 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                     searchResults.push(createTopLevelFolderNode('drafts', draftsChildren, true))
                 }
 
-                // Auto-expand only parent folders, not the matching nodes themselves
-                setTimeout(() => {
-                    actions.setExpandedSearchFolders(expandedIds)
-                }, 0)
+                const expandedIdSet = new Set(expandedSearchFolders)
+                const missingRequiredExpansion = expandedIds.some((id) => !expandedIdSet.has(id))
+
+                if (missingRequiredExpansion) {
+                    // Auto-expand only parent folders, not the matching nodes themselves.
+                    setTimeout(() => {
+                        actions.setExpandedSearchFolders(
+                            Array.from(new Set([...expandedSearchFolders, ...expandedIds]))
+                        )
+                    }, 0)
+                }
 
                 return searchResults
             },


### PR DESCRIPTION
## Problem

You could not expand tables in the SQL editor when searching for something.

https://posthog.slack.com/archives/C0A76MN8V0E/p1769547553116499

## Changes

Make it work

## How did you test this code?

Clicked around, things expanded.