### PR TITLE
chore(flags): decrease db timeouts

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -231,7 +231,7 @@ pub struct Config {
     // How long to wait for a connection from the pool before timing out
     // - Increase if seeing "pool timed out" errors under load (e.g., 5-10s)
     // - Decrease for faster failure detection (minimum 1s)
-    #[envconfig(default = "20")]
+    #[envconfig(default = "5")]
     pub acquire_timeout_secs: u64,
 
     // Close connections that have been idle for this many seconds
@@ -249,26 +249,27 @@ pub struct Config {
 
     // PostgreSQL statement_timeout for non-persons reader queries (milliseconds)
     // - Set to 0 to use database default (typically unlimited)
-    // - Non-persons readers may run longer analytical queries
-    // - Default: 5000ms (5 seconds)
+    // - Flag definitions and team lookups should complete well under 2s (P99 hold time is 5ms)
+    // - Default: 2000ms (2 seconds)
     // - This timeout is enforced server-side and properly kills queries
-    #[envconfig(default = "5000")]
+    #[envconfig(default = "2000")]
     pub non_persons_reader_statement_timeout_ms: u64,
 
     // PostgreSQL statement_timeout for persons reader queries (milliseconds)
     // - Set to 0 to use database default (typically unlimited)
-    // - Persons readers may run longer analytical queries
-    // - Default: 5000ms (5 seconds)
+    // - Person and cohort queries should complete well under 3s (P99 hold time is 25ms)
+    // - Default: 3000ms (3 seconds)
     // - This timeout is enforced server-side and properly kills queries
-    #[envconfig(default = "5000")]
+    #[envconfig(default = "3000")]
     pub persons_reader_statement_timeout_ms: u64,
 
     // PostgreSQL statement_timeout for writer database queries (milliseconds)
     // - Set to 0 to use database default (typically unlimited)
-    // - Writers should be fast transactional operations
-    // - Default: 10000ms (10 seconds)
+    // - Hash key override writes have retry logic (2 attempts, 100ms backoff)
+    // - 3s per attempt with retries gives 6s total before failure
+    // - Default: 3000ms (3 seconds)
     // - This timeout is enforced server-side and properly kills queries
-    #[envconfig(default = "10000")]
+    #[envconfig(default = "3000")]
     pub writer_statement_timeout_ms: u64,
 
     // How often to report database pool metrics (seconds)
@@ -537,9 +538,9 @@ impl Config {
             acquire_timeout_secs: 3,
             idle_timeout_secs: 300,
             test_before_acquire: FlexBool(true),
-            non_persons_reader_statement_timeout_ms: 5000,
-            persons_reader_statement_timeout_ms: 5000,
-            writer_statement_timeout_ms: 5000,
+            non_persons_reader_statement_timeout_ms: 2000,
+            persons_reader_statement_timeout_ms: 3000,
+            writer_statement_timeout_ms: 3000,
             db_monitor_interval_secs: 30,
             cohort_cache_monitor_interval_secs: 30,
             db_pool_warn_utilization: 0.8,


### PR DESCRIPTION
## Problem

Full investigation on #46222

The feature-flags service's DB timeouts are all above the Contour/Envoy response timeout (5s). The acquire timeout is 20s and statement timeouts are 5-10s, so when pool exhaustion occurs the app holds requests that Envoy has already killed with a 504. This makes 81% of 5xx errors (38.8K/day) invisible to app-level monitoring — they only show up as Envoy `upstream_rq_timeout`.

## Changes

Reduce application-level DB timeouts to fail fast instead of queueing behind the ingress ceiling:

| Setting | Before | After | Rationale |
|---------|--------|-------|-----------|
| `acquire_timeout_secs` | 20s | 5s | Matches Envoy ceiling. Prevents holding dead requests for 20s. |
| `non_persons_reader_statement_timeout_ms` | 5s | 2s | P99 hold time is 5ms. 400x headroom. |
| `persons_reader_statement_timeout_ms` | 5s | 3s | P99 hold time is 25ms. 120x headroom. |
| `writer_statement_timeout_ms` | 10s | 3s | P99 hold time is 90ms. Writer utilization near 0%. |

No retry storm risk — Contour only retries on `reset`/`cancelled`, not timeouts (115 retries/day).

## How did you test this code?

Config-only change (default values in `config.rs`). Validated by:

- Reviewing Envoy and application metrics over 24h to confirm timeout interactions
- Confirming Contour retry policy does not retry on timeout/5xx responses
- Verifying connection budget remains within PostgreSQL limits

## Publish to changelog?

No
