### PR TITLE
revert:  Use greater than and not gte for getting incremental values GAds (45814)

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/posthog/temporal/data_imports/sources/google_ads/google_ads.py
@@ -335,7 +335,7 @@ def google_ads_source(
             if isinstance(last_value, dt.datetime) or isinstance(last_value, dt.date):
                 last_value = f"'{last_value.isoformat()}'"
 
-            query += f" WHERE {incremental_field} > {last_value}"
+            query += f" WHERE {incremental_field} >= {last_value}"
 
             if incremental_field_type == IncrementalFieldType.Date:
                 # Dates require an upper bound too, so we pick something very in the future.


### PR DESCRIPTION
Reverts PostHog/posthog#45814

The new fix was missing data for incremental syncs below one day as GAds fethes data per day, not timestamp