### PR TITLE
fix(flags): add variant override support to new release conditions UI

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -57,6 +57,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
         featureFlag,
         multivariateEnabled,
         variants,
+        nonEmptyVariants,
         variantErrors,
         isEditingFlag,
         showImplementation,
@@ -655,6 +656,7 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                         id={String(props.id)}
                                         filters={featureFlag.filters}
                                         onChange={setFeatureFlagFilters}
+                                        variants={nonEmptyVariants}
                                     />
                                 </div>
                             )}

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -15,7 +15,7 @@ import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { humanFriendlyNumber } from 'lib/utils'
 import { clamp } from 'lib/utils'
 
-import { AnyPropertyFilter, FeatureFlagGroupType, PropertyFilterType } from '~/types'
+import { AnyPropertyFilter, FeatureFlagGroupType, MultivariateFlagVariant, PropertyFilterType } from '~/types'
 
 import {
     FeatureFlagReleaseConditionsLogicProps,
@@ -24,6 +24,7 @@ import {
 
 interface FeatureFlagReleaseConditionsCollapsibleProps extends FeatureFlagReleaseConditionsLogicProps {
     readOnly?: boolean
+    variants?: MultivariateFlagVariant[]
 }
 
 function summarizeProperties(properties: AnyPropertyFilter[], aggregationTargetName: string): string {
@@ -103,7 +104,7 @@ function ConditionHeader({
             </div>
             <div className="flex items-center gap-1">
                 <span className="text-sm text-muted mr-2">
-                    ({rollout}%
+                    ({rollout}%{group.variant && ` · ${group.variant}`}
                     {actualUserCount !== null &&
                         totalUsers !== null &&
                         ` · ${humanFriendlyNumber(actualUserCount)} ${aggregationTargetName}`}
@@ -167,6 +168,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
     filters,
     onChange,
     readOnly,
+    variants,
 }: FeatureFlagReleaseConditionsCollapsibleProps): JSX.Element {
     const releaseConditionsLogic = featureFlagReleaseConditionsLogic({
         id,
@@ -227,7 +229,9 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                         </span>
                                         <span>{summary}</span>
                                     </div>
-                                    <span className="text-muted">({rollout}%)</span>
+                                    <span className="text-muted">
+                                        ({rollout}%{group.variant && ` · ${group.variant}`})
+                                    </span>
                                 </div>
                             </div>
                         </div>
@@ -436,6 +440,27 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                     </div>
                                 )}
                             </div>
+
+                            {variants && variants.length > 0 && (
+                                <div>
+                                    <LemonLabel className="mb-1">Variant override (optional)</LemonLabel>
+                                    <LemonSelect
+                                        placeholder="No override"
+                                        allowClear={true}
+                                        value={group.variant ?? null}
+                                        onChange={(value) => updateConditionSet(index, undefined, undefined, value)}
+                                        options={variants.map((variant) => ({
+                                            label: variant.key,
+                                            value: variant.key,
+                                        }))}
+                                        className="w-full"
+                                        data-attr="feature-flags-variant-override-select"
+                                    />
+                                    <div className="text-xs text-muted mt-1">
+                                        Force all matching {aggregationTargetName} to receive a specific variant
+                                    </div>
+                                </div>
+                            )}
                         </div>
                     ),
                 }))}


### PR DESCRIPTION
## Problem

The new collapsible release conditions component was missing variant override functionality that existed in the old component. This is a regression from the feature flags UI rework.

## Changes

- Added `variants` prop to `FeatureFlagReleaseConditionsCollapsible` component
- Added variant override dropdown (using `LemonSelect`) in each condition set when multivariate variants are configured
- Added variant display in condition headers showing the override next to rollout percentage
- Added variant display in read-only view

## How did you test this code?

1. Create a multivariate feature flag with control/test variants
2. Add release conditions and verify the variant override dropdown appears
3. Select a variant override and verify it displays in the condition header
4. Save and verify the variant override persists