### PR TITLE
refactor: optimize capture event restriction application

### DIFF
--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -220,7 +220,7 @@ pub async fn ai_handler(
         };
 
         let restrictions = service.get_restrictions(token, &event_ctx).await;
-        let applied = AppliedRestrictions::from_restrictions(&restrictions, CaptureMode::Ai);
+        let applied = AppliedRestrictions::from_restrictions(restrictions, CaptureMode::Ai);
 
         if applied.should_drop {
             report_dropped_events("event_restriction_drop", 1);

--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -210,11 +210,12 @@ pub async fn ai_handler(
 
     // Step 2: Check event restrictions early - before parsing remaining parts
     let applied_restrictions = if let Some(ref service) = state.event_restriction_service {
+        let uuid_str = event_metadata.event_uuid();
         let event_ctx = RestrictionEventContext {
-            distinct_id: Some(event_metadata.distinct_id.clone()),
+            distinct_id: Some(&event_metadata.distinct_id),
             session_id: None,
-            event_name: Some(event_metadata.event_name.clone()),
-            event_uuid: event_metadata.event_uuid(),
+            event_name: Some(&event_metadata.event_name),
+            event_uuid: uuid_str.as_deref(),
             now_ts: state.timesource.current_time().timestamp(),
         };
 

--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -215,6 +215,7 @@ pub async fn ai_handler(
             session_id: None,
             event_name: Some(event_metadata.event_name.clone()),
             event_uuid: event_metadata.event_uuid(),
+            now_ts: state.timesource.current_time().timestamp(),
         };
 
         let restrictions = service.get_restrictions(token, &event_ctx).await;

--- a/rust/capture/src/event_restrictions/manager.rs
+++ b/rust/capture/src/event_restrictions/manager.rs
@@ -214,7 +214,7 @@ impl EventRestrictionService {
     pub async fn get_restrictions(
         &self,
         token: &str,
-        event: &EventContext,
+        event: &EventContext<'_>,
     ) -> HashSet<RestrictionType> {
         if self.is_stale_at(event.now_ts) {
             gauge!(
@@ -342,8 +342,8 @@ mod tests {
 
         // Should match when both distinct_id and event_name match
         let event_match = EventContext {
-            distinct_id: Some("user1".to_string()),
-            event_name: Some("$pageview".to_string()),
+            distinct_id: Some("user1"),
+            event_name: Some("$pageview"),
             ..Default::default()
         };
         let restrictions = manager.get_restrictions("token1", &event_match);
@@ -351,8 +351,8 @@ mod tests {
 
         // Should NOT match when event_name doesn't match (AND logic)
         let event_wrong_name = EventContext {
-            distinct_id: Some("user1".to_string()),
-            event_name: Some("$identify".to_string()),
+            distinct_id: Some("user1"),
+            event_name: Some("$identify"),
             ..Default::default()
         };
         let restrictions = manager.get_restrictions("token1", &event_wrong_name);
@@ -360,8 +360,8 @@ mod tests {
 
         // Should NOT match when distinct_id doesn't match
         let event_wrong_user = EventContext {
-            distinct_id: Some("user3".to_string()),
-            event_name: Some("$pageview".to_string()),
+            distinct_id: Some("user3"),
+            event_name: Some("$pageview"),
             ..Default::default()
         };
         let restrictions = manager.get_restrictions("token1", &event_wrong_user);
@@ -495,7 +495,7 @@ mod tests {
     // EventRestrictionService tests
     // ========================================================================
 
-    fn event_ctx_now() -> EventContext {
+    fn event_ctx_now() -> EventContext<'static> {
         EventContext {
             now_ts: chrono::Utc::now().timestamp(),
             ..Default::default()

--- a/rust/capture/src/event_restrictions/mod.rs
+++ b/rust/capture/src/event_restrictions/mod.rs
@@ -7,7 +7,7 @@ pub use manager::{EventRestrictionService, RestrictionManager};
 pub use repository::{EventRestrictionsRepository, RedisRestrictionsRepository, RestrictionEntry};
 pub use types::{
     AppliedRestrictions, EventContext, Restriction, RestrictionFilters, RestrictionScope,
-    RestrictionType,
+    RestrictionSet, RestrictionType,
 };
 
 #[cfg(test)]

--- a/rust/capture/src/event_restrictions/types.rs
+++ b/rust/capture/src/event_restrictions/types.rs
@@ -50,6 +50,48 @@ impl RestrictionType {
             Self::RedirectToDlq,
         ]
     }
+
+    /// Bit position for this restriction type (0-3).
+    const fn bit_pos(self) -> u8 {
+        match self {
+            Self::DropEvent => 0,
+            Self::ForceOverflow => 1,
+            Self::RedirectToDlq => 2,
+            Self::SkipPersonProcessing => 3,
+        }
+    }
+}
+
+/// A compact set of restriction types using a bitfield.
+/// Avoids heap allocation - just a u8 on the stack.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RestrictionSet(u8);
+
+impl RestrictionSet {
+    /// Create an empty set.
+    pub const fn new() -> Self {
+        Self(0)
+    }
+
+    /// Insert a restriction type into the set.
+    pub fn insert(&mut self, t: RestrictionType) {
+        self.0 |= 1 << t.bit_pos();
+    }
+
+    /// Check if the set contains a restriction type.
+    pub const fn contains(self, t: RestrictionType) -> bool {
+        (self.0 & (1 << t.bit_pos())) != 0
+    }
+
+    /// Check if the set is empty.
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Count the number of restrictions in the set.
+    pub const fn len(self) -> usize {
+        self.0.count_ones() as usize
+    }
 }
 
 /// Result of applying restrictions to an event.
@@ -64,15 +106,12 @@ pub struct AppliedRestrictions {
 
 impl AppliedRestrictions {
     /// Apply restrictions and emit metrics.
-    pub fn from_restrictions(
-        restrictions: &HashSet<RestrictionType>,
-        pipeline: CaptureMode,
-    ) -> Self {
+    pub fn from_restrictions(restrictions: RestrictionSet, pipeline: CaptureMode) -> Self {
         let mut result = Self::default();
         let pipeline_str = pipeline.as_pipeline_name();
 
         for restriction_type in RestrictionType::all() {
-            if restrictions.contains(&restriction_type) {
+            if restrictions.contains(restriction_type) {
                 counter!(
                     "capture_event_restrictions_applied",
                     "restriction_type" => restriction_type.as_str(),
@@ -273,5 +312,85 @@ mod tests {
             ..Default::default()
         };
         assert!(!filters.matches(&event_wrong_user));
+    }
+
+    #[test]
+    fn test_restriction_set_new_is_empty() {
+        let set = RestrictionSet::new();
+        assert!(set.is_empty());
+        assert_eq!(set.len(), 0);
+    }
+
+    #[test]
+    fn test_restriction_set_insert_and_contains() {
+        let mut set = RestrictionSet::new();
+
+        set.insert(RestrictionType::DropEvent);
+        assert!(set.contains(RestrictionType::DropEvent));
+        assert!(!set.contains(RestrictionType::ForceOverflow));
+        assert!(!set.contains(RestrictionType::RedirectToDlq));
+        assert!(!set.contains(RestrictionType::SkipPersonProcessing));
+        assert_eq!(set.len(), 1);
+        assert!(!set.is_empty());
+    }
+
+    #[test]
+    fn test_restriction_set_multiple_inserts() {
+        let mut set = RestrictionSet::new();
+
+        set.insert(RestrictionType::DropEvent);
+        set.insert(RestrictionType::ForceOverflow);
+        set.insert(RestrictionType::RedirectToDlq);
+
+        assert!(set.contains(RestrictionType::DropEvent));
+        assert!(set.contains(RestrictionType::ForceOverflow));
+        assert!(set.contains(RestrictionType::RedirectToDlq));
+        assert!(!set.contains(RestrictionType::SkipPersonProcessing));
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn test_restriction_set_all_types() {
+        let mut set = RestrictionSet::new();
+
+        for t in RestrictionType::all() {
+            set.insert(t);
+        }
+
+        assert_eq!(set.len(), 4);
+        for t in RestrictionType::all() {
+            assert!(set.contains(t));
+        }
+    }
+
+    #[test]
+    fn test_restriction_set_insert_idempotent() {
+        let mut set = RestrictionSet::new();
+
+        set.insert(RestrictionType::DropEvent);
+        set.insert(RestrictionType::DropEvent);
+        set.insert(RestrictionType::DropEvent);
+
+        assert_eq!(set.len(), 1);
+        assert!(set.contains(RestrictionType::DropEvent));
+    }
+
+    #[test]
+    fn test_restriction_set_default() {
+        let set = RestrictionSet::default();
+        assert!(set.is_empty());
+        assert_eq!(set.len(), 0);
+    }
+
+    #[test]
+    fn test_restriction_set_copy() {
+        let mut set1 = RestrictionSet::new();
+        set1.insert(RestrictionType::DropEvent);
+
+        let set2 = set1; // Copy
+        assert!(set2.contains(RestrictionType::DropEvent));
+
+        // set1 is still valid (Copy, not Move)
+        assert!(set1.contains(RestrictionType::DropEvent));
     }
 }

--- a/rust/capture/src/event_restrictions/types.rs
+++ b/rust/capture/src/event_restrictions/types.rs
@@ -132,6 +132,8 @@ pub struct EventContext {
     pub session_id: Option<String>,
     pub event_name: Option<String>,
     pub event_uuid: Option<String>,
+    /// Pre-computed timestamp to avoid syscalls per event. Use `chrono::Utc::now().timestamp()`.
+    pub now_ts: i64,
 }
 
 /// What events a restriction applies to.

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -158,6 +158,7 @@ pub async fn process_events<'a>(
     // Apply event restrictions if service is configured
     if let Some(ref service) = restriction_service {
         let mut filtered_events = Vec::with_capacity(events.len());
+        let now_ts = context.now.timestamp();
 
         for e in events {
             let event_ctx = RestrictionEventContext {
@@ -165,6 +166,7 @@ pub async fn process_events<'a>(
                 session_id: e.event.session_id.clone(),
                 event_name: Some(e.event.event.clone()),
                 event_uuid: Some(e.event.uuid.to_string()),
+                now_ts,
             };
 
             let restrictions = service.get_restrictions(&e.event.token, &event_ctx).await;

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -171,8 +171,7 @@ pub async fn process_events<'a>(
             };
 
             let restrictions = service.get_restrictions(&e.event.token, &event_ctx).await;
-            let applied =
-                AppliedRestrictions::from_restrictions(&restrictions, CaptureMode::Events);
+            let applied = AppliedRestrictions::from_restrictions(restrictions, CaptureMode::Events);
 
             if applied.should_drop {
                 report_dropped_events("event_restriction_drop", 1);

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -161,11 +161,12 @@ pub async fn process_events<'a>(
         let now_ts = context.now.timestamp();
 
         for e in events {
+            let uuid_str = e.event.uuid.to_string();
             let event_ctx = RestrictionEventContext {
-                distinct_id: Some(e.event.distinct_id.clone()),
-                session_id: e.event.session_id.clone(),
-                event_name: Some(e.event.event.clone()),
-                event_uuid: Some(e.event.uuid.to_string()),
+                distinct_id: Some(&e.event.distinct_id),
+                session_id: e.event.session_id.as_deref(),
+                event_name: Some(&e.event.event),
+                event_uuid: Some(&uuid_str),
                 now_ts,
             };
 

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -223,11 +223,12 @@ pub async fn process_replay_events<'a>(
 
     // Apply event restrictions
     let applied = if let Some(ref service) = restriction_service {
+        let uuid_str = uuid.to_string();
         let event_ctx = RestrictionEventContext {
-            distinct_id: Some(distinct_id.clone()),
-            session_id: Some(session_id_str.to_string()),
-            event_name: Some("$snapshot_items".to_string()),
-            event_uuid: Some(uuid.to_string()),
+            distinct_id: Some(&distinct_id),
+            session_id: Some(session_id_str),
+            event_name: Some("$snapshot_items"),
+            event_uuid: Some(&uuid_str),
             now_ts: context.now.timestamp(),
         };
 

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -233,8 +233,7 @@ pub async fn process_replay_events<'a>(
         };
 
         let restrictions = service.get_restrictions(&context.token, &event_ctx).await;
-        let applied =
-            AppliedRestrictions::from_restrictions(&restrictions, CaptureMode::Recordings);
+        let applied = AppliedRestrictions::from_restrictions(restrictions, CaptureMode::Recordings);
 
         if applied.should_drop {
             report_dropped_events("event_restriction_drop", 1);

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -228,6 +228,7 @@ pub async fn process_replay_events<'a>(
             session_id: Some(session_id_str.to_string()),
             event_name: Some("$snapshot_items".to_string()),
             event_uuid: Some(uuid.to_string()),
+            now_ts: context.now.timestamp(),
         };
 
         let restrictions = service.get_restrictions(&context.token, &event_ctx).await;


### PR DESCRIPTION
## Problem

We do a bit of unnecessary work in capture when evaluating event restrictions.

## Changes

- Removes an unnecessary call to `Utc::now()`
- Removes copying of event metadata fields for the restriction context
- Refactors the restriction map to be more lightweight

## How did you test this code?

- Existing tests
- Added tests for the new code