### PR TITLE
fix: try to avoid leaking image elements in canvas playback

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -415,5 +415,7 @@ const abortPreviousListeners = (id: number): void => {
     const controller = controllerById.get(id)
     if (controller) {
         controller.abort()
+        controllerById.delete(id)
     }
 }
+

--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -418,4 +418,3 @@ const abortPreviousListeners = (id: number): void => {
         controllerById.delete(id)
     }
 }
-

--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -270,6 +270,7 @@ export const CanvasReplayerPlugin = (events: eventWithTime[]): ReplayPlugin => {
                             }
 
                             finalizeUrl(data.id, url)
+                            controllerById.delete(data.id)
                         },
                         { signal: controller.signal }
                     )
@@ -277,6 +278,7 @@ export const CanvasReplayerPlugin = (events: eventWithTime[]): ReplayPlugin => {
                         'error',
                         () => {
                             finalizeUrl(data.id, url)
+                            controllerById.delete(data.id)
                         },
                         { signal: controller.signal }
                     )

--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -415,4 +415,3 @@ const abortPreviousListeners = (id: number): void => {
         controller.abort()
     }
 }
-


### PR DESCRIPTION
not a leak i've observed but spotted by the robot while we're tracking something else down

use an abort controller to avoid accidentally holding references to images and stopping them being collected

Related to #32479
