### PR TITLE
fix(logs): enhance distinct and session ID key matching

### DIFF
--- a/products/logs/frontend/utils.test.ts
+++ b/products/logs/frontend/utils.test.ts
@@ -1,0 +1,62 @@
+import { isDistinctIdKey, isSessionIdKey } from './utils'
+
+describe('logs utils', () => {
+    describe.each([
+        // Exact matches
+        ['distinct.id', true],
+        ['distinct_id', true],
+        ['distinctId', true],
+        ['distinctID', true],
+        ['posthogDistinctId', true],
+        ['posthogDistinctID', true],
+        ['posthog_distinct_id', true],
+        ['posthog.distinct.id', true],
+        ['posthog.distinct_id', true],
+        // Dotted paths
+        ['foo.distinct_id', true],
+        ['foo.bar.posthogDistinctId', true],
+        ['foo.bar.posthog_distinct_id', true],
+        ['foo.bar.distinct_id', true],
+        ['foo.bar.distinct.id', true],
+        ['resource.attributes.distinct_id', true],
+        // Non-matches
+        ['not_distinct_id_at_all', false],
+        ['distinct_id.something', false],
+        ['xdistinct_id', false],
+        ['', false],
+    ])('isDistinctIdKey(%s)', (key, expected) => {
+        it(`returns ${expected}`, () => {
+            expect(isDistinctIdKey(key)).toBe(expected)
+        })
+    })
+
+    describe.each([
+        // Exact matches
+        ['session.id', true],
+        ['session_id', true],
+        ['sessionId', true],
+        ['sessionID', true],
+        ['$session_id', true],
+        ['posthogSessionId', true],
+        ['posthogSessionID', true],
+        ['posthog_session_id', true],
+        ['posthog.session.id', true],
+        ['posthog.session_id', true],
+        // Dotted paths
+        ['foo.session_id', true],
+        ['foo.bar.posthogSessionId', true],
+        ['foo.bar.posthog_session_id', true],
+        ['foo.bar.session_id', true],
+        ['foo.bar.session.id', true],
+        ['resource.attributes.$session_id', true],
+        // Non-matches
+        ['not_session_id_at_all', false],
+        ['session_id.something', false],
+        ['xsession_id', false],
+        ['', false],
+    ])('isSessionIdKey(%s)', (key, expected) => {
+        it(`returns ${expected}`, () => {
+            expect(isSessionIdKey(key)).toBe(expected)
+        })
+    })
+})

--- a/products/logs/frontend/utils.tsx
+++ b/products/logs/frontend/utils.tsx
@@ -1,10 +1,35 @@
-const DISTINCT_ID_KEYS = ['distinct.id', 'distinct_id', 'distinctId', 'distinctID']
-const SESSION_ID_KEYS = ['session.id', 'session_id', 'sessionId', 'sessionID', '$session_id']
+const DISTINCT_ID_KEYS = [
+    'distinct.id',
+    'distinct_id',
+    'distinctId',
+    'distinctID',
+    'posthogDistinctId',
+    'posthogDistinctID',
+    'posthog_distinct_id',
+    'posthog.distinct.id',
+    'posthog.distinct_id',
+]
+const SESSION_ID_KEYS = [
+    'session.id',
+    'session_id',
+    'sessionId',
+    'sessionID',
+    '$session_id',
+    'posthogSessionId',
+    'posthogSessionID',
+    'posthog_session_id',
+    'posthog.session.id',
+    'posthog.session_id',
+]
+
+function matchesKey(key: string, candidates: string[]): boolean {
+    return candidates.some((candidate) => key === candidate || key.endsWith(`.${candidate}`))
+}
 
 export function isDistinctIdKey(key: string): boolean {
-    return DISTINCT_ID_KEYS.includes(key)
+    return matchesKey(key, DISTINCT_ID_KEYS)
 }
 
 export function isSessionIdKey(key: string): boolean {
-    return SESSION_ID_KEYS.includes(key)
+    return matchesKey(key, SESSION_ID_KEYS)
 }


### PR DESCRIPTION
## Problem

The current implementation of `isDistinctIdKey` and `isSessionIdKey` only matches exact keys, but we need to support keys that are part of dotted paths (e.g., `foo.bar.distinct_id`). Additionally, we need to expand the list of recognized distinct ID and session ID keys to include PostHog-specific variations.

## Changes

- Enhanced the key matching logic to detect distinct ID and session ID keys within dotted paths
- Added support for PostHog-specific key variations like `posthogDistinctId` and `posthog_session_id`
- Implemented a `matchesKey` helper function to handle both exact matches and dotted path matches
- Added comprehensive test coverage for both functions with various key formats

## How did you test this code?

Added a comprehensive test suite that verifies:
- Exact key matches for both distinct ID and session ID keys
- Keys within dotted paths (e.g., `foo.bar.distinct_id`)
- PostHog-specific key variations
- Negative test cases to ensure non-matching keys are properly rejected