### PR TITLE
chore: extend ingestion acceptance test logging

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/activities.py
+++ b/posthog/temporal/ingestion_acceptance_test/activities.py
@@ -36,6 +36,16 @@ async def run_ingestion_acceptance_tests() -> dict:
     logger.info("Starting ingestion acceptance tests")
 
     config = Config()
+    from posthog.models.utils import mask_key_value
+
+    logger.info(
+        "Loaded config",
+        api_host=config.api_host,
+        project_id=config.project_id,
+        project_api_key=mask_key_value(config.project_api_key),
+        personal_api_key=mask_key_value(config.personal_api_key),
+    )
+
     tests = discover_tests()
     client = PostHogClient(config)
     with ThreadPoolExecutor() as executor:

--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -3,19 +3,19 @@
 import json
 import time
 import uuid
-import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
 import requests
+import structlog
 
 # Use posthoganalytics instead of posthog to avoid conflict with local posthog/ directory
 import posthoganalytics
 
 from .config import Config
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 T = TypeVar("T")
 
@@ -56,6 +56,13 @@ class PostHogClient:
         posthoganalytics.debug = True
         posthoganalytics.sync_mode = True  # Send events synchronously for testing
 
+        logger.info(
+            "PostHog SDK configured",
+            sdk_host=posthoganalytics.host,
+            sdk_sync_mode=posthoganalytics.sync_mode,
+            sdk_debug=posthoganalytics.debug,
+        )
+
     def capture_event(
         self,
         event_name: str,
@@ -65,7 +72,13 @@ class PostHogClient:
         """Send an event using the official PostHog SDK."""
         event_uuid = str(uuid.uuid4())
 
-        logger.info("[capture] Sending event '%s' with UUID %s", event_name, event_uuid)
+        logger.info(
+            "Capturing event",
+            event_name=event_name,
+            event_uuid=event_uuid,
+            distinct_id=distinct_id,
+            sdk_host=posthoganalytics.host,
+        )
 
         posthoganalytics.capture(
             distinct_id=distinct_id,
@@ -74,7 +87,8 @@ class PostHogClient:
             uuid=event_uuid,
         )
 
-        logger.info("[capture] Event sent successfully")
+        logger.info("Event captured", event_uuid=event_uuid)
+
         return event_uuid
 
     def query_event_by_uuid(
@@ -114,22 +128,13 @@ class PostHogClient:
         """Poll until fetch_fn returns a non-None result or timeout."""
         timeout = timeout_seconds or self.config.event_timeout_seconds
         start_time = time.time()
-        attempt = 0
-
-        logger.info("[query] Polling for %s (timeout: %ds)", description, timeout)
 
         while time.time() - start_time < timeout:
-            attempt += 1
             result = fetch_fn()
             if result is not None:
-                logger.info(
-                    "[query] Found %s after %.1fs (%d attempts)", description, time.time() - start_time, attempt
-                )
                 return result
-
             time.sleep(self.config.poll_interval_seconds)
 
-        logger.warning("[query] %s not found within %ds (%d attempts)", description, timeout, attempt)
         return None
 
     def _execute_hogql_query(self, query: str, values: dict[str, Any]) -> dict[str, Any] | None:

--- a/posthog/temporal/ingestion_acceptance_test/slack.py
+++ b/posthog/temporal/ingestion_acceptance_test/slack.py
@@ -1,14 +1,14 @@
 """Slack notifications for test results using incoming webhooks."""
 
-import logging
 from typing import Any
 
 import requests
+import structlog
 
 from .config import Config
 from .results import TestSuiteResult
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def send_slack_notification(config: Config, result: TestSuiteResult) -> bool:
@@ -39,7 +39,7 @@ def send_slack_notification(config: Config, result: TestSuiteResult) -> bool:
         logger.info("Slack notification sent successfully")
         return True
     except requests.RequestException as e:
-        logger.warning("Failed to send Slack notification: %s", e)
+        logger.warning("Failed to send Slack notification", error=str(e))
         return False
 
 


### PR DESCRIPTION
## Problem

Running the temporal job on dev is not leading to data showing up Clickhouse (and hence, tests failing). Running that same code from within the pod works as expected.

## Changes

Adding some extra logging to figure out if there is a config problem.

## How did you test this code?

Manually

## Publish to changelog?
