### PR TITLE
chore(cdp): turn off hog-executor exceptions

### DIFF
--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -336,7 +336,7 @@ export class HogExecutorService {
         return result
     }
 
-    @instrumented('hog-executor.execute')
+    @instrumented({ key: 'hog-executor.execute', sendException: false })
     async execute(
         invocation: CyclotronJobInvocationHogFunction,
         options: HogExecutorExecuteOptions = {},


### PR DESCRIPTION
## Problem

currently we capture ~300-400M errors per hour so ~4-5B daily whilst not acting on it

## Changes

turn off for now and re-think what context we need to provide for this to be useful
