### PR TITLE
chore(ph-ai): track selected agent mode

### DIFF
--- a/ee/hogai/chat_agent/runner.py
+++ b/ee/hogai/chat_agent/runner.py
@@ -163,5 +163,6 @@ class ChatAgentRunner(BaseAgentRunner):
                 "is_new_conversation": self._is_new_conversation,
                 "slack_workspace_domain": self._conversation.slack_workspace_domain,
                 "$session_id": self._session_id,
+                "agent_mode": self._selected_agent_mode,
             },
         )


### PR DESCRIPTION
## Problem
The agent mode is not being tracked in the analytics events for the chat agent, we can now check what the user selects, especially interesting for plan mode.

## Changes

Added the `agent_mode` field to the analytics event properties in the `astream` function, allowing us to track which agent mode is being used during conversations.

## How did you test this code?
Locally

## Publish to changelog?

No