### PR TITLE
fix(ph-ai): attribute traces to MCP

### DIFF
--- a/ee/hogai/core/runner.py
+++ b/ee/hogai/core/runner.py
@@ -166,7 +166,7 @@ class BaseAgentRunner(ABC):
                     "is_subagent": not self._use_checkpointer,
                     "$groups": event_usage.groups(team=team),
                     "ai_support_impersonated": not is_agent_billable,
-                    "ai_product": "posthog_ai",
+                    "ai_product": "mcp" if self._conversation.type == Conversation.Type.TOOL_CALL else "posthog_ai",
                     "conversation_type": self._conversation.type,
                 }
                 # Use SubagentCallbackHandler when parent_span_id is provided to nest all events under the parent


### PR DESCRIPTION
## Problem
The current implementation of the AI product tracking in the event usage is not correctly identifying the MCP (Multi-Channel Platform) product when tool calls are being made.

## Changes

Updated the `ai_product` tracking parameter in the event usage to correctly identify "mcp" when the conversation type is a tool call, otherwise it continues to use "posthog_ai".

## How did you test this code?

Verified that the correct product identifier is sent in analytics events by testing both regular conversations and tool call conversations, confirming that the appropriate `ai_product` value is set in each case.

## Publish to changelog?

No