### PR TITLE
Add session summary timing tracking activity

### DIFF
--- a/ee/hogai/session_summaries/tracking.py
+++ b/ee/hogai/session_summaries/tracking.py
@@ -83,3 +83,31 @@ def capture_session_summary_generated(
 def generate_tracking_id() -> str:
     """Generate a unique tracking ID for correlating started/generated events."""
     return str(uuid4())
+
+
+def capture_session_summary_timing(
+    *,
+    user_distinct_id: str | None,
+    team: Team,
+    session_id: str,
+    timing_type: Literal["video_render", "video_transcript", "single_session_flow", "group_session_flow"],
+    duration_seconds: float,
+    success: bool,
+    extra_properties: dict | None = None,
+) -> None:
+    if not user_distinct_id:
+        return
+    properties: dict = {
+        "session_id": session_id,
+        "timing_type": timing_type,
+        "duration_seconds": duration_seconds,
+        "success": success,
+    }
+    if extra_properties:
+        properties.update(extra_properties)
+    posthoganalytics.capture(
+        distinct_id=user_distinct_id,
+        event="session summary timing",
+        properties=properties,
+        groups=groups(None, team),
+    )

--- a/posthog/temporal/ai/session_summary/activities/__init__.py
+++ b/posthog/temporal/ai/session_summary/activities/__init__.py
@@ -4,9 +4,12 @@ from .a3_analyze_video_segment import SESSION_VIDEO_CHUNK_DURATION_S, analyze_vi
 from .a4_consolidate_video_segments import consolidate_video_segments_activity
 from .a5_embed_and_store_segments import embed_and_store_segments_activity
 from .a6_store_video_session_summary import store_video_session_summary_activity
+from .capture_timing import CaptureTimingInputs, capture_timing_activity
 
 __all__ = [
     "SESSION_VIDEO_CHUNK_DURATION_S",
+    "CaptureTimingInputs",
+    "capture_timing_activity",
     "export_session_video_activity",
     "upload_video_to_gemini_activity",
     "analyze_video_segment_activity",

--- a/posthog/temporal/ai/session_summary/activities/capture_timing.py
+++ b/posthog/temporal/ai/session_summary/activities/capture_timing.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from typing import Literal
+
+import temporalio
+
+from posthog.models import Team
+
+from ee.hogai.session_summaries.tracking import capture_session_summary_timing
+
+
+@dataclass
+class CaptureTimingInputs:
+    user_distinct_id: str | None
+    team_id: int
+    session_id: str
+    timing_type: Literal["video_render", "video_transcript", "single_session_flow", "group_session_flow"]
+    duration_seconds: float
+    success: bool
+    extra_properties: dict | None = None
+
+
+@temporalio.activity.defn
+async def capture_timing_activity(inputs: CaptureTimingInputs) -> None:
+    team = await Team.objects.aget(id=inputs.team_id)
+    capture_session_summary_timing(
+        user_distinct_id=inputs.user_distinct_id,
+        team=team,
+        session_id=inputs.session_id,
+        timing_type=inputs.timing_type,
+        duration_seconds=inputs.duration_seconds,
+        success=inputs.success,
+        extra_properties=inputs.extra_properties,
+    )


### PR DESCRIPTION
## Problem

We need to track timing metrics for various session summary operations (video rendering, transcription, single/group session flows) to monitor performance and success rates across the platform.

## Changes

- Added `capture_session_summary_timing()` function in `ee/hogai/session_summaries/tracking.py` to capture timing events with configurable properties
- Created new Temporal activity `capture_timing_activity` in `posthog/temporal/ai/session_summary/activities/capture_timing.py` to handle async timing capture
- Added `CaptureTimingInputs` dataclass to encapsulate timing capture parameters
- Exported new activity and inputs from the activities module

The implementation allows workflows to track:
- `video_render`: Time to render session video
- `video_transcript`: Time to generate transcript
- `single_session_flow`: Time for single session processing
- `group_session_flow`: Time for group session processing

Each event captures duration, success status, and optional extra properties for detailed analysis.

## How did you test this code?

This is a foundational change that enables timing tracking. Testing should include:
- Verification that the activity integrates properly with existing Temporal workflows
- Confirmation that timing events are captured in PostHog analytics
- Validation that the tracking function gracefully handles missing user_distinct_id

## Publish to changelog?

no

https://claude.ai/code/session_01KXSJKSk1gY7AtmTT5mec1F