### PR TITLE
feat: Add `data-attr` to be able to target the customization button

### DIFF
--- a/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
@@ -62,6 +62,7 @@ export function PinnedFolder(): JSX.Element {
                     tooltipPlacement="top"
                     onClick={openEditCustomProductsModal}
                     size="xs"
+                    data-attr="edit-sidebar-apps-button"
                 >
                     <CustomProductsIcon className="size-3 text-secondary" />
                 </ButtonPrimitive>


### PR DESCRIPTION
We wanna run a product tour to let people learn about the customization button but we can't directly point to it, let's add a `data-attr` to be able to point to it