### PR TITLE
chore(kafka): Use a lower max idle time for kafka producers

### DIFF
--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -140,6 +140,10 @@ class _KafkaProducer:
                 bootstrap_servers=kafka_hosts,
                 security_protocol=kafka_security_protocol or _KafkaSecurityProtocol.PLAINTEXT,
                 compression_type=compression_type,
+                # Proactively recycle idle connections before NAT Gateway/NLB kills them (350s timeout)
+                connections_max_idle_ms=60000,  # 1 minute
+                reconnect_backoff_ms=50,
+                reconnect_backoff_max_ms=1000,
                 **{"max_request_size": max_request_size} if max_request_size else {},
                 **{"api_version_auto_timeout_ms": 30000}
                 if settings.DEBUG

--- a/posthog/kafka_client/helper.py
+++ b/posthog/kafka_client/helper.py
@@ -91,6 +91,10 @@ def get_kafka_producer(acks="all", value_serializer=lambda v: json.dumps(v).enco
         ssl_context=get_kafka_ssl_context(),
         value_serializer=value_serializer,
         acks=acks,
+        # Proactively recycle idle connections before NAT Gateway/NLB kills them (350s timeout)
+        connections_max_idle_ms=60000,  # 1 minute
+        reconnect_backoff_ms=50,
+        reconnect_backoff_max_ms=1000,
         **kwargs,
     )
 


### PR DESCRIPTION
## Problem
- We think the MSK connection is getting dropped on the server side _somewhere_ and so the client is trying to reuse a closed connection, causing request timeouts 

## Changes
- Use a lower idle timeout to force a reconnect from our producer client
