### PR TITLE
chore: auto-rebuild products.tsx on manifest changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,10 @@
         ]
     },
     "lint-staged": {
+        "products/**/manifest.tsx": [
+            "bin/hogli format:js",
+            "sh -c 'pnpm build:products && git add frontend/src/products.tsx frontend/src/products.json'"
+        ],
         "*.{json,yaml,yml}": "bin/hogli format:yaml",
         "*.{css,scss}": "bin/hogli format:css",
         "{playwright,frontend,products,common,ee,services}/**/*.{js,jsx,mjs,ts,tsx}": "bin/hogli format:js",


### PR DESCRIPTION
**Problem**: When modifying `products/*/manifest.tsx` files, developers need to manually run `pnpm build:products` and commit the generated `products.tsx` and `products.json` files. Forgetting this causes CI to fail on the diff check.

**Solution**: Add a lint-staged hook that automatically runs `build:products` and stages the generated files whenever a manifest.tsx is committed.

**Testing**: Verified locally - when committing a manifest.tsx change, the hook runs (~2.5s) and the generated files are automatically included in the commit.