### PR TITLE
fix: regenerate old and new restriction redis keys

### DIFF
--- a/posthog/models/event_ingestion_restriction_config.py
+++ b/posthog/models/event_ingestion_restriction_config.py
@@ -2,7 +2,7 @@ import json
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.db.models.signals import post_delete, post_save
+from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
 from posthog.models.utils import UUIDTModel
@@ -121,9 +121,27 @@ def regenerate_redis_for_restriction_type(restriction_type: str):
     redis_client.set(redis_key, json.dumps(data))
 
 
+@receiver(pre_save, sender=EventIngestionRestrictionConfig)
+def capture_old_restriction_type(sender, instance, **kwargs):
+    """Capture the old restriction_type before save to handle type changes."""
+    if instance.pk:
+        try:
+            old_instance = EventIngestionRestrictionConfig.objects.get(pk=instance.pk)
+            instance._old_restriction_type = old_instance.restriction_type
+        except EventIngestionRestrictionConfig.DoesNotExist:
+            instance._old_restriction_type = None
+    else:
+        instance._old_restriction_type = None
+
+
 @receiver(post_save, sender=EventIngestionRestrictionConfig)
 def update_redis_cache_with_config(sender, instance, created=False, **kwargs):
     regenerate_redis_for_restriction_type(instance.restriction_type)
+
+    # If restriction_type changed, also regenerate the old type's Redis key
+    old_restriction_type = getattr(instance, "_old_restriction_type", None)
+    if old_restriction_type and old_restriction_type != instance.restriction_type:
+        regenerate_redis_for_restriction_type(old_restriction_type)
 
 
 @receiver(post_delete, sender=EventIngestionRestrictionConfig)

--- a/posthog/models/test/test_event_ingestion_restriction_config.py
+++ b/posthog/models/test/test_event_ingestion_restriction_config.py
@@ -767,3 +767,44 @@ class TestEventIngestionRestrictionConfig(BaseTest):
                 }
             ],
         )
+
+    def test_changing_restriction_type_clears_old_redis_key(self):
+        """
+        Regression test: when changing restriction_type, the old type's Redis key
+        should be regenerated (cleared) so the old restriction doesn't remain active.
+        """
+        config = EventIngestionRestrictionConfig.objects.create(
+            token="test_token",
+            restriction_type=RestrictionType.SKIP_PERSON_PROCESSING,
+            distinct_ids=["user1"],
+            pipelines=["analytics"],
+        )
+
+        old_redis_key = f"{DYNAMIC_CONFIG_REDIS_KEY_PREFIX}:{RestrictionType.SKIP_PERSON_PROCESSING}"
+        new_redis_key = f"{DYNAMIC_CONFIG_REDIS_KEY_PREFIX}:{RestrictionType.DROP_EVENT_FROM_INGESTION}"
+
+        # Verify the old key has data
+        old_redis_data = self.redis_client.get(old_redis_key)
+        self.assertIsNotNone(old_redis_data)
+        data = json.loads(old_redis_data)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["token"], "test_token")
+
+        # Verify the new key has no data yet
+        new_redis_data = self.redis_client.get(new_redis_key)
+        self.assertIsNone(new_redis_data)
+
+        # Change the restriction type
+        config.restriction_type = RestrictionType.DROP_EVENT_FROM_INGESTION
+        config.save()
+
+        # The new key should now have the config
+        new_redis_data = self.redis_client.get(new_redis_key)
+        self.assertIsNotNone(new_redis_data)
+        data = json.loads(new_redis_data)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["token"], "test_token")
+
+        # The old key should be cleared (no configs left for that type)
+        old_redis_data = self.redis_client.get(old_redis_key)
+        self.assertIsNone(old_redis_data)

--- a/posthog/models/test/test_event_ingestion_restriction_config.py
+++ b/posthog/models/test/test_event_ingestion_restriction_config.py
@@ -786,7 +786,7 @@ class TestEventIngestionRestrictionConfig(BaseTest):
         # Verify the old key has data
         old_redis_data = self.redis_client.get(old_redis_key)
         self.assertIsNotNone(old_redis_data)
-        data = json.loads(old_redis_data)
+        data = json.loads(old_redis_data if old_redis_data is not None else b"[]")
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["token"], "test_token")
 
@@ -801,7 +801,7 @@ class TestEventIngestionRestrictionConfig(BaseTest):
         # The new key should now have the config
         new_redis_data = self.redis_client.get(new_redis_key)
         self.assertIsNotNone(new_redis_data)
-        data = json.loads(new_redis_data)
+        data = json.loads(new_redis_data if new_redis_data is not None else b"[]")
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["token"], "test_token")
 


### PR DESCRIPTION
## Problem

When changing the restriction type for an existing restriction, we only update the redis key for the new restriction type, not removing the old restriction.

## Changes

Regenerates both old and new restriction type redis keys when changing restriction type.

## How did you test this code?

- Added a regression test before implementing the fix
- Existing tests