### PR TITLE
feat(personhog): routing layer

### DIFF
--- a/proto/personhog/service/v1/service.proto
+++ b/proto/personhog/service/v1/service.proto
@@ -1,5 +1,45 @@
 syntax = "proto3";
 package personhog.service.v1;
 
+import "personhog/types/v1/person.proto";
+import "personhog/types/v1/group.proto";
+import "personhog/types/v1/cohort.proto";
+import "personhog/types/v1/feature_flag.proto";
+
 // PersonHogService is the public API exposed by the router.
-// This service will be implemented when the personhog-router is set up.
+// Clients call this service; the router handles backend selection and routing.
+service PersonHogService {
+  // Person lookups by ID
+  rpc GetPerson(personhog.types.v1.GetPersonRequest) returns (personhog.types.v1.GetPersonResponse);
+  rpc GetPersons(personhog.types.v1.GetPersonsRequest) returns (personhog.types.v1.PersonsResponse);
+  rpc GetPersonByUuid(personhog.types.v1.GetPersonByUuidRequest) returns (personhog.types.v1.GetPersonResponse);
+  rpc GetPersonsByUuids(personhog.types.v1.GetPersonsByUuidsRequest) returns (personhog.types.v1.PersonsResponse);
+
+  // Person lookups by distinct ID
+  rpc GetPersonByDistinctId(personhog.types.v1.GetPersonByDistinctIdRequest) returns (personhog.types.v1.GetPersonResponse);
+  rpc GetPersonsByDistinctIdsInTeam(personhog.types.v1.GetPersonsByDistinctIdsInTeamRequest) returns (personhog.types.v1.PersonsByDistinctIdsInTeamResponse);
+  rpc GetPersonsByDistinctIds(personhog.types.v1.GetPersonsByDistinctIdsRequest) returns (personhog.types.v1.PersonsByDistinctIdsResponse);
+
+  // Distinct ID operations
+  rpc GetDistinctIdsForPerson(personhog.types.v1.GetDistinctIdsForPersonRequest) returns (personhog.types.v1.GetDistinctIdsForPersonResponse);
+  rpc GetDistinctIdsForPersons(personhog.types.v1.GetDistinctIdsForPersonsRequest) returns (personhog.types.v1.GetDistinctIdsForPersonsResponse);
+
+  // Feature flag hash key override support
+  rpc GetHashKeyOverrideContext(personhog.types.v1.GetHashKeyOverrideContextRequest) returns (personhog.types.v1.GetHashKeyOverrideContextResponse);
+  rpc UpsertHashKeyOverrides(personhog.types.v1.UpsertHashKeyOverridesRequest) returns (personhog.types.v1.UpsertHashKeyOverridesResponse);
+  rpc DeleteHashKeyOverridesByTeams(personhog.types.v1.DeleteHashKeyOverridesByTeamsRequest) returns (personhog.types.v1.DeleteHashKeyOverridesByTeamsResponse);
+
+  // Cohort membership
+  rpc CheckCohortMembership(personhog.types.v1.CheckCohortMembershipRequest) returns (personhog.types.v1.CohortMembershipResponse);
+
+  // Groups
+  rpc GetGroup(personhog.types.v1.GetGroupRequest) returns (personhog.types.v1.GetGroupResponse);
+  rpc GetGroups(personhog.types.v1.GetGroupsRequest) returns (personhog.types.v1.GroupsResponse);
+  rpc GetGroupsBatch(personhog.types.v1.GetGroupsBatchRequest) returns (personhog.types.v1.GetGroupsBatchResponse);
+
+  // Group type mappings
+  rpc GetGroupTypeMappingsByTeamId(personhog.types.v1.GetGroupTypeMappingsByTeamIdRequest) returns (personhog.types.v1.GroupTypeMappingsResponse);
+  rpc GetGroupTypeMappingsByTeamIds(personhog.types.v1.GetGroupTypeMappingsByTeamIdsRequest) returns (personhog.types.v1.GroupTypeMappingsBatchResponse);
+  rpc GetGroupTypeMappingsByProjectId(personhog.types.v1.GetGroupTypeMappingsByProjectIdRequest) returns (personhog.types.v1.GroupTypeMappingsResponse);
+  rpc GetGroupTypeMappingsByProjectIds(personhog.types.v1.GetGroupTypeMappingsByProjectIdsRequest) returns (personhog.types.v1.GroupTypeMappingsBatchResponse);
+}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6008,6 +6008,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "personhog-router"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum 0.7.5",
+ "common-alloc",
+ "common-metrics",
+ "envconfig",
+ "health",
+ "http 1.4.0",
+ "metrics",
+ "personhog-proto",
+ "pin-project",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.3",
+ "tower 0.4.13",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "pest"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "kafka-deduplicator",
     "personhog-proto",
     "personhog-replica",
+    "personhog-router",
 ]
 
 [workspace.lints.rust]

--- a/rust/personhog-proto/build.rs
+++ b/rust/personhog-proto/build.rs
@@ -14,6 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 format!("{proto_root}/personhog/types/v1/feature_flag.proto"),
                 // Services
                 format!("{proto_root}/personhog/replica/v1/replica.proto"),
+                format!("{proto_root}/personhog/service/v1/service.proto"),
             ],
             &[proto_root],
         )?;

--- a/rust/personhog-proto/src/lib.rs
+++ b/rust/personhog-proto/src/lib.rs
@@ -9,4 +9,9 @@ pub mod personhog {
             tonic::include_proto!("personhog.replica.v1");
         }
     }
+    pub mod service {
+        pub mod v1 {
+            tonic::include_proto!("personhog.service.v1");
+        }
+    }
 }

--- a/rust/personhog-router/Cargo.toml
+++ b/rust/personhog-router/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "personhog-router"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+personhog-proto = { path = "../personhog-proto" }
+common-metrics = { path = "../common/metrics" }
+common-alloc = { path = "../common/alloc" }
+health = { path = "../common/health" }
+
+async-trait = { workspace = true }
+axum = { workspace = true }
+envconfig = { workspace = true }
+http = { workspace = true }
+metrics = { workspace = true }
+pin-project = "1.1"
+tokio = { workspace = true }
+tonic = { workspace = true }
+tower = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+tokio-stream = "0.1"
+
+[lints]
+workspace = true

--- a/rust/personhog-router/src/backend/mod.rs
+++ b/rust/personhog-router/src/backend/mod.rs
@@ -1,0 +1,108 @@
+mod replica;
+
+pub use replica::ReplicaBackend;
+
+use async_trait::async_trait;
+use personhog_proto::personhog::types::v1::{
+    CheckCohortMembershipRequest, CohortMembershipResponse, DeleteHashKeyOverridesByTeamsRequest,
+    DeleteHashKeyOverridesByTeamsResponse, GetDistinctIdsForPersonRequest,
+    GetDistinctIdsForPersonResponse, GetDistinctIdsForPersonsRequest,
+    GetDistinctIdsForPersonsResponse, GetGroupRequest, GetGroupResponse,
+    GetGroupTypeMappingsByProjectIdRequest, GetGroupTypeMappingsByProjectIdsRequest,
+    GetGroupTypeMappingsByTeamIdRequest, GetGroupTypeMappingsByTeamIdsRequest,
+    GetGroupsBatchRequest, GetGroupsBatchResponse, GetGroupsRequest,
+    GetHashKeyOverrideContextRequest, GetHashKeyOverrideContextResponse,
+    GetPersonByDistinctIdRequest, GetPersonByUuidRequest, GetPersonRequest, GetPersonResponse,
+    GetPersonsByDistinctIdsInTeamRequest, GetPersonsByDistinctIdsRequest, GetPersonsByUuidsRequest,
+    GetPersonsRequest, GroupTypeMappingsBatchResponse, GroupTypeMappingsResponse, GroupsResponse,
+    PersonsByDistinctIdsInTeamResponse, PersonsByDistinctIdsResponse, PersonsResponse,
+    UpsertHashKeyOverridesRequest, UpsertHashKeyOverridesResponse,
+};
+use tonic::Status;
+
+/// Trait defining the backend interface for person-related operations.
+/// Implementations provide the actual data access (e.g., replica, leader).
+#[async_trait]
+pub trait PersonHogBackend: Send + Sync {
+    // Person lookups by ID
+    async fn get_person(&self, request: GetPersonRequest) -> Result<GetPersonResponse, Status>;
+    async fn get_persons(&self, request: GetPersonsRequest) -> Result<PersonsResponse, Status>;
+    async fn get_person_by_uuid(
+        &self,
+        request: GetPersonByUuidRequest,
+    ) -> Result<GetPersonResponse, Status>;
+    async fn get_persons_by_uuids(
+        &self,
+        request: GetPersonsByUuidsRequest,
+    ) -> Result<PersonsResponse, Status>;
+
+    // Person lookups by distinct ID
+    async fn get_person_by_distinct_id(
+        &self,
+        request: GetPersonByDistinctIdRequest,
+    ) -> Result<GetPersonResponse, Status>;
+    async fn get_persons_by_distinct_ids_in_team(
+        &self,
+        request: GetPersonsByDistinctIdsInTeamRequest,
+    ) -> Result<PersonsByDistinctIdsInTeamResponse, Status>;
+    async fn get_persons_by_distinct_ids(
+        &self,
+        request: GetPersonsByDistinctIdsRequest,
+    ) -> Result<PersonsByDistinctIdsResponse, Status>;
+
+    // Distinct ID operations
+    async fn get_distinct_ids_for_person(
+        &self,
+        request: GetDistinctIdsForPersonRequest,
+    ) -> Result<GetDistinctIdsForPersonResponse, Status>;
+    async fn get_distinct_ids_for_persons(
+        &self,
+        request: GetDistinctIdsForPersonsRequest,
+    ) -> Result<GetDistinctIdsForPersonsResponse, Status>;
+
+    // Feature flag hash key override support
+    async fn get_hash_key_override_context(
+        &self,
+        request: GetHashKeyOverrideContextRequest,
+    ) -> Result<GetHashKeyOverrideContextResponse, Status>;
+    async fn upsert_hash_key_overrides(
+        &self,
+        request: UpsertHashKeyOverridesRequest,
+    ) -> Result<UpsertHashKeyOverridesResponse, Status>;
+    async fn delete_hash_key_overrides_by_teams(
+        &self,
+        request: DeleteHashKeyOverridesByTeamsRequest,
+    ) -> Result<DeleteHashKeyOverridesByTeamsResponse, Status>;
+
+    // Cohort membership
+    async fn check_cohort_membership(
+        &self,
+        request: CheckCohortMembershipRequest,
+    ) -> Result<CohortMembershipResponse, Status>;
+
+    // Groups
+    async fn get_group(&self, request: GetGroupRequest) -> Result<GetGroupResponse, Status>;
+    async fn get_groups(&self, request: GetGroupsRequest) -> Result<GroupsResponse, Status>;
+    async fn get_groups_batch(
+        &self,
+        request: GetGroupsBatchRequest,
+    ) -> Result<GetGroupsBatchResponse, Status>;
+
+    // Group type mappings
+    async fn get_group_type_mappings_by_team_id(
+        &self,
+        request: GetGroupTypeMappingsByTeamIdRequest,
+    ) -> Result<GroupTypeMappingsResponse, Status>;
+    async fn get_group_type_mappings_by_team_ids(
+        &self,
+        request: GetGroupTypeMappingsByTeamIdsRequest,
+    ) -> Result<GroupTypeMappingsBatchResponse, Status>;
+    async fn get_group_type_mappings_by_project_id(
+        &self,
+        request: GetGroupTypeMappingsByProjectIdRequest,
+    ) -> Result<GroupTypeMappingsResponse, Status>;
+    async fn get_group_type_mappings_by_project_ids(
+        &self,
+        request: GetGroupTypeMappingsByProjectIdsRequest,
+    ) -> Result<GroupTypeMappingsBatchResponse, Status>;
+}

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -1,0 +1,268 @@
+use async_trait::async_trait;
+use personhog_proto::personhog::replica::v1::person_hog_replica_client::PersonHogReplicaClient;
+use personhog_proto::personhog::types::v1::{
+    CheckCohortMembershipRequest, CohortMembershipResponse, DeleteHashKeyOverridesByTeamsRequest,
+    DeleteHashKeyOverridesByTeamsResponse, GetDistinctIdsForPersonRequest,
+    GetDistinctIdsForPersonResponse, GetDistinctIdsForPersonsRequest,
+    GetDistinctIdsForPersonsResponse, GetGroupRequest, GetGroupResponse,
+    GetGroupTypeMappingsByProjectIdRequest, GetGroupTypeMappingsByProjectIdsRequest,
+    GetGroupTypeMappingsByTeamIdRequest, GetGroupTypeMappingsByTeamIdsRequest,
+    GetGroupsBatchRequest, GetGroupsBatchResponse, GetGroupsRequest,
+    GetHashKeyOverrideContextRequest, GetHashKeyOverrideContextResponse,
+    GetPersonByDistinctIdRequest, GetPersonByUuidRequest, GetPersonRequest, GetPersonResponse,
+    GetPersonsByDistinctIdsInTeamRequest, GetPersonsByDistinctIdsRequest, GetPersonsByUuidsRequest,
+    GetPersonsRequest, GroupTypeMappingsBatchResponse, GroupTypeMappingsResponse, GroupsResponse,
+    PersonsByDistinctIdsInTeamResponse, PersonsByDistinctIdsResponse, PersonsResponse,
+    UpsertHashKeyOverridesRequest, UpsertHashKeyOverridesResponse,
+};
+use std::time::Duration;
+use tonic::transport::Channel;
+use tonic::{Request, Status};
+
+use super::PersonHogBackend;
+
+/// Backend implementation that forwards requests to a personhog-replica service.
+pub struct ReplicaBackend {
+    client: PersonHogReplicaClient<Channel>,
+}
+
+impl ReplicaBackend {
+    /// Create a new replica backend with a lazy connection to the given URL.
+    pub fn new(
+        url: &str,
+        timeout: Duration,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let channel = Channel::from_shared(url.to_string())?
+            .timeout(timeout)
+            .connect_lazy();
+
+        Ok(Self {
+            client: PersonHogReplicaClient::new(channel),
+        })
+    }
+}
+
+#[async_trait]
+impl PersonHogBackend for ReplicaBackend {
+    // Person lookups by ID
+
+    async fn get_person(&self, request: GetPersonRequest) -> Result<GetPersonResponse, Status> {
+        self.client
+            .clone()
+            .get_person(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn get_persons(&self, request: GetPersonsRequest) -> Result<PersonsResponse, Status> {
+        self.client
+            .clone()
+            .get_persons(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn get_person_by_uuid(
+        &self,
+        request: GetPersonByUuidRequest,
+    ) -> Result<GetPersonResponse, Status> {
+        self.client
+            .clone()
+            .get_person_by_uuid(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn get_persons_by_uuids(
+        &self,
+        request: GetPersonsByUuidsRequest,
+    ) -> Result<PersonsResponse, Status> {
+        self.client
+            .clone()
+            .get_persons_by_uuids(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    // Person lookups by distinct ID
+
+    async fn get_person_by_distinct_id(
+        &self,
+        request: GetPersonByDistinctIdRequest,
+    ) -> Result<GetPersonResponse, Status> {
+        self.client
+            .clone()
+            .get_person_by_distinct_id(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn get_persons_by_distinct_ids_in_team(
+        &self,
+        request: GetPersonsByDistinctIdsInTeamRequest,
+    ) -> Result<PersonsByDistinctIdsInTeamResponse, Status> {
+        self.client
+            .clone()
+            .get_persons_by_distinct_ids_in_team(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn get_persons_by_distinct_ids(
+        &self,
+        request: GetPersonsByDistinctIdsRequest,
+    ) -> Result<PersonsByDistinctIdsResponse, Status> {
+        self.client
+            .clone()
+            .get_persons_by_distinct_ids(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    // Distinct ID operations
+
+    async fn get_distinct_ids_for_person(
+        &self,
+        request: GetDistinctIdsForPersonRequest,
+    ) -> Result<GetDistinctIdsForPersonResponse, Status> {
+        self.client
+            .clone()
+            .get_distinct_ids_for_person(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn get_distinct_ids_for_persons(
+        &self,
+        request: GetDistinctIdsForPersonsRequest,
+    ) -> Result<GetDistinctIdsForPersonsResponse, Status> {
+        self.client
+            .clone()
+            .get_distinct_ids_for_persons(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    // Feature flag hash key override support
+
+    async fn get_hash_key_override_context(
+        &self,
+        request: GetHashKeyOverrideContextRequest,
+    ) -> Result<GetHashKeyOverrideContextResponse, Status> {
+        self.client
+            .clone()
+            .get_hash_key_override_context(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn upsert_hash_key_overrides(
+        &self,
+        request: UpsertHashKeyOverridesRequest,
+    ) -> Result<UpsertHashKeyOverridesResponse, Status> {
+        self.client
+            .clone()
+            .upsert_hash_key_overrides(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn delete_hash_key_overrides_by_teams(
+        &self,
+        request: DeleteHashKeyOverridesByTeamsRequest,
+    ) -> Result<DeleteHashKeyOverridesByTeamsResponse, Status> {
+        self.client
+            .clone()
+            .delete_hash_key_overrides_by_teams(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    // Cohort membership
+
+    async fn check_cohort_membership(
+        &self,
+        request: CheckCohortMembershipRequest,
+    ) -> Result<CohortMembershipResponse, Status> {
+        self.client
+            .clone()
+            .check_cohort_membership(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    // Groups
+
+    async fn get_group(&self, request: GetGroupRequest) -> Result<GetGroupResponse, Status> {
+        self.client
+            .clone()
+            .get_group(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn get_groups(&self, request: GetGroupsRequest) -> Result<GroupsResponse, Status> {
+        self.client
+            .clone()
+            .get_groups(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn get_groups_batch(
+        &self,
+        request: GetGroupsBatchRequest,
+    ) -> Result<GetGroupsBatchResponse, Status> {
+        self.client
+            .clone()
+            .get_groups_batch(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    // Group type mappings
+
+    async fn get_group_type_mappings_by_team_id(
+        &self,
+        request: GetGroupTypeMappingsByTeamIdRequest,
+    ) -> Result<GroupTypeMappingsResponse, Status> {
+        self.client
+            .clone()
+            .get_group_type_mappings_by_team_id(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn get_group_type_mappings_by_team_ids(
+        &self,
+        request: GetGroupTypeMappingsByTeamIdsRequest,
+    ) -> Result<GroupTypeMappingsBatchResponse, Status> {
+        self.client
+            .clone()
+            .get_group_type_mappings_by_team_ids(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn get_group_type_mappings_by_project_id(
+        &self,
+        request: GetGroupTypeMappingsByProjectIdRequest,
+    ) -> Result<GroupTypeMappingsResponse, Status> {
+        self.client
+            .clone()
+            .get_group_type_mappings_by_project_id(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+
+    async fn get_group_type_mappings_by_project_ids(
+        &self,
+        request: GetGroupTypeMappingsByProjectIdsRequest,
+    ) -> Result<GroupTypeMappingsBatchResponse, Status> {
+        self.client
+            .clone()
+            .get_group_type_mappings_by_project_ids(Request::new(request))
+            .await
+            .map(|r| r.into_inner())
+    }
+}

--- a/rust/personhog-router/src/config.rs
+++ b/rust/personhog-router/src/config.rs
@@ -1,0 +1,26 @@
+use envconfig::Envconfig;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+#[derive(Envconfig, Clone, Debug)]
+pub struct Config {
+    #[envconfig(default = "127.0.0.1:50052")]
+    pub grpc_address: SocketAddr,
+
+    /// URL of the personhog-replica backend
+    #[envconfig(default = "http://127.0.0.1:50051")]
+    pub replica_url: String,
+
+    /// Timeout for backend requests in milliseconds
+    #[envconfig(default = "5000")]
+    pub backend_timeout_ms: u64,
+
+    #[envconfig(default = "9101")]
+    pub metrics_port: u16,
+}
+
+impl Config {
+    pub fn backend_timeout(&self) -> Duration {
+        Duration::from_millis(self.backend_timeout_ms)
+    }
+}

--- a/rust/personhog-router/src/lib.rs
+++ b/rust/personhog-router/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod backend;
+pub mod config;
+pub mod middleware;
+pub mod router;
+pub mod service;

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use axum::{routing::get, Router};
+use common_metrics::setup_metrics_routes;
+use envconfig::Envconfig;
+use health::readiness_handler;
+use personhog_proto::personhog::service::v1::person_hog_service_server::PersonHogServiceServer;
+use personhog_router::backend::ReplicaBackend;
+use personhog_router::config::Config;
+use personhog_router::middleware::GrpcMetricsLayer;
+use personhog_router::router::PersonHogRouter;
+use personhog_router::service::PersonHogRouterService;
+use tokio::signal;
+use tonic::transport::Server;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::fmt;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
+
+common_alloc::used!();
+
+async fn shutdown_signal() {
+    let mut term = signal::unix::signal(signal::unix::SignalKind::terminate())
+        .expect("failed to register SIGTERM handler");
+
+    let mut interrupt = signal::unix::signal(signal::unix::SignalKind::interrupt())
+        .expect("failed to register SIGINT handler");
+
+    tokio::select! {
+        _ = term.recv() => {},
+        _ = interrupt.recv() => {},
+    };
+
+    tracing::info!("Shutting down gracefully...");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::init_from_env().expect("Invalid configuration");
+
+    // Initialize tracing
+    let log_layer = fmt::layer()
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_level(true);
+
+    tracing_subscriber::registry()
+        .with(log_layer)
+        .with(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    tracing::info!("Starting personhog-router service");
+    tracing::info!("gRPC address: {}", config.grpc_address);
+    tracing::info!("Replica URL: {}", config.replica_url);
+    tracing::info!("Backend timeout: {}ms", config.backend_timeout_ms);
+    tracing::info!("Metrics port: {}", config.metrics_port);
+
+    // Start HTTP server for metrics and health checks
+    let metrics_port = config.metrics_port;
+    let health_router = Router::new()
+        .route("/_readiness", get(readiness_handler))
+        .route("/_liveness", get(|| async { "ok" }));
+    let metrics_router = setup_metrics_routes(health_router);
+
+    tokio::spawn(async move {
+        let bind = format!("0.0.0.0:{metrics_port}");
+        let listener = tokio::net::TcpListener::bind(&bind)
+            .await
+            .expect("Failed to bind metrics port");
+        tracing::info!("Metrics server listening on {}", bind);
+        axum::serve(listener, metrics_router)
+            .await
+            .expect("Metrics server error");
+    });
+
+    // Create backend connection to personhog-replica
+    let replica_backend = ReplicaBackend::new(&config.replica_url, config.backend_timeout())
+        .expect("Failed to create replica backend");
+
+    // Create the router with the replica backend
+    let router = PersonHogRouter::new(Arc::new(replica_backend));
+    let service = PersonHogRouterService::new(Arc::new(router));
+
+    tracing::info!("Starting gRPC server on {}", config.grpc_address);
+
+    Server::builder()
+        .layer(GrpcMetricsLayer)
+        .add_service(PersonHogServiceServer::new(service))
+        .serve_with_shutdown(config.grpc_address, shutdown_signal())
+        .await?;
+
+    Ok(())
+}

--- a/rust/personhog-router/src/middleware/metrics_layer.rs
+++ b/rust/personhog-router/src/middleware/metrics_layer.rs
@@ -1,0 +1,140 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use http::{Request, Response};
+use metrics::{counter, histogram};
+use pin_project::pin_project;
+use tower::{Layer, Service};
+
+/// Tower layer that instruments gRPC requests with timing metrics.
+///
+/// Records:
+/// - `grpc_server_requests_total` - counter with method label
+/// - `grpc_server_request_duration_ms` - histogram with method label
+///
+/// Note: For error tracking, use `personhog_router_backend_errors_total` from the
+/// router layer, which has access to the actual gRPC status codes.
+#[derive(Clone, Default)]
+pub struct GrpcMetricsLayer;
+
+impl<S> Layer<S> for GrpcMetricsLayer {
+    type Service = GrpcMetricsService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        GrpcMetricsService { inner: service }
+    }
+}
+
+/// Service wrapper that records metrics for each request.
+#[derive(Clone)]
+pub struct GrpcMetricsService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for GrpcMetricsService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send,
+    ReqBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = GrpcMetricsFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let start = Instant::now();
+
+        // Extract method name from URI path (e.g., "/personhog.service.v1.PersonHogService/GetPerson")
+        let method = extract_grpc_method(request.uri().path());
+
+        let future = self.inner.call(request);
+
+        GrpcMetricsFuture {
+            inner: future,
+            start,
+            method,
+        }
+    }
+}
+
+/// Future wrapper that records metrics when the response completes.
+#[pin_project]
+pub struct GrpcMetricsFuture<F> {
+    #[pin]
+    inner: F,
+    start: Instant,
+    method: &'static str,
+}
+
+impl<F, ResBody, E> Future for GrpcMetricsFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result = this.inner.poll(cx);
+
+        if result.is_ready() {
+            let duration_ms = this.start.elapsed().as_secs_f64() * 1000.0;
+            let method = *this.method;
+
+            counter!("grpc_server_requests_total", "method" => method).increment(1);
+            histogram!("grpc_server_request_duration_ms", "method" => method).record(duration_ms);
+        }
+
+        result
+    }
+}
+
+/// Extract the gRPC method name from the URI path.
+/// Returns a static string for known methods, or "unknown" for unrecognized paths.
+fn extract_grpc_method(path: &str) -> &'static str {
+    // gRPC paths look like: /package.Service/Method
+    // We want just the Method part for cleaner metrics
+    match path.rsplit_once('/') {
+        Some((_, method)) => match method {
+            // Person lookups
+            "GetPerson" => "GetPerson",
+            "GetPersons" => "GetPersons",
+            "GetPersonByUuid" => "GetPersonByUuid",
+            "GetPersonsByUuids" => "GetPersonsByUuids",
+            "GetPersonByDistinctId" => "GetPersonByDistinctId",
+            "GetPersonsByDistinctIdsInTeam" => "GetPersonsByDistinctIdsInTeam",
+            "GetPersonsByDistinctIds" => "GetPersonsByDistinctIds",
+
+            // Distinct IDs
+            "GetDistinctIdsForPerson" => "GetDistinctIdsForPerson",
+            "GetDistinctIdsForPersons" => "GetDistinctIdsForPersons",
+
+            // Hash key overrides
+            "GetHashKeyOverrideContext" => "GetHashKeyOverrideContext",
+            "UpsertHashKeyOverrides" => "UpsertHashKeyOverrides",
+            "DeleteHashKeyOverridesByTeams" => "DeleteHashKeyOverridesByTeams",
+
+            // Cohorts
+            "CheckCohortMembership" => "CheckCohortMembership",
+
+            // Groups
+            "GetGroup" => "GetGroup",
+            "GetGroups" => "GetGroups",
+            "GetGroupsBatch" => "GetGroupsBatch",
+
+            // Group type mappings
+            "GetGroupTypeMappingsByTeamId" => "GetGroupTypeMappingsByTeamId",
+            "GetGroupTypeMappingsByTeamIds" => "GetGroupTypeMappingsByTeamIds",
+            "GetGroupTypeMappingsByProjectId" => "GetGroupTypeMappingsByProjectId",
+            "GetGroupTypeMappingsByProjectIds" => "GetGroupTypeMappingsByProjectIds",
+
+            _ => "unknown",
+        },
+        None => "unknown",
+    }
+}

--- a/rust/personhog-router/src/middleware/mod.rs
+++ b/rust/personhog-router/src/middleware/mod.rs
@@ -1,0 +1,3 @@
+mod metrics_layer;
+
+pub use metrics_layer::{GrpcMetricsLayer, GrpcMetricsService};

--- a/rust/personhog-router/src/router/mod.rs
+++ b/rust/personhog-router/src/router/mod.rs
@@ -1,0 +1,457 @@
+mod routing;
+
+pub use routing::{DataCategory, OperationType, RouteDecision, RoutingError};
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use metrics::{counter, histogram};
+use personhog_proto::personhog::types::v1::{
+    CheckCohortMembershipRequest, CohortMembershipResponse, DeleteHashKeyOverridesByTeamsRequest,
+    DeleteHashKeyOverridesByTeamsResponse, GetDistinctIdsForPersonRequest,
+    GetDistinctIdsForPersonResponse, GetDistinctIdsForPersonsRequest,
+    GetDistinctIdsForPersonsResponse, GetGroupRequest, GetGroupResponse,
+    GetGroupTypeMappingsByProjectIdRequest, GetGroupTypeMappingsByProjectIdsRequest,
+    GetGroupTypeMappingsByTeamIdRequest, GetGroupTypeMappingsByTeamIdsRequest,
+    GetGroupsBatchRequest, GetGroupsBatchResponse, GetGroupsRequest,
+    GetHashKeyOverrideContextRequest, GetHashKeyOverrideContextResponse,
+    GetPersonByDistinctIdRequest, GetPersonByUuidRequest, GetPersonRequest, GetPersonResponse,
+    GetPersonsByDistinctIdsInTeamRequest, GetPersonsByDistinctIdsRequest, GetPersonsByUuidsRequest,
+    GetPersonsRequest, GroupTypeMappingsBatchResponse, GroupTypeMappingsResponse, GroupsResponse,
+    PersonsByDistinctIdsInTeamResponse, PersonsByDistinctIdsResponse, PersonsResponse,
+    UpsertHashKeyOverridesRequest, UpsertHashKeyOverridesResponse,
+};
+use tonic::Status;
+
+use crate::backend::PersonHogBackend;
+use routing::{get_consistency, route_request};
+
+/// Macro to call a backend method with timing instrumentation.
+///
+/// Records metrics:
+/// - `personhog_router_backend_requests_total` - counter by method and backend
+/// - `personhog_router_backend_duration_ms` - histogram by method and backend
+/// - `personhog_router_backend_errors_total` - counter on errors
+macro_rules! call_backend {
+    ($self:expr, $decision:expr, $method_name:expr, $method:ident, $request:expr) => {{
+        let backend = $self.get_backend($decision)?;
+        let backend_name = match $decision {
+            RouteDecision::Replica => "replica",
+            RouteDecision::Leader => "leader",
+        };
+
+        counter!(
+            "personhog_router_backend_requests_total",
+            "method" => $method_name,
+            "backend" => backend_name
+        )
+        .increment(1);
+
+        let start = Instant::now();
+        let result = backend.$method($request).await;
+        let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+        histogram!(
+            "personhog_router_backend_duration_ms",
+            "method" => $method_name,
+            "backend" => backend_name
+        )
+        .record(duration_ms);
+
+        if result.is_err() {
+            counter!(
+                "personhog_router_backend_errors_total",
+                "method" => $method_name,
+                "backend" => backend_name
+            )
+            .increment(1);
+        }
+
+        result
+    }};
+}
+
+/// PersonHogRouter coordinates routing requests to the appropriate backend.
+///
+/// # Routing Logic
+///
+/// | Data Type       | Operation | Consistency | Target Backend           |
+/// |-----------------|-----------|-------------|--------------------------|
+/// | Person data     | Read      | EVENTUAL    | personhog-replica        |
+/// | Person data     | Read      | STRONG      | personhog-leader (Phase 2) |
+/// | Person data     | Write     | -           | personhog-leader (Phase 2) |
+/// | Non-person data | Read      | EVENTUAL    | personhog-replica        |
+/// | Non-person data | Read      | STRONG      | personhog-replica (primary) |
+/// | Non-person data | Write     | -           | personhog-replica        |
+///
+/// Non-person data includes: hash key overrides, cohort membership, groups, group type mappings
+///
+/// # Metrics
+///
+/// Records backend-specific metrics:
+/// - `personhog_router_backend_requests_total` - counter by method and backend
+/// - `personhog_router_backend_duration_ms` - histogram by method and backend
+/// - `personhog_router_backend_errors_total` - counter by method and backend
+pub struct PersonHogRouter {
+    replica_backend: Arc<dyn PersonHogBackend>,
+    // Phase 2: Add leader_backend for person data writes and strong consistency reads
+    // leader_backend: Option<Arc<dyn PersonHogBackend>>,
+}
+
+impl PersonHogRouter {
+    pub fn new(replica_backend: Arc<dyn PersonHogBackend>) -> Self {
+        Self { replica_backend }
+    }
+
+    /// Get the appropriate backend for a request based on routing decision.
+    #[allow(clippy::result_large_err)] // tonic::Status is large but we can't change it
+    fn get_backend(&self, decision: RouteDecision) -> Result<&dyn PersonHogBackend, Status> {
+        match decision {
+            RouteDecision::Replica => Ok(self.replica_backend.as_ref()),
+            RouteDecision::Leader => {
+                // Phase 2: Return leader backend when available
+                Err(Status::unimplemented(
+                    "Strong consistency for person data requires personhog-leader (not yet implemented)",
+                ))
+            }
+        }
+    }
+
+    // ============================================================
+    // Person lookups by ID - Person data, read operations
+    // ============================================================
+
+    pub async fn get_person(&self, request: GetPersonRequest) -> Result<GetPersonResponse, Status> {
+        let decision = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(self, decision, "GetPerson", get_person, request)
+    }
+
+    pub async fn get_persons(&self, request: GetPersonsRequest) -> Result<PersonsResponse, Status> {
+        let decision = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(self, decision, "GetPersons", get_persons, request)
+    }
+
+    pub async fn get_person_by_uuid(
+        &self,
+        request: GetPersonByUuidRequest,
+    ) -> Result<GetPersonResponse, Status> {
+        let decision = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetPersonByUuid",
+            get_person_by_uuid,
+            request
+        )
+    }
+
+    pub async fn get_persons_by_uuids(
+        &self,
+        request: GetPersonsByUuidsRequest,
+    ) -> Result<PersonsResponse, Status> {
+        let decision = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetPersonsByUuids",
+            get_persons_by_uuids,
+            request
+        )
+    }
+
+    // ============================================================
+    // Person lookups by distinct ID - Person data, read operations
+    // ============================================================
+
+    pub async fn get_person_by_distinct_id(
+        &self,
+        request: GetPersonByDistinctIdRequest,
+    ) -> Result<GetPersonResponse, Status> {
+        let decision = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetPersonByDistinctId",
+            get_person_by_distinct_id,
+            request
+        )
+    }
+
+    pub async fn get_persons_by_distinct_ids_in_team(
+        &self,
+        request: GetPersonsByDistinctIdsInTeamRequest,
+    ) -> Result<PersonsByDistinctIdsInTeamResponse, Status> {
+        let decision = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetPersonsByDistinctIdsInTeam",
+            get_persons_by_distinct_ids_in_team,
+            request
+        )
+    }
+
+    pub async fn get_persons_by_distinct_ids(
+        &self,
+        request: GetPersonsByDistinctIdsRequest,
+    ) -> Result<PersonsByDistinctIdsResponse, Status> {
+        let decision = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetPersonsByDistinctIds",
+            get_persons_by_distinct_ids,
+            request
+        )
+    }
+
+    // ============================================================
+    // Distinct ID operations - Person data, read operations
+    // ============================================================
+
+    pub async fn get_distinct_ids_for_person(
+        &self,
+        request: GetDistinctIdsForPersonRequest,
+    ) -> Result<GetDistinctIdsForPersonResponse, Status> {
+        let decision = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetDistinctIdsForPerson",
+            get_distinct_ids_for_person,
+            request
+        )
+    }
+
+    pub async fn get_distinct_ids_for_persons(
+        &self,
+        request: GetDistinctIdsForPersonsRequest,
+    ) -> Result<GetDistinctIdsForPersonsResponse, Status> {
+        let decision = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetDistinctIdsForPersons",
+            get_distinct_ids_for_persons,
+            request
+        )
+    }
+
+    // ============================================================
+    // Feature flag hash key overrides - Non-person data
+    // ============================================================
+
+    pub async fn get_hash_key_override_context(
+        &self,
+        request: GetHashKeyOverrideContextRequest,
+    ) -> Result<GetHashKeyOverrideContextResponse, Status> {
+        let decision = route_request(
+            DataCategory::NonPersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetHashKeyOverrideContext",
+            get_hash_key_override_context,
+            request
+        )
+    }
+
+    pub async fn upsert_hash_key_overrides(
+        &self,
+        request: UpsertHashKeyOverridesRequest,
+    ) -> Result<UpsertHashKeyOverridesResponse, Status> {
+        let decision = route_request(DataCategory::NonPersonData, OperationType::Write, None)?;
+        call_backend!(
+            self,
+            decision,
+            "UpsertHashKeyOverrides",
+            upsert_hash_key_overrides,
+            request
+        )
+    }
+
+    pub async fn delete_hash_key_overrides_by_teams(
+        &self,
+        request: DeleteHashKeyOverridesByTeamsRequest,
+    ) -> Result<DeleteHashKeyOverridesByTeamsResponse, Status> {
+        let decision = route_request(DataCategory::NonPersonData, OperationType::Write, None)?;
+        call_backend!(
+            self,
+            decision,
+            "DeleteHashKeyOverridesByTeams",
+            delete_hash_key_overrides_by_teams,
+            request
+        )
+    }
+
+    // ============================================================
+    // Cohort membership - Non-person data
+    // ============================================================
+
+    pub async fn check_cohort_membership(
+        &self,
+        request: CheckCohortMembershipRequest,
+    ) -> Result<CohortMembershipResponse, Status> {
+        let decision = route_request(
+            DataCategory::NonPersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "CheckCohortMembership",
+            check_cohort_membership,
+            request
+        )
+    }
+
+    // ============================================================
+    // Groups - Non-person data
+    // ============================================================
+
+    pub async fn get_group(&self, request: GetGroupRequest) -> Result<GetGroupResponse, Status> {
+        let decision = route_request(
+            DataCategory::NonPersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(self, decision, "GetGroup", get_group, request)
+    }
+
+    pub async fn get_groups(&self, request: GetGroupsRequest) -> Result<GroupsResponse, Status> {
+        let decision = route_request(
+            DataCategory::NonPersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(self, decision, "GetGroups", get_groups, request)
+    }
+
+    pub async fn get_groups_batch(
+        &self,
+        request: GetGroupsBatchRequest,
+    ) -> Result<GetGroupsBatchResponse, Status> {
+        let decision = route_request(
+            DataCategory::NonPersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(self, decision, "GetGroupsBatch", get_groups_batch, request)
+    }
+
+    // ============================================================
+    // Group type mappings - Non-person data
+    // ============================================================
+
+    pub async fn get_group_type_mappings_by_team_id(
+        &self,
+        request: GetGroupTypeMappingsByTeamIdRequest,
+    ) -> Result<GroupTypeMappingsResponse, Status> {
+        let decision = route_request(
+            DataCategory::NonPersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetGroupTypeMappingsByTeamId",
+            get_group_type_mappings_by_team_id,
+            request
+        )
+    }
+
+    pub async fn get_group_type_mappings_by_team_ids(
+        &self,
+        request: GetGroupTypeMappingsByTeamIdsRequest,
+    ) -> Result<GroupTypeMappingsBatchResponse, Status> {
+        let decision = route_request(
+            DataCategory::NonPersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetGroupTypeMappingsByTeamIds",
+            get_group_type_mappings_by_team_ids,
+            request
+        )
+    }
+
+    pub async fn get_group_type_mappings_by_project_id(
+        &self,
+        request: GetGroupTypeMappingsByProjectIdRequest,
+    ) -> Result<GroupTypeMappingsResponse, Status> {
+        let decision = route_request(
+            DataCategory::NonPersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetGroupTypeMappingsByProjectId",
+            get_group_type_mappings_by_project_id,
+            request
+        )
+    }
+
+    pub async fn get_group_type_mappings_by_project_ids(
+        &self,
+        request: GetGroupTypeMappingsByProjectIdsRequest,
+    ) -> Result<GroupTypeMappingsBatchResponse, Status> {
+        let decision = route_request(
+            DataCategory::NonPersonData,
+            OperationType::Read,
+            get_consistency(&request.read_options),
+        )?;
+        call_backend!(
+            self,
+            decision,
+            "GetGroupTypeMappingsByProjectIds",
+            get_group_type_mappings_by_project_ids,
+            request
+        )
+    }
+}

--- a/rust/personhog-router/src/router/routing.rs
+++ b/rust/personhog-router/src/router/routing.rs
@@ -1,0 +1,195 @@
+use personhog_proto::personhog::types::v1::{ConsistencyLevel, ReadOptions};
+use tonic::Status;
+
+/// Categories of data for routing decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataCategory {
+    /// Person table data (person, persondistinctid)
+    /// - Reads with EVENTUAL consistency → replica
+    /// - Reads with STRONG consistency → leader (Phase 2)
+    /// - Writes → leader (Phase 2)
+    PersonData,
+
+    /// Non-person data (hash key overrides, cohorts, groups, group type mappings)
+    /// - All reads → replica (any consistency level)
+    /// - All writes → replica
+    NonPersonData,
+}
+
+/// Type of operation being performed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationType {
+    Read,
+    Write,
+}
+
+/// The target backend for a routed request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteDecision {
+    /// Route to personhog-replica (Postgres replicas, or primary for strong consistency on non-person data)
+    Replica,
+    /// Route to personhog-leader (Kafka-backed cache, Phase 2)
+    Leader,
+}
+
+/// Errors that can occur during routing.
+#[derive(Debug, Clone)]
+pub enum RoutingError {
+    /// The requested operation requires a backend that isn't available yet
+    BackendNotAvailable { message: String },
+}
+
+impl From<RoutingError> for Status {
+    fn from(err: RoutingError) -> Self {
+        match err {
+            RoutingError::BackendNotAvailable { message } => Status::unimplemented(message),
+        }
+    }
+}
+
+/// Determine which backend should handle this request.
+///
+/// # Routing Rules
+///
+/// ## Person Data (person, persondistinctid tables)
+/// - EVENTUAL consistency reads → Replica
+/// - STRONG consistency reads → Leader (Phase 2, returns error now)
+/// - Writes → Leader (Phase 2, returns error now)
+///
+/// ## Non-Person Data (hash_key_overrides, cohort_membership, groups, group_type_mappings)
+/// - All reads → Replica (consistency is handled internally by replica)
+/// - All writes → Replica
+///
+/// # Phase 2 Evolution
+///
+/// When personhog-leader is implemented:
+/// 1. Add leader_backend to PersonHogRouter
+/// 2. Update this function to return RouteDecision::Leader for:
+///    - Person data with STRONG consistency
+///    - Person data writes
+/// 3. Add vnode-based routing for sharded person data
+#[allow(clippy::result_large_err)] // tonic::Status is large but we can't change it
+pub fn route_request(
+    category: DataCategory,
+    operation: OperationType,
+    consistency: Option<ConsistencyLevel>,
+) -> Result<RouteDecision, Status> {
+    match (category, operation) {
+        // Person data routing
+        (DataCategory::PersonData, OperationType::Read) => {
+            let consistency = consistency.unwrap_or(ConsistencyLevel::Eventual);
+            match consistency {
+                ConsistencyLevel::Unspecified | ConsistencyLevel::Eventual => {
+                    Ok(RouteDecision::Replica)
+                }
+                ConsistencyLevel::Strong => {
+                    // Phase 2: Return RouteDecision::Leader when available
+                    Err(RoutingError::BackendNotAvailable {
+                        message: "Strong consistency for person data requires personhog-leader \
+                                  (Phase 2). Use EVENTUAL consistency or wait for leader support."
+                            .to_string(),
+                    }
+                    .into())
+                }
+            }
+        }
+        (DataCategory::PersonData, OperationType::Write) => {
+            // Phase 2: Return RouteDecision::Leader when available
+            Err(RoutingError::BackendNotAvailable {
+                message: "Person data writes require personhog-leader (Phase 2). \
+                          Write operations are not yet supported through the router."
+                    .to_string(),
+            }
+            .into())
+        }
+
+        // Non-person data always goes to replica
+        // The replica handles consistency internally (primary vs replica pool)
+        (DataCategory::NonPersonData, OperationType::Read) => Ok(RouteDecision::Replica),
+        (DataCategory::NonPersonData, OperationType::Write) => Ok(RouteDecision::Replica),
+    }
+}
+
+/// Extract consistency level from optional ReadOptions.
+pub fn get_consistency(read_options: &Option<ReadOptions>) -> Option<ConsistencyLevel> {
+    read_options.as_ref().map(|opts| opts.consistency())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_person_data_eventual_routes_to_replica() {
+        let result = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            Some(ConsistencyLevel::Eventual),
+        );
+        assert_eq!(result.unwrap(), RouteDecision::Replica);
+    }
+
+    #[test]
+    fn test_person_data_unspecified_routes_to_replica() {
+        let result = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            Some(ConsistencyLevel::Unspecified),
+        );
+        assert_eq!(result.unwrap(), RouteDecision::Replica);
+    }
+
+    #[test]
+    fn test_person_data_none_consistency_routes_to_replica() {
+        let result = route_request(DataCategory::PersonData, OperationType::Read, None);
+        assert_eq!(result.unwrap(), RouteDecision::Replica);
+    }
+
+    #[test]
+    fn test_person_data_strong_returns_error() {
+        let result = route_request(
+            DataCategory::PersonData,
+            OperationType::Read,
+            Some(ConsistencyLevel::Strong),
+        );
+        assert!(result.is_err());
+        let status = result.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::Unimplemented);
+        assert!(status.message().contains("personhog-leader"));
+    }
+
+    #[test]
+    fn test_person_data_write_returns_error() {
+        let result = route_request(DataCategory::PersonData, OperationType::Write, None);
+        assert!(result.is_err());
+        let status = result.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::Unimplemented);
+    }
+
+    #[test]
+    fn test_non_person_data_read_eventual_routes_to_replica() {
+        let result = route_request(
+            DataCategory::NonPersonData,
+            OperationType::Read,
+            Some(ConsistencyLevel::Eventual),
+        );
+        assert_eq!(result.unwrap(), RouteDecision::Replica);
+    }
+
+    #[test]
+    fn test_non_person_data_read_strong_routes_to_replica() {
+        // Non-person data strong consistency is handled internally by replica
+        let result = route_request(
+            DataCategory::NonPersonData,
+            OperationType::Read,
+            Some(ConsistencyLevel::Strong),
+        );
+        assert_eq!(result.unwrap(), RouteDecision::Replica);
+    }
+
+    #[test]
+    fn test_non_person_data_write_routes_to_replica() {
+        let result = route_request(DataCategory::NonPersonData, OperationType::Write, None);
+        assert_eq!(result.unwrap(), RouteDecision::Replica);
+    }
+}

--- a/rust/personhog-router/src/service/mod.rs
+++ b/rust/personhog-router/src/service/mod.rs
@@ -1,0 +1,200 @@
+#[cfg(test)]
+mod tests;
+
+use std::sync::Arc;
+
+use personhog_proto::personhog::service::v1::person_hog_service_server::PersonHogService;
+use personhog_proto::personhog::types::v1::{
+    CheckCohortMembershipRequest, CohortMembershipResponse, DeleteHashKeyOverridesByTeamsRequest,
+    DeleteHashKeyOverridesByTeamsResponse, GetDistinctIdsForPersonRequest,
+    GetDistinctIdsForPersonResponse, GetDistinctIdsForPersonsRequest,
+    GetDistinctIdsForPersonsResponse, GetGroupRequest, GetGroupResponse,
+    GetGroupTypeMappingsByProjectIdRequest, GetGroupTypeMappingsByProjectIdsRequest,
+    GetGroupTypeMappingsByTeamIdRequest, GetGroupTypeMappingsByTeamIdsRequest,
+    GetGroupsBatchRequest, GetGroupsBatchResponse, GetGroupsRequest,
+    GetHashKeyOverrideContextRequest, GetHashKeyOverrideContextResponse,
+    GetPersonByDistinctIdRequest, GetPersonByUuidRequest, GetPersonRequest, GetPersonResponse,
+    GetPersonsByDistinctIdsInTeamRequest, GetPersonsByDistinctIdsRequest, GetPersonsByUuidsRequest,
+    GetPersonsRequest, GroupTypeMappingsBatchResponse, GroupTypeMappingsResponse, GroupsResponse,
+    PersonsByDistinctIdsInTeamResponse, PersonsByDistinctIdsResponse, PersonsResponse,
+    UpsertHashKeyOverridesRequest, UpsertHashKeyOverridesResponse,
+};
+use tonic::{Request, Response, Status};
+
+use crate::router::PersonHogRouter;
+
+pub struct PersonHogRouterService {
+    router: Arc<PersonHogRouter>,
+}
+
+impl PersonHogRouterService {
+    pub fn new(router: Arc<PersonHogRouter>) -> Self {
+        Self { router }
+    }
+}
+
+macro_rules! route_request {
+    ($self:expr, $method:ident, $request:expr) => {{
+        match $self.router.$method($request.into_inner()).await {
+            Ok(response) => Ok(Response::new(response)),
+            Err(status) => Err(status),
+        }
+    }};
+}
+
+#[tonic::async_trait]
+impl PersonHogService for PersonHogRouterService {
+    // Person lookups by ID
+
+    async fn get_person(
+        &self,
+        request: Request<GetPersonRequest>,
+    ) -> Result<Response<GetPersonResponse>, Status> {
+        route_request!(self, get_person, request)
+    }
+
+    async fn get_persons(
+        &self,
+        request: Request<GetPersonsRequest>,
+    ) -> Result<Response<PersonsResponse>, Status> {
+        route_request!(self, get_persons, request)
+    }
+
+    async fn get_person_by_uuid(
+        &self,
+        request: Request<GetPersonByUuidRequest>,
+    ) -> Result<Response<GetPersonResponse>, Status> {
+        route_request!(self, get_person_by_uuid, request)
+    }
+
+    async fn get_persons_by_uuids(
+        &self,
+        request: Request<GetPersonsByUuidsRequest>,
+    ) -> Result<Response<PersonsResponse>, Status> {
+        route_request!(self, get_persons_by_uuids, request)
+    }
+
+    // Person lookups by distinct ID
+
+    async fn get_person_by_distinct_id(
+        &self,
+        request: Request<GetPersonByDistinctIdRequest>,
+    ) -> Result<Response<GetPersonResponse>, Status> {
+        route_request!(self, get_person_by_distinct_id, request)
+    }
+
+    async fn get_persons_by_distinct_ids_in_team(
+        &self,
+        request: Request<GetPersonsByDistinctIdsInTeamRequest>,
+    ) -> Result<Response<PersonsByDistinctIdsInTeamResponse>, Status> {
+        route_request!(self, get_persons_by_distinct_ids_in_team, request)
+    }
+
+    async fn get_persons_by_distinct_ids(
+        &self,
+        request: Request<GetPersonsByDistinctIdsRequest>,
+    ) -> Result<Response<PersonsByDistinctIdsResponse>, Status> {
+        route_request!(self, get_persons_by_distinct_ids, request)
+    }
+
+    // Distinct ID operations
+
+    async fn get_distinct_ids_for_person(
+        &self,
+        request: Request<GetDistinctIdsForPersonRequest>,
+    ) -> Result<Response<GetDistinctIdsForPersonResponse>, Status> {
+        route_request!(self, get_distinct_ids_for_person, request)
+    }
+
+    async fn get_distinct_ids_for_persons(
+        &self,
+        request: Request<GetDistinctIdsForPersonsRequest>,
+    ) -> Result<Response<GetDistinctIdsForPersonsResponse>, Status> {
+        route_request!(self, get_distinct_ids_for_persons, request)
+    }
+
+    // Feature flag hash key override support
+
+    async fn get_hash_key_override_context(
+        &self,
+        request: Request<GetHashKeyOverrideContextRequest>,
+    ) -> Result<Response<GetHashKeyOverrideContextResponse>, Status> {
+        route_request!(self, get_hash_key_override_context, request)
+    }
+
+    async fn upsert_hash_key_overrides(
+        &self,
+        request: Request<UpsertHashKeyOverridesRequest>,
+    ) -> Result<Response<UpsertHashKeyOverridesResponse>, Status> {
+        route_request!(self, upsert_hash_key_overrides, request)
+    }
+
+    async fn delete_hash_key_overrides_by_teams(
+        &self,
+        request: Request<DeleteHashKeyOverridesByTeamsRequest>,
+    ) -> Result<Response<DeleteHashKeyOverridesByTeamsResponse>, Status> {
+        route_request!(self, delete_hash_key_overrides_by_teams, request)
+    }
+
+    // Cohort membership
+
+    async fn check_cohort_membership(
+        &self,
+        request: Request<CheckCohortMembershipRequest>,
+    ) -> Result<Response<CohortMembershipResponse>, Status> {
+        route_request!(self, check_cohort_membership, request)
+    }
+
+    // Groups
+
+    async fn get_group(
+        &self,
+        request: Request<GetGroupRequest>,
+    ) -> Result<Response<GetGroupResponse>, Status> {
+        route_request!(self, get_group, request)
+    }
+
+    async fn get_groups(
+        &self,
+        request: Request<GetGroupsRequest>,
+    ) -> Result<Response<GroupsResponse>, Status> {
+        route_request!(self, get_groups, request)
+    }
+
+    async fn get_groups_batch(
+        &self,
+        request: Request<GetGroupsBatchRequest>,
+    ) -> Result<Response<GetGroupsBatchResponse>, Status> {
+        route_request!(self, get_groups_batch, request)
+    }
+
+    // Group type mappings
+
+    async fn get_group_type_mappings_by_team_id(
+        &self,
+        request: Request<GetGroupTypeMappingsByTeamIdRequest>,
+    ) -> Result<Response<GroupTypeMappingsResponse>, Status> {
+        route_request!(self, get_group_type_mappings_by_team_id, request)
+    }
+
+    async fn get_group_type_mappings_by_team_ids(
+        &self,
+        request: Request<GetGroupTypeMappingsByTeamIdsRequest>,
+    ) -> Result<Response<GroupTypeMappingsBatchResponse>, Status> {
+        route_request!(self, get_group_type_mappings_by_team_ids, request)
+    }
+
+    async fn get_group_type_mappings_by_project_id(
+        &self,
+        request: Request<GetGroupTypeMappingsByProjectIdRequest>,
+    ) -> Result<Response<GroupTypeMappingsResponse>, Status> {
+        route_request!(self, get_group_type_mappings_by_project_id, request)
+    }
+
+    async fn get_group_type_mappings_by_project_ids(
+        &self,
+        request: Request<GetGroupTypeMappingsByProjectIdsRequest>,
+    ) -> Result<Response<GroupTypeMappingsBatchResponse>, Status> {
+        route_request!(self, get_group_type_mappings_by_project_ids, request)
+    }
+}

--- a/rust/personhog-router/src/service/tests/mocks.rs
+++ b/rust/personhog-router/src/service/tests/mocks.rs
@@ -1,0 +1,222 @@
+use async_trait::async_trait;
+use personhog_proto::personhog::types::v1::{
+    CheckCohortMembershipRequest, CohortMembershipResponse, DeleteHashKeyOverridesByTeamsRequest,
+    DeleteHashKeyOverridesByTeamsResponse, GetDistinctIdsForPersonRequest,
+    GetDistinctIdsForPersonResponse, GetDistinctIdsForPersonsRequest,
+    GetDistinctIdsForPersonsResponse, GetGroupRequest, GetGroupResponse,
+    GetGroupTypeMappingsByProjectIdRequest, GetGroupTypeMappingsByProjectIdsRequest,
+    GetGroupTypeMappingsByTeamIdRequest, GetGroupTypeMappingsByTeamIdsRequest,
+    GetGroupsBatchRequest, GetGroupsBatchResponse, GetGroupsRequest,
+    GetHashKeyOverrideContextRequest, GetHashKeyOverrideContextResponse,
+    GetPersonByDistinctIdRequest, GetPersonByUuidRequest, GetPersonRequest, GetPersonResponse,
+    GetPersonsByDistinctIdsInTeamRequest, GetPersonsByDistinctIdsRequest, GetPersonsByUuidsRequest,
+    GetPersonsRequest, GroupTypeMappingsBatchResponse, GroupTypeMappingsResponse, GroupsResponse,
+    Person, PersonsByDistinctIdsInTeamResponse, PersonsByDistinctIdsResponse, PersonsResponse,
+    UpsertHashKeyOverridesRequest, UpsertHashKeyOverridesResponse,
+};
+use std::sync::Mutex;
+use tonic::Status;
+
+use crate::backend::PersonHogBackend;
+
+pub struct MockBackend {
+    person_response: Mutex<Option<Person>>,
+    error: Mutex<Option<Status>>,
+}
+
+impl MockBackend {
+    pub fn new() -> Self {
+        Self {
+            person_response: Mutex::new(None),
+            error: Mutex::new(None),
+        }
+    }
+
+    pub fn set_person_response(&self, person: Option<Person>) {
+        *self.person_response.lock().unwrap() = person;
+    }
+
+    pub fn set_error(&self, status: Status) {
+        *self.error.lock().unwrap() = Some(status);
+    }
+
+    #[allow(clippy::result_large_err)] // tonic::Status is large but we can't change it
+    fn check_error(&self) -> Result<(), Status> {
+        if let Some(status) = self.error.lock().unwrap().clone() {
+            return Err(status);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl PersonHogBackend for MockBackend {
+    async fn get_person(&self, _request: GetPersonRequest) -> Result<GetPersonResponse, Status> {
+        self.check_error()?;
+        Ok(GetPersonResponse {
+            person: self.person_response.lock().unwrap().clone(),
+        })
+    }
+
+    async fn get_persons(&self, _request: GetPersonsRequest) -> Result<PersonsResponse, Status> {
+        self.check_error()?;
+        Ok(PersonsResponse {
+            persons: vec![],
+            missing_ids: vec![],
+        })
+    }
+
+    async fn get_person_by_uuid(
+        &self,
+        _request: GetPersonByUuidRequest,
+    ) -> Result<GetPersonResponse, Status> {
+        self.check_error()?;
+        Ok(GetPersonResponse {
+            person: self.person_response.lock().unwrap().clone(),
+        })
+    }
+
+    async fn get_persons_by_uuids(
+        &self,
+        _request: GetPersonsByUuidsRequest,
+    ) -> Result<PersonsResponse, Status> {
+        self.check_error()?;
+        Ok(PersonsResponse {
+            persons: vec![],
+            missing_ids: vec![],
+        })
+    }
+
+    async fn get_person_by_distinct_id(
+        &self,
+        _request: GetPersonByDistinctIdRequest,
+    ) -> Result<GetPersonResponse, Status> {
+        self.check_error()?;
+        Ok(GetPersonResponse {
+            person: self.person_response.lock().unwrap().clone(),
+        })
+    }
+
+    async fn get_persons_by_distinct_ids_in_team(
+        &self,
+        _request: GetPersonsByDistinctIdsInTeamRequest,
+    ) -> Result<PersonsByDistinctIdsInTeamResponse, Status> {
+        self.check_error()?;
+        Ok(PersonsByDistinctIdsInTeamResponse { results: vec![] })
+    }
+
+    async fn get_persons_by_distinct_ids(
+        &self,
+        _request: GetPersonsByDistinctIdsRequest,
+    ) -> Result<PersonsByDistinctIdsResponse, Status> {
+        self.check_error()?;
+        Ok(PersonsByDistinctIdsResponse { results: vec![] })
+    }
+
+    async fn get_distinct_ids_for_person(
+        &self,
+        _request: GetDistinctIdsForPersonRequest,
+    ) -> Result<GetDistinctIdsForPersonResponse, Status> {
+        self.check_error()?;
+        Ok(GetDistinctIdsForPersonResponse {
+            distinct_ids: vec![],
+        })
+    }
+
+    async fn get_distinct_ids_for_persons(
+        &self,
+        _request: GetDistinctIdsForPersonsRequest,
+    ) -> Result<GetDistinctIdsForPersonsResponse, Status> {
+        self.check_error()?;
+        Ok(GetDistinctIdsForPersonsResponse {
+            person_distinct_ids: vec![],
+        })
+    }
+
+    async fn get_hash_key_override_context(
+        &self,
+        _request: GetHashKeyOverrideContextRequest,
+    ) -> Result<GetHashKeyOverrideContextResponse, Status> {
+        self.check_error()?;
+        Ok(GetHashKeyOverrideContextResponse { results: vec![] })
+    }
+
+    async fn upsert_hash_key_overrides(
+        &self,
+        _request: UpsertHashKeyOverridesRequest,
+    ) -> Result<UpsertHashKeyOverridesResponse, Status> {
+        self.check_error()?;
+        Ok(UpsertHashKeyOverridesResponse { inserted_count: 0 })
+    }
+
+    async fn delete_hash_key_overrides_by_teams(
+        &self,
+        _request: DeleteHashKeyOverridesByTeamsRequest,
+    ) -> Result<DeleteHashKeyOverridesByTeamsResponse, Status> {
+        self.check_error()?;
+        Ok(DeleteHashKeyOverridesByTeamsResponse { deleted_count: 0 })
+    }
+
+    async fn check_cohort_membership(
+        &self,
+        _request: CheckCohortMembershipRequest,
+    ) -> Result<CohortMembershipResponse, Status> {
+        self.check_error()?;
+        Ok(CohortMembershipResponse {
+            memberships: vec![],
+        })
+    }
+
+    async fn get_group(&self, _request: GetGroupRequest) -> Result<GetGroupResponse, Status> {
+        self.check_error()?;
+        Ok(GetGroupResponse { group: None })
+    }
+
+    async fn get_groups(&self, _request: GetGroupsRequest) -> Result<GroupsResponse, Status> {
+        self.check_error()?;
+        Ok(GroupsResponse {
+            groups: vec![],
+            missing_groups: vec![],
+        })
+    }
+
+    async fn get_groups_batch(
+        &self,
+        _request: GetGroupsBatchRequest,
+    ) -> Result<GetGroupsBatchResponse, Status> {
+        self.check_error()?;
+        Ok(GetGroupsBatchResponse { results: vec![] })
+    }
+
+    async fn get_group_type_mappings_by_team_id(
+        &self,
+        _request: GetGroupTypeMappingsByTeamIdRequest,
+    ) -> Result<GroupTypeMappingsResponse, Status> {
+        self.check_error()?;
+        Ok(GroupTypeMappingsResponse { mappings: vec![] })
+    }
+
+    async fn get_group_type_mappings_by_team_ids(
+        &self,
+        _request: GetGroupTypeMappingsByTeamIdsRequest,
+    ) -> Result<GroupTypeMappingsBatchResponse, Status> {
+        self.check_error()?;
+        Ok(GroupTypeMappingsBatchResponse { results: vec![] })
+    }
+
+    async fn get_group_type_mappings_by_project_id(
+        &self,
+        _request: GetGroupTypeMappingsByProjectIdRequest,
+    ) -> Result<GroupTypeMappingsResponse, Status> {
+        self.check_error()?;
+        Ok(GroupTypeMappingsResponse { mappings: vec![] })
+    }
+
+    async fn get_group_type_mappings_by_project_ids(
+        &self,
+        _request: GetGroupTypeMappingsByProjectIdsRequest,
+    ) -> Result<GroupTypeMappingsBatchResponse, Status> {
+        self.check_error()?;
+        Ok(GroupTypeMappingsBatchResponse { results: vec![] })
+    }
+}

--- a/rust/personhog-router/src/service/tests/mod.rs
+++ b/rust/personhog-router/src/service/tests/mod.rs
@@ -1,0 +1,146 @@
+mod mocks;
+
+use std::sync::Arc;
+
+use mocks::MockBackend;
+use personhog_proto::personhog::service::v1::person_hog_service_server::PersonHogService;
+use personhog_proto::personhog::types::v1::{
+    ConsistencyLevel, GetPersonByDistinctIdRequest, GetPersonRequest, Person, ReadOptions,
+};
+use tonic::{Request, Status};
+
+use crate::router::PersonHogRouter;
+
+use super::PersonHogRouterService;
+
+fn create_test_person() -> Person {
+    Person {
+        id: 1,
+        team_id: 1,
+        uuid: "00000000-0000-0000-0000-000000000001".to_string(),
+        properties: b"{}".to_vec(),
+        properties_last_updated_at: vec![],
+        properties_last_operation: vec![],
+        created_at: 0,
+        version: 1,
+        is_identified: true,
+        is_user_id: false,
+    }
+}
+
+fn create_service_with_mock(mock: MockBackend) -> PersonHogRouterService {
+    let router = PersonHogRouter::new(Arc::new(mock));
+    PersonHogRouterService::new(Arc::new(router))
+}
+
+#[tokio::test]
+async fn test_get_person_routes_to_replica_with_eventual_consistency() {
+    let mock = MockBackend::new();
+    mock.set_person_response(Some(create_test_person()));
+
+    let service = create_service_with_mock(mock);
+
+    let request = Request::new(GetPersonRequest {
+        team_id: 1,
+        person_id: 1,
+        read_options: None, // Defaults to EVENTUAL
+    });
+
+    let response = service.get_person(request).await.unwrap();
+    assert!(response.get_ref().person.is_some());
+    assert_eq!(response.get_ref().person.as_ref().unwrap().id, 1);
+}
+
+#[tokio::test]
+async fn test_get_person_returns_none_when_not_found() {
+    let mock = MockBackend::new();
+    mock.set_person_response(None);
+
+    let service = create_service_with_mock(mock);
+
+    let request = Request::new(GetPersonRequest {
+        team_id: 1,
+        person_id: 999,
+        read_options: None,
+    });
+
+    let response = service.get_person(request).await.unwrap();
+    assert!(response.get_ref().person.is_none());
+}
+
+#[tokio::test]
+async fn test_get_person_by_distinct_id_routes_to_replica() {
+    let mock = MockBackend::new();
+    mock.set_person_response(Some(create_test_person()));
+
+    let service = create_service_with_mock(mock);
+
+    let request = Request::new(GetPersonByDistinctIdRequest {
+        team_id: 1,
+        distinct_id: "user-123".to_string(),
+        read_options: None,
+    });
+
+    let response = service.get_person_by_distinct_id(request).await.unwrap();
+    assert!(response.get_ref().person.is_some());
+}
+
+#[tokio::test]
+async fn test_backend_error_passthrough() {
+    let mock = MockBackend::new();
+    mock.set_error(Status::unavailable("backend unavailable"));
+
+    let service = create_service_with_mock(mock);
+
+    let request = Request::new(GetPersonRequest {
+        team_id: 1,
+        person_id: 1,
+        read_options: None,
+    });
+
+    let result = service.get_person(request).await;
+    assert!(result.is_err());
+    let status = result.unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unavailable);
+}
+
+#[tokio::test]
+async fn test_get_person_with_strong_consistency_returns_unimplemented() {
+    let mock = MockBackend::new();
+    mock.set_person_response(Some(create_test_person()));
+
+    let service = create_service_with_mock(mock);
+
+    let request = Request::new(GetPersonRequest {
+        team_id: 1,
+        person_id: 1,
+        read_options: Some(ReadOptions {
+            consistency: ConsistencyLevel::Strong.into(),
+        }),
+    });
+
+    let result = service.get_person(request).await;
+    assert!(result.is_err());
+    let status = result.unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
+    assert!(status.message().contains("personhog-leader"));
+}
+
+#[tokio::test]
+async fn test_get_person_with_explicit_eventual_consistency_succeeds() {
+    let mock = MockBackend::new();
+    mock.set_person_response(Some(create_test_person()));
+
+    let service = create_service_with_mock(mock);
+
+    let request = Request::new(GetPersonRequest {
+        team_id: 1,
+        person_id: 1,
+        read_options: Some(ReadOptions {
+            consistency: ConsistencyLevel::Eventual.into(),
+        }),
+    });
+
+    let response = service.get_person(request).await.unwrap();
+    assert!(response.get_ref().person.is_some());
+}

--- a/rust/personhog-router/tests/common/mod.rs
+++ b/rust/personhog-router/tests/common/mod.rs
@@ -1,0 +1,346 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use personhog_proto::personhog::replica::v1::person_hog_replica_server::{
+    PersonHogReplica, PersonHogReplicaServer,
+};
+use personhog_proto::personhog::service::v1::person_hog_service_client::PersonHogServiceClient;
+use personhog_proto::personhog::service::v1::person_hog_service_server::PersonHogServiceServer;
+use personhog_proto::personhog::types::v1::{
+    CheckCohortMembershipRequest, CohortMembershipResponse, DeleteHashKeyOverridesByTeamsRequest,
+    DeleteHashKeyOverridesByTeamsResponse, GetDistinctIdsForPersonRequest,
+    GetDistinctIdsForPersonResponse, GetDistinctIdsForPersonsRequest,
+    GetDistinctIdsForPersonsResponse, GetGroupRequest, GetGroupResponse,
+    GetGroupTypeMappingsByProjectIdRequest, GetGroupTypeMappingsByProjectIdsRequest,
+    GetGroupTypeMappingsByTeamIdRequest, GetGroupTypeMappingsByTeamIdsRequest,
+    GetGroupsBatchRequest, GetGroupsBatchResponse, GetGroupsRequest,
+    GetHashKeyOverrideContextRequest, GetHashKeyOverrideContextResponse,
+    GetPersonByDistinctIdRequest, GetPersonByUuidRequest, GetPersonRequest, GetPersonResponse,
+    GetPersonsByDistinctIdsInTeamRequest, GetPersonsByDistinctIdsRequest, GetPersonsByUuidsRequest,
+    GetPersonsRequest, GroupTypeMappingsBatchResponse, GroupTypeMappingsResponse, GroupsResponse,
+    Person, PersonsByDistinctIdsInTeamResponse, PersonsByDistinctIdsResponse, PersonsResponse,
+    UpsertHashKeyOverridesRequest, UpsertHashKeyOverridesResponse,
+};
+use personhog_router::backend::ReplicaBackend;
+use personhog_router::router::PersonHogRouter;
+use personhog_router::service::PersonHogRouterService;
+use tokio::net::TcpListener;
+use tonic::transport::{Channel, Server};
+use tonic::{Request, Response, Status};
+
+use personhog_proto::personhog::types::v1::{
+    CohortMembership, Group, GroupTypeMapping, HashKeyOverrideContext, PersonWithDistinctIds,
+};
+
+/// A configurable replica service implementation for integration tests.
+/// Supports setting up responses for different RPC methods.
+pub struct TestReplicaService {
+    pub person: Option<Person>,
+    pub persons_by_distinct_id: Vec<PersonWithDistinctIds>,
+    pub cohort_memberships: Vec<CohortMembership>,
+    pub hash_key_override_contexts: Vec<HashKeyOverrideContext>,
+    pub upsert_inserted_count: i64,
+    pub groups: Vec<Group>,
+    pub group_type_mappings: Vec<GroupTypeMapping>,
+}
+
+impl TestReplicaService {
+    pub fn new() -> Self {
+        Self {
+            person: None,
+            persons_by_distinct_id: vec![],
+            cohort_memberships: vec![],
+            hash_key_override_contexts: vec![],
+            upsert_inserted_count: 0,
+            groups: vec![],
+            group_type_mappings: vec![],
+        }
+    }
+
+    pub fn with_person(person: Person) -> Self {
+        Self {
+            person: Some(person),
+            ..Self::new()
+        }
+    }
+
+    pub fn with_persons_by_distinct_id(mut self, persons: Vec<PersonWithDistinctIds>) -> Self {
+        self.persons_by_distinct_id = persons;
+        self
+    }
+
+    pub fn with_cohort_memberships(mut self, memberships: Vec<CohortMembership>) -> Self {
+        self.cohort_memberships = memberships;
+        self
+    }
+
+    pub fn with_hash_key_override_contexts(
+        mut self,
+        contexts: Vec<HashKeyOverrideContext>,
+    ) -> Self {
+        self.hash_key_override_contexts = contexts;
+        self
+    }
+
+    pub fn with_upsert_inserted_count(mut self, count: i64) -> Self {
+        self.upsert_inserted_count = count;
+        self
+    }
+
+    pub fn with_groups(mut self, groups: Vec<Group>) -> Self {
+        self.groups = groups;
+        self
+    }
+
+    pub fn with_group_type_mappings(mut self, mappings: Vec<GroupTypeMapping>) -> Self {
+        self.group_type_mappings = mappings;
+        self
+    }
+}
+
+#[tonic::async_trait]
+impl PersonHogReplica for TestReplicaService {
+    async fn get_person(
+        &self,
+        _request: Request<GetPersonRequest>,
+    ) -> Result<Response<GetPersonResponse>, Status> {
+        Ok(Response::new(GetPersonResponse {
+            person: self.person.clone(),
+        }))
+    }
+
+    async fn get_persons(
+        &self,
+        _request: Request<GetPersonsRequest>,
+    ) -> Result<Response<PersonsResponse>, Status> {
+        Ok(Response::new(PersonsResponse {
+            persons: self.person.clone().into_iter().collect(),
+            missing_ids: vec![],
+        }))
+    }
+
+    async fn get_person_by_uuid(
+        &self,
+        _request: Request<GetPersonByUuidRequest>,
+    ) -> Result<Response<GetPersonResponse>, Status> {
+        Ok(Response::new(GetPersonResponse {
+            person: self.person.clone(),
+        }))
+    }
+
+    async fn get_persons_by_uuids(
+        &self,
+        _request: Request<GetPersonsByUuidsRequest>,
+    ) -> Result<Response<PersonsResponse>, Status> {
+        Ok(Response::new(PersonsResponse {
+            persons: self.person.clone().into_iter().collect(),
+            missing_ids: vec![],
+        }))
+    }
+
+    async fn get_person_by_distinct_id(
+        &self,
+        _request: Request<GetPersonByDistinctIdRequest>,
+    ) -> Result<Response<GetPersonResponse>, Status> {
+        Ok(Response::new(GetPersonResponse {
+            person: self.person.clone(),
+        }))
+    }
+
+    async fn get_persons_by_distinct_ids_in_team(
+        &self,
+        _request: Request<GetPersonsByDistinctIdsInTeamRequest>,
+    ) -> Result<Response<PersonsByDistinctIdsInTeamResponse>, Status> {
+        Ok(Response::new(PersonsByDistinctIdsInTeamResponse {
+            results: self.persons_by_distinct_id.clone(),
+        }))
+    }
+
+    async fn get_persons_by_distinct_ids(
+        &self,
+        _request: Request<GetPersonsByDistinctIdsRequest>,
+    ) -> Result<Response<PersonsByDistinctIdsResponse>, Status> {
+        Ok(Response::new(PersonsByDistinctIdsResponse {
+            results: vec![],
+        }))
+    }
+
+    async fn get_distinct_ids_for_person(
+        &self,
+        _request: Request<GetDistinctIdsForPersonRequest>,
+    ) -> Result<Response<GetDistinctIdsForPersonResponse>, Status> {
+        Ok(Response::new(GetDistinctIdsForPersonResponse {
+            distinct_ids: vec![],
+        }))
+    }
+
+    async fn get_distinct_ids_for_persons(
+        &self,
+        _request: Request<GetDistinctIdsForPersonsRequest>,
+    ) -> Result<Response<GetDistinctIdsForPersonsResponse>, Status> {
+        Ok(Response::new(GetDistinctIdsForPersonsResponse {
+            person_distinct_ids: vec![],
+        }))
+    }
+
+    async fn get_hash_key_override_context(
+        &self,
+        _request: Request<GetHashKeyOverrideContextRequest>,
+    ) -> Result<Response<GetHashKeyOverrideContextResponse>, Status> {
+        Ok(Response::new(GetHashKeyOverrideContextResponse {
+            results: self.hash_key_override_contexts.clone(),
+        }))
+    }
+
+    async fn upsert_hash_key_overrides(
+        &self,
+        _request: Request<UpsertHashKeyOverridesRequest>,
+    ) -> Result<Response<UpsertHashKeyOverridesResponse>, Status> {
+        Ok(Response::new(UpsertHashKeyOverridesResponse {
+            inserted_count: self.upsert_inserted_count,
+        }))
+    }
+
+    async fn delete_hash_key_overrides_by_teams(
+        &self,
+        _request: Request<DeleteHashKeyOverridesByTeamsRequest>,
+    ) -> Result<Response<DeleteHashKeyOverridesByTeamsResponse>, Status> {
+        Ok(Response::new(DeleteHashKeyOverridesByTeamsResponse {
+            deleted_count: 0,
+        }))
+    }
+
+    async fn check_cohort_membership(
+        &self,
+        _request: Request<CheckCohortMembershipRequest>,
+    ) -> Result<Response<CohortMembershipResponse>, Status> {
+        Ok(Response::new(CohortMembershipResponse {
+            memberships: self.cohort_memberships.clone(),
+        }))
+    }
+
+    async fn get_group(
+        &self,
+        _request: Request<GetGroupRequest>,
+    ) -> Result<Response<GetGroupResponse>, Status> {
+        Ok(Response::new(GetGroupResponse { group: None }))
+    }
+
+    async fn get_groups(
+        &self,
+        _request: Request<GetGroupsRequest>,
+    ) -> Result<Response<GroupsResponse>, Status> {
+        Ok(Response::new(GroupsResponse {
+            groups: self.groups.clone(),
+            missing_groups: vec![],
+        }))
+    }
+
+    async fn get_groups_batch(
+        &self,
+        _request: Request<GetGroupsBatchRequest>,
+    ) -> Result<Response<GetGroupsBatchResponse>, Status> {
+        Ok(Response::new(GetGroupsBatchResponse { results: vec![] }))
+    }
+
+    async fn get_group_type_mappings_by_team_id(
+        &self,
+        _request: Request<GetGroupTypeMappingsByTeamIdRequest>,
+    ) -> Result<Response<GroupTypeMappingsResponse>, Status> {
+        Ok(Response::new(GroupTypeMappingsResponse {
+            mappings: self.group_type_mappings.clone(),
+        }))
+    }
+
+    async fn get_group_type_mappings_by_team_ids(
+        &self,
+        _request: Request<GetGroupTypeMappingsByTeamIdsRequest>,
+    ) -> Result<Response<GroupTypeMappingsBatchResponse>, Status> {
+        Ok(Response::new(GroupTypeMappingsBatchResponse {
+            results: vec![],
+        }))
+    }
+
+    async fn get_group_type_mappings_by_project_id(
+        &self,
+        _request: Request<GetGroupTypeMappingsByProjectIdRequest>,
+    ) -> Result<Response<GroupTypeMappingsResponse>, Status> {
+        Ok(Response::new(GroupTypeMappingsResponse {
+            mappings: self.group_type_mappings.clone(),
+        }))
+    }
+
+    async fn get_group_type_mappings_by_project_ids(
+        &self,
+        _request: Request<GetGroupTypeMappingsByProjectIdsRequest>,
+    ) -> Result<Response<GroupTypeMappingsBatchResponse>, Status> {
+        Ok(Response::new(GroupTypeMappingsBatchResponse {
+            results: vec![],
+        }))
+    }
+}
+
+/// Start a test replica server on a random port and return its address
+pub async fn start_test_replica(service: TestReplicaService) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(PersonHogReplicaServer::new(service))
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+            .unwrap();
+    });
+
+    // Give the server a moment to start
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    addr
+}
+
+/// Start a test router server connected to the given replica address
+pub async fn start_test_router(replica_addr: SocketAddr) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let replica_url = format!("http://{}", replica_addr);
+    let backend = ReplicaBackend::new(&replica_url, Duration::from_secs(5)).unwrap();
+    let router = PersonHogRouter::new(Arc::new(backend));
+    let service = PersonHogRouterService::new(Arc::new(router));
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(PersonHogServiceServer::new(service))
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+            .unwrap();
+    });
+
+    // Give the server a moment to start
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    addr
+}
+
+/// Create a client connected to the router
+pub async fn create_client(router_addr: SocketAddr) -> PersonHogServiceClient<Channel> {
+    let url = format!("http://{}", router_addr);
+    PersonHogServiceClient::connect(url).await.unwrap()
+}
+
+pub fn create_test_person() -> Person {
+    Person {
+        id: 42,
+        team_id: 1,
+        uuid: "00000000-0000-0000-0000-000000000042".to_string(),
+        properties: b"{}".to_vec(),
+        properties_last_updated_at: vec![],
+        properties_last_operation: vec![],
+        created_at: 0,
+        version: 1,
+        is_identified: true,
+        is_user_id: false,
+    }
+}

--- a/rust/personhog-router/tests/integration.rs
+++ b/rust/personhog-router/tests/integration.rs
@@ -1,0 +1,509 @@
+mod common;
+
+use common::{
+    create_client, create_test_person, start_test_replica, start_test_router, TestReplicaService,
+};
+use personhog_proto::personhog::types::v1::{
+    CheckCohortMembershipRequest, CohortMembership, ConsistencyLevel,
+    GetGroupTypeMappingsByProjectIdRequest, GetGroupTypeMappingsByTeamIdRequest, GetGroupsRequest,
+    GetHashKeyOverrideContextRequest, GetPersonByDistinctIdRequest, GetPersonRequest,
+    GetPersonsByDistinctIdsInTeamRequest, Group, GroupIdentifier, GroupTypeMapping,
+    HashKeyOverride, HashKeyOverrideContext, HashKeyOverrideInput, Person, PersonWithDistinctIds,
+    ReadOptions, UpsertHashKeyOverridesRequest,
+};
+
+#[tokio::test]
+async fn test_get_person_roundtrip() {
+    let test_person = create_test_person();
+    let replica_service = TestReplicaService::with_person(test_person.clone());
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .get_person(GetPersonRequest {
+            team_id: 1,
+            person_id: 42,
+            read_options: None,
+        })
+        .await
+        .unwrap();
+
+    let person = response.into_inner().person;
+    assert!(person.is_some());
+    let person = person.unwrap();
+    assert_eq!(person.id, test_person.id);
+    assert_eq!(person.team_id, test_person.team_id);
+    assert_eq!(person.uuid, test_person.uuid);
+}
+
+#[tokio::test]
+async fn test_get_person_by_distinct_id_roundtrip() {
+    let test_person = create_test_person();
+    let replica_service = TestReplicaService::with_person(test_person.clone());
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .get_person_by_distinct_id(GetPersonByDistinctIdRequest {
+            team_id: 1,
+            distinct_id: "user@example.com".to_string(),
+            read_options: None,
+        })
+        .await
+        .unwrap();
+
+    let person = response.into_inner().person;
+    assert!(person.is_some());
+    let person = person.unwrap();
+    assert_eq!(person.id, test_person.id);
+}
+
+#[tokio::test]
+async fn test_get_person_not_found() {
+    let replica_service = TestReplicaService::new();
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .get_person(GetPersonRequest {
+            team_id: 1,
+            person_id: 999,
+            read_options: None,
+        })
+        .await
+        .unwrap();
+
+    let person = response.into_inner().person;
+    assert!(person.is_none());
+}
+
+// ============================================================
+// Feature-flags behavior pattern tests
+// ============================================================
+
+/// Tests batch person lookup by distinct IDs within a team.
+/// Feature-flags uses this to resolve multiple distinct IDs to persons in a single call.
+#[tokio::test]
+async fn test_get_persons_by_distinct_ids_in_team() {
+    let test_person = Person {
+        id: 42,
+        team_id: 1,
+        uuid: "00000000-0000-0000-0000-000000000042".to_string(),
+        properties: b"{}".to_vec(),
+        properties_last_updated_at: vec![],
+        properties_last_operation: vec![],
+        created_at: 0,
+        version: 1,
+        is_identified: true,
+        is_user_id: false,
+    };
+
+    // Each PersonWithDistinctIds maps one distinct_id to one person
+    let person_with_distinct_id = PersonWithDistinctIds {
+        distinct_id: "user@example.com".to_string(),
+        person: Some(test_person),
+    };
+
+    let replica_service =
+        TestReplicaService::new().with_persons_by_distinct_id(vec![person_with_distinct_id]);
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .get_persons_by_distinct_ids_in_team(GetPersonsByDistinctIdsInTeamRequest {
+            team_id: 1,
+            distinct_ids: vec!["user@example.com".to_string()],
+            read_options: None,
+        })
+        .await
+        .unwrap();
+
+    let results = response.into_inner().results;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].distinct_id, "user@example.com");
+    assert!(results[0].person.is_some());
+    assert_eq!(results[0].person.as_ref().unwrap().id, 42);
+}
+
+/// Tests cohort membership check - a batch operation that checks if a person
+/// belongs to multiple cohorts at once.
+/// Feature-flags uses this for cohort-based targeting.
+#[tokio::test]
+async fn test_check_cohort_membership() {
+    let memberships = vec![
+        CohortMembership {
+            cohort_id: 100,
+            is_member: true,
+        },
+        CohortMembership {
+            cohort_id: 200,
+            is_member: false,
+        },
+        CohortMembership {
+            cohort_id: 300,
+            is_member: true,
+        },
+    ];
+
+    let replica_service = TestReplicaService::new().with_cohort_memberships(memberships);
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .check_cohort_membership(CheckCohortMembershipRequest {
+            person_id: 42,
+            cohort_ids: vec![100, 200, 300],
+            read_options: None,
+        })
+        .await
+        .unwrap();
+
+    let result = response.into_inner();
+    assert_eq!(result.memberships.len(), 3);
+
+    // Verify specific membership results
+    let cohort_100 = result.memberships.iter().find(|m| m.cohort_id == 100);
+    assert!(cohort_100.is_some());
+    assert!(cohort_100.unwrap().is_member);
+
+    let cohort_200 = result.memberships.iter().find(|m| m.cohort_id == 200);
+    assert!(cohort_200.is_some());
+    assert!(!cohort_200.unwrap().is_member);
+}
+
+/// Tests cohort membership for non-existent person returns empty (not error).
+/// Feature-flags expects this behavior for graceful degradation.
+#[tokio::test]
+async fn test_check_cohort_membership_empty() {
+    let replica_service = TestReplicaService::new(); // No memberships configured
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .check_cohort_membership(CheckCohortMembershipRequest {
+            person_id: 999, // Non-existent person
+            cohort_ids: vec![100, 200],
+            read_options: None,
+        })
+        .await
+        .unwrap();
+
+    // Should succeed with empty memberships, not error
+    let result = response.into_inner();
+    assert!(result.memberships.is_empty());
+}
+
+/// Tests hash key override context lookup for experience continuity.
+/// Feature-flags uses this to maintain consistent flag experiences across distinct IDs.
+#[tokio::test]
+async fn test_get_hash_key_override_context() {
+    let contexts = vec![HashKeyOverrideContext {
+        person_id: 42,
+        distinct_id: "user@example.com".to_string(),
+        overrides: vec![
+            HashKeyOverride {
+                feature_flag_key: "beta-feature".to_string(),
+                hash_key: "consistent-hash-key".to_string(),
+            },
+            HashKeyOverride {
+                feature_flag_key: "experiment-1".to_string(),
+                hash_key: "experiment-hash".to_string(),
+            },
+        ],
+        existing_feature_flag_keys: vec!["beta-feature".to_string(), "experiment-1".to_string()],
+    }];
+
+    let replica_service = TestReplicaService::new().with_hash_key_override_contexts(contexts);
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .get_hash_key_override_context(GetHashKeyOverrideContextRequest {
+            team_id: 1,
+            distinct_ids: vec!["user@example.com".to_string()],
+            check_person_exists: false,
+            read_options: None,
+        })
+        .await
+        .unwrap();
+
+    let results = response.into_inner().results;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].distinct_id, "user@example.com");
+    assert_eq!(results[0].person_id, 42);
+    assert_eq!(results[0].overrides.len(), 2);
+}
+
+/// Tests upsert hash key overrides - a write operation for experience continuity.
+/// Returns the count of newly inserted overrides (ON CONFLICT DO NOTHING behavior).
+#[tokio::test]
+async fn test_upsert_hash_key_overrides() {
+    let replica_service = TestReplicaService::new().with_upsert_inserted_count(3);
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .upsert_hash_key_overrides(UpsertHashKeyOverridesRequest {
+            team_id: 1,
+            overrides: vec![
+                HashKeyOverrideInput {
+                    person_id: 42,
+                    feature_flag_key: "flag-1".to_string(),
+                },
+                HashKeyOverrideInput {
+                    person_id: 42,
+                    feature_flag_key: "flag-2".to_string(),
+                },
+                HashKeyOverrideInput {
+                    person_id: 42,
+                    feature_flag_key: "flag-3".to_string(),
+                },
+            ],
+            hash_key: "consistent-hash".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let result = response.into_inner();
+    assert_eq!(result.inserted_count, 3);
+}
+
+/// Tests batch group lookup.
+/// Feature-flags uses this to resolve group properties for group-based targeting.
+#[tokio::test]
+async fn test_get_groups() {
+    let groups = vec![
+        Group {
+            id: 1,
+            team_id: 1,
+            group_type_index: 0,
+            group_key: "company-abc".to_string(),
+            group_properties: b"{\"name\": \"Acme Corp\", \"plan\": \"enterprise\"}".to_vec(),
+            properties_last_updated_at: vec![],
+            properties_last_operation: vec![],
+            created_at: 0,
+            version: 1,
+        },
+        Group {
+            id: 2,
+            team_id: 1,
+            group_type_index: 1,
+            group_key: "project-xyz".to_string(),
+            group_properties: b"{\"name\": \"Secret Project\"}".to_vec(),
+            properties_last_updated_at: vec![],
+            properties_last_operation: vec![],
+            created_at: 0,
+            version: 1,
+        },
+    ];
+
+    let replica_service = TestReplicaService::new().with_groups(groups);
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .get_groups(GetGroupsRequest {
+            team_id: 1,
+            group_identifiers: vec![
+                GroupIdentifier {
+                    group_type_index: 0,
+                    group_key: "company-abc".to_string(),
+                },
+                GroupIdentifier {
+                    group_type_index: 1,
+                    group_key: "project-xyz".to_string(),
+                },
+            ],
+            read_options: None,
+        })
+        .await
+        .unwrap();
+
+    let result = response.into_inner();
+    assert_eq!(result.groups.len(), 2);
+    assert!(result.missing_groups.is_empty());
+
+    // Verify group data
+    let company = result.groups.iter().find(|g| g.group_key == "company-abc");
+    assert!(company.is_some());
+    assert_eq!(company.unwrap().group_type_index, 0);
+}
+
+/// Tests group lookup when groups are not found returns empty (not error).
+#[tokio::test]
+async fn test_get_groups_not_found() {
+    let replica_service = TestReplicaService::new(); // No groups configured
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .get_groups(GetGroupsRequest {
+            team_id: 1,
+            group_identifiers: vec![GroupIdentifier {
+                group_type_index: 0,
+                group_key: "nonexistent".to_string(),
+            }],
+            read_options: None,
+        })
+        .await
+        .unwrap();
+
+    // Should succeed with empty groups, not error
+    let result = response.into_inner();
+    assert!(result.groups.is_empty());
+}
+
+/// Tests group type mappings lookup by team ID.
+/// Feature-flags uses this to map group type names to indices.
+#[tokio::test]
+async fn test_get_group_type_mappings_by_team_id() {
+    let mappings = vec![
+        GroupTypeMapping {
+            id: 1,
+            team_id: 1,
+            project_id: 1,
+            group_type: "company".to_string(),
+            group_type_index: 0,
+            name_singular: Some("company".to_string()),
+            name_plural: Some("companies".to_string()),
+            default_columns: None,
+            detail_dashboard_id: None,
+            created_at: None,
+        },
+        GroupTypeMapping {
+            id: 2,
+            team_id: 1,
+            project_id: 1,
+            group_type: "project".to_string(),
+            group_type_index: 1,
+            name_singular: Some("project".to_string()),
+            name_plural: Some("projects".to_string()),
+            default_columns: None,
+            detail_dashboard_id: None,
+            created_at: None,
+        },
+    ];
+
+    let replica_service = TestReplicaService::new().with_group_type_mappings(mappings);
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .get_group_type_mappings_by_team_id(GetGroupTypeMappingsByTeamIdRequest {
+            team_id: 1,
+            read_options: None,
+        })
+        .await
+        .unwrap();
+
+    let result = response.into_inner();
+    assert_eq!(result.mappings.len(), 2);
+
+    let company_mapping = result.mappings.iter().find(|m| m.group_type == "company");
+    assert!(company_mapping.is_some());
+    assert_eq!(company_mapping.unwrap().group_type_index, 0);
+}
+
+/// Tests that Unspecified consistency level routes to replica (same as Eventual).
+#[tokio::test]
+async fn test_get_person_with_unspecified_consistency() {
+    let test_person = create_test_person();
+    let replica_service = TestReplicaService::with_person(test_person.clone());
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .get_person(GetPersonRequest {
+            team_id: 1,
+            person_id: 42,
+            read_options: Some(ReadOptions {
+                consistency: ConsistencyLevel::Unspecified.into(),
+            }),
+        })
+        .await
+        .unwrap();
+
+    let person = response.into_inner().person;
+    assert!(person.is_some());
+    assert_eq!(person.unwrap().id, test_person.id);
+}
+
+/// Tests group type mappings lookup by project ID.
+#[tokio::test]
+async fn test_get_group_type_mappings_by_project_id() {
+    let mappings = vec![
+        GroupTypeMapping {
+            id: 1,
+            team_id: 1,
+            project_id: 100,
+            group_type: "organization".to_string(),
+            group_type_index: 0,
+            name_singular: Some("organization".to_string()),
+            name_plural: Some("organizations".to_string()),
+            default_columns: None,
+            detail_dashboard_id: None,
+            created_at: None,
+        },
+        GroupTypeMapping {
+            id: 2,
+            team_id: 1,
+            project_id: 100,
+            group_type: "workspace".to_string(),
+            group_type_index: 1,
+            name_singular: Some("workspace".to_string()),
+            name_plural: Some("workspaces".to_string()),
+            default_columns: None,
+            detail_dashboard_id: None,
+            created_at: None,
+        },
+    ];
+
+    let replica_service = TestReplicaService::new().with_group_type_mappings(mappings);
+
+    let replica_addr = start_test_replica(replica_service).await;
+    let router_addr = start_test_router(replica_addr).await;
+    let mut client = create_client(router_addr).await;
+
+    let response = client
+        .get_group_type_mappings_by_project_id(GetGroupTypeMappingsByProjectIdRequest {
+            project_id: 100,
+            read_options: None,
+        })
+        .await
+        .unwrap();
+
+    let result = response.into_inner();
+    assert_eq!(result.mappings.len(), 2);
+
+    let org_mapping = result
+        .mappings
+        .iter()
+        .find(|m| m.group_type == "organization");
+    assert!(org_mapping.is_some());
+    assert_eq!(org_mapping.unwrap().group_type_index, 0);
+    assert_eq!(org_mapping.unwrap().project_id, 100);
+}


### PR DESCRIPTION
## Problem

The personhog architecture has multiple backends that will be responsible for serving requests: personhog-leader/personhog-replica.

The personhog-replica service can serve any eventual read request and any write/strong read that doesn't touch the person table.

(future implementation) The personhog-leader service will be sharded, requiring a routing/frontend layer that understands how to route incoming requests to the correct pod.

In order to expose a single gRPC client that services can call for any of their person data needs, we need a routing layer that encapsulates some routing logic within it. It will be responsible for:

1. deciding which backend to call (personhog-replica or personhog-leader), based on the incoming request
2. if we are calling the personhog-leader backend, choosing which pod to route the request to (future implementation)

**NOTE**: In the current implementation, the router is basically a proxy/pass-through to the replica. A router layer adds latency/network hop/expense, begging the question of whether or not we should use it for personhog-replica requests.

The trade-off being made with this decision is to be able to expose a single client for all personhog consumers to use, and to avoid exposing any knowledge of the "personhog cluster" architecture to clients. A client can just choose the gRPC method to call, the consistency option they need and they will get what they are looking for.

The time spent in the routing layer is instrumented in this service. We will assess how much latency is added by having this layer with some shadow traffic and we can fairly easily reverse the decision of sending personhog-replica requests through the router.



## Changes

  - Exposes the same 18 RPCs as personhog-replica through a new PersonHogService proto               
  - Routes requests based on data category and consistency level:                                    
    - Person data with EVENTUAL consistency → replica                                                
    - Person data with STRONG consistency → returns UNIMPLEMENTED (Phase 2: leader)                  
    - Non-person data (groups, cohorts, hash key overrides) → replica                                
  - Instruments request timing at two levels:                                                        
    - Tower middleware for total gRPC request duration                                               
    - Per-backend call timing via metrics   

## How did you test this code?

  - unit tests (routing logic, error passthrough)                                                 
  - integration tests covering feature-flags behavior patterns:                                   
    - Batch person lookup by distinct ID                                                             
    - Cohort membership checks                                                                       
    - Hash key override read/write                                                                   
    - Group lookups                                                                                  
    - Group type mappings   
Integration tests use an in-memory implementation of the PersonhogReplica service with stubbed responses. Does not call PG.
