### PR TITLE
fix(product tours): fix element text selection for element inference

### DIFF
--- a/frontend/src/toolbar/product-tours/elementInference.ts
+++ b/frontend/src/toolbar/product-tours/elementInference.ts
@@ -2,7 +2,7 @@ import { querySelectorAllDeep } from 'query-selector-shadow-dom'
 
 import { TAGS_TO_IGNORE } from 'lib/actionUtils'
 
-import { TOOLBAR_ID, elementIsVisible, getParent, getSafeText } from '~/toolbar/utils'
+import { TOOLBAR_ID, elementIsVisible, getParent } from '~/toolbar/utils'
 
 export interface SelectorGroup {
     cardinality: number
@@ -140,10 +140,10 @@ function getAncestorSelectors(element: HTMLElement, config: InferenceConfig): Ar
         .map(([selector]) => selector)
 }
 
-// get element text - use getSafeText, but restrict to max 250 chars.
-// anything higher -> prob not a good selector / button / target.
+// get element text using innerText to capture nested text content
+// anything higher than 250 chars -> prob not a good selector / button / target
 function getElementText(element: HTMLElement): string | null {
-    const text = getSafeText(element)
+    const text = element.innerText?.trim()
     if (!text || text.length > 250) {
         return null
     }

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -285,6 +285,7 @@ export const productToursLogic = kea<productToursLogicType>([
                 selectTour: () => null,
                 newTour: () => null,
                 removeStep: () => null,
+                startPreviewMode: () => null,
             },
         ],
         sidebarTransitioning: [

--- a/posthog/test/test_get_context_for_template.py
+++ b/posthog/test/test_get_context_for_template.py
@@ -25,7 +25,6 @@ class TestGetContextForTemplate(APIBaseTest):
             # NB: we default to the PH Cloud key
             "js_posthog_api_key": "sTMFPsFhdP1Ssg",
             "js_posthog_host": "",
-            "js_posthog_ui_host": "",
             "js_url": "http://localhost:8234",
             "opt_out_capture": False,
             "posthog_app_context": '{"persisted_feature_flags": ["the_persisted_flags"], "anonymous": false}',

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -418,11 +418,6 @@ def get_context_for_template(
         if posthoganalytics.api_key:
             context["js_posthog_api_key"] = posthoganalytics.api_key
             context["js_posthog_host"] = ""  # Becomes location.origin in the frontend
-        # In development (not test mode), point ui_host to the Vite dev server so the toolbar loads from there with hot reload
-        if settings.DEBUG and not settings.TEST and settings.JS_URL == "http://localhost:8234":
-            context["js_posthog_ui_host"] = settings.JS_URL
-        else:
-            context["js_posthog_ui_host"] = ""
     else:
         context["js_posthog_api_key"] = "sTMFPsFhdP1Ssg"
         context["js_posthog_host"] = "https://internal-j.posthog.com"


### PR DESCRIPTION
## Problem

we were using `getSafeText` for text-based element matching, but that only checks direct children, which kinda defeats the purpose for product tours

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

swaps to using `innerText`

also some bugfixes:

- removing toolbar `uiHost` dev override
- ensuring element highlights are cleared when you start a tour preview

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->