### PR TITLE
fix: event definition by_name endpoint filtering

### DIFF
--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -1,7 +1,7 @@
 from typing import Any, Literal, Optional, cast
 
 from django.core.cache import cache
-from django.db.models import Manager
+from django.db.models import Manager, Q
 
 import orjson
 from drf_spectacular.types import OpenApiTypes
@@ -457,7 +457,7 @@ class EventDefinitionViewSet(
             event_definition_object_manager = EventDefinition.objects
 
         event_def = event_definition_object_manager.filter(
-            team__project_id=self.project_id,
+            Q(project_id=self.project_id) | Q(project_id__isnull=True, team_id=self.project_id),
             name=event_name,
         ).first()
 


### PR DESCRIPTION
## Problem

Error: https://us.posthog.com/project/2/error_tracking/019c0a74-5196-7c82-b308-d42ee739a2d7?timestamp=2026-02-01%2001%3A14%3A22.670000-08%3A00

Fix for: https://github.com/PostHog/posthog/pull/46331
The `by_name` endpoint for event definitions was using a different filtering logic than the list endpoint, causing lookups to fail for existing events.

The list endpoint filters directly on EventDefinition.project_id. This caused the MCP event-definition-update tool to return "Event definition not found" errors for events that show up in the list.