### PR TITLE
feat(llma): increase evaluation runs limit to 250 and pagination to 50

### DIFF
--- a/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
@@ -130,7 +130,7 @@ export function EvaluationRunsTable(): JSX.Element {
                 loading={evaluationRunsLoading}
                 rowKey="id"
                 pagination={{
-                    pageSize: 20,
+                    pageSize: 50,
                 }}
                 emptyState={
                     <div className="text-center py-8">

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -4,6 +4,7 @@ import { dayjs } from 'lib/dayjs'
 import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
 import { hogql } from '~/queries/utils'
 
+import { EVALUATION_SUMMARY_MAX_RUNS } from './evaluations/constants'
 import type { EvaluationRun } from './evaluations/types'
 import type { SpanAggregation } from './llmAnalyticsTraceDataLogic'
 import {
@@ -886,7 +887,7 @@ export async function queryEvaluationRuns(params: {
             event = '$ai_evaluation'
             AND ${hogql.raw(`properties.${propertyName}`)} = ${propertyValue}
         ORDER BY timestamp DESC
-        LIMIT 100
+        LIMIT ${EVALUATION_SUMMARY_MAX_RUNS}
     `
 
     const response = await api.queryHogQL(


### PR DESCRIPTION
## Problem

Evaluation runs query was hardcoded to limit 100, not using the EVALUATION_SUMMARY_MAX_RUNS constant (250). Table pagination was also set to 20 rows per page.

## Changes

- Use EVALUATION_SUMMARY_MAX_RUNS constant in queryEvaluationRuns() instead of hardcoded 100
- Increase table pagination from 20 to 50 rows per page

## How did you test this code?

Load evaluation results page and verify runs are fetched up to 250 limit with 50 rows per page pagination.

## Publish to changelog?

No