### PR TITLE
fix: don't leak element references in useKeyboardNavigation hook

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonMenu/useKeyboardNavigation.ts
+++ b/frontend/src/lib/lemon-ui/LemonMenu/useKeyboardNavigation.ts
@@ -46,15 +46,14 @@ export function useKeyboardNavigation<R extends HTMLElement = HTMLElement, I ext
             }
         }
 
-        referenceRef.current?.addEventListener('keydown', handleKeyDown)
+        const controller = new AbortController()
+
+        referenceRef.current?.addEventListener('keydown', handleKeyDown, { signal: controller.signal })
         for (const item of itemsRef.current) {
-            item?.current?.addEventListener('keydown', handleKeyDown)
+            item?.current?.addEventListener('keydown', handleKeyDown, { signal: controller.signal })
         }
         return () => {
-            referenceRef.current?.removeEventListener('keydown', handleKeyDown)
-            for (const item of itemsRef.current) {
-                item?.current?.removeEventListener('keydown', handleKeyDown)
-            }
+            controller.abort()
         }
     }, [focusedItemIndex, itemCount, enabled])
 

--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -47,9 +47,7 @@ export function DashboardReloadAction(): JSX.Element {
     const { triggerDashboardRefresh, setAutoRefresh, setPageVisibility, cancelDashboardRefresh } =
         useActions(dashboardLogic)
 
-    usePageVisibilityCb((pageIsVisible) => {
-        setPageVisibility(pageIsVisible)
-    })
+    usePageVisibilityCb(setPageVisibility)
 
     // Force a re-render when nextAllowedDashboardRefresh is reached, since the blockRefresh
     // selector uses now() which isn't reactive - it only recomputes on dependency changes

--- a/products/llm_analytics/frontend/datasets/useKeyboardNavigation.tsx
+++ b/products/llm_analytics/frontend/datasets/useKeyboardNavigation.tsx
@@ -47,9 +47,10 @@ export function useKeyboardNavigation<R extends HTMLElement = HTMLElement, I ext
         const handleKeyDown = (e: KeyboardEvent): void => {
             stableListener.current(e)
         }
-        referenceRef.current?.addEventListener('keydown', handleKeyDown)
+        const controller = new AbortController()
+        referenceRef.current?.addEventListener('keydown', handleKeyDown, { signal: controller.signal })
         return () => {
-            referenceRef.current?.removeEventListener('keydown', handleKeyDown)
+            controller.abort()
         }
     }, [enabled])
 


### PR DESCRIPTION
found these using https://app.graphite.com/github/pr/PostHog/posthog/45694/chore-add-an-experimental-mem-leak-discovery-step-in-CI and the robot

leaking elements means they hold onto memory and we slowly grow our footprint

Related to #32479
