### PR TITLE
fix(flags): Stop erroring when a flag depends on an invalid flag

### DIFF
--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -579,7 +579,9 @@ def get_feature_flags(
     else:
         raise ValueError("Either team or project_id must be provided")
 
-    filter_kwargs.update({"active": True, "deleted": False})
+    # Include disabled flags (active=False) so flag dependencies can reference them
+    # and evaluate them as false, rather than raising DependencyNotFound errors
+    filter_kwargs.update({"deleted": False})
 
     # Build queryset with evaluation tags aggregated
     # Single-shot query: flags plus evaluation tag names aggregated to a string array.

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -669,7 +669,10 @@ def get_feature_flags_for_team_in_cache(project_id: int) -> Optional[list[Featur
                 # This makes cache retrieval extremely fast - no DB queries needed.
                 flag._evaluation_tag_names = evaluation_tags_list
                 flags.append(flag)
-            return flags
+            # Filter to only return active flags. The cache includes inactive flags
+            # for dependency resolution (used by the Rust service), but Python callers
+            # expect only active flags for backward compatibility.
+            return [f for f in flags if f.active]
         except Exception as e:
             logger.exception("Error parsing flags from cache")
             capture_exception(e)

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -18,6 +18,7 @@ from posthog.models import FeatureFlag, Tag, Team
 from posthog.models.feature_flag.feature_flag import FeatureFlagEvaluationTag
 from posthog.models.feature_flag.flags_cache import (
     _get_feature_flags_for_service,
+    _get_feature_flags_for_teams_batch,
     _get_team_ids_with_recently_updated_flags,
     clear_flags_cache,
     flags_hypercache,
@@ -99,8 +100,12 @@ class TestServiceFlagsCache(BaseTest):
         assert len(flags) == 1
         assert flags[0]["key"] == "active-flag"
 
-    def test_get_feature_flags_for_service_excludes_inactive(self):
-        """Test that inactive flags are excluded from cache."""
+    def test_get_feature_flags_for_service_includes_inactive(self):
+        """Test that inactive flags are included in cache.
+
+        Inactive flags must be included so that flag dependencies can reference them
+        and evaluate them as false, rather than raising DependencyNotFound errors.
+        """
         # Create active flag
         FeatureFlag.objects.create(
             team=self.team,
@@ -121,8 +126,49 @@ class TestServiceFlagsCache(BaseTest):
         result = _get_feature_flags_for_service(self.team)
         flags = result["flags"]
 
-        assert len(flags) == 1
-        assert flags[0]["key"] == "active-flag"
+        # Both active and inactive flags should be included
+        assert len(flags) == 2
+        flag_keys = {f["key"] for f in flags}
+        assert flag_keys == {"active-flag", "inactive-flag"}
+
+        # Verify the inactive flag has active=False
+        inactive_flag = next(f for f in flags if f["key"] == "inactive-flag")
+        assert inactive_flag["active"] is False
+
+    def test_get_feature_flags_for_teams_batch_includes_inactive(self):
+        """Test that batch function includes inactive flags for dependency resolution.
+
+        This tests the same behavior as test_get_feature_flags_for_service_includes_inactive
+        but for the batch function used in management commands and cache warming.
+        """
+        # Create active flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="active-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Create inactive flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="inactive-flag",
+            created_by=self.user,
+            active=False,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = _get_feature_flags_for_teams_batch([self.team])
+        flags = result[self.team.id]["flags"]
+
+        # Both active and inactive flags should be included
+        assert len(flags) == 2
+        flag_keys = {f["key"] for f in flags}
+        assert flag_keys == {"active-flag", "inactive-flag"}
+
+        # Verify the inactive flag has active=False
+        inactive_flag = next(f for f in flags if f["key"] == "inactive-flag")
+        assert inactive_flag["active"] is False
 
     def test_get_flags_from_cache_redis_hit(self):
         """Test getting flags from Redis cache."""
@@ -1935,8 +1981,10 @@ class TestGetTeamIdsWithRecentlyUpdatedFlags(BaseTest):
     def test_ignores_recently_deactivated_flags(self):
         """Test returns empty set for team with recently deactivated flag.
 
-        When a flag is deactivated, the cache update removes it. We shouldn't skip
-        verification just because an inactive flag was recently updated.
+        The grace period function only considers active flags when determining
+        whether to skip cache verification. Inactive flags are included in the
+        cache (for dependency resolution), but their recent updates should not
+        trigger the grace period because their evaluation is deterministic (always false).
         """
         flag = FeatureFlag.objects.create(
             team=self.team,

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -798,10 +798,14 @@ impl FeatureFlagMatcher {
 
             match result {
                 Ok(flag_match) => {
+                    // Always store result for dependency resolution
                     self.flag_evaluation_state
                         .add_flag_evaluation_result(flag.id, flag_match.get_flag_value());
-                    level_evaluated_flags_map
-                        .insert(flag_key, FlagDetails::create(flag, &flag_match));
+                    // Only include active flags in the response
+                    if flag.active {
+                        level_evaluated_flags_map
+                            .insert(flag_key, FlagDetails::create(flag, &flag_match));
+                    }
                 }
                 Err(e) => {
                     errors_while_computing_flags = true;
@@ -828,8 +832,11 @@ impl FeatureFlagMatcher {
                         &[("reason".to_string(), reason)],
                         1,
                     );
-                    level_evaluated_flags_map
-                        .insert(flag_key, FlagDetails::create_error(flag, &e, None));
+                    // Only include active flags in the response
+                    if flag.active {
+                        level_evaluated_flags_map
+                            .insert(flag_key, FlagDetails::create_error(flag, &e, None));
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

Previously, when an active flag depended on a disabled flag, the system raised `DependencyNotFound` errors because disabled flags were filtered out of the cache with `active=True`. Now disabled flags are cached and evaluate to false with `FlagDisabled` reason, allowing proper dependency resolution.

Note that we recently made changes to the UX to disallow disabling a flag that another flag depends on. Likewise, we don't allow depending on a disabled flag. However, there are 61 flags that depend on disabled flags and they get a lot of traffic.

There's no clear migration we could do here, so we look to handle it gracefully.

## Changes

- Python: Remove `active=True` filter from cache queries to include disabled flags
- Rust: Simplify response filtering to only include active flags (disabled flags are still evaluated internally for dependency resolution but excluded from API responses to keep them lean)
- Tests: Update and add tests to verify disabled flags behavior

## How did you test this code?

Added some unit tests.
Manual testing.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No