### PR TITLE
fix: increase affordance that timestamp label is clickable

### DIFF
--- a/frontend/src/scenes/session-recordings/components/SimpleTimeLabel.tsx
+++ b/frontend/src/scenes/session-recordings/components/SimpleTimeLabel.tsx
@@ -2,7 +2,6 @@ import clsx from 'clsx'
 import { memo } from 'react'
 
 import { Dayjs, dayjs } from 'lib/dayjs'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { shortTimeZone } from 'lib/utils'
 import { formatLocalizedDate } from 'lib/utils/dateTimeUtils'
 import { TimestampFormat } from 'scenes/session-recordings/player/playerSettingsLogic'
@@ -72,11 +71,7 @@ export function _SimpleTimeLabel({
                 size === 'small' && 'text-sm'
             )}
         >
-            {containerSize === 'small' ? (
-                <Tooltip title={formattedReplayTime(startTime, timestampFormat, false)}>{formattedTime}</Tooltip>
-            ) : (
-                formattedTime
-            )}
+            {formattedTime}
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
@@ -160,6 +160,7 @@ function SkipToNext(): JSX.Element | null {
 
     return (
         <Tooltip
+            delayMs={100}
             title={
                 <>
                     Play the next recording <KeyboardShortcut n />

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
@@ -1,11 +1,15 @@
 import { useActions, useValues } from 'kea'
+import { useState } from 'react'
 
+import { IconClock } from '@posthog/icons'
 import { LemonButton, LemonButtonProps, Tooltip } from '@posthog/lemon-ui'
 
+import { dayjs } from 'lib/dayjs'
 import { useKeyHeld } from 'lib/hooks/useKeyHeld'
 import { IconSkipBackward } from 'lib/lemon-ui/icons'
-import { capitalizeFirstLetter, colonDelimitedDuration } from 'lib/utils'
+import { capitalizeFirstLetter, colonDelimitedDuration, shortTimeZone } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
+import { formatLocalizedDate } from 'lib/utils/dateTimeUtils'
 import { SimpleTimeLabel } from 'scenes/session-recordings/components/SimpleTimeLabel'
 import {
     ONE_SECOND_MS,
@@ -17,6 +21,22 @@ import { HotKeyOrModifier } from '~/types'
 
 import { TimestampFormat, playerSettingsLogic } from '../playerSettingsLogic'
 import { seekbarLogic } from './seekbarLogic'
+
+const TIMESTAMP_FORMAT_LABELS: Record<TimestampFormat, string> = {
+    [TimestampFormat.Relative]: 'Relative',
+    [TimestampFormat.UTC]: 'UTC',
+    [TimestampFormat.Device]: 'Device',
+}
+
+function formatTimestampForTooltip(timestamp: number | undefined, format: TimestampFormat): string {
+    if (timestamp === undefined) {
+        return '--:--:--'
+    }
+    const d = format === TimestampFormat.UTC ? dayjs(timestamp).tz('UTC') : dayjs(timestamp)
+    const formatted = d.format(`${formatLocalizedDate()}, HH:mm:ss`)
+    const timezone = format === TimestampFormat.UTC ? 'UTC' : shortTimeZone(undefined, d.toDate())
+    return `${formatted} ${timezone}`
+}
 
 function RelativeTimestampLabel({ size }: { size: 'small' | 'normal' }): JSX.Element {
     const { logicProps, currentPlayerTimeSeconds, sessionPlayerData } = useValues(sessionRecordingPlayerLogic)
@@ -37,9 +57,7 @@ function RelativeTimestampLabel({ size }: { size: 'small' | 'normal' }): JSX.Ele
         </div>
     )
     return size === 'small' ? (
-        <Tooltip title={fullDisplay}>
-            <span className="text-muted text-xs">{current}</span>
-        </Tooltip>
+        <span className="text-muted text-xs">{current}</span>
     ) : (
         <span className="text-muted text-xs">{fullDisplay}</span>
     )
@@ -49,36 +67,75 @@ export function Timestamp({
     size,
     noPadding,
 }: { size: 'small' | 'normal' } & Pick<LemonButtonProps, 'noPadding'>): JSX.Element {
-    const { logicProps, currentTimestamp, sessionPlayerData } = useValues(sessionRecordingPlayerLogic)
-    const { isScrubbing, scrubbingTime } = useValues(seekbarLogic(logicProps))
+    const { logicProps, currentTimestamp, currentPlayerTimeSeconds, sessionPlayerData } =
+        useValues(sessionRecordingPlayerLogic)
+    const { isScrubbing, scrubbingTime, scrubbingTimeSeconds } = useValues(seekbarLogic(logicProps))
     const { timestampFormat } = useValues(playerSettingsLogic)
     const { setTimestampFormat } = useActions(playerSettingsLogic)
+    const [isHovered, setIsHovered] = useState(false)
 
     const scrubbingTimestamp = sessionPlayerData.start?.valueOf()
         ? scrubbingTime + sessionPlayerData.start?.valueOf()
         : undefined
 
+    const activeTimestamp = isScrubbing ? scrubbingTimestamp : currentTimestamp
+    const relativeTimeSeconds = (isScrubbing ? scrubbingTimeSeconds : currentPlayerTimeSeconds) ?? 0
+    const relativeTime = colonDelimitedDuration(relativeTimeSeconds, 2)
+
+    const values = Object.values(TimestampFormat)
+    const nextIndex = (values.indexOf(timestampFormat) + 1) % values.length
+    const nextFormat = values[nextIndex]
+
+    const tooltipContent = (
+        <div className="space-y-1">
+            {values.map((format) => {
+                const isCurrent = format === timestampFormat
+                const label = TIMESTAMP_FORMAT_LABELS[format]
+                const value =
+                    format === TimestampFormat.Relative
+                        ? relativeTime
+                        : formatTimestampForTooltip(activeTimestamp, format)
+
+                return (
+                    <div
+                        key={format}
+                        className={cn('flex justify-between gap-4 px-1 -mx-1 rounded', isCurrent && 'bg-white/20')}
+                    >
+                        <span>{label}</span>
+                        <span className="font-mono text-right">{value}</span>
+                    </div>
+                )
+            })}
+            <div className="opacity-75 text-xs border-t border-white/20 pt-1 mt-1">
+                Click to show time in {TIMESTAMP_FORMAT_LABELS[nextFormat].toLowerCase()} format
+            </div>
+        </div>
+    )
+
     return (
-        <LemonButton
-            data-attr="recording-timestamp"
-            className="text-center whitespace-nowrap font-mono text-xs inline"
-            noPadding={noPadding}
-            onClick={() => {
-                const values = Object.values(TimestampFormat)
-                const nextIndex = (values.indexOf(timestampFormat) + 1) % values.length
-                setTimestampFormat(values[nextIndex])
-            }}
-        >
-            {timestampFormat === TimestampFormat.Relative ? (
-                <RelativeTimestampLabel size={size} />
-            ) : (
-                <SimpleTimeLabel
-                    startTime={isScrubbing ? scrubbingTimestamp : currentTimestamp}
-                    timestampFormat={timestampFormat}
-                    containerSize={size}
-                />
-            )}
-        </LemonButton>
+        <Tooltip title={tooltipContent} placement="top" visible={isHovered}>
+            <LemonButton
+                data-attr="recording-timestamp"
+                className="text-center whitespace-nowrap font-mono text-xs inline"
+                noPadding={noPadding}
+                icon={<IconClock className="text-muted" />}
+                onMouseEnter={() => setIsHovered(true)}
+                onMouseLeave={() => setIsHovered(false)}
+                onClick={() => {
+                    setTimestampFormat(nextFormat)
+                }}
+            >
+                {timestampFormat === TimestampFormat.Relative ? (
+                    <RelativeTimestampLabel size={size} />
+                ) : (
+                    <SimpleTimeLabel
+                        startTime={activeTimestamp}
+                        timestampFormat={timestampFormat}
+                        containerSize={size}
+                    />
+                )}
+            </LemonButton>
+        </Tooltip>
     )
 }
 
@@ -100,6 +157,7 @@ export function SeekSkip({ direction }: { direction: 'forward' | 'backward' }): 
     return (
         <Tooltip
             placement="top"
+            delayMs={100}
             title={
                 <div className="text-center">
                     {!altKeyHeld ? (


### PR DESCRIPTION
hardly anyone clicks the timestamp label
it isn't clear it's clickable

let's try and make it more clear

[CleanShot 2026-02-01 at 14.50.45.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/112f6396-57fe-48aa-ae2c-118dfa7d6138.mp4" />](https://app.graphite.com/user-attachments/video/112f6396-57fe-48aa-ae2c-118dfa7d6138.mp4)

 * add a clock icon to the button
 * adds a tooltip that shows the three formats we support
 * highlight the current active format
 * say which format would be active on click
 * reduce the delay for all the tooltips in the player controller component