### PR TITLE
fix(product tours): add linked flag to readonly in django admin

### DIFF
--- a/posthog/admin/admins/product_tour_admin.py
+++ b/posthog/admin/admins/product_tour_admin.py
@@ -19,7 +19,7 @@ class ProductTourAdmin(admin.ModelAdmin):
     list_filter = ("archived",)
     search_fields = ("id", "name", "team__name", "team__organization__name")
     autocomplete_fields = ("team", "created_by")
-    readonly_fields = ("id", "internal_targeting_flag", "created_at", "updated_at")
+    readonly_fields = ("id", "internal_targeting_flag", "linked_flag", "created_at", "updated_at")
     ordering = ("-created_at",)
 
     def get_queryset(self, request):


### PR DESCRIPTION
## Problem
we're loading every feature flag on the PT admin cuz of linked_flag lol
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
makes linked_flag readonly in PT django admin

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
