### PR TITLE
feat(product-tours): add custom CSS selector option for banner injection

### DIFF
--- a/frontend/src/scenes/product-tours/BannerContentEditor.tsx
+++ b/frontend/src/scenes/product-tours/BannerContentEditor.tsx
@@ -68,24 +68,43 @@ export function BannerContentEditor({ step, appearance, onChange }: BannerConten
                 <div className="flex-1 min-w-0 space-y-4">
                     <div>
                         <label className="text-sm font-medium block mb-3">Settings</label>
-                        <div className="flex items-center justify-between">
-                            <div>
-                                <div className="font-medium text-sm">Behavior</div>
-                                <div className="text-muted text-xs">Stays visible while scrolling</div>
+                        <div className="space-y-3">
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <div className="font-medium text-sm">Position</div>
+                                    <div className="text-muted text-xs">
+                                        {behavior === 'sticky'
+                                            ? 'Top of page, stays visible while scrolling'
+                                            : behavior === 'static'
+                                              ? 'Top of page, scrolls with content'
+                                              : 'Injected into your container element'}
+                                    </div>
+                                </div>
+                                <LemonSegmentedButton
+                                    size="small"
+                                    value={behavior}
+                                    onChange={(value) =>
+                                        updateBannerConfig({
+                                            behavior: value as ProductTourBannerConfig['behavior'],
+                                            selector: value === 'custom' ? step.bannerConfig?.selector : undefined,
+                                        })
+                                    }
+                                    options={[
+                                        { value: 'sticky', label: 'Sticky' },
+                                        { value: 'static', label: 'Static' },
+                                        { value: 'custom', label: 'Custom' },
+                                    ]}
+                                />
                             </div>
-                            <LemonSegmentedButton
-                                size="small"
-                                value={behavior}
-                                onChange={(value) =>
-                                    updateBannerConfig({
-                                        behavior: value as ProductTourBannerConfig['behavior'],
-                                    })
-                                }
-                                options={[
-                                    { value: 'sticky', label: 'Sticky' },
-                                    { value: 'static', label: 'Static' },
-                                ]}
-                            />
+                            {behavior === 'custom' && (
+                                <LemonInput
+                                    value={step.bannerConfig?.selector ?? ''}
+                                    onChange={(selector) => updateBannerConfig({ selector })}
+                                    placeholder="#my-banner-container"
+                                    size="small"
+                                    fullWidth
+                                />
+                            )}
                         </div>
                     </div>
 

--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -40,7 +40,6 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
         productTour,
         productTourLoading,
         productTourForm,
-        productTourFormAllErrors,
         targetingFlagFilters,
         isProductTourFormSubmitting,
         editTab,
@@ -241,11 +240,6 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                 {editTab === ProductTourEditTab.Steps &&
                     (isAnnouncement(productTour) ? (
                         <>
-                            {productTourFormAllErrors._form && (
-                                <LemonField name="_form" className="mb-4">
-                                    <span />
-                                </LemonField>
-                            )}
                             {isBannerAnnouncement(productTour) ? (
                                 <BannerContentEditor
                                     step={productTourForm.content?.steps?.[0]}

--- a/frontend/src/scenes/product-tours/productTourLogic.ts
+++ b/frontend/src/scenes/product-tours/productTourLogic.ts
@@ -327,11 +327,19 @@ export const productTourLogic = kea<productTourLogicType>([
                 }
 
                 for (const step of content.steps || []) {
-                    const error =
-                        step.type === 'banner'
-                            ? validateBannerAction(step.bannerConfig?.action, 'Banner click action')
-                            : validateButton(step.buttons?.primary, 'Primary button') ||
-                              validateButton(step.buttons?.secondary, 'Secondary button')
+                    let error: string | undefined
+
+                    if (step.type === 'banner') {
+                        if (step.bannerConfig?.behavior === 'custom' && !step.bannerConfig?.selector?.trim()) {
+                            error = 'Custom banner position requires a CSS selector'
+                        } else {
+                            error = validateBannerAction(step.bannerConfig?.action, 'Banner click action')
+                        }
+                    } else {
+                        error =
+                            validateButton(step.buttons?.primary, 'Primary button') ||
+                            validateButton(step.buttons?.secondary, 'Secondary button')
+                    }
 
                     if (error) {
                         errors._form = error
@@ -418,7 +426,11 @@ export const productTourLogic = kea<productTourLogicType>([
             }
         },
         submitProductTourFormFailure: () => {
-            lemonToast.error('Failed to save product tour')
+            const errorMessage =
+                values.productTourFormAllErrors._form ||
+                values.productTourFormAllErrors.name ||
+                'Failed to save product tour'
+            lemonToast.error(errorMessage)
         },
         launchProductTour: async () => {
             if (values.productTour) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3354,7 +3354,13 @@ export type ProductTourProgressionTriggerType = 'button' | 'click'
 export type ProductTourStepType = 'element' | 'modal' | 'survey' | 'banner'
 
 export interface ProductTourBannerConfig {
-    behavior: 'sticky' | 'static'
+    /**
+     * sticky: injected at top of body, fixed pos, stays visible on scroll
+     * static: injected at top of body, fixed pos, scrolls away with page
+     * custom: injected into a container from user-supplied css selector
+     */
+    behavior: 'sticky' | 'static' | 'custom'
+    selector?: string
     action?: {
         type: 'none' | 'link' | 'trigger_tour'
         link?: string


### PR DESCRIPTION
## Problem

if a customer's site has any fixed-position elements, our banner breaks. example:

![fixed-banner-bug.png](https://app.graphite.com/user-attachments/assets/d842784f-12be-49ff-b83e-e0ab01725fba.png)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds support for a new `custom` banner behavior - in this case, we'll inject the banner into the existing element instead of positioning it top / fixed

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

also tidies up the error handling

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

![Screenshot 2026-01-28 at 6.32.41 PM.png](https://app.graphite.com/user-attachments/assets/67e77afb-0b2e-4753-b291-40c11407b87b.png)

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->