### PR TITLE
feat: generify key and message parsing kafka-deduplicator

### DIFF
--- a/rust/kafka-deduplicator/src/deduplication_batch_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_batch_processor.rs
@@ -33,7 +33,7 @@ use crate::{
     store::deduplication_store::{
         DeduplicationResult, DeduplicationResultReason, DeduplicationType, TimestampBatchEntry,
     },
-    store::keys::TimestampKey,
+    store::keys::DeduplicationKeyExtractor,
     store::metadata::TimestampMetadata,
     store::DeduplicationStoreConfig,
     store_manager::{StoreError, StoreManager},
@@ -405,8 +405,7 @@ impl BatchDeduplicationProcessor {
         let enriched_events: Vec<EnrichedEvent> = events
             .into_iter()
             .map(|raw_event| {
-                let timestamp_key = TimestampKey::from(raw_event);
-                let timestamp_key_bytes: Vec<u8> = (&timestamp_key).into();
+                let timestamp_key_bytes = raw_event.extract_dedup_key();
 
                 EnrichedEvent {
                     raw_event,

--- a/rust/kafka-deduplicator/src/event_parser.rs
+++ b/rust/kafka-deduplicator/src/event_parser.rs
@@ -1,0 +1,23 @@
+//! Trait for parsing Kafka messages into domain events.
+
+use anyhow::Result;
+
+use crate::kafka::batch_message::KafkaMessage;
+
+/// Trait for parsing Kafka messages into domain events.
+///
+/// This trait allows different pipelines to define how their
+/// wire format (what comes from Kafka) is transformed into
+/// the domain event type used for deduplication.
+///
+/// # Type Parameters
+///
+/// * `W` - The wire format type deserialized from Kafka (e.g., `CapturedEvent`)
+/// * `E` - The domain event type used for deduplication (e.g., `RawEvent`)
+pub trait EventParser<W, E> {
+    /// Parse a Kafka message into a domain event.
+    ///
+    /// This method transforms the wire format into the domain event type,
+    /// applying any necessary validation, normalization, or enrichment.
+    fn parse(message: &KafkaMessage<W>) -> Result<E>;
+}

--- a/rust/kafka-deduplicator/src/lib.rs
+++ b/rust/kafka-deduplicator/src/lib.rs
@@ -5,6 +5,7 @@ pub mod deduplication_batch_processor;
 pub mod duplicate_event;
 pub mod duplicate_metrics;
 pub mod event;
+pub mod event_parser;
 pub mod kafka;
 pub mod metrics;
 pub mod metrics_const;

--- a/rust/kafka-deduplicator/src/lib.rs
+++ b/rust/kafka-deduplicator/src/lib.rs
@@ -8,6 +8,7 @@ pub mod event;
 pub mod kafka;
 pub mod metrics;
 pub mod metrics_const;
+pub mod pipelines;
 pub mod processor_rebalance_handler;
 pub mod rebalance_tracker;
 pub mod rocksdb;

--- a/rust/kafka-deduplicator/src/pipelines/ingestion_events/keys.rs
+++ b/rust/kafka-deduplicator/src/pipelines/ingestion_events/keys.rs
@@ -1,0 +1,93 @@
+//! Deduplication key extraction for ingestion events.
+
+use common_types::RawEvent;
+
+use crate::store::keys::{DeduplicationKeyExtractor, TimestampKey};
+
+impl DeduplicationKeyExtractor for RawEvent {
+    fn extract_dedup_key(&self) -> Vec<u8> {
+        let key = TimestampKey::from(self);
+        (&key).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn create_test_event() -> RawEvent {
+        RawEvent {
+            uuid: Some(uuid::Uuid::new_v4()),
+            event: "test_event".to_string(),
+            distinct_id: Some(serde_json::Value::String("user123".to_string())),
+            token: Some("token456".to_string()),
+            properties: HashMap::new(),
+            timestamp: Some("2021-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_raw_event_dedup_key_extraction() {
+        let event = create_test_event();
+        let key_bytes = event.extract_dedup_key();
+
+        // Key should be non-empty
+        assert!(!key_bytes.is_empty());
+
+        // Should be at least 8 bytes (timestamp) plus some data
+        assert!(key_bytes.len() > 8);
+    }
+
+    #[test]
+    fn test_same_event_produces_same_key() {
+        let event1 = RawEvent {
+            uuid: Some(uuid::Uuid::new_v4()),
+            event: "page_view".to_string(),
+            distinct_id: Some(serde_json::Value::String("user1".to_string())),
+            token: Some("token1".to_string()),
+            properties: HashMap::new(),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        };
+
+        let event2 = RawEvent {
+            uuid: Some(uuid::Uuid::new_v4()), // Different UUID
+            event: "page_view".to_string(),
+            distinct_id: Some(serde_json::Value::String("user1".to_string())),
+            token: Some("token1".to_string()),
+            properties: HashMap::new(),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        };
+
+        // Same dedup key despite different UUIDs
+        assert_eq!(event1.extract_dedup_key(), event2.extract_dedup_key());
+    }
+
+    #[test]
+    fn test_different_events_produce_different_keys() {
+        let event1 = RawEvent {
+            uuid: Some(uuid::Uuid::new_v4()),
+            event: "page_view".to_string(),
+            distinct_id: Some(serde_json::Value::String("user1".to_string())),
+            token: Some("token1".to_string()),
+            properties: HashMap::new(),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        };
+
+        let event2 = RawEvent {
+            uuid: Some(uuid::Uuid::new_v4()),
+            event: "button_click".to_string(), // Different event name
+            distinct_id: Some(serde_json::Value::String("user1".to_string())),
+            token: Some("token1".to_string()),
+            properties: HashMap::new(),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        };
+
+        assert_ne!(event1.extract_dedup_key(), event2.extract_dedup_key());
+    }
+}

--- a/rust/kafka-deduplicator/src/pipelines/ingestion_events/mod.rs
+++ b/rust/kafka-deduplicator/src/pipelines/ingestion_events/mod.rs
@@ -1,0 +1,6 @@
+//! Ingestion events pipeline implementation.
+//!
+//! This module contains the deduplication logic specific to PostHog's
+//! ingestion events (CapturedEvent/RawEvent from the capture service).
+
+mod keys;

--- a/rust/kafka-deduplicator/src/pipelines/ingestion_events/mod.rs
+++ b/rust/kafka-deduplicator/src/pipelines/ingestion_events/mod.rs
@@ -4,3 +4,6 @@
 //! ingestion events (CapturedEvent/RawEvent from the capture service).
 
 mod keys;
+mod parser;
+
+pub use parser::IngestionEventParser;

--- a/rust/kafka-deduplicator/src/pipelines/ingestion_events/parser.rs
+++ b/rust/kafka-deduplicator/src/pipelines/ingestion_events/parser.rs
@@ -1,0 +1,173 @@
+//! Event parser for ingestion events (CapturedEvent -> RawEvent).
+
+use anyhow::Result;
+use common_types::{CapturedEvent, RawEvent};
+use tracing::{debug, error};
+
+use crate::event_parser::EventParser;
+use crate::kafka::batch_message::KafkaMessage;
+use crate::utils::timestamp;
+
+/// Parser for ingestion events.
+///
+/// Transforms `CapturedEvent` (the wire format from capture service)
+/// into `RawEvent` (the domain event used for deduplication).
+pub struct IngestionEventParser;
+
+impl EventParser<CapturedEvent, RawEvent> for IngestionEventParser {
+    fn parse(message: &KafkaMessage<CapturedEvent>) -> Result<RawEvent> {
+        let captured_event = match message.get_message() {
+            Some(captured_event) => captured_event,
+            None => {
+                error!(
+                    "Failed to extract CapturedEvent from KafkaMessage at {}:{} offset {}",
+                    message.get_topic_partition().topic(),
+                    message.get_topic_partition().partition_number(),
+                    message.get_offset()
+                );
+
+                return Err(anyhow::anyhow!(
+                    "Failed to extract CapturedEvent from KafkaMessage at {}:{} offset {}",
+                    message.get_topic_partition().topic(),
+                    message.get_topic_partition().partition_number(),
+                    message.get_offset(),
+                ));
+            }
+        };
+
+        // Extract well-validated values from the CapturedEvent that
+        // may or may not be present in the wrapped RawEvent
+        let now = captured_event.now.clone();
+        let extracted_distinct_id = captured_event.distinct_id.clone();
+        let extracted_token = captured_event.token.clone();
+        let extracted_uuid = captured_event.uuid;
+
+        // The RawEvent is serialized in the data field
+        match serde_json::from_str::<RawEvent>(&captured_event.data) {
+            Ok(mut raw_event) => {
+                // Validate timestamp: if it's None or unparseable, use CapturedEvent.now
+                // This ensures we always have a valid timestamp for deduplication
+                match raw_event.timestamp {
+                    None => {
+                        debug!("No timestamp in RawEvent, using CapturedEvent.now");
+                        raw_event.timestamp = Some(now);
+                    }
+                    Some(ref ts) if !timestamp::is_valid_timestamp(ts) => {
+                        debug!(
+                            "Invalid timestamp detected at {}:{} offset {}, replacing with CapturedEvent.now",
+                            message.get_topic_partition().topic(),
+                            message.get_topic_partition().partition_number(),
+                            message.get_offset()
+                        );
+                        raw_event.timestamp = Some(now);
+                    }
+                    _ => {
+                        // Timestamp exists and is valid, keep it
+                    }
+                }
+
+                // If RawEvent is missing any of the core values
+                // extracted by capture into the CapturedEvent
+                // wrapper, use those values for downstream analysis
+                if raw_event.uuid.is_none() {
+                    raw_event.uuid = Some(extracted_uuid);
+                }
+                if raw_event.distinct_id.is_none() && !extracted_distinct_id.is_empty() {
+                    raw_event.distinct_id = Some(serde_json::Value::String(extracted_distinct_id));
+                }
+                if raw_event.token.is_none() && !extracted_token.is_empty() {
+                    raw_event.token = Some(extracted_token);
+                }
+
+                Ok(raw_event)
+            }
+            Err(e) => {
+                error!(
+                    "Failed to parse RawEvent from data field at {}:{} offset {}: {}",
+                    message.get_topic_partition().topic(),
+                    message.get_topic_partition().partition_number(),
+                    message.get_offset(),
+                    e
+                );
+                Err(anyhow::anyhow!(
+                    "Failed to parse RawEvent from data field at {}:{} offset {}: {}",
+                    message.get_topic_partition().topic(),
+                    message.get_topic_partition().partition_number(),
+                    message.get_offset(),
+                    e
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kafka::types::Partition;
+    use uuid::Uuid;
+
+    fn create_test_captured_event(data: &str) -> CapturedEvent {
+        CapturedEvent {
+            uuid: Uuid::new_v4(),
+            distinct_id: "test_user".to_string(),
+            session_id: None,
+            ip: "127.0.0.1".to_string(),
+            now: "2024-01-01T00:00:00Z".to_string(),
+            token: "test_token".to_string(),
+            data: data.to_string(),
+            sent_at: None,
+            event: "test_event".to_string(),
+            timestamp: chrono::Utc::now(),
+            is_cookieless_mode: false,
+            historical_migration: false,
+        }
+    }
+
+    #[test]
+    fn test_parse_valid_event() {
+        let data = r#"{"event": "page_view", "properties": {}}"#;
+        let captured = create_test_captured_event(data);
+        let message =
+            KafkaMessage::new_for_test(Partition::new("test-topic".to_string(), 0), 0, captured);
+
+        let result = IngestionEventParser::parse(&message);
+        assert!(result.is_ok());
+
+        let raw_event = result.unwrap();
+        assert_eq!(raw_event.event, "page_view");
+        // UUID should be filled from CapturedEvent
+        assert!(raw_event.uuid.is_some());
+        // Token should be filled from CapturedEvent
+        assert_eq!(raw_event.token, Some("test_token".to_string()));
+    }
+
+    #[test]
+    fn test_parse_event_with_missing_timestamp() {
+        let data = r#"{"event": "click", "properties": {}}"#;
+        let captured = create_test_captured_event(data);
+        let message =
+            KafkaMessage::new_for_test(Partition::new("test-topic".to_string(), 0), 0, captured);
+
+        let result = IngestionEventParser::parse(&message);
+        assert!(result.is_ok());
+
+        let raw_event = result.unwrap();
+        // Timestamp should be filled from CapturedEvent.now
+        assert_eq!(
+            raw_event.timestamp,
+            Some("2024-01-01T00:00:00Z".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_json() {
+        let data = r#"not valid json"#;
+        let captured = create_test_captured_event(data);
+        let message =
+            KafkaMessage::new_for_test(Partition::new("test-topic".to_string(), 0), 0, captured);
+
+        let result = IngestionEventParser::parse(&message);
+        assert!(result.is_err());
+    }
+}

--- a/rust/kafka-deduplicator/src/pipelines/mod.rs
+++ b/rust/kafka-deduplicator/src/pipelines/mod.rs
@@ -1,0 +1,19 @@
+//! Pipeline-specific implementations for the deduplicator.
+//!
+//! Each pipeline module contains event-specific logic for:
+//! - Deduplication key extraction
+//! - Metadata creation and storage
+//! - Similarity calculation
+//! - Metrics emission
+//!
+//! # Structure
+//!
+//! Each pipeline is a submodule with its own internal structure:
+//! ```text
+//! pipelines/
+//! └── ingestion_events/
+//!     ├── mod.rs      # Pipeline module root
+//!     └── keys.rs     # DeduplicationKeyExtractor impl
+//! ```
+
+pub mod ingestion_events;

--- a/rust/kafka-deduplicator/src/store/keys.rs
+++ b/rust/kafka-deduplicator/src/store/keys.rs
@@ -6,6 +6,20 @@ use crate::utils::timestamp::parse_timestamp;
 
 const UNKNOWN_STR: &str = "unknown";
 
+/// Trait for extracting deduplication keys from events.
+///
+/// This trait allows different event types to define how their
+/// deduplication key is computed, enabling the deduplicator to
+/// work with multiple event schemas.
+pub trait DeduplicationKeyExtractor {
+    /// Extract a deduplication key as bytes.
+    ///
+    /// The returned bytes are used as the key in RocksDB for
+    /// duplicate detection. Events with the same key are considered
+    /// potential duplicates.
+    fn extract_dedup_key(&self) -> Vec<u8>;
+}
+
 /// Timestamp-based deduplication key
 /// Uses bincode serialization to handle arbitrary characters in fields
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Problem

The kafka-deduplicator is currently tightly coupled to PostHog's ingestion events (`CapturedEvent`/`RawEvent`). We want to reuse it for other topics with different event schemas.

## Changes

- **`DeduplicationKeyExtractor` trait** - Defines how events produce deduplication keys
- **`EventParser` trait** - Defines how wire formats are parsed into domain events
- **`pipelines/ingestion_events/` module** - Contains the existing `RawEvent` implementations

No behavioral changes, as this is a pure refactor that moves existing logic behind trait abstractions. The processor now uses `IngestionEventParser::parse()` and `event.extract_dedup_key()` instead of hardcoded methods.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
