### PR TITLE
feat(deduplicator): add fail-fast cancellation for in flight exports

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -58,6 +58,9 @@ pub struct CheckpointConfig {
     /// Timeout for a single S3 operation attempt
     pub s3_attempt_timeout: Duration,
 
+    /// Maximum number of retries for S3 operations before giving up
+    pub s3_max_retries: usize,
+
     /// Number of recent historical checkpoint attempts to try to import,
     /// starting from most recent, when attempting to import from remote
     /// storage. A failed download or corrupt files will result in fallback
@@ -101,6 +104,7 @@ impl Default for CheckpointConfig {
             checkpoint_import_window_hours: 24,
             s3_operation_timeout: Duration::from_secs(120),
             s3_attempt_timeout: Duration::from_secs(20),
+            s3_max_retries: 3,
             checkpoint_import_attempt_depth: 10,
             max_concurrent_checkpoint_file_downloads: 50,
             max_concurrent_checkpoint_file_uploads: 25,

--- a/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
@@ -108,7 +108,7 @@ impl S3Downloader {
             .with_bucket_name(&config.s3_bucket)
             .with_client_options(client_options)
             .with_retry(object_store::RetryConfig {
-                max_retries: 3,
+                max_retries: config.s3_max_retries,
                 // Total retry budget (analogous to operation_timeout in aws_sdk_s3)
                 retry_timeout: config.s3_operation_timeout,
                 ..Default::default()

--- a/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use object_store::aws::AmazonS3Builder;
 use object_store::buffered::BufWriter;
@@ -9,11 +10,55 @@ use object_store::{ClientOptions, ObjectStore, ObjectStoreExt, PutPayload};
 use std::path::Path;
 use std::sync::Arc;
 use tokio::fs::File;
-use tokio::io::AsyncWriteExt;
-use tracing::info;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
 
 use super::config::CheckpointConfig;
 use super::uploader::CheckpointUploader;
+use crate::metrics_const::CHECKPOINT_FILE_UPLOADS_COUNTER;
+
+/// Chunk size for streaming file reads during upload.
+/// Balances memory usage and cancellation responsiveness.
+const UPLOAD_CHUNK_SIZE: usize = 8 * 1024 * 1024; // 8MB
+
+/// Result of attempting to read the next chunk from a file with cancellation support
+enum ChunkResult {
+    Data(usize), // Number of bytes read
+    EndOfStream,
+    Cancelled,
+    Error(std::io::Error),
+}
+
+/// Read next chunk from file with cancellation support.
+/// Uses `tokio::select!` with `biased;` to ensure cancellation is checked promptly,
+/// even if the read is slow or stalled.
+async fn read_chunk_cancellable(
+    file: &mut File,
+    buf: &mut [u8],
+    cancel_token: Option<&CancellationToken>,
+) -> ChunkResult {
+    match cancel_token {
+        Some(token) => {
+            tokio::select! {
+                biased;
+
+                _ = token.cancelled() => ChunkResult::Cancelled,
+
+                result = file.read(buf) => match result {
+                    Ok(0) => ChunkResult::EndOfStream,
+                    Ok(n) => ChunkResult::Data(n),
+                    Err(e) => ChunkResult::Error(e),
+                }
+            }
+        }
+        None => match file.read(buf).await {
+            Ok(0) => ChunkResult::EndOfStream,
+            Ok(n) => ChunkResult::Data(n),
+            Err(e) => ChunkResult::Error(e),
+        },
+    }
+}
 
 /// S3Uploader using `object_store` crate with `LimitStore` for bounded concurrency.
 /// The LimitStore wraps the S3 client with a semaphore that limits concurrent requests.
@@ -32,7 +77,7 @@ impl S3Uploader {
             .with_bucket_name(&config.s3_bucket)
             .with_client_options(client_options)
             .with_retry(object_store::RetryConfig {
-                max_retries: 3,
+                max_retries: config.s3_max_retries,
                 // Total retry budget (analogous to operation_timeout in aws_sdk_s3)
                 retry_timeout: config.s3_operation_timeout,
                 ..Default::default()
@@ -99,10 +144,26 @@ impl S3Uploader {
         Ok(Self { store, config })
     }
 
-    /// Upload a file using object_store's streaming multipart upload.
-    /// Data is streamed from disk to S3 with automatic backpressure handling.
-    /// Uses BufWriter which handles chunking and multipart upload internally.
-    async fn upload_file(&self, local_path: &Path, s3_key: &str) -> Result<()> {
+    /// Upload a file with cancellation support.
+    /// On cancellation or error, calls abort() to clean up multipart upload parts.
+    async fn upload_file_cancellable(
+        &self,
+        local_path: &Path,
+        s3_key: &str,
+        cancel_token: Option<&CancellationToken>,
+    ) -> Result<()> {
+        // Pre-start cancellation check
+        if let Some(token) = cancel_token {
+            if token.is_cancelled() {
+                metrics::counter!(CHECKPOINT_FILE_UPLOADS_COUNTER, "status" => "cancelled")
+                    .increment(1);
+                warn!("Upload cancelled before starting: {s3_key}");
+                return Err(anyhow::anyhow!(
+                    "Upload cancelled before starting: {s3_key}"
+                ));
+            }
+        }
+
         let path = ObjectPath::from(s3_key);
 
         let mut file = File::open(local_path)
@@ -119,13 +180,38 @@ impl S3Uploader {
         // It buffers data and automatically uses multipart upload for large files.
         let mut upload = BufWriter::new(Arc::clone(&self.store), path.clone());
 
-        // Stream data from disk to S3 with automatic backpressure.
-        // On failure, we must abort to clean up any uploaded parts (ghost upload prevention).
-        if let Err(e) = tokio::io::copy(&mut file, &mut upload).await {
-            // Attempt to clean up S3 side; ignore secondary error if abort fails
-            let _ = upload.abort().await;
-            return Err(anyhow::Error::new(e))
-                .with_context(|| format!("Failed to stream file to S3: {local_path:?}"));
+        let mut buf = vec![0u8; UPLOAD_CHUNK_SIZE];
+
+        loop {
+            let chunk_result = read_chunk_cancellable(&mut file, &mut buf, cancel_token).await;
+
+            match chunk_result {
+                ChunkResult::Data(n) => {
+                    if let Err(e) = upload.write_all(&buf[..n]).await {
+                        let _ = upload.abort().await;
+                        metrics::counter!(CHECKPOINT_FILE_UPLOADS_COUNTER, "status" => "error")
+                            .increment(1);
+                        return Err(anyhow::Error::new(e))
+                            .with_context(|| format!("Failed to write chunk to S3: {s3_key}"));
+                    }
+                }
+                ChunkResult::EndOfStream => break,
+                ChunkResult::Cancelled => {
+                    let _ = upload.abort().await;
+                    metrics::counter!(CHECKPOINT_FILE_UPLOADS_COUNTER, "status" => "cancelled")
+                        .increment(1);
+                    warn!("Upload of {s3_key} cancelled mid-stream");
+                    return Err(anyhow::anyhow!("Upload cancelled: {s3_key}"));
+                }
+                ChunkResult::Error(e) => {
+                    let _ = upload.abort().await;
+                    metrics::counter!(CHECKPOINT_FILE_UPLOADS_COUNTER, "status" => "error")
+                        .increment(1);
+                    return Err(anyhow::Error::new(e)).with_context(|| {
+                        format!("Failed to read chunk from file: {local_path:?}")
+                    });
+                }
+            }
         }
 
         // Finalize the upload (triggers CompleteMultipartUpload API call for large files)
@@ -134,6 +220,7 @@ impl S3Uploader {
             .await
             .with_context(|| format!("Failed to complete upload for: {s3_key}"))?;
 
+        metrics::counter!(CHECKPOINT_FILE_UPLOADS_COUNTER, "status" => "success").increment(1);
         info!(
             "Uploaded file {local_path:?} ({file_size} bytes) to s3://{}/{}",
             self.config.s3_bucket, s3_key
@@ -156,39 +243,82 @@ impl S3Uploader {
 
 #[async_trait]
 impl CheckpointUploader for S3Uploader {
-    async fn upload_checkpoint_with_plan(
+    async fn upload_checkpoint_with_plan_cancellable(
         &self,
         plan: &super::CheckpointPlan,
+        cancel_token: Option<&CancellationToken>,
     ) -> Result<Vec<String>> {
+        // Pre-start check
+        if let Some(token) = cancel_token {
+            if token.is_cancelled() {
+                warn!("Upload cancelled before starting batch");
+                return Err(anyhow::anyhow!("Upload cancelled before starting"));
+            }
+        }
+
         info!(
             "Starting upload with plan: {} files to upload, {} files referenced from parents",
             plan.files_to_upload.len(),
             plan.info.metadata.files.len() - plan.files_to_upload.len()
         );
 
-        // Upload all files concurrently
-        let upload_futures: Vec<_> = plan
+        // Create child token for sibling cancellation - allows cancelling siblings
+        // without cancelling parent (so caller can continue with other work)
+        let upload_token = cancel_token
+            .map(|parent| parent.child_token())
+            .unwrap_or_default();
+
+        // Build upload futures using FuturesUnordered for early exit with sibling cancellation.
+        // LimitStore's semaphore still limits concurrent S3 requests.
+        let mut futures: FuturesUnordered<_> = plan
             .files_to_upload
             .iter()
             .map(|local_file| {
-                let bucket: String = self.config.s3_bucket.clone();
-                let src = local_file.local_path.to_path_buf();
-                let dest: String = plan.info.get_file_key(&local_file.filename);
+                let src = local_file.local_path.clone();
+                let dest = plan.info.get_file_key(&local_file.filename);
+                let token = upload_token.clone();
 
                 async move {
-                    self.upload_file(&src, &dest).await.with_context(|| {
-                        format!("Failed to upload file: {src:?} to s3://{bucket}/{dest}")
-                    })?;
+                    self.upload_file_cancellable(&src, &dest, Some(&token))
+                        .await?;
                     Ok::<String, anyhow::Error>(dest)
                 }
             })
             .collect();
 
-        let uploaded_keys = futures::future::try_join_all(upload_futures)
-            .await
-            .with_context(|| format!("Failed to upload files with plan: {plan:?}"))?;
+        let mut uploaded_keys = Vec::with_capacity(plan.files_to_upload.len());
+        let mut first_error: Option<anyhow::Error> = None;
 
-        // Upload metadata.json
+        // Process completions, cancel siblings on first error
+        while let Some(result) = futures.next().await {
+            match result {
+                Ok(key) => uploaded_keys.push(key),
+                Err(e) => {
+                    first_error = Some(e);
+                    // Cancel siblings - they'll exit on next chunk read
+                    upload_token.cancel();
+                    break;
+                }
+            }
+        }
+
+        // Drain remaining futures - they'll exit quickly due to cancellation
+        while futures.next().await.is_some() {}
+
+        // Return early on error - DO NOT upload metadata
+        if let Some(e) = first_error {
+            return Err(e);
+        }
+
+        // Check cancellation before uploading metadata (final gate)
+        if let Some(token) = cancel_token {
+            if token.is_cancelled() {
+                warn!("Upload cancelled before metadata upload");
+                return Err(anyhow::anyhow!("Upload cancelled before metadata upload"));
+            }
+        }
+
+        // ALL files succeeded - now safe to upload metadata
         let metadata_json = plan.info.metadata.to_json()?;
         let metadata_key = plan.info.get_metadata_key();
         self.upload_bytes(&metadata_key, metadata_json.into_bytes())
@@ -209,5 +339,95 @@ impl CheckpointUploader for S3Uploader {
 
     async fn is_available(&self) -> bool {
         !self.config.s3_bucket.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn test_read_chunk_cancellable_returns_data_without_token() {
+        let tmp_dir = TempDir::new().unwrap();
+        let file_path = tmp_dir.path().join("test_file.txt");
+
+        // Create a test file with some content
+        let mut file = tokio::fs::File::create(&file_path).await.unwrap();
+        file.write_all(b"hello world").await.unwrap();
+        file.flush().await.unwrap();
+        drop(file);
+
+        // Read without cancellation token
+        let mut file = tokio::fs::File::open(&file_path).await.unwrap();
+        let mut buf = vec![0u8; 1024];
+
+        let result = read_chunk_cancellable(&mut file, &mut buf, None).await;
+        match result {
+            ChunkResult::Data(n) => {
+                assert_eq!(n, 11);
+                assert_eq!(&buf[..n], b"hello world");
+            }
+            _ => panic!("Expected Data result"),
+        }
+
+        // Next read should return EndOfStream
+        let result = read_chunk_cancellable(&mut file, &mut buf, None).await;
+        assert!(matches!(result, ChunkResult::EndOfStream));
+    }
+
+    #[tokio::test]
+    async fn test_read_chunk_cancellable_returns_cancelled_when_pre_cancelled() {
+        let tmp_dir = TempDir::new().unwrap();
+        let file_path = tmp_dir.path().join("test_file.txt");
+
+        // Create a test file
+        let mut file = tokio::fs::File::create(&file_path).await.unwrap();
+        file.write_all(b"hello world").await.unwrap();
+        file.flush().await.unwrap();
+        drop(file);
+
+        // Create a pre-cancelled token
+        let token = CancellationToken::new();
+        token.cancel();
+
+        // Read with pre-cancelled token should return Cancelled
+        let mut file = tokio::fs::File::open(&file_path).await.unwrap();
+        let mut buf = vec![0u8; 1024];
+
+        let result = read_chunk_cancellable(&mut file, &mut buf, Some(&token)).await;
+        assert!(
+            matches!(result, ChunkResult::Cancelled),
+            "Expected Cancelled result"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_chunk_cancellable_returns_data_with_active_token() {
+        let tmp_dir = TempDir::new().unwrap();
+        let file_path = tmp_dir.path().join("test_file.txt");
+
+        // Create a test file
+        let mut file = tokio::fs::File::create(&file_path).await.unwrap();
+        file.write_all(b"hello world").await.unwrap();
+        file.flush().await.unwrap();
+        drop(file);
+
+        // Create an active (not cancelled) token
+        let token = CancellationToken::new();
+
+        // Read with active token should return Data
+        let mut file = tokio::fs::File::open(&file_path).await.unwrap();
+        let mut buf = vec![0u8; 1024];
+
+        let result = read_chunk_cancellable(&mut file, &mut buf, Some(&token)).await;
+        match result {
+            ChunkResult::Data(n) => {
+                assert_eq!(n, 11);
+                assert_eq!(&buf[..n], b"hello world");
+            }
+            _ => panic!("Expected Data result"),
+        }
     }
 }

--- a/rust/kafka-deduplicator/src/checkpoint/uploader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/uploader.rs
@@ -1,13 +1,26 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
 
 use super::CheckpointPlan;
 
 /// Trait for uploading checkpoints to remote storage
 #[async_trait]
 pub trait CheckpointUploader: Send + Sync + std::fmt::Debug {
-    /// Upload checkpoint using a plan (specific files + metadata)
-    async fn upload_checkpoint_with_plan(&self, plan: &CheckpointPlan) -> Result<Vec<String>>;
+    /// Upload checkpoint using a plan (specific files + metadata) - legacy non-cancellable
+    async fn upload_checkpoint_with_plan(&self, plan: &CheckpointPlan) -> Result<Vec<String>> {
+        self.upload_checkpoint_with_plan_cancellable(plan, None)
+            .await
+    }
+
+    /// Upload checkpoint with cancellation support.
+    /// If cancel_token is provided and cancelled during upload, returns an error early
+    /// and aborts any in-progress multipart uploads to prevent ghost uploads.
+    async fn upload_checkpoint_with_plan_cancellable(
+        &self,
+        plan: &CheckpointPlan,
+        cancel_token: Option<&CancellationToken>,
+    ) -> Result<Vec<String>>;
 
     /// Check if the uploader is available/configured
     async fn is_available(&self) -> bool;

--- a/rust/kafka-deduplicator/src/checkpoint/worker.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/worker.rs
@@ -14,6 +14,7 @@ use crate::store::{DeduplicationStore, LocalCheckpointInfo};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use metrics;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 /// Worker that handles checkpoint processing for individual partitions
@@ -85,19 +86,31 @@ impl CheckpointWorker {
         }
     }
 
-    /// Perform a complete checkpoint operation: create, export, and cleanup
-    /// Returns (remote_path, metadata) on success
+    /// Perform a complete checkpoint operation: create, export, and cleanup.
+    /// Returns checkpoint info on success, None if export was skipped.
     pub async fn checkpoint_partition(
         &self,
         store: &DeduplicationStore,
         previous_metadata: Option<&CheckpointMetadata>,
     ) -> Result<Option<CheckpointInfo>> {
+        self.checkpoint_partition_cancellable(store, previous_metadata, None)
+            .await
+    }
+
+    /// Perform a complete checkpoint operation with cancellation support.
+    /// If cancel_token is provided and cancelled during export, returns an error early.
+    pub async fn checkpoint_partition_cancellable(
+        &self,
+        store: &DeduplicationStore,
+        previous_metadata: Option<&CheckpointMetadata>,
+        cancel_token: Option<&CancellationToken>,
+    ) -> Result<Option<CheckpointInfo>> {
         // Create the local checkpoint
         let rocks_metadata = self.create_checkpoint(store).await?;
 
-        // Export checkpoint
+        // Export checkpoint with cancellation support
         let result = self
-            .export_checkpoint(&rocks_metadata, previous_metadata)
+            .export_checkpoint_cancellable(&rocks_metadata, previous_metadata, cancel_token)
             .await;
 
         // Clean up temp checkpoint directory (skip in test mode to allow verification)
@@ -239,10 +252,11 @@ impl CheckpointWorker {
         }
     }
 
-    async fn export_checkpoint(
+    async fn export_checkpoint_cancellable(
         &self,
         rocks_metadata: &LocalCheckpointInfo,
         previous_metadata: Option<&CheckpointMetadata>,
+        cancel_token: Option<&CancellationToken>,
     ) -> Result<Option<CheckpointInfo>> {
         let local_attempt_path_tag = self.get_local_attempt_path().to_string_lossy().to_string();
         let attempt_type = if previous_metadata.is_some() {
@@ -297,8 +311,11 @@ impl CheckpointWorker {
                     "Checkpoint worker: plan created"
                 );
 
-                // Export checkpoint using the plan
-                match exporter.export_checkpoint_with_plan(&plan).await {
+                // Export checkpoint using the plan with cancellation support
+                match exporter
+                    .export_checkpoint_with_plan_cancellable(&plan, cancel_token)
+                    .await
+                {
                     Ok(()) => {
                         let tags = [("result", "success"), ("export", "success")];
                         metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
@@ -314,15 +331,29 @@ impl CheckpointWorker {
                     }
 
                     Err(e) => {
-                        let tags = [("result", "error"), ("cause", "export")];
-                        metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
-                        error!(
-                            self.worker_id,
-                            local_attempt_path = local_attempt_path_tag,
-                            attempt_type,
-                            "Checkpoint worker: export failed: {}",
-                            e
-                        );
+                        // Cancellation is NOT an error - use distinct metrics tag and warn! instead of error!
+                        let is_cancelled = e.to_string().contains("cancelled");
+
+                        if is_cancelled {
+                            let tags = [("result", "skipped"), ("cause", "cancelled")];
+                            metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
+                            warn!(
+                                self.worker_id,
+                                local_attempt_path = local_attempt_path_tag,
+                                attempt_type,
+                                "Checkpoint worker: export cancelled"
+                            );
+                        } else {
+                            let tags = [("result", "error"), ("cause", "export")];
+                            metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
+                            error!(
+                                self.worker_id,
+                                local_attempt_path = local_attempt_path_tag,
+                                attempt_type,
+                                "Checkpoint worker: export failed: {}",
+                                e
+                            );
+                        }
 
                         Err(e)
                     }

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -423,7 +423,9 @@ impl CheckpointManager {
         self.exporter.is_some()
     }
 
-    /// Trigger an immediate flush of all stores (currenty used only in tests)
+    /// Trigger an immediate flush of all stores (currently used only in tests).
+    /// Uses the cancellable checkpoint method with the manager's cancel token
+    /// for consistency with the main checkpoint loop.
     pub async fn flush_all(&self) -> Result<()> {
         info!("Triggering manual flush of all stores");
 
@@ -449,7 +451,10 @@ impl CheckpointManager {
                 self.offset_tracker.clone(),
             );
 
-            worker.checkpoint_partition(&store, None).await?;
+            // Use cancellable variant with the manager's cancel token
+            worker
+                .checkpoint_partition_cancellable(&store, None, Some(&self.cancel_token))
+                .await?;
         }
 
         Ok(())

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -161,6 +161,11 @@ pub struct Config {
     #[envconfig(default = "20")] // 20 seconds
     pub s3_attempt_timeout_secs: u64,
 
+    /// Maximum number of retries for S3 operations before giving up.
+    /// Works in conjunction with s3_operation_timeout which provides the total retry budget.
+    #[envconfig(default = "3")]
+    pub s3_max_retries: usize,
+
     /// S3 endpoint URL (for non-AWS S3-compatible stores like MinIO)
     pub s3_endpoint: Option<String>,
 

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -69,13 +69,20 @@ pub const CHECKPOINT_DURATION_HISTOGRAM: &str = "checkpoint_duration_seconds";
 pub const CHECKPOINT_WORKER_STATUS_COUNTER: &str = "checkpoint_worker_status";
 
 /// Histogram for checkpoint upload duration
+/// Tags: result=success|error|cancelled
 pub const CHECKPOINT_UPLOAD_DURATION_HISTOGRAM: &str = "checkpoint_upload_duration_seconds";
 
 /// Counter for checkpoint upload outcome status
+/// Tags: result=success|error|cancelled|unavailable
 pub const CHECKPOINT_UPLOADS_COUNTER: &str = "checkpoint_upload_status";
 
 /// Counter for checkpoint file downloads outcome status
+/// Tags: status=success|error|cancelled
 pub const CHECKPOINT_FILE_DOWNLOADS_COUNTER: &str = "checkpoint_file_downloads_status";
+
+/// Counter for checkpoint file uploads outcome status
+/// Tags: status=success|error|cancelled
+pub const CHECKPOINT_FILE_UPLOADS_COUNTER: &str = "checkpoint_file_uploads_status";
 
 /// Counter for checkpoint files tracked in each attempt plan tagged by action taken
 pub const CHECKPOINT_PLAN_FILE_TRACKED_COUNTER: &str = "checkpoint_plan_file_tracked";

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -142,6 +142,7 @@ impl KafkaDeduplicatorService {
             checkpoint_import_window_hours: config.checkpoint_import_window_hours,
             s3_operation_timeout: config.s3_operation_timeout(),
             s3_attempt_timeout: config.s3_attempt_timeout(),
+            s3_max_retries: config.s3_max_retries,
             checkpoint_import_attempt_depth: config.checkpoint_import_attempt_depth,
             max_concurrent_checkpoint_file_downloads: config
                 .max_concurrent_checkpoint_file_downloads,

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -618,3 +618,377 @@ async fn test_parent_cancellation_stops_all_attempts() -> Result<()> {
 
     Ok(())
 }
+
+/// Integration test for export-side cancellation via MinIO.
+/// This test verifies the main feature of this PR: fail-fast cancellation during
+/// checkpoint exports to spare local resource utilization during rebalancing.
+///
+/// Tests:
+/// 1. Pre-cancelled token prevents upload from starting
+/// 2. Cancellation returns appropriate error with "cancelled" message
+/// 3. No files are uploaded when pre-cancelled
+/// 4. Verifies the cancellation flows through exporter → uploader correctly
+#[tokio::test]
+async fn test_export_cancellation_via_minio() -> Result<()> {
+    let test_topic = "test_export_cancellation";
+    let test_partition = 0;
+
+    // Create MinIO client and ensure bucket exists
+    let minio_client = create_minio_client().await;
+    ensure_bucket_exists(&minio_client, TEST_BUCKET).await;
+
+    // Clean up any previous test data
+    let test_prefix = format!("checkpoints/{test_topic}/{test_partition}");
+    cleanup_bucket(&minio_client, TEST_BUCKET, &test_prefix).await;
+
+    // Create temp directory for store (shared across test cases)
+    let tmp_store_dir = TempDir::new()?;
+
+    // Create dedup store and populate with enough test data to generate real SST files
+    let store = create_test_dedup_store(tmp_store_dir.path(), test_topic, test_partition);
+    for i in 0..100 {
+        let event = TestRawEventBuilder::new()
+            .distinct_id(&format!("user_{i}"))
+            .token("token1")
+            .event(&format!("event_{i}"))
+            .current_timestamp()
+            .build();
+        let key = TimestampKey::from(&event);
+        let metadata = TimestampMetadata::new(&event);
+        store.put_timestamp_record(&key, &metadata)?;
+    }
+
+    let partition = Partition::new(test_topic.to_string(), test_partition);
+
+    // ============================================================
+    // Test 1: Pre-cancelled token should fail immediately
+    // ============================================================
+    info!("Test 1: Pre-cancelled token should fail immediately");
+
+    // Each test case gets its own TempDir to avoid directory collision
+    let tmp_checkpoint_dir_1 = TempDir::new()?;
+    let config_1 = create_test_checkpoint_config(&tmp_checkpoint_dir_1);
+    let uploader_1 = S3Uploader::new(config_1.clone()).await?;
+    let exporter_1 = Arc::new(CheckpointExporter::new(Box::new(uploader_1)));
+
+    let worker_1 = CheckpointWorker::new_for_testing(
+        1,
+        Path::new(&config_1.local_checkpoint_dir),
+        &config_1.s3_key_prefix,
+        partition.clone(),
+        Utc::now(),
+        Some(exporter_1),
+    );
+
+    let pre_cancelled_token = CancellationToken::new();
+    pre_cancelled_token.cancel();
+
+    let start = Instant::now();
+    let result = worker_1
+        .checkpoint_partition_cancellable(&store, None, Some(&pre_cancelled_token))
+        .await;
+    let elapsed = start.elapsed();
+
+    assert!(result.is_err(), "Checkpoint should fail when pre-cancelled");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.to_lowercase().contains("cancelled"),
+        "Error should mention cancellation: {}",
+        err_msg
+    );
+
+    info!(
+        elapsed_ms = elapsed.as_millis(),
+        error = err_msg,
+        "Pre-cancelled export failed as expected"
+    );
+
+    // Verify: No objects should have been uploaded to MinIO
+    let list_result = minio_client
+        .list_objects_v2()
+        .bucket(TEST_BUCKET)
+        .prefix(&test_prefix)
+        .send()
+        .await?;
+
+    let uploaded_keys: Vec<String> = list_result
+        .contents()
+        .iter()
+        .filter_map(|obj| obj.key().map(String::from))
+        .collect();
+
+    assert!(
+        uploaded_keys.is_empty(),
+        "No files should be uploaded when pre-cancelled. Found: {:?}",
+        uploaded_keys
+    );
+
+    info!("Test 1 passed: Pre-cancelled token prevents upload");
+
+    // ============================================================
+    // Test 2: Normal (non-cancelled) export should succeed
+    // ============================================================
+    info!("Test 2: Normal export should succeed");
+
+    cleanup_bucket(&minio_client, TEST_BUCKET, &test_prefix).await;
+
+    let tmp_checkpoint_dir_2 = TempDir::new()?;
+    let config_2 = create_test_checkpoint_config(&tmp_checkpoint_dir_2);
+    let uploader_2 = S3Uploader::new(config_2.clone()).await?;
+    let exporter_2 = Arc::new(CheckpointExporter::new(Box::new(uploader_2)));
+
+    let worker_2 = CheckpointWorker::new_for_testing(
+        2,
+        Path::new(&config_2.local_checkpoint_dir),
+        &config_2.s3_key_prefix,
+        partition.clone(),
+        Utc::now(),
+        Some(exporter_2),
+    );
+
+    // Export without cancellation token (normal path)
+    let result = worker_2.checkpoint_partition(&store, None).await?;
+    assert!(
+        result.is_some(),
+        "Checkpoint should succeed and return CheckpointInfo"
+    );
+
+    let checkpoint_info = result.unwrap();
+    info!(
+        remote_path = checkpoint_info.get_remote_attempt_path(),
+        file_count = checkpoint_info.metadata.files.len(),
+        "Normal export succeeded"
+    );
+
+    // Verify files were uploaded
+    let list_result = minio_client
+        .list_objects_v2()
+        .bucket(TEST_BUCKET)
+        .prefix(&test_prefix)
+        .send()
+        .await?;
+
+    let uploaded_keys: Vec<String> = list_result
+        .contents()
+        .iter()
+        .filter_map(|obj| obj.key().map(String::from))
+        .collect();
+
+    assert!(
+        !uploaded_keys.is_empty(),
+        "Files should be uploaded for normal export"
+    );
+    assert!(
+        uploaded_keys.iter().any(|k| k.ends_with("metadata.json")),
+        "Should have uploaded metadata.json"
+    );
+    assert!(
+        uploaded_keys.iter().any(|k| k.ends_with(".sst")),
+        "Should have uploaded SST files"
+    );
+
+    info!(
+        uploaded_count = uploaded_keys.len(),
+        "Test 2 passed: Normal export succeeded with {} files",
+        uploaded_keys.len()
+    );
+
+    // ============================================================
+    // Test 3: Export with active (non-cancelled) token should succeed
+    // ============================================================
+    info!("Test 3: Export with active token should succeed");
+
+    cleanup_bucket(&minio_client, TEST_BUCKET, &test_prefix).await;
+
+    let tmp_checkpoint_dir_3 = TempDir::new()?;
+    let config_3 = create_test_checkpoint_config(&tmp_checkpoint_dir_3);
+    let uploader_3 = S3Uploader::new(config_3.clone()).await?;
+    let exporter_3 = Arc::new(CheckpointExporter::new(Box::new(uploader_3)));
+
+    let worker_3 = CheckpointWorker::new_for_testing(
+        3,
+        Path::new(&config_3.local_checkpoint_dir),
+        &config_3.s3_key_prefix,
+        partition.clone(),
+        Utc::now(),
+        Some(exporter_3),
+    );
+
+    let active_token = CancellationToken::new();
+    let result = worker_3
+        .checkpoint_partition_cancellable(&store, None, Some(&active_token))
+        .await?;
+
+    assert!(
+        result.is_some(),
+        "Checkpoint with active token should succeed"
+    );
+
+    let checkpoint_info = result.unwrap();
+
+    // Verify files were uploaded
+    let list_result = minio_client
+        .list_objects_v2()
+        .bucket(TEST_BUCKET)
+        .prefix(&test_prefix)
+        .send()
+        .await?;
+
+    let uploaded_keys: Vec<String> = list_result
+        .contents()
+        .iter()
+        .filter_map(|obj| obj.key().map(String::from))
+        .collect();
+
+    assert!(
+        !uploaded_keys.is_empty(),
+        "Files should be uploaded when token is active"
+    );
+
+    info!(
+        uploaded_count = uploaded_keys.len(),
+        file_count = checkpoint_info.metadata.files.len(),
+        "Test 3 passed: Export with active token succeeded"
+    );
+
+    // Cleanup MinIO bucket
+    cleanup_bucket(&minio_client, TEST_BUCKET, &test_prefix).await;
+
+    info!("All export cancellation tests passed");
+    Ok(())
+}
+
+/// Test that mid-upload cancellation stops quickly and doesn't leave orphaned objects.
+/// This test creates a larger checkpoint and cancels mid-stream to verify:
+/// 1. Cancellation is detected during upload
+/// 2. Upload stops promptly (doesn't complete all files)
+/// 3. No metadata.json is uploaded (ensuring all-or-nothing semantics)
+#[tokio::test]
+async fn test_export_mid_upload_cancellation() -> Result<()> {
+    let test_topic = "test_export_mid_cancel";
+    let test_partition = 0;
+
+    // Create MinIO client and ensure bucket exists
+    let minio_client = create_minio_client().await;
+    ensure_bucket_exists(&minio_client, TEST_BUCKET).await;
+
+    // Clean up any previous test data
+    let test_prefix = format!("checkpoints/{test_topic}/{test_partition}");
+    cleanup_bucket(&minio_client, TEST_BUCKET, &test_prefix).await;
+
+    // Create temp directories
+    let tmp_store_dir = TempDir::new()?;
+    let tmp_checkpoint_dir = TempDir::new()?;
+
+    // Create dedup store with more data to increase upload time
+    let store = create_test_dedup_store(tmp_store_dir.path(), test_topic, test_partition);
+    for i in 0..500 {
+        let event = TestRawEventBuilder::new()
+            .distinct_id(&format!("user_{i}"))
+            .token(&format!("token_{}", i % 10))
+            .event(&format!("event_type_{}", i % 5))
+            .current_timestamp()
+            .build();
+        let key = TimestampKey::from(&event);
+        let metadata = TimestampMetadata::new(&event);
+        store.put_timestamp_record(&key, &metadata)?;
+    }
+
+    // Create checkpoint config with real MinIO
+    let config = create_test_checkpoint_config(&tmp_checkpoint_dir);
+
+    // Create S3Uploader and exporter
+    let uploader = S3Uploader::new(config.clone()).await?;
+    let exporter = Arc::new(CheckpointExporter::new(Box::new(uploader)));
+
+    let partition = Partition::new(test_topic.to_string(), test_partition);
+    let attempt_timestamp = Utc::now();
+
+    let worker = CheckpointWorker::new_for_testing(
+        1,
+        Path::new(&config.local_checkpoint_dir),
+        &config.s3_key_prefix,
+        partition.clone(),
+        attempt_timestamp,
+        Some(exporter.clone()),
+    );
+
+    // Create a token that will be cancelled shortly after starting
+    // This simulates a rebalance occurring during checkpoint export
+    let cancel_token = CancellationToken::new();
+    let cancel_token_clone = cancel_token.clone();
+
+    // Spawn a task to cancel after a short delay
+    tokio::spawn(async move {
+        // Small delay to let the upload start
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        cancel_token_clone.cancel();
+        info!("Cancellation token triggered");
+    });
+
+    let start = Instant::now();
+    let result = worker
+        .checkpoint_partition_cancellable(&store, None, Some(&cancel_token))
+        .await;
+    let elapsed = start.elapsed();
+
+    // The result depends on timing - it may succeed if upload completed before cancellation,
+    // or fail with cancellation error if caught mid-upload
+    match &result {
+        Ok(Some(info)) => {
+            info!(
+                elapsed_ms = elapsed.as_millis(),
+                remote_path = info.get_remote_attempt_path(),
+                "Upload completed before cancellation (timing dependent)"
+            );
+        }
+        Ok(None) => {
+            info!(
+                elapsed_ms = elapsed.as_millis(),
+                "Export was skipped (no exporter configured - unexpected)"
+            );
+        }
+        Err(e) => {
+            let err_msg = e.to_string();
+            info!(
+                elapsed_ms = elapsed.as_millis(),
+                error = err_msg,
+                "Upload cancelled mid-stream as expected"
+            );
+
+            // If cancelled, verify no metadata.json was uploaded (all-or-nothing)
+            let list_result = minio_client
+                .list_objects_v2()
+                .bucket(TEST_BUCKET)
+                .prefix(&test_prefix)
+                .send()
+                .await?;
+
+            let uploaded_keys: Vec<String> = list_result
+                .contents()
+                .iter()
+                .filter_map(|obj| obj.key().map(String::from))
+                .collect();
+
+            // metadata.json should NOT exist if cancelled mid-upload
+            // (it's uploaded last, after all files succeed)
+            let has_metadata = uploaded_keys.iter().any(|k| k.ends_with("metadata.json"));
+            if !has_metadata && !uploaded_keys.is_empty() {
+                info!(
+                    partial_files = uploaded_keys.len(),
+                    "Verified: No metadata.json uploaded (all-or-nothing semantics preserved)"
+                );
+            }
+        }
+    }
+
+    info!(
+        elapsed_ms = elapsed.as_millis(),
+        "Mid-upload cancellation test completed"
+    );
+
+    // Cleanup
+    cleanup_bucket(&minio_client, TEST_BUCKET, &test_prefix).await;
+
+    Ok(())
+}

--- a/rust/kafka-deduplicator/tests/checkpoint_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_tests.rs
@@ -115,7 +115,11 @@ impl Default for MockUploader {
 
 #[async_trait]
 impl CheckpointUploader for MockUploader {
-    async fn upload_checkpoint_with_plan(&self, plan: &CheckpointPlan) -> Result<Vec<String>> {
+    async fn upload_checkpoint_with_plan_cancellable(
+        &self,
+        plan: &CheckpointPlan,
+        _cancel_token: Option<&tokio_util::sync::CancellationToken>,
+    ) -> Result<Vec<String>> {
         info!(
             "Mock uploading checkpoint with plan: {} files to upload to remote path: {}",
             plan.files_to_upload.len(),

--- a/rust/kafka-deduplicator/tests/checkpoint_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_tests.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
+use tokio_util::sync::CancellationToken;
 
 use kafka_deduplicator::checkpoint::{
     CheckpointConfig, CheckpointExporter, CheckpointMetadata, CheckpointPlan, CheckpointUploader,
@@ -18,9 +19,13 @@ use anyhow::{Context, Result};
 use tempfile::TempDir;
 use tracing::info;
 
-/// Mock uploader for testing that stores files in local filesystem
+/// Mock uploader for testing that stores files in local filesystem.
+/// Holds ownership of TempDir via Arc to ensure the directory persists for the uploader's lifetime
+/// and survives cloning (multiple references share the same temp directory).
 #[derive(Debug, Clone)]
 pub struct MockUploader {
+    /// TempDir that owns the upload directory (shared across clones, dropped when all refs gone)
+    _temp_dir: Arc<TempDir>,
     /// Local directory where uploaded files are stored
     upload_dir: PathBuf,
     /// Whether the uploader should simulate being available
@@ -30,16 +35,20 @@ pub struct MockUploader {
 impl MockUploader {
     pub fn new() -> Result<Self> {
         let temp_dir = TempDir::new()?;
+        let upload_dir = temp_dir.path().to_path_buf();
         Ok(Self {
-            upload_dir: temp_dir.path().to_path_buf(),
+            _temp_dir: Arc::new(temp_dir),
+            upload_dir,
             available: true,
         })
     }
 
     pub fn new_unavailable() -> Result<Self> {
         let temp_dir = TempDir::new()?;
+        let upload_dir = temp_dir.path().to_path_buf();
         Ok(Self {
-            upload_dir: temp_dir.path().to_path_buf(),
+            _temp_dir: Arc::new(temp_dir),
+            upload_dir,
             available: false,
         })
     }
@@ -92,19 +101,6 @@ impl MockUploader {
         let files = self.get_stored_files().await?;
         Ok(files.len())
     }
-
-    async fn upload_files(&self, files_to_upload: Vec<(PathBuf, String)>) -> Result<Vec<String>> {
-        let mut uploaded_keys = Vec::new();
-
-        for (local_file_path, remote_file_path_str) in files_to_upload {
-            let remote_file_path = self.upload_dir.join(&remote_file_path_str);
-            // Copy the file to the upload directory
-            tokio::fs::copy(&local_file_path, &remote_file_path).await?;
-            uploaded_keys.push(remote_file_path_str);
-        }
-
-        Ok(uploaded_keys)
-    }
 }
 
 impl Default for MockUploader {
@@ -118,8 +114,16 @@ impl CheckpointUploader for MockUploader {
     async fn upload_checkpoint_with_plan_cancellable(
         &self,
         plan: &CheckpointPlan,
-        _cancel_token: Option<&tokio_util::sync::CancellationToken>,
+        cancel_token: Option<&CancellationToken>,
     ) -> Result<Vec<String>> {
+        // Check cancellation before starting (matching real S3Uploader behavior)
+        if let Some(token) = cancel_token {
+            if token.is_cancelled() {
+                info!("Mock uploader: cancelled before starting");
+                return Err(anyhow::anyhow!("Upload cancelled before starting"));
+            }
+        }
+
         info!(
             "Mock uploading checkpoint with plan: {} files to upload to remote path: {}",
             plan.files_to_upload.len(),
@@ -137,7 +141,27 @@ impl CheckpointUploader for MockUploader {
             ));
         }
 
-        let mut uploaded_keys = self.upload_files(files_to_upload).await?;
+        // Check cancellation before each file upload (simulating real behavior)
+        let mut uploaded_keys = Vec::new();
+        for (local_file_path, remote_file_path_str) in files_to_upload {
+            if let Some(token) = cancel_token {
+                if token.is_cancelled() {
+                    info!("Mock uploader: cancelled during file upload");
+                    return Err(anyhow::anyhow!("Upload cancelled during file upload"));
+                }
+            }
+            let remote_file_path = self.upload_dir.join(&remote_file_path_str);
+            tokio::fs::copy(&local_file_path, &remote_file_path).await?;
+            uploaded_keys.push(remote_file_path_str);
+        }
+
+        // Check cancellation before metadata upload (final gate, matching S3Uploader)
+        if let Some(token) = cancel_token {
+            if token.is_cancelled() {
+                info!("Mock uploader: cancelled before metadata upload");
+                return Err(anyhow::anyhow!("Upload cancelled before metadata upload"));
+            }
+        }
 
         let metadata_key = self.upload_dir.join(plan.info.get_metadata_key());
         let metadata_json = &plan
@@ -546,4 +570,201 @@ async fn test_checkpoint_from_plan_with_previous_metadata() {
     assert!(next_remote_checkpoint_files
         .keys()
         .all(|k| !k.ends_with(".log")));
+}
+
+// ============================================================
+// Cancellation Tests
+// ============================================================
+
+#[tokio::test]
+async fn test_checkpoint_with_pre_cancelled_token_fails() {
+    let test_topic = "test_pre_cancelled";
+    let test_partition = 0;
+    let tmp_store_dir = TempDir::new().unwrap();
+    let store = create_test_dedup_store(tmp_store_dir.path(), test_topic, test_partition);
+
+    // Add test data
+    let event = TestRawEventBuilder::new()
+        .distinct_id("user1")
+        .token("token1")
+        .event("event1")
+        .current_timestamp()
+        .build();
+    let key = (&event).into();
+    let metadata = TimestampMetadata::new(&event);
+    store.put_timestamp_record(&key, &metadata).unwrap();
+
+    let tmp_checkpoint_dir = TempDir::new().unwrap();
+    let config = CheckpointConfig {
+        checkpoint_interval: Duration::from_secs(60),
+        local_checkpoint_dir: tmp_checkpoint_dir.path().to_string_lossy().to_string(),
+        s3_bucket: "test-bucket".to_string(),
+        s3_key_prefix: "test-prefix".to_string(),
+        aws_region: Some("us-east-1".to_string()),
+        ..Default::default()
+    };
+
+    let uploader = Box::new(MockUploader::new().unwrap());
+    let exporter = Some(Arc::new(CheckpointExporter::new(uploader.clone())));
+
+    let partition = Partition::new(test_topic.to_string(), test_partition);
+    let attempt_timestamp = Utc::now();
+
+    let worker = CheckpointWorker::new(
+        1,
+        Path::new(&config.local_checkpoint_dir),
+        config.s3_key_prefix.clone(),
+        partition.clone(),
+        attempt_timestamp,
+        exporter.clone(),
+        None,
+    );
+
+    // Create pre-cancelled token
+    let cancel_token = CancellationToken::new();
+    cancel_token.cancel();
+
+    // Checkpoint should fail with cancellation error
+    let result = worker
+        .checkpoint_partition_cancellable(&store, None, Some(&cancel_token))
+        .await;
+
+    assert!(result.is_err(), "Checkpoint should fail when pre-cancelled");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.to_lowercase().contains("cancelled"),
+        "Error should mention cancellation: {}",
+        err_msg
+    );
+
+    // Verify no files were uploaded
+    let file_count = uploader.file_count().await.unwrap();
+    assert_eq!(
+        file_count, 0,
+        "No files should be uploaded when pre-cancelled"
+    );
+}
+
+#[tokio::test]
+async fn test_checkpoint_with_active_token_succeeds() {
+    let test_topic = "test_active_token";
+    let test_partition = 0;
+    let tmp_store_dir = TempDir::new().unwrap();
+    let store = create_test_dedup_store(tmp_store_dir.path(), test_topic, test_partition);
+
+    // Add test data
+    let event = TestRawEventBuilder::new()
+        .distinct_id("user1")
+        .token("token1")
+        .event("event1")
+        .current_timestamp()
+        .build();
+    let key = (&event).into();
+    let metadata = TimestampMetadata::new(&event);
+    store.put_timestamp_record(&key, &metadata).unwrap();
+
+    let tmp_checkpoint_dir = TempDir::new().unwrap();
+    let config = CheckpointConfig {
+        checkpoint_interval: Duration::from_secs(60),
+        local_checkpoint_dir: tmp_checkpoint_dir.path().to_string_lossy().to_string(),
+        s3_bucket: "test-bucket".to_string(),
+        s3_key_prefix: "test-prefix".to_string(),
+        aws_region: Some("us-east-1".to_string()),
+        ..Default::default()
+    };
+
+    let uploader = Box::new(MockUploader::new().unwrap());
+    let exporter = Some(Arc::new(CheckpointExporter::new(uploader.clone())));
+
+    let partition = Partition::new(test_topic.to_string(), test_partition);
+    let attempt_timestamp = Utc::now();
+
+    let worker = CheckpointWorker::new(
+        1,
+        Path::new(&config.local_checkpoint_dir),
+        config.s3_key_prefix.clone(),
+        partition.clone(),
+        attempt_timestamp,
+        exporter.clone(),
+        None,
+    );
+
+    // Create active (non-cancelled) token
+    let cancel_token = CancellationToken::new();
+
+    // Checkpoint should succeed with active token
+    let result = worker
+        .checkpoint_partition_cancellable(&store, None, Some(&cancel_token))
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "Checkpoint should succeed with active token"
+    );
+    let info = result.unwrap();
+    assert!(info.is_some(), "Should return CheckpointInfo");
+
+    // Verify files were uploaded
+    let file_count = uploader.file_count().await.unwrap();
+    assert!(
+        file_count > 0,
+        "Files should be uploaded when token is active"
+    );
+}
+
+#[tokio::test]
+async fn test_checkpoint_without_token_succeeds() {
+    // Verify the legacy non-cancellable path still works
+    let test_topic = "test_no_token";
+    let test_partition = 0;
+    let tmp_store_dir = TempDir::new().unwrap();
+    let store = create_test_dedup_store(tmp_store_dir.path(), test_topic, test_partition);
+
+    // Add test data
+    let event = TestRawEventBuilder::new()
+        .distinct_id("user1")
+        .token("token1")
+        .event("event1")
+        .current_timestamp()
+        .build();
+    let key = (&event).into();
+    let metadata = TimestampMetadata::new(&event);
+    store.put_timestamp_record(&key, &metadata).unwrap();
+
+    let tmp_checkpoint_dir = TempDir::new().unwrap();
+    let config = CheckpointConfig {
+        checkpoint_interval: Duration::from_secs(60),
+        local_checkpoint_dir: tmp_checkpoint_dir.path().to_string_lossy().to_string(),
+        s3_bucket: "test-bucket".to_string(),
+        s3_key_prefix: "test-prefix".to_string(),
+        aws_region: Some("us-east-1".to_string()),
+        ..Default::default()
+    };
+
+    let uploader = Box::new(MockUploader::new().unwrap());
+    let exporter = Some(Arc::new(CheckpointExporter::new(uploader.clone())));
+
+    let partition = Partition::new(test_topic.to_string(), test_partition);
+    let attempt_timestamp = Utc::now();
+
+    let worker = CheckpointWorker::new(
+        1,
+        Path::new(&config.local_checkpoint_dir),
+        config.s3_key_prefix.clone(),
+        partition.clone(),
+        attempt_timestamp,
+        exporter.clone(),
+        None,
+    );
+
+    // Use legacy non-cancellable method (no token)
+    let result = worker.checkpoint_partition(&store, None).await;
+
+    assert!(result.is_ok(), "Legacy checkpoint should succeed");
+    let info = result.unwrap();
+    assert!(info.is_some(), "Should return CheckpointInfo");
+
+    // Verify files were uploaded
+    let file_count = uploader.file_count().await.unwrap();
+    assert!(file_count > 0, "Files should be uploaded");
 }


### PR DESCRIPTION
## Problem
Unless we cancel in-flight checkpoint exports rapidly we can waste IOPS and time as remaining files transfer for no improvement on the outcome. Due the nature of the service, we need to conserve IO and CPU time where possible especially on the store volumes.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add comprehensive, granular fail-fast handling on cancel to export flow as we did to import today
* New config values to support the new features
* Related updates to export metrics and test suites
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
