### PR TITLE
fix: org delete errors

### DIFF
--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -29,8 +29,14 @@ def delete_bulky_postgres_data(team_ids: list[int]):
     from posthog.models.insight_caching_state import InsightCachingState
     from posthog.models.person import Person, PersonDistinctId, PersonlessDistinctId
 
+    from products.data_modeling.backend.models import Edge, Node
     from products.early_access_features.backend.models import EarlyAccessFeature
     from products.error_tracking.backend.models import ErrorTrackingIssueFingerprintV2
+
+    # Delete data modeling nodes and edges first to not block Team deletion.
+    # Team cascades to DataWarehouseSavedQuery, but it has PROTECT on delete.
+    _raw_delete(Edge.objects.filter(team_id__in=team_ids))
+    _raw_delete(Node.objects.filter(team_id__in=team_ids))
 
     _raw_delete(EarlyAccessFeature.objects.filter(team_id__in=team_ids))
     _raw_delete_batch(PersonDistinctId.objects.filter(team_id__in=team_ids))

--- a/posthog/tasks/test/test_deletion_tasks.py
+++ b/posthog/tasks/test/test_deletion_tasks.py
@@ -83,6 +83,47 @@ class TestDeleteOrganizationDataAndNotifyTask(BaseTest):
         self.assertFalse(Organization.objects.filter(id=org_id).exists())
         self.assertFalse(Team.objects.filter(id=team_id).exists())
 
+    @patch("posthog.email.is_email_available", return_value=False)
+    def test_deletes_organization_with_data_warehouse_saved_query_and_node(self, mock_email: Any) -> None:
+        """
+        Verify that Node.saved_query doesn't block organization and team deletion.
+        """
+        from products.data_modeling.backend.models import Node
+        from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+
+        org = Organization.objects.create(name="Org to delete")
+        org.members.add(self.user)
+        team = Team.objects.create(organization=org, name="Team in org")
+        org_id = str(org.id)
+        team_id = team.id
+
+        # Create a DataWarehouseSavedQuery (view definition)
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=team,
+            name="test_view",
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+        )
+
+        # Create a Node referencing the saved query (this has PROTECT on saved_query)
+        node = Node.objects.create(
+            team=team,
+            saved_query=saved_query,
+            type="view",
+        )
+
+        delete_organization_data_and_notify_task(
+            team_ids=[team_id],
+            organization_id=org_id,
+            user_id=self.user.id,
+            organization_name="Org to delete",
+            project_names=["Team in org"],
+        )
+
+        self.assertFalse(Organization.objects.filter(id=org_id).exists())
+        self.assertFalse(Team.objects.filter(id=team_id).exists())
+        self.assertFalse(DataWarehouseSavedQuery.objects.filter(id=saved_query.id).exists())
+        self.assertFalse(Node.objects.filter(id=node.id).exists())
+
     @patch("posthog.tasks.email.send_organization_deleted_email")
     @patch("posthog.email.is_email_available", return_value=True)
     def test_sends_email_when_available(self, mock_email_available: Any, mock_send_email: Any) -> None:


### PR DESCRIPTION
## Problem

Org deletion failing with two errors in production logs:
1. ProtectedError: Cannot delete some instances of model 'Team' because they are referenced through protected foreign keys: 'DataWarehouseSavedQuery.team' - caused by Node.saved_query having on_delete=PROTECT
2. DoesNotExist: Team matching query does not exist - noisy errors from FileSystemMixin post_delete signal when team is already cascade-deleted

## Changes
- Modified the team deletion process to first delete data modeling nodes and edges before attempting to delete the team
- Added handling for `Team.DoesNotExist` exception

## How did you test this code?
Tests

## Publish to changelog?
No