### PR TITLE
fix(capture-logs): convert non-string OTEL log bodies to JSON instead of debug format

### DIFF
--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -45,15 +45,11 @@ impl KafkaLogRow {
         resource: Option<Resource>,
         scope: Option<InstrumentationScope>,
     ) -> Result<Self> {
-        // Extract body
+        // Extract body - convert any AnyValue type to JSON string
         let body = match record.body {
             Some(body) => match body.value {
-                Some(value) => match value {
-                    opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s) => {
-                        s.clone()
-                    }
-                    _ => format!("{value:?}"),
-                },
+                Some(any_value::Value::StringValue(s)) => s,
+                Some(_) => any_value_to_json(body).to_string(),
                 None => "".to_string(),
             },
             None => "".to_string(),


### PR DESCRIPTION
## Problem

The current implementation of `KafkaLogRow` doesn't properly handle non-string AnyValue types in log records. It simply uses debug formatting for non-string values, which isn't ideal for JSON processing.  
  
![image.png](https://app.graphite.com/user-attachments/assets/9f6f7843-a3b6-43f4-94c3-55b9f075f463.png)



## Changes

Improved the handling of AnyValue types in log records by:

- Simplifying the pattern matching for string values
- Using a proper conversion to JSON for non-string AnyValue types instead of debug formatting
- Leveraging the `any_value_to_json` function to ensure proper JSON serialization

After:  
![image.png](https://app.graphite.com/user-attachments/assets/95c9d51a-5c82-4318-93b9-bbf1d3e8d137.png)

## How did you test this code?

Verified that log records with different AnyValue types are properly converted to JSON strings.

## Publish to changelog?

No