### PR TITLE
Support sidebar wording

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -381,7 +381,6 @@ export function SidePanelSupport(): JSX.Element {
                             {showMaxAI && isBillingLoaded && (
                                 <Section title="Ask PostHog AI">
                                     <div>
-                                        <p>PostHog AI can now answer 80%+ of the support questions we receive! Nice.</p>
                                         <p>
                                             Let PostHog AI read 100s of pages of docs for you, write SQL queries and
                                             expressions, regex patterns, etc.

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -382,8 +382,9 @@ export function SidePanelSupport(): JSX.Element {
                                 <Section title="Ask PostHog AI">
                                     <div>
                                         <p>
-                                            Let PostHog AI read 100s of pages of docs for you, write SQL queries and
-                                            expressions, regex patterns, etc.
+                                            Your AI assistant for PostHog. Search through 1000s of pages of docs, write
+                                            and fix SQL queries, build insights, find errors, and analyze data - all in
+                                            seconds.
                                         </p>
                                         <LemonButton
                                             type="primary"

--- a/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
+++ b/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
@@ -99,7 +99,7 @@ export function HelpMenu(): JSX.Element {
                             </span>
                             <span className="text-sm font-medium">Ask PostHog AI</span>
                             <span className="text-xs text-tertiary text-center text-pretty">
-                                Get instant answers from docs, SQL queries, regex patterns, and more
+                                Search docs, write SQL, build insights, and analyze data - instantly
                             </span>
                         </Link>
                     </DropdownMenuItem>

--- a/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
+++ b/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
@@ -99,7 +99,7 @@ export function HelpMenu(): JSX.Element {
                             </span>
                             <span className="text-sm font-medium">Ask PostHog AI</span>
                             <span className="text-xs text-tertiary text-center text-pretty">
-                                PostHog AI answers 80%+ of support questions we receive!
+                                Get instant answers from docs, SQL queries, regex patterns, and more
                             </span>
                         </Link>
                     </DropdownMenuItem>


### PR DESCRIPTION
## Problem

The existing wording for PostHog AI in the support sidebar and help menu included an unsubstantiated claim about answering 80% of support tickets. This update aims to provide more accurate and descriptive information about PostHog AI's actual capabilities, setting clearer expectations for users.

## Changes

*   Updated the text in the Help Menu dropdown from "PostHog AI answers 80%+ of support questions we receive!" to "Get instant answers from docs, SQL queries, regex patterns, and more".
*   Removed the paragraph claiming "PostHog AI can now answer 80%+ of the support questions we receive! Nice." from the Support panel.

## How did you test this code?

Manually verified the updated text in the Help Menu dropdown and the Support panel within the application UI.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C075D3C5HST/p1769693849323809?thread_ts=1769693849.323809&cid=C075D3C5HST)

<a href="https://cursor.com/background-agent?bcId=bc-12694b3e-aafe-4330-b130-7921ecf92d10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12694b3e-aafe-4330-b130-7921ecf92d10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

