### PR TITLE
chore(llma): bump summarization rate and clustering limits

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/README.md
+++ b/posthog/temporal/llm_analytics/trace_clustering/README.md
@@ -101,7 +101,7 @@ graph TB
 
 - `team_id` (required): Team ID to cluster traces for
 - `lookback_days` (optional): Days of trace history to analyze (default: 7)
-- `max_samples` (optional): Maximum traces to sample (default: 1000)
+- `max_samples` (optional): Maximum traces to sample (default: 2500)
 - `min_k` (optional): Minimum clusters for k-means (default: 2)
 - `max_k` (optional): Maximum clusters for k-means (default: 10)
 - `embedding_normalization` (optional): L2 normalize embeddings - "none" or "l2" (default: "l2")
@@ -341,7 +341,7 @@ Key constants in `constants.py`:
 | `WORKFLOW_NAME`                     | llma-trace-clustering             | Temporal workflow name                        |
 | `COORDINATOR_WORKFLOW_NAME`         | llma-trace-clustering-coordinator | Temporal coordinator workflow name            |
 | `DEFAULT_LOOKBACK_DAYS`             | 7                                 | Days of trace history to analyze              |
-| `DEFAULT_MAX_SAMPLES`               | 1000                              | Maximum traces to sample                      |
+| `DEFAULT_MAX_SAMPLES`               | 2500                              | Maximum traces to sample                      |
 | `MIN_TRACES_FOR_CLUSTERING`         | 20                                | Minimum traces required for workflow          |
 | `COMPUTE_ACTIVITY_TIMEOUT`          | 120s                              | Clustering compute timeout                    |
 | `EMIT_ACTIVITY_TIMEOUT`             | 60s                               | Event emission timeout                        |

--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -6,7 +6,7 @@ from temporalio.common import RetryPolicy
 
 # Clustering parameters
 DEFAULT_LOOKBACK_DAYS = 7
-DEFAULT_MAX_SAMPLES = 1000
+DEFAULT_MAX_SAMPLES = 2500
 DEFAULT_MIN_K = 2
 DEFAULT_MAX_K = 10
 

--- a/posthog/temporal/llm_analytics/trace_clustering/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/tests/test_workflow.py
@@ -5,6 +5,7 @@ import pytest
 import numpy as np
 
 from posthog.temporal.llm_analytics.trace_clustering.clustering import perform_kmeans_with_optimal_k
+from posthog.temporal.llm_analytics.trace_clustering.constants import DEFAULT_MAX_SAMPLES
 from posthog.temporal.llm_analytics.trace_clustering.models import (
     ClusteringActivityInputs,
     ClusteringComputeResult,
@@ -118,7 +119,7 @@ class TestWorkflowInputs:
 
         assert inputs.team_id == 1
         assert inputs.lookback_days == 7
-        assert inputs.max_samples == 1000
+        assert inputs.max_samples == DEFAULT_MAX_SAMPLES
         assert inputs.min_k == 2
         assert inputs.max_k == 10
 
@@ -149,7 +150,7 @@ class TestWorkflowInputs:
         assert inputs.team_id == 1
         assert inputs.window_start == "2025-01-01T00:00:00Z"
         assert inputs.window_end == "2025-01-08T00:00:00Z"
-        assert inputs.max_samples == 1000
+        assert inputs.max_samples == DEFAULT_MAX_SAMPLES
         assert inputs.min_k == 2
         assert inputs.max_k == 10
 

--- a/posthog/temporal/llm_analytics/trace_summarization/README.md
+++ b/posthog/temporal/llm_analytics/trace_summarization/README.md
@@ -109,7 +109,7 @@ Key constants in `constants.py`:
 
 | Constant                             | Default        | Description                 |
 | ------------------------------------ | -------------- | --------------------------- |
-| `DEFAULT_MAX_ITEMS_PER_WINDOW`       | 10             | Max items per window        |
+| `DEFAULT_MAX_ITEMS_PER_WINDOW`       | 15             | Max items per window        |
 | `DEFAULT_BATCH_SIZE`                 | 3              | Concurrent trace processing |
 | `DEFAULT_MODE`                       | "detailed"     | Summary detail level        |
 | `DEFAULT_MODEL`                      | "gpt-4.1-nano" | LLM model for summarization |

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -7,7 +7,9 @@ from temporalio.common import RetryPolicy
 from products.llm_analytics.backend.summarization.models import OpenAIModel, SummarizationMode
 
 # Window processing configuration
-DEFAULT_MAX_ITEMS_PER_WINDOW = 10  # Max items to process per window (conservative for worst-case 30s/item)
+DEFAULT_MAX_ITEMS_PER_WINDOW = (
+    15  # Max items to process per window (targets ~2500 summaries in 7-day clustering window)
+)
 DEFAULT_BATCH_SIZE = 3  # Number of traces to process in parallel (reduced to avoid rate limits)
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -328,7 +328,7 @@ class TestBatchTraceSummarizationWorkflow:
 
         assert inputs.team_id == 123
         assert inputs.analysis_level == "trace"
-        assert inputs.max_items == 10
+        assert inputs.max_items == 15
         assert inputs.batch_size == 3
         assert inputs.mode == "detailed"
         assert inputs.window_minutes == 60


### PR DESCRIPTION
## Problem

Current summarization rate (10/hour) only produces ~1680 summaries in the 7-day clustering window, limiting clustering quality.

Part of #45868

## Changes

- `DEFAULT_MAX_ITEMS_PER_WINDOW`: 10 -> 15/hour
- `DEFAULT_MAX_SAMPLES`: 1000 -> 2500

At 15/hour: ~2500 summaries available for clustering, ~$3.60/day per customer.

## How did you test this code?

Existing unit tests pass. Updated hardcoded test assertions to use constants.

## Publish to changelog?

No