### PR TITLE
fix(insights): prevent search results being overwritten 

### DIFF
--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.test.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.test.ts
@@ -65,8 +65,8 @@ describe('addSavedInsightsModalLogic', () => {
         logic = addSavedInsightsModalLogic()
         logic.mount()
 
-        // afterMount dispatches loadInsights(true) which is immediate
-        // Before it completes, set a search filter which dispatches loadInsights() (debounced)
+        // afterMount dispatches loadInsights which debounces.
+        // Setting a filter dispatches another loadInsights, cancelling the first via breakpoint.
         logic.actions.setModalFilters({ search: 'my query' })
 
         await expectLogic(logic)
@@ -102,14 +102,5 @@ describe('addSavedInsightsModalLogic', () => {
             })
 
         expect(apiCallCount).toBe(1)
-    })
-
-    it('page changes load immediately without debounce', async () => {
-        logic.actions.setModalPage(2)
-        await expectLogic(logic)
-            .toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
-            .toMatchValues({
-                filters: partial({ page: 2 }),
-            })
     })
 })

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.test.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.test.ts
@@ -1,0 +1,115 @@
+import { expectLogic, partial } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { QueryBasedInsightModel } from '~/types'
+
+import { addSavedInsightsModalLogic } from './addSavedInsightsModalLogic'
+
+const createInsight = (id: number, name = 'test'): QueryBasedInsightModel =>
+    ({
+        id,
+        name: `${name} ${id}`,
+        short_id: `ii${id}`,
+        order: 0,
+        layouts: [],
+        last_refresh: 'now',
+        refreshing: false,
+        created_by: null,
+        is_sample: false,
+        updated_at: 'now',
+        result: {},
+        color: null,
+        created_at: 'now',
+        dashboard: null,
+        deleted: false,
+        saved: true,
+        query: {},
+    }) as any as QueryBasedInsightModel
+
+describe('addSavedInsightsModalLogic', () => {
+    let logic: ReturnType<typeof addSavedInsightsModalLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/insights/': (req) => {
+                    const search = req.url.searchParams.get('search') ?? ''
+                    const results = [createInsight(1, search || 'default'), createInsight(2, search || 'default')]
+                    return [200, { count: results.length, results }]
+                },
+            },
+        })
+        initKeaTests()
+        logic = addSavedInsightsModalLogic()
+        logic.mount()
+    })
+
+    beforeEach(async () => {
+        await expectLogic(logic).toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
+    })
+
+    it('search filter cancels in-flight unfiltered request', async () => {
+        logic.unmount()
+
+        useMocks({
+            get: {
+                '/api/environments/:team_id/insights/': (req) => {
+                    const search = req.url.searchParams.get('search')
+                    const label = search || 'unfiltered'
+                    return [200, { count: 1, results: [createInsight(1, label)] }]
+                },
+            },
+        })
+
+        logic = addSavedInsightsModalLogic()
+        logic.mount()
+
+        // afterMount dispatches loadInsights(true) which is immediate
+        // Before it completes, set a search filter which dispatches loadInsights() (debounced)
+        logic.actions.setModalFilters({ search: 'my query' })
+
+        await expectLogic(logic)
+            .toDispatchActions(['loadInsightsSuccess'])
+            .toMatchValues({
+                filters: partial({ search: 'my query' }),
+                insights: partial({ results: [partial({ name: 'my query 1' })] }),
+            })
+    })
+
+    it('rapid filter changes only produce one API call due to debounce', async () => {
+        let apiCallCount = 0
+
+        useMocks({
+            get: {
+                '/api/environments/:team_id/insights/': () => {
+                    apiCallCount++
+                    return [200, { count: 1, results: [createInsight(1, 'abc')] }]
+                },
+            },
+        })
+
+        apiCallCount = 0
+
+        logic.actions.setModalFilters({ search: 'a' })
+        logic.actions.setModalFilters({ search: 'ab' })
+        logic.actions.setModalFilters({ search: 'abc' })
+
+        await expectLogic(logic)
+            .toDispatchActions(['loadInsightsSuccess'])
+            .toMatchValues({
+                filters: partial({ search: 'abc' }),
+            })
+
+        expect(apiCallCount).toBe(1)
+    })
+
+    it('page changes load immediately without debounce', async () => {
+        logic.actions.setModalPage(2)
+        await expectLogic(logic)
+            .toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
+            .toMatchValues({
+                filters: partial({ page: 2 }),
+            })
+    })
+})

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
@@ -29,7 +29,7 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
             filters,
             merge,
         }),
-        loadInsights: (immediate?: boolean) => ({ immediate: immediate ?? false }),
+        loadInsights: true,
         setModalPage: (page: number) => ({ page }),
 
         setDashboardUpdateLoading: (insightId: number, loading: boolean) => ({ insightId, loading }),
@@ -44,10 +44,8 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
     loaders(({ values }) => ({
         insights: {
             __default: { results: [] as QueryBasedInsightModel[], count: 0 },
-            loadInsights: async ({ immediate }, breakpoint) => {
-                if (!immediate) {
-                    await breakpoint(300)
-                }
+            loadInsights: async (_, breakpoint) => {
+                await breakpoint(300)
 
                 const { order, page, search, dashboardId, insightType, createdBy, dateFrom, dateTo } = values.filters
 
@@ -138,7 +136,6 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
     listeners(({ actions, values, selectors }) => ({
         setModalPage: async ({ page }) => {
             actions.setModalFilters({ page }, true)
-            actions.loadInsights(true)
         },
         setModalFilters: async (_, _breakpoint, __, previousState) => {
             const oldFilters = selectors.filters(previousState)


### PR DESCRIPTION
## Problem                                                                                                                                         
When opening the "Add insight to dashboard" modal and searching before the initial load completes, the response overwrites the search results.        
                                                                                                                   
## Changes                                                                                                                                                                                                                                                     
  - Moved the debounce from the setModalFilters listener into the loadInsights loader via breakpoint(300), so each new loadInsights dispatch immediately cancels any in-flight request                                                                                     
  - Added breakpoint() after the API call to discard stale responses                                                                     
  - Removed redundant loadInsights call from setModalPage since setModalFilters already triggers it via its listener                     
  - Added tests for the race condition and debounce batching      

## How did you test this code?
Before:
https://github.com/user-attachments/assets/6e47d186-42e4-43c5-995d-8544004344f6

After:
https://github.com/user-attachments/assets/2d8ed7b8-5bf6-48d9-82a3-b4c2cd162a74

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
