### PR TITLE
fix(devenv): make docker:services:up respect intent config

### DIFF
--- a/common/hogli/devenv/__init__.py
+++ b/common/hogli/devenv/__init__.py
@@ -10,7 +10,14 @@ Key components:
 - MprocsGenerator: Generates mprocs.yaml configuration
 """
 
-from .generator import DevenvConfig, MprocsConfig, MprocsGenerator, get_generated_mprocs_path, load_devenv_config
+from .generator import (
+    DevenvConfig,
+    MprocsConfig,
+    MprocsGenerator,
+    build_docker_compose_command,
+    get_generated_mprocs_path,
+    load_devenv_config,
+)
 from .registry import MprocsRegistry, ProcessRegistry, create_mprocs_registry
 from .resolver import IntentMap, IntentResolver, load_intent_map
 from .wizard import run_setup_wizard
@@ -22,6 +29,7 @@ __all__ = [
     "DevenvConfig",
     "load_devenv_config",
     "get_generated_mprocs_path",
+    "build_docker_compose_command",
     "ProcessRegistry",
     "MprocsRegistry",
     "create_mprocs_registry",

--- a/common/hogli/devenv/cli.py
+++ b/common/hogli/devenv/cli.py
@@ -231,5 +231,6 @@ def docker_services_up(yes: bool) -> None:
         click.echo("Starting Docker core services only (no intent config found)")
     click.echo(f"  {cmd}")
 
-    result = subprocess.run(cmd, shell=True)
+    # cmd is built from internal config (intent-map.yaml), not user input
+    result = subprocess.run(cmd, shell=True)  # nosemgrep: subprocess-shell-true
     raise SystemExit(result.returncode)

--- a/common/hogli/devenv/cli.py
+++ b/common/hogli/devenv/cli.py
@@ -8,7 +8,13 @@ from __future__ import annotations
 import click
 from hogli.core.cli import cli
 
-from .generator import DevenvConfig, MprocsGenerator, get_generated_mprocs_path, load_devenv_config
+from .generator import (
+    DevenvConfig,
+    MprocsGenerator,
+    build_docker_compose_command,
+    get_generated_mprocs_path,
+    load_devenv_config,
+)
 from .registry import create_mprocs_registry
 from .resolver import IntentResolver, load_intent_map
 
@@ -176,3 +182,49 @@ def dev_setup(log_to_files: bool) -> None:
         raise SystemExit(1)
 
     run_setup_wizard(intent_map, log_to_files=log_to_files)
+
+
+def _get_docker_profiles_from_config() -> list[str]:
+    """Get docker profiles from saved intent config."""
+    try:
+        resolver = _create_resolver()
+    except FileNotFoundError:
+        return []
+
+    output_path = get_generated_mprocs_path()
+    saved_config = load_devenv_config(output_path)
+
+    if saved_config is None:
+        return []
+
+    try:
+        resolved = resolver.resolve(
+            saved_config.intents,
+            include_units=saved_config.include_units,
+            exclude_units=saved_config.exclude_units,
+        )
+        return sorted(resolved.docker_profiles)
+    except ValueError:
+        return []
+
+
+@cli.command(name="docker:services:up", help="Start Docker services based on your intent config")
+def docker_services_up() -> None:
+    """Start Docker infrastructure services respecting intent configuration.
+
+    Uses docker compose profiles based on your configured intents.
+    Run 'hogli dev:setup' to configure which services to start.
+    """
+    import subprocess
+
+    profiles = _get_docker_profiles_from_config()
+    cmd = build_docker_compose_command(profiles, "up -d")
+
+    if profiles:
+        click.echo(f"Starting Docker services with profiles: {', '.join(profiles)}")
+    else:
+        click.echo("Starting Docker core services only (no intent config found)")
+    click.echo(f"  {cmd}")
+
+    result = subprocess.run(cmd, shell=True)
+    raise SystemExit(result.returncode)

--- a/common/hogli/devenv/cli.py
+++ b/common/hogli/devenv/cli.py
@@ -208,8 +208,13 @@ def _get_docker_profiles_from_config() -> list[str]:
         return []
 
 
-@cli.command(name="docker:services:up", help="Start Docker services based on your intent config")
-def docker_services_up() -> None:
+@cli.command(
+    name="docker:services:up",
+    help="Start Docker services based on your intent config",
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
+)
+@click.option("--yes", is_flag=True, hidden=True, help="Ignored, for composite command compatibility")
+def docker_services_up(yes: bool) -> None:
     """Start Docker infrastructure services respecting intent configuration.
 
     Uses docker compose profiles based on your configured intents.

--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -33,6 +33,26 @@ class DevenvConfig(BaseModel):
     log_to_files: bool = False
 
 
+# Docker compose command building
+DOCKER_COMPOSE_BASE = "docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml"
+
+
+def build_docker_compose_command(profiles: list[str], action: str = "up -d") -> str:
+    """Build docker compose command with profile flags.
+
+    Args:
+        profiles: List of docker compose profiles to activate
+        action: The docker compose action (e.g., "up -d", "down", "down -v")
+
+    Returns:
+        Complete docker compose command string
+    """
+    if profiles:
+        profile_flags = " ".join(f"--profile {p}" for p in profiles)
+        return f"{DOCKER_COMPOSE_BASE} {profile_flags} {action}"
+    return f"{DOCKER_COMPOSE_BASE} {action}"
+
+
 class ConfigGenerator(ABC):
     """Abstract generator for process manager configurations."""
 
@@ -179,19 +199,14 @@ class MprocsGenerator(ConfigGenerator):
         Returns:
             Process configuration dict with modified shell command
         """
-        # Build the compose command with profiles overlay
-        compose_base = "docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml"
-
         # Build the profile flags (may be empty for minimal stack)
         if profiles:
-            profile_flags = " " + " ".join(f"--profile {p}" for p in profiles)
             message = f"echo '▶ docker-compose: profiles: {', '.join(profiles)} (configure via: hogli dev:setup)' && "
         else:
-            profile_flags = ""
             message = "echo '▶ docker-compose: core services only (configure via: hogli dev:setup)' && "
 
-        up_cmd = f"{compose_base}{profile_flags} up --pull always -d"
-        logs_cmd = f"{compose_base}{profile_flags} logs --tail=0 -f"
+        up_cmd = build_docker_compose_command(profiles, "up --pull always -d")
+        logs_cmd = build_docker_compose_command(profiles, "logs --tail=0 -f")
 
         return {
             "shell": f"{message}{up_cmd} && {logs_cmd}",

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -326,10 +326,15 @@ docker:
     # docker:services:up is a Python command in common/hogli/devenv/cli.py that respects intent config
     docker:services:down:
         cmd: docker compose -f docker-compose.dev.yml down
-        description: Stop all Docker infrastructure services
+        description: Stop Docker infrastructure services
+        services:
+            - docker
     docker:services:remove:
         cmd: docker compose -f docker-compose.dev.yml down -v
-        description: Stop all Docker services and remove volumes (complete wipe)
+        description: Stop Docker infrastructure services and remove all volumes (complete wipe)
+        services:
+            - docker
+        prompt: true
     docker:deprecated:
         bin_script: docker
         description: '[DEPRECATED] Use `hogli start` instead'

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -323,26 +323,13 @@ build:
         cmd: pnpm --filter=@posthog/frontend run build:products
         description: Build products manifest from TypeScript/JSX files
 docker:
-    docker:services:up:
-        cmd: docker compose -f docker-compose.dev.yml up -d
-        description: Start Docker infrastructure services
-        services:
-            - docker
-            - postgresql
-            - clickhouse
-            - redis
-            - kafka
+    # docker:services:up is a Python command in common/hogli/devenv/cli.py that respects intent config
     docker:services:down:
         cmd: docker compose -f docker-compose.dev.yml down
-        description: Stop Docker infrastructure services
-        services:
-            - docker
+        description: Stop all Docker infrastructure services
     docker:services:remove:
         cmd: docker compose -f docker-compose.dev.yml down -v
-        description: Stop Docker infrastructure services and remove all volumes (complete wipe)
-        services:
-            - docker
-        prompt: true
+        description: Stop all Docker services and remove volumes (complete wipe)
     docker:deprecated:
         bin_script: docker
         description: '[DEPRECATED] Use `hogli start` instead'


### PR DESCRIPTION
**Problem**
`hogli docker:services:up` was starting all services from docker-compose.dev.yml instead of respecting the user's intent configuration. Users configuring specific intents (e.g., `product_analytics, debug_tools`) expected only those services to start.

**Solution**
- `docker:services:up` is now a Python command that reads the saved intent config and uses appropriate docker compose profiles
- `docker:services:down` and `docker:services:remove` remain simple manifest commands that stop all containers (using just docker-compose.dev.yml)
- Added `build_docker_compose_command()` helper for reuse between generator and CLI

**How it works now**
```
$ hogli docker:services:up
Starting Docker services with profiles: dev_tools
  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml --profile dev_tools up -d
```

If no intent config exists, starts core services only.