### PR TITLE
fix(customers): Add css class for customer profiles

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -615,3 +615,9 @@
         padding: 0 0.75rem; // Padding to fit in the HeadingToggles
     }
 }
+
+.NotebookProfileCanvas {
+    .Notebook_content {
+        padding: 0;
+    }
+}

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -28,6 +28,7 @@ export type NotebookProps = NotebookLogicProps & {
     initialAutofocus?: EditorFocusPosition
     initialContent?: JSONContent
     editable?: boolean
+    className?: string
 }
 
 export function Notebook({
@@ -36,6 +37,7 @@ export function Notebook({
     editable = true,
     initialAutofocus = 'start',
     initialContent,
+    className,
 }: NotebookProps): JSX.Element {
     const logicProps: NotebookLogicProps = { shortId, mode }
     const logic = notebookLogic(logicProps)
@@ -96,7 +98,8 @@ export function Notebook({
                         !isExpanded && 'Notebook--compact',
                         mode && `Notebook--${mode}`,
                         size === 'small' && `Notebook--single-column`,
-                        isEditable && 'Notebook--editable'
+                        isEditable && 'Notebook--editable',
+                        className
                     )}
                     ref={ref}
                 >

--- a/frontend/src/scenes/persons/PersonProfileCanvas.tsx
+++ b/frontend/src/scenes/persons/PersonProfileCanvas.tsx
@@ -63,6 +63,7 @@ const PersonProfileCanvas = ({ person }: PersonProfileCanvasProps): JSX.Element 
                     editable={false}
                     shortId={shortId}
                     mode={mode}
+                    className="NotebookProfileCanvas"
                     initialContent={{
                         type: 'doc',
                         content,

--- a/products/customer_analytics/frontend/components/GroupProfileCanvas.tsx
+++ b/products/customer_analytics/frontend/components/GroupProfileCanvas.tsx
@@ -69,6 +69,7 @@ export const GroupProfileCanvas = ({ group, tabId }: GroupProfileCanvasProps): J
                         editable={false}
                         shortId={shortId}
                         mode={mode}
+                        className="NotebookProfileCanvas"
                         canvasFiltersOverride={groupFilter}
                         initialContent={{
                             type: 'doc',


### PR DESCRIPTION
## Problem

Profile canvases in the notebook component have unnecessary padding, which affects the visual presentation of person and group profiles.

## Changes

Added a new CSS class `NotebookProfileCanvas` that removes padding from notebook content when applied. Also updated the `Notebook` component to accept a `className` prop, which is then applied to the notebook container. This class is now used in both `PersonProfileCanvas` and `GroupProfileCanvas` components.

## How did you test this code?

Tested by viewing person and group profile canvases with the new styling applied, verifying that the padding is properly removed and the visual presentation is improved.

## Publish to changelog?
No