### PR TITLE
chore(ux): remove sidepanel part 7 (fixes)

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -135,7 +135,7 @@ export function Navigation({
                                         sceneConfig?.layout === 'app-raw',
                                     'rounded-tl-none': firstTabIsActive,
                                     'focus-visible:outline-none': isRemovingSidePanelFlag,
-                                    'max-w-[calc(100%-var(--side-panel-width))] rounded-r-none':
+                                    'lg:max-w-[calc(100%-var(--side-panel-width))] rounded-r-none':
                                         isRemovingSidePanelFlag && sidePanelOpen,
                                 }
                             )}

--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -273,7 +273,10 @@ export function SidePanel({
                             'top-0 h-full': sidePanelOpenAndAvailable && isRemovingSidePanelFlag,
                         })}
                     />
-                    {isRemovingSidePanelFlag && <div className="hidden lg:block fixed inset-0 z-10 bg-[red]" />}
+                    {/* Overlay for mobile to click outside to close the side panel */}
+                    {isRemovingSidePanelFlag && (
+                        <div onClick={() => closeSidePanel()} className="lg:hidden fixed inset-0 -z-1" />
+                    )}
                 </>
             )}
 

--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -1,6 +1,5 @@
 import './SidePanel.scss'
 
-import { Tabs } from '@base-ui/react/tabs'
 import { useActions, useValues } from 'kea'
 import { useEffect, useRef } from 'react'
 
@@ -12,9 +11,7 @@ import {
     IconLock,
     IconLogomark,
     IconNotebook,
-    IconSparkles,
     IconSupport,
-    IconX,
 } from '@posthog/icons'
 import { LemonButton, LemonMenu, LemonMenuItems, LemonModal } from '@posthog/lemon-ui'
 
@@ -22,7 +19,6 @@ import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { cn } from 'lib/utils/css-classes'
 import { NotebookPanel } from 'scenes/notebooks/NotebookPanel/NotebookPanel'
 
@@ -36,6 +32,7 @@ import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
 import { SidePanelTab } from '~/types'
 
+import { SidePanelNavigation } from './SidePanelNavigation'
 import { SidePanelChangelog } from './panels/SidePanelChangelog'
 import { SidePanelDocs } from './panels/SidePanelDocs'
 import { SidePanelHealth, SidePanelHealthIcon } from './panels/SidePanelHealth'
@@ -69,7 +66,7 @@ export const SIDE_PANEL_TABS: Record<
         label: 'Notebooks',
         Icon: IconNotebook,
         Content: NotebookPanel,
-        noModalSupport: true,
+        // noModalSupport: true,
     },
     [SidePanelTab.Support]: {
         label: 'Help',
@@ -231,8 +228,9 @@ export function SidePanel({
           ]
         : undefined
 
-    if (modalMode) {
+    if (modalMode && !isRemovingSidePanelFlag) {
         const supportsModal = activeTab ? !SIDE_PANEL_TABS[activeTab]?.noModalSupport : true
+
         return (
             <LemonModal
                 simple
@@ -266,14 +264,17 @@ export function SidePanel({
             id="side-panel"
         >
             {sidePanelOpenAndAvailable && (
-                <Resizer
-                    {...resizerLogicProps}
-                    className={cn('top-[calc(var(--scene-layout-header-height)+8px)] left-[-1px] bottom-4', {
-                        'left-0': sidePanelOpenAndAvailable,
-                        // Hide handle line, make it as thick as the gap between scene and sidepanel (looking like split-screen, nice.)
-                        'top-0 h-full': sidePanelOpenAndAvailable && isRemovingSidePanelFlag,
-                    })}
-                />
+                <>
+                    <Resizer
+                        {...resizerLogicProps}
+                        className={cn('top-[calc(var(--scene-layout-header-height)+8px)] left-[-1px] bottom-4', {
+                            'left-0': sidePanelOpenAndAvailable,
+                            // Hide handle line, make it as thick as the gap between scene and sidepanel (looking like split-screen, nice.)
+                            'top-0 h-full': sidePanelOpenAndAvailable && isRemovingSidePanelFlag,
+                        })}
+                    />
+                    {isRemovingSidePanelFlag && <div className="hidden lg:block fixed inset-0 z-10 bg-[red]" />}
+                </>
             )}
 
             {!isRemovingSidePanelFlag && (
@@ -350,99 +351,12 @@ export function SidePanel({
                             </ErrorBoundary>
                         </div>
                     ) : (
-                        <>
-                            <Tabs.Root
-                                className={cn(
-                                    'scene-panel-container bg-surface-secondary flex flex-col overflow-hidden h-full min-w-0',
-                                    'z-[var(--z-scene-panel)] lg:rounded-none '
-                                )}
-                                value={activeTab}
-                                onValueChange={(value) => openSidePanel(value as SidePanelTab)}
-                            >
-                                {/* Header with close button */}
-                                <div className="h-[50px] flex items-center justify-between gap-2 pl-2 pr-1.5 border-b border-primary shrink-0">
-                                    {/* Tab buttons */}
-                                    <Tabs.List className="relative z-0 flex gap-1 grow">
-                                        {[
-                                            ...(scenePanelIsPresent ? [SidePanelTab.Info] : []),
-                                            SidePanelTab.Discussion,
-                                            SidePanelTab.AccessControl,
-                                            SidePanelTab.Notebooks,
-                                            ...(activeTab === SidePanelTab.Max ? [SidePanelTab.Max] : []),
-                                        ]
-                                            .filter((tab) => tab === SidePanelTab.Info || visibleTabs.includes(tab))
-                                            .map((tab) => {
-                                                const { Icon, label } = SIDE_PANEL_TABS[tab]!
-                                                return (
-                                                    <Tabs.Tab
-                                                        key={tab}
-                                                        value={tab}
-                                                        render={(props) => (
-                                                            <ButtonPrimitive
-                                                                {...props}
-                                                                onClick={() => openSidePanel(tab as SidePanelTab)}
-                                                                tooltip={label}
-                                                                className="size-[33px] @[600px]/side-panel:w-auto hover:bg-transparent group justify-center @[600px]/side-panel:justify-normal"
-                                                            >
-                                                                {tab === SidePanelTab.Max ? (
-                                                                    <IconSparkles
-                                                                        className={cn(
-                                                                            'size-4 text-tertiary group-hover:text-primary -mt-[1px] ml-[2px]',
-                                                                            activeTab === tab
-                                                                                ? 'text-primary'
-                                                                                : 'text-tertiary'
-                                                                        )}
-                                                                    />
-                                                                ) : (
-                                                                    <Icon
-                                                                        className={cn(
-                                                                            'size-4 text-tertiary group-hover:text-primary',
-                                                                            activeTab === tab
-                                                                                ? 'text-primary'
-                                                                                : 'text-tertiary'
-                                                                        )}
-                                                                    />
-                                                                )}
-                                                                <span
-                                                                    className={cn(
-                                                                        'hidden @[600px]/side-panel:block text-tertiary group-hover:text-primary',
-                                                                        activeTab === tab
-                                                                            ? 'text-primary'
-                                                                            : 'text-tertiary'
-                                                                    )}
-                                                                >
-                                                                    {label}
-                                                                </span>
-                                                            </ButtonPrimitive>
-                                                        )}
-                                                    />
-                                                )
-                                            })}
-                                        <Tabs.Indicator className="transform-gpu absolute top-1/2 left-0 z-[-1] h-[33px] w-[var(--active-tab-width)] translate-x-[var(--active-tab-left)] -translate-y-1/2 rounded bg-[var(--color-bg-fill-button-tertiary-active)] transition-all duration-200 ease-in-out" />
-
-                                        <ButtonPrimitive
-                                            onClick={() => {
-                                                closeSidePanel()
-                                            }}
-                                            tooltip="Close side panel"
-                                            tooltipPlacement="bottom-end"
-                                            iconOnly
-                                            className="group size-[33px] ml-auto"
-                                        >
-                                            <IconX className="text-tertiary size-3 group-hover:text-primary z-10" />
-                                        </ButtonPrimitive>
-                                    </Tabs.List>
-                                </div>
-
-                                {/* Content area */}
-                                <Tabs.Panel
-                                    className="h-full grow flex flex-col gap-2 relative -outline-offset-1 outline-blue-800 focus-visible:rounded-md overflow-hidden"
-                                    value={activeTab}
-                                >
-                                    {PanelContent && <PanelContent />}
-                                </Tabs.Panel>
-                            </Tabs.Root>
-                        </>
+                        <SidePanelNavigation
+                            activeTab={activeTab as SidePanelTab}
+                            onTabChange={(tab) => openSidePanel(tab)}
+                        >
+                            <PanelContent />
+                        </SidePanelNavigation>
                     )}
                 </>
             )}

--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanelNavigation.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanelNavigation.tsx
@@ -1,0 +1,114 @@
+import { Tabs } from '@base-ui/react/tabs'
+import { useActions, useValues } from 'kea'
+
+import { IconSparkles, IconX } from '@posthog/icons'
+
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { cn } from 'lib/utils/css-classes'
+
+import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
+import { SidePanelTab } from '~/types'
+
+import { SIDE_PANEL_TABS } from './SidePanel'
+import { sidePanelLogic } from './sidePanelLogic'
+import { sidePanelStateLogic } from './sidePanelStateLogic'
+
+interface SidePanelNavigationProps {
+    activeTab: SidePanelTab
+    onTabChange: (tab: SidePanelTab) => void
+    children: React.ReactNode
+}
+
+export function SidePanelNavigation({ activeTab, onTabChange, children }: SidePanelNavigationProps): JSX.Element {
+    const { openSidePanel, closeSidePanel } = useActions(sidePanelStateLogic)
+    const { scenePanelIsPresent } = useValues(sceneLayoutLogic)
+    const { visibleTabs } = useValues(sidePanelLogic)
+
+    return (
+        <Tabs.Root
+            className={cn(
+                'scene-panel-container bg-surface-secondary flex flex-col overflow-hidden h-full min-w-0',
+                'z-[var(--z-scene-panel)] lg:rounded-none '
+            )}
+            value={activeTab}
+            onValueChange={(value) => onTabChange(value as SidePanelTab)}
+        >
+            {/* Header with close button */}
+            <div className="h-[50px] flex items-center justify-between gap-2 pl-2 pr-1.5 border-b border-primary shrink-0">
+                {/* Tab buttons */}
+                <Tabs.List className="relative z-0 flex gap-1 grow">
+                    {[
+                        ...(scenePanelIsPresent ? [SidePanelTab.Info] : []),
+                        SidePanelTab.Discussion,
+                        SidePanelTab.AccessControl,
+                        SidePanelTab.Notebooks,
+                        ...(activeTab === SidePanelTab.Max ? [SidePanelTab.Max] : []),
+                    ]
+                        .filter((tab) => tab === SidePanelTab.Info || visibleTabs.includes(tab))
+                        .map((tab) => {
+                            const { Icon, label } = SIDE_PANEL_TABS[tab]!
+                            return (
+                                <Tabs.Tab
+                                    key={tab}
+                                    value={tab}
+                                    render={(props) => (
+                                        <ButtonPrimitive
+                                            {...props}
+                                            onClick={() => openSidePanel(tab as SidePanelTab)}
+                                            tooltip={label}
+                                            className="size-[33px] @[600px]/side-panel:w-auto hover:bg-transparent group justify-center @[600px]/side-panel:justify-normal"
+                                        >
+                                            {tab === SidePanelTab.Max ? (
+                                                <IconSparkles
+                                                    className={cn(
+                                                        'size-4 text-tertiary group-hover:text-primary -mt-[1px] ml-[2px]',
+                                                        activeTab === tab ? 'text-primary' : 'text-tertiary'
+                                                    )}
+                                                />
+                                            ) : (
+                                                <Icon
+                                                    className={cn(
+                                                        'size-4 text-tertiary group-hover:text-primary',
+                                                        activeTab === tab ? 'text-primary' : 'text-tertiary'
+                                                    )}
+                                                />
+                                            )}
+                                            <span
+                                                className={cn(
+                                                    'hidden @[600px]/side-panel:block text-tertiary group-hover:text-primary',
+                                                    activeTab === tab ? 'text-primary' : 'text-tertiary'
+                                                )}
+                                            >
+                                                {label}
+                                            </span>
+                                        </ButtonPrimitive>
+                                    )}
+                                />
+                            )
+                        })}
+                    <Tabs.Indicator className="transform-gpu absolute top-1/2 left-0 z-[-1] h-[33px] w-[var(--active-tab-width)] translate-x-[var(--active-tab-left)] -translate-y-1/2 rounded bg-[var(--color-bg-fill-button-tertiary-active)] transition-all duration-200 ease-in-out" />
+
+                    <ButtonPrimitive
+                        onClick={() => {
+                            closeSidePanel()
+                        }}
+                        tooltip="Close side panel"
+                        tooltipPlacement="bottom-end"
+                        iconOnly
+                        className="group size-[33px] ml-auto"
+                    >
+                        <IconX className="text-tertiary size-3 group-hover:text-primary z-10" />
+                    </ButtonPrimitive>
+                </Tabs.List>
+            </div>
+
+            {/* Content area */}
+            <Tabs.Panel
+                className="h-full grow flex flex-col gap-2 relative -outline-offset-1 outline-blue-800 focus-visible:rounded-md overflow-hidden"
+                value={activeTab}
+            >
+                {children}
+            </Tabs.Panel>
+        </Tabs.Root>
+    )
+}

--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -63,7 +63,7 @@ export function SceneTabs(): JSX.Element {
     }
 
     return (
-        <div className="h-[var(--scene-layout-header-height)] flex items-center w-full min-w-0 bg-surface-primary lg:bg-surface-tertiary z-[var(--z-top-navigation)] relative">
+        <div className="h-[var(--scene-layout-header-height)] flex items-center w-full min-w-0 bg-surface-tertiary z-[var(--z-top-navigation)] relative">
             {/* Mobile button to show/hide the layout navbar */}
             {mobileLayout && (
                 <ButtonPrimitive
@@ -76,7 +76,7 @@ export function SceneTabs(): JSX.Element {
             )}
 
             {/* Line below tabs to to complete border on <main> element */}
-            <div className="absolute bottom-0 w-full pl-[5px] pr-3">
+            <div className="absolute bottom-0 w-full lg:pl-[5px] lg:pr-3">
                 <div className="w-full bottom-0 h-px border-b border-primary z-10" />
             </div>
 

--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -58,6 +58,11 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
     const { isAccountMenuOpen } = useValues(newAccountMenuLogic)
     const { setAccountMenuOpen } = useActions(newAccountMenuLogic)
 
+    const projectNameStartsWithEmoji = currentTeam?.name?.match(/^\p{Emoji}/u) !== null
+    const projectNameWithoutFirstEmoji = projectNameStartsWithEmoji
+        ? currentTeam?.name?.replace(/^\p{Emoji}/u, '').trimStart()
+        : currentTeam?.name
+
     return (
         <DropdownMenu open={isAccountMenuOpen} onOpenChange={setAccountMenuOpen}>
             <DropdownMenuTrigger asChild>
@@ -91,7 +96,9 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                             >
                                 {String.fromCodePoint(currentTeam.name.codePointAt(0)!).toLocaleUpperCase()}
                             </div>
-                            {!isLayoutNavCollapsed && <span className="truncate">{currentTeam.name ?? 'Project'}</span>}
+                            {!isLayoutNavCollapsed && (
+                                <span className="truncate">{projectNameWithoutFirstEmoji ?? 'Project'}</span>
+                            )}
                         </>
                     )}
                     {!isLayoutNavCollapsed && <MenuOpenIndicator />}
@@ -153,7 +160,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                     {String.fromCodePoint(currentTeam.name.codePointAt(0)!).toLocaleUpperCase()}
                                 </div>
                                 <span className="truncate font-semibold">
-                                    {currentTeam ? currentTeam.name : 'Select project'}
+                                    {currentTeam ? projectNameWithoutFirstEmoji : 'Select project'}
                                 </span>
                                 {currentTeam && (
                                     <div className="ml-auto flex items-center gap-1">


### PR DESCRIPTION
## Problem

#### Rendering the emoji twice in new accout menu

<img width="259" height="220" alt="image" src="https://github.com/user-attachments/assets/3f075e58-dc2d-4cea-a56b-af321075ee25" />

#### Mobile scene tabs line doesn't go across app

<img width="501" height="99" alt="image" src="https://github.com/user-attachments/assets/972fabfc-1ce8-4ee7-a938-3de750f9d851" />


#### Side panel renders in modal... 
<img width="500" height="708" alt="image" src="https://github.com/user-attachments/assets/1c41a1d3-e4ba-499f-bcc4-8e65da31304a" />

## Changes
* Strip first character of project name if it's an emoji as it's already rendered in lettermark (component is flagged)
* Mobile scene tabs line now reaches across whole app (not flagged)
* Side panel no longer renders in modal for mobile (flagged)
* Side panel now not a modal, get's a clickable underlay that closes it. (flagged)


<img width="285" height="459" alt="image" src="https://github.com/user-attachments/assets/1dfb197b-0b63-4605-8da3-470404169466" />

<img width="578" height="857" alt="image" src="https://github.com/user-attachments/assets/5059c51f-a94b-4e43-af98-cdb08dc79803" />




## How did you test this code?
Locally

## Publish to changelog?
No