### PR TITLE
fix(signals): Support video-first summarization in Replay

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1176,9 +1176,12 @@ class SessionRecordingViewSet(
             )
 
         except Exception as e:
+            # Capture detailed exception server-side while returning a generic error to the client
+            capture_exception(e)
+            error_payload = {"status": "error", "message": "Failed to generate session summary."}
             yield serialize_to_sse_event(
                 event_label="session-summary-error",
-                event_data=str(e),
+                event_data=json.dumps(error_payload),
             )
 
 

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1174,12 +1174,13 @@ class SessionRecordingViewSet(
                 event_label="session-summary-stream",
                 event_data=json.dumps(summary_result),
             )
+
         except Exception as e:
             yield serialize_to_sse_event(
                 event_label="session-summary-error",
                 event_data=str(e),
             )
-            raise
+
 
     @extend_schema(exclude=True)
     @action(methods=["POST"], detail=True)

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -82,10 +82,12 @@ from posthog.session_recordings.utils import (
 from posthog.settings.session_replay import SESSION_REPLAY_AI_REGEX_MODEL
 from posthog.storage import session_recording_v2_object_storage
 from posthog.storage.session_recording_v2_object_storage import BlockFetchError
+from posthog.temporal.ai.session_summary.summarize_session import execute_summarize_session
 
 from ee.hogai.session_summaries.llm.call import get_openai_client
 from ee.hogai.session_summaries.session.stream import stream_recording_summary
 from ee.hogai.session_summaries.tracking import capture_session_summary_started, generate_tracking_id
+from ee.hogai.session_summaries.utils import serialize_to_sse_event
 
 from ..models.product_intent.product_intent import ProductIntent
 from .queries.combine_session_ids_for_filtering import combine_session_id_filters
@@ -1143,6 +1145,42 @@ class SessionRecordingViewSet(
         except:
             return "unknown"
 
+    def _determine_video_based_summarization_enabled(self, user: User) -> bool:
+        """Check if video-based summarization is enabled (uses video as base instead of events)."""
+        return (
+            posthoganalytics.feature_enabled(
+                "max-session-summarization-video-as-base",
+                str(user.distinct_id),
+                groups={"organization": str(self.team.organization_id)},
+                group_properties={"organization": {"id": str(self.team.organization_id)}},
+                send_feature_flag_events=False,
+            )
+            or False
+        )
+
+    def _generate_video_based_summary(self, session_id: str, user: User) -> Generator[str, None, None]:
+        """Execute video-based summarization and yield result as SSE event."""
+
+        try:
+            summary_result = asyncio.run(
+                execute_summarize_session(
+                    session_id=session_id,
+                    user=user,
+                    team=self.team,
+                    video_validation_enabled="full",
+                )
+            )
+            yield serialize_to_sse_event(
+                event_label="session-summary-stream",
+                event_data=json.dumps(summary_result),
+            )
+        except Exception as e:
+            yield serialize_to_sse_event(
+                event_label="session-summary-error",
+                event_data=str(e),
+            )
+            raise
+
     @extend_schema(exclude=True)
     @action(methods=["POST"], detail=True)
     def summarize(self, request: request.Request, **kwargs):
@@ -1178,24 +1216,43 @@ class SessionRecordingViewSet(
         ):
             raise exceptions.ValidationError("session summary is not enabled for this user")
         session_id = str(recording.session_id)
-        # Track streaming summary start (no completion tracking for streaming)
         tracking_id = generate_tracking_id()
-        capture_session_summary_started(
-            user=user,
-            team=self.team,
-            tracking_id=tracking_id,
-            summary_source="api",
-            summary_type="single",
-            is_streaming=True,
-            session_ids=[session_id],
-            video_validation_enabled=None,  # Not checked for streaming endpoint
-        )
-        # If you want to test sessions locally - override `session_id` and `self.team.pk`
-        # with session/team ids of your choice and set `local_reads_prod` to True
-        return StreamingHttpResponse(
-            stream_recording_summary(session_id=session_id, user=user, team=self.team),
-            content_type=ServerSentEventRenderer.media_type,
-        )
+        video_based_summarization_enabled = self._determine_video_based_summarization_enabled(user)
+
+        if video_based_summarization_enabled:
+            # Use non-streaming workflow for video-based summarization
+            capture_session_summary_started(
+                user=user,
+                team=self.team,
+                tracking_id=tracking_id,
+                summary_source="api",
+                summary_type="single",
+                is_streaming=False,
+                session_ids=[session_id],
+                video_validation_enabled="full",
+            )
+            return StreamingHttpResponse(
+                self._generate_video_based_summary(session_id, user),
+                content_type=ServerSentEventRenderer.media_type,
+            )
+        else:
+            # Use existing streaming workflow for event-based summarization
+            capture_session_summary_started(
+                user=user,
+                team=self.team,
+                tracking_id=tracking_id,
+                summary_source="api",
+                summary_type="single",
+                is_streaming=True,
+                session_ids=[session_id],
+                video_validation_enabled=None,
+            )
+            # If you want to test sessions locally - override `session_id` and `self.team.pk`
+            # with session/team ids of your choice and set `local_reads_prod` to True
+            return StreamingHttpResponse(
+                stream_recording_summary(session_id=session_id, user=user, team=self.team),
+                content_type=ServerSentEventRenderer.media_type,
+            )
 
     async def _stream_lts_blob_v2_to_client_async(
         self,

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1,3 +1,4 @@
+import os
 from datetime import UTC, datetime, timedelta
 from typing import cast
 from urllib.parse import urlencode
@@ -1832,3 +1833,61 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         # Check cache was NOT set for negative result
         cached_value = cache.get(cache_key)
         assert cached_value is None
+
+    @parameterized.expand(
+        [
+            ("video_based", True),
+            ("event_based", False),
+        ]
+    )
+    @patch("posthog.session_recordings.session_recording_api.stream_recording_summary")
+    @patch("posthog.session_recordings.session_recording_api.execute_summarize_session")
+    @patch("posthog.session_recordings.session_recording_api.is_cloud", return_value=True)
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("posthoganalytics.feature_enabled")
+    def test_summarize_uses_correct_path_based_on_feature_flag(
+        self,
+        _name: str,
+        video_based_enabled: bool,
+        mock_feature_enabled: MagicMock,
+        mock_is_cloud: MagicMock,
+        mock_execute_summarize: MagicMock,
+        mock_stream_summary: MagicMock,
+    ):
+        session_id = str(uuid7())
+        self.produce_replay_summary(
+            distinct_id="user",
+            session_id=session_id,
+            timestamp=now() - timedelta(hours=1),
+        )
+
+        def feature_flag_side_effect(flag_name, *args, **kwargs):
+            if flag_name == "max-session-summarization-video-as-base":
+                return video_based_enabled
+            return True
+
+        mock_feature_enabled.side_effect = feature_flag_side_effect
+
+        async def mock_async_summarize(*args, **kwargs):
+            return {"summary": "test"}
+
+        mock_execute_summarize.side_effect = mock_async_summarize
+        mock_stream_summary.return_value = iter(["data: test\n\n"])
+
+        response = self.client.post(f"/api/projects/{self.team.id}/session_recordings/{session_id}/summarize")
+
+        assert response.status_code == status.HTTP_200_OK
+        # Consume streaming response to trigger the generator
+        list(response.streaming_content)
+
+        if video_based_enabled:
+            mock_execute_summarize.assert_called_once()
+            call_kwargs = mock_execute_summarize.call_args.kwargs
+            assert call_kwargs["session_id"] == session_id
+            assert call_kwargs["user"] == self.user
+            assert call_kwargs["team"] == self.team
+            assert call_kwargs["video_validation_enabled"] == "full"
+            mock_stream_summary.assert_not_called()
+        else:
+            mock_stream_summary.assert_called_once_with(session_id=session_id, user=self.user, team=self.team)
+            mock_execute_summarize.assert_not_called()

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1878,7 +1878,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
         assert response.status_code == status.HTTP_200_OK
         # Consume streaming response to trigger the generator
-        list(response.streaming_content)
+        list(response.streaming_content)  # type: ignore[attr-defined]
 
         if video_based_enabled:
             mock_execute_summarize.assert_called_once()


### PR DESCRIPTION
## Problem

Session summarization in the Session Replay UI currently only supports event-based summarization, and not the newer video-based version.

## Changes

This PR adds support for video-based summarization, where the _streaming_ variant of text-based summarization is replaced with the _non-streaming_ video-based summarization.
This is flagged with the existing `max-session-summarization-video-as-base`.

## How did you test this code?

Added a simple test to `test_session_recordings.py`.
Also, manual testing with feature flag enabled.

## Publish to changelog?

No