### PR TITLE
Replay DOM inspector centering

### DIFF
--- a/frontend/src/scenes/session-recordings/player/view-explorer/SessionRecordingPlayerExplorer.tsx
+++ b/frontend/src/scenes/session-recordings/player/view-explorer/SessionRecordingPlayerExplorer.tsx
@@ -54,7 +54,7 @@ export function SessionRecordingPlayerExplorer({
         <div className="SessionRecordingPlayerExplorer flex flex-1 flex-col h-full overflow-hidden">
             <PlayerExplorerSettings iframeKey={iframeKey} setIframeKey={setIframeKey} onClose={onClose} />
             <div
-                className="flex-1 p-0.5 overflow-hidden bg-text-3000 border SessionRecordingPlayerExplorer__wrapper"
+                className="flex-1 p-0.5 overflow-hidden bg-text-3000 border SessionRecordingPlayerExplorer__wrapper flex items-center justify-center"
                 ref={elementRef}
             >
                 <iframe
@@ -63,7 +63,7 @@ export function SessionRecordingPlayerExplorer({
                     sandbox=""
                     width={width}
                     height={height}
-                    className="origin-top-left ph-no-capture"
+                    className="origin-center ph-no-capture"
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{ transform: `scale(${scale})` }}
                 />


### PR DESCRIPTION
## Problem

When using the "Inspect DOM" feature in session replay, the content within the inspector iframe was incorrectly positioned at the top-left of its container after scaling, instead of remaining centered. This resulted in a poor visual experience for users.

## Changes

- In `frontend/src/scenes/session-recordings/player/view-explorer/SessionRecordingPlayerExplorer.tsx`:
    - Added `flex items-center justify-center` to the `SessionRecordingPlayerExplorer__wrapper` div.
    - Changed the iframe's `transform-origin` from `origin-top-left` to `origin-center`.

## How did you test this code?

Manually tested by navigating to a session replay, clicking "Inspect DOM", and verifying that the content within the inspector iframe remains centered regardless of the zoom level.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1769724104411359?thread_ts=1769724104.411359&cid=D0ACMC57HDE)

<a href="https://cursor.com/background-agent?bcId=bc-98da4855-117f-4742-b685-b48db91e3448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-98da4855-117f-4742-b685-b48db91e3448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

