### PR TITLE
chore(data-warehouse): Print the stack when init'ing the kafka producer for dwh workers

### DIFF
--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -1,3 +1,4 @@
+import os
 import json
 from collections.abc import Callable
 from enum import StrEnum
@@ -114,6 +115,12 @@ class _KafkaProducer:
         max_request_size=None,
         compression_type=None,
     ):
+        hostname = os.environ.get("HOSTNAME", "")
+        if "temporal-worker-data-warehouse" in hostname:
+            import traceback
+
+            logger.info(f"KafkaProducer stack: {traceback.format_stack()}")
+
         if settings.TEST:
             test = True  # Set at runtime so that overriden settings.TEST is supported
         if kafka_security_protocol is None:


### PR DESCRIPTION
## Problem
- We're not so sure what's kicking off the kafka producer

## Changes
- Print the stack from traceback only for temporal-worker-data-warehouse
