### PR TITLE
chore(cyclotron): add separate shadow manager for cyclotron dual-write

### DIFF
--- a/nodejs/src/cdp/services/job-queue/cyclotron-manager-isolation.test.ts
+++ b/nodejs/src/cdp/services/job-queue/cyclotron-manager-isolation.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration test to verify CyclotronManager and CyclotronShadowManager
+ * write to separate databases. This tests the fix for the singleton collision
+ * bug where both managers would write to whichever database was initialized first.
+ */
+import { Pool } from 'pg'
+import { v4 as uuidv4 } from 'uuid'
+
+import { CyclotronManager, CyclotronShadowManager } from '@posthog/cyclotron'
+
+const TEST_CYCLOTRON_URL = 'postgres://posthog:posthog@localhost:5432/test_cyclotron'
+const TEST_CYCLOTRON_SHADOW_URL = 'postgres://posthog:posthog@localhost:5432/test_cyclotron_shadow'
+
+describe('CyclotronManager isolation', () => {
+    jest.setTimeout(10000)
+
+    let mainPool: Pool
+    let shadowPool: Pool
+
+    beforeAll(() => {
+        mainPool = new Pool({ connectionString: TEST_CYCLOTRON_URL })
+        shadowPool = new Pool({ connectionString: TEST_CYCLOTRON_SHADOW_URL })
+    })
+
+    afterAll(async () => {
+        await mainPool.end()
+        await shadowPool.end()
+    })
+
+    beforeEach(async () => {
+        // Clean up jobs from both databases
+        await mainPool.query('DELETE FROM cyclotron_jobs')
+        await shadowPool.query('DELETE FROM cyclotron_jobs')
+    })
+
+    it('should write to separate databases when both managers are initialized', async () => {
+        // Initialize both managers - order matters, this is what caused the original bug
+        const mainManager = new CyclotronManager({
+            shards: [{ dbUrl: TEST_CYCLOTRON_URL }],
+        })
+        const shadowManager = new CyclotronShadowManager({
+            shards: [{ dbUrl: TEST_CYCLOTRON_SHADOW_URL }],
+        })
+
+        await mainManager.connect()
+        await shadowManager.connect()
+
+        // Create unique IDs to identify which job went where
+        const mainJobId = uuidv4()
+        const shadowJobId = uuidv4()
+
+        // Write a job through the main manager
+        await mainManager.createJob({
+            id: mainJobId,
+            teamId: 1,
+            functionId: uuidv4(),
+            queueName: 'hog',
+            priority: 1,
+        })
+
+        // Write a job through the shadow manager
+        await shadowManager.createJob({
+            id: shadowJobId,
+            teamId: 1,
+            functionId: uuidv4(),
+            queueName: 'hog',
+            priority: 1,
+        })
+
+        // Query both databases to verify isolation
+        const mainDbJobs = await mainPool.query('SELECT id FROM cyclotron_jobs')
+        const shadowDbJobs = await shadowPool.query('SELECT id FROM cyclotron_jobs')
+
+        // Main DB should only have the main job
+        expect(mainDbJobs.rows).toHaveLength(1)
+        expect(mainDbJobs.rows[0].id).toBe(mainJobId)
+
+        // Shadow DB should only have the shadow job
+        expect(shadowDbJobs.rows).toHaveLength(1)
+        expect(shadowDbJobs.rows[0].id).toBe(shadowJobId)
+    })
+
+    it('should write bulk jobs to separate databases', async () => {
+        const mainManager = new CyclotronManager({
+            shards: [{ dbUrl: TEST_CYCLOTRON_URL }],
+        })
+        const shadowManager = new CyclotronShadowManager({
+            shards: [{ dbUrl: TEST_CYCLOTRON_SHADOW_URL }],
+        })
+
+        await mainManager.connect()
+        await shadowManager.connect()
+
+        const mainJobIds = [uuidv4(), uuidv4()]
+        const shadowJobIds = [uuidv4(), uuidv4(), uuidv4()]
+
+        // Bulk create jobs through main manager
+        await mainManager.bulkCreateJobs(
+            mainJobIds.map((id) => ({
+                id,
+                teamId: 1,
+                functionId: uuidv4(),
+                queueName: 'hog',
+                priority: 1,
+            }))
+        )
+
+        // Bulk create jobs through shadow manager
+        await shadowManager.bulkCreateJobs(
+            shadowJobIds.map((id) => ({
+                id,
+                teamId: 1,
+                functionId: uuidv4(),
+                queueName: 'hog',
+                priority: 1,
+            }))
+        )
+
+        // Query both databases
+        const mainDbJobs = await mainPool.query('SELECT id FROM cyclotron_jobs ORDER BY id')
+        const shadowDbJobs = await shadowPool.query('SELECT id FROM cyclotron_jobs ORDER BY id')
+
+        // Verify counts
+        expect(mainDbJobs.rows).toHaveLength(2)
+        expect(shadowDbJobs.rows).toHaveLength(3)
+
+        // Verify the right jobs are in each database
+        const mainDbJobIds = mainDbJobs.rows.map((r) => r.id).sort()
+        const shadowDbJobIds = shadowDbJobs.rows.map((r) => r.id).sort()
+
+        expect(mainDbJobIds).toEqual(mainJobIds.sort())
+        expect(shadowDbJobIds).toEqual(shadowJobIds.sort())
+    })
+})

--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres.ts
@@ -25,6 +25,7 @@ import { CyclotronJobInvocation, CyclotronJobInvocationResult, CyclotronJobQueue
 export class CyclotronJobQueuePostgres {
     private cyclotronWorker?: CyclotronWorker
     private cyclotronManager?: CyclotronManager
+    private dbHost: string = 'not-connected'
 
     constructor(
         private config: PluginsServerConfig,
@@ -39,6 +40,14 @@ export class CyclotronJobQueuePostgres {
         if (!this.config.CYCLOTRON_DATABASE_URL) {
             throw new Error('Cyclotron database URL not set! This is required for the CDP services to work.')
         }
+
+        // Capture host for debugging which database this instance connects to
+        try {
+            this.dbHost = new URL(this.config.CYCLOTRON_DATABASE_URL).host
+        } catch {
+            this.dbHost = 'invalid-url'
+        }
+
         this.cyclotronManager = new CyclotronManager({
             shards: [
                 {
@@ -103,6 +112,12 @@ export class CyclotronJobQueuePostgres {
         if (invocations.length === 0) {
             return
         }
+
+        logger.info('CyclotronJobQueuePostgres.queueInvocations', {
+            dbHost: this.dbHost,
+            count: invocations.length,
+            queue: this.queue,
+        })
 
         const cyclotronManager = this.getCyclotronManager()
 

--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres.ts
@@ -296,7 +296,7 @@ function cyclotronJobToInvocation(job: CyclotronJob): CyclotronJobInvocation {
 /**
  * Shadow version of CyclotronJobQueuePostgres for dual-write testing.
  * Uses CyclotronShadowManager which connects to a separate static singleton in the Rust library,
- * allowing it to connect to a different database (e.g., PlanetScale) than the main manager.
+ * allowing it to connect to a different database than the main manager.
  *
  * Only supports producer functionality (queueInvocations) - not consumer functionality.
  */

--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres.ts
@@ -12,6 +12,7 @@ import {
     CyclotronJobInit,
     CyclotronJobUpdate,
     CyclotronManager,
+    CyclotronShadowManager,
     CyclotronWorker,
 } from '@posthog/cyclotron'
 
@@ -25,7 +26,6 @@ import { CyclotronJobInvocation, CyclotronJobInvocationResult, CyclotronJobQueue
 export class CyclotronJobQueuePostgres {
     private cyclotronWorker?: CyclotronWorker
     private cyclotronManager?: CyclotronManager
-    private dbHost: string = 'not-connected'
 
     constructor(
         private config: PluginsServerConfig,
@@ -39,13 +39,6 @@ export class CyclotronJobQueuePostgres {
     public async startAsProducer() {
         if (!this.config.CYCLOTRON_DATABASE_URL) {
             throw new Error('Cyclotron database URL not set! This is required for the CDP services to work.')
-        }
-
-        // Capture host for debugging which database this instance connects to
-        try {
-            this.dbHost = new URL(this.config.CYCLOTRON_DATABASE_URL).host
-        } catch {
-            this.dbHost = 'invalid-url'
         }
 
         this.cyclotronManager = new CyclotronManager({
@@ -112,12 +105,6 @@ export class CyclotronJobQueuePostgres {
         if (invocations.length === 0) {
             return
         }
-
-        logger.info('CyclotronJobQueuePostgres.queueInvocations', {
-            dbHost: this.dbHost,
-            count: invocations.length,
-            queue: this.queue,
-        })
 
         const cyclotronManager = this.getCyclotronManager()
 
@@ -304,4 +291,70 @@ function cyclotronJobToInvocation(job: CyclotronJob): CyclotronJobInvocation {
     }
 
     return invocation
+}
+
+/**
+ * Shadow version of CyclotronJobQueuePostgres for dual-write testing.
+ * Uses CyclotronShadowManager which connects to a separate static singleton in the Rust library,
+ * allowing it to connect to a different database (e.g., PlanetScale) than the main manager.
+ *
+ * Only supports producer functionality (queueInvocations) - not consumer functionality.
+ */
+export class CyclotronJobQueuePostgresShadow {
+    private cyclotronManager?: CyclotronShadowManager
+
+    constructor(
+        private config: PluginsServerConfig,
+        private queue: CyclotronJobQueueKind
+    ) {}
+
+    public async startAsProducer() {
+        if (!this.config.CYCLOTRON_DATABASE_URL) {
+            throw new Error('Cyclotron database URL not set!')
+        }
+
+        this.cyclotronManager = new CyclotronShadowManager({
+            shards: [
+                {
+                    dbUrl: this.config.CYCLOTRON_DATABASE_URL,
+                },
+            ],
+            shardDepthLimit: this.config.CYCLOTRON_SHARD_DEPTH_LIMIT ?? 1000000,
+            shouldCompressVmState: this.config.CDP_CYCLOTRON_COMPRESS_VM_STATE,
+            shouldUseBulkJobCopy: this.config.CDP_CYCLOTRON_USE_BULK_COPY_JOB,
+        })
+
+        await this.cyclotronManager.connect()
+    }
+
+    public async stopProducer() {
+        return Promise.resolve()
+    }
+
+    public async queueInvocations(invocations: CyclotronJobInvocation[]) {
+        if (invocations.length === 0) {
+            return
+        }
+
+        if (!this.cyclotronManager) {
+            throw new Error('CyclotronShadowManager not initialized')
+        }
+
+        const cyclotronJobs = invocations.map((item) => invocationToCyclotronJobInitial(item))
+
+        try {
+            const chunkedCyclotronJobs = chunk(cyclotronJobs, this.config.CDP_CYCLOTRON_INSERT_MAX_BATCH_SIZE)
+
+            if (this.config.CDP_CYCLOTRON_INSERT_PARALLEL_BATCHES) {
+                await Promise.all(chunkedCyclotronJobs.map((jobs) => this.cyclotronManager!.bulkCreateJobs(jobs)))
+            } else {
+                for (const jobs of chunkedCyclotronJobs) {
+                    await this.cyclotronManager.bulkCreateJobs(jobs)
+                }
+            }
+        } catch (e) {
+            logger.error('⚠️', 'Error creating shadow cyclotron jobs', e)
+            throw e
+        }
+    }
 }

--- a/nodejs/src/cdp/services/job-queue/job-queue.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.ts
@@ -18,7 +18,7 @@ import {
 } from '../../types'
 import { CyclotronJobQueueDelay } from './job-queue-delay'
 import { CyclotronJobQueueKafka } from './job-queue-kafka'
-import { CyclotronJobQueuePostgres } from './job-queue-postgres'
+import { CyclotronJobQueuePostgres, CyclotronJobQueuePostgresShadow } from './job-queue-postgres'
 
 const cyclotronBatchUtilizationGauge = new Gauge({
     name: 'cdp_cyclotron_batch_utilization',
@@ -53,7 +53,7 @@ export class CyclotronJobQueue {
     private jobQueuePostgres: CyclotronJobQueuePostgres
     private jobQueueKafka: CyclotronJobQueueKafka
     private jobQueueDelay: CyclotronJobQueueDelay
-    private shadowPostgres: CyclotronJobQueuePostgres | null = null
+    private shadowPostgres: CyclotronJobQueuePostgresShadow | null = null
     private shadowFailures = 0
     private shadowCircuitOpenUntil = 0
 
@@ -83,9 +83,7 @@ export class CyclotronJobQueue {
                 ...this.config,
                 CYCLOTRON_DATABASE_URL: this.config.CYCLOTRON_SHADOW_DATABASE_URL,
             }
-            this.shadowPostgres = new CyclotronJobQueuePostgres(shadowConfig, this.queue, () =>
-                Promise.resolve({ backgroundTask: Promise.resolve() })
-            )
+            this.shadowPostgres = new CyclotronJobQueuePostgresShadow(shadowConfig, this.queue)
         }
 
         logger.info('🔄', 'CyclotronJobQueue initialized', {
@@ -250,20 +248,12 @@ export class CyclotronJobQueue {
 
         if (this.shadowPostgres && Date.now() >= this.shadowCircuitOpenUntil) {
             const hogInvocations = invocations.filter((x) => x.queue === 'hog')
-            const allQueues = [...new Set(invocations.map((x) => x.queue))]
-            logger.info('Shadow write check', {
-                totalInvocations: invocations.length,
-                hogInvocations: hogInvocations.length,
-                allQueues,
-            })
             if (!hogInvocations.length) {
-                logger.info('Shadow write skipped - no hog invocations', { allQueues })
                 return
             }
             void this.shadowPostgres
                 .queueInvocations(hogInvocations)
                 .then(() => {
-                    logger.info('Shadow write succeeded', { count: hogInvocations.length })
                     this.shadowFailures = 0
                 })
                 .catch((err) => {
@@ -273,7 +263,7 @@ export class CyclotronJobQueue {
                         this.shadowFailures = 0
                         logger.warn('Shadow cyclotron circuit breaker opened')
                     }
-                    logger.warn('Shadow cyclotron write failed', { error: err.message, stack: err.stack })
+                    logger.warn('Shadow cyclotron write failed', { error: err.message })
                 })
         }
     }

--- a/nodejs/src/cdp/services/job-queue/job-queue.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.ts
@@ -250,12 +250,20 @@ export class CyclotronJobQueue {
 
         if (this.shadowPostgres && Date.now() >= this.shadowCircuitOpenUntil) {
             const hogInvocations = invocations.filter((x) => x.queue === 'hog')
+            const allQueues = [...new Set(invocations.map((x) => x.queue))]
+            logger.info('Shadow write check', {
+                totalInvocations: invocations.length,
+                hogInvocations: hogInvocations.length,
+                allQueues,
+            })
             if (!hogInvocations.length) {
+                logger.info('Shadow write skipped - no hog invocations', { allQueues })
                 return
             }
             void this.shadowPostgres
                 .queueInvocations(hogInvocations)
                 .then(() => {
+                    logger.info('Shadow write succeeded', { count: hogInvocations.length })
                     this.shadowFailures = 0
                 })
                 .catch((err) => {
@@ -265,7 +273,7 @@ export class CyclotronJobQueue {
                         this.shadowFailures = 0
                         logger.warn('Shadow cyclotron circuit breaker opened')
                     }
-                    logger.warn('Shadow cyclotron write failed', { error: err.message })
+                    logger.warn('Shadow cyclotron write failed', { error: err.message, stack: err.stack })
                 })
         }
     }

--- a/rust/cyclotron-node/src/manager.ts
+++ b/rust/cyclotron-node/src/manager.ts
@@ -94,3 +94,83 @@ export class CyclotronManager {
         return await cyclotron.bulkCreateJobs(json, blobs, blobLengths)
     }
 }
+
+/**
+ * Shadow manager for dual-write testing.
+ * Uses a separate static singleton in the Rust library so it can connect to a different database.
+ */
+export class CyclotronShadowManager {
+    constructor(private config: CyclotronManagerConfig) {
+        this.config = config
+    }
+
+    async connect(): Promise<void> {
+        const config: CyclotronManagerInternalConfig = {
+            shards: this.config.shards.map((shard) => convertToInternalPoolConfig(shard)),
+            shardDepthLimit: this.config.shardDepthLimit,
+            shardDepthCheckIntervalSeconds: this.config.shardDepthCheckIntervalSeconds,
+            shouldCompressVmState: this.config.shouldCompressVmState,
+            shouldUseBulkJobCopy: this.config.shouldUseBulkJobCopy,
+        }
+        return await cyclotron.maybeInitShadowManager(JSON.stringify(config))
+    }
+
+    async createJob(job: CyclotronJobInit): Promise<string> {
+        job.priority ??= 1
+        job.scheduled ??= new Date().toISOString()
+
+        const jobInitInternal = {
+            id: job.id,
+            team_id: job.teamId,
+            function_id: job.functionId,
+            queue_name: job.queueName,
+            priority: job.priority,
+            scheduled: job.scheduled,
+            vm_state: job.vmState ? serializeObject('vmState', job.vmState) : null,
+            parameters: job.parameters ? serializeObject('parameters', job.parameters) : null,
+            metadata: job.metadata ? serializeObject('metadata', job.metadata) : null,
+        }
+
+        const json = JSON.stringify(jobInitInternal)
+        return await cyclotron.shadowCreateJob(json, job.blob ? job.blob : undefined)
+    }
+
+    async bulkCreateJobs(jobs: CyclotronJobInit[]): Promise<string[]> {
+        const jobInitsInternal = jobs.map((job) => {
+            job.priority ??= 1
+            job.scheduled ??= new Date().toISOString()
+
+            return {
+                id: job.id,
+                team_id: job.teamId,
+                function_id: job.functionId,
+                queue_name: job.queueName,
+                priority: job.priority,
+                scheduled: job.scheduled,
+                vm_state: job.vmState ? serializeObject('vmState', job.vmState) : null,
+                parameters: job.parameters ? serializeObject('parameters', job.parameters) : null,
+                metadata: job.metadata ? serializeObject('metadata', job.metadata) : null,
+            }
+        })
+        const json = JSON.stringify(jobInitsInternal)
+
+        const totalBytes = jobs.reduce((total, job) => total + (job.blob ? job.blob.byteLength : 0), 0)
+
+        const blobs = new Uint8Array(totalBytes)
+        const blobLengths = new Uint32Array(jobs.length)
+
+        let offset = 0
+        for (let i = 0; i < jobs.length; i++) {
+            const blob = jobs[i].blob
+            if (blob) {
+                blobLengths[i] = blob.byteLength
+                blobs.set(blob, offset)
+                offset += blob.byteLength
+            } else {
+                blobLengths[i] = 0
+            }
+        }
+
+        return await cyclotron.shadowBulkCreateJobs(json, blobs, blobLengths)
+    }
+}


### PR DESCRIPTION
### Summary

Adds a separate `SHADOW_MANAGER` singleton in the Rust cyclotron-node library to enable true dual-write to a shadow database for testing.        
                                                                                                                                                                                                              
### Problem

The previous implementation reused the same `CyclotronJobQueuePostgres` class for shadow writes, which used the shared `MANAGER` singleton in rust. Since `MANAGER` uses `OnceCell`, whichever database URL was passed first won causing shadow writes to silently go to the main cyclotron database instead of the comparison-db.

### Testing

- [x] added tests to ensure dual write works to both pg-instances
- rolled out the image on dev and tested verifying that writes happen in the shadow-db
- verified that writes also go to actual cyclotron on dev
                                                                       