### PR TITLE
feat(llma): Eval results summarization limit bump

### DIFF
--- a/products/llm_analytics/backend/api/evaluation_summary.py
+++ b/products/llm_analytics/backend/api/evaluation_summary.py
@@ -58,8 +58,8 @@ class EvaluationSummaryRequestSerializer(serializers.Serializer):
     generation_ids = serializers.ListField(
         child=serializers.UUIDField(),
         required=False,
-        max_length=100,
-        help_text="Optional: specific generation IDs to include in summary (max 100)",
+        max_length=250,
+        help_text="Optional: specific generation IDs to include in summary (max 250)",
     )
     force_refresh = serializers.BooleanField(
         default=False,
@@ -97,7 +97,7 @@ def _fetch_evaluation_runs(
     evaluation_id: str,
     filter_type: str = "all",
     generation_ids: list[str] | None = None,
-    limit: int = 100,
+    limit: int = 250,
 ) -> list[dict]:
     """
     Fetch evaluation runs from ClickHouse using HogQL.
@@ -374,7 +374,7 @@ Data is fetched server-side by evaluation ID to ensure data integrity.
                 evaluation_id=evaluation_id,
                 filter_type=filter_type,
                 generation_ids=generation_id_strs,
-                limit=100,
+                limit=250,
             )
 
             if len(runs) == 0:

--- a/products/llm_analytics/backend/api/evaluation_summary.py
+++ b/products/llm_analytics/backend/api/evaluation_summary.py
@@ -39,6 +39,7 @@ from posthog.rate_limit import (
 
 from products.llm_analytics.backend.api.metrics import llma_track_latency
 from products.llm_analytics.backend.models.evaluations import Evaluation
+from products.llm_analytics.backend.summarization.constants import EVALUATION_SUMMARY_MAX_RUNS
 from products.llm_analytics.backend.summarization.llm.evaluation_summary import summarize_evaluation_runs
 from products.llm_analytics.backend.summarization.models import OpenAIModel
 
@@ -58,8 +59,8 @@ class EvaluationSummaryRequestSerializer(serializers.Serializer):
     generation_ids = serializers.ListField(
         child=serializers.UUIDField(),
         required=False,
-        max_length=250,
-        help_text="Optional: specific generation IDs to include in summary (max 250)",
+        max_length=EVALUATION_SUMMARY_MAX_RUNS,
+        help_text=f"Optional: specific generation IDs to include in summary (max {EVALUATION_SUMMARY_MAX_RUNS})",
     )
     force_refresh = serializers.BooleanField(
         default=False,
@@ -97,7 +98,7 @@ def _fetch_evaluation_runs(
     evaluation_id: str,
     filter_type: str = "all",
     generation_ids: list[str] | None = None,
-    limit: int = 250,
+    limit: int = EVALUATION_SUMMARY_MAX_RUNS,
 ) -> list[dict]:
     """
     Fetch evaluation runs from ClickHouse using HogQL.
@@ -374,7 +375,7 @@ Data is fetched server-side by evaluation ID to ensure data integrity.
                 evaluation_id=evaluation_id,
                 filter_type=filter_type,
                 generation_ids=generation_id_strs,
-                limit=250,
+                limit=EVALUATION_SUMMARY_MAX_RUNS,
             )
 
             if len(runs) == 0:

--- a/products/llm_analytics/backend/api/test/test_evaluation_summary.py
+++ b/products/llm_analytics/backend/api/test/test_evaluation_summary.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from rest_framework import status
 
 from products.llm_analytics.backend.models.evaluations import Evaluation
+from products.llm_analytics.backend.summarization.constants import EVALUATION_SUMMARY_MAX_RUNS
 from products.llm_analytics.backend.summarization.llm.evaluation_schema import (
     EvaluationPattern,
     EvaluationSummaryResponse,
@@ -326,8 +327,8 @@ class TestEvaluationSummaryAPI(APIBaseTest):
         self.organization.is_ai_data_processing_approved = True
         self.organization.save()
 
-        # Try to pass more than 250 generation_ids
-        generation_ids = [str(uuid.uuid4()) for _ in range(251)]
+        # Try to pass more than EVALUATION_SUMMARY_MAX_RUNS generation_ids
+        generation_ids = [str(uuid.uuid4()) for _ in range(EVALUATION_SUMMARY_MAX_RUNS + 1)]
 
         response = self.client.post(
             f"/api/environments/{self.team.id}/llm_analytics/evaluation_summary/",

--- a/products/llm_analytics/backend/api/test/test_evaluation_summary.py
+++ b/products/llm_analytics/backend/api/test/test_evaluation_summary.py
@@ -326,8 +326,8 @@ class TestEvaluationSummaryAPI(APIBaseTest):
         self.organization.is_ai_data_processing_approved = True
         self.organization.save()
 
-        # Try to pass more than 100 generation_ids
-        generation_ids = [str(uuid.uuid4()) for _ in range(101)]
+        # Try to pass more than 250 generation_ids
+        generation_ids = [str(uuid.uuid4()) for _ in range(251)]
 
         response = self.client.post(
             f"/api/environments/{self.team.id}/llm_analytics/evaluation_summary/",

--- a/products/llm_analytics/backend/summarization/constants.py
+++ b/products/llm_analytics/backend/summarization/constants.py
@@ -8,3 +8,6 @@ DEFAULT_MODE = SummarizationMode.MINIMAL
 
 # Timeout configuration (seconds)
 SUMMARIZATION_TIMEOUT = 120
+
+# Evaluation summary limits
+EVALUATION_SUMMARY_MAX_RUNS = 250

--- a/products/llm_analytics/frontend/evaluations/constants.ts
+++ b/products/llm_analytics/frontend/evaluations/constants.ts
@@ -1,0 +1,3 @@
+// Evaluation summary limits
+// This should match EVALUATION_SUMMARY_MAX_RUNS in backend/summarization/constants.py
+export const EVALUATION_SUMMARY_MAX_RUNS = 250

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
@@ -4,6 +4,7 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import { LLMProviderKey, llmProviderKeysLogic } from '../settings/llmProviderKeysLogic'
+import { EVALUATION_SUMMARY_MAX_RUNS } from './constants'
 import { llmEvaluationLogic } from './llmEvaluationLogic'
 import { EvaluationConfig, EvaluationRun } from './types'
 
@@ -457,8 +458,8 @@ describe('llmEvaluationLogic', () => {
                 })
             })
 
-            it('caps count at 250', async () => {
-                const manyRuns = Array.from({ length: 300 }, (_, i) => ({
+            it(`caps count at ${EVALUATION_SUMMARY_MAX_RUNS}`, async () => {
+                const manyRuns = Array.from({ length: EVALUATION_SUMMARY_MAX_RUNS + 50 }, (_, i) => ({
                     ...mockRuns[0],
                     id: `run-${i}`,
                     generation_id: `gen-${i}`,
@@ -466,7 +467,7 @@ describe('llmEvaluationLogic', () => {
                 logic.actions.loadEvaluationRunsSuccess(manyRuns)
 
                 await expectLogic(logic).toMatchValues({
-                    runsToSummarizeCount: 250,
+                    runsToSummarizeCount: EVALUATION_SUMMARY_MAX_RUNS,
                 })
             })
         })

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
@@ -457,8 +457,8 @@ describe('llmEvaluationLogic', () => {
                 })
             })
 
-            it('caps count at 100', async () => {
-                const manyRuns = Array.from({ length: 150 }, (_, i) => ({
+            it('caps count at 250', async () => {
+                const manyRuns = Array.from({ length: 300 }, (_, i) => ({
                     ...mockRuns[0],
                     id: `run-${i}`,
                     generation_id: `gen-${i}`,
@@ -466,7 +466,7 @@ describe('llmEvaluationLogic', () => {
                 logic.actions.loadEvaluationRunsSuccess(manyRuns)
 
                 await expectLogic(logic).toMatchValues({
-                    runsToSummarizeCount: 100,
+                    runsToSummarizeCount: 250,
                 })
             })
         })

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -11,6 +11,7 @@ import { Breadcrumb } from '~/types'
 
 import { LLMProvider, LLMProviderKey, llmProviderKeysLogic } from '../settings/llmProviderKeysLogic'
 import { queryEvaluationRuns } from '../utils'
+import { EVALUATION_SUMMARY_MAX_RUNS } from './constants'
 import type { llmEvaluationLogicType } from './llmEvaluationLogicType'
 import { EvaluationTemplateKey, defaultEvaluationTemplates } from './templates'
 import {
@@ -566,7 +567,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 } else if (filter === 'na') {
                     filteredRuns = filteredRuns.filter((r) => r.result === null)
                 }
-                return Math.min(filteredRuns.length, 250)
+                return Math.min(filteredRuns.length, EVALUATION_SUMMARY_MAX_RUNS)
             },
         ],
 

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -566,7 +566,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 } else if (filter === 'na') {
                     filteredRuns = filteredRuns.filter((r) => r.result === null)
                 }
-                return Math.min(filteredRuns.length, 100)
+                return Math.min(filteredRuns.length, 250)
             },
         ],
 

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -399,8 +399,8 @@ export interface EvaluationSummaryRequestApi {
 * `na` - na */
     filter?: FilterEnumApi
     /**
-     * Optional: specific generation IDs to include in summary (max 100)
-     * @maxItems 100
+     * Optional: specific generation IDs to include in summary (max 250)
+     * @maxItems 250
      */
     generation_ids?: string[]
     /** If true, bypass cache and generate a fresh summary */


### PR DESCRIPTION
## Problem

Users of the LLM analytics evaluation results summarization feature are currently limited to summarizing only 100 evaluation runs. This enhancement increases that limit to 250, allowing for more comprehensive analysis of LLM evaluations.

## Changes

*   Increased the maximum number of evaluation runs for summarization from 100 to 250.
*   Introduced `EVALUATION_SUMMARY_MAX_RUNS` constant in `products/llm_analytics/backend/summarization/constants.py` and `products/llm_analytics/frontend/evaluations/constants.ts`.
*   Updated backend (`evaluation_summary.py`) to use the new constant for `generation_ids` max length, default `limit`, and function call `limit`.
*   Updated frontend (`llmEvaluationLogic.ts`) to use the new constant for capping the `runsToSummarizeCount`.
*   Updated relevant tests (`test_evaluation_summary.py`, `llmEvaluationLogic.test.ts`) to reflect the new limit and use the constants.

## How did you test this code?

*   Updated existing unit tests for both backend and frontend to assert the new limit of 250.
*   Verified Python linting and TypeScript compilation.

## Publish to changelog?

No

---
<a href="https://cursor.com/background-agent?bcId=bc-115ef3cf-0e2a-4ac0-ab9c-3cc4ddb5d60e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-115ef3cf-0e2a-4ac0-ab9c-3cc4ddb5d60e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

