### PR TITLE
chore(ducklake): simplify schema and table naming

### DIFF
--- a/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
@@ -191,11 +191,11 @@ async def prepare_data_imports_ducklake_metadata_activity(
                 source_normalized_name=normalized_name,
                 source_table_uri=source_table_uri,
                 ducklake_schema_name=_sanitize_ducklake_identifier(
-                    f"{DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX}_team_{inputs.team_id}",
+                    f"{DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX}",
                     default_prefix=DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX,
                 ),
                 ducklake_table_name=_sanitize_ducklake_identifier(
-                    f"{source_type}_{normalized_name}_{schema.id.hex[:8]}", default_prefix="data_imports"
+                    f"{source_type}_{normalized_name}", default_prefix="data_imports"
                 ),
                 verification_queries=list(get_data_imports_verification_queries(normalized_name)),
                 source_partition_column=partition_column,

--- a/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
@@ -151,7 +151,7 @@ async def prepare_data_modeling_ducklake_metadata_activity(
                 normalized_name=normalized_name,
                 source_table_uri=model.table_uri,
                 schema_name=_sanitize_ducklake_identifier(
-                    f"{DATA_MODELING_DUCKLAKE_WORKFLOW_PREFIX}_team_{inputs.team_id}",
+                    f"{DATA_MODELING_DUCKLAKE_WORKFLOW_PREFIX}",
                     default_prefix=DATA_MODELING_DUCKLAKE_WORKFLOW_PREFIX,
                 ),
                 table_name=_sanitize_ducklake_identifier(model.model_label or normalized_name, default_prefix="model"),

--- a/posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py
@@ -132,8 +132,8 @@ async def test_prepare_data_imports_ducklake_metadata_activity_basic(ateam, monk
     assert len(result) == 1
     metadata = result[0]
     assert metadata.source_normalized_name == "customers"
-    assert metadata.ducklake_schema_name == f"data_imports_team_{ateam.id}"
-    assert metadata.ducklake_table_name.startswith("postgres_customers_")
+    assert metadata.ducklake_schema_name == "data_imports"
+    assert metadata.ducklake_table_name == "postgres_customers"
     assert metadata.source_partition_column == "created_at"
 
 

--- a/posthog/temporal/tests/ducklake/test_ducklake_copy_data_modeling_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_copy_data_modeling_workflow.py
@@ -82,7 +82,7 @@ async def test_prepare_data_modeling_ducklake_metadata_activity_returns_models(
     assert model_metadata.model_label == saved_query.id.hex
     assert model_metadata.saved_query_name == saved_query.name
     assert model_metadata.source_table_uri == table_uri
-    assert model_metadata.schema_name == f"data_modeling_team_{ateam.pk}"
+    assert model_metadata.schema_name == "data_modeling"
     assert model_metadata.table_name == f"model_{saved_query.id.hex}"
     assert model_metadata.verification_queries
     assert model_metadata.verification_queries[0].name == "row_count_delta_vs_ducklake"


### PR DESCRIPTION
## Summary
- Remove `_team_{team_id}` suffix from ducklake schema names
- Remove `_{schema.id.hex[:8]}` suffix from data imports table names
- not needed after #45739 

## Test plan
- [ ] Verify ducklake copy workflows still function correctly with simplified names

🤖 Generated with [Claude Code](https://claude.com/claude-code)