### PR TITLE
feat(customers): Add revenue data to person profiles

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.test.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.test.tsx
@@ -7,7 +7,7 @@ import { CurrencyCode } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { Group } from '~/types'
 
-import { DataSourceIcon, GroupInfo, LifetimeValue, MRR } from './NotebookNodeGroup'
+import { GroupInfo, LifetimeValue, MRR } from './NotebookNodeGroup'
 
 // Mock NodeWrapper to avoid circular dependencies
 jest.mock('./NodeWrapper', () => ({
@@ -41,34 +41,6 @@ jest.mock('./utils', () => ({
         return groupData.group_properties?.paid_products || []
     },
 }))
-
-describe('DataSourceIcon', () => {
-    afterEach(() => {
-        cleanup()
-    })
-
-    it('should render piggybank icon for revenue-analytics source', async () => {
-        render(<DataSourceIcon source="revenue-analytics" />)
-
-        expect(screen.getByTestId('piggybank-icon')).toHaveClass('w-3 h-3 text-muted')
-        expect(screen.getByTestId('piggybank-icon')).toBeInTheDocument()
-        expect(screen.getByTestId('From Revenue analytics')).toBeInTheDocument()
-    })
-
-    it('should render database icon for properties source', () => {
-        render(<DataSourceIcon source="properties" />)
-
-        expect(screen.getByTestId('database-icon')).toBeInTheDocument()
-        expect(screen.getByTestId('database-icon')).toHaveClass('w-3 h-3 text-muted')
-        expect(screen.getByTestId('From group properties')).toBeInTheDocument()
-    })
-
-    it('should render nothing for null source', () => {
-        const { container } = render(<DataSourceIcon source={null} />)
-
-        expect(container.firstChild).toBeNull()
-    })
-})
 
 describe('MRR Component', () => {
     afterEach(() => {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { IconDatabase, IconPiggyBank, IconTrending } from '@posthog/icons'
+import { IconTrending } from '@posthog/icons'
 import { LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
@@ -22,28 +22,9 @@ import { CurrencyCode, NodeKind } from '~/queries/schema/schema-general'
 import { Group, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { NotebookNodeProps, NotebookNodeType } from '../types'
+import { DataSourceIcon } from './components/DataSourceIcon'
 import { notebookNodeLogic } from './notebookNodeLogic'
 import { calculateMRRData, getPaidProducts } from './utils'
-
-export function DataSourceIcon({ source }: { source: 'revenue-analytics' | 'properties' | null }): JSX.Element | null {
-    if (!source) {
-        return null
-    }
-
-    if (source === 'revenue-analytics') {
-        return (
-            <Tooltip title="From Revenue analytics">
-                <IconPiggyBank className="w-3 h-3 text-muted" data-attr="piggybank-icon" />
-            </Tooltip>
-        )
-    }
-
-    return (
-        <Tooltip title="From group properties">
-            <IconDatabase className="w-3 h-3 text-muted" data-attr="database-icon" />
-        </Tooltip>
-    )
-}
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeGroupAttributes>): JSX.Element => {
     const { id, groupTypeIndex, tabId, title } = attributes

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
 import { Tooltip } from '@posthog/lemon-ui'
@@ -16,6 +16,7 @@ import { personLogic } from 'scenes/persons/personLogic'
 import { urls } from 'scenes/urls'
 
 import { NodeKind } from '~/queries/schema/schema-general'
+import { PersonType } from '~/types'
 
 import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { notebookNodeLogic } from './notebookNodeLogic'
@@ -24,8 +25,8 @@ import { OPTIONAL_PROJECT_NON_CAPTURE_GROUP } from './utils'
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonAttributes>): JSX.Element => {
     const { id, distinctId } = attributes
 
-    const logic = personLogic({ distinctId, id })
-    const { info, infoLoading, person, personLoading } = useValues(logic)
+    const personLogicProps = { id, distinctId }
+    const { person, personLoading } = useValues(personLogic(personLogicProps))
     const { setExpanded, setActions, insertAfter } = useActions(notebookNodeLogic)
     const { setTitlePlaceholder } = useActions(notebookNodeLogic)
 
@@ -106,61 +107,99 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonAttribute
     }
 
     return (
-        <div className="flex flex-col overflow-hidden">
-            <div className={clsx('p-4 flex-0 flex flex-col gap-2 justify-between min-h-20 items-start')}>
-                {personLoading ? (
-                    <LemonSkeleton className="h-6" />
-                ) : (
-                    <>
-                        <div className="flex gap-2">
-                            <PersonIcon person={person} size="xl" />
-                            <div>
-                                <div className="font-semibold ph-no-capture">{asDisplay(person)}</div>
-                                <div>{propertyIcons}</div>
-                            </div>
-                        </div>
-
-                        {person ? (
-                            <div className="flex flex-col">
-                                <div className="flex items-center gap-1">
-                                    <span className="text-secondary">First seen:</span>{' '}
-                                    {person.created_at ? <TZLabel time={person.created_at} /> : 'unknown'}
-                                </div>
-                                <div className="flex items-center gap-1">
-                                    <span className="text-secondary">Last seen:</span>{' '}
-                                    {infoLoading ? (
-                                        <LemonSkeleton className="h-4 w-24" />
-                                    ) : info?.lastSeen ? (
-                                        <TZLabel time={info.lastSeen} />
-                                    ) : (
-                                        'unknown'
-                                    )}
-                                </div>
-                                <div className="flex items-center gap-1">
-                                    <span className="text-secondary">Session count (30d):</span>{' '}
-                                    {infoLoading ? (
-                                        <LemonSkeleton className="h-4 w-24" />
-                                    ) : info?.sessionCount ? (
-                                        compactNumber(info.sessionCount)
-                                    ) : (
-                                        'unknown'
-                                    )}
-                                </div>
-                                <div className="flex items-center gap-1">
-                                    <span className="text-secondary">Event count (30d):</span>{' '}
-                                    {infoLoading ? (
-                                        <LemonSkeleton className="h-4 w-24" />
-                                    ) : info?.eventCount ? (
-                                        compactNumber(info.eventCount)
-                                    ) : (
-                                        'unknown'
-                                    )}
+        <BindLogic logic={personLogic} props={personLogicProps}>
+            <div className="flex flex-col overflow-hidden">
+                <div className={clsx('p-4 flex-0 flex flex-col gap-2 justify-between min-h-20 items-start')}>
+                    {personLoading ? (
+                        <LemonSkeleton className="h-6" />
+                    ) : (
+                        <>
+                            <div className="flex gap-2">
+                                <PersonIcon person={person} size="xl" />
+                                <div>
+                                    <div className="font-semibold ph-no-capture">{asDisplay(person)}</div>
+                                    <div>{propertyIcons}</div>
                                 </div>
                             </div>
-                        ) : null}
-                    </>
-                )}
+                            <PersonInfo />
+                        </>
+                    )}
+                </div>
             </div>
+        </BindLogic>
+    )
+}
+
+function PersonInfo(): JSX.Element | null {
+    const { person } = useValues(personLogic)
+
+    if (!person) {
+        return null
+    }
+
+    return (
+        <div className="flex flex-col">
+            <FirstSeen person={person} />
+            <LastSeen />
+            <SessionCount />
+            <EventCount />
+        </div>
+    )
+}
+
+function FirstSeen({ person }: { person: PersonType }): JSX.Element {
+    return (
+        <div className="flex items-center gap-1">
+            <span className="text-secondary">First seen:</span>{' '}
+            {person.created_at ? <TZLabel time={person.created_at} /> : 'unknown'}
+        </div>
+    )
+}
+
+function LastSeen(): JSX.Element {
+    const { info, infoLoading } = useValues(personLogic)
+    return (
+        <div className="flex items-center gap-1">
+            <span className="text-secondary">Last seen:</span>{' '}
+            {infoLoading ? (
+                <LemonSkeleton className="h-4 w-24" />
+            ) : info?.lastSeen ? (
+                <TZLabel time={info.lastSeen} />
+            ) : (
+                'unknown'
+            )}
+        </div>
+    )
+}
+
+function SessionCount(): JSX.Element {
+    const { info, infoLoading } = useValues(personLogic)
+    return (
+        <div className="flex items-center gap-1">
+            <span className="text-secondary">Session count (30d):</span>{' '}
+            {infoLoading ? (
+                <LemonSkeleton className="h-4 w-24" />
+            ) : info?.sessionCount ? (
+                compactNumber(info.sessionCount)
+            ) : (
+                'unknown'
+            )}
+        </div>
+    )
+}
+
+function EventCount(): JSX.Element {
+    const { info, infoLoading } = useValues(personLogic)
+    return (
+        <div className="flex items-center gap-1">
+            <span className="text-secondary">Event count (30d):</span>{' '}
+            {infoLoading ? (
+                <LemonSkeleton className="h-4 w-24" />
+            ) : info?.eventCount ? (
+                compactNumber(info.eventCount)
+            ) : (
+                'unknown'
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/notebooks/Nodes/components/DataSourceIcon.test.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/DataSourceIcon.test.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { DataSourceIcon } from './DataSourceIcon'
+
+// Mocking because it is annoying to mock the hover to assert the tooltip text
+jest.mock('@posthog/lemon-ui', () => ({
+    ...jest.requireActual('@posthog/lemon-ui'),
+    Tooltip: ({ children, title }: { children: React.ReactNode; title: string }) => (
+        <div data-attr={title}>{children}</div>
+    ),
+}))
+
+describe('DataSourceIcon', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('should render piggybank icon for revenue-analytics source', async () => {
+        render(<DataSourceIcon source="revenue-analytics" />)
+
+        expect(screen.getByTestId('piggybank-icon')).toHaveClass('w-3 h-3 text-muted')
+        expect(screen.getByTestId('piggybank-icon')).toBeInTheDocument()
+        expect(screen.getByTestId('From Revenue analytics')).toBeInTheDocument()
+    })
+
+    it('should render database icon for properties source', () => {
+        render(<DataSourceIcon source="properties" />)
+
+        expect(screen.getByTestId('database-icon')).toBeInTheDocument()
+        expect(screen.getByTestId('database-icon')).toHaveClass('w-3 h-3 text-muted')
+        expect(screen.getByTestId('From group properties')).toBeInTheDocument()
+    })
+
+    it('should render nothing for null source', () => {
+        const { container } = render(<DataSourceIcon source={null} />)
+
+        expect(container.firstChild).toBeNull()
+    })
+})

--- a/frontend/src/scenes/notebooks/Nodes/components/DataSourceIcon.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/DataSourceIcon.tsx
@@ -1,0 +1,22 @@
+import { IconDatabase, IconPiggyBank } from '@posthog/icons'
+import { Tooltip } from '@posthog/lemon-ui'
+
+export function DataSourceIcon({ source }: { source: 'revenue-analytics' | 'properties' | null }): JSX.Element | null {
+    if (!source) {
+        return null
+    }
+
+    if (source === 'revenue-analytics') {
+        return (
+            <Tooltip title="From Revenue analytics">
+                <IconPiggyBank className="w-3 h-3 text-muted" data-attr="piggybank-icon" />
+            </Tooltip>
+        )
+    }
+
+    return (
+        <Tooltip title="From group properties">
+            <IconDatabase className="w-3 h-3 text-muted" data-attr="database-icon" />
+        </Tooltip>
+    )
+}

--- a/frontend/src/scenes/persons/personLogic.tsx
+++ b/frontend/src/scenes/persons/personLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, kea, key, path, props, selectors } from 'kea'
+import { actions, connect, kea, key, path, props, selectors } from 'kea'
 import { lazyLoaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
@@ -7,8 +7,11 @@ import { Scene } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
 
 import { hogqlQuery } from '~/queries/query'
+import { NodeKind } from '~/queries/schema/schema-general'
 import { hogql } from '~/queries/utils'
 import { Breadcrumb, PersonType } from '~/types'
+
+import { revenueAnalyticsLogic } from 'products/revenue_analytics/frontend/revenueAnalyticsLogic'
 
 import { getHogqlQueryStringForPersonId } from './person-utils'
 import type { personLogicType } from './personLogicType'
@@ -28,6 +31,9 @@ export const personLogic = kea<personLogicType>([
     props({} as PersonLogicProps),
     key((props) => props.distinctId ?? props.id ?? 'undefined'),
     path((key) => ['scenes', 'persons', 'personLogic', key]),
+    connect({
+        values: [revenueAnalyticsLogic, ['isRevenueAnalyticsEnabled']],
+    }),
     actions({
         loadPerson: true,
         loadInfo: true,
@@ -48,7 +54,7 @@ export const personLogic = kea<personLogicType>([
             },
         ],
     })),
-    lazyLoaders(({ props }) => ({
+    lazyLoaders(({ props, values }) => ({
         person: [
             null as PersonType | null,
             {
@@ -121,6 +127,41 @@ export const personLogic = kea<personLogicType>([
                             eventCount: 0,
                             lastSeen: null,
                         }
+                    }
+                },
+            },
+        ],
+        revenueData: [
+            null as { mrr: number | null; lifetimeValue: number | null } | null,
+            {
+                loadRevenueData: async () => {
+                    if (!values.isRevenueAnalyticsEnabled) {
+                        return null
+                    }
+
+                    try {
+                        const result = await api.query({
+                            kind: NodeKind.HogQLQuery,
+                            query: `
+                    SELECT mrr, revenue
+                    FROM persons_revenue_analytics
+                    WHERE person_id = {personId}
+                    `,
+                            values: { personId: props.id },
+                        })
+
+                        const row = (result as any).results?.[0]
+                        if (!row) {
+                            return null
+                        }
+
+                        return {
+                            mrr: row[0] ?? null,
+                            lifetimeValue: row[1] ?? null,
+                        }
+                    } catch (error) {
+                        posthog.captureException(error, { tag: 'person_revenue_analytics_data_query_failed' })
+                        return null
                     }
                 },
             },


### PR DESCRIPTION
## Problem

The person notebook node lacks revenue analytics data, which is valuable for understanding a user's financial contribution to the business.

Closes https://github.com/PostHog/posthog/issues/44006
## Changes

- Added MRR (Monthly Recurring Revenue) and Lifetime Value metrics to the person notebook node
- Refactored the person node component into smaller, more maintainable components
- Improved the layout and scrolling behavior of the person node

![image.png](https://app.graphite.com/user-attachments/assets/54530044-d10f-4b09-b4b0-4c8255422e29.png)

## How did you test this code?

Tested with both revenue analytics enabled and disabled to ensure proper conditional rendering of the new metrics. Verified that the data is correctly fetched and displayed with appropriate loading states and formatting. Checked that the DataSourceIcon correctly indicates the source of the revenue data.

## Publish to changelog?

Yes