### PR TITLE
fix: yet annother annotation mem leak

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
@@ -113,6 +113,8 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
             null as Dayjs | null,
             {
                 activateDate: (_, { date }) => date,
+                deactivateDate: () => null,
+                closePopover: () => null,
             },
         ],
         isDateLocked: [


### PR DESCRIPTION
identified this leak with memlabs

clear the reference in the reducer

after this the only leak left in annotations is the known one that is hopefully fixed by https://app.graphite.com/github/pr/PostHog/posthog-js/2993/fix-upgrade-to-posthog%2Frrweb-0.0.38

Related to #32479
