### PR TITLE
chore(llma): use dash prefix for cluster bullet lists

### DIFF
--- a/products/llm_analytics/backend/summarization/llm/evaluation_schema.py
+++ b/products/llm_analytics/backend/summarization/llm/evaluation_schema.py
@@ -16,7 +16,7 @@ class EvaluationPattern(BaseModel):
     example_reasoning: str = Field(
         description="An example reasoning from the evaluated runs that demonstrates this pattern"
     )
-    example_generation_ids: list[str] = Field(description="List of 1-3 generation IDs that exemplify this pattern")
+    example_generation_ids: list[str] = Field(description="List of 1-5 generation IDs that exemplify this pattern")
 
 
 class EvaluationSummaryStatistics(BaseModel):

--- a/products/llm_analytics/backend/summarization/prompts/evaluation_summary.djt
+++ b/products/llm_analytics/backend/summarization/prompts/evaluation_summary.djt
@@ -54,14 +54,14 @@ IMPORTANT GUIDELINES:
 - Limit to 0-4 patterns per category
 - Recommendations should be specific and actionable (2-4 total)
 - If there are no patterns for a category, return an empty array
-- For each pattern, include 1-3 generation_ids that exemplify the pattern
+- For each pattern, include 1-5 generation_ids that exemplify the pattern
 
 PATTERN IDENTIFICATION:
 - Look for repeated phrases, similar concerns, or common themes
 - A pattern should appear in multiple evaluations to be worth noting
 - For each pattern, provide a concrete example from the input reasoning
 - Use frequency terms: "common" (majority), "occasional" (several), "rare" (few)
-- Include the generation_ids of runs that match this pattern (pick 1-3 representative examples)
+- Include the generation_ids of runs that match this pattern (pick 1-5 representative examples)
 
 STRUCTURED OUTPUT:
 You must return valid JSON matching this schema:

--- a/products/llm_analytics/frontend/clusters/ClusterDescriptionComponents.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterDescriptionComponents.tsx
@@ -21,11 +21,11 @@ export function parseBullets(bullets: string): BulletItem[] {
 
 export function BulletList({ items }: { items: BulletItem[] }): JSX.Element {
     return (
-        <ul className="p-2 bg-surface-secondary rounded text-sm space-y-1 list-disc list-inside">
+        <div className="p-2 bg-surface-secondary rounded text-sm space-y-1">
             {items.map((item, index) => (
-                <li key={index}>{item.text}</li>
+                <div key={index}>- {item.text}</div>
             ))}
-        </ul>
+        </div>
     )
 }
 
@@ -35,11 +35,11 @@ export function ClusterDescription({ description }: { description: string }): JS
 
     if (isBulletList) {
         return (
-            <ul className="text-secondary text-sm list-disc list-inside space-y-0.5 m-0">
+            <div className="text-secondary text-sm space-y-0.5 m-0">
                 {lines.map((line, index) => (
-                    <li key={index}>{line.trim().slice(2)}</li>
+                    <div key={index}>{line.trim()}</div>
                 ))}
-            </ul>
+            </div>
         )
     }
     return <p className="text-secondary m-0">{description}</p>

--- a/products/llm_analytics/frontend/evaluations/components/PatternCard.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/PatternCard.tsx
@@ -1,7 +1,7 @@
 import posthog from 'posthog-js'
 
 import { IconCheck, IconMinus, IconX } from '@posthog/icons'
-import { Link } from '@posthog/lemon-ui'
+import { Link, Tooltip } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
 
@@ -26,9 +26,6 @@ export function PatternCard({ pattern, type, runsLookup }: PatternCardProps): JS
                 <span className="text-xs text-muted bg-bg-light px-2 py-0.5 rounded">{pattern.frequency}</span>
             </div>
             <p className="text-sm text-default mb-2">{pattern.description}</p>
-            <div className="text-xs text-muted bg-bg-light p-2 rounded">
-                <strong>Example:</strong> {pattern.example_reasoning}
-            </div>
             {pattern.example_generation_ids.length > 0 && (
                 <div className="mt-2 flex items-baseline gap-1.5 flex-wrap">
                     <span className="text-xs text-muted">Generations:</span>
@@ -36,25 +33,26 @@ export function PatternCard({ pattern, type, runsLookup }: PatternCardProps): JS
                         const run = runsLookup[genId]
                         if (run) {
                             return (
-                                <Link
-                                    key={genId}
-                                    to={urls.llmAnalyticsTrace(run.trace_id, { event: genId, tab: 'evals' })}
-                                    className="text-xs font-mono text-primary hover:underline"
-                                    data-attr="llma-evaluation-summary-example-link"
-                                    onClick={() => {
-                                        posthog.capture('llma evaluation summary example clicked', {
-                                            pattern_type: type,
-                                            pattern_title: pattern.title,
-                                        })
-                                    }}
-                                >
-                                    {genId.slice(0, 8)}...
-                                </Link>
+                                <Tooltip key={genId} title={run.reasoning}>
+                                    <Link
+                                        to={urls.llmAnalyticsTrace(run.trace_id, { event: genId, tab: 'evals' })}
+                                        className="text-xs font-mono text-primary hover:underline"
+                                        data-attr="llma-evaluation-summary-example-link"
+                                        onClick={() => {
+                                            posthog.capture('llma evaluation summary example clicked', {
+                                                pattern_type: type,
+                                                pattern_title: pattern.title,
+                                            })
+                                        }}
+                                    >
+                                        {genId.slice(0, 8)}
+                                    </Link>
+                                </Tooltip>
                             )
                         }
                         return (
                             <span key={genId} className="text-xs font-mono text-muted">
-                                {genId.slice(0, 8)}...
+                                {genId.slice(0, 8)}
                             </span>
                         )
                     })}


### PR DESCRIPTION
## Problem

Inconsistent bullet styling in the clusters tab compared to other LLMA components.

## Changes

- Replace `list-disc` bullet points with "-" prefix in `BulletList` component
- Replace `list-disc` bullet points with "-" prefix in `ClusterDescription` component

## How did you test this code?

Manual testing in the clusters UI.

## Publish to changelog?

No