### PR TITLE
feat(deduplicator): implement offset rewind on checkpoint import

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -142,6 +142,10 @@ pub struct Config {
     #[envconfig(default = "200")] // 200ms (reduced from 500ms for lower latency)
     pub kafka_consumer_batch_timeout_ms: u64,
 
+    // Timeout for consumer.seek_partitions() after checkpoint import (seconds)
+    #[envconfig(default = "5")]
+    pub kafka_consumer_seek_timeout_secs: u64,
+
     // Kafka consumer fetch settings for throughput optimization
     #[envconfig(default = "1048576")] // 1MB minimum fetch size
     pub kafka_consumer_fetch_min_bytes: u32,
@@ -359,6 +363,11 @@ impl Config {
     /// Get kafka consumer batch timeout as Duration
     pub fn kafka_consumer_batch_timeout(&self) -> Duration {
         Duration::from_millis(self.kafka_consumer_batch_timeout_ms)
+    }
+
+    /// Get kafka consumer seek timeout as Duration (for seek_partitions after checkpoint import)
+    pub fn kafka_consumer_seek_timeout(&self) -> Duration {
+        Duration::from_secs(self.kafka_consumer_seek_timeout_secs)
     }
 
     /// Get flush interval as Duration

--- a/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
@@ -6,6 +6,7 @@ use crate::kafka::batch_message::{Batch, BatchError, KafkaMessage};
 use crate::kafka::metrics_consts::{
     BATCH_CONSUMER_BATCH_COLLECTION_DURATION_MS, BATCH_CONSUMER_BATCH_FILL_RATIO,
     BATCH_CONSUMER_BATCH_SIZE, BATCH_CONSUMER_KAFKA_ERROR, BATCH_CONSUMER_MESSAGES_RECEIVED,
+    BATCH_CONSUMER_SEEK_DURATION_MS, BATCH_CONSUMER_SEEK_ERROR,
 };
 use crate::kafka::offset_tracker::OffsetTracker;
 use crate::kafka::rebalance_handler::RebalanceHandler;
@@ -53,8 +54,11 @@ pub struct BatchConsumer<T> {
     // in a spawned thread
     shutdown_rx: Receiver<()>,
 
-    // receiver for consumer commands (e.g., resume partitions after checkpoint import)
+    // receiver for consumer commands (e.g., seek partitions after checkpoint import, resume partitions)
     consumer_command_rx: ConsumerCommandReceiver,
+
+    // timeout for seek_partitions after checkpoint import
+    seek_timeout: Duration,
 }
 
 impl<T> BatchConsumer<T>
@@ -72,8 +76,9 @@ where
         batch_size: usize,
         batch_timeout: Duration,
         commit_interval: Duration,
+        seek_timeout: Duration,
     ) -> Result<Self> {
-        // Create channel for consumer commands (e.g., resume partitions after checkpoint import)
+        // Create channel for consumer commands (e.g., seek partitions after checkpoint import, resume partitions)
         let (consumer_command_tx, consumer_command_rx) = mpsc::unbounded_channel();
 
         let consumer_ctx = BatchConsumerContext::new(rebalance_handler, consumer_command_tx);
@@ -99,6 +104,7 @@ where
             offset_tracker,
             shutdown_rx,
             consumer_command_rx,
+            seek_timeout,
         })
     }
 
@@ -121,7 +127,7 @@ where
                     break;
                 }
 
-                // Handle consumer commands (e.g., resume partitions after checkpoint import)
+                // Handle consumer commands (e.g., seek partitions after checkpoint import, resume partitions)
                 Some(command) = self.consumer_command_rx.recv() => {
                     match command {
                         ConsumerCommand::Resume(partitions) => {
@@ -141,6 +147,50 @@ where
                                     partition_count = partition_count,
                                     "Successfully resumed partitions - messages will now be delivered"
                                 );
+                            }
+                        }
+                        ConsumerCommand::SeekPartitions(offsets) => {
+                            let partition_count = offsets.count();
+                            info!(
+                                partition_count = partition_count,
+                                "Received seek_partitions command after checkpoint import"
+                            );
+                            let seek_start = Instant::now();
+                            match consumer.seek_partitions(offsets, self.seek_timeout) {
+                                Ok(result_tpl) => {
+                                    metrics::histogram!(BATCH_CONSUMER_SEEK_DURATION_MS)
+                                        .record(seek_start.elapsed().as_millis() as f64);
+                                    let mut error_count = 0u64;
+                                    for elem in result_tpl.elements() {
+                                        if elem.error().is_err() {
+                                            warn!(
+                                                topic = elem.topic(),
+                                                partition = elem.partition(),
+                                                error = ?elem.error(),
+                                                "Failed to seek partition"
+                                            );
+                                            error_count += 1;
+                                        }
+                                    }
+                                    if error_count > 0 {
+                                        metrics::counter!(BATCH_CONSUMER_SEEK_ERROR)
+                                            .increment(error_count);
+                                    }
+                                    info!(
+                                        partition_count = partition_count,
+                                        error_count = error_count,
+                                        "Batch seek_partitions completed"
+                                    );
+                                }
+                                Err(e) => {
+                                    metrics::counter!(BATCH_CONSUMER_SEEK_ERROR)
+                                        .increment(partition_count as u64);
+                                    error!(
+                                        error = %e,
+                                        partition_count = partition_count,
+                                        "seek_partitions call failed"
+                                    );
+                                }
                             }
                         }
                     }

--- a/rust/kafka-deduplicator/src/kafka/batch_context.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_context.rs
@@ -23,6 +23,8 @@ pub enum RebalanceEvent {
 pub enum ConsumerCommand {
     /// Resume consumption for the specified partitions (after checkpoint import completes)
     Resume(TopicPartitionList),
+    /// Seek consumer to specific offsets (after checkpoint import, before resume)
+    SeekPartitions(TopicPartitionList),
 }
 
 /// Sender for consumer commands - passed to rebalance handler

--- a/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
+++ b/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
@@ -65,6 +65,9 @@ pub const BATCH_CONSUMER_BATCH_FILL_RATIO: &str = "kafka_batch_consumer_batch_fi
 pub const BATCH_CONSUMER_BATCH_COLLECTION_DURATION_MS: &str =
     "kafka_batch_consumer_batch_collection_duration_ms";
 
+pub const BATCH_CONSUMER_SEEK_ERROR: &str = "kafka_batch_consumer_seek_error";
+pub const BATCH_CONSUMER_SEEK_DURATION_MS: &str = "kafka_batch_consumer_seek_duration_ms";
+
 // ==== Partition Worker metrics ====
 /// Counter for partition worker channel backpressure events
 /// Incremented when route_batch has to wait because the worker channel is full

--- a/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
+++ b/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
@@ -53,6 +53,7 @@ pub struct PipelineBuilder {
     batch_size: usize,
     batch_timeout: std::time::Duration,
     commit_interval: std::time::Duration,
+    seek_timeout: std::time::Duration,
     checkpoint_importer: Option<Arc<CheckpointImporter>>,
     rebalance_cleanup_parallelism: usize,
 
@@ -73,6 +74,7 @@ impl PipelineBuilder {
         batch_size: usize,
         batch_timeout: std::time::Duration,
         commit_interval: std::time::Duration,
+        seek_timeout: std::time::Duration,
         rebalance_cleanup_parallelism: usize,
     ) -> Self {
         Self {
@@ -84,6 +86,7 @@ impl PipelineBuilder {
             batch_size,
             batch_timeout,
             commit_interval,
+            seek_timeout,
             checkpoint_importer: None,
             rebalance_cleanup_parallelism,
             dedup_config: None,
@@ -177,6 +180,7 @@ impl PipelineBuilder {
             self.batch_size,
             self.batch_timeout,
             self.commit_interval,
+            self.seek_timeout,
         )
         .with_context(|| format!("Failed to create consumer for topic '{}'", self.topic))?;
 
@@ -230,6 +234,7 @@ impl PipelineBuilder {
             self.batch_size,
             self.batch_timeout,
             self.commit_interval,
+            self.seek_timeout,
         )
         .with_context(|| format!("Failed to create consumer for topic '{}'", self.topic))?;
 

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -303,6 +303,7 @@ impl KafkaDeduplicatorService {
             self.config.kafka_consumer_batch_size,
             self.config.kafka_consumer_batch_timeout(),
             self.config.commit_interval(),
+            self.config.kafka_consumer_seek_timeout(),
             self.config.rebalance_cleanup_parallelism,
         )
         .with_checkpoint_importer(self.checkpoint_importer.clone());

--- a/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
@@ -362,6 +362,7 @@ async fn test_rebalance_with_checkpoint_import() -> Result<()> {
         50,
         Duration::from_millis(100),
         Duration::from_millis(500),
+        Duration::from_secs(5), // seek_timeout
     )?;
 
     // Start consumer in background


### PR DESCRIPTION
## Problem
**Part one of our plan to fast-forward input topic to match output topic on rebalance:** ensure the local consumer has rewound it's input topic/partition offsets to match the initial offset of the checkpoints that were imported on startup or rebalance.

_EDIT: this is a simplified version of the original changeset. I'm adding the `SeekPartitions` command to `BatchConsumer` but not wiring it up or changing the import return values to expose the checkpoint's input offset. The plan is to write import `metadata.json` files to the local store dir too, and then post-rebalance (at pre-Resume step) whether our `owned_partitions` are from a local store or a new import, we'll pull the input/output offsets we need from those local files directly._


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement SeekPartitions command on the Batch Consumer
* Related test and config updates
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; smoke tests TBD in PoC env when the rest of the fast-fwd plumbing is landed
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
