### PR TITLE
fix(modeling): 10x the page size for nodes and edges

### DIFF
--- a/products/data_modeling/backend/api/edge.py
+++ b/products/data_modeling/backend/api/edge.py
@@ -31,7 +31,7 @@ class EdgeSerializer(serializers.ModelSerializer):
 
 
 class EdgePagination(PageNumberPagination):
-    page_size = 500
+    page_size = 5000
 
 
 class EdgeViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):

--- a/products/data_modeling/backend/api/node.py
+++ b/products/data_modeling/backend/api/node.py
@@ -62,7 +62,7 @@ class NodeSerializer(serializers.ModelSerializer):
 
 
 class NodePagination(PageNumberPagination):
-    page_size = 100
+    page_size = 1000
 
 
 # TODO: consolidate graph traversal logic. similar implementations exist in:


### PR DESCRIPTION
## Problem

the page size is too small to render the DAG for team 2

## Changes

the models are relatively small from a data xfer perspective so we just up the page size. in the future i may place hard limits on how many nodes / edges can belong to a single dag and the frontend will only ever render one dag at a time (but teams can have as many as they want)

## How did you test this code?

i didn't

## Publish to changelog?

no