### PR TITLE
feat: Add Redirect Source metric to stateful overflow

### DIFF
--- a/nodejs/src/ingestion/utils/overflow-redirect/metrics.ts
+++ b/nodejs/src/ingestion/utils/overflow-redirect/metrics.ts
@@ -45,3 +45,10 @@ export const overflowRedirectRateLimitDecisions = new Counter({
     help: 'Total number of rate limit decisions',
     labelNames: ['type', 'decision'], // decision: 'allowed' | 'exceeded'
 })
+
+// Redirect source metrics - tracks WHERE the redirect decision came from
+export const overflowRedirectSourceEventsTotal = new Counter({
+    name: 'overflow_redirect_source_events_total',
+    help: 'Total number of events redirected by source',
+    labelNames: ['type', 'source'], // source: 'redis' | 'rate_limiter'
+})


### PR DESCRIPTION
## Problem

We need more visibility into the source of the overflow redirect (in-memory rate limiter vs redis). This PR adds that

## Changes

- Add `overflow_redirect_source_events_total` metric

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
