### PR TITLE
fix: sidebar pipeline status mat view failed age out

### DIFF
--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -235,6 +235,7 @@ export const exportsLogic = kea<exportsLogicType>([
                             if (apiError?.data?.attr === 'export_limit_exceeded') {
                                 actions.setHasReachedExportFullVideoLimit(true)
                                 lemonToast.error(apiError?.data?.detail || 'You reached your export limit.', {
+                                    autoClose: false,
                                     button: {
                                         label: 'I want more',
                                         className: 'replay-export-limit-reached-button',

--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -235,7 +235,6 @@ export const exportsLogic = kea<exportsLogicType>([
                             if (apiError?.data?.attr === 'export_limit_exceeded') {
                                 actions.setHasReachedExportFullVideoLimit(true)
                                 lemonToast.error(apiError?.data?.detail || 'You reached your export limit.', {
-                                    autoClose: false,
                                     button: {
                                         label: 'I want more',
                                         className: 'replay-export-limit-reached-button',

--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -542,7 +542,7 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                     Q(status=DataWarehouseSavedQuery.Status.FAILED)
                     | Q(is_materialized=False, latest_error__isnull=False)
                 )
-                .filter(Q(last_run_at__gte=one_day_ago) | Q(last_run_at__isnull=True))
+                .filter(Q(last_run_at__gte=one_day_ago))
             )
 
             for query in failed_materializations:
@@ -635,7 +635,7 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                         BatchExportRun.Status.TERMINATED,
                     ],
                 )
-                .filter(Q(finished_at__gte=one_day_ago) | Q(finished_at__isnull=True))
+                .filter(Q(finished_at__gte=one_day_ago))
                 .select_related("batch_export")
             )
 


### PR DESCRIPTION
## Problem

Pipeline status is being removed from the sidebar at some point, but this specific issue has caused confusion with customers.

## Changes

Mat views and batch export failures only show the last 1 days worth of failures instead of historical views

## How did you test this code?

I didn't 

## Publish to changelog?

No
