### PR TITLE
feat(llma): add user task focus guideline to summarization prompts

### DIFF
--- a/products/llm_analytics/backend/summarization/prompts/system_detailed.djt
+++ b/products/llm_analytics/backend/summarization/prompts/system_detailed.djt
@@ -10,6 +10,7 @@ NOTES:
 - The goal here is for useful and actionable summarization.
 
 IMPORTANT GUIDELINES:
+- Focus, when feasible, on what the user or human was trying to accomplish and how the AI agent helped or failed to help them complete their task.
 - Provide 5-10 bullet points covering the main aspects of what happened.
 - Include interesting notes highlighting notable aspects that a human user responsible for the system might want to know.
 - Line references go in the line_refs field - DO NOT include them in the text field.

--- a/products/llm_analytics/backend/summarization/prompts/system_minimal.djt
+++ b/products/llm_analytics/backend/summarization/prompts/system_minimal.djt
@@ -9,6 +9,7 @@ NOTES:
 - The goal here is for useful and actionable summarization.
 
 IMPORTANT GUIDELINES:
+- Focus, when feasible, on what the user or human was trying to accomplish and how the AI agent helped or failed to help them complete their task.
 - Provide 3-5 bullet points covering only the most critical aspects.
 - Include 0-2 interesting notes ONLY if they are critical (errors, failures, strong user emotions, or unusual patterns).
 - Focus on key actions, outcomes, tool calls, errors, or notable outputs.


### PR DESCRIPTION
## Problem

LLM trace summaries could better highlight the user's intent and whether the AI successfully helped them accomplish their goal.

## Changes

Added a guideline to both detailed and minimal summarization prompts to focus on what the user was trying to accomplish and how the AI agent helped or failed to help them complete their task.

## How did you test this code?

Prompt change only. Will be validated through summarization output quality.

## Publish to changelog?

No