### PR TITLE
fix(subscriptions): fail fast on unsupported target types 

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -74,6 +74,9 @@ def get_subscription_failure_metric(
     )
 
 
+SUPPORTED_TARGET_TYPES = frozenset(["email", "slack"])
+
+
 async def deliver_subscription_report_async(
     subscription_id: int,
     previous_value: Optional[str] = None,
@@ -95,6 +98,15 @@ async def deliver_subscription_report_async(
         has_dashboard=bool(subscription.dashboard_id),
         has_insight=bool(subscription.insight_id),
     )
+
+    # Fail fast: validate target type before generating assets
+    if subscription.target_type not in SUPPORTED_TARGET_TYPES:
+        logger.error(
+            "deliver_subscription_report_async.unsupported_target",
+            subscription_id=subscription_id,
+            target_type=subscription.target_type,
+        )
+        raise NotImplementedError(f"{subscription.target_type} is not supported")
 
     is_new_subscription_target = False
     if previous_value is not None:
@@ -235,13 +247,6 @@ async def deliver_subscription_report_async(
                 exc_info=True,
             )
             capture_exception(e)
-    else:
-        logger.error(
-            "deliver_subscription_report_async.unsupported_target",
-            subscription_id=subscription_id,
-            target_type=subscription.target_type,
-        )
-        raise NotImplementedError(f"{subscription.target_type} is not supported")
 
     if not is_new_subscription_target:
         logger.info("deliver_subscription_report_async.updating_next_delivery", subscription_id=subscription_id)

--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -148,7 +148,7 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(minutes=5),
                     maximum_attempts=3,
-                    non_retryable_error_types=[],
+                    non_retryable_error_types=["NotImplementedError"],
                 ),
             )
             tasks.append(task)
@@ -174,5 +174,6 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
                 initial_interval=dt.timedelta(seconds=5),
                 maximum_interval=dt.timedelta(minutes=2),
                 maximum_attempts=3,
+                non_retryable_error_types=["NotImplementedError"],
             ),
         )


### PR DESCRIPTION

- Move target type validation before asset generation to avoid wasted compute
- Add NotImplementedError to non_retryable_error_types in temporal workflows

## Problem

We don't need to generate assets and use Temporal retries if the desitnation is not vaild. 

https://posthog.slack.com/archives/C09BDQLM8KA/p1769788523901039

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

fail fast

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
