### PR TITLE
feat(customers): Add events node to group profile

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -50,6 +50,7 @@ const Component = ({
     const { expanded } = useValues(nodeLogic)
     const { setTitlePlaceholder } = useActions(nodeLogic)
     const summarizeInsight = useSummarizeInsight()
+    const { canvasFiltersOverride } = useValues(notebookLogic)
 
     const insightLogicProps = {
         dashboardItemId: query.kind === NodeKind.SavedInsightNode ? query.shortId : ('new' as const),
@@ -105,6 +106,11 @@ const Component = ({
             modifiedQuery.showTable = false
             modifiedQuery.showCorrelationTable = false
             modifiedQuery.embedded = true
+        }
+
+        if (isDataTableNode(modifiedQuery) && isEventsQuery(modifiedQuery.source)) {
+            modifiedQuery.source.fixedProperties = canvasFiltersOverride
+            updateAttributes({ ...attributes, isDefaultFilterApplied: true })
         }
 
         return modifiedQuery

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -166,7 +166,6 @@ export const notebookLogic = kea<notebookLogicType>([
         setAccessDeniedToNotebook: true,
     }),
     reducers(({ props }) => ({
-        canvasFiltersOverride: [props.canvasFiltersOverride ?? ([] as AnyPropertyFilter[])],
         isShareModalOpen: [
             false,
             {
@@ -438,6 +437,7 @@ export const notebookLogic = kea<notebookLogicType>([
         ],
     })),
     selectors({
+        canvasFiltersOverride: [() => [(_, props) => props], (props) => props.canvasFiltersOverride || []],
         shortId: [(_, p) => [p.shortId], (shortId) => shortId],
         mode: [() => [(_, props) => props], (props): NotebookLogicMode => props.mode ?? 'notebook'],
         isTemplate: [(s) => [s.shortId], (shortId): boolean => shortId.startsWith('template-')],

--- a/products/customer_analytics/frontend/customerProfileLogic.ts
+++ b/products/customer_analytics/frontend/customerProfileLogic.ts
@@ -12,33 +12,33 @@ import { customerProfileConfigLogic } from './customerProfileConfigLogic'
 import type { customerProfileLogicType } from './customerProfileLogicType'
 
 export const DEFAULT_PERSON_PROFILE_SIDEBAR: JSONContent[] = [
-    { type: 'ph-person', attrs: { title: 'Info' } },
+    { type: NotebookNodeType.Person, attrs: { title: 'Info' } },
     // FIXME: Map bg image is broken
-    // { type: 'ph-map', attrs: { title: 'Map' } },
-    { type: 'ph-person-properties', attrs: { title: 'Properties' } },
-    { type: 'ph-related-groups', attrs: { title: 'Related groups' } },
+    // { type: NotebookNodeType.Map, attrs: { title: 'Map' } },
+    { type: NotebookNodeType.PersonProperties, attrs: { title: 'Properties' } },
+    { type: NotebookNodeType.RelatedGroups, attrs: { title: 'Related groups' } },
 ]
 
 export const DEFAULT_PERSON_PROFILE_CONTENT: JSONContent[] = [
-    { type: 'ph-usage-metrics', index: 0, attrs: { title: 'Usage metrics' } },
-    { type: 'ph-person-feed', index: 1, attrs: { title: 'Session feed' } },
-    { type: 'ph-llm-trace', index: 2, attrs: { title: 'LLM traces' } },
-    { type: 'ph-zendesk-tickets', index: 3, attrs: { title: 'Zendesk tickets' } },
-    { type: 'ph-issues', index: 4, attrs: { title: 'Issues' } },
+    { type: NotebookNodeType.UsageMetrics, index: 0, attrs: { title: 'Usage metrics' } },
+    { type: NotebookNodeType.PersonFeed, index: 1, attrs: { title: 'Session feed' } },
+    { type: NotebookNodeType.LLMTrace, index: 2, attrs: { title: 'LLM traces' } },
+    { type: NotebookNodeType.ZendeskTickets, index: 3, attrs: { title: 'Zendesk tickets' } },
+    { type: NotebookNodeType.Issues, index: 4, attrs: { title: 'Issues' } },
 ]
 
 export const DEFAULT_GROUP_PROFILE_SIDEBAR: JSONContent[] = [
-    { type: 'ph-group', attrs: { title: 'Info' } },
-    { type: 'ph-group-properties', attrs: { title: 'Properties' } },
-    { type: 'ph-related-groups', attrs: { title: 'Related people', type: 'person' } },
+    { type: NotebookNodeType.Group, attrs: { title: 'Info' } },
+    { type: NotebookNodeType.GroupProperties, attrs: { title: 'Properties' } },
+    { type: NotebookNodeType.RelatedGroups, attrs: { title: 'Related people', type: 'person' } },
 ]
 
 export const DEFAULT_GROUP_PROFILE_CONTENT: JSONContent[] = [
-    { type: 'ph-usage-metrics', index: 0, attrs: { title: 'Usage metrics' } },
+    { type: NotebookNodeType.UsageMetrics, index: 0, attrs: { title: 'Usage metrics' } },
     { type: NotebookNodeType.Query, index: 1, attrs: { title: 'Events' } },
-    { type: 'ph-llm-trace', index: 2, attrs: { title: 'LLM traces' } },
-    { type: 'ph-zendesk-tickets', index: 3, attrs: { title: 'Zendesk tickets' } },
-    { type: 'ph-issues', index: 4, attrs: { title: 'Issues' } },
+    { type: NotebookNodeType.LLMTrace, index: 2, attrs: { title: 'LLM traces' } },
+    { type: NotebookNodeType.ZendeskTickets, index: 3, attrs: { title: 'Zendesk tickets' } },
+    { type: NotebookNodeType.Issues, index: 4, attrs: { title: 'Issues' } },
 ]
 
 export type CustomerProfileAttrs = {
@@ -272,15 +272,15 @@ export function addPersonAttrsToNode({ attrs, node, children = [] }: AddAttrsToN
     const nodeId = `${node.type}-${personId}`
 
     switch (node.type) {
-        case 'ph-usage-metrics':
-        case 'ph-llm-trace':
-        case 'ph-zendesk-tickets':
-        case 'ph-issues':
+        case NotebookNodeType.UsageMetrics:
+        case NotebookNodeType.LLMTrace:
+        case NotebookNodeType.ZendeskTickets:
+        case NotebookNodeType.Issues:
             return {
                 ...node,
                 attrs: { ...node.attrs, nodeId, personId, children },
             }
-        case 'ph-person-feed':
+        case NotebookNodeType.PersonFeed:
             return {
                 ...node,
                 attrs: {
@@ -293,13 +293,13 @@ export function addPersonAttrsToNode({ attrs, node, children = [] }: AddAttrsToN
                     children,
                 },
             }
-        case 'ph-person':
-        case 'ph-person-properties':
+        case NotebookNodeType.Person:
+        case NotebookNodeType.PersonProperties:
             return {
                 ...node,
                 attrs: { ...node.attrs, nodeId, id: personId, distinctId, children },
             }
-        case 'ph-related-groups':
+        case NotebookNodeType.RelatedGroups:
             return {
                 ...node,
                 attrs: {
@@ -321,9 +321,9 @@ export function addGroupAttrsToNode({ attrs, node, children = [] }: AddAttrsToNo
     const nodeId = `${node.type}-${groupKey}-${groupTypeIndex}`
 
     switch (node.type) {
-        case 'ph-usage-metrics':
-        case 'ph-llm-trace':
-        case 'ph-issues':
+        case NotebookNodeType.UsageMetrics:
+        case NotebookNodeType.LLMTrace:
+        case NotebookNodeType.Issues:
             return {
                 ...node,
                 attrs: {
@@ -334,13 +334,13 @@ export function addGroupAttrsToNode({ attrs, node, children = [] }: AddAttrsToNo
                     children,
                 },
             }
-        case 'ph-zendesk-tickets':
+        case NotebookNodeType.ZendeskTickets:
             return {
                 ...node,
                 attrs: { ...node.attrs, nodeId, groupKey, children },
             }
-        case 'ph-group':
-        case 'ph-related-groups':
+        case NotebookNodeType.Group:
+        case NotebookNodeType.RelatedGroups:
             return {
                 ...node,
                 attrs: {
@@ -351,7 +351,7 @@ export function addGroupAttrsToNode({ attrs, node, children = [] }: AddAttrsToNo
                     children,
                 },
             }
-        case 'ph-group-properties':
+        case NotebookNodeType.GroupProperties:
             return {
                 ...node,
                 attrs: {

--- a/products/customer_analytics/frontend/customerProfileLogic.ts
+++ b/products/customer_analytics/frontend/customerProfileLogic.ts
@@ -4,6 +4,7 @@ import { JSONContent } from 'lib/components/RichContentEditor/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
+import { NotebookNodeType } from 'scenes/notebooks/types'
 
 import { CustomerProfileScope, GroupTypeIndex } from '~/types'
 
@@ -34,9 +35,10 @@ export const DEFAULT_GROUP_PROFILE_SIDEBAR: JSONContent[] = [
 
 export const DEFAULT_GROUP_PROFILE_CONTENT: JSONContent[] = [
     { type: 'ph-usage-metrics', index: 0, attrs: { title: 'Usage metrics' } },
-    { type: 'ph-llm-trace', index: 1, attrs: { title: 'LLM traces' } },
-    { type: 'ph-zendesk-tickets', index: 2, attrs: { title: 'Zendesk tickets' } },
-    { type: 'ph-issues', index: 3, attrs: { title: 'Issues' } },
+    { type: NotebookNodeType.Query, index: 1, attrs: { title: 'Events' } },
+    { type: 'ph-llm-trace', index: 2, attrs: { title: 'LLM traces' } },
+    { type: 'ph-zendesk-tickets', index: 3, attrs: { title: 'Zendesk tickets' } },
+    { type: 'ph-issues', index: 4, attrs: { title: 'Issues' } },
 ]
 
 export type CustomerProfileAttrs = {
@@ -358,6 +360,13 @@ export function addGroupAttrsToNode({ attrs, node, children = [] }: AddAttrsToNo
                 },
             }
         default:
-            return node
+            return {
+                ...node,
+                attrs: {
+                    ...node.attrs,
+                    nodeId,
+                    children,
+                },
+            }
     }
 }


### PR DESCRIPTION
## Problem

Group profile does not show events data. Events tab is currently the most accessed tab in group profiles. Let's save folks a few clicks by adding an events query to the group profile.

## Changes

- Fix canvas filters to data table nodes in notebooks when they are events queries
- Update the `isDefaultFilterApplied` attribute when filters are applied
- Refactor `canvasFiltersOverride` from a reducer to a selector in notebook logic
- Replace string literals with `NotebookNodeType` enum values in customer profile logic
- Add an "Events" query node to the default group profile content
- Ensure all node types properly handle attributes in `addGroupAttrsToNode`

## How did you test this code?

Tested by opening group profiles and checking that:

- Events node shows up
- I can toggle on/off the node
- The node shows only events related to the group I'm viewing

## Publish to changelog?

No