### PR TITLE
feat(vercel): notify billing when integration is uninstalled

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -566,6 +566,31 @@ class BillingManager:
 
         return res.json()
 
+    def deauthorize(self, organization: Organization, billing_provider: BillingProvider) -> dict[str, Any]:
+        """
+        Deauthorize billing for an organization when a marketplace provider uninstalls.
+
+        This cancels the Stripe subscription and resets the billing provider to default,
+        effectively ending the customer's paid access through the marketplace.
+
+        Args:
+            organization: The organization to deauthorize billing for
+            billing_provider: The marketplace provider being uninstalled (e.g., "vercel")
+
+        Returns:
+            Response from billing service with success status
+        """
+        res = requests.post(
+            f"{BILLING_SERVICE_URL}/api/activate/authorize/uninstall",
+            headers=self.get_auth_headers(organization),
+            json={"billing_provider": billing_provider.value},
+            timeout=30,
+        )
+
+        handle_billing_service_error(res)
+
+        return res.json()
+
     def switch_plan(self, organization: Organization, data: dict[str, Any]) -> dict[str, Any]:
         res = requests.post(
             f"{BILLING_SERVICE_URL}/api/subscription/switch-plan/",


### PR DESCRIPTION
## Problem

When a Vercel customer uninstalls the integration from Vercel Marketplace:
1. Vercel calls DELETE on the installation endpoint
2. PostHog deletes the OrganizationIntegration record
3. **But billing is NOT notified**

This leaves billing in an orphaned state:
- Billing keeps trying to submit usage to Vercel (fails with 404)
- The Stripe subscription remains active
- Customer's billing_provider stays as vercel even though there's no integration

## Changes

Update delete_installation() to notify billing before deleting:
- Add BillingManager.deauthorize() method that calls billing service uninstall endpoint
- Call deauthorize() in delete_installation() before deleting the OrganizationIntegration
- Handle billing failures gracefully (log error, capture exception, but continue deletion)

**Requires:** PostHog/billing#1767

## How did you test this code?

- [x] Unit tests for BillingManager.deauthorize()
- [x] Unit tests for delete_installation billing notification
- [x] E2E test with real Vercel uninstall

## Changelog

Yes - Vercel integration uninstall now properly cancels billing subscription

Generated with Claude Code