### PR TITLE
fix(modeling): succeed jobs which return no results

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -627,6 +627,19 @@ async def materialize_model(
             await mark_job_as_failed(job, error_message, logger)
             await logger.ainfo("Paused temporal schedule for query: saved_query_id=%s", saved_query.id)
             raise NonRetryableException(f"Query exceeded timeout limit for model {model_label}: {error_message}") from e
+        elif "query returned no results" in error_message.lower():
+            await logger.awarning(
+                "Query returned no results: saved_query_id=%s saved_query_name=%s", saved_query.id, saved_query.name
+            )
+            # succeed the job but leave the error on the saved_query and the job and raise for temporal
+            saved_query.latest_error = str(e)
+            await database_sync_to_async(saved_query.save)()
+            job.error = str(e)
+            job.rows_materialized = 0
+            job.status = DataModelingJob.Status.COMPLETED
+            job.last_run_at = dt.datetime.now(dt.UTC)
+            await database_sync_to_async(job.save)()
+            raise
         else:
             saved_query.latest_error = f"Query failed to materialize: {error_message}"
             await logger.aerror("Failed to materialize model with unexpected error: %s", str(e))

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -1690,7 +1690,7 @@ async def test_materialize_model_empty_results(ateam, bucket_name, minio_client)
         assert "returned no results" in str(exc_info.value)
 
         await database_sync_to_async(job.refresh_from_db)()
-        assert job.status == DataModelingJob.Status.FAILED
+        assert job.status == DataModelingJob.Status.COMPLETED
         assert job.error is not None
         assert "returned no results" in job.error
 


### PR DESCRIPTION
## Problem

4k jobs fail for "no results"

## Changes

don't fail them while i figure out a more appropriate handling. looking into how much compute these jobs waste. if its high we should free the temporal slots by pausing schedules and notifying customers. but that needs to be done thoughtfully.

## How did you test this code?

i didn't

## Publish to changelog?

no

<!-- branch-stack-start -->

-------------------------
- master
  - https://github.com/PostHog/posthog/pull/46341 :point_left:

<sup>[Stack](https://www.git-town.com/how-to/proposal-breadcrumb.html) generated by [Git Town](https://github.com/git-town/git-town)</sup>

<!-- branch-stack-end -->
