### PR TITLE
fix(logs): show relative label for custom rolling date range picker

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/LogsDateRangePicker/utils.test.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsDateRangePicker/utils.test.ts
@@ -100,6 +100,24 @@ describe('formatDateRangeLabel', () => {
         expect(result).toBe('2024-01-10 10:00 - 2024-01-15 12:00')
     })
 
+    it.each([
+        ['-10M', 'Last 10 minutes'],
+        ['-1M', 'Last 1 minute'],
+        ['-5h', 'Last 5 hours'],
+        ['-1h', 'Last 1 hour'], // also matches preset, but relative fallback produces same label
+        ['-3d', 'Last 3 days'],
+        ['-1d', 'Last 1 day'],
+        ['-2w', 'Last 2 weeks'],
+        ['-1w', 'Last 1 week'],
+        ['-6m', 'Last 6 months'],
+        ['-1y', 'Last 1 year'],
+        ['-2q', 'Last 2 quarters'],
+        ['-45s', 'Last 45 seconds'],
+    ])('formats non-preset relative expression %s as "%s"', (dateFrom, expected) => {
+        const result = formatDateRangeLabel({ date_from: dateFrom, date_to: null }, TEST_TIMEZONE, [])
+        expect(result).toBe(expected)
+    })
+
     it('returns default message when date_from is empty', () => {
         const result = formatDateRangeLabel({ date_from: '', date_to: null }, TEST_TIMEZONE, TEST_DATE_OPTIONS)
         expect(result).toBe('Select date range')

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsDateRangePicker/utils.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsDateRangePicker/utils.ts
@@ -19,6 +19,17 @@ export function formatDateRangeLabel(dateRange: DateRange, timezone: string, dat
         return matchingOption.key
     }
 
+    // Handle relative date expressions (e.g. "-10M") that don't match a preset
+    if (date_from && !date_to) {
+        const relativeMatch = date_from.match(RELATIVE_DATE_REGEX)
+        if (relativeMatch) {
+            const amount = parseInt(relativeMatch[1], 10)
+            const unit = relativeMatch[2]
+            const label = amount === 1 ? UNIT_LABEL_SINGULAR[unit] : UNIT_LABEL_PLURAL[unit]
+            return `Last ${amount} ${label}`
+        }
+    }
+
     const from = date_from ? parseDateExpression(date_from, timezone) : null
     const to = date_to ? parseDateExpression(date_to, timezone) : dayjs().tz(timezone)
 
@@ -41,6 +52,28 @@ const UNIT_MAP: Record<string, 'minute' | 'month' | 'hour' | 'day' | 'week' | 'y
     w: 'week',
     y: 'year',
     q: 'month', // 'q' represents quarters; it maps to 'month' and is treated as 3 months via a multiplier in parseDateExpression.
+    s: 'second',
+}
+
+const UNIT_LABEL_PLURAL: Record<string, string> = {
+    M: 'minutes',
+    m: 'months',
+    h: 'hours',
+    d: 'days',
+    w: 'weeks',
+    y: 'years',
+    q: 'quarters',
+    s: 'seconds',
+}
+
+const UNIT_LABEL_SINGULAR: Record<string, string> = {
+    M: 'minute',
+    m: 'month',
+    h: 'hour',
+    d: 'day',
+    w: 'week',
+    y: 'year',
+    q: 'quarter',
     s: 'second',
 }
 


### PR DESCRIPTION
## Problem

The date range picker in the Logs Viewer doesn't properly format non-preset relative date expressions. When users select custom relative time ranges like "-10M" (last 10 minutes) or "-3d" (last 3 days), the UI doesn't display these in a human-readable format.

## Changes  
![image.png](https://app.graphite.com/user-attachments/assets/0497708a-521a-42c2-b8e5-377b360ba589.png)

Added support for formatting non-preset relative date expressions in the LogsDateRangePicker component. Now expressions like "-10M" will display as "Last 10 minutes" in the UI.

- Added dictionaries for singular and plural unit labels
- Implemented logic to detect and format relative date expressions
- Added comprehensive tests for various time units and quantities

## How did you test this code?

Added unit tests covering various relative date expressions including:

- Different time units (minutes, hours, days, weeks, months, years, quarters, seconds)
- Both singular and plural cases
- Edge cases like "-1h" which could match both a preset and a relative expression

All tests pass and verify the correct formatting of relative date expressions.

## Publish to changelog?

No