### PR TITLE
fix: allow `@` characters in MySQL identifiers

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -91,10 +91,10 @@ def _sanitize_identifier(identifier: str) -> str:
             return f"`{identifier}`"
 
         if identifier.startswith("$") or (len(identifier) > 0 and identifier[0].isdigit()):
-            if not identifier[1:].replace(".", "").replace("_", "").replace("-", "").isidentifier():
+            if not identifier[1:].replace(".", "").replace("_", "").replace("-", "").replace("@", "").isidentifier():
                 raise ValueError(f"Invalid SQL identifier: {identifier}")
 
-    if not identifier.replace(".", "").replace("_", "").replace("-", "").replace("$", "").isalnum():
+    if not identifier.replace(".", "").replace("_", "").replace("-", "").replace("$", "").replace("@", "").isalnum():
         raise ValueError(f"Invalid SQL identifier: {identifier}")
 
     return f"`{identifier}`"

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1,6 +1,28 @@
+import pytest
+
 from posthog.temporal.data_imports.sources.mysql.mysql import _sanitize_identifier
 
 
-def test_sanitize_identifier_with_digits():
-    res = _sanitize_identifier("851")
-    assert res == "`851`"
+@pytest.mark.parametrize(
+    "identifier,expected",
+    [
+        ("mydb", "`mydb`"),
+        ("851", "`851`"),
+        ("$col", "`$col`"),
+        ("db@prod", "`db@prod`"),
+    ],
+)
+def test_sanitize_identifier_valid(identifier, expected):
+    assert _sanitize_identifier(identifier) == expected
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "bad;id",
+        "$bad!",
+    ],
+)
+def test_sanitize_identifier_invalid(identifier):
+    with pytest.raises(ValueError, match="Invalid SQL identifier"):
+        _sanitize_identifier(identifier)


### PR DESCRIPTION
## Problem

[A customer reported](https://posthoghelp.zendesk.com/agent/tickets/48710) their MySQL source was failing because their schema name contained an `@` character.

## Changes

Support `@` characters inside `_sanitize_identifier`.

I feel this could be slightly playing whack-a-mole because there are probably other characters that _could_ be supported. I don't know if an alternative fix might be to only reject the identifier if it contains a backtick character - as that would potentially escape the backticks in the sanitized string.