### PR TITLE
feat(insights): make combine events button more visible

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -443,22 +443,29 @@ export function ActionFilterRow({
         </LemonButton>
     )
 
-    const combineRowButton = (
-        <Tooltip title="Count multiple events as a single event">
-            <LemonButton
-                key="combine"
-                icon={<IconStack />}
-                data-attr={`show-prop-combine-${index}`}
-                noPadding={!enablePopup}
-                onClick={() => {
-                    setIsMenuVisible(false)
-                    convertFilterToGroup(index)
-                }}
-                fullWidth={enablePopup}
-            >
-                {enablePopup ? 'Combine' : undefined}
-            </LemonButton>
-        </Tooltip>
+    const combineInlineButton = (
+        <LemonButton
+            key="combine-inline"
+            icon={<IconStack />}
+            title="Count multiple events as a single event"
+            data-attr={`show-prop-combine-${index}`}
+            noPadding
+            onClick={() => {
+                convertFilterToGroup(index)
+            }}
+            tooltip={
+                <>
+                    Combine events
+                    <br />
+                    <Link
+                        to="https://posthog.com/docs/product-analytics/trends/overview#combine-events-inline"
+                        target="_blank"
+                    >
+                        Read the docs
+                    </Link>
+                </>
+            }
+        />
     )
 
     const deleteButton = (
@@ -499,7 +506,6 @@ export function ActionFilterRow({
                   !hideFilter && propertyFiltersButton,
                   !hideRename && renameRowButton,
                   !hideDuplicate && !singleFilter && duplicateRowButton,
-                  showCombine && combineRowButton,
                   !hideDeleteBtn && !singleFilter && deleteButton,
               ].filter(Boolean)
             : []
@@ -659,6 +665,7 @@ export function ActionFilterRow({
                                 {showPopupMenu ? (
                                     <>
                                         {!hideFilter && propertyFiltersButton}
+                                        {showCombine && combineInlineButton}
                                         <div className="relative">
                                             <LemonMenu
                                                 placement={isTrendsContext ? 'bottom-end' : 'bottom-start'}
@@ -734,13 +741,6 @@ export function ActionFilterRow({
                                                         ? [
                                                               {
                                                                   label: () => duplicateRowButton,
-                                                              },
-                                                          ]
-                                                        : []),
-                                                    ...(showCombine
-                                                        ? [
-                                                              {
-                                                                  label: () => combineRowButton,
                                                               },
                                                           ]
                                                         : []),


### PR DESCRIPTION
## Problem

Currently, the combine events button is in the pop-up menu, and it is hard for users to discover it.
Moved it outside of the menu for better visibility.

<img width="660" height="226" alt="Screenshot 2026-01-29 at 16 35 19" src="https://github.com/user-attachments/assets/416b3295-ef7e-4bba-980a-31c6249bc42a" />

## Changes

<img width="1159" height="347" alt="Screenshot 2026-01-29 at 16 39 33" src="https://github.com/user-attachments/assets/491bdb19-d69e-42c9-9927-39beef7fb814" />

## How did you test this code?

Manually

## Publish to changelog?
No
