### PR TITLE
fix: pass subTemplateId to HogFunctionConfiguration

### DIFF
--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -300,7 +300,7 @@ export function HogFunctionScene(): JSX.Element {
     const { setCurrentTab } = useActions(hogFunctionSceneLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const { id, templateId } = logicProps
+    const { id, templateId, subTemplateId } = logicProps
 
     useFileSystemLogView({
         type: `hog_function/${type ?? ''}`,
@@ -386,7 +386,7 @@ export function HogFunctionScene(): JSX.Element {
                     </LemonBanner>
                 )}
                 {templateId ? (
-                    <HogFunctionConfiguration templateId={templateId} />
+                    <HogFunctionConfiguration templateId={templateId} subTemplateId={subTemplateId} />
                 ) : (
                     <LemonTabs activeKey={currentTab} tabs={tabs} onChange={setCurrentTab} sceneInset={true} />
                 )}

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -35,12 +35,18 @@ import { HogFunctionTemplateOptions } from './components/HogFunctionTemplateOpti
 
 export interface HogFunctionConfigurationProps {
     templateId?: string | null
+    subTemplateId?: string | null
     id?: string | null
     logicKey?: string
 }
 
-export function HogFunctionConfiguration({ templateId, id, logicKey }: HogFunctionConfigurationProps): JSX.Element {
-    const logicProps = { templateId, id, logicKey }
+export function HogFunctionConfiguration({
+    templateId,
+    subTemplateId,
+    id,
+    logicKey,
+}: HogFunctionConfigurationProps): JSX.Element {
+    const logicProps = { templateId, subTemplateId, id, logicKey }
     const logic = hogFunctionConfigurationLogic(logicProps)
     const {
         configuration,


### PR DESCRIPTION
## Problem

Reported in https://posthoghelp.zendesk.com/agent/tickets/48953 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/51123) - the header button had stopped working to submit hog function forms when a sub-template was in use.

## Changes

Pass the `subTemplateId` to `HogFunctionConfiguration` so that the header button binds to the same `hogFunctionConfigurationLogic` and correctly submits the form.

## How did you test this code?

Tested locally.