### PR TITLE
feat: Change actions icon from IconCursor (which clashes with events) to IconPlay

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -7,7 +7,6 @@ import {
     IconBug,
     IconCircleDashed,
     IconCode2,
-    IconCursor,
     IconDashboard,
     IconDatabase,
     IconDecisionTree,
@@ -31,6 +30,7 @@ import {
     IconPeople,
     IconPieChart,
     IconPiggyBank,
+    IconPlay,
     IconPlug,
     IconRetention,
     IconRewindPlay,
@@ -185,7 +185,7 @@ const iconTypes: Record<FileSystemIconType, { icon: JSX.Element; iconColor?: Fil
         icon: <IconBug />,
     },
     action: {
-        icon: <IconCursor />,
+        icon: <IconPlay />,
     },
     comment: {
         icon: <IconNotification />,

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -127,7 +127,7 @@ export function getEventDefinitionIcon(definition: EventDefinition & { value?: s
                 icon={<IconPlay />}
                 verified={definition.verified}
                 hidden={definition.hidden}
-                tooltipTitle="Custom Action"
+                tooltipTitle="Custom action"
                 className="taxonomy-icon taxonomy-icon-ph taxonomy-icon-muted"
             />
         )

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { IconBadge, IconBolt, IconCursor, IconEye, IconLeave, IconList, IconLogomark } from '@posthog/icons'
+import { IconBadge, IconBolt, IconCursor, IconEye, IconLeave, IconList, IconLogomark, IconPlay } from '@posthog/icons'
 
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -118,6 +118,17 @@ export function getEventDefinitionIcon(definition: EventDefinition & { value?: s
                 hidden={definition.hidden}
                 tooltipTitle="All events"
                 className="taxonomy-icon taxonomy-icon-built-in"
+            />
+        )
+    }
+    if (definition.is_action) {
+        return (
+            <IconWithBadge
+                icon={<IconPlay />}
+                verified={definition.verified}
+                hidden={definition.hidden}
+                tooltipTitle="Custom Action"
+                className="taxonomy-icon taxonomy-icon-ph taxonomy-icon-muted"
             />
         )
     }


### PR DESCRIPTION
## Problem
Custom events and actions have the same icon
<img width="798" height="500" alt="Screenshot 2026-02-01 at 21 19 37" src="https://github.com/user-attachments/assets/d411362d-631a-4fff-ae94-1e826bd965dc" />
<img width="484" height="441" alt="Screenshot 2026-02-01 at 21 14 29" src="https://github.com/user-attachments/assets/4a8a3d45-6160-45d2-b774-e2d13757021f" />

This was pointed out by a user in this ticket: https://posthoghelp.zendesk.com/agent/tickets/47248 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/51073)

## Changes

Change actions to use IconPlay instead. I'm not wedded to IconPlay, check out this icons list here https://posthog-icons.vercel.app/

<img width="1154" height="479" alt="Screenshot 2026-02-01 at 21 15 26" src="https://github.com/user-attachments/assets/0a7b13ea-6cdd-4487-b6e8-ede2db2a75b0" />


## How did you test this code?

See screenshots

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
