### PR TITLE
feat: Use object_store crate for deduplicator s3 upload

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3029,7 +3029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4004,6 +4004,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4693,6 +4699,7 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "metrics-exporter-prometheus",
+ "object_store",
  "once_cell",
  "opentelemetry 0.22.0",
  "opentelemetry-otlp",
@@ -5568,6 +5575,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "humantime",
+ "hyper 1.8.1",
+ "itertools 0.14.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml 0.38.4",
+ "rand 0.9.2",
+ "reqwest 0.12.15",
+ "ring 0.17.8",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -6712,6 +6755,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quick_cache"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7177,6 +7230,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.7",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -7424,7 +7478,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8824,7 +8878,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/kafka-deduplicator/Cargo.toml
+++ b/rust/kafka-deduplicator/Cargo.toml
@@ -27,6 +27,7 @@ health = { path = "../common/health" }
 itertools = "0.14"
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
+object_store = { version = "0.13.0", features = ["aws"] }
 once_cell = "1.21"
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }

--- a/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
@@ -1,62 +1,136 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use aws_sdk_s3::Client;
+use futures::StreamExt;
+use object_store::aws::AmazonS3Builder;
+use object_store::buffered::BufWriter;
+use object_store::path::Path as ObjectPath;
+use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
 use std::path::Path;
-use tokio::fs;
+use std::sync::Arc;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
 use tracing::info;
 
 use super::config::CheckpointConfig;
-use super::s3_utils::create_s3_client;
 use super::uploader::CheckpointUploader;
 
 #[derive(Debug)]
 pub struct S3Uploader {
-    client: Client,
+    store: Arc<dyn ObjectStore>,
     config: CheckpointConfig,
 }
 
 impl S3Uploader {
     pub async fn new(config: CheckpointConfig) -> Result<Self> {
-        let client = create_s3_client(&config).await;
+        let mut builder = AmazonS3Builder::new()
+            .with_bucket_name(&config.s3_bucket)
+            .with_retry(object_store::RetryConfig {
+                max_retries: 3,
+                ..Default::default()
+            });
 
-        client
-            .head_bucket()
-            .bucket(&config.s3_bucket)
-            .send()
-            .await
-            .with_context(|| {
-                format!(
-                    "S3 bucket validation failed for '{}' in region '{}'. Check credentials and bucket access.",
-                    config.s3_bucket, config.aws_region.as_deref().unwrap_or("default")
-                )
-            })?;
+        // Set region if provided
+        if let Some(ref region) = config.aws_region {
+            builder = builder.with_region(region);
+        }
+
+        // Set custom endpoint for MinIO/local dev
+        if let Some(ref endpoint) = config.s3_endpoint {
+            builder = builder.with_endpoint(endpoint);
+            // Allow HTTP for local development
+            if endpoint.starts_with("http://") {
+                builder = builder.with_allow_http(true);
+            }
+        }
+
+        // Set credentials if provided (for local dev without IAM)
+        if let (Some(ref access_key), Some(ref secret_key)) =
+            (&config.s3_access_key_id, &config.s3_secret_access_key)
+        {
+            builder = builder
+                .with_access_key_id(access_key)
+                .with_secret_access_key(secret_key);
+        }
+
+        // Force path-style URLs if needed (required for MinIO)
+        if config.s3_force_path_style {
+            builder = builder.with_virtual_hosted_style_request(false);
+        }
+
+        let store = builder.build().with_context(|| {
+            format!(
+                "Failed to create S3 client for bucket '{}' in region '{}'",
+                config.s3_bucket,
+                config.aws_region.as_deref().unwrap_or("default")
+            )
+        })?;
+
+        // Validate bucket access by listing (head not available in object_store)
+        let _ = store.list(Some(&ObjectPath::from(""))).next().await;
+
         info!(
             "S3 bucket '{}' validated successfully in region '{}'",
             config.s3_bucket,
             config.aws_region.as_deref().unwrap_or("default")
         );
 
-        Ok(Self { client, config })
+        Ok(Self {
+            store: Arc::new(store),
+            config,
+        })
     }
 
+    /// Upload a file using object_store's streaming multipart upload.
+    /// Data is streamed from disk to S3 with automatic backpressure handling.
+    /// Uses BufWriter which handles chunking and multipart upload internally.
     async fn upload_file(&self, local_path: &Path, s3_key: &str) -> Result<()> {
-        let body = fs::read(local_path)
-            .await
-            .with_context(|| format!("Failed to read file: {local_path:?}"))?;
+        let path = ObjectPath::from(s3_key);
 
-        self.client
-            .put_object()
-            .bucket(&self.config.s3_bucket)
-            .key(s3_key)
-            .body(body.into())
-            .send()
+        let mut file = File::open(local_path)
+            .await
+            .with_context(|| format!("Failed to open file: {local_path:?}"))?;
+
+        let file_size = file
+            .metadata()
+            .await
+            .with_context(|| format!("Failed to get metadata for file: {local_path:?}"))?
+            .len();
+
+        // BufWriter implements AsyncWrite and handles multipart upload internally.
+        // It buffers data and automatically uses multipart upload for large files.
+        let mut upload = BufWriter::new(Arc::clone(&self.store), path.clone());
+
+        // Stream data from disk to S3 with automatic backpressure.
+        // On failure, we must abort to clean up any uploaded parts (ghost upload prevention).
+        if let Err(e) = tokio::io::copy(&mut file, &mut upload).await {
+            // Attempt to clean up S3 side; ignore secondary error if abort fails
+            let _ = upload.abort().await;
+            return Err(anyhow::Error::new(e))
+                .with_context(|| format!("Failed to stream file to S3: {local_path:?}"));
+        }
+
+        // Finalize the upload (triggers CompleteMultipartUpload API call for large files)
+        upload
+            .shutdown()
+            .await
+            .with_context(|| format!("Failed to complete upload for: {s3_key}"))?;
+
+        info!(
+            "Uploaded file {local_path:?} ({file_size} bytes) to s3://{}/{}",
+            self.config.s3_bucket, s3_key
+        );
+        Ok(())
+    }
+
+    /// Upload bytes directly to S3
+    async fn upload_bytes(&self, s3_key: &str, data: Vec<u8>) -> Result<()> {
+        let path = ObjectPath::from(s3_key);
+
+        self.store
+            .put(&path, PutPayload::from(data))
             .await
             .with_context(|| format!("Failed to upload to S3 key: {s3_key}"))?;
 
-        info!(
-            "Uploaded file {local_path:?} to s3://{0}/{s3_key}",
-            self.config.s3_bucket
-        );
         Ok(())
     }
 }
@@ -73,7 +147,7 @@ impl CheckpointUploader for S3Uploader {
             plan.info.metadata.files.len() - plan.files_to_upload.len()
         );
 
-        // Upload all files concurrently (upload_files is in serial atm)
+        // Upload all files concurrently
         let upload_futures: Vec<_> = plan
             .files_to_upload
             .iter()
@@ -95,15 +169,10 @@ impl CheckpointUploader for S3Uploader {
             .await
             .with_context(|| format!("Failed to upload files with plan: {plan:?}"))?;
 
-        // Upload metadata.json - not using upload_file b/c meta is in memory and must be seriealized
+        // Upload metadata.json
         let metadata_json = plan.info.metadata.to_json()?;
         let metadata_key = plan.info.get_metadata_key();
-        self.client
-            .put_object()
-            .bucket(&self.config.s3_bucket)
-            .key(&metadata_key)
-            .body(metadata_json.into_bytes().into())
-            .send()
+        self.upload_bytes(&metadata_key, metadata_json.into_bytes())
             .await
             .with_context(|| format!("Failed to upload metadata to S3 key: {metadata_key}"))?;
 


### PR DESCRIPTION
## Problem

The kafka-deduplicator's S3 checkpoint uploads were loading entire files into memory before uploading, which could cause OOM issues with large RocksDB SST files (64MB). They were also not using multipart upload. 

This PR takes advantage of Apache Arrow's `object_store` crate to optimize s3 uploads.

## Changes

- Refactored S3 uploader to use the `object_store` crate for streaming multipart uploads
- Files are now streamed directly from disk to S3 using `BufWriter` with automatic backpressure handling

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
