### PR TITLE
chore(flags): some feedback on the new flags UI

### DIFF
--- a/frontend/src/lib/components/ObjectTags/ObjectTags.tsx
+++ b/frontend/src/lib/components/ObjectTags/ObjectTags.tsx
@@ -65,7 +65,7 @@ export function ObjectTags({
         style.color = 'var(--color-text-secondary)'
     }
 
-    const hasTags = tagsAvailable && tagsAvailable.length > 0
+    const hasTags = tags && tags.length > 0
 
     return (
         <div

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -603,7 +603,13 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
                                 </>
                             )}
                             <SceneDivider />
-                            <SceneSection title="Tags & Evaluation Contexts">
+                            <SceneSection
+                                title={
+                                    featureFlags[FEATURE_FLAGS.FLAG_EVALUATION_TAGS]
+                                        ? 'Tags & evaluation contexts'
+                                        : 'Tags'
+                                }
+                            >
                                 {featureFlags[FEATURE_FLAGS.FLAG_EVALUATION_TAGS] && (
                                     <div className="text-secondary text-sm mb-2">
                                         Use tags to organize and filter your feature flags. Mark specific tags as{' '}

--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -73,7 +73,6 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
         loadFeatureFlag,
         setShowImplementation,
         setOpenVariants,
-        markFieldAsEdited,
     } = useActions(featureFlagLogic)
     const { tags: availableTags } = useValues(tagsModel)
     const hasEvaluationTags = useFeatureFlag('FLAG_EVALUATION_TAGS')
@@ -208,7 +207,6 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                         autoCorrect="off"
                                         spellCheck={false}
                                         placeholder="Enter a unique key - e.g. new-landing-page, betaFeature, ab_test_1"
-                                        onFocus={() => markFieldAsEdited('key')}
                                     />
                                 </LemonField>
 
@@ -217,7 +215,6 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                         className="ph-ignore-input"
                                         data-attr="feature-flag-description"
                                         placeholder="(Optional) A description of the feature flag for your reference."
-                                        onFocus={() => markFieldAsEdited('name')}
                                     />
                                 </LemonField>
 
@@ -231,10 +228,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                         >
                                             <LemonSwitch
                                                 checked={value}
-                                                onChange={(newValue) => {
-                                                    markFieldAsEdited('active')
-                                                    onChange(newValue)
-                                                }}
+                                                onChange={onChange}
                                                 label={
                                                     <span className="flex items-center">
                                                         <span>Enabled</span>
@@ -660,10 +654,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                     <FeatureFlagReleaseConditionsCollapsible
                                         id={String(props.id)}
                                         filters={featureFlag.filters}
-                                        onChange={(filters, errors) => {
-                                            markFieldAsEdited('filters')
-                                            setFeatureFlagFilters(filters, errors)
-                                        }}
+                                        onChange={setFeatureFlagFilters}
                                     />
                                 </div>
                             )}

--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -191,7 +191,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
 
                     {/* Two-column layout */}
                     <div className="flex gap-4 flex-wrap items-start">
-                        {/* Left column - narrow, sticky on large screens */}
+                        {/* Left column */}
                         <div className="flex-1 min-w-[20rem] flex flex-col gap-4">
                             {/* Main settings card */}
                             <div className="rounded border p-3 bg-bg-light gap-2 flex flex-col">
@@ -402,7 +402,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                             </div>
                         </div>
 
-                        {/* Right column - wide */}
+                        {/* Right column */}
                         <div className="flex-2 flex flex-col gap-4" style={{ minWidth: '30rem' }}>
                             {/* Flag type card */}
                             <div className="rounded border p-3 bg-bg-light gap-4 flex flex-col">

--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -250,7 +250,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                 </LemonField>
                             </div>
 
-                            {/* Tags & Evaluation Contexts card */}
+                            {/* Tags card */}
                             <div className="rounded border p-3 bg-bg-light gap-2 flex flex-col">
                                 <LemonLabel
                                     info={
@@ -259,7 +259,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                             : 'Use tags to organize and filter your feature flags.'
                                     }
                                 >
-                                    Tags & evaluation contexts
+                                    {hasEvaluationTags ? 'Tags & evaluation contexts' : 'Tags'}
                                 </LemonLabel>
                                 {hasEvaluationTags ? (
                                     <LemonField name="tags">
@@ -288,6 +288,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                             <ObjectTags
                                                 tags={formTags}
                                                 onChange={onChangeTags}
+                                                saving={false}
                                                 tagsAvailable={availableTags.filter(
                                                     (tag: string) => !formTags?.includes(tag)
                                                 )}

--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -189,15 +189,10 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                     {/* Templates - only show for new flags */}
                     {isNewFeatureFlag && <FeatureFlagTemplates onTemplateApplied={() => {}} />}
 
-                    {/* Section heading to clarify templates are optional */}
-                    {isNewFeatureFlag && (
-                        <h3 className="text-sm font-semibold text-muted mb-2">Or customize your flag</h3>
-                    )}
-
                     {/* Two-column layout */}
                     <div className="flex gap-4 flex-wrap items-start">
                         {/* Left column - narrow, sticky on large screens */}
-                        <div className="flex-1 min-w-[20rem] flex flex-col gap-4 sticky top-4 self-start max-h-[calc(100vh-6rem)] overflow-y-auto">
+                        <div className="flex-1 min-w-[20rem] flex flex-col gap-4">
                             {/* Main settings card */}
                             <div className="rounded border p-3 bg-bg-light gap-2 flex flex-col">
                                 <LemonField

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -747,7 +747,12 @@ export function FeatureFlagReleaseConditions({
                 ))}
             </div>
             {!readOnly && (
-                <LemonButton type="secondary" className="mt-0 w-max" onClick={addConditionSet} icon={<IconPlus />}>
+                <LemonButton
+                    type="secondary"
+                    className="mt-0 w-max"
+                    onClick={() => addConditionSet()}
+                    icon={<IconPlus />}
+                >
                     Add condition set
                 </LemonButton>
             )}

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -201,13 +201,8 @@ export function FeatureFlagReleaseConditionsCollapsible({
     )
 
     const handleAddConditionSet = (): void => {
-        // Get the next sort_key - it will be max(existing sort_keys) + 1
-        const maxSortKey = filterGroups.reduce(
-            (max, group) => Math.max(max, typeof group.sort_key === 'number' ? group.sort_key : 0),
-            -1
-        )
-        const newSortKey = maxSortKey + 1
-        addConditionSet()
+        const newSortKey = crypto.randomUUID()
+        addConditionSet(newSortKey)
         setOpenConditions((prev) => [...prev, `condition-${newSortKey}`])
     }
 

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -1,5 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 
 import { IconCopy, IconPlus, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonCollapse, LemonInput, LemonLabel, LemonSelect, Spinner } from '@posthog/lemon-ui'
@@ -201,7 +202,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
     )
 
     const handleAddConditionSet = (): void => {
-        const newSortKey = crypto.randomUUID()
+        const newSortKey = uuidv4()
         addConditionSet(newSortKey)
         setOpenConditions((prev) => [...prev, `condition-${newSortKey}`])
     }

--- a/frontend/src/scenes/feature-flags/FeatureFlagTemplates.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagTemplates.tsx
@@ -1,17 +1,8 @@
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
-import {
-    IconCheckCircle,
-    IconChevronDown,
-    IconEye,
-    IconGlobe,
-    IconPeople,
-    IconRocket,
-    IconShield,
-    IconTestTube,
-} from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { IconCheckCircle, IconEye, IconGlobe, IconPeople, IconRocket, IconShield, IconTestTube } from '@posthog/icons'
+import { LemonButton, LemonCollapse } from '@posthog/lemon-ui'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
@@ -44,7 +35,7 @@ export function FeatureFlagTemplates({ onTemplateApplied }: FeatureFlagTemplates
     const { featureFlag, featureFlagLoading } = useValues(featureFlagLogic)
     const { setFeatureFlag } = useActions(featureFlagLogic)
     const { user } = useValues(userLogic)
-    const [isCollapsed, setIsCollapsed] = useState(false)
+    const [isExpanded, setIsExpanded] = useState(true)
 
     const applyTemplate = (template: FlagTemplate): void => {
         if (!featureFlag) {
@@ -238,35 +229,40 @@ export function FeatureFlagTemplates({ onTemplateApplied }: FeatureFlagTemplates
     return (
         <>
             <div className="mb-4">
-                <button
-                    type="button"
-                    className="flex items-center gap-1 mb-2 cursor-pointer bg-transparent border-none p-0"
-                    onClick={() => setIsCollapsed(!isCollapsed)}
-                >
-                    <IconChevronDown className={`text-muted transition-transform ${isCollapsed ? '-rotate-90' : ''}`} />
-                    <h3 className="mb-0 text-sm font-semibold">Start with a template</h3>
-                </button>
-                {!isCollapsed && (
-                    <div className="flex gap-3 overflow-x-auto">
-                        {templates.map((template) => (
-                            <LemonButton
-                                key={template.id}
-                                type="secondary"
-                                onClick={() => applyTemplate(template)}
-                                disabledReason={isLoading ? 'Loading flag data…' : undefined}
-                                className="flex-shrink-0 w-36 !h-auto !items-start"
-                            >
-                                <div className="flex flex-col text-left py-1">
-                                    <div className="text-muted mb-2">{template.icon}</div>
-                                    <div className="font-semibold text-sm mb-1">{template.name}</div>
-                                    <div className="text-xs text-muted whitespace-normal">{template.description}</div>
+                <LemonCollapse
+                    activeKey={isExpanded ? 'templates' : null}
+                    onChange={(key) => setIsExpanded(key === 'templates')}
+                    panels={[
+                        {
+                            key: 'templates',
+                            header: 'Start with a template',
+                            content: (
+                                <div className="flex gap-3 overflow-x-auto pt-2">
+                                    {templates.map((template) => (
+                                        <LemonButton
+                                            key={template.id}
+                                            type="secondary"
+                                            onClick={() => applyTemplate(template)}
+                                            disabledReason={isLoading ? 'Loading flag data…' : undefined}
+                                            className="flex-shrink-0 w-36 !h-auto !items-start"
+                                        >
+                                            <div className="flex flex-col text-left py-1">
+                                                <div className="text-muted mb-2">{template.icon}</div>
+                                                <div className="font-semibold text-sm mb-1">{template.name}</div>
+                                                <div className="text-xs text-muted whitespace-normal">
+                                                    {template.description}
+                                                </div>
+                                            </div>
+                                        </LemonButton>
+                                    ))}
                                 </div>
-                            </LemonButton>
-                        ))}
-                    </div>
-                )}
+                            ),
+                        },
+                    ]}
+                    embedded
+                />
             </div>
-            {!isCollapsed && <h3 className="text-sm font-semibold text-muted mb-2">Or customize your flag</h3>}
+            {isExpanded && <h3 className="text-sm font-semibold text-muted mb-2">Or customize your flag</h3>}
         </>
     )
 }

--- a/frontend/src/scenes/feature-flags/FeatureFlagTemplates.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagTemplates.tsx
@@ -1,6 +1,16 @@
 import { useActions, useValues } from 'kea'
+import { useState } from 'react'
 
-import { IconCheckCircle, IconPeople, IconRocket, IconShield } from '@posthog/icons'
+import {
+    IconCheckCircle,
+    IconChevronDown,
+    IconEye,
+    IconGlobe,
+    IconPeople,
+    IconRocket,
+    IconShield,
+    IconTestTube,
+} from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -10,10 +20,11 @@ import { FeatureFlagType, PropertyFilterType, PropertyOperator } from '~/types'
 import { userLogic } from '../userLogic'
 import { featureFlagLogic } from './featureFlagLogic'
 
-export interface TemplateValues {
+interface TemplateValues {
     key?: string
     name?: string
     active?: boolean
+    is_remote_configuration?: boolean
     filters?: FeatureFlagType['filters']
 }
 
@@ -25,84 +36,32 @@ interface FlagTemplate {
     getValues: (currentFlag: FeatureFlagType) => TemplateValues
 }
 
-export interface ApplyTemplateResult {
-    updatedFlag: Partial<FeatureFlagType>
-    preservedFields: string[]
-}
-
-/** Pure function that merges template values into a flag, respecting user-edited fields. */
-export function mergeTemplateValues(
-    currentFlag: FeatureFlagType,
-    templateValues: TemplateValues,
-    userEditedFields: Set<string>
-): ApplyTemplateResult {
-    const preservedFields: string[] = []
-    const updates: Partial<FeatureFlagType> = { ...currentFlag }
-
-    if (templateValues.key !== undefined) {
-        if (userEditedFields.has('key')) {
-            preservedFields.push('flag key')
-        } else {
-            updates.key = currentFlag.key || templateValues.key
-        }
-    }
-
-    if (templateValues.name !== undefined) {
-        if (userEditedFields.has('name')) {
-            preservedFields.push('description')
-        } else {
-            updates.name = currentFlag.name || templateValues.name
-        }
-    }
-
-    if (templateValues.active !== undefined) {
-        if (userEditedFields.has('active')) {
-            preservedFields.push('enabled state')
-        } else {
-            updates.active = templateValues.active
-        }
-    }
-
-    if (templateValues.filters !== undefined) {
-        if (userEditedFields.has('filters')) {
-            preservedFields.push('release conditions')
-        } else {
-            updates.filters = {
-                ...currentFlag.filters,
-                ...templateValues.filters,
-            }
-        }
-    }
-
-    return { updatedFlag: updates, preservedFields }
-}
-
 interface FeatureFlagTemplatesProps {
     onTemplateApplied?: (sectionsToOpen: string[]) => void
 }
 
 export function FeatureFlagTemplates({ onTemplateApplied }: FeatureFlagTemplatesProps): JSX.Element | null {
-    const { featureFlag, featureFlagLoading, userEditedFields } = useValues(featureFlagLogic)
+    const { featureFlag, featureFlagLoading } = useValues(featureFlagLogic)
     const { setFeatureFlag } = useActions(featureFlagLogic)
     const { user } = useValues(userLogic)
+    const [isCollapsed, setIsCollapsed] = useState(false)
 
     const applyTemplate = (template: FlagTemplate): void => {
-        const currentFlag = featureFlag
-        if (!currentFlag) {
+        if (!featureFlag) {
             return
         }
-        const templateValues = template.getValues(currentFlag)
-        const { updatedFlag, preservedFields } = mergeTemplateValues(currentFlag, templateValues, userEditedFields)
+        const templateValues = template.getValues(featureFlag)
 
-        setFeatureFlag(updatedFlag as FeatureFlagType)
+        setFeatureFlag({
+            ...featureFlag,
+            ...templateValues,
+            filters: {
+                ...featureFlag.filters,
+                ...templateValues.filters,
+            },
+        } as FeatureFlagType)
 
-        if (preservedFields.length > 0) {
-            lemonToast.info(
-                `Template applied: ${template.name}. Your ${preservedFields.join(', ')} ${preservedFields.length === 1 ? 'was' : 'were'} preserved.`
-            )
-        } else {
-            lemonToast.success(`Template applied: ${template.name}`)
-        }
+        lemonToast.success(`${template.name} template applied`)
         onTemplateApplied?.(['basics', 'targeting'])
     }
 
@@ -119,13 +78,16 @@ export function FeatureFlagTemplates({ onTemplateApplied }: FeatureFlagTemplates
     const templates: FlagTemplate[] = [
         {
             id: 'percentage-rollout',
-            name: '% Rollout',
+            name: 'Gradual Rollout',
             description: 'Gradually roll out to a percentage of users',
             icon: <IconRocket className="text-2xl" />,
             getValues: (flag) => ({
                 key: 'gradual-rollout',
+                name: 'Gradual rollout to 20% of users',
+                is_remote_configuration: false,
                 filters: {
                     ...flag.filters,
+                    multivariate: null,
                     groups: [{ properties: [], rollout_percentage: 20, variant: null }],
                 },
             }),
@@ -137,8 +99,11 @@ export function FeatureFlagTemplates({ onTemplateApplied }: FeatureFlagTemplates
             icon: <IconShield className="text-2xl" />,
             getValues: (flag) => ({
                 key: 'internal-only',
+                name: `Only users with @${emailDomain} emails`,
+                is_remote_configuration: false,
                 filters: {
                     ...flag.filters,
+                    multivariate: null,
                     groups: [
                         {
                             properties: [
@@ -163,8 +128,11 @@ export function FeatureFlagTemplates({ onTemplateApplied }: FeatureFlagTemplates
             icon: <IconPeople className="text-2xl" />,
             getValues: (flag) => ({
                 key: 'beta-feature',
+                name: 'Only users with beta property set to true',
+                is_remote_configuration: false,
                 filters: {
                     ...flag.filters,
+                    multivariate: null,
                     groups: [
                         {
                             properties: [
@@ -191,36 +159,114 @@ export function FeatureFlagTemplates({ onTemplateApplied }: FeatureFlagTemplates
                 key: 'kill-switch',
                 name: 'Emergency kill switch for…',
                 active: true,
+                is_remote_configuration: false,
                 filters: {
                     ...flag.filters,
+                    multivariate: null,
                     groups: [{ properties: [], rollout_percentage: 100, variant: null }],
+                },
+            }),
+        },
+        {
+            id: 'ab-test',
+            name: 'A/B Test',
+            description: '50/50 split for experiments',
+            icon: <IconTestTube className="text-2xl" />,
+            getValues: (flag) => ({
+                key: 'ab-test',
+                name: '50/50 split between control and test variants',
+                is_remote_configuration: false,
+                filters: {
+                    ...flag.filters,
+                    multivariate: {
+                        variants: [
+                            { key: 'control', rollout_percentage: 50 },
+                            { key: 'test', rollout_percentage: 50 },
+                        ],
+                    },
+                    groups: [{ properties: [], rollout_percentage: 100, variant: null }],
+                },
+            }),
+        },
+        {
+            id: 'canary',
+            name: 'Canary',
+            description: '1% rollout for safe testing',
+            icon: <IconEye className="text-2xl" />,
+            getValues: (flag) => ({
+                key: 'canary-release',
+                name: 'Canary release to 1% of users',
+                is_remote_configuration: false,
+                filters: {
+                    ...flag.filters,
+                    multivariate: null,
+                    groups: [{ properties: [], rollout_percentage: 1, variant: null }],
+                },
+            }),
+        },
+        {
+            id: 'geography',
+            name: 'By Country',
+            description: 'Target users in specific countries',
+            icon: <IconGlobe className="text-2xl" />,
+            getValues: (flag) => ({
+                key: 'country-rollout',
+                name: 'Only users in the United States',
+                is_remote_configuration: false,
+                filters: {
+                    ...flag.filters,
+                    multivariate: null,
+                    groups: [
+                        {
+                            properties: [
+                                {
+                                    key: '$geoip_country_code',
+                                    type: PropertyFilterType.Person,
+                                    value: ['US'],
+                                    operator: PropertyOperator.Exact,
+                                },
+                            ],
+                            rollout_percentage: 100,
+                            variant: null,
+                        },
+                    ],
                 },
             }),
         },
     ]
 
     return (
-        <div className="mb-4">
-            <div className="flex items-center justify-between mb-2">
-                <h3 className="mb-0 text-sm font-semibold">Start with a template</h3>
+        <>
+            <div className="mb-4">
+                <button
+                    type="button"
+                    className="flex items-center gap-1 mb-2 cursor-pointer bg-transparent border-none p-0"
+                    onClick={() => setIsCollapsed(!isCollapsed)}
+                >
+                    <IconChevronDown className={`text-muted transition-transform ${isCollapsed ? '-rotate-90' : ''}`} />
+                    <h3 className="mb-0 text-sm font-semibold">Start with a template</h3>
+                </button>
+                {!isCollapsed && (
+                    <div className="flex gap-3 overflow-x-auto">
+                        {templates.map((template) => (
+                            <LemonButton
+                                key={template.id}
+                                type="secondary"
+                                onClick={() => applyTemplate(template)}
+                                disabledReason={isLoading ? 'Loading flag data…' : undefined}
+                                className="flex-shrink-0 w-36 !h-auto !items-start"
+                            >
+                                <div className="flex flex-col text-left py-1">
+                                    <div className="text-muted mb-2">{template.icon}</div>
+                                    <div className="font-semibold text-sm mb-1">{template.name}</div>
+                                    <div className="text-xs text-muted whitespace-normal">{template.description}</div>
+                                </div>
+                            </LemonButton>
+                        ))}
+                    </div>
+                )}
             </div>
-            <div className="flex gap-3 overflow-x-auto">
-                {templates.map((template) => (
-                    <LemonButton
-                        key={template.id}
-                        type="secondary"
-                        onClick={() => applyTemplate(template)}
-                        disabledReason={isLoading ? 'Loading flag data…' : undefined}
-                        className="flex-shrink-0 w-36 !h-auto !items-start"
-                    >
-                        <div className="flex flex-col text-left py-1">
-                            <div className="text-muted mb-2">{template.icon}</div>
-                            <div className="font-semibold text-sm mb-1">{template.name}</div>
-                            <div className="text-xs text-muted whitespace-normal">{template.description}</div>
-                        </div>
-                    </LemonButton>
-                ))}
-            </div>
-        </div>
+            {!isCollapsed && <h3 className="text-sm font-semibold text-muted mb-2">Or customize your flag</h3>}
+        </>
     )
 }

--- a/frontend/src/scenes/feature-flags/FeatureFlagTemplates.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagTemplates.tsx
@@ -230,7 +230,7 @@ export function FeatureFlagTemplates({ onTemplateApplied }: FeatureFlagTemplates
         <>
             <div className="mb-4">
                 <LemonCollapse
-                    activeKey={isExpanded ? 'templates' : null}
+                    activeKey={isExpanded ? 'templates' : undefined}
                     onChange={(key) => setIsExpanded(key === 'templates')}
                     panels={[
                         {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -407,48 +407,4 @@ describe('featureFlagLogic', () => {
             testLogic.unmount()
         })
     })
-
-    describe('userEditedFields tracking', () => {
-        it('tracks fields marked as edited', async () => {
-            await expectLogic(logic).toMatchValues({
-                userEditedFields: new Set(),
-            })
-
-            await expectLogic(logic, () => {
-                logic.actions.markFieldAsEdited('key')
-            }).toMatchValues({
-                userEditedFields: new Set(['key']),
-            })
-
-            await expectLogic(logic, () => {
-                logic.actions.markFieldAsEdited('filters')
-            }).toMatchValues({
-                userEditedFields: new Set(['key', 'filters']),
-            })
-        })
-
-        it('does not duplicate fields when marked multiple times', async () => {
-            await expectLogic(logic, () => {
-                logic.actions.markFieldAsEdited('key')
-                logic.actions.markFieldAsEdited('key')
-            }).toMatchValues({
-                userEditedFields: new Set(['key']),
-            })
-        })
-
-        it('resets edited fields', async () => {
-            await expectLogic(logic, () => {
-                logic.actions.markFieldAsEdited('key')
-                logic.actions.markFieldAsEdited('name')
-            }).toMatchValues({
-                userEditedFields: new Set(['key', 'name']),
-            })
-
-            await expectLogic(logic, () => {
-                logic.actions.resetEditedFields()
-            }).toMatchValues({
-                userEditedFields: new Set(),
-            })
-        })
-    })
 })

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -6,7 +6,6 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { FeatureFlagType, PropertyFilterType, PropertyOperator } from '~/types'
 
-import { mergeTemplateValues } from './FeatureFlagTemplates'
 import { detectFeatureFlagChanges } from './featureFlagConfirmationLogic'
 import { NEW_FLAG, featureFlagLogic } from './featureFlagLogic'
 
@@ -451,100 +450,5 @@ describe('featureFlagLogic', () => {
                 userEditedFields: new Set(),
             })
         })
-    })
-})
-
-describe('mergeTemplateValues', () => {
-    const baseFlag = {
-        ...NEW_FLAG,
-        id: 1,
-        key: '',
-        name: '',
-        active: false,
-    } as unknown as FeatureFlagType
-
-    it('applies all template values when no fields are edited', () => {
-        const templateValues = {
-            key: 'gradual-rollout',
-            name: 'Gradual rollout flag',
-            active: true,
-            filters: { groups: [{ properties: [], rollout_percentage: 20, variant: null }] },
-        }
-
-        const result = mergeTemplateValues(baseFlag, templateValues, new Set())
-
-        expect(result.updatedFlag.key).toBe('gradual-rollout')
-        expect(result.updatedFlag.name).toBe('Gradual rollout flag')
-        expect(result.updatedFlag.active).toBe(true)
-        expect(result.updatedFlag.filters?.groups).toEqual([{ properties: [], rollout_percentage: 20, variant: null }])
-        expect(result.preservedFields).toEqual([])
-    })
-
-    it('preserves user-edited key and applies other template values', () => {
-        const flagWithKey = { ...baseFlag, key: 'my-custom-key' }
-        const templateValues = {
-            key: 'template-key',
-            filters: { groups: [{ properties: [], rollout_percentage: 50, variant: null }] },
-        }
-
-        const result = mergeTemplateValues(flagWithKey, templateValues, new Set(['key']))
-
-        expect(result.updatedFlag.key).toBe('my-custom-key')
-        expect(result.updatedFlag.filters?.groups).toEqual([{ properties: [], rollout_percentage: 50, variant: null }])
-        expect(result.preservedFields).toEqual(['flag key'])
-    })
-
-    it('preserves multiple user-edited fields', () => {
-        const editedFlag = { ...baseFlag, key: 'my-key', name: 'My description' }
-        const templateValues = {
-            key: 'template-key',
-            name: 'Template description',
-            active: true,
-            filters: { groups: [{ properties: [], rollout_percentage: 100, variant: null }] },
-        }
-
-        const result = mergeTemplateValues(editedFlag, templateValues, new Set(['key', 'name', 'filters']))
-
-        expect(result.updatedFlag.key).toBe('my-key')
-        expect(result.updatedFlag.name).toBe('My description')
-        expect(result.updatedFlag.active).toBe(true)
-        expect(result.updatedFlag.filters).toEqual(editedFlag.filters)
-        expect(result.preservedFields).toEqual(['flag key', 'description', 'release conditions'])
-    })
-
-    it('does not overwrite existing key with template key when flag already has a key', () => {
-        const flagWithKey = { ...baseFlag, key: 'existing-key' }
-        const templateValues = { key: 'template-key' }
-
-        const result = mergeTemplateValues(flagWithKey, templateValues, new Set())
-
-        expect(result.updatedFlag.key).toBe('existing-key')
-    })
-
-    it('sets template key when flag key is empty', () => {
-        const templateValues = { key: 'template-key' }
-
-        const result = mergeTemplateValues(baseFlag, templateValues, new Set())
-
-        expect(result.updatedFlag.key).toBe('template-key')
-    })
-
-    it('merges template filters with existing flag filters', () => {
-        const flagWithFilters = {
-            ...baseFlag,
-            filters: {
-                groups: [{ properties: [], rollout_percentage: 100, variant: null }],
-                payloads: { true: '{"existing": true}' },
-            },
-        } as unknown as FeatureFlagType
-
-        const templateValues = {
-            filters: { groups: [{ properties: [], rollout_percentage: 20, variant: null }] },
-        }
-
-        const result = mergeTemplateValues(flagWithFilters, templateValues, new Set())
-
-        expect(result.updatedFlag.filters?.groups).toEqual([{ properties: [], rollout_percentage: 20, variant: null }])
-        expect(result.updatedFlag.filters?.payloads).toEqual({ true: '{"existing": true}' })
     })
 })

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -381,9 +381,6 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
         // V2 form UI actions
         setShowImplementation: (show: boolean) => ({ show }),
         setOpenVariants: (openVariants: string[]) => ({ openVariants }),
-        // Track which fields have been manually edited by the user (not by templates)
-        markFieldAsEdited: (field: string) => ({ field }),
-        resetEditedFields: true,
     }),
     forms(({ actions, values }) => ({
         featureFlag: {
@@ -707,16 +704,6 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             [] as string[],
             {
                 setOpenVariants: (_, { openVariants }) => openVariants,
-            },
-        ],
-        // Track which fields have been manually edited by the user
-        userEditedFields: [
-            new Set<string>() as Set<string>,
-            {
-                markFieldAsEdited: (state, { field }) => new Set([...state, field]),
-                resetEditedFields: () => new Set<string>(),
-                // Reset when loading a new flag
-                loadFeatureFlagSuccess: () => new Set<string>(),
             },
         ],
     }),

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -82,7 +82,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
     actions({
         setFilters: (filters: FeatureFlagFilters) => ({ filters }),
         setAggregationGroupTypeIndex: (value: number | null) => ({ value }),
-        addConditionSet: true,
+        addConditionSet: (sortKey?: string) => ({ sortKey }),
         removeConditionSet: (index: number) => ({ index }),
         duplicateConditionSet: (index: number) => ({ index }),
         moveConditionSetUp: (index: number) => ({ index }),
@@ -151,13 +151,13 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     ],
                 }
             },
-            addConditionSet: (state) => {
+            addConditionSet: (state, { sortKey }) => {
                 if (!state) {
                     return state
                 }
                 const groups = [
                     ...(state?.groups || []),
-                    { properties: [], rollout_percentage: 0, variant: null, sort_key: uuidv4() },
+                    { properties: [], rollout_percentage: 0, variant: null, sort_key: sortKey ?? uuidv4() },
                 ]
                 return { ...state, groups }
             },


### PR DESCRIPTION
## Problem

  The new feature flags creation form has several UI/UX issues that need polish:

  1. **Templates section**: Limited template options (only 4), no way to collapse, and complex "smart
  merge" logic that preserves user edits was confusing rather than helpful
  2. **Layout bugs**: Sticky positioning on the left column broke on mobile/small screens
  3. **"Add tag" button missing**: The ObjectTags component wasn't showing the "Add tag" button due to
   a missing prop
  4. **Wrong button text**: "Edit tags" was showing instead of "Add tag" when there were no tags
  (checking available tags instead of current tags)
  5. **Condition sets collapsed by default**: When adding a new condition set, it would be collapsed,
  requiring an extra click to configure it
  6. **Inconsistent section titles**: Tags section always showed "Tags & evaluation contexts" even
  when the evaluation tags feature flag was off

  ## Changes

  **Templates (`FeatureFlagTemplates.tsx`):**
  - Made the templates section collapsible (session state, not persisted)
  - Added 3 new templates: A/B Test (50/50 split), Canary (1% rollout), By Country (US users)
  - Renamed "% Rollout" to "Gradual Rollout" for clarity
  - All templates now have descriptions and explicitly set `multivariate: null` for non-multivariate
  flags
  - Simplified template application - templates now fully override values instead of complex merge
  logic
  - "Internal Only" template uses the logged-in user's email domain
  - Changed toast format to "$TEMPLATE template applied"

  **Layout (`FeatureFlagForm.tsx`):**
  - Removed sticky positioning from left column that was breaking on smaller viewports

  **Tags section (`FeatureFlag.tsx`, `FeatureFlagForm.tsx`):**
  - Section title now conditionally shows "Tags" or "Tags & evaluation contexts" based on the
  `FLAG_EVALUATION_TAGS` feature flag

  **ObjectTags fix (`ObjectTags.tsx`):**
  - Fixed "Add tag" button not appearing by adding missing `saving={false}` prop
  - Fixed button text logic to check `tags.length` instead of `tagsAvailable.length`

  **Condition sets (`featureFlagReleaseConditionsLogic.ts`,
  `FeatureFlagReleaseConditionsCollapsible.tsx`):**
  - New condition sets are now expanded by default when added
  - Modified `addConditionSet` action to accept optional `sortKey` parameter so the collapsible
  component can track which condition to open

  ## How did you test this code?

  Manual testing:
  1. Created new feature flag, verified all 7 templates appear and are clickable
  2. Collapsed/expanded templates section, verified state resets on page refresh
  3. Applied each template and verified correct behavior
  4. Verified toast shows "$TEMPLATE template applied" format
  5. Resized browser to mobile width, verified left column no longer breaks layout
  6. Added tags to a flag, verified "Add tag" button appears correctly
  7. Verified tag button shows "Add tag" when no tags exist
  8. Added new condition set, verified it opens expanded
  9. Toggled `FLAG_EVALUATION_TAGS` feature flag off, verified section title shows just "Tags"