### PR TITLE
fix(sql-editor): delete and expand joins to dwh tables

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -232,6 +232,49 @@ export const QueryDatabase = (): JSX.Element => {
                 )
             }}
             itemSideAction={(item) => {
+                const joinMenu =
+                    item.record?.field && item.record?.table
+                        ? (() => {
+                              const joinKey = `${item.record.table}.${item.record.field.name}`
+                              const join = joinsByFieldName[joinKey]
+
+                              if (
+                                  !join ||
+                                  !isJoined(item.record.field) ||
+                                  join.source_table_name !== item.record.table
+                              ) {
+                                  return null
+                              }
+
+                              return (
+                                  <DropdownMenuGroup>
+                                      <DropdownMenuItem
+                                          asChild
+                                          onClick={(e) => {
+                                              e.stopPropagation()
+                                              toggleEditJoinModal(join)
+                                          }}
+                                      >
+                                          <ButtonPrimitive menuItem>Edit</ButtonPrimitive>
+                                      </DropdownMenuItem>
+                                      <DropdownMenuItem
+                                          asChild
+                                          onClick={(e) => {
+                                              e.stopPropagation()
+                                              deleteJoin(join)
+                                          }}
+                                      >
+                                          <ButtonPrimitive menuItem>Delete join</ButtonPrimitive>
+                                      </DropdownMenuItem>
+                                  </DropdownMenuGroup>
+                              )
+                          })()
+                        : null
+
+                if (joinMenu) {
+                    return joinMenu
+                }
+
                 // Show menu for drafts
                 if (item.record?.type === 'draft') {
                     const draft = item.record.draft
@@ -409,47 +452,6 @@ export const QueryDatabase = (): JSX.Element => {
                             </DropdownMenuItem>
                         </DropdownMenuGroup>
                     )
-                }
-
-                if (item.record?.type === 'column') {
-                    if (
-                        isJoined(item.record.field) &&
-                        joinsByFieldName[`${item.record.table}.${item.record.columnName}`] &&
-                        joinsByFieldName[`${item.record.table}.${item.record.columnName}`].source_table_name ===
-                            item.record.table
-                    ) {
-                        return (
-                            <DropdownMenuGroup>
-                                <DropdownMenuItem
-                                    asChild
-                                    onClick={(e) => {
-                                        e.stopPropagation()
-                                        if (item.record?.columnName) {
-                                            toggleEditJoinModal(
-                                                joinsByFieldName[`${item.record.table}.${item.record.columnName}`]
-                                            )
-                                        }
-                                    }}
-                                >
-                                    <ButtonPrimitive menuItem>Edit</ButtonPrimitive>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                    asChild
-                                    onClick={(e) => {
-                                        e.stopPropagation()
-                                        if (item.record?.columnName) {
-                                            const join =
-                                                joinsByFieldName[`${item.record.table}.${item.record.columnName}`]
-
-                                            deleteJoin(join)
-                                        }
-                                    }}
-                                >
-                                    <ButtonPrimitive menuItem>Delete join</ButtonPrimitive>
-                                </DropdownMenuItem>
-                            </DropdownMenuGroup>
-                        )
-                    }
                 }
 
                 if (item.record?.type === 'unsaved-query') {

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -99,6 +99,14 @@ const draftsFuse = new Fuse<DataWarehouseSavedQueryDraft>([], FUSE_OPTIONS)
 // Factory functions for creating tree nodes
 type TableLookup = Record<string, DatabaseSchemaTable | DatabaseSchemaDataWarehouseTable>
 
+const normalizeTableLookupKey = (tableName?: string | null): string | null => {
+    if (!tableName) {
+        return null
+    }
+
+    return tableName.replaceAll('`', '')
+}
+
 const getPrimaryKeyName = (tableName: string, fields: DatabaseSchemaField[]): string | null => {
     const fieldNames = new Set(fields.map((field) => field.name))
     const baseTableName = tableName.split('.').pop() ?? tableName
@@ -282,10 +290,31 @@ const createLazyTableChildren = (
     tableLookup: TableLookup | undefined,
     expandedLazyNodeIds: Set<string>
 ): TreeDataItem[] => {
-    const referencedTable = field.table ? tableLookup?.[field.table] : undefined
+    const normalizedTableName = normalizeTableLookupKey(field.table)
+    const referencedTable = field.table
+        ? (tableLookup?.[field.table] ?? (normalizedTableName ? tableLookup?.[normalizedTableName] : undefined))
+        : undefined
 
     if (!referencedTable || !('fields' in referencedTable)) {
-        return []
+        if (!field.fields) {
+            return []
+        }
+
+        return field.fields.map((childFieldName) =>
+            createFieldNode(
+                tableName,
+                {
+                    name: childFieldName,
+                    hogql_value: childFieldName,
+                    type: 'unknown',
+                    schema_valid: true,
+                },
+                isSearch,
+                `${columnPath}.${childFieldName}`,
+                tableLookup,
+                { expandedLazyNodeIds }
+            )
+        )
     }
 
     return Object.values(referencedTable.fields).map((childField) =>


### PR DESCRIPTION
## Problem

We couldn't delete DWH joins in the SQL editor after some recent changes. Also the joins only expanded if joining system tables, not DWH tables.

## Changes

Fix all of that:

![2026-01-30 16 39 07](https://github.com/user-attachments/assets/05dee23b-80e6-42d9-8fda-f7ba36651508)

## How did you test this code?

See the gif above