### PR TITLE
fix(customers): Default empty filters to array instead of object

### DIFF
--- a/posthog/api/column_configuration.py
+++ b/posthog/api/column_configuration.py
@@ -18,6 +18,8 @@ from posthog.models import ColumnConfiguration
 
 
 class ColumnConfigurationSerializer(serializers.ModelSerializer):
+    filters = serializers.JSONField(required=False, default=dict)
+
     class Meta:
         model = ColumnConfiguration
         fields = [
@@ -32,6 +34,17 @@ class ColumnConfigurationSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = ["id", "created_at", "updated_at", "created_by", "team"]
+
+    @classmethod
+    def validate_filters(cls, filters):
+        if not filters:
+            return []
+        return filters
+
+    def to_representation(self, instance: ColumnConfiguration):
+        values = super().to_representation(instance)
+        values["filters"] = self.validate_filters(values["filters"])
+        return values
 
 
 @extend_schema(tags=[ProductKey.PRODUCT_ANALYTICS])

--- a/posthog/api/column_configuration.py
+++ b/posthog/api/column_configuration.py
@@ -35,8 +35,7 @@ class ColumnConfigurationSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_at", "updated_at", "created_by", "team"]
 
-    @classmethod
-    def validate_filters(cls, filters):
+    def validate_filters(self, filters):
         if not filters:
             return []
         return filters

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -25,7 +25,7 @@ export interface ColumnConfigurationApi {
     columns?: string[]
     /** @maxLength 255 */
     name?: string
-    filters?: unknown | null
+    filters?: unknown
     visibility?: VisibilityEnumApi
     /** @nullable */
     readonly created_by: number | null
@@ -49,7 +49,7 @@ export interface PatchedColumnConfigurationApi {
     columns?: string[]
     /** @maxLength 255 */
     name?: string
-    filters?: unknown | null
+    filters?: unknown
     visibility?: VisibilityEnumApi
     /** @nullable */
     readonly created_by?: number | null


### PR DESCRIPTION
## Problem
<img width="1269" height="384" alt="image" src="https://github.com/user-attachments/assets/554f6fba-ec9c-40bb-84c5-2418cc6e23bf" />

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Make sure that empty filters are always returned as empty arrays instead of empty objects, as the queries interpret empty arrays as filter groups.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
