### PR TITLE
fix: Braze template payload format

### DIFF
--- a/posthog/cdp/templates/braze/template_braze.py
+++ b/posthog/cdp/templates/braze/template_braze.py
@@ -11,10 +11,10 @@ template: HogFunctionTemplateDC = HogFunctionTemplateDC(
     category=["Customer Success"],
     code_language="hog",
     code="""
-let getPayload := () -> [{
-  'attributes': inputs.attributes,
+let getPayload := () -> {
+  'attributes': [inputs.attributes],
   'events': [inputs.event]
-}]
+}
 
 let res := fetch(f'{inputs.brazeEndpoint}/users/track', {
   'method': 'POST',

--- a/posthog/cdp/templates/braze/test_template_braze.py
+++ b/posthog/cdp/templates/braze/test_template_braze.py
@@ -31,19 +31,17 @@ class TestTemplateBraze(BaseHogFunctionTemplateTest):
                     "Content-Type": "application/json",
                     "Authorization": "Bearer my_secret_key",
                 },
-                "body": [
-                    {
-                        "attributes": {"email": "{person.properties.email}"},
-                        "events": [
-                            {
-                                "external_id": "{event.distinct_id}",
-                                "name": "{event.event}",
-                                "properties": "{event.properties}",
-                                "time": "{event.timestamp}",
-                            },
-                        ],
-                    }
-                ],
+                "body": {
+                    "attributes": [{"email": "{person.properties.email}"}],
+                    "events": [
+                        {
+                            "external_id": "{event.distinct_id}",
+                            "name": "{event.event}",
+                            "properties": "{event.properties}",
+                            "time": "{event.timestamp}",
+                        },
+                    ],
+                },
                 "method": "POST",
             },
         )


### PR DESCRIPTION
## Problem

The [Braze destination](https://posthog.com/docs/cdp/destinations/braze) did not work out of the box.

https://posthoghelp.zendesk.com/agent/tickets/48519 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50424)

https://www.braze.com/docs/api/endpoints/user_data/post_user_track/#rate-limit

## Changes

- The payload needs to be an object, not a list.
- Attributes has to be a list.

## How did you test this code?

Did our own Braze integration.

## Publish to changelog?

no
