### PR TITLE
feat(logs): improve logs onboarding with framework specific docs and links

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -22481,6 +22481,7 @@
                 "llm_analytics_docs_viewed",
                 "logs_docs_viewed",
                 "logs_set_filters",
+                "logs_settings_opened",
                 "taxonomic filter empty state",
                 "create_experiment_from_funnel_button",
                 "web_analytics_insight",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -5271,6 +5271,7 @@ export enum ProductIntentContext {
     // Logs
     LOGS_DOCS_VIEWED = 'logs_docs_viewed',
     LOGS_SET_FILTERS = 'logs_set_filters',
+    LOGS_SETTINGS_OPENED = 'logs_settings_opened',
 
     // Product Analytics
     TAXONOMIC_FILTER_EMPTY_STATE = 'taxonomic filter empty state',

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2843,6 +2843,7 @@ class ProductIntentContext(StrEnum):
     LLM_ANALYTICS_DOCS_VIEWED = "llm_analytics_docs_viewed"
     LOGS_DOCS_VIEWED = "logs_docs_viewed"
     LOGS_SET_FILTERS = "logs_set_filters"
+    LOGS_SETTINGS_OPENED = "logs_settings_opened"
     TAXONOMIC_FILTER_EMPTY_STATE = "taxonomic filter empty state"
     CREATE_EXPERIMENT_FROM_FUNNEL_BUTTON = "create_experiment_from_funnel_button"
     WEB_ANALYTICS_INSIGHT = "web_analytics_insight"

--- a/products/logs/frontend/components/SetupPrompt/SetupPrompt.tsx
+++ b/products/logs/frontend/components/SetupPrompt/SetupPrompt.tsx
@@ -1,16 +1,33 @@
 import { useActions, useValues } from 'kea'
 
-import { IconExternal } from '@posthog/icons'
-import { LemonButton, Spinner } from '@posthog/lemon-ui'
+import { IconGear } from '@posthog/icons'
+import { LemonButton, Link, Spinner } from '@posthog/lemon-ui'
 
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { ListHog } from 'lib/components/hedgehogs'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useInterval } from 'lib/hooks/useInterval'
+import goImage from 'scenes/onboarding/sdks/logos/go.svg'
+import javaImage from 'scenes/onboarding/sdks/logos/java.svg'
+import nextjsImage from 'scenes/onboarding/sdks/logos/nextjs.svg'
+import nodejsImage from 'scenes/onboarding/sdks/logos/nodejs.svg'
+import pythonImage from 'scenes/onboarding/sdks/logos/python.svg'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { sidePanelSettingsLogic } from '~/layout/navigation-3000/sidepanel/panels/sidePanelSettingsLogic'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 
 import { logsIngestionLogic } from './logsIngestionLogic'
+
+const FRAMEWORK_LINKS: { name: string; image?: string; docsLink: string }[] = [
+    { name: 'Node.js', image: nodejsImage, docsLink: 'https://posthog.com/docs/logs/installation/nodejs' },
+    { name: 'Next.js', image: nextjsImage, docsLink: 'https://posthog.com/docs/logs/installation/nextjs' },
+    { name: 'Python', image: pythonImage, docsLink: 'https://posthog.com/docs/logs/installation/python' },
+    { name: 'Java', image: javaImage, docsLink: 'https://posthog.com/docs/logs/installation/java' },
+    { name: 'Go', image: goImage, docsLink: 'https://posthog.com/docs/logs/installation/go' },
+    { name: 'Datadog', docsLink: 'https://posthog.com/docs/logs/installation/datadog' },
+    { name: 'Other', docsLink: 'https://posthog.com/docs/logs/installation' },
+]
 
 const POLLING_INTERVAL_MS = 5000
 
@@ -47,6 +64,8 @@ const NoLogsPrompt = ({ className }: { className?: string }): JSX.Element | null
     const { addProductIntent } = useActions(teamLogic)
     const { hasLogs } = useValues(logsIngestionLogic)
     const { loadTeamHasLogs } = useActions(logsIngestionLogic)
+    const { openSettingsPanel } = useActions(sidePanelSettingsLogic)
+    const hasLogsSettings = useFeatureFlag('LOGS_SETTINGS')
 
     useInterval(() => {
         if (!hasLogs) {
@@ -66,26 +85,78 @@ const NoLogsPrompt = ({ className }: { className?: string }): JSX.Element | null
             customHog={ListHog}
             actionElementOverride={
                 <div className="flex flex-col items-start gap-4">
-                    <LemonButton
-                        type="primary"
-                        targetBlank
-                        sideIcon={<IconExternal className="w-5 h-5" />}
-                        to="https://posthog.com/docs/logs/"
-                        onClick={() => {
-                            addProductIntent({
-                                product_type: ProductKey.LOGS,
-                                intent_context: ProductIntentContext.LOGS_DOCS_VIEWED,
-                            })
-                        }}
-                    >
-                        Configure your logging client
-                    </LemonButton>
-                    <div className="flex items-center gap-2 px-3 py-1.5 border border-accent rounded">
-                        <div className="relative flex items-center justify-center">
-                            <div className="absolute w-3 h-3 border-2 border-accent rounded-full animate-ping" />
-                            <div className="w-2 h-2 bg-accent rounded-full" />
+                    <p className="text-sm text-secondary m-0">
+                        Learn more about{' '}
+                        <Link
+                            to="https://opentelemetry.io/docs/what-is-opentelemetry/"
+                            target="_blank"
+                            onClick={() =>
+                                addProductIntent({
+                                    product_type: ProductKey.LOGS,
+                                    intent_context: ProductIntentContext.LOGS_DOCS_VIEWED,
+                                })
+                            }
+                        >
+                            OpenTelemetry
+                        </Link>
+                        , or pick a framework to get started:
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                        {FRAMEWORK_LINKS.map(({ name, image, docsLink }) => (
+                            <LemonButton
+                                key={name}
+                                type="secondary"
+                                size="small"
+                                targetBlank
+                                to={docsLink}
+                                onClick={() => {
+                                    addProductIntent({
+                                        product_type: ProductKey.LOGS,
+                                        intent_context: ProductIntentContext.LOGS_DOCS_VIEWED,
+                                    })
+                                }}
+                                icon={image ? <img src={image} alt={name} className="w-5 h-5" /> : undefined}
+                            >
+                                {name}
+                            </LemonButton>
+                        ))}
+                    </div>
+                    {hasLogsSettings && (
+                        <p className="text-sm text-secondary m-0">
+                            Already using <code>posthog-js</code>?{' '}
+                            <LemonButton
+                                type="tertiary"
+                                size="xsmall"
+                                icon={<IconGear />}
+                                onClick={() => {
+                                    addProductIntent({
+                                        product_type: ProductKey.LOGS,
+                                        intent_context: ProductIntentContext.LOGS_SETTINGS_OPENED,
+                                    })
+                                    openSettingsPanel({
+                                        sectionId: 'environment-logs',
+                                        settingId: 'logs',
+                                    })
+                                }}
+                            >
+                                Enable console log capture
+                            </LemonButton>
+                        </p>
+                    )}
+                    <div className="flex items-center gap-4">
+                        <div className="flex items-center gap-2 px-3 py-1.5 border border-accent rounded">
+                            <div className="relative flex items-center justify-center">
+                                <div className="absolute w-3 h-3 border-2 border-accent rounded-full animate-ping" />
+                                <div className="w-2 h-2 bg-accent rounded-full" />
+                            </div>
+                            <span className="text-sm">Watching for logs</span>
                         </div>
-                        <span className="text-sm">Watching for logs</span>
+                        <span className="text-sm text-secondary">
+                            Missing an integration?{' '}
+                            <button id="logs-feedback-button" className="text-link font-semibold cursor-pointer">
+                                Let us know
+                            </button>
+                        </span>
                     </div>
                 </div>
             }


### PR DESCRIPTION
## Problem

Users need clearer guidance on how to integrate logs with their applications and access to framework-specific documentation.

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/c2e2696c-00d5-4866-a7fc-fe0da1e3a6a5.png)

- Added a new product intent context `LOGS_SETTINGS_OPENED` to track when users open logs settings
- Enhanced the logs setup prompt with:
  - Framework-specific integration buttons (Node.js, Next.js, Python, Java, Go, Datadog, and others)
  - Added OpenTelemetry reference link
  - Added option to enable console log capture for users already using posthog-js (behind feature flag)
  - Improved the "watching for logs" indicator with better layout
  - Added a feedback button for users to request missing integrations

## How did you test this code?

Verified that the product intent tracking works properly when clicking on documentation links and the settings button.

## Publish to changelog?

No