### PR TITLE
chore(experiments): add client-side search/filter

### DIFF
--- a/frontend/src/lib/components/FilteredTable/FilteredTableCount.tsx
+++ b/frontend/src/lib/components/FilteredTable/FilteredTableCount.tsx
@@ -1,0 +1,35 @@
+import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
+import { pluralize } from 'lib/utils'
+import { cn } from 'lib/utils/css-classes'
+
+export interface FilteredTableCountProps {
+    filtersChanged: boolean
+    effectiveCount: number
+    page: number
+    pageSize: number
+    noun: string
+}
+
+export function FilteredTableCount({
+    filtersChanged,
+    effectiveCount,
+    page,
+    pageSize,
+    noun,
+}: FilteredTableCountProps): JSX.Element | null {
+    const startCount = effectiveCount === 0 ? 0 : (page - 1) * pageSize + 1
+    const endCount = page * pageSize < effectiveCount ? page * pageSize : effectiveCount
+    const countText = `${startCount}${endCount - startCount > 1 ? '-' + endCount : ''} of ${pluralize(effectiveCount, noun)}`
+
+    return (
+        <div>
+            <span className={cn('text-secondary transition-opacity', filtersChanged && 'opacity-50')}>
+                {filtersChanged ? (
+                    <WrappingLoadingSkeleton>{countText}</WrappingLoadingSkeleton>
+                ) : effectiveCount > 0 ? (
+                    countText
+                ) : null}
+            </span>
+        </div>
+    )
+}

--- a/frontend/src/lib/components/FilteredTable/utils.ts
+++ b/frontend/src/lib/components/FilteredTable/utils.ts
@@ -1,0 +1,34 @@
+import { PaginationManual } from '@posthog/lemon-ui'
+
+import { objectsEqual } from 'lib/utils'
+
+export function haveFiltersChanged<T extends { page?: number }>(
+    currentFilters: T,
+    responseFilters: T | null | undefined
+): boolean {
+    if (!responseFilters) {
+        return false
+    }
+    return !objectsEqual({ ...responseFilters, page: undefined }, { ...currentFilters, page: undefined })
+}
+
+export function buildClientFilteredPagination({
+    currentPage,
+    pageSize,
+    clientCount,
+    apiCount,
+    filtersChanged,
+}: {
+    currentPage: number
+    pageSize: number
+    clientCount: number
+    apiCount: number
+    filtersChanged: boolean
+}): PaginationManual {
+    return {
+        controlled: true,
+        pageSize,
+        currentPage,
+        entryCount: filtersChanged ? clientCount : apiCount,
+    }
+}

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -9,6 +9,7 @@ import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
+import { FilteredTableCount } from 'lib/components/FilteredTable/FilteredTableCount'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import PropertyFiltersDisplay from 'lib/components/PropertyFilters/components/PropertyFiltersDisplay'
@@ -23,10 +24,7 @@ import { createdAtColumn, createdByColumn, updatedAtColumn } from 'lib/lemon-ui/
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
-import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
-import { pluralize } from 'lib/utils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
-import { cn } from 'lib/utils/css-classes'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import stringWithWBR from 'lib/utils/stringWithWBR'
 import MaxTool from 'scenes/max/MaxTool'
@@ -275,12 +273,6 @@ export function OverViewTab({
     const { setFeatureFlagsFilters } = useActions(flagLogic)
     const { featureFlags: enabledFeatureFlags } = useValues(enabledFeaturesLogic)
 
-    const page = filters.page || 1
-    const startCount = (page - 1) * FLAGS_PER_PAGE + 1
-    const effectiveCount = pagination.entryCount ?? 0
-    const endCount = page * FLAGS_PER_PAGE < effectiveCount ? page * FLAGS_PER_PAGE : effectiveCount
-    const flagCountText = `${startCount}${endCount - startCount > 1 ? '-' + endCount : ''} of ${pluralize(effectiveCount, 'flag')}`
-
     const columns: LemonTableColumns<FeatureFlagType> = [
         {
             title: 'Key',
@@ -468,19 +460,17 @@ export function OverViewTab({
                 action={() => router.actions.push(urls.featureFlag('new'))}
                 isEmpty={shouldShowEmptyState}
                 customHog={FeatureFlagHog}
-                className={cn('my-0')}
+                className="my-0"
             />
             <div>{filtersSection}</div>
             <LemonDivider className="my-0" />
-            <div>
-                <span className={cn('text-secondary transition-opacity', filtersChanged && 'opacity-50')}>
-                    {filtersChanged ? (
-                        <WrappingLoadingSkeleton>{flagCountText}</WrappingLoadingSkeleton>
-                    ) : effectiveCount > 0 ? (
-                        flagCountText
-                    ) : null}
-                </span>
-            </div>
+            <FilteredTableCount
+                filtersChanged={filtersChanged}
+                effectiveCount={pagination.entryCount ?? 0}
+                page={filters.page || 1}
+                pageSize={FLAGS_PER_PAGE}
+                noun="flag"
+            />
 
             <LemonTable
                 dataSource={displayedFlags}


### PR DESCRIPTION
## Problem

experiments trigger a backend query on every search/filter operation - this could be smoother :)

i did this for feature flags, wanted it for experiments too!

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- extracted some helpers based on feature flag logic client-side search logic
- applied client-side search/filter to experiments
- vibe-slopped a `generate_random_experiments` command

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->