### PR TITLE
fix(notebooks): handle non-string code attribute in Python/DuckSQL nodes

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -169,7 +169,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
         pythonExecutionSandboxId?: string | null
     }
     const pythonExecutionCodeHash = pythonAttributes.pythonExecutionCodeHash ?? null
-    const pythonCodeHash = hashCodeForString(pythonAttributes.code ?? '')
+    const pythonCodeHash = hashCodeForString(typeof pythonAttributes.code === 'string' ? pythonAttributes.code : '')
     const pythonExecutionSandboxId = pythonAttributes.pythonExecutionSandboxId ?? null
     const kernelSandboxId = kernelInfo?.sandbox_id ?? null
     const kernelIsRunning = kernelInfo?.status === 'running'
@@ -186,7 +186,9 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
         returnVariable?: string
     }
     const duckSqlExecutionCodeHash = duckSqlAttributes.duckExecutionCodeHash ?? null
-    const duckSqlCodeHash = hashCodeForString(`${duckSqlAttributes.code ?? ''}\n${duckSqlReturnVariable}`)
+    const duckSqlCodeHash = hashCodeForString(
+        `${typeof duckSqlAttributes.code === 'string' ? duckSqlAttributes.code : ''}\n${duckSqlReturnVariable}`
+    )
     const duckSqlExecutionSandboxId = duckSqlAttributes.duckExecutionSandboxId ?? null
     const duckSqlHasExecution = duckSqlExecutionCodeHash !== null
     const duckSqlSandboxMatches =

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeDuckSQL.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeDuckSQL.tsx
@@ -288,7 +288,7 @@ const Settings = ({
     return (
         <CodeEditorResizeable
             language="sql"
-            value={attributes.code}
+            value={typeof attributes.code === 'string' ? attributes.code : ''}
             onChange={(value) => updateAttributes({ code: value ?? '' })}
             onPressCmdEnter={() => {
                 void runDuckSqlNodeWithMode({ mode: 'auto' })

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePython.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePython.tsx
@@ -325,7 +325,7 @@ const Settings = ({
     return (
         <CodeEditorResizeable
             language="python"
-            value={attributes.code}
+            value={typeof attributes.code === 'string' ? attributes.code : ''}
             onChange={(value) => updateAttributes({ code: value ?? '' })}
             onPressCmdEnter={() => {
                 void runPythonNodeWithMode({ mode: 'auto' })


### PR DESCRIPTION
## Problem                                                                                                                                                                               
                                                                                                                                                                                           
  Users with Python notebook cells containing content that is valid JSON (e.g., just `1`, `[1,2,3]`, `true`, `null`) experience crashes when opening the notebook.                         
                                                                                                                                                                                           
  The `tryJsonParse` function in `useSyncedAttributes` parses all node attributes as JSON. When `code` contains valid JSON like `"1"`, it gets converted from the string `"1"` to the      
  number `1`. This causes `TypeError: e.trim is not a function` when the code is passed to `hashCodeForString()` or the Monaco editor.                                                     
                                                                                                                                                                                           
  ## Changes                                                                                                                                                                               
                                                                                                                                                                                           
  Added defensive type checking in three places where `attributes.code` is used:                                                                                                           
  - `NodeWrapper.tsx`: `hashCodeForString` calls for Python and DuckSQL code hash computation                                                                                              
  - `NotebookNodePython.tsx`: CodeEditor `value` prop                                                                                                                                      
  - `NotebookNodeDuckSQL.tsx`: CodeEditor `value` prop                                                                                                                                     
                                                                                                                                                                                           
  ## How did you test this code?                                                                                                                                                           
                                                                                                                                                                                           
  Identified the affected notebook via SQL query and confirmed `code: "1"` was being parsed to a number. Verified the fix handles this case by falling back to empty string for non-string values.                                                                                                                                                                                  
                                                                                                                                                                                           
  ## Publish to changelog?                                                                                                                                                                 
                                                                                                                                                                                           
  no                                                                                                                                                                                       
                 