### PR TITLE
fix(surveys): set proper types for hosted survey custom properties

### DIFF
--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -999,14 +999,22 @@
         }
 
         // Extract additional survey event properties from URL parameters
-        const URL_PARAMS_TO_IGNORE = ['distinct_id', '__posthog_debug__', 'auto_submit'];
+        const URL_PARAMS_TO_IGNORE = ['distinct_id', '__posthog_debug__', '__posthog_debug', 'auto_submit'];
         const surveyEventProperties = {};
 
         for (const [key, value] of searchParams.entries()) {
             // Skip question prefill parameters (q1, q2, etc.) and ignored params
             const keyLower = key.toLowerCase();
             if (!URL_PARAMS_TO_IGNORE.includes(keyLower) && !keyLower.match(/^q\d+$/)) {
-                surveyEventProperties[key] = value;
+                if (/^-?\d+(\.\d+)?$/.test(value)) {
+                    surveyEventProperties[key] = Number(value);
+                } else if (value === 'true') {
+                    surveyEventProperties[key] = true;
+                } else if (value === 'false') {
+                    surveyEventProperties[key] = false;
+                } else {
+                    surveyEventProperties[key] = value;
+                }
             }
         }
 


### PR DESCRIPTION
## Problem
we pass all custom property URL params from hosted surveys along as-is, which means they are always strings, and that causes problems for customers who use these properties (and their proper types) in other events
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
adds simple type coercion for numeric and boolean url params; falls back to string for everything else

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
