### PR TITLE
fix: resource utilization bug in windowed reconciliation job 

### DIFF
--- a/posthog/dags/PERSON_PROPERTY_RECONCILIATION.md
+++ b/posthog/dags/PERSON_PROPERTY_RECONCILIATION.md
@@ -1,0 +1,400 @@
+# Person Property Reconciliation Job
+
+This document provides a comprehensive overview of the person property reconciliation job, including architecture diagrams, parameter reference, and example configurations.
+
+For detailed query explanations, see [person_property_reconciliation_query_explanation.md](person_property_reconciliation_query_explanation.md).
+
+## Overview
+
+The reconciliation job fixes person properties that were missed due to a bug where `PERSON_BATCH_WRITING_DB_WRITE_MODE=ASSERT_VERSION` caused `updatePersonAssertVersion()` to not properly merge properties.
+
+The job:
+
+1. Reads events from ClickHouse to find property updates (`$set`, `$set_once`, `$unset`) within a bug window
+2. Compares with current person properties in ClickHouse
+3. Applies any missed updates to Postgres
+4. Publishes updated persons to Kafka for ClickHouse ingestion
+
+## Architecture
+
+### Non-Windowed Mode (Default)
+
+Best for: Smaller teams or short bug windows where a single ClickHouse query can handle the data.
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           Non-Windowed Flow                                  │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+    ┌──────────────────────────────────────────────────────────────────┐
+    │  ClickHouse: Single Query                                         │
+    │  ┌────────────────────────────────────────────────────────────┐  │
+    │  │ get_person_property_updates_from_clickhouse()              │  │
+    │  │                                                             │  │
+    │  │ • Scans events from bug_window_start to now()              │  │
+    │  │ • Joins with person_distinct_id_overrides (merge handling) │  │
+    │  │ • Joins with person table for current state                │  │
+    │  │ • Computes diffs IN SQL (efficient)                        │  │
+    │  │ • Returns only persons with actual differences             │  │
+    │  └────────────────────────────────────────────────────────────┘  │
+    └──────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+                    ┌───────────────────────────────┐
+                    │ filter_event_person_properties │
+                    │ (resolve set/unset conflicts)  │
+                    └───────────────────────────────┘
+                                    │
+                                    ▼
+                    ┌───────────────────────────────┐
+                    │ process_persons_in_batches     │
+                    │ • Update Postgres              │
+                    │ • Publish to Kafka             │
+                    │ • Commit in batches            │
+                    └───────────────────────────────┘
+```
+
+### Windowed Batched Mode
+
+Best for: Large teams with millions of persons where a single query would OOM.
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        Windowed Batched Flow                                 │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+    ┌──────────────────────────────────────────────────────────────────┐
+    │  Step 1: Identify Affected Persons (BOUNDED)                      │
+    │  ┌────────────────────────────────────────────────────────────┐  │
+    │  │ get_affected_person_ids_from_clickhouse()                  │  │
+    │  │                                                             │  │
+    │  │ • Scans events from bug_window_start to bug_window_end     │  │
+    │  │ • Returns ONLY distinct person_ids (not full data)         │  │
+    │  │ • Bounded query = predictable result size                  │  │
+    │  └────────────────────────────────────────────────────────────┘  │
+    └──────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+    ┌──────────────────────────────────────────────────────────────────┐
+    │  Step 2: Process Persons in Batches (~10K each)                   │
+    │                                                                   │
+    │  FOR EACH person_batch (chunk of ~10K person_ids):               │
+    │                                                                   │
+    │  ┌────────────────────────────────────────────────────────────┐  │
+    │  │  Step 2a: Windowed Event Aggregation                       │  │
+    │  │                                                             │  │
+    │  │  FOR EACH time_window (1 hour chunks from start to now): │  │
+    │  │    • Query events filtered to this batch's person_ids      │  │
+    │  │    • Merge into batch accumulator (timestamp-based)        │  │
+    │  └────────────────────────────────────────────────────────────┘  │
+    │                          │                                        │
+    │                          ▼                                        │
+    │  ┌────────────────────────────────────────────────────────────┐  │
+    │  │  Step 2b: Compare with Person State                        │  │
+    │  │                                                             │  │
+    │  │  • Query current person properties from ClickHouse         │  │
+    │  │  • Filter to actual diffs (set: value differs, etc.)       │  │
+    │  └────────────────────────────────────────────────────────────┘  │
+    │                          │                                        │
+    │                          ▼                                        │
+    │  ┌────────────────────────────────────────────────────────────┐  │
+    │  │  Step 2c: Process & Commit Batch                           │  │
+    │  │                                                             │  │
+    │  │  • Filter set/unset conflicts                              │  │
+    │  │  • Update Postgres                                         │  │
+    │  │  • Publish to Kafka                                        │  │
+    │  │  • Commit transaction                                      │  │
+    │  │  • Clear memory for next batch                             │  │
+    │  └────────────────────────────────────────────────────────────┘  │
+    │                                                                   │
+    │  END FOR EACH person_batch                                        │
+    └──────────────────────────────────────────────────────────────────┘
+```
+
+### Why Windowed Batched Mode?
+
+The key insight is that Step 1 uses `bug_window_end` to bound the set of affected persons, while Step 2 still reads events up to `now()` to capture all property updates for those persons.
+
+This prevents the problem where the original windowed implementation accumulated ALL persons with events from `bug_window_start` to `now()` (potentially millions), causing OOM.
+
+## Parameter Reference
+
+### Job Configuration (`PersonPropertyReconciliationConfig`)
+
+| Parameter                            | Type                | Default  | Description                                                              |
+| ------------------------------------ | ------------------- | -------- | ------------------------------------------------------------------------ |
+| `bug_window_start`                   | `str`               | Required | Start of bug window (ClickHouse format: "YYYY-MM-DD HH:MM:SS", UTC)      |
+| `bug_window_end`                     | `str \| None`       | `None`   | End of bug window. Required if `team_ids` not supplied                   |
+| `team_ids`                           | `list[int] \| None` | `None`   | Explicit list of team IDs to process                                     |
+| `min_team_id`                        | `int \| None`       | `None`   | Minimum team_id (inclusive) for range scanning                           |
+| `max_team_id`                        | `int \| None`       | `None`   | Maximum team_id (inclusive) for range scanning                           |
+| `exclude_team_ids`                   | `list[int] \| None` | `None`   | Team IDs to exclude from processing                                      |
+| `dry_run`                            | `bool`              | `False`  | Log changes without applying to Postgres                                 |
+| `backup_enabled`                     | `bool`              | `True`   | Store before/after state in backup table                                 |
+| `batch_size`                         | `int`               | `100`    | Commit Postgres transaction every N persons (0 = single commit)          |
+| `teams_per_chunk`                    | `int`               | `100`    | Teams per k8s task (reduces pod overhead)                                |
+| `team_ch_props_fetch_window_seconds` | `int`               | `0`      | **Mode selector**: 0 = non-windowed, >0 = windowed with N-second windows |
+| `person_batch_size`                  | `int`               | `10000`  | Persons per batch in windowed mode (keeps IN clauses under limit)        |
+
+### Sensor Configuration (`ReconciliationSchedulerConfig`)
+
+The sensor automates launching multiple reconciliation jobs across teams.
+
+| Parameter                            | Type                | Default                 | Description                               |
+| ------------------------------------ | ------------------- | ----------------------- | ----------------------------------------- |
+| **Team Selection**                   |                     |                         |                                           |
+| `team_ids`                           | `list[int] \| None` | `None`                  | Explicit list of team IDs (Option 1)      |
+| `range_start`                        | `int \| None`       | `None`                  | First team_id for range scan (Option 2)   |
+| `range_end`                          | `int \| None`       | `None`                  | Last team_id for range scan (Option 2)    |
+| **Concurrency**                      |                     |                         |                                           |
+| `chunk_size`                         | `int`               | `1000`                  | Teams per job run                         |
+| `max_concurrent_jobs`                | `int`               | `5`                     | Max reconciliation jobs at once (cap: 50) |
+| `max_concurrent_tasks`               | `int`               | `10`                    | Max k8s pods per job (cap: 100)           |
+| **Bug Window**                       |                     |                         |                                           |
+| `bug_window_start`                   | `str`               | Required                | Start of bug window                       |
+| `bug_window_end`                     | `str`               | Required                | End of bug window                         |
+| **Processing**                       |                     |                         |                                           |
+| `dry_run`                            | `bool`              | `False`                 | Log changes without applying              |
+| `backup_enabled`                     | `bool`              | `True`                  | Store before/after state                  |
+| `batch_size`                         | `int`               | `100`                   | Postgres commit batch size                |
+| `teams_per_chunk`                    | `int`               | `100`                   | Teams per k8s task                        |
+| `team_ch_props_fetch_window_seconds` | `int`               | `0`                     | Mode selector (0 = non-windowed)          |
+| `person_batch_size`                  | `int`               | `10000`                 | Persons per batch in windowed mode        |
+| **Resources**                        |                     |                         |                                           |
+| `persons_db_env_var`                 | `str`               | `PERSONS_DB_WRITER_URL` | Env var for Postgres connection           |
+
+## Example Sensor Cursor Configurations
+
+Set the sensor cursor in Dagster UI to one of these JSON configurations.
+
+### Non-Windowed Mode (Small Teams)
+
+Best for teams with < 100K affected persons or short bug windows.
+
+```json
+{
+  "team_ids": [123, 456, 789],
+  "bug_window_start": "2026-01-06 20:01:00",
+  "bug_window_end": "2026-01-07 14:52:00",
+  "team_ch_props_fetch_window_seconds": 0,
+  "dry_run": true,
+  "backup_enabled": true,
+  "batch_size": 100
+}
+```
+
+### Windowed Batched Mode (Large Teams)
+
+Best for teams with 100K+ affected persons. Uses 1-hour windows and 10K person batches.
+
+```json
+{
+  "team_ids": [2],
+  "bug_window_start": "2026-01-06 20:01:00",
+  "bug_window_end": "2026-01-07 14:52:00",
+  "team_ch_props_fetch_window_seconds": 3600,
+  "person_batch_size": 10000,
+  "dry_run": true,
+  "backup_enabled": true,
+  "batch_size": 100
+}
+```
+
+### Range-Based Scanning (All Teams)
+
+Process all teams in a team_id range, in chunks.
+
+```json
+{
+  "range_start": 1,
+  "range_end": 100000,
+  "chunk_size": 1000,
+  "bug_window_start": "2026-01-06 20:01:00",
+  "bug_window_end": "2026-01-07 14:52:00",
+  "team_ch_props_fetch_window_seconds": 0,
+  "max_concurrent_jobs": 5,
+  "max_concurrent_tasks": 10,
+  "dry_run": false
+}
+```
+
+### Production Run with Windowed Mode
+
+Full production configuration for a large team.
+
+```json
+{
+  "team_ids": [2],
+  "bug_window_start": "2026-01-06 20:01:00",
+  "bug_window_end": "2026-01-07 14:52:00",
+  "team_ch_props_fetch_window_seconds": 3600,
+  "person_batch_size": 10000,
+  "dry_run": false,
+  "backup_enabled": true,
+  "batch_size": 100,
+  "teams_per_chunk": 1,
+  "max_concurrent_jobs": 1,
+  "max_concurrent_tasks": 1
+}
+```
+
+## Choosing the Right Mode
+
+| Scenario                     | Recommended Mode | Config                                     |
+| ---------------------------- | ---------------- | ------------------------------------------ |
+| Small team (< 100K persons)  | Non-windowed     | `team_ch_props_fetch_window_seconds: 0`    |
+| Short bug window (< 1 day)   | Non-windowed     | `team_ch_props_fetch_window_seconds: 0`    |
+| Large team (100K+ persons)   | Windowed batched | `team_ch_props_fetch_window_seconds: 3600` |
+| Long bug window (days/weeks) | Windowed batched | `team_ch_props_fetch_window_seconds: 3600` |
+| Unknown size, being cautious | Windowed batched | Start with `dry_run: true`                 |
+
+## Recommended Workflow
+
+For a full reconciliation across all teams, use this two-pass approach:
+
+### Pass 1: Non-Windowed Mode for Most Teams
+
+Run the sensor with non-windowed mode to process the majority of teams quickly:
+
+```json
+{
+  "range_start": 1,
+  "range_end": 100000,
+  "chunk_size": 1000,
+  "bug_window_start": "2026-01-06 20:01:00",
+  "bug_window_end": "2026-01-07 14:52:00",
+  "team_ch_props_fetch_window_seconds": 0,
+  "max_concurrent_jobs": 5,
+  "max_concurrent_tasks": 10,
+  "dry_run": false,
+  "backup_enabled": true
+}
+```
+
+This will complete successfully for most teams but may fail (OOM or timeout) for very large teams.
+
+### Extract Failed Teams
+
+Use the extraction script to identify which teams failed:
+
+```bash
+export DAGSTER_CLOUD_TOKEN="<your-user-token>"
+
+# Extract failed teams from recent runs
+python posthog/dags/scripts/extract_reconciliation_results.py \
+    --org posthog \
+    --deployment prod-us \
+    --since "2026-01-27" \
+    --until "2026-01-30" \
+    --verbose \
+    --output-csv failed_teams.csv
+
+# The script outputs:
+# - Summary of succeeded/failed teams
+# - List of failed team IDs
+# - CSV with error details for each failed team
+```
+
+See the script's `--help` for additional options (filter by status, specific run ID, etc.).
+
+### Pass 2: Windowed Mode for Failed Teams
+
+Re-run the sensor targeting only the failed teams using windowed batched mode:
+
+```json
+{
+  "team_ids": [2, 15847, 23456],
+  "bug_window_start": "2026-01-06 20:01:00",
+  "bug_window_end": "2026-01-07 14:52:00",
+  "team_ch_props_fetch_window_seconds": 3600,
+  "person_batch_size": 10000,
+  "max_concurrent_jobs": 1,
+  "max_concurrent_tasks": 1,
+  "dry_run": false,
+  "backup_enabled": true,
+  "teams_per_chunk": 1
+}
+```
+
+Key differences for Pass 2:
+
+- `team_ids`: Explicit list of failed teams from the extraction script
+- `team_ch_props_fetch_window_seconds: 3600`: Enable windowed mode (1-hour windows)
+- `person_batch_size: 10000`: Process persons in batches to avoid OOM
+- `max_concurrent_jobs: 1` and `max_concurrent_tasks: 1`: Serialize for large teams
+- `teams_per_chunk: 1`: One team per task for better isolation
+
+If a team still fails, try reducing `person_batch_size` (e.g., 5000) or check the error logs for specific issues.
+
+## Monitoring and Troubleshooting
+
+### Logs to Watch
+
+In windowed batched mode, look for these log patterns:
+
+```text
+# Step 1: Affected persons query
+Querying affected persons: team_id={id}, bug_window=[{start}, {end}]
+Found {N} affected persons for team_id={id}
+
+# Step 2: Per-batch progress
+Starting batched windowed processing: team_id={id}, {N} batches of ~10000 persons, ~{M} windows of 3600s each
+Processing batch {n}/{total} for team_id={id}, {N} persons
+Batch {n}: processed window {w}/{total_windows}, accumulated {N} persons
+Batch {n}: comparing {N} persons against current state
+Batch {n}: yielding {N} persons with diffs
+
+# Completion
+Completed team_id={id} (windowed batched): processed={N}, updated={M}, skipped={K}, person_batches={B}
+```
+
+### Error Logs
+
+When failures occur, errors are logged via `logger.exception()` which includes the full stack trace. Look for these message patterns:
+
+```text
+# Failed to query affected persons
+Failed to query affected persons for team_id={id}, bug_window=[{start}, {end}]
+[full stack trace follows]
+
+# Failed during a specific window query
+Batch {n}: failed to query window {w}/{total} [{window_start}, {window_end}) for team_id={id}
+[full stack trace follows]
+Batch {n}: failed during windowed event collection for team_id={id} after {w} windows, accumulated {N} persons
+[full stack trace follows]
+
+# Failed during person state comparison
+Batch {n}: failed to compare {N} persons against current state for team_id={id}
+[full stack trace follows]
+```
+
+**Partial Progress**: If a failure occurs mid-processing, already-committed batches are persisted to Postgres and Kafka. The job will be marked as failed, but partial progress is saved.
+
+### Common Issues
+
+1. **OOM in windowed mode**: Reduce `person_batch_size` (e.g., 5000 instead of 10000)
+2. **Query size exceeded**: The code handles this by batching person_ids, but if you see this error, reduce `person_batch_size`
+3. **Slow progress**: Increase `team_ch_props_fetch_window_seconds` (e.g., 7200 for 2-hour windows) to reduce query count
+
+### Metrics
+
+The job emits these metrics to ClickHouse:
+
+- `person_property_reconciliation_persons_processed_total`
+- `person_property_reconciliation_persons_updated_total`
+- `person_property_reconciliation_persons_skipped_total`
+- `person_property_reconciliation_teams_succeeded_total`
+- `person_property_reconciliation_teams_failed_total`
+- `person_property_reconciliation_duration_seconds_total`
+- `person_property_reconciliation_error` (on failures)
+
+## Backup and Recovery
+
+When `backup_enabled: true`, the job stores before/after state in `posthog_person_reconciliation_backup`:
+
+- `job_id`: Dagster run ID
+- `properties` / `properties_after`: Before/after JSON
+- `version` / `version_after`: Before/after version numbers
+- `pending_operations`: Array of operations that were applied
+
+To restore a person to their pre-reconciliation state, use the companion job `person_property_reconciliation_restore.py`.

--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -434,7 +434,7 @@ def get_raw_person_property_updates_from_clickhouse(
                   AND e.timestamp >= %(bug_window_start)s
                   AND e.timestamp < %(bug_window_end)s
                   AND (JSONExtractString(e.properties, '$set') != '' OR JSONExtractString(e.properties, '$set_once') != '' OR notEmpty(JSONExtractArrayRaw(e.properties, '$unset')))
-                  AND (%(person_ids)s IS NULL OR if(notEmpty(o.distinct_id), o.person_id, e.person_id) IN %(person_ids_tuple)s)
+                  AND (%(filter_by_person_ids)s = 0 OR if(notEmpty(o.distinct_id), o.person_id, e.person_id) IN %(person_ids_tuple)s)
                 GROUP BY if(notEmpty(o.distinct_id), o.person_id, e.person_id), kv_tuple.2, kv_tuple.1
             )
             GROUP BY person_id
@@ -468,7 +468,7 @@ def get_raw_person_property_updates_from_clickhouse(
         "bug_window_start": bug_window_start,
         "bug_window_end": bug_window_end,
         "filtered_properties": tuple(FILTERED_PERSON_UPDATE_PROPERTIES),
-        "person_ids": None if person_ids is None else 1,  # Flag for IS NULL check
+        "filter_by_person_ids": 1 if person_ids else 0,  # Integer flag: 0 = no filter, 1 = filter by person_ids
         "person_ids_tuple": person_ids if person_ids else ("__placeholder__",),  # Tuple for IN clause
     }
 

--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -5,10 +5,18 @@ to not properly merge properties.
 This job reads events from ClickHouse to find property updates ($set, $set_once, $unset)
 within a bug window, compares timestamps with properties_last_updated_at in Postgres,
 and applies any missed updates.
+
+For comprehensive documentation including architecture diagrams, parameter reference,
+and example sensor configurations, see:
+    PERSON_PROPERTY_RECONCILIATION.md
+
+For detailed query explanations, see:
+    person_property_reconciliation_query_explanation.md
 """
 
 import json
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -44,6 +52,7 @@ class PersonPropertyReconciliationConfig(dagster.Config):
     batch_size: int = 100  # Commit Postgres transaction every N persons (0 = single commit at end)
     teams_per_chunk: int = 100  # Number of teams to process per task (reduces task overhead)
     team_ch_props_fetch_window_seconds: int = 0  # 0 = single query; >0 = split into N-second windows
+    person_batch_size: int = 10000  # Persons per batch in windowed mode (keeps IN clauses small)
 
 
 @dataclass
@@ -342,6 +351,7 @@ def get_raw_person_property_updates_from_clickhouse(
     team_id: int,
     bug_window_start: str,
     bug_window_end: str,
+    person_ids: tuple[str, ...] | None = None,
 ) -> list[RawPersonPropertyUpdates]:
     """
     Query ClickHouse to get raw property updates from events WITHOUT comparing to person state.
@@ -358,6 +368,7 @@ def get_raw_person_property_updates_from_clickhouse(
         team_id: Team ID to query
         bug_window_start: Start of time window (ClickHouse format: "YYYY-MM-DD HH:MM:SS")
         bug_window_end: End of time window (ClickHouse format: "YYYY-MM-DD HH:MM:SS")
+        person_ids: Optional tuple of person_ids to filter to (for batched processing)
 
     Returns:
         List of RawPersonPropertyUpdates with aggregated event data (no person comparison)
@@ -423,6 +434,7 @@ def get_raw_person_property_updates_from_clickhouse(
                   AND e.timestamp >= %(bug_window_start)s
                   AND e.timestamp < %(bug_window_end)s
                   AND (JSONExtractString(e.properties, '$set') != '' OR JSONExtractString(e.properties, '$set_once') != '' OR notEmpty(JSONExtractArrayRaw(e.properties, '$unset')))
+                  AND (%(person_ids)s IS NULL OR if(notEmpty(o.distinct_id), o.person_id, e.person_id) IN %(person_ids_tuple)s)
                 GROUP BY if(notEmpty(o.distinct_id), o.person_id, e.person_id), kv_tuple.2, kv_tuple.1
             )
             GROUP BY person_id
@@ -456,6 +468,8 @@ def get_raw_person_property_updates_from_clickhouse(
         "bug_window_start": bug_window_start,
         "bug_window_end": bug_window_end,
         "filtered_properties": tuple(FILTERED_PERSON_UPDATE_PROPERTIES),
+        "person_ids": None if person_ids is None else 1,  # Flag for IS NULL check
+        "person_ids_tuple": person_ids if person_ids else ("__placeholder__",),  # Tuple for IN clause
     }
 
     rows = sync_execute(query, params)
@@ -496,6 +510,83 @@ def get_raw_person_property_updates_from_clickhouse(
             )
 
     return results
+
+
+def get_affected_person_ids_from_clickhouse(
+    team_id: int,
+    bug_window_start: str,
+    bug_window_end: str,
+) -> list[str]:
+    """
+    Query ClickHouse for distinct person_ids who had property-setting events in the bug window.
+
+    This is the first step of the batched windowed query flow:
+    1. get_affected_person_ids_from_clickhouse() - identify affected persons (bounded)
+    2. For each batch of persons: run windowed event queries filtered to that batch
+    3. compare_raw_updates_with_person_state() to filter to actual diffs
+
+    The query is bounded by bug_window_end to limit the set of affected persons,
+    even though the actual event property aggregation will extend to now() to
+    capture all property updates for those persons.
+
+    Note: This query checks for presence of $set/$set_once/$unset but doesn't filter
+    FILTERED_PERSON_UPDATE_PROPERTIES. This may include persons who only had filtered
+    properties updated, but the subsequent raw update queries will filter them out.
+    This is a minor inefficiency that doesn't affect correctness.
+
+    Args:
+        team_id: Team ID to query
+        bug_window_start: Start of bug window (ClickHouse format: "YYYY-MM-DD HH:MM:SS")
+        bug_window_end: End of bug window (ClickHouse format: "YYYY-MM-DD HH:MM:SS")
+
+    Returns:
+        List of person_id strings (UUIDs) affected in the bug window
+    """
+    query = """
+    -- CTE 1: Get all overrides for the team
+    WITH overrides AS (
+        SELECT
+            argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, %(team_id)s)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0)
+    )
+    -- Get distinct resolved person_ids with property-setting events in the bug window
+    SELECT DISTINCT
+        if(notEmpty(o.distinct_id), o.person_id, e.person_id) AS person_id
+    FROM events e
+    LEFT JOIN overrides o ON e.distinct_id = o.distinct_id
+    WHERE e.team_id = %(team_id)s
+      AND e.timestamp >= %(bug_window_start)s
+      AND e.timestamp < %(bug_window_end)s
+      AND (
+        JSONExtractString(e.properties, '$set') != ''
+        OR JSONExtractString(e.properties, '$set_once') != ''
+        OR notEmpty(JSONExtractArrayRaw(e.properties, '$unset'))
+      )
+    ORDER BY person_id
+    SETTINGS
+        readonly=2,
+        max_execution_time=600,
+        allow_experimental_analyzer=1
+    """
+
+    params = {
+        "team_id": team_id,
+        "bug_window_start": bug_window_start,
+        "bug_window_end": bug_window_end,
+    }
+
+    rows = sync_execute(query, params)
+    return [str(row[0]) for row in rows]
+
+
+# Default batch size for processing persons in windowed mode.
+# Keeps IN clauses under ClickHouse's max_query_size limit.
+# 10K UUIDs × ~40 chars ≈ 400KB query text.
+WINDOWED_PERSON_BATCH_SIZE = 10000
 
 
 def merge_raw_person_property_updates(
@@ -767,6 +858,166 @@ def get_person_property_updates_windowed(
         logger.info(f"Comparing {len(accumulated)} persons against current state for team_id={team_id}")
 
     return compare_raw_updates_with_person_state(team_id, list(accumulated.values()))
+
+
+def get_person_property_updates_windowed_batched(
+    team_id: int,
+    bug_window_start: str,
+    bug_window_end: str,
+    window_seconds: int,
+    person_batch_size: int = WINDOWED_PERSON_BATCH_SIZE,
+    logger: Any = None,
+) -> Iterator[list[PersonPropertyDiffs]]:
+    """
+    Yield batches of PersonPropertyDiffs, processing persons in chunks.
+
+    This is the memory-efficient version of get_person_property_updates_windowed()
+    that processes persons in batches to prevent OOM on large teams.
+
+    Flow:
+    1. Get affected person_ids (bounded by bug_window_end)
+    2. For each batch of person_ids:
+       a. For each time window [start → now()]:
+          - Query raw events filtered to this batch's person_ids
+          - Merge into batch accumulator
+       b. Compare batch with person state
+       c. Yield batch results (allows caller to process and clear memory)
+
+    Args:
+        team_id: Team ID to query
+        bug_window_start: Start of bug window (ClickHouse format: "YYYY-MM-DD HH:MM:SS")
+        bug_window_end: End of bug window - used to bound affected persons
+        window_seconds: Size of each query window in seconds
+        person_batch_size: Number of persons per batch (default 10K)
+        logger: Optional logger for progress tracking
+
+    Yields:
+        List of PersonPropertyDiffs for each batch of persons
+    """
+    # Step 1: Get affected person_ids (bounded by bug_window_end)
+    if logger:
+        logger.info(f"Querying affected persons: team_id={team_id}, bug_window=[{bug_window_start}, {bug_window_end}]")
+
+    try:
+        affected_person_ids = get_affected_person_ids_from_clickhouse(
+            team_id=team_id,
+            bug_window_start=bug_window_start,
+            bug_window_end=bug_window_end,
+        )
+    except Exception:
+        if logger:
+            logger.exception(
+                f"Failed to query affected persons for team_id={team_id}, "
+                f"bug_window=[{bug_window_start}, {bug_window_end}]"
+            )
+        raise
+
+    if logger:
+        logger.info(f"Found {len(affected_person_ids)} affected persons for team_id={team_id}")
+
+    if not affected_person_ids:
+        return
+
+    # Calculate total batches and windows for logging
+    total_batches = (len(affected_person_ids) + person_batch_size - 1) // person_batch_size
+    now = datetime.now(UTC)
+    current_start_for_count = parse_ch_timestamp(bug_window_start)
+    total_windows = int((now - current_start_for_count).total_seconds() / window_seconds) + 1
+
+    if logger:
+        logger.info(
+            f"Starting batched windowed processing: team_id={team_id}, "
+            f"{total_batches} batches of ~{person_batch_size} persons, "
+            f"~{total_windows} windows of {window_seconds}s each"
+        )
+
+    # Step 2: Process each batch of persons
+    for batch_idx in range(0, len(affected_person_ids), person_batch_size):
+        batch_person_ids = affected_person_ids[batch_idx : batch_idx + person_batch_size]
+        batch_num = (batch_idx // person_batch_size) + 1
+
+        if logger:
+            logger.info(
+                f"Processing batch {batch_num}/{total_batches} for team_id={team_id}, {len(batch_person_ids)} persons"
+            )
+
+        # Step 2a: Query raw updates per window for this batch and merge
+        accumulated: dict[str, RawPersonPropertyUpdates] = {}
+        current_start = parse_ch_timestamp(bug_window_start)
+        window_count = 0
+
+        try:
+            while current_start < now:
+                current_end = min(current_start + timedelta(seconds=window_seconds), now)
+                try:
+                    window_updates = get_raw_person_property_updates_from_clickhouse(
+                        team_id,
+                        format_ch_timestamp(current_start),
+                        format_ch_timestamp(current_end),
+                        person_ids=tuple(batch_person_ids),
+                    )
+                except Exception:
+                    if logger:
+                        logger.exception(
+                            f"Batch {batch_num}: failed to query window {window_count + 1}/{total_windows} "
+                            f"[{format_ch_timestamp(current_start)}, {format_ch_timestamp(current_end)}) "
+                            f"for team_id={team_id}"
+                        )
+                    raise
+
+                merge_raw_person_property_updates(accumulated, window_updates)
+                window_count += 1
+
+                if logger and window_count % 10 == 0:
+                    logger.info(
+                        f"Batch {batch_num}: processed window {window_count}/{total_windows}, "
+                        f"accumulated {len(accumulated)} persons"
+                    )
+
+                current_start = current_end
+
+        except Exception:
+            if logger:
+                logger.exception(
+                    f"Batch {batch_num}: failed during windowed event collection for team_id={team_id} "
+                    f"after {window_count} windows, accumulated {len(accumulated)} persons"
+                )
+            raise
+
+        if logger:
+            logger.info(
+                f"Batch {batch_num}: completed {window_count} windows, total persons with updates: {len(accumulated)}"
+            )
+
+        # Step 2b: Compare batch with person state
+        if accumulated:
+            if logger:
+                logger.info(f"Batch {batch_num}: comparing {len(accumulated)} persons against current state")
+
+            try:
+                batch_diffs = compare_raw_updates_with_person_state(team_id, list(accumulated.values()))
+            except Exception:
+                if logger:
+                    logger.exception(
+                        f"Batch {batch_num}: failed to compare {len(accumulated)} persons "
+                        f"against current state for team_id={team_id}"
+                    )
+                raise
+
+            if batch_diffs:
+                if logger:
+                    logger.info(f"Batch {batch_num}: yielding {len(batch_diffs)} persons with diffs")
+                # Step 2c: Yield batch results
+                yield batch_diffs
+            else:
+                if logger:
+                    logger.info(f"Batch {batch_num}: no diffs found after comparison")
+        else:
+            if logger:
+                logger.info(f"Batch {batch_num}: no updates found in time windows")
+
+    if logger:
+        logger.info(f"Completed all {total_batches} batches for team_id={team_id}")
 
 
 def filter_event_person_properties(
@@ -1546,11 +1797,13 @@ class TeamReconciliationResult:
 def reconcile_single_team(
     team_id: int,
     bug_window_start: str,
+    bug_window_end: str,
     run_id: str,
     batch_size: int,
     dry_run: bool,
     backup_enabled: bool,
     team_ch_props_fetch_window_seconds: int,
+    person_batch_size: int,
     persons_database: psycopg2.extensions.connection,
     kafka_producer: _KafkaProducer,
     logger: Any,
@@ -1558,34 +1811,13 @@ def reconcile_single_team(
     """
     Reconcile person properties for all affected persons in a single team.
 
+    This function supports two modes:
+    - Non-windowed (team_ch_props_fetch_window_seconds <= 0): Single query to ClickHouse
+    - Windowed batched (team_ch_props_fetch_window_seconds > 0): Process persons in batches,
+      each batch iterating through time windows. This prevents OOM on large teams.
+
     This function does not catch exceptions - the caller is responsible for error handling.
     """
-    # Query ClickHouse for all persons with property updates in this team
-    logger.info(
-        f"Querying ClickHouse for property updates: team_id={team_id}, "
-        f"bug_window_start={bug_window_start}, window_seconds={team_ch_props_fetch_window_seconds}"
-    )
-    person_property_diffs = get_person_property_updates_windowed(
-        team_id=team_id,
-        bug_window_start=bug_window_start,
-        window_seconds=team_ch_props_fetch_window_seconds,
-        logger=logger,
-    )
-    logger.info(f"Found {len(person_property_diffs)} persons with property diffs for team_id={team_id}")
-
-    # Filter conflicting set/unset operations
-    person_property_diffs = filter_event_person_properties(person_property_diffs)
-
-    if not person_property_diffs:
-        logger.info(f"No persons to reconcile for team_id={team_id}")
-        return TeamReconciliationResult(
-            team_id=team_id,
-            persons_processed=0,
-            persons_updated=0,
-            persons_skipped=0,
-        )
-
-    logger.info(f"Processing {len(person_property_diffs)} persons for team_id={team_id}")
 
     # Callback for batch commits - handles Kafka publishing after each batch
     def on_batch_committed(batch_num: int, batch_persons: list[dict]) -> None:
@@ -1603,6 +1835,97 @@ def reconcile_single_team(
             logger.info(f"Batch {batch_num}: committed {len(batch_persons)} updates for team_id={team_id}")
         elif batch_persons and dry_run:
             logger.info(f"[DRY RUN] Batch {batch_num}: would apply {len(batch_persons)} updates for team_id={team_id}")
+
+    # Use windowed batched mode for large teams (window_seconds > 0)
+    if team_ch_props_fetch_window_seconds > 0:
+        logger.info(
+            f"Using windowed batched mode: team_id={team_id}, "
+            f"bug_window=[{bug_window_start}, {bug_window_end}], "
+            f"window_seconds={team_ch_props_fetch_window_seconds}, "
+            f"person_batch_size={person_batch_size}"
+        )
+
+        total_processed = 0
+        total_updated = 0
+        total_skipped = 0
+        person_batch_num = 0
+
+        with persons_database.cursor() as cursor:
+            cursor.execute("SET application_name = 'person_property_reconciliation'")
+            cursor.execute("SET lock_timeout = '5s'")
+            cursor.execute("SET statement_timeout = '30min'")
+            cursor.execute("SET synchronous_commit = off")
+
+            # Process each batch of persons from the iterator
+            for person_batch in get_person_property_updates_windowed_batched(
+                team_id=team_id,
+                bug_window_start=bug_window_start,
+                bug_window_end=bug_window_end,
+                window_seconds=team_ch_props_fetch_window_seconds,
+                person_batch_size=person_batch_size,
+                logger=logger,
+            ):
+                person_batch_num += 1
+
+                # Filter conflicting set/unset operations for this batch
+                filtered_batch = filter_event_person_properties(person_batch)
+
+                if not filtered_batch:
+                    logger.info(f"Person batch {person_batch_num}: no diffs after filtering for team_id={team_id}")
+                    continue
+
+                logger.info(
+                    f"Person batch {person_batch_num}: processing {len(filtered_batch)} persons for team_id={team_id}"
+                )
+
+                # Process this batch
+                result = process_persons_in_batches(
+                    person_property_diffs=filtered_batch,
+                    cursor=cursor,
+                    job_id=run_id,
+                    team_id=team_id,
+                    batch_size=batch_size,
+                    dry_run=dry_run,
+                    backup_enabled=backup_enabled,
+                    commit_fn=persons_database.commit,
+                    on_batch_committed=on_batch_committed,
+                    logger=logger,
+                )
+
+                total_processed += result.total_processed
+                total_updated += result.total_updated
+                total_skipped += result.total_skipped
+
+        logger.info(
+            f"Completed team_id={team_id} (windowed batched): processed={total_processed}, "
+            f"updated={total_updated}, skipped={total_skipped}, person_batches={person_batch_num}"
+        )
+
+        return TeamReconciliationResult(
+            team_id=team_id,
+            persons_processed=total_processed,
+            persons_updated=total_updated,
+            persons_skipped=total_skipped,
+        )
+
+    # Non-windowed mode (original behavior)
+    logger.info(f"Using non-windowed mode: team_id={team_id}, bug_window_start={bug_window_start}")
+    person_property_diffs = get_person_property_updates_from_clickhouse(team_id, bug_window_start)
+    logger.info(f"Found {len(person_property_diffs)} persons with property diffs for team_id={team_id}")
+
+    # Filter conflicting set/unset operations
+    person_property_diffs = filter_event_person_properties(person_property_diffs)
+
+    if not person_property_diffs:
+        logger.info(f"No persons to reconcile for team_id={team_id}")
+        return TeamReconciliationResult(
+            team_id=team_id,
+            persons_processed=0,
+            persons_updated=0,
+            persons_skipped=0,
+        )
+
+    logger.info(f"Processing {len(person_property_diffs)} persons for team_id={team_id}")
 
     with persons_database.cursor() as cursor:
         cursor.execute("SET application_name = 'person_property_reconciliation'")
@@ -1684,11 +2007,13 @@ def reconcile_team_chunk(
             result = reconcile_single_team(
                 team_id=team_id,
                 bug_window_start=config.bug_window_start,
+                bug_window_end=config.bug_window_end or config.bug_window_start,  # Fallback for backward compat
                 run_id=run_id,
                 batch_size=config.batch_size,
                 dry_run=config.dry_run,
                 backup_enabled=config.backup_enabled,
                 team_ch_props_fetch_window_seconds=config.team_ch_props_fetch_window_seconds,
+                person_batch_size=config.person_batch_size,
                 persons_database=persons_database,
                 kafka_producer=kafka_producer,
                 logger=context.log,
@@ -1848,6 +2173,7 @@ class ReconciliationSchedulerConfig(dagster.Config):
     batch_size: int = 100
     teams_per_chunk: int = 100  # Number of teams to process per task
     team_ch_props_fetch_window_seconds: int = 0  # 0 = single query; >0 = split into N-second windows
+    person_batch_size: int = 10000  # Persons per batch in windowed mode (keeps IN clauses small)
 
     # Resource configuration - the env var name for the PG connection string
     persons_db_env_var: str = "PERSONS_DB_WRITER_URL"  # Env var for Postgres connection URL
@@ -1871,6 +2197,7 @@ def build_reconciliation_run_config(
         "batch_size": config.batch_size,
         "teams_per_chunk": config.teams_per_chunk,
         "team_ch_props_fetch_window_seconds": config.team_ch_props_fetch_window_seconds,
+        "person_batch_size": config.person_batch_size,
     }
 
     if team_ids is not None:
@@ -2017,6 +2344,7 @@ def person_property_reconciliation_scheduler(context: dagster.SensorEvaluationCo
         batch_size=cursor_data.get("batch_size", 100),
         teams_per_chunk=cursor_data.get("teams_per_chunk", 100),
         team_ch_props_fetch_window_seconds=cursor_data.get("team_ch_props_fetch_window_seconds", 0),
+        person_batch_size=cursor_data.get("person_batch_size", 10000),
         persons_db_env_var=cursor_data.get("persons_db_env_var", "PERSONS_DB_WRITER_URL"),
     )
 

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -2132,11 +2132,15 @@ class TestGetPersonPropertyUpdatesWindowed:
     @patch("posthog.dags.person_property_reconciliation.compare_raw_updates_with_person_state")
     @patch("posthog.dags.person_property_reconciliation.datetime")
     @patch("posthog.dags.person_property_reconciliation.get_raw_person_property_updates_from_clickhouse")
-    def test_window_seconds_positive_creates_windows(self, mock_get_raw, mock_datetime, mock_compare):
+    @patch("posthog.dags.person_property_reconciliation.get_affected_person_ids_from_clickhouse")
+    def test_window_seconds_positive_creates_windows(
+        self, mock_get_affected, mock_get_raw, mock_datetime, mock_compare
+    ):
         """Test that positive window_seconds creates multiple query windows."""
         mock_now = datetime(2024, 1, 1, 2, 0, 0, tzinfo=UTC)
         mock_datetime.now.return_value = mock_now
         mock_datetime.strptime = datetime.strptime
+        mock_get_affected.return_value = ["person-1"]
         mock_get_raw.return_value = []
         mock_compare.return_value = []
 
@@ -2146,22 +2150,28 @@ class TestGetPersonPropertyUpdatesWindowed:
             window_seconds=3600,  # 1 hour windows
         )
 
-        # Should have 2 calls: 00:00-01:00 and 01:00-02:00
+        # Should first fetch affected person_ids
+        mock_get_affected.assert_called_once()
+        # Should have 2 calls: 00:00-01:00 and 01:00-02:00, with person_ids filter
         assert mock_get_raw.call_count == 2
         calls = mock_get_raw.call_args_list
         assert calls[0][0] == (1, "2024-01-01 00:00:00", "2024-01-01 01:00:00")
+        assert calls[0][1] == {"person_ids": ("person-1",)}
         assert calls[1][0] == (1, "2024-01-01 01:00:00", "2024-01-01 02:00:00")
+        assert calls[1][1] == {"person_ids": ("person-1",)}
         # compare_raw_updates_with_person_state should be called once at the end
         mock_compare.assert_called_once()
 
     @patch("posthog.dags.person_property_reconciliation.compare_raw_updates_with_person_state")
     @patch("posthog.dags.person_property_reconciliation.datetime")
     @patch("posthog.dags.person_property_reconciliation.get_raw_person_property_updates_from_clickhouse")
-    def test_window_merges_results_across_windows(self, mock_get_raw, mock_datetime, mock_compare):
+    @patch("posthog.dags.person_property_reconciliation.get_affected_person_ids_from_clickhouse")
+    def test_window_merges_results_across_windows(self, mock_get_affected, mock_get_raw, mock_datetime, mock_compare):
         """Test that results are properly merged across windows."""
         mock_now = datetime(2024, 1, 1, 2, 0, 0, tzinfo=UTC)
         mock_datetime.now.return_value = mock_now
         mock_datetime.strptime = datetime.strptime
+        mock_get_affected.return_value = ["person-1"]
 
         # First window returns one update, second window returns a newer update for same key
         mock_get_raw.side_effect = [
@@ -2256,8 +2266,8 @@ class TestGetRawPersonPropertyUpdatesWithPersonIds:
     """Test the person_ids filter parameter in get_raw_person_property_updates_from_clickhouse."""
 
     @patch("posthog.dags.person_property_reconciliation.sync_execute")
-    def test_filters_by_person_ids_when_provided(self, mock_sync_execute):
-        """Test that query filters to specific person_ids when provided."""
+    def test_filters_by_person_ids(self, mock_sync_execute):
+        """Test that query filters to specific person_ids (required param)."""
         mock_sync_execute.return_value = []
 
         get_raw_person_property_updates_from_clickhouse(
@@ -2268,24 +2278,8 @@ class TestGetRawPersonPropertyUpdatesWithPersonIds:
         )
 
         params = mock_sync_execute.call_args[0][1]
-        assert params["person_ids"] == 1  # Flag for IS NULL check
-        assert params["person_ids_tuple"] == ("person-1", "person-2")
-
-    @patch("posthog.dags.person_property_reconciliation.sync_execute")
-    def test_no_filter_when_person_ids_is_none(self, mock_sync_execute):
-        """Test that no person_id filter is applied when person_ids is None."""
-        mock_sync_execute.return_value = []
-
-        get_raw_person_property_updates_from_clickhouse(
-            team_id=1,
-            bug_window_start="2024-01-01 00:00:00",
-            bug_window_end="2024-01-02 00:00:00",
-            person_ids=None,
-        )
-
-        params = mock_sync_execute.call_args[0][1]
-        assert params["person_ids"] is None
-        assert params["person_ids_tuple"] == ("__placeholder__",)
+        # person_ids is required and used directly in IN clause
+        assert params["person_ids"] == ("person-1", "person-2")
 
 
 class TestGetPersonPropertyUpdatesWindowedBatched:
@@ -4717,6 +4711,424 @@ class TestClickHouseQueryIntegration:
         assert "$referring_domain" not in set_once_keys, (
             "Filtered property '$referring_domain' should NOT be in results"
         )
+
+    def test_person_ids_filter_only_returns_specified_persons(self, cluster: ClickhouseCluster):
+        """
+        Integration test: verify person_ids filter correctly restricts query results.
+
+        This tests the fix for the NULL IS NULL bug - when person_ids is provided,
+        only those persons should be returned.
+        """
+        team_id = 99970
+        now = datetime.now().replace(microsecond=0)
+        bug_window_start = now - timedelta(days=10)
+        event_ts = now - timedelta(days=5)
+
+        # Create 5 persons, but we'll only query for 2 of them
+        person_ids = [UUID(f"77770000-0000-0000-0000-00000000000{i}") for i in range(1, 6)]
+        target_person_ids = (str(person_ids[0]), str(person_ids[2]))  # Person 1 and 3
+
+        # Insert events for all 5 persons
+        events = []
+        for i, pid in enumerate(person_ids):
+            events.append(
+                (
+                    team_id,
+                    f"distinct_{i}",
+                    pid,
+                    event_ts,
+                    json.dumps({"$set": {"email": f"person{i}@example.com"}}),
+                )
+            )
+
+        def insert_events(client: Client) -> None:
+            client.execute(
+                """INSERT INTO writable_events (team_id, distinct_id, person_id, timestamp, properties)
+                VALUES""",
+                events,
+            )
+
+        cluster.any_host(insert_events).result()
+
+        # Insert all 5 persons in ClickHouse with different email (so diff is detected)
+        person_data = []
+        for i, pid in enumerate(person_ids):
+            person_data.append(
+                (
+                    team_id,
+                    pid,
+                    json.dumps({"email": f"old{i}@example.com"}),
+                    1,
+                    now - timedelta(days=8),
+                )
+            )
+
+        def insert_persons(client: Client) -> None:
+            client.execute(
+                """INSERT INTO person (team_id, id, properties, version, _timestamp)
+                VALUES""",
+                person_data,
+            )
+
+        cluster.any_host(insert_persons).result()
+
+        # Query with person_ids filter - should only return the 2 specified persons
+        results = get_raw_person_property_updates_from_clickhouse(
+            team_id=team_id,
+            bug_window_start=bug_window_start.strftime("%Y-%m-%d %H:%M:%S"),
+            bug_window_end=now.strftime("%Y-%m-%d %H:%M:%S"),
+            person_ids=target_person_ids,
+        )
+
+        # Should only have 2 results (the filtered persons)
+        result_person_ids = {r.person_id for r in results}
+        expected_person_ids = set(target_person_ids)
+
+        assert result_person_ids == expected_person_ids, (
+            f"person_ids filter failed.\n"
+            f"Expected: {expected_person_ids}\n"
+            f"Got: {result_person_ids}\n"
+            f"This may indicate the NULL IS NULL bug has regressed!"
+        )
+
+        # Verify the data is correct for the returned persons
+        for result in results:
+            assert len(result.set_updates) == 1
+            assert "email" in result.set_updates
+
+    def test_interleaved_events_multiple_persons_realistic_scenario(self, cluster: ClickhouseCluster):
+        """
+        Integration test: realistic scenario with multiple persons and interleaved events.
+
+        Simulates a real-world scenario where:
+        - Multiple users are active simultaneously
+        - Events arrive in arbitrary order (not grouped by person)
+        - Different operation types ($set, $set_once, $unset) are mixed
+        - Some properties conflict (same key, different operations)
+
+        This tests that the query correctly aggregates per-person despite
+        events being interleaved in the events table.
+        """
+        team_id = 99971
+        now = datetime.now().replace(microsecond=0)
+        bug_window_start = now - timedelta(days=10)
+
+        # Three users with different activity patterns
+        alice = UUID("aaaa0000-0000-0000-0000-000000000001")
+        bob = UUID("bbbb0000-0000-0000-0000-000000000002")
+        charlie = UUID("cccc0000-0000-0000-0000-000000000003")
+
+        # Events arrive interleaved (not grouped by person) - this is realistic
+        # Time ordering simulates events arriving from different user sessions
+        events = [
+            # t+1h: Alice sets email
+            (team_id, "alice_1", alice, now - timedelta(hours=9), json.dumps({"$set": {"email": "alice@v1.com"}})),
+            # t+1h: Bob sets name
+            (team_id, "bob_1", bob, now - timedelta(hours=9), json.dumps({"$set": {"name": "Bob v1"}})),
+            # t+2h: Charlie sets email and set_once for referrer
+            (
+                team_id,
+                "charlie_1",
+                charlie,
+                now - timedelta(hours=8),
+                json.dumps({"$set": {"email": "charlie@example.com"}, "$set_once": {"referrer": "google"}}),
+            ),
+            # t+3h: Alice updates email (should win over v1)
+            (team_id, "alice_2", alice, now - timedelta(hours=7), json.dumps({"$set": {"email": "alice@v2.com"}})),
+            # t+3h: Bob also tries set_once referrer (should use first value)
+            (team_id, "bob_2", bob, now - timedelta(hours=7), json.dumps({"$set_once": {"referrer": "facebook"}})),
+            # t+4h: Alice sets name
+            (team_id, "alice_3", alice, now - timedelta(hours=6), json.dumps({"$set": {"name": "Alice"}})),
+            # t+4h: Bob updates name (should win over v1)
+            (team_id, "bob_3", bob, now - timedelta(hours=6), json.dumps({"$set": {"name": "Bob v2"}})),
+            # t+5h: Charlie tries set_once referrer again (should NOT override google)
+            (
+                team_id,
+                "charlie_2",
+                charlie,
+                now - timedelta(hours=5),
+                json.dumps({"$set_once": {"referrer": "twitter"}}),
+            ),
+            # t+6h: Alice unsets email (should override the $set)
+            (team_id, "alice_4", alice, now - timedelta(hours=4), json.dumps({"$unset": ["email"]})),
+            # t+7h: Bob's set_once for referrer again (still should be facebook - first one)
+            (team_id, "bob_4", bob, now - timedelta(hours=3), json.dumps({"$set_once": {"referrer": "linkedin"}})),
+        ]
+
+        def insert_events(client: Client) -> None:
+            client.execute(
+                """INSERT INTO writable_events (team_id, distinct_id, person_id, timestamp, properties)
+                VALUES""",
+                events,
+            )
+
+        cluster.any_host(insert_events).result()
+
+        # Create persons with existing properties
+        # Alice: has old email (different, so $set shows in diff) and no name
+        # Bob: has old name (different), no referrer
+        # Charlie: has old email (different), no referrer
+        person_data = [
+            (team_id, alice, json.dumps({"email": "alice@old.com"}), 1, now - timedelta(days=8)),
+            (team_id, bob, json.dumps({"name": "Old Bob"}), 1, now - timedelta(days=8)),
+            (team_id, charlie, json.dumps({"email": "charlie@old.com"}), 1, now - timedelta(days=8)),
+        ]
+
+        def insert_persons(client: Client) -> None:
+            client.execute(
+                """INSERT INTO person (team_id, id, properties, version, _timestamp)
+                VALUES""",
+                person_data,
+            )
+
+        cluster.any_host(insert_persons).result()
+
+        # Query and verify
+        results = get_person_property_updates_from_clickhouse(
+            team_id=team_id,
+            bug_window_start=bug_window_start.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+        results_by_person = {str(r.person_id): r for r in results}
+
+        # Alice assertions:
+        # - email: $set alice@v2.com at t+3h, then $unset at t+6h → both should appear
+        # - name: $set "Alice" at t+4h → but no name in person, so NOT in set_diff
+        alice_result = results_by_person[str(alice)]
+        assert "email" in alice_result.set_updates, "Alice should have email in set_updates"
+        assert alice_result.set_updates["email"].value == "alice@v2.com", "Alice email should be v2"
+        assert "email" in alice_result.unset_updates, "Alice should have email in unset_updates"
+        # name not in person, so $set won't create a diff
+        assert "name" not in alice_result.set_updates, "Alice name should NOT be in set_updates (key doesn't exist)"
+
+        # Bob assertions:
+        # - name: latest is "Bob v2" at t+4h, person has different value
+        # - referrer: first set_once is "facebook" at t+3h, person doesn't have it
+        bob_result = results_by_person[str(bob)]
+        assert "name" in bob_result.set_updates, "Bob should have name in set_updates"
+        assert bob_result.set_updates["name"].value == "Bob v2", "Bob name should be v2"
+        assert "referrer" in bob_result.set_once_updates, "Bob should have referrer in set_once"
+        assert bob_result.set_once_updates["referrer"].value == "facebook", "Bob referrer should be facebook (first)"
+
+        # Charlie assertions:
+        # - email: "charlie@example.com", person has different value
+        # - referrer: "google" (first set_once), person doesn't have it
+        charlie_result = results_by_person[str(charlie)]
+        assert "email" in charlie_result.set_updates, "Charlie should have email"
+        assert charlie_result.set_updates["email"].value == "charlie@example.com"
+        assert "referrer" in charlie_result.set_once_updates, "Charlie should have referrer"
+        assert charlie_result.set_once_updates["referrer"].value == "google", (
+            "Charlie referrer should be google (first)"
+        )
+
+    def test_unicode_and_emoji_in_property_keys_and_values(self, cluster: ClickhouseCluster):
+        """
+        Integration test: verify Unicode and emoji characters work in property keys and values.
+
+        Real users often have international names, emoji in custom properties, etc.
+        This ensures the query handles UTF-8 properly throughout the pipeline.
+        """
+        team_id = 99972
+        person_id = UUID("88880000-0000-0000-0000-000000000001")
+        now = datetime.now().replace(microsecond=0)
+        bug_window_start = now - timedelta(days=10)
+        event_ts = now - timedelta(days=5)
+
+        # Unicode and emoji test cases
+        events = [
+            (
+                team_id,
+                "distinct_unicode",
+                person_id,
+                event_ts,
+                json.dumps(
+                    {
+                        "$set": {
+                            "名前": "田中太郎",  # Japanese: name -> Taro Tanaka
+                            "город": "Москва",  # Russian: city -> Moscow
+                            "emoji_status": "🎉🚀💯",  # Emoji value
+                            "Ñoño": "Señor",  # Spanish with ñ
+                            "العربية": "مرحبا",  # Arabic
+                        },
+                        "$set_once": {
+                            "🔑_key": "emoji_key_value",  # Emoji in key
+                            "first_emoji": "👋",
+                        },
+                    }
+                ),
+            )
+        ]
+
+        def insert_events(client: Client) -> None:
+            client.execute(
+                """INSERT INTO writable_events (team_id, distinct_id, person_id, timestamp, properties)
+                VALUES""",
+                events,
+            )
+
+        cluster.any_host(insert_events).result()
+
+        # Person with different values for the Unicode keys
+        person_data = [
+            (
+                team_id,
+                person_id,
+                json.dumps(
+                    {
+                        "名前": "山田花子",  # Different Japanese name
+                        "город": "Санкт-Петербург",  # Different Russian city
+                        "emoji_status": "😢",
+                        "Ñoño": "Señora",
+                        "العربية": "وداعا",
+                    }
+                ),
+                1,
+                now - timedelta(days=8),
+            )
+        ]
+
+        def insert_persons(client: Client) -> None:
+            client.execute(
+                """INSERT INTO person (team_id, id, properties, version, _timestamp)
+                VALUES""",
+                person_data,
+            )
+
+        cluster.any_host(insert_persons).result()
+
+        results = get_person_property_updates_from_clickhouse(
+            team_id=team_id,
+            bug_window_start=bug_window_start.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+        assert len(results) == 1
+        person_diffs = results[0]
+
+        # Verify all Unicode keys are present with correct values
+        assert "名前" in person_diffs.set_updates
+        assert person_diffs.set_updates["名前"].value == "田中太郎"
+
+        assert "город" in person_diffs.set_updates
+        assert person_diffs.set_updates["город"].value == "Москва"
+
+        assert "emoji_status" in person_diffs.set_updates
+        assert person_diffs.set_updates["emoji_status"].value == "🎉🚀💯"
+
+        assert "Ñoño" in person_diffs.set_updates
+        assert person_diffs.set_updates["Ñoño"].value == "Señor"
+
+        assert "العربية" in person_diffs.set_updates
+        assert person_diffs.set_updates["العربية"].value == "مرحبا"
+
+        # Verify set_once with emoji key
+        assert "🔑_key" in person_diffs.set_once_updates
+        assert person_diffs.set_once_updates["🔑_key"].value == "emoji_key_value"
+
+        assert "first_emoji" in person_diffs.set_once_updates
+        assert person_diffs.set_once_updates["first_emoji"].value == "👋"
+
+    def test_no_affected_persons_returns_empty_results(self, cluster: ClickhouseCluster):
+        """
+        Integration test: verify graceful handling when no persons are affected.
+
+        This ensures the query doesn't error when:
+        - No events exist in the bug window
+        - Events exist but properties match (no diff)
+        - Team has no data at all
+        """
+        team_id = 99973
+        now = datetime.now().replace(microsecond=0)
+
+        # Bug window that has no events (far in the past, unique team_id)
+        bug_window_start = now - timedelta(days=1000)
+        bug_window_end = now - timedelta(days=999)
+
+        # Query should return empty, not error
+        results = get_person_property_updates_from_clickhouse(
+            team_id=team_id,
+            bug_window_start=bug_window_start.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+        assert results == [], f"Expected empty results for team with no data, got {len(results)} results"
+
+        # Also test get_affected_person_ids_from_clickhouse
+        affected_ids = get_affected_person_ids_from_clickhouse(
+            team_id=team_id,
+            bug_window_start=bug_window_start.strftime("%Y-%m-%d %H:%M:%S"),
+            bug_window_end=bug_window_end.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+        assert affected_ids == [], f"Expected no affected persons, got {len(affected_ids)}"
+
+    def test_rapid_fire_events_within_same_second(self, cluster: ClickhouseCluster):
+        """
+        Integration test: multiple events for same person within the same second.
+
+        Real-world scenario: rapid client-side events, SDK batching, etc.
+        Verifies deterministic behavior when timestamps collide.
+        """
+        team_id = 99974
+        person_id = UUID("99990000-0000-0000-0000-000000000001")
+        now = datetime.now().replace(microsecond=0)
+        bug_window_start = now - timedelta(days=10)
+
+        # Same timestamp for all events (within same second)
+        same_ts = now - timedelta(days=5)
+
+        # Multiple rapid-fire $set events for same key with same timestamp
+        # ClickHouse argMax should pick one deterministically
+        events = [
+            (team_id, "rapid_1", person_id, same_ts, json.dumps({"$set": {"counter": 1}})),
+            (team_id, "rapid_2", person_id, same_ts, json.dumps({"$set": {"counter": 2}})),
+            (team_id, "rapid_3", person_id, same_ts, json.dumps({"$set": {"counter": 3}})),
+            (team_id, "rapid_4", person_id, same_ts, json.dumps({"$set": {"counter": 4}})),
+            (team_id, "rapid_5", person_id, same_ts, json.dumps({"$set": {"counter": 5}})),
+        ]
+
+        def insert_events(client: Client) -> None:
+            client.execute(
+                """INSERT INTO writable_events (team_id, distinct_id, person_id, timestamp, properties)
+                VALUES""",
+                events,
+            )
+
+        cluster.any_host(insert_events).result()
+
+        # Person with different counter value
+        person_data = [(team_id, person_id, json.dumps({"counter": 0}), 1, now - timedelta(days=8))]
+
+        def insert_persons(client: Client) -> None:
+            client.execute(
+                """INSERT INTO person (team_id, id, properties, version, _timestamp)
+                VALUES""",
+                person_data,
+            )
+
+        cluster.any_host(insert_persons).result()
+
+        # Run query multiple times - result should be consistent (deterministic)
+        results_1 = get_person_property_updates_from_clickhouse(
+            team_id=team_id,
+            bug_window_start=bug_window_start.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+        results_2 = get_person_property_updates_from_clickhouse(
+            team_id=team_id,
+            bug_window_start=bug_window_start.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+        assert len(results_1) == 1
+        assert len(results_2) == 1
+
+        # Should be deterministic - same value both times
+        counter_1 = results_1[0].set_updates["counter"].value
+        counter_2 = results_2[0].set_updates["counter"].value
+
+        assert counter_1 == counter_2, (
+            f"Rapid-fire events should produce deterministic results. Got {counter_1} then {counter_2}"
+        )
+
+        # Value should be one of the inserted values (1-5)
+        assert counter_1 in [1, 2, 3, 4, 5], f"Counter should be one of 1-5, got {counter_1}"
 
     def test_windowed_query_produces_same_result_as_single_query(self, cluster: ClickhouseCluster):
         """


### PR DESCRIPTION
## Problem
The new windowed mode for person property reconciliation job has a resource utilization problem via a naive pattern in the 3 step aggregation query.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Fix resource util bug
* Update test cases, job config etc. accordingly
* Add design and usage document describing the two run modes and when and how to use each
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI - smoke test in dry run mode in US coming after this merges
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
