### PR TITLE
fix: enable presorted events table in activity explore scene

### DIFF
--- a/frontend/src/scenes/activity/explore/defaults.ts
+++ b/frontend/src/scenes/activity/explore/defaults.ts
@@ -10,6 +10,9 @@ export const getDefaultEventsSceneQuery = (properties?: AnyPropertyFilter[]): Da
         select: defaultDataTableColumns(NodeKind.EventsQuery),
         orderBy: ['timestamp DESC'],
         after: '-1h',
+        modifiers: {
+            usePresortedEventsTable: true,
+        },
         ...(properties ? { properties } : {}),
     },
     propertiesViaUrl: true,


### PR DESCRIPTION
## Problem

I noticed that changing the events view to last 24 hours was horribly slow

The activity explore scene's events query should use the presorted events table for improved performance and user experience.

## Changes

Added `usePresortedEventsTable: true` modifier to the default events scene query configuration in `frontend/src/scenes/activity/explore/defaults.ts`. This enables the presorted events table optimization for the activity explore view.

## How did you test this code?

- Verified the configuration change is syntactically correct
- Confirmed the modifier is properly nested within the query object
- The presorted events table feature should be tested in the activity explore scene to ensure events are displayed correctly and with improved performance

## Publish to changelog?

no

https://claude.ai/code/session_019MMXA2ELxRV7fMkvLUg4FC