### PR TITLE
chore: merge endpoints into data modeling

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -317,6 +317,7 @@ export type SupportTicketTargetArea =
     | 'data_management'
     | 'notebooks'
     | 'data_warehouse'
+    | 'data_modeling'
     | 'feature_flags'
     | 'analytics'
     | 'session_replay'
@@ -324,7 +325,6 @@ export type SupportTicketTargetArea =
     | 'surveys'
     | 'web_analytics'
     | 'error_tracking'
-    | 'logs'
     | 'cdp_destinations'
     | 'data_ingestion'
     | 'batch_exports'
@@ -333,7 +333,6 @@ export type SupportTicketTargetArea =
     | 'max-ai'
     | 'customer-analytics'
     | 'logs'
-    | 'endpoints'
 export type SupportTicketSeverityLevel = keyof typeof SEVERITY_LEVEL_TO_NAME
 export type SupportTicketKind = keyof typeof SUPPORT_KIND_TO_SUBJECT
 
@@ -378,7 +377,6 @@ export const URL_PATH_TO_TARGET_AREA: Record<string, SupportTicketTargetArea> = 
     workflows: 'workflows',
     billing: 'billing',
     logs: 'logs',
-    endpoints: 'endpoints',
 }
 
 export const SUPPORT_TICKET_TEMPLATES = {

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -191,6 +191,11 @@ export const TARGET_AREA_TO_NAME = [
                 label: 'Data warehouse (sources)',
             },
             {
+                value: 'data_modeling',
+                'data-attr': `support-form-target-area-data_modeling`,
+                label: 'Data modeling (views, matviews, endpoints)',
+            },
+            {
                 value: 'batch_exports',
                 'data-attr': `support-form-target-area-batch_exports`,
                 label: 'Destinations (batch exports)',
@@ -284,11 +289,6 @@ export const TARGET_AREA_TO_NAME = [
                 value: 'logs',
                 'data-attr': `support-form-target-area-logs`,
                 label: 'Logs',
-            },
-            {
-                value: 'endpoints',
-                'data-attr': `support-form-target-area-endpoints`,
-                label: 'Endpoints',
             },
         ],
     },


### PR DESCRIPTION
## Problem

endpoints is a generic name so support tickets related to any api get routed here by customers by mistake. by merging it under data modeling (which is kinda what it is) i think we will reduce that.

## Changes

add data modeling support product area

## How did you test this code?

ran locally

## Publish to changelog?

no