### PR TITLE
fix: show black screen during inactivity

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -631,7 +631,7 @@ describe('sessionRecordingPlayerLogic', () => {
             expect(startBufferSpy).toHaveBeenCalled()
         })
 
-        it('keeps current player for gap segments without calling tryInitReplayer', () => {
+        it('calls tryInitReplayer for gap segments to show black screen', () => {
             const tryInitReplayerSpy = jest.spyOn(logic.actions, 'tryInitReplayer')
             const startBufferSpy = jest.spyOn(logic.actions, 'startBuffer')
 
@@ -650,7 +650,7 @@ describe('sessionRecordingPlayerLogic', () => {
 
             logic.actions.setCurrentSegment(gapSegment)
 
-            expect(tryInitReplayerSpy).not.toHaveBeenCalled()
+            expect(tryInitReplayerSpy).toHaveBeenCalled()
             expect(startBufferSpy).not.toHaveBeenCalled()
         })
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1290,11 +1290,10 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     segment.windowId !== undefined &&
                     values.sessionPlayerData.snapshotsByWindowId[segment.windowId]?.length >= 2
 
-                if (canReinit) {
+                if (canReinit || segment.kind === 'gap') {
+                    // Can reinitialize, or it's a gap segment (should show black screen)
                     values.player?.replayer?.pause()
                     actions.tryInitReplayer()
-                } else if (segment.kind === 'gap') {
-                    // Gap segment - keep current player visible, updateAnimation handles time
                 } else if (segment.windowId !== undefined) {
                     // WindowId exists but snapshots not loaded - buffer and load
                     actions.startBuffer()


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Skipping gap segments on player logic shows the last screen instead of the black screen we had before for skipping activity section

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
bring back the black screen for skipping inactivity section

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
