### PR TITLE
feat: browser notifications in support

### DIFF
--- a/products/conversations/frontend/browserNotificationLogic.ts
+++ b/products/conversations/frontend/browserNotificationLogic.ts
@@ -7,13 +7,12 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import type { browserNotificationLogicType } from './browserNotificationLogicType'
+import type { NotificationPermission } from './types'
 
 const STORAGE_KEY_PREFIX = 'posthog-support-notifications'
 const NOTIFICATION_TAG = 'posthog-support-ticket'
 const NOTIFICATION_ICON = '/static/posthog-icon.svg'
 const NOTIFICATION_AUTO_CLOSE_MS = 5000
-
-type NotificationPermission = 'default' | 'granted' | 'denied'
 
 const getStorageKey = (): string => {
     const teamId = getCurrentTeamIdOrNone() ?? teamLogic.findMounted()?.values.currentTeamId ?? 'null'

--- a/products/conversations/frontend/browserNotificationLogic.ts
+++ b/products/conversations/frontend/browserNotificationLogic.ts
@@ -52,7 +52,6 @@ export const browserNotificationLogic = kea<browserNotificationLogicType>([
         requestPermission: true,
         setPermission: (permission: NotificationPermission) => ({ permission }),
         setEnabled: (enabled: boolean) => ({ enabled }),
-        toggleEnabled: true,
         showNotification: (count: number) => ({ count }),
     }),
     reducers({
@@ -69,7 +68,7 @@ export const browserNotificationLogic = kea<browserNotificationLogicType>([
             },
         ],
     }),
-    listeners(({ actions, values }) => ({
+    listeners(({ actions }) => ({
         requestPermission: async () => {
             if (!isNotificationSupported()) {
                 return
@@ -87,13 +86,6 @@ export const browserNotificationLogic = kea<browserNotificationLogicType>([
                 // Permission request failed - likely user dismissed
                 actions.setPermission(Notification.permission as NotificationPermission)
             }
-        },
-        toggleEnabled: () => {
-            // Toggle is only meaningful if permission is granted
-            if (!isNotificationSupported() || Notification.permission !== 'granted') {
-                return
-            }
-            actions.setEnabled(!values.enabled)
         },
         setEnabled: ({ enabled }) => {
             setStoredPreference(enabled)

--- a/products/conversations/frontend/browserNotificationLogic.ts
+++ b/products/conversations/frontend/browserNotificationLogic.ts
@@ -1,0 +1,165 @@
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { router } from 'kea-router'
+import { subscriptions } from 'kea-subscriptions'
+
+import { getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import type { browserNotificationLogicType } from './browserNotificationLogicType'
+
+const STORAGE_KEY_PREFIX = 'posthog-support-notifications'
+const NOTIFICATION_TAG = 'posthog-support-ticket'
+const NOTIFICATION_ICON = '/static/posthog-icon.svg'
+const NOTIFICATION_AUTO_CLOSE_MS = 5000
+
+type NotificationPermission = 'default' | 'granted' | 'denied'
+
+const getStorageKey = (): string => {
+    const teamId = getCurrentTeamIdOrNone() ?? teamLogic.findMounted()?.values.currentTeamId ?? 'null'
+    return `${STORAGE_KEY_PREFIX}-${teamId}`
+}
+
+const isNotificationSupported = (): boolean => {
+    return typeof window !== 'undefined' && 'Notification' in window
+}
+
+const getStoredPreference = (): boolean => {
+    if (typeof localStorage === 'undefined') {
+        return false
+    }
+    const stored = localStorage.getItem(getStorageKey())
+    return stored === 'true'
+}
+
+const setStoredPreference = (enabled: boolean): void => {
+    if (typeof localStorage === 'undefined') {
+        return
+    }
+    if (enabled) {
+        localStorage.setItem(getStorageKey(), 'true')
+    } else {
+        localStorage.removeItem(getStorageKey())
+    }
+}
+
+export const browserNotificationLogic = kea<browserNotificationLogicType>([
+    path(['products', 'conversations', 'frontend', 'browserNotificationLogic']),
+    connect({
+        values: [teamLogic, ['currentTeam']],
+    }),
+    actions({
+        requestPermission: true,
+        setPermission: (permission: NotificationPermission) => ({ permission }),
+        setEnabled: (enabled: boolean) => ({ enabled }),
+        toggleEnabled: true,
+        showNotification: (count: number) => ({ count }),
+    }),
+    reducers({
+        permission: [
+            (isNotificationSupported() ? Notification.permission : 'denied') as NotificationPermission,
+            {
+                setPermission: (_, { permission }) => permission,
+            },
+        ],
+        enabled: [
+            false,
+            {
+                setEnabled: (_, { enabled }) => enabled,
+            },
+        ],
+    }),
+    listeners(({ actions, values }) => ({
+        requestPermission: async () => {
+            if (!isNotificationSupported()) {
+                return
+            }
+
+            try {
+                const result = await Notification.requestPermission()
+                actions.setPermission(result as NotificationPermission)
+
+                // Auto-enable if permission granted
+                if (result === 'granted') {
+                    actions.setEnabled(true)
+                }
+            } catch {
+                // Permission request failed - likely user dismissed
+                actions.setPermission(Notification.permission as NotificationPermission)
+            }
+        },
+        toggleEnabled: () => {
+            // Toggle is only meaningful if permission is granted
+            if (!isNotificationSupported() || Notification.permission !== 'granted') {
+                return
+            }
+            actions.setEnabled(!values.enabled)
+        },
+        setEnabled: ({ enabled }) => {
+            setStoredPreference(enabled)
+        },
+        showNotification: ({ count }) => {
+            // Defense in depth - caller should check canShowNotifications but verify here too
+            if (!isNotificationSupported() || Notification.permission !== 'granted') {
+                return
+            }
+
+            const title = count === 1 ? 'New support message' : `${count} unread support messages`
+            const body = 'Click to view your support tickets'
+
+            const notification = new Notification(title, {
+                body,
+                icon: NOTIFICATION_ICON,
+                tag: NOTIFICATION_TAG, // Replaces previous notification with same tag
+                requireInteraction: false,
+            })
+
+            notification.onclick = () => {
+                // Focus the window/tab
+                window.focus()
+                // Navigate to tickets
+                router.actions.push(urls.supportTickets())
+                // Close the notification
+                notification.close()
+            }
+
+            // Auto-close after timeout
+            setTimeout(() => {
+                notification.close()
+            }, NOTIFICATION_AUTO_CLOSE_MS)
+        },
+    })),
+    selectors({
+        isSupported: [() => [], () => isNotificationSupported()],
+        canShowNotifications: [
+            (s) => [s.isSupported, s.permission, s.enabled, s.currentTeam],
+            (isSupported, permission, enabled, currentTeam): boolean =>
+                isSupported && permission === 'granted' && enabled && !!currentTeam?.conversations_enabled,
+        ],
+        isPermissionDenied: [
+            (s) => [s.isSupported, s.permission],
+            (isSupported, permission): boolean => isSupported && permission === 'denied',
+        ],
+    }),
+    subscriptions(({ actions }) => ({
+        // Reset enabled preference when team changes (keep in sync with new team's localStorage)
+        currentTeam: (currentTeam, oldTeam) => {
+            // Skip initial mount
+            if (oldTeam === undefined) {
+                return
+            }
+            // Team changed - load preference for new team
+            if (currentTeam?.id !== oldTeam?.id) {
+                actions.setEnabled(getStoredPreference())
+            }
+        },
+    })),
+    afterMount(({ actions }) => {
+        // Load initial permission state
+        if (isNotificationSupported()) {
+            actions.setPermission(Notification.permission as NotificationPermission)
+        }
+        // Load stored preference
+        actions.setEnabled(getStoredPreference())
+    }),
+])

--- a/products/conversations/frontend/scenes/settings/BrowserNotificationsSection.tsx
+++ b/products/conversations/frontend/scenes/settings/BrowserNotificationsSection.tsx
@@ -1,0 +1,48 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonBanner, LemonButton, LemonSwitch } from '@posthog/lemon-ui'
+
+import { browserNotificationLogic } from '../../browserNotificationLogic'
+
+export function BrowserNotificationsSection(): JSX.Element | null {
+    const { isSupported, permission, enabled, isPermissionDenied } = useValues(browserNotificationLogic)
+    const { requestPermission, setEnabled } = useActions(browserNotificationLogic)
+
+    // Don't show if browser doesn't support notifications
+    if (!isSupported) {
+        return null
+    }
+
+    return (
+        <div className="mb-8 max-w-[800px]">
+            <h3>Browser notifications</h3>
+            <p>Get notified in your browser when new support messages arrive.</p>
+
+            {isPermissionDenied ? (
+                <LemonBanner type="info">
+                    Browser notifications are blocked. To enable them, click the lock icon in your browser's address bar
+                    and allow notifications for this site.
+                </LemonBanner>
+            ) : permission === 'default' ? (
+                <LemonButton type="secondary" onClick={requestPermission}>
+                    Enable browser notifications
+                </LemonButton>
+            ) : (
+                <>
+                    <LemonSwitch
+                        checked={enabled}
+                        onChange={setEnabled}
+                        label={enabled ? 'Browser notifications enabled' : 'Browser notifications disabled'}
+                        bordered
+                    />
+                    {enabled && (
+                        <LemonBanner type="info" className="mt-2">
+                            Not seeing notifications? Make sure notifications are enabled for your browser in your
+                            operating system settings (e.g., macOS System Settings → Notifications → Chrome).
+                        </LemonBanner>
+                    )}
+                </>
+            )}
+        </div>
+    )
+}

--- a/products/conversations/frontend/scenes/settings/SupportSettingsScene.tsx
+++ b/products/conversations/frontend/scenes/settings/SupportSettingsScene.tsx
@@ -13,6 +13,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { ScenesTabs } from '../../components/ScenesTabs'
+import { BrowserNotificationsSection } from './BrowserNotificationsSection'
 import { supportSettingsLogic } from './supportSettingsLogic'
 
 export const scene: SceneExport = {
@@ -183,6 +184,8 @@ export function SupportSettingsScene(): JSX.Element {
                                 onChange={setNotificationRecipients}
                             />
                         </div>
+
+                        <BrowserNotificationsSection />
 
                         <div>
                             <h3>In-app widget</h3>

--- a/products/conversations/frontend/supportTicketCounterLogic.ts
+++ b/products/conversations/frontend/supportTicketCounterLogic.ts
@@ -86,7 +86,6 @@ export const supportTicketCounterLogic = kea<supportTicketCounterLogicType>([
     })),
     selectors({
         isSupportEnabled: [(s) => [s.currentTeam], (currentTeam): boolean => !!currentTeam?.conversations_enabled],
-        hasUnread: [(s) => [s.unreadCount], (unreadCount) => unreadCount > 0],
     }),
     listeners(({ actions, values, cache }) => ({
         togglePolling: ({ pageIsVisible }) => {
@@ -100,10 +99,6 @@ export const supportTicketCounterLogic = kea<supportTicketCounterLogicType>([
             // Public action for other logics to trigger immediate refresh (e.g., after viewing a ticket)
             cache.disposables.dispose('pollTimeout')
             actions.loadUnreadCount()
-        },
-        resetCount: () => {
-            // Stop polling when count is reset (team change/logout)
-            // Note: pollTimeout is already disposed in subscriptions
         },
     })),
     subscriptions(({ actions, values, cache }) => ({

--- a/products/conversations/frontend/types.ts
+++ b/products/conversations/frontend/types.ts
@@ -1,5 +1,6 @@
 import type { TicketAssignee } from './components/Assignee'
 
+export type NotificationPermission = 'default' | 'granted' | 'denied'
 export type TicketStatus = 'new' | 'open' | 'pending' | 'on_hold' | 'resolved'
 export type TicketChannel = 'widget' | 'slack' | 'email'
 export type TicketSlaState = 'on-track' | 'at-risk' | 'breached'


### PR DESCRIPTION
## Problem

Customers want to allow browser notifications.

## Changes

Per browser, local storage.

<img width="831" height="221" alt="Screenshot 2026-01-30 at 12 09 31" src="https://github.com/user-attachments/assets/bb4dbae0-b7ea-4519-9511-5647e24931e5" />
<img width="372" height="138" alt="Screenshot 2026-01-30 at 11 26 10" src="https://github.com/user-attachments/assets/1cffa28e-93e8-42bf-9a99-6070186047f1" />