### PR TITLE
feat(llma): prompt management improvements

### DIFF
--- a/products/llm_analytics/frontend/prompts/LLMPromptScene.tsx
+++ b/products/llm_analytics/frontend/prompts/LLMPromptScene.tsx
@@ -60,6 +60,7 @@ export function LLMPromptScene(): JSX.Element {
                                 onClick={() => router.actions.push(urls.llmAnalyticsPrompts())}
                                 disabledReason={isPromptFormSubmitting ? 'Saving…' : undefined}
                                 size="small"
+                                data-attr="prompt-cancel-button"
                             >
                                 Cancel
                             </LemonButton>
@@ -71,6 +72,7 @@ export function LLMPromptScene(): JSX.Element {
                                     icon={<IconTrash />}
                                     onClick={() => openDeletePromptDialog(deletePrompt)}
                                     size="small"
+                                    data-attr="prompt-delete-button"
                                 >
                                     Delete
                                 </LemonButton>
@@ -81,6 +83,7 @@ export function LLMPromptScene(): JSX.Element {
                                 onClick={submitPromptForm}
                                 loading={isPromptFormSubmitting}
                                 size="small"
+                                data-attr={isNewPrompt ? 'prompt-create-button' : 'prompt-save-button'}
                             >
                                 {isNewPrompt ? 'Create prompt' : 'Save'}
                             </LemonButton>

--- a/products/llm_analytics/frontend/prompts/LLMPromptsScene.tsx
+++ b/products/llm_analytics/frontend/prompts/LLMPromptsScene.tsx
@@ -34,7 +34,11 @@ export function LLMPromptsScene(): JSX.Element {
             width: '25%',
             render: function renderName(_, prompt) {
                 return (
-                    <Link to={urls.llmAnalyticsPrompt(prompt.id)} className="font-semibold">
+                    <Link
+                        to={urls.llmAnalyticsPrompt(prompt.id)}
+                        className="font-semibold"
+                        data-attr="prompt-name-link"
+                    >
                         {prompt.name}
                     </Link>
                 )
@@ -75,7 +79,7 @@ export function LLMPromptsScene(): JSX.Element {
                             <>
                                 <LemonButton
                                     to={urls.llmAnalyticsPrompt(prompt.id)}
-                                    data-attr={`prompt-item-${prompt.id}-dropdown-view`}
+                                    data-attr="prompt-dropdown-view"
                                     fullWidth
                                 >
                                     View
@@ -84,7 +88,7 @@ export function LLMPromptsScene(): JSX.Element {
                                 <LemonButton
                                     status="danger"
                                     onClick={() => openDeletePromptDialog(() => deletePrompt(prompt.id))}
-                                    data-attr={`prompt-item-${prompt.id}-dropdown-delete`}
+                                    data-attr="prompt-dropdown-delete"
                                     fullWidth
                                 >
                                     Delete


### PR DESCRIPTION
## Problem

The LLM Analytics prompt management feature needed proper feature flag protection on all endpoints and analytics tracking to understand usage patterns.

## Changes

- Put all prompt management API endpoints behind the `llm-analytics-prompts` feature flag
- Add `data-attr` tracking attributes to prompt management UI elements (create, edit, delete buttons)
- Add backend event tracking for prompt CRUD operations:
  - `llma prompt created/updated/deleted` via `report_user_action`
  - `llma prompt fetched` via `report_team_action` for SDK calls

## How did you test this code?

Automated tests.

## Publish to changelog?

no
