### PR TITLE
feat: counter for support product for us

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -3,16 +3,7 @@ import './SidePanel.scss'
 import { useActions, useValues } from 'kea'
 import { useEffect, useRef } from 'react'
 
-import {
-    IconBook,
-    IconEllipsis,
-    IconGear,
-    IconInfo,
-    IconLock,
-    IconLogomark,
-    IconNotebook,
-    IconSupport,
-} from '@posthog/icons'
+import { IconBook, IconEllipsis, IconGear, IconInfo, IconLock, IconLogomark, IconNotebook } from '@posthog/icons'
 import { LemonButton, LemonMenu, LemonMenuItems, LemonModal } from '@posthog/lemon-ui'
 
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
@@ -31,6 +22,8 @@ import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
 import { SidePanelTab } from '~/types'
+
+import { SidePanelSupportIcon } from 'products/conversations/frontend/components/SidePanel/SidePanelSupportIcon'
 
 import { SidePanelNavigation } from './SidePanelNavigation'
 import { SidePanelChangelog } from './panels/SidePanelChangelog'
@@ -70,7 +63,7 @@ export const SIDE_PANEL_TABS: Record<
     },
     [SidePanelTab.Support]: {
         label: 'Help',
-        Icon: IconSupport,
+        Icon: SidePanelSupportIcon,
         Content: SidePanelSupport,
     },
     [SidePanelTab.Docs]: {

--- a/products/conversations/frontend/components/SidePanel/SidePanelSupportIcon.tsx
+++ b/products/conversations/frontend/components/SidePanel/SidePanelSupportIcon.tsx
@@ -1,0 +1,16 @@
+import { useValues } from 'kea'
+
+import { IconSupport } from '@posthog/icons'
+
+import { IconWithCount } from 'lib/lemon-ui/icons'
+
+import { sidepanelTicketsLogic } from './sidepanelTicketsLogic'
+
+export const SidePanelSupportIcon = (props: { className?: string }): JSX.Element => {
+    const { totalUnreadCount } = useValues(sidepanelTicketsLogic)
+    return (
+        <IconWithCount count={totalUnreadCount} {...props}>
+            <IconSupport />
+        </IconWithCount>
+    )
+}


### PR DESCRIPTION
## Problem

For our own support product we don't have a counter - badge that would show to a customer that there is a reply to the ticket.

## Changes

Let's add polling (ONLY if user has tickets) and show the badge on the sidebar.

<img width="626" height="248" alt="Screenshot 2026-01-30 at 13 23 10" src="https://github.com/user-attachments/assets/29f247c6-fb21-453a-9963-65c057984255" />

