### PR TITLE
fix: memory leak in annotation overlay

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
@@ -74,11 +74,23 @@ export function AnnotationsOverlay({
         // (tick objects contain $context which holds references to scales/chart/canvas)
         ticks: chart.scales.x.ticks.map(({ value }) => ({ value })),
     }
-    const { activeBadgeElement, tickDates } = useValues(annotationsOverlayLogic(annotationsOverlayLogicProps))
+    const logic = annotationsOverlayLogic(annotationsOverlayLogicProps)
+    const { activeDate, tickDates } = useValues(logic)
+    const { closePopover } = useActions(logic)
+    const { closeModal } = useActions(annotationModalLogic)
+
+    useEffect(() => {
+        return () => {
+            closePopover()
+            closeModal()
+        }
+    }, [closePopover, closeModal])
 
     const overlayRef = useRef<HTMLDivElement | null>(null)
     const modalContentRef = useRef<HTMLDivElement | null>(null)
     const modalOverlayRef = useRef<HTMLDivElement | null>(null)
+    const badgeRefs = useRef<Map<string, HTMLButtonElement>>(new Map())
+    const activeBadgeElement = activeDate ? badgeRefs.current.get(activeDate.toISOString()) : undefined
 
     return (
         <BindLogic logic={annotationsOverlayLogic} props={annotationsOverlayLogicProps}>
@@ -97,10 +109,13 @@ export function AnnotationsOverlay({
                 ref={overlayRef}
             >
                 {tickDates.map((date, index) => (
-                    <AnnotationsBadge key={date.toISOString()} index={index} date={date} />
+                    <AnnotationsBadge key={date.toISOString()} index={index} date={date} badgeRefs={badgeRefs} />
                 ))}
                 {activeBadgeElement && (
-                    <AnnotationsPopover overlayRefs={[overlayRef, modalContentRef, modalOverlayRef]} />
+                    <AnnotationsPopover
+                        overlayRefs={[overlayRef, modalContentRef, modalOverlayRef]}
+                        badgeElement={activeBadgeElement}
+                    />
                 )}
                 <AnnotationModal
                     contentRef={(el) => (modalContentRef.current = el)}
@@ -114,6 +129,7 @@ export function AnnotationsOverlay({
 interface AnnotationsBadgeProps {
     index: number
     date: dayjs.Dayjs
+    badgeRefs: React.MutableRefObject<Map<string, HTMLButtonElement>>
 }
 
 interface AnnotationsBadgeCSSProperties extends React.CSSProperties {
@@ -121,13 +137,28 @@ interface AnnotationsBadgeCSSProperties extends React.CSSProperties {
     '--annotations-badge-scale': number
 }
 
-const AnnotationsBadge = React.memo(function AnnotationsBadgeRaw({ index, date }: AnnotationsBadgeProps): JSX.Element {
+const AnnotationsBadge = React.memo(function AnnotationsBadgeRaw({
+    index,
+    date,
+    badgeRefs,
+}: AnnotationsBadgeProps): JSX.Element {
     const { intervalUnit, groupedAnnotations, isDateLocked, activeDate, isPopoverShown, dateRange, pointsPerTick } =
         useValues(annotationsOverlayLogic)
     const { activateDate, deactivateDate, lockDate, unlockDate } = useActions(annotationsOverlayLogic)
 
     const [hovered, setHovered] = useState(false)
     const buttonRef = useRef<HTMLButtonElement>(null)
+    const dateKey = date.toISOString()
+
+    useEffect(() => {
+        const el = buttonRef.current
+        if (el) {
+            badgeRefs.current.set(dateKey, el)
+        }
+        return () => {
+            badgeRefs.current.delete(dateKey)
+        }
+    }, [dateKey, badgeRefs])
 
     const dateGroup = determineAnnotationsDateGroup(date, intervalUnit, dateRange, pointsPerTick)
     const annotations = groupedAnnotations[dateGroup] || []
@@ -149,7 +180,7 @@ const AnnotationsBadge = React.memo(function AnnotationsBadgeRaw({ index, date }
             onMouseEnter={() => {
                 setHovered(true)
                 if (!isDateLocked) {
-                    activateDate(date, buttonRef.current as HTMLButtonElement)
+                    activateDate(date)
                 }
             }}
             onMouseLeave={() => {
@@ -158,13 +189,7 @@ const AnnotationsBadge = React.memo(function AnnotationsBadgeRaw({ index, date }
                     deactivateDate()
                 }
             }}
-            onClick={
-                !isDateLocked
-                    ? lockDate
-                    : active
-                      ? unlockDate
-                      : () => activateDate(date, buttonRef.current as HTMLButtonElement)
-            }
+            onClick={!isDateLocked ? lockDate : active ? unlockDate : () => activateDate(date)}
         >
             {annotations.length ? (
                 <LemonBadge.Number
@@ -182,8 +207,10 @@ const AnnotationsBadge = React.memo(function AnnotationsBadgeRaw({ index, date }
 
 function AnnotationsPopover({
     overlayRefs,
+    badgeElement,
 }: {
     overlayRefs: React.MutableRefObject<HTMLDivElement | null>[]
+    badgeElement: HTMLButtonElement | null
 }): JSX.Element {
     const {
         popoverAnnotations,
@@ -191,7 +218,6 @@ function AnnotationsPopover({
         intervalUnit,
         isDateLocked,
         insightId,
-        activeBadgeElement,
         isPopoverShown,
         annotationsOverlayProps,
     } = useValues(annotationsOverlayLogic)
@@ -217,7 +243,7 @@ function AnnotationsPopover({
             className="AnnotationsPopover"
             placement="top"
             fallbackPlacements={['top-end', 'top-start']}
-            referenceElement={activeBadgeElement as HTMLElement}
+            referenceElement={badgeElement}
             visible={isPopoverShown}
             onClickOutside={closePopover}
             showArrow

--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
@@ -94,7 +94,7 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
     })),
     actions({
         createAnnotation: (annotationData: AnnotationDataWithoutInsight) => ({ annotationData }),
-        activateDate: (date: Dayjs, badgeElement: HTMLButtonElement) => ({ date, badgeElement }),
+        activateDate: (date: Dayjs) => ({ date }),
         deactivateDate: true,
         lockDate: true,
         unlockDate: true,
@@ -113,14 +113,6 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
             null as Dayjs | null,
             {
                 activateDate: (_, { date }) => date,
-            },
-        ],
-        activeBadgeElement: [
-            null as HTMLButtonElement | null,
-            {
-                activateDate: (_, { badgeElement }) => badgeElement,
-                deactivateDate: () => null,
-                closePopover: () => null,
             },
         ],
         isDateLocked: [


### PR DESCRIPTION
identified this leak with memlabs

instead of passing elements into kea use refs and indexes

Related to #32479
