### PR TITLE
fix: Improving the manual mapping with suggestions and more space

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/stringSimilarity.test.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/stringSimilarity.test.ts
@@ -1,0 +1,104 @@
+import { findCampaignSuggestions, levenshteinDistance, similarityScore } from './stringSimilarity'
+
+describe('stringSimilarity', () => {
+    describe('levenshteinDistance', () => {
+        it.each([
+            ['', '', 0],
+            ['a', 'a', 0],
+            ['abc', 'abc', 0],
+            ['a', 'b', 1],
+            ['abc', 'abd', 1],
+            ['abc', 'abcd', 1],
+            ['abcd', 'abc', 1],
+            ['kitten', 'sitting', 3],
+            ['saturday', 'sunday', 3],
+        ])('distance between "%s" and "%s" should be %i', (a, b, expected) => {
+            expect(levenshteinDistance(a, b)).toBe(expected)
+        })
+    })
+
+    describe('similarityScore', () => {
+        it.each([
+            ['brand', 'brand', 1],
+            ['Brand', 'brand', 1],
+            ['BRAND', 'brand', 1],
+            ['', '', 1], // empty strings are identical
+            ['a', '', 0],
+            ['', 'b', 0],
+        ])('score between "%s" and "%s" should be %d', (a, b, expected) => {
+            expect(similarityScore(a, b)).toBe(expected)
+        })
+
+        it('should give bonus for substring match', () => {
+            const withSubstring = similarityScore('summer', 'summer_sale_2024')
+            const withoutSubstring = similarityScore('summer', 'winter_sale_2024')
+            expect(withSubstring).toBeGreaterThan(withoutSubstring)
+        })
+
+        it('should return score between 0 and 1', () => {
+            const score = similarityScore('completely', 'different')
+            expect(score).toBeGreaterThanOrEqual(0)
+            expect(score).toBeLessThanOrEqual(1)
+        })
+    })
+
+    describe('findCampaignSuggestions', () => {
+        const campaigns = [
+            { name: 'Summer Sale 2024', id: '123456' },
+            { name: 'Winter Campaign', id: '789012' },
+            { name: 'Brand Awareness', id: '345678' },
+            { name: 'Black Friday', id: '901234' },
+        ]
+
+        it('should return empty array for empty input', () => {
+            expect(findCampaignSuggestions('', campaigns)).toEqual([])
+            expect(findCampaignSuggestions('  ', campaigns)).toEqual([])
+        })
+
+        it('should return empty array for empty campaigns', () => {
+            expect(findCampaignSuggestions('test', [])).toEqual([])
+        })
+
+        it('should find exact match by name', () => {
+            const results = findCampaignSuggestions('Brand Awareness', campaigns)
+            expect(results[0].name).toBe('Brand Awareness')
+            expect(results[0].score).toBe(1)
+        })
+
+        it('should find exact match by id', () => {
+            const results = findCampaignSuggestions('123456', campaigns)
+            expect(results[0].id).toBe('123456')
+            expect(results[0].score).toBe(1)
+            expect(results[0].matchedBy).toBe('id')
+        })
+
+        it('should find partial match by name', () => {
+            const results = findCampaignSuggestions('summer', campaigns)
+            expect(results[0].name).toBe('Summer Sale 2024')
+            expect(results[0].matchedBy).toBe('name')
+        })
+
+        it('should return top N results', () => {
+            const results = findCampaignSuggestions('a', campaigns, 2)
+            expect(results.length).toBeLessThanOrEqual(2)
+        })
+
+        it('should sort by score descending', () => {
+            const results = findCampaignSuggestions('brand', campaigns)
+            for (let i = 1; i < results.length; i++) {
+                expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score)
+            }
+        })
+
+        it('should match by id when id is more similar', () => {
+            const results = findCampaignSuggestions('12345', campaigns)
+            expect(results[0].matchedBy).toBe('id')
+        })
+
+        it('should match by name when name is more similar', () => {
+            const results = findCampaignSuggestions('Black', campaigns)
+            expect(results[0].matchedBy).toBe('name')
+            expect(results[0].name).toBe('Black Friday')
+        })
+    })
+})

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/stringSimilarity.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/stringSimilarity.ts
@@ -1,0 +1,68 @@
+export function levenshteinDistance(a: string, b: string): number {
+    const matrix: number[][] = []
+
+    for (let i = 0; i <= a.length; i++) {
+        matrix[i] = [i]
+    }
+    for (let j = 0; j <= b.length; j++) {
+        matrix[0][j] = j
+    }
+
+    for (let i = 1; i <= a.length; i++) {
+        for (let j = 1; j <= b.length; j++) {
+            const cost = a[i - 1] === b[j - 1] ? 0 : 1
+            matrix[i][j] = Math.min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + cost)
+        }
+    }
+
+    return matrix[a.length][b.length]
+}
+
+export function similarityScore(a: string, b: string): number {
+    const normA = a.toLowerCase().trim()
+    const normB = b.toLowerCase().trim()
+
+    if (normA === normB) {
+        return 1
+    }
+    if (normA.length === 0 || normB.length === 0) {
+        return 0
+    }
+
+    const maxLen = Math.max(normA.length, normB.length)
+    const distance = levenshteinDistance(normA, normB)
+    const base = 1 - distance / maxLen
+
+    // Bonus if one contains the other
+    const bonus = normA.includes(normB) || normB.includes(normA) ? 0.2 : 0
+
+    return Math.min(1, base + bonus)
+}
+
+export interface CampaignSuggestion {
+    name: string
+    id: string
+    score: number
+    matchedBy: 'name' | 'id'
+}
+
+export function findCampaignSuggestions(
+    input: string,
+    campaigns: Array<{ name: string; id: string }>,
+    topN: number = 3
+): CampaignSuggestion[] {
+    if (!input.trim() || campaigns.length === 0) {
+        return []
+    }
+
+    return campaigns
+        .map((c) => {
+            const nameScore = similarityScore(input, c.name)
+            const idScore = similarityScore(input, c.id)
+            return nameScore >= idScore
+                ? { ...c, score: nameScore, matchedBy: 'name' as const }
+                : { ...c, score: idScore, matchedBy: 'id' as const }
+        })
+        .sort((a, b) => b.score - a.score)
+        .slice(0, topN)
+}


### PR DESCRIPTION
## Problem

After meeting a customer, I realized it was really hard to find the correct campaign for doing the manual mapping.

## Changes

Added a suggestion based on [levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) and also adjusted the UI so a very large input doesn't get complicated to map.

## How did you test this code?
Manually and added a new test for the utility fns.

<img width="613" height="479" alt="Screenshot 2026-01-29 at 3 50 59 PM" src="https://github.com/user-attachments/assets/ff6114ad-ea2b-494a-8a0e-aa2caf9e26ae" />
<img width="640" height="481" alt="Screenshot 2026-01-29 at 3 51 09 PM" src="https://github.com/user-attachments/assets/26781fbe-723f-44a4-9655-205b859f76bc" />
<img width="603" height="466" alt="Screenshot 2026-01-29 at 3 51 17 PM" src="https://github.com/user-attachments/assets/e93202ea-4dc4-44e2-92ec-8d73ebf1c938" />
<img width="601" height="461" alt="Screenshot 2026-01-29 at 3 52 22 PM" src="https://github.com/user-attachments/assets/483f933f-0884-4436-a54c-e85312a55dd4" />
<img width="614" height="470" alt="Screenshot 2026-01-29 at 3 53 01 PM" src="https://github.com/user-attachments/assets/c0feaa89-64d5-4c25-8ca7-dd9267828239" />
<img width="599" height="488" alt="Screenshot 2026-01-29 at 3 54 10 PM" src="https://github.com/user-attachments/assets/a46feef1-52d1-47ce-b90c-9b8ac1aade10" />
