### PR TITLE
feat(deduplicator: fix new object_store IRSA AWS S3 cfg for prod deploys

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/mod.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/mod.rs
@@ -5,6 +5,7 @@ pub mod export;
 pub mod import;
 pub mod metadata;
 pub mod planner;
+pub mod s3_client;
 pub mod s3_downloader;
 pub mod s3_uploader;
 pub mod uploader;

--- a/rust/kafka-deduplicator/src/checkpoint/s3_client.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_client.rs
@@ -1,0 +1,141 @@
+//! Shared S3 client setup for checkpoint uploader and downloader.
+//!
+//! This module provides a unified way to create S3 clients with proper
+//! credential resolution for both production (IRSA) and local dev (MinIO).
+
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use object_store::aws::{AmazonS3, AmazonS3Builder};
+use object_store::limit::LimitStore;
+use object_store::path::Path as ObjectPath;
+use object_store::{ClientOptions, ObjectStore};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, info};
+
+use super::config::CheckpointConfig;
+
+/// Timeout for bucket validation during client initialization.
+/// Keep this short to fail fast on misconfiguration rather than hanging.
+const VALIDATION_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Create an S3 client with proper credential resolution.
+///
+/// Credential priority:
+/// 1. Explicit credentials from config (for local dev/CI with MinIO)
+/// 2. IRSA via AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN (for EKS production)
+/// 3. Default credential chain (IMDS, env vars, config files)
+///
+/// The client is wrapped in a `LimitStore` to bound concurrent requests.
+pub async fn create_s3_client(
+    config: &CheckpointConfig,
+    max_concurrent_requests: usize,
+) -> Result<Arc<LimitStore<AmazonS3>>> {
+    // Start with from_env() to pick up AWS_* vars including IRSA credentials
+    // (AWS_WEB_IDENTITY_TOKEN_FILE, AWS_ROLE_ARN, AWS_REGION, etc.)
+    let mut builder = AmazonS3Builder::from_env()
+        .with_bucket_name(&config.s3_bucket)
+        .with_client_options(ClientOptions::new().with_timeout(config.s3_attempt_timeout))
+        .with_retry(object_store::RetryConfig {
+            max_retries: config.s3_max_retries,
+            retry_timeout: config.s3_operation_timeout,
+            ..Default::default()
+        });
+
+    // Set region if provided (overrides env)
+    if let Some(ref region) = config.aws_region {
+        builder = builder.with_region(region);
+    }
+
+    // Set custom endpoint for MinIO/local dev
+    if let Some(ref endpoint) = config.s3_endpoint {
+        builder = builder.with_endpoint(endpoint);
+        if endpoint.starts_with("http://") {
+            builder = builder.with_allow_http(true);
+        }
+    }
+
+    // Explicit credentials override env (for local dev without IAM)
+    if let (Some(ref access_key), Some(ref secret_key)) =
+        (&config.s3_access_key_id, &config.s3_secret_access_key)
+    {
+        info!("Using explicit S3 credentials from config");
+        builder = builder
+            .with_access_key_id(access_key)
+            .with_secret_access_key(secret_key);
+    } else if std::env::var("AWS_WEB_IDENTITY_TOKEN_FILE").is_ok()
+        && std::env::var("AWS_ROLE_ARN").is_ok()
+    {
+        info!("Using IRSA credentials (AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN)");
+    } else {
+        debug!("Using default AWS credential chain");
+    }
+
+    // Force path-style URLs if needed (required for MinIO)
+    if config.s3_force_path_style {
+        builder = builder.with_virtual_hosted_style_request(false);
+    }
+
+    let base_store = builder.build().with_context(|| {
+        format!(
+            "Failed to create S3 client for bucket '{}' in region '{}'",
+            config.s3_bucket,
+            config.aws_region.as_deref().unwrap_or("default")
+        )
+    })?;
+
+    let store = Arc::new(LimitStore::new(base_store, max_concurrent_requests));
+
+    // Validate bucket access with SHORT timeout - fail fast if misconfigured
+    validate_bucket_access(&store, &config.s3_bucket, &config.aws_region).await?;
+
+    Ok(store)
+}
+
+/// Validate bucket access with a short timeout to fail fast on misconfiguration.
+///
+/// This prevents the service from hanging for minutes when S3 is unreachable
+/// or credentials are invalid, allowing K8s health checks to fail quickly
+/// with a meaningful error message.
+async fn validate_bucket_access(
+    store: &LimitStore<AmazonS3>,
+    bucket: &str,
+    region: &Option<String>,
+) -> Result<()> {
+    info!(bucket = %bucket, "Validating S3 bucket access...");
+
+    let prefix = ObjectPath::from("");
+    let mut stream = store.list(Some(&prefix));
+
+    match tokio::time::timeout(VALIDATION_TIMEOUT, stream.next()).await {
+        Ok(Some(Err(e))) => Err(anyhow::anyhow!(e)).with_context(|| {
+            format!(
+                "S3 bucket validation failed for '{}' in region '{}' - check bucket exists, credentials, and network",
+                bucket,
+                region.as_deref().unwrap_or("default")
+            )
+        }),
+        Err(_) => Err(anyhow::anyhow!(
+            "S3 bucket validation timed out after {:?} for bucket '{}' - check network connectivity and credentials",
+            VALIDATION_TIMEOUT,
+            bucket
+        )),
+        Ok(Some(Ok(_))) | Ok(None) => {
+            info!(bucket = %bucket, "S3 bucket validated successfully");
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validation_timeout_is_reasonable() {
+        // Ensure the validation timeout is short enough to fail fast
+        // but long enough for a healthy S3 to respond
+        assert!(VALIDATION_TIMEOUT >= Duration::from_secs(5));
+        assert!(VALIDATION_TIMEOUT <= Duration::from_secs(30));
+    }
+}

--- a/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
@@ -7,6 +7,7 @@ use tokio_util::bytes::Bytes;
 use super::config::CheckpointConfig;
 use super::downloader::CheckpointDownloader;
 use super::metadata::{DATE_PLUS_HOURS_ONLY_FORMAT, METADATA_FILENAME};
+use super::s3_client::create_s3_client;
 use crate::metrics_const::{
     CHECKPOINT_BATCH_FETCH_STORE_HISTOGRAM, CHECKPOINT_FILE_DOWNLOADS_COUNTER,
     CHECKPOINT_FILE_FETCH_HISTOGRAM, CHECKPOINT_FILE_FETCH_STORE_HISTOGRAM,
@@ -18,10 +19,9 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use futures::stream::FuturesUnordered;
 use futures::{StreamExt, TryStreamExt};
-use object_store::aws::AmazonS3Builder;
 use object_store::limit::LimitStore;
 use object_store::path::Path as ObjectPath;
-use object_store::{ClientOptions, ObjectStore, ObjectStoreExt};
+use object_store::{ObjectStore, ObjectStoreExt};
 use tokio::io::AsyncWriteExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -100,78 +100,16 @@ pub struct S3Downloader {
 
 impl S3Downloader {
     pub async fn new(config: &CheckpointConfig) -> Result<Self> {
-        // Per-request timeout (analogous to operation_attempt_timeout in aws_sdk_s3)
-        let client_options = ClientOptions::new().with_timeout(config.s3_attempt_timeout);
-
-        // Build the base S3 store using the same pattern as S3Uploader
-        let mut builder = AmazonS3Builder::new()
-            .with_bucket_name(&config.s3_bucket)
-            .with_client_options(client_options)
-            .with_retry(object_store::RetryConfig {
-                max_retries: config.s3_max_retries,
-                // Total retry budget (analogous to operation_timeout in aws_sdk_s3)
-                retry_timeout: config.s3_operation_timeout,
-                ..Default::default()
-            });
-
-        // Set region if provided
-        if let Some(ref region) = config.aws_region {
-            builder = builder.with_region(region);
-        }
-
-        // Set custom endpoint for MinIO/local dev
-        if let Some(ref endpoint) = config.s3_endpoint {
-            builder = builder.with_endpoint(endpoint);
-            // Allow HTTP for local development
-            if endpoint.starts_with("http://") {
-                builder = builder.with_allow_http(true);
-            }
-        }
-
-        // Set credentials if provided (for local dev without IAM)
-        if let (Some(ref access_key), Some(ref secret_key)) =
-            (&config.s3_access_key_id, &config.s3_secret_access_key)
-        {
-            builder = builder
-                .with_access_key_id(access_key)
-                .with_secret_access_key(secret_key);
-        }
-
-        // Force path-style URLs if needed (required for MinIO)
-        if config.s3_force_path_style {
-            builder = builder.with_virtual_hosted_style_request(false);
-        }
-
-        let base_store = builder.build().with_context(|| {
-            format!(
-                "Failed to create S3 client for bucket '{}' in region '{}'",
-                config.s3_bucket,
-                config.aws_region.as_deref().unwrap_or("default")
-            )
-        })?;
-
-        // Wrap with LimitStore for bounded concurrency
-        // The semaphore permit is held for the entire stream duration
-        let store = LimitStore::new(base_store, config.max_concurrent_checkpoint_file_downloads);
-
-        // Validate bucket access by attempting to list - fail fast if misconfigured
-        if let Some(Err(e)) = store.list(Some(&ObjectPath::from(""))).next().await {
-            return Err(anyhow::anyhow!(e)).with_context(|| {
-                format!(
-                    "S3 bucket validation failed for '{}' in region '{}' - check bucket exists, credentials, and network connectivity",
-                    config.s3_bucket,
-                    config.aws_region.as_deref().unwrap_or("default")
-                )
-            });
-        }
+        let store =
+            create_s3_client(config, config.max_concurrent_checkpoint_file_downloads).await?;
 
         info!(
-            "S3 bucket '{}' validated successfully with max {} concurrent downloads",
+            "S3 downloader initialized for bucket '{}' with max {} concurrent downloads",
             config.s3_bucket, config.max_concurrent_checkpoint_file_downloads
         );
 
         Ok(Self {
-            store: Arc::new(store),
+            store,
             s3_bucket: config.s3_bucket.clone(),
             s3_key_prefix: config.s3_key_prefix.clone(),
             checkpoint_import_window_hours: config.checkpoint_import_window_hours,

--- a/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
@@ -2,11 +2,9 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use object_store::aws::AmazonS3Builder;
 use object_store::buffered::BufWriter;
-use object_store::limit::LimitStore;
 use object_store::path::Path as ObjectPath;
-use object_store::{ClientOptions, ObjectStore, ObjectStoreExt, PutPayload};
+use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
 use std::path::Path;
 use std::sync::Arc;
 use tokio::fs::File;
@@ -15,6 +13,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::config::CheckpointConfig;
+use super::s3_client::create_s3_client;
 use super::uploader::CheckpointUploader;
 use crate::metrics_const::CHECKPOINT_FILE_UPLOADS_COUNTER;
 
@@ -70,77 +69,16 @@ pub struct S3Uploader {
 
 impl S3Uploader {
     pub async fn new(config: CheckpointConfig) -> Result<Self> {
-        // Per-request timeout (analogous to operation_attempt_timeout in aws_sdk_s3)
-        let client_options = ClientOptions::new().with_timeout(config.s3_attempt_timeout);
-
-        let mut builder = AmazonS3Builder::new()
-            .with_bucket_name(&config.s3_bucket)
-            .with_client_options(client_options)
-            .with_retry(object_store::RetryConfig {
-                max_retries: config.s3_max_retries,
-                // Total retry budget (analogous to operation_timeout in aws_sdk_s3)
-                retry_timeout: config.s3_operation_timeout,
-                ..Default::default()
-            });
-
-        // Set region if provided
-        if let Some(ref region) = config.aws_region {
-            builder = builder.with_region(region);
-        }
-
-        // Set custom endpoint for MinIO/local dev
-        if let Some(ref endpoint) = config.s3_endpoint {
-            builder = builder.with_endpoint(endpoint);
-            // Allow HTTP for local development
-            if endpoint.starts_with("http://") {
-                builder = builder.with_allow_http(true);
-            }
-        }
-
-        // Set credentials if provided (for local dev without IAM)
-        if let (Some(ref access_key), Some(ref secret_key)) =
-            (&config.s3_access_key_id, &config.s3_secret_access_key)
-        {
-            builder = builder
-                .with_access_key_id(access_key)
-                .with_secret_access_key(secret_key);
-        }
-
-        // Force path-style URLs if needed (required for MinIO)
-        if config.s3_force_path_style {
-            builder = builder.with_virtual_hosted_style_request(false);
-        }
-
-        let base_store = builder.build().with_context(|| {
-            format!(
-                "Failed to create S3 client for bucket '{}' in region '{}'",
-                config.s3_bucket,
-                config.aws_region.as_deref().unwrap_or("default")
-            )
-        })?;
-
-        // Wrap with LimitStore for bounded concurrency
-        let store: Arc<dyn ObjectStore> = Arc::new(LimitStore::new(
-            base_store,
-            config.max_concurrent_checkpoint_file_uploads,
-        ));
-
-        // Validate bucket access by attempting to list - fail fast if misconfigured
-        if let Some(Err(e)) = store.list(Some(&ObjectPath::from(""))).next().await {
-            return Err(anyhow::anyhow!(e)).with_context(|| {
-                format!(
-                    "S3 bucket validation failed for '{}' in region '{}' - check bucket exists, credentials, and network connectivity",
-                    config.s3_bucket,
-                    config.aws_region.as_deref().unwrap_or("default")
-                )
-            });
-        }
+        let store =
+            create_s3_client(&config, config.max_concurrent_checkpoint_file_uploads).await?;
 
         info!(
-            "S3 bucket '{}' validated successfully with max {} concurrent uploads",
+            "S3 uploader initialized for bucket '{}' with max {} concurrent uploads",
             config.s3_bucket, config.max_concurrent_checkpoint_file_uploads
         );
 
+        // Coerce to trait object for use with BufWriter
+        let store: Arc<dyn ObjectStore> = store;
         Ok(Self { store, config })
     }
 


### PR DESCRIPTION
## Problem
When we swapped out our AWS S3 client crate for `object_store` we didn't set up production creds at initialization the way we did before. This broke the deploy
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Fix creds handling for prod deploys at init
* Refactor `object_store` init to DRY things up
* Related test changes
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
