### PR TITLE
fix: Filter out falsy values in getPersonsFromResponse

### DIFF
--- a/products/customer_analytics/frontend/components/PersonDisplayNameNudgeBanner.test.ts
+++ b/products/customer_analytics/frontend/components/PersonDisplayNameNudgeBanner.test.ts
@@ -1,0 +1,20 @@
+import { ActorsQueryResponse } from '~/queries/schema/schema-general'
+
+import { getPersonsFromResponse } from './PersonDisplayNameNudgeBanner'
+
+describe('getPersonsFromResponse', () => {
+    it('should not return null values', () => {
+        const response = {
+            results: [
+                [{ display_name: 'John Doe' }],
+                [{ display_name: 'Jane Doe' }],
+                [null],
+                [{ name: 'Wrong name field' }],
+                [['This should be an object']],
+            ],
+        } as ActorsQueryResponse
+
+        const persons = getPersonsFromResponse(response)
+        expect(persons).toEqual([{ display_name: 'John Doe' }, { display_name: 'Jane Doe' }])
+    })
+})

--- a/products/customer_analytics/frontend/components/PersonDisplayNameNudgeBanner.tsx
+++ b/products/customer_analytics/frontend/components/PersonDisplayNameNudgeBanner.tsx
@@ -17,17 +17,19 @@ interface PersonDisplayNameNudgeBannerProps {
 
 const UUID_THRESHOLD = 0.5
 
-function getPersonsFromResponse(response: ActorsQueryResponse | null): Record<string, string>[] {
+export function getPersonsFromResponse(response: ActorsQueryResponse | null): Record<string, string>[] {
     if (!response?.results) {
         return []
     }
-    return response.results.map((result) => {
-        const person = result[0]
-        if (typeof person === 'object' && person !== null && 'display_name' in person) {
-            return person
-        }
-        return null
-    })
+    return response.results
+        .map((result) => {
+            const person = result[0]
+            if (typeof person === 'object' && person !== null && 'display_name' in person) {
+                return person
+            }
+            return null
+        })
+        .filter(Boolean)
 }
 
 export function PersonDisplayNameNudgeBanner({ uniqueKey }: PersonDisplayNameNudgeBannerProps): JSX.Element | null {


### PR DESCRIPTION
## Problem
https://github.com/PostHog/posthog/pull/46156#issuecomment-3824194548
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
