### PR TITLE
fix: Keep showing MCP logs in Cloudflare

### DIFF
--- a/services/mcp/typescript/wrangler.jsonc
+++ b/services/mcp/typescript/wrangler.jsonc
@@ -43,7 +43,7 @@
                 "posthog"
             ],
             "head_sampling_rate": 1.0, // Collect all logs for now
-            "persist": false // Don't persist logs in Cloudflare dashboard
+            "persist": true // Keep showing logs in Cloudflare dashboard
         }
     },
     "rules": [


### PR DESCRIPTION
At least for now let's show all logs inside Cloudflare rather than have them only inside our logs product