### PR TITLE
fix(ux): remove sidepanel part 6 (small fix)

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
@@ -52,7 +52,7 @@ export const SidePanelDiscussion = (): JSX.Element => {
             ) : null}
 
             <SidePanelContentContainer flagOffClassName="contents">
-                {commentsLogicProps && commentsLogicProps.disabled && !isRemovingSidePanelFlag ? (
+                {commentsLogicProps && commentsLogicProps.disabled && isRemovingSidePanelFlag ? (
                     <SidePanelPaneHeader
                         title={
                             <div className="flex deprecated-space-x-2">


### PR DESCRIPTION
## Problem
<img width="467" height="268" alt="image" src="https://github.com/user-attachments/assets/8bb31aa7-4a31-4aff-aea1-31ffaf98b60e" />
Flag off leaked a second header

## Changes
Fix logic and hide correct second header

## How did you test this code?

Locally

## Publish to changelog?
No
