### PR TITLE
chore(deduplicator): increase rockdb default buffer and target SST file size

### DIFF
--- a/rust/kafka-deduplicator/src/rocksdb/store.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/store.rs
@@ -111,7 +111,7 @@ fn rocksdb_options() -> Options {
     // Write buffer tuning for batch workloads:
     // - Larger buffers = fewer flushes = less I/O pressure on PVC storage
     // - With 64 partitions and shared write buffer manager (2GB), each partition
-    //   effectively gets ~32MB of write buffer space on average
+    //   can use up to 64MB per memtable, but the shared manager limits total usage
     opts.set_write_buffer_size(WRITE_BUFFER_SIZE); // 64MB per memtable (up from 32MB)
     opts.set_max_write_buffer_number(2); // 2 buffers to allow writes during flush
     opts.set_min_write_buffer_number_to_merge(1); // Merge 1 buffer before flush (faster)

--- a/rust/kafka-deduplicator/src/rocksdb/store.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/store.rs
@@ -47,6 +47,9 @@ static SHARED_WRITE_BUFFER_MANAGER: Lazy<Arc<WriteBufferManager>> = Lazy::new(||
     ))
 });
 
+const WRITE_BUFFER_SIZE: usize = 64 * 1024 * 1024; // 64MB
+const TARGET_FILE_SIZE_BASE: u64 = 256 * 1024 * 1024; // 256MB
+
 pub fn block_based_table_factory() -> BlockBasedOptions {
     // Optimize for point lookups (dedup check)
     let mut block_opts = BlockBasedOptions::default();
@@ -109,12 +112,12 @@ fn rocksdb_options() -> Options {
     // - Larger buffers = fewer flushes = less I/O pressure on PVC storage
     // - With 64 partitions and shared write buffer manager (2GB), each partition
     //   effectively gets ~32MB of write buffer space on average
-    opts.set_write_buffer_size(32 * 1024 * 1024); // 32MB per memtable (up from 8MB)
+    opts.set_write_buffer_size(WRITE_BUFFER_SIZE); // 32MB per memtable (up from 8MB)
     opts.set_max_write_buffer_number(2); // 2 buffers to allow writes during flush
     opts.set_min_write_buffer_number_to_merge(1); // Merge 1 buffer before flush (faster)
 
     // SST file size should be proportional to write buffer for efficient compaction
-    opts.set_target_file_size_base(256 * 1024 * 1024); // 256MB SST files
+    opts.set_target_file_size_base(TARGET_FILE_SIZE_BASE); // 256MB SST files
 
     // L0 tuning to reduce write stalls:
     // - Higher trigger = batch more L0 files before compaction

--- a/rust/kafka-deduplicator/src/rocksdb/store.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/store.rs
@@ -112,7 +112,7 @@ fn rocksdb_options() -> Options {
     // - Larger buffers = fewer flushes = less I/O pressure on PVC storage
     // - With 64 partitions and shared write buffer manager (2GB), each partition
     //   effectively gets ~32MB of write buffer space on average
-    opts.set_write_buffer_size(WRITE_BUFFER_SIZE); // 32MB per memtable (up from 8MB)
+    opts.set_write_buffer_size(WRITE_BUFFER_SIZE); // 64MB per memtable (up from 32MB)
     opts.set_max_write_buffer_number(2); // 2 buffers to allow writes during flush
     opts.set_min_write_buffer_number_to_merge(1); // Merge 1 buffer before flush (faster)
 


### PR DESCRIPTION
## Problem
We want larger rocks store files and less of them
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adjust config values - opted not to param them in app cfg since most of these would also benefit from a reset of the store volumes in k8s after a change and (days) of observation, which is why we haven't done this previously.

Planning to revisit this and param them properly if we need to do more tuning here 👍 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
