### PR TITLE
feat(customers): Add saved views to person profile events

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -41,12 +41,15 @@ export interface PersonsLogicProps {
     fixedProperties?: PersonPropertyFilter[]
 }
 
+export const PERSON_EVENTS_CONTEXT_KEY = 'person-profile-events'
+
 function createInitialEventsPayload(personId: string): DataTableNode {
     return {
         kind: NodeKind.DataTableNode,
         full: true,
         showEventsFilter: true,
-        showSavedFilters: true,
+        showTableViews: true,
+        contextKey: PERSON_EVENTS_CONTEXT_KEY,
         hiddenColumns: [PERSON_DISPLAY_NAME_COLUMN_NAME],
         source: {
             kind: NodeKind.EventsQuery,


### PR DESCRIPTION
## Problem

Saving predefined filters/columns for events tab in person profiles is something that came up quite a lot in the feedback survey

## Changes

Add table views to person profile events table. Had to adjust the tableViewLogic a bit as events query has some specificity.

## How did you test this code?

Tested by:
- Creating and saving custom views for person events
- Verifying that columns and filters are properly saved
- Checking that views can be applied correctly, restoring both column selections and property filters
- Ensuring that event-specific properties are properly handled in the save/restore process

## Publish to changelog?

Yes