### PR TITLE
feat: improve passkey signup for invites

### DIFF
--- a/frontend/src/scenes/authentication/InviteSignup.tsx
+++ b/frontend/src/scenes/authentication/InviteSignup.tsx
@@ -277,10 +277,11 @@ function UnauthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite })
                         {passkeySignupEnabled && (
                             <>
                                 {passkeyRegistered ? (
-                                    <div className="border border-success-lighter rounded-lg p-4 bg-success-highlight text-center">
+                                    <div className="bg-surface-secondary rounded-lg p-4 text-center">
                                         <img src={passkeyLogo} alt="Passkey" className="w-8 h-8 mx-auto mb-2" />
-                                        <p className="font-semibold text-success mb-1">
-                                            Passkey registered successfully!
+                                        <p className="font-semibold mb-1">Passkey registered successfully!</p>
+                                        <p className="text-sm text-muted">
+                                            Complete the form below and press "Continue" to create your account.
                                         </p>
                                     </div>
                                 ) : (
@@ -300,32 +301,37 @@ function UnauthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite })
                                         Sign up with passkey
                                     </LemonButton>
                                 )}
-                                <div className="flex items-center gap-3 my-4">
-                                    <div className="flex-1 border-t border-border" />
-                                    <span className="text-secondary text-sm">or use a password</span>
-                                    <div className="flex-1 border-t border-border" />
-                                </div>
+
+                                {!passkeyRegistered && (
+                                    <div className="flex items-center gap-3 my-4">
+                                        <div className="flex-1 border-t border-border" />
+                                        <span className="text-secondary text-sm">or use a password</span>
+                                        <div className="flex-1 border-t border-border" />
+                                    </div>
+                                )}
                             </>
                         )}
-                        <LemonField
-                            name="password"
-                            label={
-                                <div className="flex flex-1 items-center justify-between">
-                                    <span>Password</span>
-                                    <PasswordStrength validatedPassword={validatedPassword} />
-                                </div>
-                            }
-                        >
-                            <LemonInput
-                                type="password"
-                                className="ph-ignore-input"
-                                data-attr="password"
-                                placeholder="••••••••••"
-                                autoComplete="new-password"
-                                autoFocus={window.screen.width >= 768} // do not autofocus on small-width screens
-                                disabled={isSignupSubmitting || passkeyRegistered}
-                            />
-                        </LemonField>
+                        {!passkeyRegistered && (
+                            <LemonField
+                                name="password"
+                                label={
+                                    <div className="flex flex-1 items-center justify-between">
+                                        <span>Password</span>
+                                        <PasswordStrength validatedPassword={validatedPassword} />
+                                    </div>
+                                }
+                            >
+                                <LemonInput
+                                    type="password"
+                                    className="ph-ignore-input"
+                                    data-attr="password"
+                                    placeholder="••••••••••"
+                                    autoComplete="new-password"
+                                    autoFocus={window.screen.width >= 768} // do not autofocus on small-width screens
+                                    disabled={isSignupSubmitting || passkeyRegistered}
+                                />
+                            </LemonField>
+                        )}
 
                         <LemonField
                             name="first_name"


### PR DESCRIPTION
## Problem

The passkey signup UX on the invite screen is confusing and leads people to think that they completed the signup process.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- De-emphasize the passkey registration success alert
- Hide password fields when passkey is registered


<img width="452" height="655" alt="Screenshot 2026-01-30 at 10 33 40 AM" src="https://github.com/user-attachments/assets/f2e17e39-5689-4e88-96cb-fba8dddb8dcd" />



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
