### PR TITLE
fix(batch-exports): Add non-retryable errors for Databricks

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -74,6 +74,10 @@ NON_RETRYABLE_ERROR_TYPES: list[str] = [
     # Raised when we hit our self-imposed long running operation timeout.
     # We don't want to continually retry as it could consume a lot of compute resources in the user's account.
     "DatabricksOperationTimeoutError",
+    # Raised when the Databricks catalog is not found.
+    "DatabricksCatalogNotFoundError",
+    # Raised when the Databricks schema is not found.
+    "DatabricksSchemaNotFoundError",
 ]
 
 DatabricksField = tuple[str, str]


### PR DESCRIPTION
## Problem

If a Databricks schema or catalog is not found we continuously retry.

## Changes

Return an error if the specified schema or catalog cannot be found.

## How did you test this code?

I didn't
