### PR TITLE
feat: temporal get_client pick clickhouse users same as sync_execute

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -93,6 +93,25 @@ def init_clickhouse_users() -> Mapping[ClickHouseUser, tuple[str, str]]:
 
 
 def get_clickhouse_creds(user: ClickHouseUser) -> tuple[str, str]:
+    """
+    Retrieve ClickHouse credentials for the specified user.
+
+    This function retrieves the credentials associated with a given ClickHouse
+    user. If the specified user is not found, it will fall back to the default
+    user credentials.
+
+    The user and password must be properly passed as ENVs:
+        CLICKHOUSE_<USER_NAME>_USER
+        CLICKHOUSE_<USER_NAME>_PASSWORD
+
+    Args:
+        user (ClickHouseUser): The user whose ClickHouse credentials need
+                               to be retrieved.
+
+    Returns:
+        tuple[str, str]: A tuple containing the username and password associated
+                         with the specified user.
+    """
     global __user_dict
     if not __user_dict:
         __user_dict = init_clickhouse_users()

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -123,10 +123,53 @@ def sync_execute(
     *,
     workload: Workload = Workload.DEFAULT,
     team_id: Optional[int] = None,
+    no_team_id: Optional[bool] = False,
     readonly=False,
     sync_client: Optional[SyncClient] = None,
     ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
 ):
+    """
+    Executes a synchronous query on the ClickHouse database based on predefined workloads and tags.
+
+    IF THE QUERY IS EXECUTED FOR ONE TEAM, YOU SHOULD SPECIFY team_id.
+
+    This function determines the appropriate workload and user for the query execution based on its
+    tags, including whether it is from a personal API key or if it pertains to specific tasks, such as
+    Celery. Depending on the workload, it adjusts query settings and logging attributes before
+    executing the query. A variety of pre- and post-query logic is performed, including metrics
+    tracking, tag updates, and potential error wrapping.
+
+    Attributes added or modified, such as tags and settings, are used to fine-tune query
+    behavior. For offline workloads, certain settings may also be altered to improve performance under
+    high load scenarios.
+
+    Various counters are incremented to monitor the number of queries started, completed, and failed.
+    Execution timings and metrics specific to the workload are tracked for analytics purposes.
+
+    Raises a specific error by wrapping the original exception, which allows for better error
+    management and debugging of failed queries.
+
+    Arguments:
+    query (str): The SQL query string to be executed.
+    args (Optional[Union[Tuple, Dict]]): Arguments referenced in the query, if any.
+    settings (Optional[Dict]): Custom ClickHouse settings for this query.
+    with_column_types (bool): Whether to include column types in the query result.
+    flush (bool): Whether to flush data (like persons and events) in testing environments.
+    workload (Workload): The workload type defining where the query should be executed. Defaults
+        to Workload.DEFAULT.
+    team_id (Optional[int]): Optional team ID used to customize query behavior.
+    readonly (bool): Specifies whether the query intends to modify data. Default is False.
+    sync_client (Optional[SyncClient]): A specific ClickHouse client to use for the query.
+    ch_user (ClickHouseUser): The user context for the query execution. Defaults to
+        ClickHouseUser.DEFAULT.
+
+    Returns:
+    Union[List[Tuple], int, None]: The result of the query. For select queries, it returns a list of
+        tuples. For insert queries, it may return the number of rows written.
+
+    Raises:
+    ClickHouseError: Custom wrapped ClickHouse error generated in case of query execution failure.
+    """
     if not workload:
         workload = Workload.DEFAULT
         # TODO replace this by assert, sorry, no messing with ClickHouse should be possible

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -123,7 +123,6 @@ def sync_execute(
     *,
     workload: Workload = Workload.DEFAULT,
     team_id: Optional[int] = None,
-    no_team_id: Optional[bool] = False,
     readonly=False,
     sync_client: Optional[SyncClient] = None,
     ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -851,7 +851,7 @@ async def get_client(
     *,
     team_id: typing.Optional[int] = None,
     clickhouse_url: str | None = None,
-    ch_user: typing.Optional[ClickHouseUser] = None,
+    ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
     **kwargs,
 ) -> collections.abc.AsyncIterator[ClickHouseClient]:
     """


### PR DESCRIPTION
## Problem

Temporal defaults to a settings.CLICKHOUSE_USER

## Changes

make temporal clickhouse get_client respect clickhouse user


