### PR TITLE
fix(flags): fixing the cohort name field in the collapsible flag filter UI

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -14,7 +14,7 @@ import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { humanFriendlyNumber } from 'lib/utils'
 import { clamp } from 'lib/utils'
 
-import { AnyPropertyFilter, FeatureFlagGroupType, PropertyFilterType } from '~/types'
+import { AnyPropertyFilter, CohortPropertyFilter, FeatureFlagGroupType, PropertyFilterType } from '~/types'
 
 import {
     FeatureFlagReleaseConditionsLogicProps,
@@ -35,9 +35,16 @@ function summarizeProperties(properties: AnyPropertyFilter[], aggregationTargetN
     const parts = properties.slice(0, 2).map((property) => {
         const key = property.type === PropertyFilterType.Cohort ? 'Cohort' : property.key || 'property'
         const operator = isPropertyFilterWithOperator(property) ? allOperatorsToHumanName(property.operator) : 'is'
-        const value = Array.isArray(property.value)
-            ? property.value.slice(0, 2).join(', ') + (property.value.length > 2 ? '...' : '')
-            : property.value
+
+        let value: string | number
+        if (property.type === PropertyFilterType.Cohort) {
+            const cohortProperty = property as CohortPropertyFilter
+            value = cohortProperty.cohort_name || `ID ${cohortProperty.value}`
+        } else if (Array.isArray(property.value)) {
+            value = property.value.slice(0, 2).join(', ') + (property.value.length > 2 ? '...' : '')
+        } else {
+            value = property.value ?? ''
+        }
 
         return `${key} ${operator} ${value}`
     })

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -14,7 +14,7 @@ import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { humanFriendlyNumber } from 'lib/utils'
 import { clamp } from 'lib/utils'
 
-import { AnyPropertyFilter, CohortPropertyFilter, FeatureFlagGroupType, PropertyFilterType } from '~/types'
+import { AnyPropertyFilter, FeatureFlagGroupType, PropertyFilterType } from '~/types'
 
 import {
     FeatureFlagReleaseConditionsLogicProps,
@@ -38,12 +38,14 @@ function summarizeProperties(properties: AnyPropertyFilter[], aggregationTargetN
 
         let value: string | number
         if (property.type === PropertyFilterType.Cohort) {
-            const cohortProperty = property as CohortPropertyFilter
+            const cohortProperty = property
             value = cohortProperty.cohort_name || `ID ${cohortProperty.value}`
         } else if (Array.isArray(property.value)) {
             value = property.value.slice(0, 2).join(', ') + (property.value.length > 2 ? '...' : '')
+        } else if (property.value === null || property.value === undefined) {
+            value = ''
         } else {
-            value = property.value ?? ''
+            value = String(property.value)
         }
 
         return `${key} ${operator} ${value}`

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -38,8 +38,7 @@ function summarizeProperties(properties: AnyPropertyFilter[], aggregationTargetN
 
         let value: string | number
         if (property.type === PropertyFilterType.Cohort) {
-            const cohortProperty = property
-            value = cohortProperty.cohort_name || `ID ${cohortProperty.value}`
+            value = property.cohort_name || `ID ${property.value}`
         } else if (Array.isArray(property.value)) {
             value = property.value.slice(0, 2).join(', ') + (property.value.length > 2 ? '...' : '')
         } else if (property.value === null || property.value === undefined) {


### PR DESCRIPTION
## Problem

When users configure feature flag release conditions with cohort filters, the UI shows inconsistent information:
- The Match filters section correctly displays the cohort name (e.g., "PostHog Team")
- But the condition set header/summary shows the raw cohort ID instead (e.g., "Cohort in 98")

This makes it harder for users to understand which cohorts are being targeted at a glance without expanding each condition set.

## Changes

Updated the `summarizeProperties` function in `FeatureFlagReleaseConditionsCollapsible.tsx` to:
- Check if the property is a cohort filter
- Display the `cohort_name` when available
- Fall back to `ID ${value}` if the cohort name isn't populated

**Before:** Condition header shows "Cohort in 98"
**After:** Condition header shows "Cohort in PostHog Team"

## How did you test this code?

- Manually verified in the feature flags UI with existing cohort-based release conditions
- Confirmed the cohort name now displays correctly in condition set headers
- Verified fallback behavior when `cohort_name` is not present (shows "ID {number}")
- Confirmed non-cohort property filters continue to work as expected

## Publish to changelog?

No - this is a minor UI consistency fix.