### PR TITLE
fix(session-summaries): handle already-running video export workflow

### DIFF
--- a/posthog/temporal/ai/session_summary/activities/a1_export_session_video.py
+++ b/posthog/temporal/ai/session_summary/activities/a1_export_session_video.py
@@ -13,6 +13,7 @@ from django.utils.timezone import now
 import structlog
 import temporalio
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from posthog.models.exported_asset import ExportedAsset
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
@@ -116,15 +117,26 @@ async def export_session_video_activity(inputs: VideoSummarySingleSessionInputs)
 
         # Actually export the video
         client = await async_connect()
-        await client.execute_workflow(
-            VideoExportWorkflow.run,
-            VideoExportInputs(exported_asset_id=exported_asset.id),
-            id=f"session-video-summary-export_{inputs.session_id}",
-            task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
-            retry_policy=RetryPolicy(maximum_attempts=int(TEMPORAL_WORKFLOW_MAX_ATTEMPTS)),
-            # Allow duplicates for testing purposes - this shouldn't happen in prod anyway
-            id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-        )
+        workflow_id = f"session-video-summary-export_{inputs.session_id}"
+        try:
+            await client.execute_workflow(
+                VideoExportWorkflow.run,
+                VideoExportInputs(exported_asset_id=exported_asset.id),
+                id=workflow_id,
+                task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
+                retry_policy=RetryPolicy(maximum_attempts=int(TEMPORAL_WORKFLOW_MAX_ATTEMPTS)),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+            )
+        except WorkflowAlreadyStartedError:
+            # Workflow is already running for this session, wait for it to complete
+            logger.debug(
+                f"Video export workflow already running for session {inputs.session_id}, waiting for it to complete",
+                session_id=inputs.session_id,
+                workflow_id=workflow_id,
+                signals_type="session-summaries",
+            )
+            handle = client.get_workflow_handle(workflow_id)
+            await handle.result()
 
         logger.debug(
             f"Video exported successfully for session {inputs.session_id}",


### PR DESCRIPTION
## Problem

When video-based session summarization is triggered multiple times for the same session concurrently (e.g., from scheduled tasks), the second attempt fails with `WorkflowExecutionAlreadyStartedError` because a video export workflow with the same ID is already running.

This happens because `WorkflowIDReusePolicy.ALLOW_DUPLICATE` only allows starting workflows when a previous workflow with the same ID has **closed** - it does not permit starting when one is **still running**.

[Slack thread where @sachinr raised this.](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1769631239050289)

## Changes

When `WorkflowAlreadyStartedError` is raised, get a handle to the existing workflow and wait for it to complete instead of failing. This is what we already do in a bunch of places.
