### PR TITLE
fix(experiments): resets the experiment form when cancelling.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.tsx
@@ -70,9 +70,7 @@ export const ExperimentForm = ({ draftExperiment, tabId }: ExperimentFormProps):
 
     const [selectedPanel, setSelectedPanel] = useState<string | null>(null)
     const handleCancel = (): void => {
-        if (!isEditMode) {
-            clearDraft()
-        }
+        clearDraft()
         router.actions.push(urls.experiments())
     }
 

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -243,6 +243,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
             })() as { primary: ExperimentMetric[]; secondary: ExperimentMetric[] },
             {
                 setSharedMetrics: (_, { sharedMetrics }) => sharedMetrics,
+                resetExperiment: () => ({ primary: [], secondary: [] }),
             },
         ],
         isExperimentSubmitting: [
@@ -331,10 +332,8 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
     })),
     listeners(({ values, actions, props }) => ({
         clearDraft: () => {
-            if (props.experiment || values.experiment.id !== 'new') {
-                return
-            }
             clearDraftStorage(props.tabId)
+            actions.resetExperiment()
         },
         setExperiment: () => {},
         setExperimentValue: ({ name, value }) => {


### PR DESCRIPTION
## Problem

When we cancel an experiment form, either when creating or editing, the state does not reset correctly and the form persists between operations.

| cancel preserves state |
| - |
| ![cancel-before](https://github.com/user-attachments/assets/5b7ed257-6665-41a2-963a-4796c2ca1344) |


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We just needed to call `resetExperiment` when handling the cancel action.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest scenes/experiments/ExperimentForm/createExperimentLogic.test.ts
```

![cat-type-small](https://github.com/user-attachments/assets/b54ebde9-51a0-4d16-9e01-7500cde230be)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
