### PR TITLE
chore(flags): improve variant override UX in release conditions

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -2,8 +2,8 @@ import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
-import { IconCopy, IconPlus, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonCollapse, LemonInput, LemonLabel, LemonSelect, Spinner } from '@posthog/lemon-ui'
+import { IconCopy, IconInfo, IconPlus, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonCollapse, LemonInput, LemonLabel, LemonSelect, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { allOperatorsToHumanName } from 'lib/components/DefinitionPopover/utils'
 import { EditableField } from 'lib/components/EditableField/EditableField'
@@ -11,6 +11,7 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/utils'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
+import { Link } from 'lib/lemon-ui/Link'
 import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { humanFriendlyNumber } from 'lib/utils'
 import { clamp } from 'lib/utils'
@@ -442,10 +443,29 @@ export function FeatureFlagReleaseConditionsCollapsible({
                             </div>
 
                             {variants && variants.length > 0 && (
-                                <div>
-                                    <LemonLabel className="mb-1">Variant override (optional)</LemonLabel>
+                                <div className="flex items-center gap-2 flex-wrap text-sm text-muted">
+                                    <span className="flex items-center gap-1">
+                                        <span className="font-medium text-default">Optional override</span>
+                                        <Tooltip
+                                            title={
+                                                <>
+                                                    Force all matching {aggregationTargetName} to receive a specific
+                                                    variant.{' '}
+                                                    <Link
+                                                        to="https://posthog.com/docs/feature-flags/testing#method-1-assign-a-user-a-specific-flag-value"
+                                                        target="_blank"
+                                                    >
+                                                        Learn more
+                                                    </Link>
+                                                </>
+                                            }
+                                        >
+                                            <IconInfo className="text-base" />
+                                        </Tooltip>
+                                    </span>
+                                    <span>Set variant for all {aggregationTargetName} in this set to</span>
                                     <LemonSelect
-                                        placeholder="No override"
+                                        placeholder="Select variant"
                                         allowClear={true}
                                         value={group.variant ?? null}
                                         onChange={(value) => updateConditionSet(index, undefined, undefined, value)}
@@ -453,12 +473,9 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                             label: variant.key,
                                             value: variant.key,
                                         }))}
-                                        className="w-full"
+                                        size="small"
                                         data-attr="feature-flags-variant-override-select"
                                     />
-                                    <div className="text-xs text-muted mt-1">
-                                        Force all matching {aggregationTargetName} to receive a specific variant
-                                    </div>
                                 </div>
                             )}
                         </div>


### PR DESCRIPTION
## Summary

- Makes the variant override section in feature flag release conditions more compact and less visually prominent
- Changes from a full-width labeled section to an inline sentence format
- Adds an info icon with tooltip linking to the docs

**Before:** Full-width dropdown with label above and helper text below - took up significant vertical space for a rarely-used optional feature.

**After:** Compact inline format: "**Optional override** ℹ️ Set variant for all users in this set to [Select variant]"

![2026-02-01 14 56 26](https://github.com/user-attachments/assets/7dc18013-7484-4d23-b627-bdcad8cc787a)
