### PR TITLE
chore(funnels): remove obsolete isUDF flag from funnels response

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4327,9 +4327,6 @@
                     "description": "Generated HogQL query.",
                     "type": "string"
                 },
-                "isUdf": {
-                    "type": "boolean"
-                },
                 "is_cached": {
                     "type": "boolean"
                 },
@@ -16577,9 +16574,6 @@
                     "description": "Generated HogQL query.",
                     "type": "string"
                 },
-                "isUdf": {
-                    "type": "boolean"
-                },
                 "modifiers": {
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
@@ -26348,9 +26342,6 @@
                         "hogql": {
                             "description": "Generated HogQL query.",
                             "type": "string"
-                        },
-                        "isUdf": {
-                            "type": "boolean"
                         },
                         "modifiers": {
                             "$ref": "#/definitions/HogQLQueryModifiers",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1502,7 +1502,6 @@ export interface FunnelsQueryResponse extends AnalyticsQueryResponseBase {
     // This is properly FunnelStepsResults | FunnelStepsBreakdownResults | FunnelTimeToConvertResults | FunnelTrendsResults
     // but this large of a union doesn't provide any type-safety and causes python mypy issues, so represented as any.
     results: any
-    isUdf?: boolean
 }
 
 export type CachedFunnelsQueryResponse = CachedQueryResponse<FunnelsQueryResponse>

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7994,7 +7994,6 @@ class CachedFunnelsQueryResponse(BaseModel):
         ),
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    isUdf: bool | None = None
     is_cached: bool
     last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
@@ -11260,7 +11259,6 @@ class FunnelsQueryResponse(BaseModel):
         ),
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    isUdf: bool | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     query_status: QueryStatus | None = Field(
         default=None,
@@ -13200,7 +13198,6 @@ class QueryResponseAlternative66(BaseModel):
         ),
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
-    isUdf: bool | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     query_status: QueryStatus | None = Field(
         default=None,

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -2281,8 +2281,6 @@ export interface FunnelsQueryResponseApi {
      * @nullable
      */
     hogql?: string | null
-    /** @nullable */
-    isUdf?: boolean | null
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
     /** Query status indicates whether next to the provided data, a query is still running. */


### PR DESCRIPTION
## Problem

Cached funnels should be expired by now, so we can safely remove the unused `isUDF` flag from funnels response schema.

## Changes

Does so.

## How did you test this code?

n/a