### PR TITLE
feat: Add distinct id usage job

### DIFF
--- a/posthog/dags/distinct_id_usage.py
+++ b/posthog/dags/distinct_id_usage.py
@@ -1,0 +1,368 @@
+import io
+import csv
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import dagster
+import pydantic
+import dagster_slack
+from clickhouse_driver import Client
+
+from posthog import settings
+from posthog.clickhouse.cluster import ClickhouseCluster
+from posthog.dags.common import JobOwners, settings_with_log_comment
+from posthog.models.distinct_id_usage.sql import TABLE_BASE_NAME
+
+JOB_NAME = "distinct_id_usage_monitoring"
+
+
+class DistinctIdUsageMonitoringConfig(dagster.Config):
+    """Configuration for distinct_id usage monitoring thresholds."""
+
+    high_usage_percentage_threshold: int = pydantic.Field(
+        default=30,
+        description="Percentage of events from a single distinct_id that triggers an alert (0-100)",
+    )
+    high_cardinality_threshold: int = pydantic.Field(
+        default=1_000_000,
+        description="Number of unique distinct_ids per team that triggers a high cardinality alert",
+    )
+    burst_threshold: int = pydantic.Field(
+        default=10_000,
+        description="Events per minute from a single (team, distinct_id) that triggers a burst alert",
+    )
+    default_lookback_hours: int = pydantic.Field(
+        default=6,
+        description="Default lookback hours if no previous successful run is found",
+    )
+
+
+@dataclass
+class HighUsageDistinctId:
+    team_id: int
+    distinct_id: str
+    event_count: int
+    total_team_events: int
+    percentage: float
+
+
+@dataclass
+class HighCardinalityTeam:
+    team_id: int
+    distinct_id_count: int
+
+
+@dataclass
+class BurstEvent:
+    team_id: int
+    distinct_id: str
+    minute: str
+    event_count: int
+
+
+@dataclass
+class MonitoringResults:
+    high_usage: list[HighUsageDistinctId]
+    high_cardinality: list[HighCardinalityTeam]
+    bursts: list[BurstEvent]
+    lookback_start: datetime
+
+
+def get_last_successful_run_time(context: dagster.OpExecutionContext) -> datetime | None:
+    """Get the end time of the last successful run of this job."""
+    run_records = context.instance.get_run_records(
+        dagster.RunsFilter(
+            job_name=JOB_NAME,
+            statuses=[dagster.DagsterRunStatus.SUCCESS],
+        ),
+        limit=1,
+    )
+
+    if run_records and run_records[0].end_time:
+        return datetime.fromtimestamp(run_records[0].end_time, tz=UTC)
+
+    return None
+
+
+@dagster.op
+def query_distinct_id_usage(
+    context: dagster.OpExecutionContext,
+    config: DistinctIdUsageMonitoringConfig,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> MonitoringResults:
+    """Query the distinct_id_usage table to find problematic patterns."""
+
+    last_run_time = get_last_successful_run_time(context)
+
+    if last_run_time:
+        lookback_start = last_run_time
+        context.log.info(f"Using last successful run time as lookback start: {lookback_start}")
+    else:
+        lookback_start = datetime.now(tz=UTC) - timedelta(hours=config.default_lookback_hours)
+        context.log.info(f"No previous successful run found, using default lookback: {lookback_start}")
+
+    def run_queries(client: Client) -> MonitoringResults:
+        query_settings = settings_with_log_comment(context)
+
+        # Query 1: Find distinct_ids with high percentage of team's events
+        high_usage_query = f"""
+        WITH team_totals AS (
+            SELECT
+                team_id,
+                sum(event_count) as total_events
+            FROM {settings.CLICKHOUSE_DATABASE}.{TABLE_BASE_NAME}
+            WHERE minute >= %(lookback_start)s
+            GROUP BY team_id
+            HAVING total_events > 0
+        ),
+        distinct_id_totals AS (
+            SELECT
+                team_id,
+                distinct_id,
+                sum(event_count) as event_count
+            FROM {settings.CLICKHOUSE_DATABASE}.{TABLE_BASE_NAME}
+            WHERE minute >= %(lookback_start)s
+            GROUP BY team_id, distinct_id
+        )
+        SELECT
+            d.team_id,
+            d.distinct_id,
+            d.event_count,
+            t.total_events,
+            round(d.event_count * 100.0 / t.total_events, 2) as percentage
+        FROM distinct_id_totals d
+        JOIN team_totals t ON d.team_id = t.team_id
+        WHERE d.event_count * 100.0 / t.total_events >= %(threshold)s
+        ORDER BY percentage DESC
+        LIMIT 100
+        """
+
+        high_usage_results = client.execute(
+            high_usage_query,
+            {
+                "lookback_start": lookback_start,
+                "threshold": config.high_usage_percentage_threshold,
+            },
+            settings=query_settings,
+        )
+
+        high_usage = [
+            HighUsageDistinctId(
+                team_id=row[0],
+                distinct_id=row[1],
+                event_count=row[2],
+                total_team_events=row[3],
+                percentage=row[4],
+            )
+            for row in high_usage_results
+        ]
+
+        # Query 2: Find teams with high distinct_id cardinality
+        high_cardinality_query = f"""
+        SELECT
+            team_id,
+            uniq(distinct_id) as distinct_id_count
+        FROM {settings.CLICKHOUSE_DATABASE}.{TABLE_BASE_NAME}
+        WHERE minute >= %(lookback_start)s
+        GROUP BY team_id
+        HAVING distinct_id_count >= %(threshold)s
+        ORDER BY distinct_id_count DESC
+        LIMIT 100
+        """
+
+        high_cardinality_results = client.execute(
+            high_cardinality_query,
+            {
+                "lookback_start": lookback_start,
+                "threshold": config.high_cardinality_threshold,
+            },
+            settings=query_settings,
+        )
+
+        high_cardinality = [
+            HighCardinalityTeam(team_id=row[0], distinct_id_count=row[1]) for row in high_cardinality_results
+        ]
+
+        # Query 3: Find burst events (high events per minute)
+        burst_query = f"""
+        SELECT
+            team_id,
+            distinct_id,
+            minute,
+            sum(event_count) as event_count
+        FROM {settings.CLICKHOUSE_DATABASE}.{TABLE_BASE_NAME}
+        WHERE minute >= %(lookback_start)s
+        GROUP BY team_id, distinct_id, minute
+        HAVING event_count >= %(threshold)s
+        ORDER BY event_count DESC
+        LIMIT 100
+        """
+
+        burst_results = client.execute(
+            burst_query,
+            {
+                "lookback_start": lookback_start,
+                "threshold": config.burst_threshold,
+            },
+            settings=query_settings,
+        )
+
+        bursts = [
+            BurstEvent(
+                team_id=row[0],
+                distinct_id=row[1],
+                minute=str(row[2]),
+                event_count=row[3],
+            )
+            for row in burst_results
+        ]
+
+        return MonitoringResults(
+            high_usage=high_usage,
+            high_cardinality=high_cardinality,
+            bursts=bursts,
+            lookback_start=lookback_start,
+        )
+
+    results = cluster.any_host(run_queries).result()
+
+    context.log.info(f"Found {len(results.high_usage)} high usage distinct_ids")
+    context.log.info(f"Found {len(results.high_cardinality)} high cardinality teams")
+    context.log.info(f"Found {len(results.bursts)} burst events")
+
+    return results
+
+
+def generate_csv_report(results: MonitoringResults) -> str:
+    """Generate a CSV report with all detected issues."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+
+    # High usage section
+    writer.writerow(["=== HIGH USAGE DISTINCT IDS ==="])
+    writer.writerow(["team_id", "distinct_id", "event_count", "total_team_events", "percentage"])
+    for item in results.high_usage:
+        writer.writerow([item.team_id, item.distinct_id, item.event_count, item.total_team_events, item.percentage])
+
+    writer.writerow([])
+
+    # High cardinality section
+    writer.writerow(["=== HIGH CARDINALITY TEAMS ==="])
+    writer.writerow(["team_id", "distinct_id_count"])
+    for item in results.high_cardinality:
+        writer.writerow([item.team_id, item.distinct_id_count])
+
+    writer.writerow([])
+
+    # Bursts section
+    writer.writerow(["=== BURST EVENTS ==="])
+    writer.writerow(["team_id", "distinct_id", "minute", "event_count"])
+    for item in results.bursts:
+        writer.writerow([item.team_id, item.distinct_id, item.minute, item.event_count])
+
+    return output.getvalue()
+
+
+def truncate_distinct_id(distinct_id: str, max_length: int = 30) -> str:
+    """Truncate distinct_id for display, adding ellipsis if needed."""
+    if len(distinct_id) <= max_length:
+        return distinct_id
+    return distinct_id[: max_length - 3] + "..."
+
+
+@dagster.op
+def send_alerts(
+    context: dagster.OpExecutionContext,
+    results: MonitoringResults,
+    slack: dagster_slack.SlackResource,
+) -> None:
+    """Send Slack alerts for any detected issues."""
+
+    if not results.high_usage and not results.high_cardinality and not results.bursts:
+        context.log.info("No issues detected, skipping alerts")
+        return
+
+    if not settings.CLOUD_DEPLOYMENT:
+        context.log.info("Skipping Slack notification in non-prod environment")
+        return
+
+    total_issues = len(results.high_usage) + len(results.high_cardinality) + len(results.bursts)
+    lookback_info = f"Since: {results.lookback_start.strftime('%Y-%m-%d %H:%M:%S')} UTC"
+
+    blocks = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "Distinct ID Usage Alert", "emoji": True},
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": f"Environment: {settings.CLOUD_DEPLOYMENT} | {lookback_info} | Total issues: {total_issues}",
+                }
+            ],
+        },
+    ]
+
+    # Show top 3 for each category
+    if results.high_usage:
+        high_usage_text = f"*High Usage Distinct IDs* ({len(results.high_usage)} found):\n"
+        for item in results.high_usage[:3]:
+            high_usage_text += f"• Team `{item.team_id}`: `{truncate_distinct_id(item.distinct_id)}` - {item.percentage}% ({item.event_count:,} events)\n"
+        if len(results.high_usage) > 3:
+            high_usage_text += f"_...and {len(results.high_usage) - 3} more in attached report_\n"
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": high_usage_text}})
+
+    if results.high_cardinality:
+        cardinality_text = f"*High Cardinality Teams* ({len(results.high_cardinality)} found):\n"
+        for item in results.high_cardinality[:3]:
+            cardinality_text += f"• Team `{item.team_id}`: {item.distinct_id_count:,} unique distinct_ids\n"
+        if len(results.high_cardinality) > 3:
+            cardinality_text += f"_...and {len(results.high_cardinality) - 3} more in attached report_\n"
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": cardinality_text}})
+
+    if results.bursts:
+        burst_text = f"*Burst Events* ({len(results.bursts)} found):\n"
+        for item in results.bursts[:3]:
+            burst_text += f"• Team `{item.team_id}`: `{truncate_distinct_id(item.distinct_id)}` at {item.minute} - {item.event_count:,} events/min\n"
+        if len(results.bursts) > 3:
+            burst_text += f"_...and {len(results.bursts) - 3} more in attached report_\n"
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": burst_text}})
+
+    try:
+        slack_client = slack.get_client()
+        channel = settings.DAGSTER_DEFAULT_SLACK_ALERTS_CHANNEL
+
+        # Post the summary message
+        slack_client.chat_postMessage(channel=channel, blocks=blocks)
+
+        # Upload detailed report as a file
+        csv_report = generate_csv_report(results)
+        timestamp = datetime.now(tz=UTC).strftime("%Y%m%d_%H%M%S")
+        slack_client.files_upload_v2(
+            channel=channel,
+            content=csv_report,
+            filename=f"distinct_id_usage_report_{timestamp}.csv",
+            title="Distinct ID Usage Report",
+            initial_comment="Full report attached:",
+        )
+
+        context.log.info("Sent Slack alert with attached report for distinct_id usage issues")
+    except Exception as e:
+        context.log.exception(f"Failed to send Slack notification: {e}")
+
+
+@dagster.job(tags={"owner": JobOwners.TEAM_INGESTION.value})
+def distinct_id_usage_monitoring():
+    """Monitor distinct_id usage patterns and alert on anomalies."""
+    results = query_distinct_id_usage()
+    send_alerts(results)
+
+
+distinct_id_usage_monitoring_schedule = dagster.ScheduleDefinition(
+    job=distinct_id_usage_monitoring,
+    cron_schedule="0 */6 * * *",  # Every 6 hours
+    execution_timezone="UTC",
+    name="distinct_id_usage_monitoring_schedule",
+)

--- a/posthog/dags/locations/ingestion.py
+++ b/posthog/dags/locations/ingestion.py
@@ -2,6 +2,7 @@ import dagster
 
 from posthog.dags import (
     delete_persons_from_trigger_log,
+    distinct_id_usage,
     ingestion_assets,
     person_property_reconciliation,
     persondistinctids_without_person_cleanup,
@@ -17,10 +18,14 @@ defs = dagster.Definitions(
     ],
     jobs=[
         delete_persons_from_trigger_log.delete_persons_from_trigger_log_job,
+        distinct_id_usage.distinct_id_usage_monitoring,
         person_property_reconciliation.person_property_reconciliation_job,
         persondistinctids_without_person_cleanup.persondistinctids_without_person_cleanup_job,
         persons_new_backfill.persons_new_backfill_job,
         persons_without_distinct_ids_cleanup.persons_without_distinct_ids_cleanup_job,
+    ],
+    schedules=[
+        distinct_id_usage.distinct_id_usage_monitoring_schedule,
     ],
     sensors=[
         person_property_reconciliation.person_property_reconciliation_scheduler,

--- a/posthog/dags/tests/test_distinct_id_usage.py
+++ b/posthog/dags/tests/test_distinct_id_usage.py
@@ -1,0 +1,224 @@
+from datetime import UTC, datetime
+
+from unittest import mock
+
+import dagster
+
+from posthog.clickhouse.cluster import ClickhouseCluster, Query
+from posthog.dags.distinct_id_usage import (
+    BurstEvent,
+    DistinctIdUsageMonitoringConfig,
+    HighCardinalityTeam,
+    HighUsageDistinctId,
+    MonitoringResults,
+    generate_csv_report,
+    get_last_successful_run_time,
+    query_distinct_id_usage,
+    truncate_distinct_id,
+)
+from posthog.models.distinct_id_usage.sql import DATA_TABLE_NAME
+
+
+class TestTruncateDistinctId:
+    def test_short_string_unchanged(self):
+        assert truncate_distinct_id("short", max_length=30) == "short"
+
+    def test_exact_length_unchanged(self):
+        assert truncate_distinct_id("a" * 30, max_length=30) == "a" * 30
+
+    def test_long_string_truncated(self):
+        result = truncate_distinct_id("a" * 50, max_length=30)
+        assert len(result) == 30
+        assert result.endswith("...")
+
+    def test_custom_max_length(self):
+        result = truncate_distinct_id("hello world", max_length=8)
+        assert result == "hello..."
+        assert len(result) == 8
+
+
+class TestGetLastSuccessfulRunTime:
+    def test_returns_none_when_no_previous_runs(self):
+        mock_context = mock.MagicMock(spec=dagster.OpExecutionContext)
+        mock_context.instance.get_run_records.return_value = []
+
+        result = get_last_successful_run_time(mock_context)
+
+        assert result is None
+
+    def test_returns_end_time_of_last_successful_run(self):
+        mock_context = mock.MagicMock(spec=dagster.OpExecutionContext)
+        expected_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+        mock_record = mock.MagicMock()
+        mock_record.end_time = expected_time.timestamp()
+        mock_context.instance.get_run_records.return_value = [mock_record]
+
+        result = get_last_successful_run_time(mock_context)
+
+        assert result == expected_time
+
+    def test_returns_none_when_end_time_is_none(self):
+        mock_context = mock.MagicMock(spec=dagster.OpExecutionContext)
+        mock_record = mock.MagicMock()
+        mock_record.end_time = None
+        mock_context.instance.get_run_records.return_value = [mock_record]
+
+        result = get_last_successful_run_time(mock_context)
+
+        assert result is None
+
+
+class TestGenerateCsvReport:
+    def test_empty_results(self):
+        results = MonitoringResults(
+            high_usage=[],
+            high_cardinality=[],
+            bursts=[],
+            lookback_start=datetime(2025, 1, 15, tzinfo=UTC),
+        )
+
+        csv_output = generate_csv_report(results)
+
+        assert "=== HIGH USAGE DISTINCT IDS ===" in csv_output
+        assert "=== HIGH CARDINALITY TEAMS ===" in csv_output
+        assert "=== BURST EVENTS ===" in csv_output
+
+    def test_includes_high_usage_data(self):
+        results = MonitoringResults(
+            high_usage=[
+                HighUsageDistinctId(
+                    team_id=1,
+                    distinct_id="test_user",
+                    event_count=1000,
+                    total_team_events=2000,
+                    percentage=50.0,
+                )
+            ],
+            high_cardinality=[],
+            bursts=[],
+            lookback_start=datetime(2025, 1, 15, tzinfo=UTC),
+        )
+
+        csv_output = generate_csv_report(results)
+
+        assert "1,test_user,1000,2000,50.0" in csv_output
+
+    def test_includes_high_cardinality_data(self):
+        results = MonitoringResults(
+            high_usage=[],
+            high_cardinality=[HighCardinalityTeam(team_id=42, distinct_id_count=1500000)],
+            bursts=[],
+            lookback_start=datetime(2025, 1, 15, tzinfo=UTC),
+        )
+
+        csv_output = generate_csv_report(results)
+
+        assert "42,1500000" in csv_output
+
+    def test_includes_burst_data(self):
+        results = MonitoringResults(
+            high_usage=[],
+            high_cardinality=[],
+            bursts=[
+                BurstEvent(
+                    team_id=5,
+                    distinct_id="burst_user",
+                    minute="2025-01-15 10:00:00",
+                    event_count=50000,
+                )
+            ],
+            lookback_start=datetime(2025, 1, 15, tzinfo=UTC),
+        )
+
+        csv_output = generate_csv_report(results)
+
+        assert "5,burst_user,2025-01-15 10:00:00,50000" in csv_output
+
+
+class TestMonitoringResultsDataclasses:
+    def test_high_usage_distinct_id(self):
+        item = HighUsageDistinctId(
+            team_id=1,
+            distinct_id="user123",
+            event_count=500,
+            total_team_events=1000,
+            percentage=50.0,
+        )
+        assert item.team_id == 1
+        assert item.distinct_id == "user123"
+        assert item.event_count == 500
+        assert item.total_team_events == 1000
+        assert item.percentage == 50.0
+
+    def test_high_cardinality_team(self):
+        item = HighCardinalityTeam(team_id=42, distinct_id_count=2000000)
+        assert item.team_id == 42
+        assert item.distinct_id_count == 2000000
+
+    def test_burst_event(self):
+        item = BurstEvent(
+            team_id=5,
+            distinct_id="burst_user",
+            minute="2025-01-15 10:00:00",
+            event_count=15000,
+        )
+        assert item.team_id == 5
+        assert item.distinct_id == "burst_user"
+        assert item.minute == "2025-01-15 10:00:00"
+        assert item.event_count == 15000
+
+
+def test_query_distinct_id_usage(cluster: ClickhouseCluster) -> None:
+    """Integration test for the query_distinct_id_usage op."""
+    now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
+
+    # Insert test data directly into the sharded table
+    cluster.any_host(
+        Query(
+            f"INSERT INTO {DATA_TABLE_NAME} (team_id, distinct_id, minute, event_count, _timestamp, _offset, _partition) VALUES",
+            [
+                # High usage: one distinct_id with 80% of team's events
+                (1, "high_usage_user", now, 800, now, 0, 0),
+                (1, "normal_user_1", now, 100, now, 0, 0),
+                (1, "normal_user_2", now, 100, now, 0, 0),
+                # High cardinality team: many unique distinct_ids
+                *[(2, f"user_{i}", now, 1, now, 0, 0) for i in range(100)],
+                # Burst event: high events in single minute
+                (3, "burst_user", now, 15000, now, 0, 0),
+            ],
+        )
+    ).result()
+
+    # Create config with thresholds that will match our test data
+    config = DistinctIdUsageMonitoringConfig(
+        high_usage_percentage_threshold=70,  # 80% > 70%
+        high_cardinality_threshold=50,  # 100 > 50
+        burst_threshold=10000,  # 15000 > 10000
+        default_lookback_hours=2,
+    )
+
+    # Build proper dagster op context
+    context = dagster.build_op_context()
+
+    # Run the query
+    results = query_distinct_id_usage(context, config, cluster)
+
+    # Verify high usage detection
+    assert len(results.high_usage) >= 1
+    high_usage_user = next((h for h in results.high_usage if h.distinct_id == "high_usage_user"), None)
+    assert high_usage_user is not None
+    assert high_usage_user.team_id == 1
+    assert high_usage_user.percentage >= 70
+
+    # Verify high cardinality detection
+    assert len(results.high_cardinality) >= 1
+    high_card_team = next((h for h in results.high_cardinality if h.team_id == 2), None)
+    assert high_card_team is not None
+    assert high_card_team.distinct_id_count >= 50
+
+    # Verify burst detection
+    assert len(results.bursts) >= 1
+    burst = next((b for b in results.bursts if b.distinct_id == "burst_user"), None)
+    assert burst is not None
+    assert burst.team_id == 3
+    assert burst.event_count >= 10000

--- a/posthog/dags/tests/test_distinct_id_usage.py
+++ b/posthog/dags/tests/test_distinct_id_usage.py
@@ -175,16 +175,16 @@ def test_query_distinct_id_usage(cluster: ClickhouseCluster) -> None:
     # Insert test data directly into the sharded table
     cluster.any_host(
         Query(
-            f"INSERT INTO {DATA_TABLE_NAME} (team_id, distinct_id, minute, event_count, _timestamp, _offset, _partition) VALUES",
+            f"INSERT INTO {DATA_TABLE_NAME} (team_id, distinct_id, minute, event_count) VALUES",
             [
                 # High usage: one distinct_id with 80% of team's events
-                (1, "high_usage_user", now, 800, now, 0, 0),
-                (1, "normal_user_1", now, 100, now, 0, 0),
-                (1, "normal_user_2", now, 100, now, 0, 0),
+                (1, "high_usage_user", now, 800),
+                (1, "normal_user_1", now, 100),
+                (1, "normal_user_2", now, 100),
                 # High cardinality team: many unique distinct_ids
-                *[(2, f"user_{i}", now, 1, now, 0, 0) for i in range(100)],
+                *[(2, f"user_{i}", now, 1) for i in range(100)],
                 # Burst event: high events in single minute
-                (3, "burst_user", now, 15000, now, 0, 0),
+                (3, "burst_user", now, 15000),
             ],
         )
     ).result()

--- a/posthog/dags/tests/test_distinct_id_usage.py
+++ b/posthog/dags/tests/test_distinct_id_usage.py
@@ -192,6 +192,7 @@ def test_query_distinct_id_usage(cluster: ClickhouseCluster) -> None:
     # Create config with thresholds that will match our test data
     config = DistinctIdUsageMonitoringConfig(
         high_usage_percentage_threshold=70,  # 80% > 70%
+        high_usage_min_events_threshold=500,  # 1000 total events > 500
         high_cardinality_threshold=50,  # 100 > 50
         burst_threshold=10000,  # 15000 > 10000
         default_lookback_hours=2,


### PR DESCRIPTION
## Problem

We need visibility into distinct_id usage patterns across teams to detect potential issues like:
- **High usage distinct_ids**: A single distinct_id generating a disproportionate percentage of a team's events (e.g., a misconfigured bot or server-side tracking using a shared identifier)
- **High cardinality teams**: Teams with an unusually large number of unique distinct_ids, which can indicate data quality issues or abuse
- **Burst events**: Sudden spikes in events from a single (team, distinct_id) pair, which may indicate misconfigured integrations

Without monitoring, these patterns can go unnoticed until they cause performance issues or billing surprises for customers.

## Changes


Adds a new Dagster job `distinct_id_usage_monitoring` that:

- Runs every 6 hours via schedule
- Queries the `distinct_id_usage` ClickHouse table (populated by the existing Kafka MV pipeline)
- Detects three types of anomalies with configurable thresholds:
  - Distinct_ids with  more than X% of a team's events
  - Teams with more than unique distinct_ids
  - Burst events more than X events/minute from a single distinct_id
- Sends Slack alerts with a summary and attached CSV report when issues are found
- Uses incremental lookback (from last successful run) to avoid duplicate alerting

Note: The default values for this job are subject to change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
