### PR TITLE
fix: stop polling live users when not visible

### DIFF
--- a/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
+++ b/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
@@ -77,7 +77,7 @@ export function LiveUserCount({
     const { liveUserCount } = useValues(liveUserCountLogic({ pollIntervalMs }))
     const { pauseStream, resumeStream } = useActions(liveUserCountLogic({ pollIntervalMs }))
 
-    const isVisible = usePageVisibility()
+    const { isVisible } = usePageVisibility()
     useEffect(() => {
         if (isVisible) {
             resumeStream()
@@ -121,7 +121,7 @@ export function LiveRecordingsCount({ pollIntervalMs = 30000 }: LiveCountProps):
     const { activeRecordings } = useValues(liveUserCountLogic({ pollIntervalMs }))
     const { pauseStream, resumeStream } = useActions(liveUserCountLogic({ pollIntervalMs }))
 
-    const isVisible = usePageVisibility()
+    const { isVisible } = usePageVisibility()
     useEffect(() => {
         if (isVisible) {
             resumeStream()

--- a/frontend/src/lib/components/LiveUserCount/liveUserCountLogic.ts
+++ b/frontend/src/lib/components/LiveUserCount/liveUserCountLogic.ts
@@ -26,7 +26,6 @@ export const liveUserCountLogic = kea<liveUserCountLogicType>([
         setStats: (stats: LiveUserCountStats, now: Date) => ({ stats, now }),
         setNow: (now: Date) => ({ now }),
         setIsHovering: (isHovering: boolean) => ({ isHovering }),
-        setPageVisibility: (visible: boolean) => ({ visible }),
         pauseStream: true,
         resumeStream: true,
     })),
@@ -117,25 +116,11 @@ export const liveUserCountLogic = kea<liveUserCountLogicType>([
                 return () => clearInterval(intervalId)
             }, 'statsInterval')
         },
-        setPageVisibility: ({ visible }) => {
-            if (visible) {
-                actions.resumeStream()
-            } else {
-                actions.pauseStream()
-            }
-        },
     })),
-    events(({ actions, cache }) => ({
+    events(({ actions }) => ({
         afterMount: () => {
             actions.setNow(new Date())
             actions.resumeStream()
-            cache.disposables.add(() => {
-                const onVisibilityChange = (): void => {
-                    actions.setPageVisibility(document.visibilityState === 'visible')
-                }
-                document.addEventListener('visibilitychange', onVisibilityChange)
-                return () => document.removeEventListener('visibilitychange', onVisibilityChange)
-            }, 'visibilityListener')
         },
     })),
 ])

--- a/frontend/src/lib/components/LiveUserCount/liveUserCountLogic.ts
+++ b/frontend/src/lib/components/LiveUserCount/liveUserCountLogic.ts
@@ -26,6 +26,7 @@ export const liveUserCountLogic = kea<liveUserCountLogicType>([
         setStats: (stats: LiveUserCountStats, now: Date) => ({ stats, now }),
         setNow: (now: Date) => ({ now }),
         setIsHovering: (isHovering: boolean) => ({ isHovering }),
+        setPageVisibility: (visible: boolean) => ({ visible }),
         pauseStream: true,
         resumeStream: true,
     })),
@@ -116,11 +117,25 @@ export const liveUserCountLogic = kea<liveUserCountLogicType>([
                 return () => clearInterval(intervalId)
             }, 'statsInterval')
         },
+        setPageVisibility: ({ visible }) => {
+            if (visible) {
+                actions.resumeStream()
+            } else {
+                actions.pauseStream()
+            }
+        },
     })),
-    events(({ actions }) => ({
+    events(({ actions, cache }) => ({
         afterMount: () => {
             actions.setNow(new Date())
             actions.resumeStream()
+            cache.disposables.add(() => {
+                const onVisibilityChange = (): void => {
+                    actions.setPageVisibility(document.visibilityState === 'visible')
+                }
+                document.addEventListener('visibilitychange', onVisibilityChange)
+                return () => document.removeEventListener('visibilitychange', onVisibilityChange)
+            }, 'visibilityListener')
         },
     })),
 ])


### PR DESCRIPTION
when we poll an API in the background it stops pages going idle and that stops browsers reclaiming memory

we shouldn't use the bleedin' memory

but let's not make life harder than it needs to be

## here's 2 logics polling frequently in the background

![CleanShot 2026-01-30 at 20.35.38@2x.png](https://app.graphite.com/user-attachments/assets/7c3560d7-f93a-4810-b961-313c903b28bb.png)

this fixes one of them which was _almost_ doing the right thing
