### PR TITLE
fix(onboarding): remove lemon-ui import

### DIFF
--- a/docs/onboarding/session-replay/_snippets/session-replay-final-steps.tsx
+++ b/docs/onboarding/session-replay/_snippets/session-replay-final-steps.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 
-import { Link } from '@posthog/lemon-ui'
-
 export const SessionReplayFinalSteps = (): React.ReactElement => {
     return (
         <>
@@ -10,7 +8,7 @@ export const SessionReplayFinalSteps = (): React.ReactElement => {
                 between pages, click buttons, and fill out forms to capture meaningful interactions.
             </p>
             <p>
-                <Link to="/replay/home">Watch your first recording →</Link>
+                <a href="/replay/home">Watch your first recording →</a>
             </p>
         </>
     )


### PR DESCRIPTION
## Problem

vercel builds are failing for session replay shared onboarding: https://vercel.com/post-hog/posthog/GzDhnCk3hLiP78ypVYan3gND462j#L9981

files in `docs/onboarding/` are shared between the PostHog monorepo and posthog.com via `gatsby-source-git` - the `session-replay-final-steps.tsx` snippet was importing Link from `@posthog/lemon-ui`, which exists in the monorepo but not in posthog.com's `node_modules`... oops! 

## Changes

replaced lemon ui link with a plan <a> tag, keeping the snippet dependency free

## How did you test this code?

verified no other `@posthog/lemon-ui` imports exist in `docs/onboarding/`

## Publish to changelog?

no
