### PR TITLE
chore: Move endpoints from unreleased to tools section

### DIFF
--- a/frontend/src/products.json
+++ b/frontend/src/products.json
@@ -51,7 +51,7 @@
         },
         {
             "path": "Endpoints",
-            "category": "Unreleased",
+            "category": "Tools",
             "iconType": "endpoints",
             "type": "endpoints",
             "intents": ["endpoints"]
@@ -211,7 +211,7 @@
             "type": null,
             "intents": []
         },
-        { "path": "Endpoints", "category": "Unreleased", "iconType": null, "type": null, "intents": [] },
+        { "path": "Endpoints", "category": "Tools", "iconType": null, "type": null, "intents": [] },
         {
             "path": "Event definitions",
             "category": "Schema",

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1082,7 +1082,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     {
         path: 'Endpoints',
         intents: [ProductKey.ENDPOINTS],
-        category: 'Unreleased',
+        category: 'Tools',
         href: urls.endpoints(),
         type: 'endpoints',
         flag: FEATURE_FLAGS.ENDPOINTS,
@@ -1419,7 +1419,7 @@ export const getTreeItemsMetadata = (): FileSystemImport[] => [
     },
     {
         path: 'Endpoints',
-        category: 'Unreleased',
+        category: 'Tools',
         iconType: 'endpoints' as FileSystemIconType,
         iconColor: ['var(--color-product-endpoints-light)'] as FileSystemIconColor,
         href: urls.endpoints(),

--- a/products/endpoints/manifest.tsx
+++ b/products/endpoints/manifest.tsx
@@ -88,7 +88,7 @@ export const manifest: ProductManifest = {
         {
             path: 'Endpoints',
             intents: [ProductKey.ENDPOINTS],
-            category: 'Unreleased',
+            category: 'Tools',
             href: urls.endpoints(),
             type: 'endpoints',
             flag: FEATURE_FLAGS.ENDPOINTS,
@@ -101,7 +101,7 @@ export const manifest: ProductManifest = {
     treeItemsMetadata: [
         {
             path: 'Endpoints',
-            category: 'Unreleased',
+            category: 'Tools',
             iconType: 'endpoints' as FileSystemIconType,
             iconColor: ['var(--color-product-endpoints-light)'] as FileSystemIconColor,
             href: urls.endpoints(),


### PR DESCRIPTION
## Problem

I got stuck earlier because I couldn't find Endpoints despite having the flag enabled - and it wasn't showing up in global search because it was under the Unreleased section, which is filtered out.

## Changes

Now it's in beta and we have people using it, move it to the 'Tools' section.

## How did you test this code?

Verified locally this only works when the `embedded-analytics` flag is enabled.