### PR TITLE
fix(web-analytics): Deconstruct isVisible in LiveUserCount

### DIFF
--- a/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
+++ b/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
@@ -77,7 +77,7 @@ export function LiveUserCount({
     const { liveUserCount } = useValues(liveUserCountLogic({ pollIntervalMs }))
     const { pauseStream, resumeStream } = useActions(liveUserCountLogic({ pollIntervalMs }))
 
-    const isVisible = usePageVisibility()
+    const { isVisible } = usePageVisibility()
     useEffect(() => {
         if (isVisible) {
             resumeStream()
@@ -121,7 +121,7 @@ export function LiveRecordingsCount({ pollIntervalMs = 30000 }: LiveCountProps):
     const { activeRecordings } = useValues(liveUserCountLogic({ pollIntervalMs }))
     const { pauseStream, resumeStream } = useActions(liveUserCountLogic({ pollIntervalMs }))
 
-    const isVisible = usePageVisibility()
+    const { isVisible } = usePageVisibility()
     useEffect(() => {
         if (isVisible) {
             resumeStream()


### PR DESCRIPTION
## Problem
In the `LiveUserCount` component, we were not deconstructing the `isVisible` boolean so re-renders could for stats to over poll.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Deconstruct `isVisible`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Ran locally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
