### PR TITLE
feat(llm-analytics): add dynamic tab descriptions

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -587,6 +587,21 @@ const DOCS_URLS_BY_TAB: Record<string, string> = {
     evaluations: 'https://posthog.com/docs/llm-analytics/evaluations',
 }
 
+const TAB_DESCRIPTIONS: Record<string, string> = {
+    dashboard: 'Overview of your LLM usage, costs, and performance metrics.',
+    traces: 'Explore end-to-end traces of your LLM interactions.',
+    generations: 'View individual LLM generations and their details.',
+    users: 'Understand how users are interacting with your LLM features.',
+    errors: 'Monitor and debug errors in your LLM pipeline.',
+    sessions: 'Analyze user sessions containing LLM interactions.',
+    playground: 'Test and experiment with LLM prompts in a sandbox environment.',
+    evaluations: 'Configure and monitor automated LLM output evaluations.',
+    datasets: 'Manage datasets for testing and evaluation.',
+    clusters: 'Discover patterns and clusters in your LLM usage.',
+    prompts: 'Track and manage your LLM prompts.',
+    settings: 'Configure LLM analytics settings and API keys.',
+}
+
 export function LLMAnalyticsScene(): JSX.Element {
     const { activeTab } = useValues(llmAnalyticsSharedLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -812,7 +827,7 @@ export function LLMAnalyticsScene(): JSX.Element {
             <SceneContent>
                 <SceneTitleSection
                     name={sceneConfigurations[Scene.LLMAnalytics].name}
-                    description={sceneConfigurations[Scene.LLMAnalytics].description}
+                    description={TAB_DESCRIPTIONS[activeTab] || sceneConfigurations[Scene.LLMAnalytics].description}
                     resourceType={{
                         type: sceneConfigurations[Scene.LLMAnalytics].iconType || 'default_icon_type',
                     }}


### PR DESCRIPTION
## Problem

The LLM analytics page subtitle always shows "Analyze and understand your LLM usage and performance." regardless of which tab is selected.

## Changes

- Added `TAB_DESCRIPTIONS` mapping with tab-specific descriptions
- Updated `SceneTitleSection` to use dynamic description based on active tab

Each tab now shows a relevant subtitle (e.g., "Explore end-to-end traces of your LLM interactions." for the Traces tab).

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing by switching between tabs and verifying the subtitle updates.