### PR TITLE
feat(hogli): support worktree mprocs config discovery

### DIFF
--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -306,6 +306,9 @@ def get_main_repo_from_worktree() -> Path | None:
             content = git_path.read_text().strip()
             if content.startswith("gitdir: ") and "worktrees" in content:
                 gitdir = Path(content.removeprefix("gitdir: ").strip())
+                # Resolve relative paths against .git file's directory
+                if not gitdir.is_absolute():
+                    gitdir = (git_path.parent / gitdir).resolve()
                 return gitdir.parent.parent.parent
         elif git_path.is_dir():
             break  # Regular repo, not a worktree

--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -303,7 +303,10 @@ def get_main_repo_from_worktree() -> Path | None:
         git_path = parent / ".git"
         if git_path.is_file():
             # Worktree: .git file contains "gitdir: /path/to/main/.git/worktrees/<name>"
-            content = git_path.read_text().strip()
+            try:
+                content = git_path.read_text().strip()
+            except OSError:
+                return None
             if content.startswith("gitdir: ") and "worktrees" in content:
                 gitdir = Path(content.removeprefix("gitdir: ").strip())
                 # Resolve relative paths against .git file's directory

--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -296,15 +296,47 @@ def load_devenv_config(mprocs_path: Path) -> DevenvConfig | None:
     return DevenvConfig.model_validate(posthog_data)
 
 
+def get_main_repo_from_worktree() -> Path | None:
+    """If in a worktree, return the main repo root. Otherwise None."""
+    current = Path.cwd().resolve()
+    for parent in [current, *current.parents]:
+        git_path = parent / ".git"
+        if git_path.is_file():
+            # Worktree: .git file contains "gitdir: /path/to/main/.git/worktrees/<name>"
+            content = git_path.read_text().strip()
+            if content.startswith("gitdir: ") and "worktrees" in content:
+                gitdir = Path(content.removeprefix("gitdir: ").strip())
+                return gitdir.parent.parent.parent
+        elif git_path.is_dir():
+            break  # Regular repo, not a worktree
+    return None
+
+
 def get_generated_mprocs_path() -> Path:
-    """Get the default path for generated mprocs config."""
-    # check global shell env override first
+    """Get the default path for generated mprocs config.
+
+    Checks local path first, then main repo if in a worktree.
+    """
     override_path = os.getenv("HOGLI_MPROCS_PATH")
     if override_path:
         return Path(override_path)
-    # Walk up from cwd to find repo root
+
     current = Path.cwd().resolve()
+    local_path = current / ".posthog" / ".generated" / "mprocs.yaml"
     for parent in [current, *current.parents]:
         if (parent / ".git").exists():
-            return parent / ".posthog" / ".generated" / "mprocs.yaml"
-    return current / ".posthog" / ".generated" / "mprocs.yaml"
+            local_path = parent / ".posthog" / ".generated" / "mprocs.yaml"
+            break
+
+    # If local config exists (or is symlink), use it
+    if local_path.exists():
+        return local_path
+
+    # Check main repo if in a worktree
+    main_repo = get_main_repo_from_worktree()
+    if main_repo:
+        main_path = main_repo / ".posthog" / ".generated" / "mprocs.yaml"
+        if main_path.exists():
+            return main_path
+
+    return local_path

--- a/common/hogli/devenv/wizard.py
+++ b/common/hogli/devenv/wizard.py
@@ -39,6 +39,7 @@ def _choose_config_location(local_path: Path) -> Path:
 
     # Create symlink from worktree to main repo
     local_path.parent.mkdir(parents=True, exist_ok=True)
+    main_path.parent.mkdir(parents=True, exist_ok=True)
     if local_path.exists() or local_path.is_symlink():
         local_path.unlink()
     local_path.symlink_to(main_path)
@@ -69,7 +70,7 @@ def run_setup_wizard(intent_map: IntentMap, log_to_files: bool = False) -> Deven
     existing = load_devenv_config(local_path)
     if existing:
         if local_path.is_symlink():
-            click.echo(f"Found config (symlinked from main repo):")
+            click.echo("Found config (symlinked from main repo):")
         else:
             click.echo("Found existing config:")
         _show_config_summary(existing)

--- a/common/hogli/devenv/wizard.py
+++ b/common/hogli/devenv/wizard.py
@@ -37,9 +37,10 @@ def _choose_config_location(local_path: Path) -> Path:
     if choice == "1":
         return local_path
 
-    # Create symlink from worktree to main repo
+    # Create symlink from worktree to main repo (config file created after this)
     local_path.parent.mkdir(parents=True, exist_ok=True)
     main_path.parent.mkdir(parents=True, exist_ok=True)
+    # exists() is False for broken symlinks, so check both
     if local_path.exists() or local_path.is_symlink():
         local_path.unlink()
     local_path.symlink_to(main_path)


### PR DESCRIPTION
**Problem**
When using git worktrees, each worktree needed its own `hogli dev:setup` run to create mprocs config. No way to share config across worktrees.

**Solution**
- `get_generated_mprocs_path()` now checks main repo for config if none exists locally in a worktree
- `dev:setup` wizard asks where to save config when in worktree: local or main repo (with symlink)

**Behavior**
| Scenario | Result |
|----------|--------|
| `bin/start` in worktree, local config exists | Uses it |
| `bin/start` in worktree, no local, main has config | Uses main's |
| `dev:setup` in worktree, no config anywhere | Asks where to save |

Supersedes approach in #46350 (env var override) with automatic discovery.