### PR TITLE
chore(kafka): Dont block when producing internal cdp events to kafka

### DIFF
--- a/posthog/cdp/internal_events.py
+++ b/posthog/cdp/internal_events.py
@@ -66,8 +66,7 @@ def produce_internal_event(team_id: int, event: InternalEventEvent, person: Opti
 
     try:
         producer = KafkaProducer()
-        future = producer.produce(topic=kafka_topic, data=serialized_data, key=data.event.uuid)
-        future.get()
+        producer.produce(topic=kafka_topic, data=serialized_data, key=data.event.uuid)
     except Exception as e:
         logger.exception("Failed to produce internal event", data=serialized_data, error=e)
         raise


### PR DESCRIPTION
## Problem
- https://posthog.slack.com/archives/C0AA66SHDFU/p1769714121860259?thread_ts=1769395146.094789&cid=C0AA66SHDFU
- The blocking of this kafka produce may be causing long waits in temporal workers

## Changes
Use the fire and forget pattern instead of blocking for a response
