### PR TITLE
fix(ux): side panel sql editor gets panel trigger, fixed unflagged scene tab line

### DIFF
--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -11,6 +11,7 @@ import { IconPlus, IconX } from '@posthog/icons'
 
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { IconMenu } from 'lib/lemon-ui/icons'
@@ -36,6 +37,7 @@ export function SceneTabs(): JSX.Element {
     const { isLayoutNavbarVisibleForMobile } = useValues(panelLayoutLogic)
     const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }))
     const [isConfigurePinnedTabsOpen, setIsConfigurePinnedTabsOpen] = useState(false)
+    const isRemovingSidePanelFlag = useFeatureFlag('UX_REMOVE_SIDEPANEL')
 
     const handleDragEnd = ({ active, over }: DragEndEvent): void => {
         if (!over || over.id === 'new' || active.id === over.id) {
@@ -76,7 +78,11 @@ export function SceneTabs(): JSX.Element {
             )}
 
             {/* Line below tabs to to complete border on <main> element */}
-            <div className="absolute bottom-0 w-full lg:pl-[5px] lg:pr-3">
+            <div
+                className={cn('absolute bottom-0 w-full lg:px-[5px] ', {
+                    'lg:pr-3': isRemovingSidePanelFlag,
+                })}
+            >
                 <div className="w-full bottom-0 h-px border-b border-primary z-10" />
             </div>
 

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -9,6 +9,7 @@ import { LemonDivider, Spinner } from '@posthog/lemon-ui'
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
 import { IconCancel } from 'lib/lemon-ui/icons'
@@ -58,6 +59,7 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
     const { response } = useValues(dataNodeLogic)
     const { updatingDataWarehouseSavedQuery } = useValues(dataWarehouseViewsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const isRemovingSidePanelFlag = useFeatureFlag('UX_REMOVE_SIDEPANEL')
     const [editingViewDisabledReason, EditingViewButtonIcon] = useMemo(() => {
         if (updatingDataWarehouseSavedQuery) {
             return ['Saving...', Spinner]
@@ -240,9 +242,11 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                     </>
                 )}
                 <FixErrorButton type="tertiary" size="xsmall" source="action-bar" />
-                <div className="ml-auto -mr-2">
-                    <SceneTitlePanelButton />
-                </div>
+                {isRemovingSidePanelFlag && (
+                    <div className="ml-auto -mr-2">
+                        <SceneTitlePanelButton />
+                    </div>
+                )}
             </div>
             <QueryPane
                 originalValue={originalQueryInput ?? ''}

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -16,6 +16,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { SceneTitlePanelButton } from '~/layout/scenes/components/SceneTitleSection'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { NodeKind } from '~/queries/schema/schema-general'
 
@@ -239,6 +240,9 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                     </>
                 )}
                 <FixErrorButton type="tertiary" size="xsmall" source="action-bar" />
+                <div className="ml-auto -mr-2">
+                    <SceneTitlePanelButton />
+                </div>
             </div>
             <QueryPane
                 originalValue={originalQueryInput ?? ''}


### PR DESCRIPTION
## Problem
SQL editor didn't have a side panel trigger 
scene tabs line padding wasn't properly flagged

<img width="234" height="204" alt="image" src="https://github.com/user-attachments/assets/bd1de96c-149b-4133-bff7-b224cc70c7a4" />


## Changes
![2026-01-29 22 46 05](https://github.com/user-attachments/assets/773bd472-4cb2-42be-b85d-3f602a868263)

<img width="136" height="104" alt="image" src="https://github.com/user-attachments/assets/4a0dfc29-9e16-479e-ad71-3ce8465ad6f2" />


## How did you test this code?
Locally

## Publish to changelog?
No