### PR TITLE
fix: Prevent infinite re-render loop in useAppShortcut

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/AppsMenu.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/AppsMenu.tsx
@@ -96,7 +96,7 @@ export function AppsMenu({ isCollapsed }: { isCollapsed: boolean }): JSX.Element
         intent: 'Open all apps menu',
         interaction: 'function',
         callback: () => {
-            setOpen(!open)
+            setOpen((open) => !open)
         },
     })
 

--- a/frontend/src/layout/panel-layout/ai-first/ConversationsMenu.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/ConversationsMenu.tsx
@@ -127,7 +127,7 @@ export function ConversationsMenu({ isCollapsed }: { isCollapsed: boolean }): JS
         intent: 'Open all chats menu',
         interaction: 'function',
         callback: () => {
-            setOpen(!open)
+            setOpen((open) => !open)
         },
     })
 

--- a/frontend/src/lib/components/AppShortcuts/useAppShortcut.ts
+++ b/frontend/src/lib/components/AppShortcuts/useAppShortcut.ts
@@ -118,6 +118,9 @@ export function useAppShortcut<T extends HTMLElement = HTMLElement>(
     const externalRef = options.interaction !== 'function' ? options.externalRef : undefined
     const callback = options.interaction === 'function' ? options.callback : undefined
 
+    const callbackFnRef = useRef(callback)
+    callbackFnRef.current = callback
+
     const ref = (externalRef as React.RefObject<T>) ?? internalRef
 
     const callbackRef = useCallback((node: T | null) => {
@@ -130,12 +133,12 @@ export function useAppShortcut<T extends HTMLElement = HTMLElement>(
             return
         }
 
-        if (interaction === 'function' && callback) {
+        if (interaction === 'function' && callbackFnRef.current) {
             const platformAgnosticKeybinds = convertPlatformKeybinds(keybind)
             registerAppShortcut({
                 name,
                 keybind: platformAgnosticKeybinds,
-                callback,
+                callback: () => callbackFnRef.current?.(),
                 intent,
                 interaction: 'function',
                 scope,
@@ -157,7 +160,7 @@ export function useAppShortcut<T extends HTMLElement = HTMLElement>(
         return () => {
             unregisterAppShortcut(name)
         }
-    }, [isRefReady, name, intent, interaction, scope, disabled, ref, callback, priority, registerAppShortcut]) // oxlint-disable-line react-hooks/exhaustive-deps
+    }, [isRefReady, name, intent, interaction, scope, disabled, ref, priority, registerAppShortcut]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     return { ref, callbackRef }
 }

--- a/frontend/src/lib/components/AppShortcuts/useAppShortcut.ts
+++ b/frontend/src/lib/components/AppShortcuts/useAppShortcut.ts
@@ -118,6 +118,9 @@ export function useAppShortcut<T extends HTMLElement = HTMLElement>(
     const externalRef = options.interaction !== 'function' ? options.externalRef : undefined
     const callback = options.interaction === 'function' ? options.callback : undefined
 
+    // Keep a ref to the callback to avoid re-registering on every render
+    // This way, the latest callback is always called and callers
+    // don't need to remember to memoize it
     const callbackFnRef = useRef(callback)
     callbackFnRef.current = callback
 


### PR DESCRIPTION
## Problem

I think in https://github.com/PostHog/posthog/pull/43951 we introduced [this error](https://us.posthog.com/project/2/error_tracking/019b6024-214d-7df0-8d89-f54b5f81c474?bf5336c3c69c0ca1edeb5347393f14e8571dd52eb948e96dc7247a02d36db4f54bbf27d035e297564f7cfa5bd53cad70b35104eb14fc5df5ec99f56066782b26&timestamp=2026-01-29T11%3A56%3A50.851000-08%3A00&dateRange=%7B%22date_from%22%3A%22-14d%22%2C%22date_to%22%3Anull%7D).

## Changes

- Store the callback in a ref to avoid the effect re-running when callback identity changes, preventing infinite re-renders.   

## How did you test this code?

Wasn't able to reproduce it locally, but the fix should be safe.