### PR TITLE
chore(feature flags): client-side search/filter

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -218,10 +218,15 @@ export function LemonTable<T extends Record<string, any>>({
             const realTableOffsetTop = scrollRef.current.getBoundingClientRect().top - 320 // Extra breathing room
             // If the table starts above the top edge of the view, scroll to the top of the table minus breathing room
             if (realTableOffsetTop < 0) {
-                window.scrollTo(window.scrollX, window.scrollY + realTableOffsetTop)
+                const scrollContainer = document.querySelector('main') || window
+                if (scrollContainer === window) {
+                    window.scrollTo(window.scrollX, window.scrollY + realTableOffsetTop)
+                } else {
+                    scrollContainer.scrollBy(0, realTableOffsetTop)
+                }
             }
         }
-    }, [paginationState.currentPage, scrollRef.current])
+    }, [paginationState.currentPage])
 
     if (firstColumnSticky && expandable) {
         // Due to CSS, for firstColumnSticky to work the first column needs to be a content column

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
@@ -1,10 +1,71 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
-import { FeatureFlagsTab, featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
+import { NEW_FLAG } from 'scenes/feature-flags/featureFlagLogic'
+import {
+    FeatureFlagsTab,
+    featureFlagsLogic,
+    flagMatchesSearch,
+    flagMatchesStatus,
+    flagMatchesType,
+} from 'scenes/feature-flags/featureFlagsLogic'
 import { urls } from 'scenes/urls'
 
 import { initKeaTests } from '~/test/init'
+import { FeatureFlagType } from '~/types'
+
+describe('flagMatchesSearch', () => {
+    const flag = { ...NEW_FLAG, id: 1, key: 'my-feature', name: 'My Feature Flag' } as FeatureFlagType
+
+    it.each<[string | undefined, boolean]>([
+        [undefined, true],
+        ['my', true],
+        ['MY-FEATURE', true],
+        ['flag', true],
+        ['nonexistent', false],
+    ])('search=%p → %p', (search, expected) => {
+        expect(flagMatchesSearch(flag, search)).toBe(expected)
+    })
+})
+
+describe('flagMatchesStatus', () => {
+    it.each<[boolean, FeatureFlagType['status'], string | undefined, boolean]>([
+        [true, 'ACTIVE', undefined, true],
+        [true, 'ACTIVE', 'true', true],
+        [true, 'ACTIVE', 'false', false],
+        [false, 'INACTIVE', 'false', true],
+        [true, 'STALE', 'STALE', true],
+        [true, 'ACTIVE', 'STALE', false],
+    ])('active=%p status=%p filter=%p → %p', (active, status, filter, expected) => {
+        const flag = { ...NEW_FLAG, id: 1, key: 'test', active, status } as FeatureFlagType
+        expect(flagMatchesStatus(flag, filter)).toBe(expected)
+    })
+})
+
+describe('flagMatchesType', () => {
+    const flags = {
+        boolean: { ...NEW_FLAG, id: 1, key: 'bool', filters: { groups: [] } } as FeatureFlagType,
+        multivariant: {
+            ...NEW_FLAG,
+            id: 2,
+            key: 'multi',
+            filters: { groups: [], multivariate: { variants: [{ key: 'a', rollout_percentage: 100 }] } },
+        } as FeatureFlagType,
+        experiment: { ...NEW_FLAG, id: 3, key: 'exp', experiment_set: [1] } as FeatureFlagType,
+        remote_config: { ...NEW_FLAG, id: 4, key: 'remote', is_remote_configuration: true } as FeatureFlagType,
+    }
+
+    it.each<[keyof typeof flags, string | undefined, boolean]>([
+        ['boolean', undefined, true],
+        ['boolean', 'boolean', true],
+        ['boolean', 'multivariant', false],
+        ['multivariant', 'multivariant', true],
+        ['experiment', 'experiment', true],
+        ['remote_config', 'remote_config', true],
+    ])('%s with type=%p → %p', (flagKey, type, expected) => {
+        expect(flagMatchesType(flags[flagKey], type)).toBe(expected)
+    })
+})
 
 describe('the feature flags logic', () => {
     let logic: ReturnType<typeof featureFlagsLogic.build>


### PR DESCRIPTION
## Problem

feature flags table hits the backend every single time you change a search or filter, nothing client-side, which makes it feel slow :(

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds client-side search/filter to the flags table:

- maintain local cache of all flags we've gotten from the backend
- search/filter those first
- debounce changes and hit the backend, then update cache + results if necessary

new vid after revisions: https://screen.studio/share/ofMbiVvm?state=uploading

[flag-search-cache.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/3b644e15-8c59-4ada-9f34-43c94512d69b.mp4" />](https://app.graphite.com/user-attachments/video/3b644e15-8c59-4ada-9f34-43c94512d69b.mp4)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

sure?