### PR TITLE
feat(ph-ai): research mode rate limits

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -665,7 +665,10 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                         }
 
                         if (e.status === 429) {
-                            relevantErrorMessage.content = `You've reached PostHog AI's usage limit for the moment. Please try again ${e.formattedRetryAfter}.`
+                            // Use server-provided message (includes research beta messaging)
+                            relevantErrorMessage.content =
+                                e.detail ||
+                                `You've reached PostHog AI's usage limit for the moment. Please try again ${e.formattedRetryAfter}.`
                         }
 
                         if (e.status === 402) {

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -363,34 +363,38 @@ class ClickHouseSustainedRateThrottle(PersonalApiKeyRateThrottle):
     rate = "1200/hour"
 
 
-class AIBurstRateThrottle(UserRateThrottle):
-    # Throttle class that's very aggressive and is used specifically on endpoints that hit OpenAI
-    # Intended to block quick bursts of requests, per user
+class _AIThrottleBase(UserRateThrottle):
+    action_name: str
+
+    def allow_request(self, request, view):
+        request_allowed = super().allow_request(request, view)
+        if not request_allowed and request.user.is_authenticated:
+            report_user_action(request.user, self.action_name)
+        return request_allowed
+
+
+class AIBurstRateThrottle(_AIThrottleBase):
     scope = "ai_burst"
     rate = "10/minute"
-
-    def allow_request(self, request, view):
-        request_allowed = super().allow_request(request, view)
-
-        if not request_allowed and request.user.is_authenticated:
-            report_user_action(request.user, "ai burst rate limited")
-
-        return request_allowed
+    action_name = "ai burst rate limited"
 
 
-class AISustainedRateThrottle(UserRateThrottle):
-    # Throttle class that's very aggressive and is used specifically on endpoints that hit OpenAI
-    # Intended to block slower but sustained bursts of requests, per user
+class AISustainedRateThrottle(_AIThrottleBase):
     scope = "ai_sustained"
     rate = "100/day"
+    action_name = "ai sustained rate limited"
 
-    def allow_request(self, request, view):
-        request_allowed = super().allow_request(request, view)
 
-        if not request_allowed and request.user.is_authenticated:
-            report_user_action(request.user, "ai sustained rate limited")
+class AIResearchBurstRateThrottle(_AIThrottleBase):
+    scope = "ai_research_burst"
+    rate = "3/minute"
+    action_name = "ai research burst rate limited"
 
-        return request_allowed
+
+class AIResearchSustainedRateThrottle(_AIThrottleBase):
+    scope = "ai_research_sustained"
+    rate = "10/day"
+    action_name = "ai research sustained rate limited"
 
 
 class LLMProxyBurstRateThrottle(UserRateThrottle):

--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -476,8 +476,9 @@ class TestUserAPI(APIBaseTest):
         mock_request.user = self.user
         mock_view = Mock()
 
-        # Mock the parent allow_request to return False (rate limited)
-        with patch.object(throttle.__class__.__bases__[0], "allow_request", return_value=False):
+        # Mock UserRateThrottle.allow_request (the grandparent) to return False (rate limited)
+        # We need to patch the grandparent so _AIThrottleBase.allow_request still executes
+        with patch("rest_framework.throttling.UserRateThrottle.allow_request", return_value=False):
             result = throttle.allow_request(mock_request, mock_view)
 
             # Should return False (rate limited)
@@ -495,8 +496,9 @@ class TestUserAPI(APIBaseTest):
         mock_request.user = self.user
         mock_view = Mock()
 
-        # Mock the parent allow_request to return False (rate limited)
-        with patch.object(throttle.__class__.__bases__[0], "allow_request", return_value=False):
+        # Mock UserRateThrottle.allow_request (the grandparent) to return False (rate limited)
+        # We need to patch the grandparent so _AIThrottleBase.allow_request still executes
+        with patch("rest_framework.throttling.UserRateThrottle.allow_request", return_value=False):
             result = throttle.allow_request(mock_request, mock_view)
 
             # Should return False (rate limited)
@@ -514,8 +516,9 @@ class TestUserAPI(APIBaseTest):
         mock_request.user = self.user
         mock_view = Mock()
 
-        # Mock the parent allow_request to return False (rate limited)
-        with patch.object(throttle.__class__.__bases__[0], "allow_request", return_value=False):
+        # Mock UserRateThrottle.allow_request (the grandparent) to return False (rate limited)
+        # We need to patch the grandparent so _AIThrottleBase.allow_request still executes
+        with patch("rest_framework.throttling.UserRateThrottle.allow_request", return_value=False):
             result = throttle.allow_request(mock_request, mock_view)
 
             # Should return False (rate limited)
@@ -533,8 +536,9 @@ class TestUserAPI(APIBaseTest):
         mock_request.user = self.user
         mock_view = Mock()
 
-        # Mock the parent allow_request to return False (rate limited)
-        with patch.object(throttle.__class__.__bases__[0], "allow_request", return_value=False):
+        # Mock UserRateThrottle.allow_request (the grandparent) to return False (rate limited)
+        # We need to patch the grandparent so _AIThrottleBase.allow_request still executes
+        with patch("rest_framework.throttling.UserRateThrottle.allow_request", return_value=False):
             result = throttle.allow_request(mock_request, mock_view)
 
             # Should return False (rate limited)

--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -20,7 +20,14 @@ from posthog.models import Team
 from posthog.models.instance_setting import override_instance_config
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
 from posthog.models.utils import generate_random_token_personal
-from posthog.rate_limit import AIBurstRateThrottle, AISustainedRateThrottle, HogQLQueryThrottle, get_route_from_path
+from posthog.rate_limit import (
+    AIBurstRateThrottle,
+    AIResearchBurstRateThrottle,
+    AIResearchSustainedRateThrottle,
+    AISustainedRateThrottle,
+    HogQLQueryThrottle,
+    get_route_from_path,
+)
 
 
 class TestUserAPI(APIBaseTest):
@@ -497,6 +504,56 @@ class TestUserAPI(APIBaseTest):
 
             # Should call report_user_action with correct parameters
             mock_report_user_action.assert_called_once_with(self.user, "ai sustained rate limited")
+
+    @patch("posthog.rate_limit.report_user_action")
+    def test_ai_research_burst_rate_throttle_calls_report_user_action(self, mock_report_user_action):
+        """Test that AIResearchBurstRateThrottle calls report_user_action when rate limit is exceeded"""
+        throttle = AIResearchBurstRateThrottle()
+
+        mock_request = Mock()
+        mock_request.user = self.user
+        mock_view = Mock()
+
+        # Mock the parent allow_request to return False (rate limited)
+        with patch.object(throttle.__class__.__bases__[0], "allow_request", return_value=False):
+            result = throttle.allow_request(mock_request, mock_view)
+
+            # Should return False (rate limited)
+            self.assertFalse(result)
+
+            # Should call report_user_action with correct parameters
+            mock_report_user_action.assert_called_once_with(self.user, "ai research burst rate limited")
+
+    @patch("posthog.rate_limit.report_user_action")
+    def test_ai_research_sustained_rate_throttle_calls_report_user_action(self, mock_report_user_action):
+        """Test that AIResearchSustainedRateThrottle calls report_user_action when rate limit is exceeded"""
+        throttle = AIResearchSustainedRateThrottle()
+
+        mock_request = Mock()
+        mock_request.user = self.user
+        mock_view = Mock()
+
+        # Mock the parent allow_request to return False (rate limited)
+        with patch.object(throttle.__class__.__bases__[0], "allow_request", return_value=False):
+            result = throttle.allow_request(mock_request, mock_view)
+
+            # Should return False (rate limited)
+            self.assertFalse(result)
+
+            # Should call report_user_action with correct parameters
+            mock_report_user_action.assert_called_once_with(self.user, "ai research sustained rate limited")
+
+    def test_ai_research_burst_rate_throttle_has_correct_scope_and_rate(self):
+        """Test that AIResearchBurstRateThrottle has correct scope and rate"""
+        throttle = AIResearchBurstRateThrottle()
+        self.assertEqual(throttle.scope, "ai_research_burst")
+        self.assertEqual(throttle.rate, "3/minute")
+
+    def test_ai_research_sustained_rate_throttle_has_correct_scope_and_rate(self):
+        """Test that AIResearchSustainedRateThrottle has correct scope and rate"""
+        throttle = AIResearchSustainedRateThrottle()
+        self.assertEqual(throttle.scope, "ai_research_sustained")
+        self.assertEqual(throttle.rate, "10/day")
 
     def test_local_evaluation_throttle_uses_default_rate_when_no_custom_limit(self):
         throttle = LocalEvaluationThrottle()


### PR DESCRIPTION
## Problem
Research mode is in beta, it needs more aggressive rate limits.

## Changes

- Implemented separate, more restrictive rate limits for Research mode conversations:
  - Burst limit: 3 requests/minute (vs 10/minute for regular AI)
  - Sustained limit: 10 requests/day (vs 100/day for regular AI)
- Added detection logic to identify research conversations, both new and existing
- Created custom error messages for research rate limits that explain the beta status
- Refactored throttling logic to handle different conversation types appropriately
- Updated frontend to display server-provided rate limit messages

## How did you test this code?
- Added tests + tested locally

## Publish to changelog?

No