### PR TITLE
fix(modeling): add running and recent actions to data modeling job api

### DIFF
--- a/products/data_warehouse/backend/api/data_modeling_job.py
+++ b/products/data_warehouse/backend/api/data_modeling_job.py
@@ -65,7 +65,11 @@ class DataModelingJobViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewS
 
     @action(methods=["GET"], detail=False)
     def recent(self, request, *args, **kwargs):
-        """Get recent jobs (last 24 hours)."""
-        queryset = self.safely_get_queryset().order_by("-created_at")
+        """Get recently completed/failed jobs (paginated)."""
+        queryset = self.safely_get_queryset().exclude(status__in=["Running", "Cancelled"])
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)

--- a/products/data_warehouse/frontend/generated/api.ts
+++ b/products/data_warehouse/frontend/generated/api.ts
@@ -116,6 +116,40 @@ export const dataModelingJobsRetrieve = async (
 }
 
 /**
+ * Get recently completed/failed jobs (paginated).
+ */
+export const getDataModelingJobsRecentRetrieveUrl = (projectId: string) => {
+    return `/api/environments/${projectId}/data_modeling_jobs/recent/`
+}
+
+export const dataModelingJobsRecentRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<DataModelingJobApi> => {
+    return apiMutator<DataModelingJobApi>(getDataModelingJobsRecentRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
+ * Get all currently running jobs.
+ */
+export const getDataModelingJobsRunningRetrieveUrl = (projectId: string) => {
+    return `/api/environments/${projectId}/data_modeling_jobs/running/`
+}
+
+export const dataModelingJobsRunningRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<DataModelingJobApi> => {
+    return apiMutator<DataModelingJobApi>(getDataModelingJobsRunningRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
  * Returns completed/non-running activities (jobs with status 'Completed').
 Supports pagination and cutoff time filtering.
  */
@@ -1290,6 +1324,40 @@ export const dataModelingJobsRetrieve2 = async (
     options?: RequestInit
 ): Promise<DataModelingJobApi> => {
     return apiMutator<DataModelingJobApi>(getDataModelingJobsRetrieve2Url(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
+ * Get recently completed/failed jobs (paginated).
+ */
+export const getDataModelingJobsRecentRetrieve2Url = (projectId: string) => {
+    return `/api/projects/${projectId}/data_modeling_jobs/recent/`
+}
+
+export const dataModelingJobsRecentRetrieve2 = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<DataModelingJobApi> => {
+    return apiMutator<DataModelingJobApi>(getDataModelingJobsRecentRetrieve2Url(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
+ * Get all currently running jobs.
+ */
+export const getDataModelingJobsRunningRetrieve2Url = (projectId: string) => {
+    return `/api/projects/${projectId}/data_modeling_jobs/running/`
+}
+
+export const dataModelingJobsRunningRetrieve2 = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<DataModelingJobApi> => {
+    return apiMutator<DataModelingJobApi>(getDataModelingJobsRunningRetrieve2Url(projectId), {
         ...options,
         method: 'GET',
     })


### PR DESCRIPTION
## Problem

right now the new modeling scene for team 2 depends on actions running/ and recent/ for data modeling jobs. those don't exist yet because claude didn't break up my large PR perfectly. so we are getting 404s for those endpoints

## Changes

add those actions

## How did you test this code?

ran locally

## Publish to changelog?

no

<!-- branch-stack -->

-------------------------
 - master
   - https://github.com/PostHog/posthog/pull/46224 :point_left:
     - https://github.com/PostHog/posthog/pull/46226

<sup>[Stack](https://www.git-town.com/how-to/github-actions-breadcrumb.html) generated by [Git Town](https://github.com/git-town/git-town)</sup>

<!-- branch-stack-end -->