### PR TITLE
fix(batch-exports): Fixes to support weekly schedule

### DIFF
--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -336,6 +336,8 @@ def get_data_interval(interval: str, data_interval_end: str | None) -> tuple[dt.
         data_interval_start_dt = data_interval_end_dt - dt.timedelta(hours=1)
     elif interval == "day":
         data_interval_start_dt = data_interval_end_dt - dt.timedelta(days=1)
+    elif interval == "week":
+        data_interval_start_dt = data_interval_end_dt - dt.timedelta(weeks=1)
     elif interval.startswith("every"):
         _, value, unit = interval.split(" ")
         kwargs = {unit: int(value)}
@@ -915,6 +917,8 @@ async def execute_batch_export_insert_activity(
         start_to_close_timeout = dt.timedelta(hours=2)
     elif interval == "day":
         start_to_close_timeout = dt.timedelta(days=1)
+    elif interval == "week":
+        start_to_close_timeout = dt.timedelta(days=3)
     elif interval.startswith("every"):
         _, value, unit = interval.split(" ")
         kwargs = {unit: int(value)}

--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -126,7 +126,11 @@ async def execute_batch_export_using_internal_stage(
         stage_activity_start_to_close_timeout = dt.timedelta(hours=1)
     elif interval == "day":
         main_activity_start_to_close_timeout = max(dt.timedelta(days=1), override_start_to_close_timeout_timedelta)
-        stage_activity_start_to_close_timeout = main_activity_start_to_close_timeout
+        stage_activity_start_to_close_timeout = dt.timedelta(hours=6)
+    elif interval == "week":
+        # TODO - review these once we have more users using weekly batch exports
+        main_activity_start_to_close_timeout = max(dt.timedelta(days=3), override_start_to_close_timeout_timedelta)
+        stage_activity_start_to_close_timeout = dt.timedelta(days=1)
     elif interval.startswith("every"):
         _, value, unit = interval.split(" ")
         kwargs = {unit: int(value)}

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_with_minio_bucket.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_with_minio_bucket.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 TEST_DATA_INTERVAL_END = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
 
 
-@pytest.mark.parametrize("interval", ["hour", "day", "every 5 minutes"], indirect=True)
+@pytest.mark.parametrize("interval", ["hour", "day", "every 5 minutes", "week"], indirect=True)
 @pytest.mark.parametrize("model", TEST_S3_MODELS)
 @pytest.mark.parametrize("compression", [None], indirect=True)
 @pytest.mark.parametrize("exclude_events", [None], indirect=True)

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
@@ -56,6 +56,27 @@ async def batch_export(
     await destination.adelete()
 
 
+@pytest.fixture(params=["hour", "day", "week", "every 5 minutes"])
+def interval(request):
+    return request.param
+
+
+@pytest_asyncio.fixture
+async def batch_export_by_interval(ateam, interval):
+    destination = await BatchExportDestination.objects.acreate(type="Dummy", config={})
+    batch_export = await BatchExport.objects.acreate(
+        team=ateam,
+        name="test-batch-export",
+        destination=destination,
+        interval=interval,
+    )
+
+    yield batch_export
+
+    await batch_export.adelete()
+    await destination.adelete()
+
+
 class DummyNonRetryableError(Exception):
     def __init__(self, message: str = "This is a user error"):
         super().__init__(message)
@@ -234,3 +255,15 @@ class TestErrorHandling:
         run = await self._run_workflow(inputs, expect_workflow_failure=True)
         assert run.status == "FailedRetryable"
         assert run.latest_error == "DummyRetryableError: This is an unexpected internal error"
+
+    async def test_successful_run(self, batch_export_by_interval, interval):
+        inputs = DummyExportInputs(
+            team_id=batch_export_by_interval.team_id,
+            batch_export_id=str(batch_export_by_interval.id),
+            interval=interval,
+            data_interval_end=dt.datetime(2025, 7, 21, 13, 0, 0, tzinfo=dt.UTC).isoformat(),
+            batch_export_model=BatchExportModel(name="events", schema=None),
+        )
+        run = await self._run_workflow(inputs, expect_workflow_failure=False)
+        assert run.status == "Completed"
+        assert run.records_completed == 100


### PR DESCRIPTION
## Problem

Weekly schedules don't work currently.

## Changes

- Add support for `week` interval where previously it was missing 
- Fix bug in frontend, where backfill dates for day/week were not taking into account the timezone correctly

## How did you test this code?

- Added unit tests for backend
- Ran frontend locally to test those changes
