### PR TITLE
chore(flags): migrate verification, sync, and rollback tasks to dedicated queues

### DIFF
--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -20,7 +20,7 @@ from posthog.tasks.utils import CeleryQueue, PushGatewayTask
 logger = structlog.get_logger(__name__)
 
 
-@shared_task(ignore_result=True, queue=CeleryQueue.FEATURE_FLAGS.value)
+@shared_task(ignore_result=True, queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value)
 def update_team_flags_cache(team_id: int) -> None:
     try:
         team = Team.objects.get(id=team_id)

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -91,7 +91,7 @@ def _run_cache_verification(cache_type: CacheType, chunk_size: int) -> None:
 
 @shared_task(
     ignore_result=True,
-    queue=CeleryQueue.DEFAULT.value,
+    queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value,
     soft_time_limit=20 * 60,  # 20 min soft limit
     time_limit=25 * 60,  # 25 min hard limit (matches LOCK_TIMEOUT_SECONDS)
 )

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -797,7 +797,7 @@ def clickhouse_send_license_usage() -> None:
         pass
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=CeleryQueue.FEATURE_FLAGS.value)
 def check_flags_to_rollback() -> None:
     try:
         from ee.tasks.auto_rollback_feature_flag import check_flags_to_rollback

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -1086,7 +1086,7 @@ def delete_organization_data_and_notify_task(
     bind=True,
     base=PushGatewayTask,
     ignore_result=True,
-    queue=CeleryQueue.DEFAULT.value,
+    queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value,
     autoretry_for=(Exception,),
     retry_backoff=30,
     retry_backoff_max=120,


### PR DESCRIPTION
## Problem

To ensure that the `/flags` service remains robust and reliable, we want to insulate it as much as possible from other systems' resources. When other systems start getting resource hungry, we want to avoid having an impact on the `/flags` service.

This is a follow-up to #45467 which migrated the hypercache tasks. This PR migrates additional flags-related tasks that impact flag evaluation correctness and safety.

## Changes

Move additional feature flags tasks from the `DEFAULT` queue to dedicated feature flags queues for better workload isolation and scaling:

- `verify_and_fix_flags_cache_task` → `FEATURE_FLAGS_LONG_RUNNING` (periodic cache verification/repair)
- `sync_feature_flag_last_called` → `FEATURE_FLAGS_LONG_RUNNING` (syncs usage timestamps from ClickHouse to PostgreSQL)
- `check_flags_to_rollback` → `FEATURE_FLAGS` (auto-rollback safety feature)

## How did you test this code?

- Verified existing tests pass

## Publish to changelog?

No
