### PR TITLE
feat(analytics-platform): Add dagster job to clean up sessions v1

### DIFF
--- a/posthog/dags/sessions_v1_cleanup.py
+++ b/posthog/dags/sessions_v1_cleanup.py
@@ -1,0 +1,76 @@
+"""
+Dagster job for cleaning up sessions v1 rows that don't belong to allowed teams.
+
+The sessions v1 table (sharded_sessions) is only used by grandfathered teams listed in
+ALLOWED_TEAM_IDS. This job deletes any rows for teams not in that list.
+"""
+
+import dagster
+
+from posthog.clickhouse.cluster import AlterTableMutationRunner, ClickhouseCluster, MutationWaiter
+from posthog.dags.common import JobOwners
+from posthog.models.sessions.sql import ALLOWED_TEAM_IDS, SESSIONS_DATA_TABLE
+
+
+@dagster.op
+def delete_sessions_not_in_allowed_teams(
+    context: dagster.OpExecutionContext,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> dict[int, MutationWaiter]:
+    """Delete sessions v1 rows for teams not in ALLOWED_TEAM_IDS using ALTER TABLE DELETE."""
+
+    allowed_ids_str = ", ".join(str(tid) for tid in ALLOWED_TEAM_IDS)
+    delete_predicate = f"team_id NOT IN ({allowed_ids_str})"
+
+    delete_mutation_runner = AlterTableMutationRunner(
+        table=SESSIONS_DATA_TABLE(),
+        commands={f"DELETE WHERE {delete_predicate}"},
+        force=True,
+    )
+
+    context.log.info(f"Starting deletion of sessions v1 rows where {delete_predicate}")
+
+    shard_mutations = {
+        host.shard_num: mutation
+        for host, mutation in cluster.map_one_host_per_shard(delete_mutation_runner).result().items()
+        if host.shard_num is not None
+    }
+
+    context.add_output_metadata(
+        {
+            "shards_with_mutations": dagster.MetadataValue.int(len(shard_mutations)),
+            "predicate": dagster.MetadataValue.text(delete_predicate),
+            "allowed_team_ids": dagster.MetadataValue.text(allowed_ids_str),
+        }
+    )
+
+    return shard_mutations
+
+
+@dagster.op
+def wait_for_sessions_delete_mutations(
+    context: dagster.OpExecutionContext,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+    shard_mutations: dict[int, MutationWaiter],
+) -> bool:
+    """Wait for all deletion mutations to complete across shards."""
+
+    if not shard_mutations:
+        context.log.info("No mutations to wait for.")
+        return True
+
+    context.log.info(f"Waiting for mutations to complete on {len(shard_mutations)} shards...")
+
+    cluster.map_all_hosts_in_shards({shard: mutation.wait for shard, mutation in shard_mutations.items()}).result()
+
+    context.log.info("All mutations completed.")
+    context.add_output_metadata({"mutations_completed": dagster.MetadataValue.int(len(shard_mutations))})
+
+    return True
+
+
+@dagster.job(tags={"owner": JobOwners.TEAM_CLICKHOUSE.value})
+def sessions_v1_cleanup_job():
+    """Job that deletes sessions v1 rows for teams not in ALLOWED_TEAM_IDS."""
+    shard_mutations = delete_sessions_not_in_allowed_teams()
+    wait_for_sessions_delete_mutations(shard_mutations)

--- a/posthog/dags/sessions_v1_cleanup.py
+++ b/posthog/dags/sessions_v1_cleanup.py
@@ -20,9 +20,8 @@ def delete_sessions_not_in_allowed_teams(
     """Delete sessions v1 rows for teams not in ALLOWED_TEAM_IDS using ALTER TABLE DELETE."""
 
     if not ALLOWED_TEAM_IDS:
-        context.log.warning("ALLOWED_TEAM_IDS is empty - this would delete all sessions")
         raise ValueError("ALLOWED_TEAM_IDS must not be empty")
-    
+
     allowed_ids_str = ", ".join(str(tid) for tid in ALLOWED_TEAM_IDS)
     delete_predicate = f"team_id NOT IN ({allowed_ids_str})"
 

--- a/posthog/dags/sessions_v1_cleanup.py
+++ b/posthog/dags/sessions_v1_cleanup.py
@@ -72,7 +72,7 @@ def wait_for_sessions_delete_mutations(
     return True
 
 
-@dagster.job(tags={"owner": JobOwners.TEAM_CLICKHOUSE.value})
+@dagster.job(tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value})
 def sessions_v1_cleanup_job():
     """Job that deletes sessions v1 rows for teams not in ALLOWED_TEAM_IDS."""
     shard_mutations = delete_sessions_not_in_allowed_teams()

--- a/posthog/dags/sessions_v1_cleanup.py
+++ b/posthog/dags/sessions_v1_cleanup.py
@@ -19,6 +19,10 @@ def delete_sessions_not_in_allowed_teams(
 ) -> dict[int, MutationWaiter]:
     """Delete sessions v1 rows for teams not in ALLOWED_TEAM_IDS using ALTER TABLE DELETE."""
 
+    if not ALLOWED_TEAM_IDS:
+        context.log.warning("ALLOWED_TEAM_IDS is empty - this would delete all sessions")
+        raise ValueError("ALLOWED_TEAM_IDS must not be empty")
+    
     allowed_ids_str = ", ".join(str(tid) for tid in ALLOWED_TEAM_IDS)
     delete_predicate = f"team_id NOT IN ({allowed_ids_str})"
 

--- a/posthog/dags/tests/test_sessions_v1_cleanup.py
+++ b/posthog/dags/tests/test_sessions_v1_cleanup.py
@@ -1,0 +1,154 @@
+import uuid
+from datetime import datetime
+from functools import partial
+
+import pytest
+
+from clickhouse_driver import Client
+
+from posthog.clickhouse.cluster import ClickhouseCluster
+from posthog.dags.sessions_v1_cleanup import sessions_v1_cleanup_job
+from posthog.models.sessions.sql import ALLOWED_TEAM_IDS, SESSIONS_DATA_TABLE
+
+
+def generate_test_prefix() -> str:
+    """Generate a unique prefix for test session IDs to avoid conflicts."""
+    return f"test_{uuid.uuid4().hex[:8]}"
+
+
+def insert_sessions(client: Client, sessions: list[tuple[str, int, datetime]]) -> None:
+    """Insert test sessions into the sessions table."""
+    client.execute(
+        f"""
+        INSERT INTO {SESSIONS_DATA_TABLE()} (session_id, team_id, min_timestamp, max_timestamp)
+        VALUES
+        """,
+        [(sid, tid, ts, ts) for sid, tid, ts in sessions],
+    )
+
+
+def count_sessions_with_prefix(prefix: str, table: str, client: Client) -> dict[int, int]:
+    """Count sessions per team_id where session_id starts with prefix."""
+    result = client.execute(
+        f"SELECT team_id, count() FROM {table} WHERE session_id LIKE %(prefix)s GROUP BY team_id",
+        {"prefix": f"{prefix}%"},
+    )
+    return {row[0]: row[1] for row in result} if result else {}
+
+
+def get_team_ids_with_prefix(prefix: str, table: str, client: Client) -> set[int]:
+    """Get all unique team_ids where session_id starts with prefix."""
+    result = client.execute(
+        f"SELECT DISTINCT team_id FROM {table} WHERE session_id LIKE %(prefix)s",
+        {"prefix": f"{prefix}%"},
+    )
+    return {row[0] for row in result} if result else set()
+
+
+@pytest.mark.django_db
+def test_cleanup_job_deletes_non_allowed_teams(cluster: ClickhouseCluster):
+    """Test that the cleanup job deletes sessions for teams not in ALLOWED_TEAM_IDS."""
+    timestamp = datetime.now()
+    prefix = generate_test_prefix()
+
+    allowed_team_id = ALLOWED_TEAM_IDS[0]
+    non_allowed_team_ids = [99999, 88888, 77777]
+
+    sessions = []
+    for i in range(10):
+        sessions.append((f"{prefix}_allowed_{i}", allowed_team_id, timestamp))
+    for team_id in non_allowed_team_ids:
+        for i in range(5):
+            sessions.append((f"{prefix}_non_allowed_{team_id}_{i}", team_id, timestamp))
+
+    cluster.any_host(partial(insert_sessions, sessions=sessions)).result()
+
+    sessions_v1_cleanup_job.execute_in_process(
+        resources={"cluster": cluster},
+    )
+
+    final_counts = cluster.any_host(partial(count_sessions_with_prefix, prefix, SESSIONS_DATA_TABLE())).result()
+    assert final_counts.get(allowed_team_id, 0) == 10, "Allowed team sessions should remain"
+    for team_id in non_allowed_team_ids:
+        assert team_id not in final_counts, f"Team {team_id} sessions should be deleted"
+
+
+@pytest.mark.django_db
+def test_cleanup_job_handles_empty_table(cluster: ClickhouseCluster):
+    """Test that the job handles when there's nothing to delete gracefully."""
+    result = sessions_v1_cleanup_job.execute_in_process(
+        resources={"cluster": cluster},
+    )
+    assert result.success
+
+
+@pytest.mark.django_db
+def test_cleanup_job_handles_only_allowed_teams(cluster: ClickhouseCluster):
+    """Test that the job handles a table with only allowed teams (nothing to delete)."""
+    timestamp = datetime.now()
+    prefix = generate_test_prefix()
+
+    sessions = []
+    for team_id in ALLOWED_TEAM_IDS[:3]:
+        for i in range(5):
+            sessions.append((f"{prefix}_allowed_{team_id}_{i}", team_id, timestamp))
+
+    cluster.any_host(partial(insert_sessions, sessions=sessions)).result()
+
+    initial_team_ids = cluster.any_host(partial(get_team_ids_with_prefix, prefix, SESSIONS_DATA_TABLE())).result()
+
+    result = sessions_v1_cleanup_job.execute_in_process(
+        resources={"cluster": cluster},
+    )
+
+    assert result.success
+
+    final_team_ids = cluster.any_host(partial(get_team_ids_with_prefix, prefix, SESSIONS_DATA_TABLE())).result()
+    assert final_team_ids == initial_team_ids
+
+
+@pytest.mark.django_db
+def test_delete_with_multiple_allowed_teams_in_data(cluster: ClickhouseCluster):
+    """Test deletion when multiple allowed teams have data alongside non-allowed teams."""
+    timestamp = datetime.now()
+    prefix = generate_test_prefix()
+
+    sessions = []
+    for team_id in ALLOWED_TEAM_IDS[:5]:
+        for i in range(3):
+            sessions.append((f"{prefix}_allowed_{team_id}_{i}", team_id, timestamp))
+    for team_id in [99999, 88888]:
+        for i in range(7):
+            sessions.append((f"{prefix}_non_allowed_{team_id}_{i}", team_id, timestamp))
+
+    cluster.any_host(partial(insert_sessions, sessions=sessions)).result()
+
+    sessions_v1_cleanup_job.execute_in_process(
+        resources={"cluster": cluster},
+    )
+
+    final_counts = cluster.any_host(partial(count_sessions_with_prefix, prefix, SESSIONS_DATA_TABLE())).result()
+
+    for team_id in ALLOWED_TEAM_IDS[:5]:
+        assert final_counts.get(team_id, 0) == 3, f"Allowed team {team_id} sessions should remain"
+
+    assert 99999 not in final_counts, "Non-allowed team 99999 should be deleted"
+    assert 88888 not in final_counts, "Non-allowed team 88888 should be deleted"
+
+
+class TestAllowedTeamIdsConstant:
+    """Tests to verify ALLOWED_TEAM_IDS is properly configured."""
+
+    def test_allowed_team_ids_is_not_empty(self):
+        assert len(ALLOWED_TEAM_IDS) > 0
+
+    def test_allowed_team_ids_are_integers(self):
+        for team_id in ALLOWED_TEAM_IDS:
+            assert isinstance(team_id, int), f"Team ID {team_id} should be an integer"
+
+    def test_allowed_team_ids_are_positive(self):
+        for team_id in ALLOWED_TEAM_IDS:
+            assert team_id > 0, f"Team ID {team_id} should be positive"
+
+    def test_allowed_team_ids_are_unique(self):
+        assert len(ALLOWED_TEAM_IDS) == len(set(ALLOWED_TEAM_IDS))


### PR DESCRIPTION
## Problem

Only a small number of teams are grandfathered into sessions v1 (everyone else is on 2, soon 3)

When v1 was the only option, we wrote a bunch of rows into this table that are now literally never read

## Changes

Add dagster job to delete all rows from sessions v1 except for grandfathered teams

## How did you test this code?

My robot wrote a bunch of tests for the dagster job

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
