### PR TITLE
feat(llma): add cluster distribution bar to visualization header

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/README.md
+++ b/posthog/temporal/llm_analytics/trace_clustering/README.md
@@ -101,7 +101,7 @@ graph TB
 
 - `team_id` (required): Team ID to cluster traces for
 - `lookback_days` (optional): Days of trace history to analyze (default: 7)
-- `max_samples` (optional): Maximum traces to sample (default: 1000)
+- `max_samples` (optional): Maximum traces to sample (default: 2500)
 - `min_k` (optional): Minimum clusters for k-means (default: 2)
 - `max_k` (optional): Maximum clusters for k-means (default: 10)
 - `embedding_normalization` (optional): L2 normalize embeddings - "none" or "l2" (default: "l2")
@@ -341,7 +341,7 @@ Key constants in `constants.py`:
 | `WORKFLOW_NAME`                     | llma-trace-clustering             | Temporal workflow name                        |
 | `COORDINATOR_WORKFLOW_NAME`         | llma-trace-clustering-coordinator | Temporal coordinator workflow name            |
 | `DEFAULT_LOOKBACK_DAYS`             | 7                                 | Days of trace history to analyze              |
-| `DEFAULT_MAX_SAMPLES`               | 1000                              | Maximum traces to sample                      |
+| `DEFAULT_MAX_SAMPLES`               | 2500                              | Maximum traces to sample                      |
 | `MIN_TRACES_FOR_CLUSTERING`         | 20                                | Minimum traces required for workflow          |
 | `COMPUTE_ACTIVITY_TIMEOUT`          | 120s                              | Clustering compute timeout                    |
 | `EMIT_ACTIVITY_TIMEOUT`             | 60s                               | Event emission timeout                        |

--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -6,7 +6,7 @@ from temporalio.common import RetryPolicy
 
 # Clustering parameters
 DEFAULT_LOOKBACK_DAYS = 7
-DEFAULT_MAX_SAMPLES = 1000
+DEFAULT_MAX_SAMPLES = 2500
 DEFAULT_MIN_K = 2
 DEFAULT_MAX_K = 10
 

--- a/posthog/temporal/llm_analytics/trace_clustering/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/tests/test_workflow.py
@@ -5,6 +5,7 @@ import pytest
 import numpy as np
 
 from posthog.temporal.llm_analytics.trace_clustering.clustering import perform_kmeans_with_optimal_k
+from posthog.temporal.llm_analytics.trace_clustering.constants import DEFAULT_MAX_SAMPLES
 from posthog.temporal.llm_analytics.trace_clustering.models import (
     ClusteringActivityInputs,
     ClusteringComputeResult,
@@ -118,7 +119,7 @@ class TestWorkflowInputs:
 
         assert inputs.team_id == 1
         assert inputs.lookback_days == 7
-        assert inputs.max_samples == 1000
+        assert inputs.max_samples == DEFAULT_MAX_SAMPLES
         assert inputs.min_k == 2
         assert inputs.max_k == 10
 
@@ -149,7 +150,7 @@ class TestWorkflowInputs:
         assert inputs.team_id == 1
         assert inputs.window_start == "2025-01-01T00:00:00Z"
         assert inputs.window_end == "2025-01-08T00:00:00Z"
-        assert inputs.max_samples == 1000
+        assert inputs.max_samples == DEFAULT_MAX_SAMPLES
         assert inputs.min_k == 2
         assert inputs.max_k == 10
 

--- a/posthog/temporal/llm_analytics/trace_summarization/README.md
+++ b/posthog/temporal/llm_analytics/trace_summarization/README.md
@@ -109,7 +109,7 @@ Key constants in `constants.py`:
 
 | Constant                             | Default        | Description                 |
 | ------------------------------------ | -------------- | --------------------------- |
-| `DEFAULT_MAX_ITEMS_PER_WINDOW`       | 10             | Max items per window        |
+| `DEFAULT_MAX_ITEMS_PER_WINDOW`       | 15             | Max items per window        |
 | `DEFAULT_BATCH_SIZE`                 | 3              | Concurrent trace processing |
 | `DEFAULT_MODE`                       | "detailed"     | Summary detail level        |
 | `DEFAULT_MODEL`                      | "gpt-4.1-nano" | LLM model for summarization |

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -7,7 +7,9 @@ from temporalio.common import RetryPolicy
 from products.llm_analytics.backend.summarization.models import OpenAIModel, SummarizationMode
 
 # Window processing configuration
-DEFAULT_MAX_ITEMS_PER_WINDOW = 10  # Max items to process per window (conservative for worst-case 30s/item)
+DEFAULT_MAX_ITEMS_PER_WINDOW = (
+    15  # Max items to process per window (targets ~2500 summaries in 7-day clustering window)
+)
 DEFAULT_BATCH_SIZE = 3  # Number of traces to process in parallel (reduced to avoid rate limits)
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -328,7 +328,7 @@ class TestBatchTraceSummarizationWorkflow:
 
         assert inputs.team_id == 123
         assert inputs.analysis_level == "trace"
-        assert inputs.max_items == 10
+        assert inputs.max_items == 15
         assert inputs.batch_size == 3
         assert inputs.mode == "detailed"
         assert inputs.window_minutes == 60

--- a/products/llm_analytics/frontend/clusters/ClusterDistributionBar.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterDistributionBar.tsx
@@ -26,7 +26,7 @@ export function ClusterDistributionBar({ clusters, runId }: ClusterDistributionB
     }
 
     return (
-        <div className="flex-1 min-w-0 h-4 flex items-center">
+        <div className="flex-1 min-w-0 flex items-center">
             <div className="flex w-full h-2.5 rounded-sm overflow-hidden bg-border-light">
                 {clusters.map((cluster) => {
                     const percentage = (cluster.size / totalInClusters) * 100

--- a/products/llm_analytics/frontend/clusters/ClusterDistributionBar.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterDistributionBar.tsx
@@ -24,7 +24,7 @@ export function ClusterDistributionBar({ clusters, runId }: ClusterDistributionB
     const totalInClusters = clusters.reduce((sum, cluster) => sum + cluster.size, 0)
 
     return (
-        <div className="flex h-3 w-full rounded-sm overflow-hidden bg-border-light">
+        <div className="flex-1 min-w-0 flex h-3 rounded-sm overflow-hidden bg-border-light">
             {clusters.map((cluster) => {
                 const percentage = (cluster.size / totalInClusters) * 100
                 const isOutlier = cluster.cluster_id === NOISE_CLUSTER_ID

--- a/products/llm_analytics/frontend/clusters/ClusterDistributionBar.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterDistributionBar.tsx
@@ -24,43 +24,45 @@ export function ClusterDistributionBar({ clusters, runId }: ClusterDistributionB
     const totalInClusters = clusters.reduce((sum, cluster) => sum + cluster.size, 0)
 
     return (
-        <div className="flex-1 min-w-0 flex h-3 rounded-sm overflow-hidden bg-border-light">
-            {clusters.map((cluster) => {
-                const percentage = (cluster.size / totalInClusters) * 100
-                const isOutlier = cluster.cluster_id === NOISE_CLUSTER_ID
-                const color = isOutlier ? OUTLIER_COLOR : getSeriesColor(cluster.cluster_id)
+        <div className="flex-1 min-w-0 h-4 flex items-center">
+            <div className="flex w-full h-2.5 rounded-sm overflow-hidden bg-border-light">
+                {clusters.map((cluster) => {
+                    const percentage = (cluster.size / totalInClusters) * 100
+                    const isOutlier = cluster.cluster_id === NOISE_CLUSTER_ID
+                    const color = isOutlier ? OUTLIER_COLOR : getSeriesColor(cluster.cluster_id)
 
-                if (percentage < 0.5) {
-                    return null
-                }
+                    if (percentage < 0.5) {
+                        return null
+                    }
 
-                return (
-                    <Tooltip
-                        key={cluster.cluster_id}
-                        title={
-                            <div className="text-xs">
-                                <div className="font-semibold">{cluster.title}</div>
-                                <div>
-                                    {cluster.size} ({Math.round(percentage)}%)
+                    return (
+                        <Tooltip
+                            key={cluster.cluster_id}
+                            title={
+                                <div className="text-xs">
+                                    <div className="font-semibold">{cluster.title}</div>
+                                    <div>
+                                        {cluster.size} ({Math.round(percentage)}%)
+                                    </div>
                                 </div>
-                            </div>
-                        }
-                    >
-                        <div
-                            className="h-full transition-all hover:opacity-80 cursor-pointer"
-                            // eslint-disable-next-line react/forbid-dom-props
-                            style={{
-                                width: `${percentage}%`,
-                                backgroundColor: color,
-                            }}
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                router.actions.push(urls.llmAnalyticsCluster(runId, cluster.cluster_id))
-                            }}
-                        />
-                    </Tooltip>
-                )
-            })}
+                            }
+                        >
+                            <div
+                                className="h-full transition-all hover:opacity-80 cursor-pointer"
+                                // eslint-disable-next-line react/forbid-dom-props
+                                style={{
+                                    width: `${percentage}%`,
+                                    backgroundColor: color,
+                                }}
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    router.actions.push(urls.llmAnalyticsCluster(runId, cluster.cluster_id))
+                                }}
+                            />
+                        </Tooltip>
+                    )
+                })}
+            </div>
         </div>
     )
 }

--- a/products/llm_analytics/frontend/clusters/ClusterDistributionBar.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterDistributionBar.tsx
@@ -5,10 +5,8 @@ import { Tooltip } from '@posthog/lemon-ui'
 import { getSeriesColor } from 'lib/colors'
 import { urls } from 'scenes/urls'
 
-import { NOISE_CLUSTER_ID } from './constants'
+import { NOISE_CLUSTER_ID, OUTLIER_COLOR } from './constants'
 import { Cluster } from './types'
-
-const OUTLIER_COLOR = '#888888'
 
 interface ClusterDistributionBarProps {
     clusters: Cluster[]
@@ -22,6 +20,10 @@ export function ClusterDistributionBar({ clusters, runId }: ClusterDistributionB
 
     // Calculate total from actual cluster sizes so the bar fills 100%
     const totalInClusters = clusters.reduce((sum, cluster) => sum + cluster.size, 0)
+
+    if (totalInClusters === 0) {
+        return null
+    }
 
     return (
         <div className="flex-1 min-w-0 h-4 flex items-center">

--- a/products/llm_analytics/frontend/clusters/ClusterDistributionBar.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterDistributionBar.tsx
@@ -1,0 +1,66 @@
+import { router } from 'kea-router'
+
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { getSeriesColor } from 'lib/colors'
+import { urls } from 'scenes/urls'
+
+import { NOISE_CLUSTER_ID } from './constants'
+import { Cluster } from './types'
+
+const OUTLIER_COLOR = '#888888'
+
+interface ClusterDistributionBarProps {
+    clusters: Cluster[]
+    runId: string
+}
+
+export function ClusterDistributionBar({ clusters, runId }: ClusterDistributionBarProps): JSX.Element | null {
+    if (clusters.length === 0) {
+        return null
+    }
+
+    // Calculate total from actual cluster sizes so the bar fills 100%
+    const totalInClusters = clusters.reduce((sum, cluster) => sum + cluster.size, 0)
+
+    return (
+        <div className="flex h-3 w-full rounded-sm overflow-hidden bg-border-light">
+            {clusters.map((cluster) => {
+                const percentage = (cluster.size / totalInClusters) * 100
+                const isOutlier = cluster.cluster_id === NOISE_CLUSTER_ID
+                const color = isOutlier ? OUTLIER_COLOR : getSeriesColor(cluster.cluster_id)
+
+                if (percentage < 0.5) {
+                    return null
+                }
+
+                return (
+                    <Tooltip
+                        key={cluster.cluster_id}
+                        title={
+                            <div className="text-xs">
+                                <div className="font-semibold">{cluster.title}</div>
+                                <div>
+                                    {cluster.size} ({Math.round(percentage)}%)
+                                </div>
+                            </div>
+                        }
+                    >
+                        <div
+                            className="h-full transition-all hover:opacity-80 cursor-pointer"
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{
+                                width: `${percentage}%`,
+                                backgroundColor: color,
+                            }}
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                router.actions.push(urls.llmAnalyticsCluster(runId, cluster.cluster_id))
+                            }}
+                        />
+                    </Tooltip>
+                )
+            })}
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/clusters/ClusterTraceList.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterTraceList.tsx
@@ -88,14 +88,18 @@ function TraceListItem({
                         clusteringLevel === 'generation' ? traceInfo.trace_id : traceId,
                         clusteringLevel === 'generation'
                             ? {
+                                  tab: 'summary',
                                   event: traceInfo.generation_id,
                                   ...(traceInfo.timestamp
                                       ? { timestamp: dayjs.utc(traceInfo.timestamp).toISOString() }
                                       : {}),
                               }
-                            : traceInfo.timestamp
-                              ? { timestamp: dayjs.utc(traceInfo.timestamp).toISOString() }
-                              : {}
+                            : {
+                                  tab: 'summary',
+                                  ...(traceInfo.timestamp
+                                      ? { timestamp: dayjs.utc(traceInfo.timestamp).toISOString() }
+                                      : {}),
+                              }
                     )}
                     className="text-xs text-link hover:underline shrink-0"
                 >

--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -257,7 +257,6 @@ export function ClustersView(): JSX.Element {
                         onClick={toggleScatterPlotExpanded}
                     >
                         <div className="flex items-center gap-4">
-                            <h3 className="font-semibold text-base shrink-0 leading-none">Cluster visualization</h3>
                             <ClusterDistributionBar clusters={sortedClusters} runId={effectiveRunId || ''} />
                             <LemonButton
                                 size="small"

--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -8,6 +8,7 @@ import { dayjs } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { ClusterCard } from './ClusterCard'
+import { ClusterDistributionBar } from './ClusterDistributionBar'
 import { ClusterScatterPlot } from './ClusterScatterPlot'
 import { ClusteringAdminModal } from './ClusteringAdminModal'
 import { clustersAdminLogic } from './clustersAdminLogic'
@@ -255,8 +256,11 @@ export function ClustersView(): JSX.Element {
                         className="p-4 cursor-pointer hover:bg-surface-secondary transition-colors"
                         onClick={toggleScatterPlotExpanded}
                     >
-                        <div className="flex items-center justify-between">
-                            <h3 className="font-semibold text-base">Cluster visualization</h3>
+                        <div className="flex items-center gap-4">
+                            <h3 className="font-semibold text-base shrink-0">Cluster visualization</h3>
+                            <div className="flex-1 min-w-0 flex items-center">
+                                <ClusterDistributionBar clusters={sortedClusters} runId={effectiveRunId || ''} />
+                            </div>
                             <LemonButton
                                 size="small"
                                 noPadding

--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -257,10 +257,8 @@ export function ClustersView(): JSX.Element {
                         onClick={toggleScatterPlotExpanded}
                     >
                         <div className="flex items-center gap-4">
-                            <h3 className="font-semibold text-base shrink-0">Cluster visualization</h3>
-                            <div className="flex-1 min-w-0 flex items-center">
-                                <ClusterDistributionBar clusters={sortedClusters} runId={effectiveRunId || ''} />
-                            </div>
+                            <h3 className="font-semibold text-base shrink-0 leading-none">Cluster visualization</h3>
+                            <ClusterDistributionBar clusters={sortedClusters} runId={effectiveRunId || ''} />
                             <LemonButton
                                 size="small"
                                 noPadding

--- a/products/llm_analytics/frontend/clusters/LLMAnalyticsClusterScene.tsx
+++ b/products/llm_analytics/frontend/clusters/LLMAnalyticsClusterScene.tsx
@@ -230,6 +230,7 @@ function TraceListItem({
                 <span className="font-medium flex-1 min-w-0 truncate">{summary?.title || 'Loading...'}</span>
                 <Link
                     to={urls.llmAnalyticsTrace(clusteringLevel === 'generation' ? traceInfo.trace_id : traceId, {
+                        tab: 'summary',
                         // For generation-level, highlight the specific generation
                         ...(clusteringLevel === 'generation' && traceInfo.generation_id
                             ? { event: traceInfo.generation_id }

--- a/products/llm_analytics/frontend/clusters/clusterDetailLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clusterDetailLogic.ts
@@ -11,7 +11,7 @@ import { hogql } from '~/queries/utils'
 import { Breadcrumb } from '~/types'
 
 import type { clusterDetailLogicType } from './clusterDetailLogicType'
-import { NOISE_CLUSTER_ID, TRACES_PER_PAGE } from './constants'
+import { NOISE_CLUSTER_ID, OUTLIER_COLOR, TRACES_PER_PAGE } from './constants'
 import { loadTraceSummaries } from './traceSummaryLoader'
 import { Cluster, ClusterItemInfo, ClusteringLevel, TraceSummary, getTimestampBoundsFromRunId } from './types'
 
@@ -44,8 +44,6 @@ export interface ScatterDataset {
     pointHoverRadius: number
     pointStyle?: 'circle' | 'crossRot'
 }
-
-const OUTLIER_COLOR = '#888888'
 
 export const clusterDetailLogic = kea<clusterDetailLogicType>([
     path(['products', 'llm_analytics', 'frontend', 'clusters', 'clusterDetailLogic']),

--- a/products/llm_analytics/frontend/clusters/clustersLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clustersLogic.ts
@@ -12,7 +12,7 @@ import { hogql } from '~/queries/utils'
 import { Breadcrumb } from '~/types'
 
 import type { clustersLogicType } from './clustersLogicType'
-import { MAX_CLUSTERING_RUNS, NOISE_CLUSTER_ID } from './constants'
+import { MAX_CLUSTERING_RUNS, NOISE_CLUSTER_ID, OUTLIER_COLOR } from './constants'
 import { loadTraceSummaries } from './traceSummaryLoader'
 import {
     Cluster,
@@ -24,9 +24,6 @@ import {
     getLevelFromRunId,
     getTimestampBoundsFromRunId,
 } from './types'
-
-// Special color for outliers cluster
-const OUTLIER_COLOR = '#888888'
 
 export interface ScatterDataset {
     label: string

--- a/products/llm_analytics/frontend/clusters/constants.ts
+++ b/products/llm_analytics/frontend/clusters/constants.ts
@@ -1,6 +1,9 @@
 // Noise/outlier cluster ID from HDBSCAN
 export const NOISE_CLUSTER_ID = -1
 
+// Color for outlier/noise cluster
+export const OUTLIER_COLOR = '#888888'
+
 // Pagination
 export const TRACES_PER_PAGE = 50
 


### PR DESCRIPTION
## Problem

Users viewing the clusters page need to expand the scatter plot visualization to understand the relative distribution of traces across clusters. There's no quick visual indicator of cluster sizes when the visualization is collapsed.

## Changes

Adds a horizontal stacked bar to the collapsible visualization header that:
- Shows the relative size distribution of all clusters at a glance
- Uses the same colors as the scatter plot dots for consistency
- Clicking a segment navigates to that cluster's detail page
- Includes tooltips showing cluster name and count/percentage on hover

<img width="2792" height="1630" alt="image" src="https://github.com/user-attachments/assets/c560b053-12f0-40fe-9014-44342a8630fb" />

The bar is always visible in the header row, providing quick insight into cluster distribution even when the scatter plot is collapsed.

### Additional improvements

- Fixed division by zero when all clusters have size 0
- Extracted `OUTLIER_COLOR` constant to `constants.ts` (was duplicated in 3 files)
- Added `tab=summary` to trace links to prevent auto-navigation to next generation/span

## How did you test this code?

- Manual testing on local dev environment
- Verified colors match scatter plot
- Verified click navigation works
- Verified tooltips display correctly

## Publish to changelog?

no