### PR TITLE
fix(proxy): detect proxy type from target_cname for monitor/delete

### DIFF
--- a/posthog/api/proxy_record.py
+++ b/posthog/api/proxy_record.py
@@ -114,6 +114,7 @@ class ProxyRecordViewset(TeamAndOrgViewSetMixin, ModelViewSet):
                 organization_id=record.organization_id,
                 proxy_record_id=record.id,
                 domain=record.domain,
+                target_cname=record.target_cname,
             )
             workflow_id = f"proxy-delete-{inputs.proxy_record_id}"
             asyncio.run(

--- a/posthog/temporal/proxy_service/common.py
+++ b/posthog/temporal/proxy_service/common.py
@@ -32,8 +32,34 @@ def use_gateway_api() -> bool:
 
 
 def use_cloudflare_proxy() -> bool:
-    """Returns whether to use Cloudflare for SaaS for proxy provisioning."""
+    """Returns whether to use Cloudflare for SaaS for NEW proxy provisioning."""
     return settings.CLOUDFLARE_PROXY_ENABLED
+
+
+def is_cloudflare_proxy_by_cname(target_cname: str) -> bool:
+    """
+    Determine if a proxy was created with Cloudflare based on its target_cname string.
+
+    This is used to determine which system to use for monitoring and deletion,
+    since proxies created before CLOUDFLARE_PROXY_ENABLED was turned on still
+    exist in the legacy system and need to be handled accordingly.
+    """
+    cloudflare_base = settings.CLOUDFLARE_PROXY_BASE_CNAME
+    if not cloudflare_base:
+        return False
+    # Strip trailing dot for comparison (DNS records may or may not have it)
+    cloudflare_base = cloudflare_base.rstrip(".")
+    target_cname = target_cname.rstrip(".")
+    return target_cname.endswith(cloudflare_base)
+
+
+def is_cloudflare_proxy(proxy_record: "ProxyRecord") -> bool:
+    """
+    Determine if a proxy was created with Cloudflare based on its target_cname.
+
+    Convenience wrapper around is_cloudflare_proxy_by_cname for use with ProxyRecord objects.
+    """
+    return is_cloudflare_proxy_by_cname(proxy_record.target_cname)
 
 
 class NonRetriableException(Exception):

--- a/posthog/temporal/proxy_service/monitor.py
+++ b/posthog/temporal/proxy_service/monitor.py
@@ -35,7 +35,7 @@ from posthog.temporal.proxy_service.common import (
     activity_update_proxy_record,
     get_grpc_client,
     get_record,
-    use_cloudflare_proxy,
+    is_cloudflare_proxy,
 )
 from posthog.temporal.proxy_service.proto import CertificateState_READY, StatusRequest
 
@@ -152,8 +152,9 @@ async def check_certificate_status(inputs: CheckActivityInput) -> CheckActivityO
         proxy_record.domain,
     )
 
-    # Branch based on whether to use Cloudflare or legacy proxy provisioner
-    if use_cloudflare_proxy():
+    # Branch based on how the proxy was created (detected from target_cname),
+    # not the global flag, since legacy proxies still need legacy monitoring
+    if is_cloudflare_proxy(proxy_record):
         return await _check_cloudflare_certificate_status(proxy_record, logger)
     else:
         return await _check_legacy_certificate_status(proxy_record, logger)


### PR DESCRIPTION
## Problem

Managed reverse proxies created before the Cloudflare migration were failing monitoring with "Custom Hostname not found in Cloudflare" errors. This happened because the monitor workflow used the global `CLOUDFLARE_PROXY_ENABLED` flag to decide which system to check, rather than detecting how each individual proxy was originally created.

## Changes

- Add `is_cloudflare_proxy_by_cname()` function in `common.py` that detects proxy type from `target_cname` (checks if it ends with `CLOUDFLARE_PROXY_BASE_CNAME`)
- Update `monitor.py` to use per-proxy detection instead of global flag for certificate status checks
- Update `delete.py` to use per-proxy detection and pass `target_cname` in workflow inputs
- Update `proxy_record.py` API to include `target_cname` when starting delete workflow

This ensures:
- Contour-based proxies (`*.proxy-*.posthog.com`) → monitored/deleted via gRPC to proxy-provisioner
- Cloudflare proxies (`*.cf-*-proxy.proxyhog.com`) → monitored/deleted via Cloudflare API

## How did you test this code?

- Test build deployed in dev, validating the detection logic routes correctly based on target_cname

## Publish to changelog?

no
