### PR TITLE
fix(ph-ai): read-only subagents

### DIFF
--- a/ee/hogai/chat_agent/mode_manager.py
+++ b/ee/hogai/chat_agent/mode_manager.py
@@ -15,10 +15,13 @@ from ee.hogai.context import AssistantContextManager
 from ee.hogai.core.agent_modes.factory import AgentModeDefinition
 from ee.hogai.core.agent_modes.mode_manager import AgentModeManager
 from ee.hogai.core.agent_modes.presets.error_tracking import chat_agent_plan_error_tracking_agent, error_tracking_agent
-from ee.hogai.core.agent_modes.presets.product_analytics import product_analytics_agent
+from ee.hogai.core.agent_modes.presets.product_analytics import (
+    product_analytics_agent,
+    subagent_product_analytics_agent,
+)
 from ee.hogai.core.agent_modes.presets.session_replay import chat_agent_plan_session_replay_agent, session_replay_agent
 from ee.hogai.core.agent_modes.presets.sql import chat_agent_plan_sql_agent, sql_agent
-from ee.hogai.core.agent_modes.presets.survey import survey_agent
+from ee.hogai.core.agent_modes.presets.survey import subagent_survey_agent, survey_agent
 from ee.hogai.core.agent_modes.prompt_builder import AgentPromptBuilder
 from ee.hogai.core.agent_modes.toolkit import AgentToolkit, AgentToolkitManager
 from ee.hogai.utils.feature_flags import (
@@ -54,6 +57,12 @@ DEFAULT_CHAT_AGENT_PLAN_MODE_REGISTRY: dict[AgentMode, AgentModeDefinition] = {
     AgentMode.EXECUTION: execution_agent,
 }
 
+SUBAGENT_CHAT_AGENT_MODE_REGISTRY: dict[AgentMode, AgentModeDefinition] = {
+    AgentMode.PRODUCT_ANALYTICS: subagent_product_analytics_agent,
+    AgentMode.SQL: sql_agent,
+    AgentMode.SESSION_REPLAY: session_replay_agent,
+}
+
 
 class ChatAgentModeManager(AgentModeManager):
     def __init__(
@@ -65,6 +74,8 @@ class ChatAgentModeManager(AgentModeManager):
         context_manager: AssistantContextManager,
         state: AssistantState,
     ):
+        self._is_subagent = context_manager.is_subagent
+
         super().__init__(
             team=team,
             user=user,
@@ -85,6 +96,9 @@ class ChatAgentModeManager(AgentModeManager):
 
     @property
     def mode_registry(self) -> dict[AgentMode, AgentModeDefinition]:
+        if self._is_subagent:
+            return self._subagent_mode_registry
+
         if self._supermode == AgentMode.PLAN:
             registry = dict(DEFAULT_CHAT_AGENT_PLAN_MODE_REGISTRY)
         else:
@@ -98,6 +112,15 @@ class ChatAgentModeManager(AgentModeManager):
                 registry[AgentMode.ERROR_TRACKING] = error_tracking_agent
         if has_survey_mode_feature_flag(self._team, self._user):
             registry[AgentMode.SURVEY] = survey_agent
+        return registry
+
+    @property
+    def _subagent_mode_registry(self) -> dict[AgentMode, AgentModeDefinition]:
+        registry = dict(SUBAGENT_CHAT_AGENT_MODE_REGISTRY)
+        if has_error_tracking_mode_feature_flag(self._team, self._user):
+            registry[AgentMode.ERROR_TRACKING] = error_tracking_agent
+        if has_survey_mode_feature_flag(self._team, self._user):
+            registry[AgentMode.SURVEY] = subagent_survey_agent
         return registry
 
     @property

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -106,6 +106,10 @@ class AssistantContextManager(AssistantContextMixin):
 
         return contextual_tools
 
+    @property
+    def is_subagent(self) -> bool:
+        return (self._config.get("configurable") or {}).get("is_subagent", False)
+
     def get_billing_context(self) -> MaxBillingContext | None:
         """
         Extracts the billing context from the runnable config.

--- a/ee/hogai/core/agent_modes/presets/product_analytics.py
+++ b/ee/hogai/core/agent_modes/presets/product_analytics.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import posthoganalytics
@@ -82,3 +83,14 @@ product_analytics_agent = AgentModeDefinition(
     node_class=ChatAgentExecutable,
     tools_node_class=ChatAgentToolsExecutable,
 )
+
+
+class SubagentProductAnalyticsAgentToolkit(AgentToolkit):
+    """Product analytics toolkit for subagents — excludes UpsertDashboardTool (dangerous operation)."""
+
+    @property
+    def tools(self) -> list[type["MaxTool"]]:
+        return [CreateInsightTool]
+
+
+subagent_product_analytics_agent = replace(product_analytics_agent, toolkit_class=SubagentProductAnalyticsAgentToolkit)

--- a/ee/hogai/core/agent_modes/presets/survey.py
+++ b/ee/hogai/core/agent_modes/presets/survey.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from posthog.schema import AgentMode
@@ -111,3 +112,16 @@ survey_agent = AgentModeDefinition(
     mode_description="Specialized mode for creating and analyzing surveys. Create surveys with natural language including targeting by URL, user properties, and feature flags. Analyze survey responses to extract themes, sentiment, and actionable insights.",
     toolkit_class=SurveyAgentToolkit,
 )
+
+
+class SubagentSurveyAgentToolkit(AgentToolkit):
+    """Survey toolkit for subagents — only includes SurveyAnalysisTool (read-only)."""
+
+    @property
+    def tools(self) -> list[type["MaxTool"]]:
+        from products.surveys.backend.max_tools import SurveyAnalysisTool
+
+        return [SurveyAnalysisTool]
+
+
+subagent_survey_agent = replace(survey_agent, toolkit_class=SubagentSurveyAgentToolkit)


### PR DESCRIPTION
## Problem
When using subagents in the chat assistant, they currently have access to the same tools as regular agents, including potentially dangerous operations like creating or modifying surveys and dashboards. We need to restrict subagent capabilities to prevent unintended modifications.

## Changes
- Added a new `is_subagent` property to the `AssistantContextManager` to identify when an agent is running as a subagent
- Created a separate mode registry for subagents (`SUBAGENT_CHAT_AGENT_MODE_REGISTRY`) with limited capabilities
- Implemented specialized toolkits for subagents:
  - `SubagentProductAnalyticsAgentToolkit`: Excludes `UpsertDashboardTool` to prevent dashboard modifications
  - `SubagentSurveyAgentToolkit`: Only includes `SurveyAnalysisTool` (read-only operations)
- Added comprehensive tests to verify subagent mode registry and toolkit restrictions

## How did you test this code?
Added tests

## Publish to changelog?
No