### PR TITLE
test(batch-export): Speed up batch export tests

### DIFF
--- a/posthog/api/test/batch_exports/conftest.py
+++ b/posthog/api/test/batch_exports/conftest.py
@@ -51,16 +51,16 @@ async def describe_workflow(temporal: TemporalClient, workflow_id: str):
     return temporal_workflow
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="package")
 def temporal():
     """Return a TemporalClient instance."""
     client = sync_connect()
     yield client
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="package", autouse=True)
 def temporal_worker(temporal):
-    """Use a module scoped fixture to start a Temporal Worker.
+    """Use a package scoped fixture to start a Temporal Worker.
 
     This saves a lot of time, as waiting for the worker to stop takes a while.
     """

--- a/products/batch_exports/backend/tests/temporal/test_backfill_batch_export.py
+++ b/products/batch_exports/backend/tests/temporal/test_backfill_batch_export.py
@@ -35,8 +35,6 @@ from products.batch_exports.backend.temporal.backfill_batch_export import (
     get_batch_export_interval,
 )
 
-pytestmark = [pytest.mark.django_db(transaction=True)]
-
 
 async def wait_for_workflows(
     temporal_client: temporalio.client.Client,


### PR DESCRIPTION
## Problem

The batch export tests are quite slow to run.

## Changes

Try to update the scope of some of the most expensive fixtures to reduce setup and teardown times.

This saves around 5 mins or so on the total batch export test suite.

## How did you test this code?

These are tests ;) 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No