### PR TITLE
chore: add ingestion acceptance tests on general worker changes check

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -250,7 +250,7 @@ jobs:
             - name: Check for changes that affect general purpose temporal worker
               id: check_changes_general_purpose_temporal_worker
               run: |
-                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/subscriptions|^posthog/temporal/common|^posthog/temporal/session_recordings|^posthog/temporal/proxy_service|^posthog/temporal/usage_reports|^posthog/temporal/llm_analytics|^posthog/temporal/product_analytics|^posthog/temporal/delete_persons|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/subscriptions|^posthog/temporal/common|^posthog/temporal/session_recordings|^posthog/temporal/proxy_service|^posthog/temporal/usage_reports|^posthog/temporal/llm_analytics|^posthog/temporal/product_analytics|^posthog/temporal/delete_persons|^posthog/temporal/ingestion_acceptance_test|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
 
             - name: Check for changes that affect billing temporal worker
               id: check_changes_billing_temporal_worker

--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -13,6 +13,8 @@ import structlog
 # Use posthoganalytics instead of posthog to avoid conflict with local posthog/ directory
 import posthoganalytics
 
+from posthog.models.utils import mask_key_value
+
 from .config import Config
 
 logger = structlog.get_logger(__name__)
@@ -59,6 +61,7 @@ class PostHogClient:
         logger.info(
             "PostHog SDK configured",
             sdk_host=posthoganalytics.host,
+            sdk_api_key=mask_key_value(config.project_api_key),
             sdk_sync_mode=posthoganalytics.sync_mode,
             sdk_debug=posthoganalytics.debug,
         )


### PR DESCRIPTION
## Problem

The ingestion acceptance tests workflow path was not included in the paths that would trigger a state update.

## Changes

Include in the regex that checks it and additionally, make one small code change so that it will trigger the deployment

## How did you test this code?

Locally

## Publish to changelog?
