### PR TITLE
Action dropdown icons

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -24,6 +24,7 @@ import { Link } from 'lib/lemon-ui/Link'
 import { IconCohort } from 'lib/lemon-ui/icons'
 import { capitalizeFirstLetter, isString, pluralize, toParams } from 'lib/utils'
 import {
+    getActionDefinitionIcon,
     getEventDefinitionIcon,
     getEventMetadataDefinitionIcon,
     getPropertyDefinitionIcon,
@@ -335,7 +336,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getName: (action: ActionType) => action.name || '',
                         getValue: (action: ActionType) => action.id,
                         getPopoverHeader: () => 'Action',
-                        getIcon: getEventDefinitionIcon,
+                        getIcon: getActionDefinitionIcon,
                     },
                     {
                         name: 'Data warehouse tables',

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { IconBadge, IconBolt, IconCursor, IconEye, IconLeave, IconList, IconLogomark } from '@posthog/icons'
+import { IconBadge, IconBolt, IconCursor, IconEye, IconLeave, IconList, IconLogomark, IconStack } from '@posthog/icons'
 
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -11,7 +11,7 @@ import { IconEyeHidden, IconSelectAll } from 'lib/lemon-ui/icons'
 
 import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 import { CORE_FILTER_DEFINITIONS_BY_GROUP } from '~/taxonomy/taxonomy'
-import { EventDefinition, PropertyDefinition } from '~/types'
+import { ActionType, EventDefinition, PropertyDefinition } from '~/types'
 
 interface IconWithBadgeProps {
     icon: JSX.Element
@@ -145,6 +145,15 @@ export function getRevenueAnalyticsDefinitionIcon(definition: PropertyDefinition
     }
 
     return <IconList />
+}
+
+// eslint-disable-next-line no-unused-vars
+export function getActionDefinitionIcon(_action: ActionType): JSX.Element {
+    return (
+        <Tooltip title="Action">
+            <IconStack className="taxonomy-icon taxonomy-icon-muted" />
+        </Tooltip>
+    )
 }
 
 export function DefinitionHeader({

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -6,7 +6,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { BuiltLogic, useActions, useValues } from 'kea'
 import { useState } from 'react'
 
-import { IconCopy, IconEllipsis, IconFilter, IconPencil, IconStack, IconTrash, IconWarning } from '@posthog/icons'
+import { IconCalculator, IconCopy, IconEllipsis, IconFilter, IconPencil, IconTrash, IconWarning } from '@posthog/icons'
 import {
     LemonBadge,
     LemonCheckbox,
@@ -446,7 +446,7 @@ export function ActionFilterRow({
     const combineInlineButton = (
         <LemonButton
             key="combine-inline"
-            icon={<IconStack />}
+            icon={<IconCalculator />}
             title="Count multiple events as a single event"
             data-attr={`show-prop-combine-${index}`}
             noPadding

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -6,7 +6,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { BuiltLogic, useActions, useValues } from 'kea'
 import { useState } from 'react'
 
-import { IconCalculator, IconCopy, IconEllipsis, IconFilter, IconPencil, IconTrash, IconWarning } from '@posthog/icons'
+import { IconCopy, IconEllipsis, IconFilter, IconPencil, IconStack, IconTrash, IconWarning } from '@posthog/icons'
 import {
     LemonBadge,
     LemonCheckbox,
@@ -446,7 +446,7 @@ export function ActionFilterRow({
     const combineInlineButton = (
         <LemonButton
             key="combine-inline"
-            icon={<IconCalculator />}
+            icon={<IconStack />}
             title="Count multiple events as a single event"
             data-attr={`show-prop-combine-${index}`}
             noPadding

--- a/products/actions/frontend/components/ActionsTable.tsx
+++ b/products/actions/frontend/components/ActionsTable.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconCheckCircle, IconPin, IconPinFilled } from '@posthog/icons'
+import { IconCheckCircle, IconPin, IconPinFilled, IconStack } from '@posthog/icons'
 import { LemonInput, LemonSegmentedButton } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
@@ -79,6 +79,17 @@ export function ActionsTable(): JSX.Element {
                         tooltip={pinned ? 'Unpin action' : 'Pin action'}
                         icon={pinned ? <IconPinFilled /> : <IconPin />}
                     />
+                )
+            },
+        },
+        {
+            key: 'icon',
+            width: 0,
+            render: function RenderIcon() {
+                return (
+                    <span className="text-xl text-secondary">
+                        <IconStack />
+                    </span>
                 )
             },
         },


### PR DESCRIPTION
## Problem
 
In event/action dropdown menus (taxonomic filters), actions were using the same icon as events, making them visually indistinguishable. Users needed a way to quickly differentiate between:
- Custom events (cursor icon)
- PostHog events (logomark icon)
- Autocapture events (bolt icon)
- **Actions** (previously shared event icons)
 
## Changes
 
- Created new `getActionDefinitionIcon()` function that returns `IconStack` for actions
- Updated the Actions taxonomic filter group to use this dedicated icon function instead of sharing `getEventDefinitionIcon` with events
- Actions now display with a distinct stack icon in all dropdown menus
 
## Visual Impact
 
Actions will now be easily distinguishable in:
- Event/action selector dropdowns in insights
- Taxonomic filter menus throughout the app
- Any component using the TaxonomicFilter system
 
## How did you test this code?
 
Manually verified that actions display with the stack icon in event dropdowns while events retain their existing icons (cursor, logomark, bolt, etc.)
 
## Publish to changelog?
 
no