### PR TITLE
fix(batch-exports): Fix progress bar running color

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportBackfills.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportBackfills.tsx
@@ -83,7 +83,7 @@ function BatchExportLatestBackfills({ id }: BatchExportBackfillsLogicProps): JSX
                             const color = colorForStatus(status)
                             const statusStyles = {
                                 success: 'border-success text-success-dark',
-                                accent: 'border-accent text-primary-dark',
+                                'color-accent': 'border-accent text-accent',
                                 warning: 'border-warning text-warning-dark',
                                 danger: 'border-danger text-danger-dark',
                                 default: 'border-default text-default-dark',
@@ -239,14 +239,14 @@ function BackfillCancelButton({
 
 const colorForStatus = (
     status: BatchExportBackfill['status']
-): 'success' | 'accent' | 'warning' | 'danger' | 'default' => {
+): 'success' | 'color-accent' | 'warning' | 'danger' | 'default' => {
     switch (status) {
         case 'Completed':
             return 'success'
         case 'ContinuedAsNew':
         case 'Running':
         case 'Starting':
-            return 'accent'
+            return 'color-accent'
         case 'Cancelled':
         case 'Terminated':
         case 'TimedOut':


### PR DESCRIPTION
## Problem

The progress bar of running backfills doesn't display since it is using an outdated CSS variable.

## Changes

Fix the CSS variable used so that running backfills display progress correctly

<img width="418" height="279" alt="image" src="https://github.com/user-attachments/assets/8a3b436b-fdea-441d-af56-3e9e37a9a615" />


## How did you test this code?

Local testing

## Publish to changelog?

No