### PR TITLE
feat(heatmap): add heatmapFixedPositionMode to state and keying logic

### DIFF
--- a/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
@@ -66,8 +66,16 @@ export function HeatmapCanvas({
     context: 'in-app' | 'toolbar'
     exportToken?: string
 }): JSX.Element | null {
-    const { heatmapJsData, heatmapFilters, windowWidth, windowHeight, heatmapColorPalette, isReady, heightOverride } =
-        useValues(heatmapDataLogic({ context, exportToken }))
+    const {
+        heatmapJsData,
+        heatmapFilters,
+        windowWidth,
+        windowHeight,
+        heatmapColorPalette,
+        isReady,
+        heightOverride,
+        heatmapFixedPositionMode,
+    } = useValues(heatmapDataLogic({ context, exportToken }))
 
     const heatmapsJsRef = useRef<HeatmapJS<'value', 'x', 'y'>>()
     const heatmapsJsContainerRef = useRef<HTMLDivElement | null>()
@@ -158,10 +166,12 @@ export function HeatmapCanvas({
             )}
             data-attr="heatmap-canvas"
         >
-            {/* NOTE: We key on the window dimensions which triggers a recreation of the canvas except when it's an export */}
+            {/* NOTE: We key on the window dimensions and fixed position mode which triggers a recreation of the canvas */}
             <div
                 key={
-                    exportToken ? 'export-heatmap' : `${widthOverride ?? windowWidth}x${windowHeight}x${heightOverride}`
+                    exportToken
+                        ? 'export-heatmap'
+                        : `${widthOverride ?? windowWidth}x${windowHeight}x${heightOverride}x${heatmapFixedPositionMode}`
                 }
                 className="absolute inset-0"
                 ref={setHeatmapContainer}

--- a/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
+++ b/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
@@ -335,12 +335,6 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
             }
             actions.loadHeatmap()
         },
-        setHeatmapFixedPositionMode: () => {
-            actions.loadHeatmap()
-        },
-        setHeatmapColorPalette: () => {
-            actions.loadHeatmap()
-        },
         setHref: () => {
             actions.loadHeatmap()
         },


### PR DESCRIPTION
## Problem

Bug when switching between Fixed positioning calculation modes accumulated events.

## Changes

- Updated HeatmapCanvas to include heatmapFixedPositionMode in state management.
- Adjusted keying logic in the canvas to account for fixed position mode, ensuring proper recreation of the canvas.
- Removed redundant actions related to heatmapFixedPositionMode and heatmapColorPalette in heatmapDataLogic.

## How did you test this code?
Manually:

before:
https://github.com/user-attachments/assets/b0e295af-ea09-464c-9781-cc187c97bef7
after:
https://github.com/user-attachments/assets/c921ab04-f5ed-4605-870b-ce06f161c06a


