### PR TITLE
fix(subscriptions): skip unsupported target types without failing activity

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -99,14 +99,14 @@ async def deliver_subscription_report_async(
         has_insight=bool(subscription.insight_id),
     )
 
-    # Fail fast: validate target type before generating assets
+    # Skip unsupported target types before generating assets
     if subscription.target_type not in SUPPORTED_TARGET_TYPES:
         logger.error(
             "deliver_subscription_report_async.unsupported_target",
             subscription_id=subscription_id,
             target_type=subscription.target_type,
         )
-        raise NotImplementedError(f"{subscription.target_type} is not supported")
+        return
 
     is_new_subscription_target = False
     if previous_value is not None:

--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -148,7 +148,7 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(minutes=5),
                     maximum_attempts=3,
-                    non_retryable_error_types=["NotImplementedError"],
+                    non_retryable_error_types=[],
                 ),
             )
             tasks.append(task)
@@ -174,6 +174,5 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
                 initial_interval=dt.timedelta(seconds=5),
                 maximum_interval=dt.timedelta(minutes=2),
                 maximum_attempts=3,
-                non_retryable_error_types=["NotImplementedError"],
             ),
         )


### PR DESCRIPTION
## Problem

Raising the exception causes the Temporal activity to fail potentially stopping the entire workflow and thus other acitvities 

https://posthog.slack.com/archives/C09BDQLM8KA/p1769788523901039

https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/schedule-all-subscriptions-schedule-2026-01-30T17%3A55%3A00Z/019c100b-458c-72b8-8bee-6c0cf0a50d3f/history

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Don't raise the exception, so that the Temporal activity succeeds. 


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
