### PR TITLE
chore(flags): Drop `/has_active_dependents`

### DIFF
--- a/posthog/api/test/test_feature_flag_dependency_deletion.py
+++ b/posthog/api/test/test_feature_flag_dependency_deletion.py
@@ -296,20 +296,3 @@ class TestFeatureFlagDependencyDeletion(APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), [])
-
-    def test_deprecated_has_active_dependents_endpoint(self):
-        """
-        Test the deprecated has_active_dependents endpoint still works.
-        Safe to delete after usage falls to zero, expected by Jan 22, 2026.
-        """
-        base_flag = self.create_flag("base_flag")
-        self.create_flag("dependent_flag", dependencies=[base_flag.id])
-
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/feature_flags/{base_flag.id}/has_active_dependents/",
-            format="json",
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["has_active_dependents"], True)
-        self.assertEqual(len(response.json()["dependent_flags"]), 1)

--- a/products/feature_flags/frontend/generated/api.ts
+++ b/products/feature_flags/frontend/generated/api.ts
@@ -325,28 +325,6 @@ export const featureFlagsEnrichUsageDashboardCreate = async (
 }
 
 /**
- * Deprecated: Use GET /dependent_flags instead.
-Safe to delete after usage falls to zero, expected by Jan 22, 2026.
- */
-export const getFeatureFlagsHasActiveDependentsCreateUrl = (projectId: string, id: number) => {
-    return `/api/projects/${projectId}/feature_flags/${id}/has_active_dependents/`
-}
-
-export const featureFlagsHasActiveDependentsCreate = async (
-    projectId: string,
-    id: number,
-    featureFlagApi: NonReadonly<FeatureFlagApi>,
-    options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getFeatureFlagsHasActiveDependentsCreateUrl(projectId, id), {
-        ...options,
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(featureFlagApi),
-    })
-}
-
-/**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
 
 If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.


### PR DESCRIPTION
## Problem

The route was replaced a couple of weeks ago and metrics state it's safe to drop this route (~0-2 usages/day).

## Changes

The unused route is removed
