### PR TITLE
fix(e2e tests): Run CH migrations after Postgres in e2e CI

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -338,7 +338,7 @@ jobs:
                   sqlx database create -D "$PERSONS_DATABASE_URL"
                   sqlx migrate run -D "$PERSONS_DATABASE_URL" --source rust/persons_migrations/
 
-                  python manage.py migrate_clickhouse 2>&1 | tee /tmp/migrate_clickhouse.log
+                  python manage.py migrate_clickhouse 2>&1
                   python manage.py setup_dev
 
             - name: Source celery queues
@@ -455,9 +455,6 @@ jobs:
               if: always()
               run: |
                   docker logs posthog-proxy-1 > playwright/test-results/docker-proxy.log 2>&1 || echo "No proxy container" > playwright/test-results/docker-proxy.log
-                  docker logs posthog-clickhouse-1 > playwright/test-results/docker-clickhouse-stdout.log 2>&1 || echo "No clickhouse container" > playwright/test-results/docker-clickhouse-stdout.log
-                  docker cp posthog-clickhouse-1:/var/log/clickhouse-server/clickhouse-server.log playwright/test-results/clickhouse-server.log 2>/dev/null || echo "No clickhouse log file" > playwright/test-results/clickhouse-server.log
-                  docker cp posthog-clickhouse-1:/var/log/clickhouse-server/clickhouse-server.err.log playwright/test-results/clickhouse-server.err.log 2>/dev/null || echo "No clickhouse error log file" > playwright/test-results/clickhouse-server.err.log
 
             - name: Archive test artifacts
               if: always()

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -329,7 +329,8 @@ jobs:
 
             - name: Apply postgres and clickhouse migrations and setup dev
               run: |
-                  python manage.py migrate_clickhouse &
+                  # Postgres migrations must run first — ClickHouse migration 0026
+                  # depends on the posthog_instancesetting table in Postgres
                   python manage.py migrate --noinput
 
                   # Run Rust migrations for persons e2e test database
@@ -337,8 +338,8 @@ jobs:
                   sqlx database create -D "$PERSONS_DATABASE_URL"
                   sqlx migrate run -D "$PERSONS_DATABASE_URL" --source rust/persons_migrations/
 
+                  python manage.py migrate_clickhouse 2>&1 | tee /tmp/migrate_clickhouse.log
                   python manage.py setup_dev
-                  wait
 
             - name: Source celery queues
               run: |
@@ -452,7 +453,11 @@ jobs:
             # ── Artifacts on failure / always ─────────────────────────────────────
             - name: Capture docker logs
               if: always()
-              run: docker logs posthog-proxy-1 > playwright/test-results/docker-proxy.log 2>&1 || echo "No proxy container" > playwright/test-results/docker-proxy.log
+              run: |
+                  docker logs posthog-proxy-1 > playwright/test-results/docker-proxy.log 2>&1 || echo "No proxy container" > playwright/test-results/docker-proxy.log
+                  docker logs posthog-clickhouse-1 > playwright/test-results/docker-clickhouse-stdout.log 2>&1 || echo "No clickhouse container" > playwright/test-results/docker-clickhouse-stdout.log
+                  docker cp posthog-clickhouse-1:/var/log/clickhouse-server/clickhouse-server.log playwright/test-results/clickhouse-server.log 2>/dev/null || echo "No clickhouse log file" > playwright/test-results/clickhouse-server.log
+                  docker cp posthog-clickhouse-1:/var/log/clickhouse-server/clickhouse-server.err.log playwright/test-results/clickhouse-server.err.log 2>/dev/null || echo "No clickhouse error log file" > playwright/test-results/clickhouse-server.err.log
 
             - name: Archive test artifacts
               if: always()
@@ -466,6 +471,7 @@ jobs:
                       playwright/test-results-attempt-*/
                       /tmp/celery.log
                       /tmp/server.log
+                      /tmp/migrate_clickhouse.log
                       /tmp/playwright-output-attempt-*.log
                   retention-days: 30
                   if-no-files-found: ignore

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -453,8 +453,7 @@ jobs:
             # ── Artifacts on failure / always ─────────────────────────────────────
             - name: Capture docker logs
               if: always()
-              run: |
-                  docker logs posthog-proxy-1 > playwright/test-results/docker-proxy.log 2>&1 || echo "No proxy container" > playwright/test-results/docker-proxy.log
+              run: docker logs posthog-proxy-1 > playwright/test-results/docker-proxy.log 2>&1 || echo "No proxy container" > playwright/test-results/docker-proxy.log
 
             - name: Archive test artifacts
               if: always()
@@ -468,7 +467,6 @@ jobs:
                       playwright/test-results-attempt-*/
                       /tmp/celery.log
                       /tmp/server.log
-                      /tmp/migrate_clickhouse.log
                       /tmp/playwright-output-attempt-*.log
                   retention-days: 30
                   if-no-files-found: ignore


### PR DESCRIPTION
## Problem
I'm trying to write some e2e tests that depend on /query data. They usually all fail on CI with something like this:
 <img width="500"  alt="test-failed-1" src="https://github.com/user-attachments/assets/80500906-a64f-4143-bd82-3420b4fb5e37" />

- Any `/query` requests were returning a 500, with some CH error.
- Turns out CH migrations were have been failing, and the tables just didn't exist. 
- Happens because they require some Postgres tables already existing, but we run CH migrations first and they didn't exist yet

## Changes
- Do CH migrations after Postgres is done
                                          
## How did you test this code?
These tests fail without this: https://github.com/PostHog/posthog/pull/46526
They pass when this is added.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
