### PR TITLE
feat(hogli): allow overriding hogli mprocs path

### DIFF
--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -6,6 +6,7 @@ The system is designed to be process-manager agnostic - mprocs is just one outpu
 
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -268,6 +269,10 @@ def load_devenv_config(mprocs_path: Path) -> DevenvConfig | None:
 
 def get_generated_mprocs_path() -> Path:
     """Get the default path for generated mprocs config."""
+    # check global shell env override first
+    override_path = os.getenv("HOGLI_MPROCS_PATH")
+    if override_path:
+        return Path(override_path)
     # Walk up from cwd to find repo root
     current = Path.cwd().resolve()
     for parent in [current, *current.parents]:


### PR DESCRIPTION
## Problem

when developing with twig a common workflow is git worktrees. each worktree would need to regen its own mprocs with dev:setup. this is also a problem with flox where the flox caches aren't shared among worktrees.

## Changes

make the hogli mprocs path overridable via shell env. (i've also gotten back off of flox by reusing a global uv venv shared among all my worktrees. i just have to be religious about running uv sync)

## How did you test this code?

ran locally

## Publish to changelog?

no