### PR TITLE
fix(early-access): Renaming early access feature no longer autosaves

### DIFF
--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -149,21 +149,12 @@ export function EarlyAccessFeature({ id }: EarlyAccessFeatureLogicProps): JSX.El
                     resourceType={{
                         type: 'early_access_feature',
                     }}
-                    canEdit
-                    renameDebounceMs={isNewEarlyAccessFeature ? undefined : 1000}
+                    canEdit={isNewEarlyAccessFeature || isEditingFeature}
                     onNameChange={(name) => {
-                        if (isNewEarlyAccessFeature) {
-                            setEarlyAccessFeatureValue('name', name)
-                        } else {
-                            saveEarlyAccessFeature({ ...earlyAccessFeature, name })
-                        }
+                        setEarlyAccessFeatureValue('name', name)
                     }}
                     onDescriptionChange={(description) => {
-                        if (isNewEarlyAccessFeature) {
-                            setEarlyAccessFeatureValue('description', description)
-                        } else {
-                            saveEarlyAccessFeature({ ...earlyAccessFeature, description })
-                        }
+                        setEarlyAccessFeatureValue('description', description)
                     }}
                     forceEdit={isEditingFeature || isNewEarlyAccessFeature}
                     actions={


### PR DESCRIPTION
## Problem

Previously there were two ways of editing the title and description.
1. via edit mode described above
2. via inline editing (clicking the pencil)

However, the inline edit saved automatically when the user stopped typing for one second. This behavior also occurred in edit mode, unexpectedly. E.g. if you enter edit mode and type something in the title or description, the record would save and a hard reload would occur.

## Changes

The inline edit is removed, along with the automatic save / hard reload after one second of not typing.

The flow is now similar / equal to the feature flags edit flow:
1. The user clicks 'edit'
2. They make changes
3. They click 'save' to persist them

**Before** (note, I'm not submitting the form with enter or anything, it just saves after 1s)

https://github.com/user-attachments/assets/ab77d47f-8d66-4a6b-8104-7aaf895e0feb

After

https://github.com/user-attachments/assets/de93ae02-98bd-477b-bd11-df158a7713af


## How did you test this code?

Verified manually