### PR TITLE
fix(llma): Trace view summary tab from clusters 

### DIFF
--- a/products/llm_analytics/frontend/llmAnalyticsTraceDataLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsTraceDataLogic.ts
@@ -89,7 +89,7 @@ export const llmAnalyticsTraceDataLogic = kea<llmAnalyticsTraceDataLogicType>([
     connect((props: TraceDataLogicProps) => ({
         values: [
             llmAnalyticsTraceLogic,
-            ['eventId', 'searchQuery'],
+            ['eventId', 'searchQuery', 'initialTab'],
             dataNodeLogic(getDataNodeLogicProps(props)),
             ['response', 'responseLoading', 'responseError'],
         ],
@@ -235,9 +235,12 @@ export const llmAnalyticsTraceDataLogic = kea<llmAnalyticsTraceDataLogicType>([
                 })),
         ],
         initialFocusEventId: [
-            (s) => [s.showableEvents, s.filteredTree],
-            (showableEvents: LLMTraceEvent[], filteredTree: TraceTreeNode[]): string | null =>
-                getInitialFocusEventId(showableEvents, filteredTree),
+            (s) => [s.showableEvents, s.filteredTree, s.initialTab],
+            (
+                showableEvents: LLMTraceEvent[],
+                filteredTree: TraceTreeNode[],
+                initialTab: string | null
+            ): string | null => getInitialFocusEventId(showableEvents, filteredTree, initialTab),
         ],
         effectiveEventId: [
             (s) => [s.eventId, s.initialFocusEventId],
@@ -404,12 +407,22 @@ function aggregateSpanMetrics(node: TraceTreeNode): SpanAggregation {
 // Export functions for testing
 export { findEventWithParents }
 
-export function getInitialFocusEventId(showableEvents: LLMTraceEvent[], filteredTree: TraceTreeNode[]): string | null {
+export function getInitialFocusEventId(
+    showableEvents: LLMTraceEvent[],
+    filteredTree: TraceTreeNode[],
+    initialTab: string | null
+): string | null {
     // First, look for an $ai_trace event
     const aiTraceEvent = showableEvents.find((event) => event.event === '$ai_trace')
 
     if (aiTraceEvent) {
         return aiTraceEvent.id
+    }
+
+    // If tab=summary is specified, user wants to stay at the trace level (e.g., from clusters view)
+    // Don't skip to first generation event in this case
+    if (initialTab === 'summary') {
+        return null
     }
 
     // If no $ai_trace event, look for the first $ai_generation event


### PR DESCRIPTION
## Problem

When navigating to an LLM trace from the clusters tab, the URL includes `tab=summary`. However, the trace view's logic to skip to the first generation or event on pseudo-traces overrides this, preventing the user from landing on the trace-level summary tab. This breaks the intended user flow from the clusters view.

## Changes

-   **`llmAnalyticsTraceDataLogic.ts`**:
    -   Connected `initialTab` from `llmAnalyticsTraceLogic` to `llmAnalyticsTraceDataLogic`.
    -   Modified the `initialFocusEventId` selector to pass `initialTab` to the `getInitialFocusEventId` function.
    -   Updated `getInitialFocusEventId` to return `null` (preventing a skip) if `initialTab` is `'summary'` and no `$ai_trace` event exists.
-   **`llmAnalyticsTraceDataLogic.test.ts`**:
    -   Updated existing tests to include the `initialTab` parameter.
    -   Added new test cases to verify the behavior when `initialTab` is `'summary'` for both pseudo-traces and traces with an `$ai_trace` event.

## How did you test this code?

-   Updated and ran unit tests for `llmAnalyticsTraceDataLogic`.
-   Manually verified that navigating to a trace from the clusters tab (which sets `tab=summary`) now correctly lands on the trace-level summary.
-   Manually verified that direct links to traces without `tab=summary` still correctly jump to the first generation or event.

## Publish to changelog?

no

---
<a href="https://cursor.com/background-agent?bcId=bc-80f7222d-4854-4da6-a9c5-6954c82b20cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80f7222d-4854-4da6-a9c5-6954c82b20cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

