### PR TITLE
refactor(heatmap): extract heatmap configuration to a constant

### DIFF
--- a/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
@@ -9,6 +9,11 @@ import { cn } from 'lib/utils/css-classes'
 import { ScrollDepthCanvas } from './ScrollDepthCanvas'
 import { useMousePosition } from './useMousePosition'
 
+const HEATMAP_CONFIG = {
+    minOpacity: 0,
+    maxOpacity: 0.8,
+}
+
 function HeatmapMouseInfo({
     heatmapJsRef,
     containerRef,
@@ -87,11 +92,6 @@ export function HeatmapCanvas({
         }
     }, [heatmapColorPalette])
 
-    const heatmapConfig = {
-        minOpacity: 0,
-        maxOpacity: 0.8,
-    }
-
     const updateHeatmapData = useCallback((): void => {
         try {
             heatmapsJsRef.current?.setData(heatmapJsData)
@@ -108,7 +108,7 @@ export function HeatmapCanvas({
             }
 
             heatmapsJsRef.current = heatmapsJs.create({
-                ...heatmapConfig,
+                ...HEATMAP_CONFIG,
                 container,
                 gradient: heatmapJSColorGradient,
             })
@@ -128,7 +128,7 @@ export function HeatmapCanvas({
         }
 
         heatmapsJsRef.current?.configure({
-            ...heatmapConfig, // oxlint-disable-line react-hooks/exhaustive-deps
+            ...HEATMAP_CONFIG,
             container: heatmapsJsContainerRef.current,
             gradient: heatmapJSColorGradient,
         })


### PR DESCRIPTION
## Problem

Oxlint problem.

## Changes

Moved heatmap configuration to a constant `HEATMAP_CONFIG` for better readability and maintainability. Updated references in the `HeatmapCanvas` component to use the new constant instead of inline configuration.

## How did you test this code?
Manually