### PR TITLE
test(batch-exports): Improve batch export tests

### DIFF
--- a/posthog/api/test/batch_exports/backfills/test_cancel.py
+++ b/posthog/api/test/batch_exports/backfills/test_cancel.py
@@ -16,6 +16,10 @@ from posthog.api.test.batch_exports.operations import (
     list_batch_export_backfills_ok,
 )
 
+pytestmark = [
+    pytest.mark.usefixtures("temporal_worker", "cleanup"),
+]
+
 
 def wait_for_backfill_creation(client: HttpClient, team_id: int, batch_export_id: str):
     total = 0

--- a/posthog/api/test/batch_exports/backfills/test_create.py
+++ b/posthog/api/test/batch_exports/backfills/test_create.py
@@ -16,6 +16,7 @@ from posthog.models.team import Team
 
 pytestmark = [
     pytest.mark.django_db,
+    pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
 
 

--- a/posthog/api/test/batch_exports/conftest.py
+++ b/posthog/api/test/batch_exports/conftest.py
@@ -58,7 +58,7 @@ def temporal():
     yield client
 
 
-@pytest.fixture(scope="package", autouse=True)
+@pytest.fixture(scope="package")
 def temporal_worker(temporal):
     """Use a package scoped fixture to start a Temporal Worker.
 
@@ -68,7 +68,7 @@ def temporal_worker(temporal):
         yield
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def cleanup(temporal):
     yield
     cleanup_temporal_schedules(temporal)

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -517,6 +517,10 @@ def test_create_batch_export_with_custom_schema(client: HttpClient, temporal, or
         ("SELECT event FROM events UNION ALL SELECT event FROM events", "UNIONs are not supported"),
         ("WITH cte AS (SELECT event FROM events) SELECT event FROM cte", "Subqueries or CTEs are not supported"),
         ("SELECT event FROM (SELECT event FROM events)", "Subqueries or CTEs are not supported"),
+        (
+            "SELECT uuid, (SELECT event FROM events LIMIT 1) AS leaked FROM events",
+            "Subqueries in SELECT expressions are not supported",
+        ),
     ],
 )
 def test_create_batch_export_fails_with_invalid_query(

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -28,6 +28,7 @@ from posthog.temporal.common.codec import EncryptionCodec
 
 pytestmark = [
     pytest.mark.django_db,
+    pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
 
 

--- a/posthog/api/test/batch_exports/test_delete.py
+++ b/posthog/api/test/batch_exports/test_delete.py
@@ -26,6 +26,7 @@ from posthog.temporal.common.schedule import describe_schedule
 
 pytestmark = [
     pytest.mark.django_db,
+    pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
 
 

--- a/posthog/api/test/batch_exports/test_get.py
+++ b/posthog/api/test/batch_exports/test_get.py
@@ -11,6 +11,7 @@ from posthog.api.test.test_user import create_user
 
 pytestmark = [
     pytest.mark.django_db,
+    pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
 
 

--- a/posthog/api/test/batch_exports/test_list.py
+++ b/posthog/api/test/batch_exports/test_list.py
@@ -14,6 +14,7 @@ from posthog.api.test.test_user import create_user
 
 pytestmark = [
     pytest.mark.django_db,
+    pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
 
 

--- a/posthog/api/test/batch_exports/test_pause.py
+++ b/posthog/api/test/batch_exports/test_pause.py
@@ -20,6 +20,7 @@ from posthog.temporal.common.schedule import describe_schedule
 
 pytestmark = [
     pytest.mark.django_db,
+    pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
 
 

--- a/posthog/api/test/batch_exports/test_runs.py
+++ b/posthog/api/test/batch_exports/test_runs.py
@@ -22,6 +22,7 @@ from posthog.api.test.batch_exports.operations import (
 
 pytestmark = [
     pytest.mark.django_db,
+    pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
 
 

--- a/posthog/api/test/batch_exports/test_serializers.py
+++ b/posthog/api/test/batch_exports/test_serializers.py
@@ -1,0 +1,112 @@
+from typing import cast
+
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from posthog.schema import HogQLQueryModifiers, PersonsOnEventsMode
+
+from posthog.hogql import ast
+from posthog.hogql.hogql import HogQLContext
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_ast_for_printing
+
+from posthog.batch_exports.http import BatchExportSerializer
+
+
+def prepare_query(query: str, team_id: int) -> ast.SelectQuery:
+    """Parse and resolve a HogQL query string into a prepared AST."""
+    parsed = parse_select(query)
+    return cast(
+        ast.SelectQuery,
+        prepare_ast_for_printing(
+            parsed,
+            context=HogQLContext(
+                team_id=team_id,
+                enable_select_queries=True,
+                modifiers=HogQLQueryModifiers(
+                    personsOnEventsMode=PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS
+                ),
+            ),
+            dialect="clickhouse",
+        ),
+    )
+
+
+class TestSerializeHogQLQueryToBatchExportSchema(BaseTest):
+    def _make_serializer(self) -> BatchExportSerializer:
+        return BatchExportSerializer(context={"team_id": self.team.pk})
+
+    @parameterized.expand(
+        [
+            (
+                "simple_fields_use_original_name_as_alias",
+                "SELECT event, person_id FROM events",
+                [
+                    {"expression": "events.event", "alias": "event"},
+                    {"expression": "events.person_id", "alias": "person_id"},
+                ],
+                {},
+            ),
+            (
+                "aliased_fields",
+                "SELECT event AS my_event, team_id AS my_team FROM events",
+                [
+                    {"expression": "events.event", "alias": "my_event"},
+                    {"expression": "events.team_id", "alias": "my_team"},
+                ],
+                {},
+            ),
+            (
+                "property_access_populates_values",
+                "SELECT properties.$browser AS browser FROM events",
+                [
+                    {
+                        "expression": "replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '')",
+                        "alias": "browser",
+                    },
+                ],
+                {"hogql_val_0": "$browser"},
+            ),
+            (
+                "mixed_simple_and_property_fields",
+                "SELECT event, properties.$browser AS browser, properties.custom AS custom, person_id FROM events",
+                [
+                    {"expression": "events.event", "alias": "event"},
+                    {
+                        "expression": "replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^\"|\"$', '')",
+                        "alias": "browser",
+                    },
+                    {
+                        "expression": "replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', '')",
+                        "alias": "custom",
+                    },
+                    {"expression": "events.person_id", "alias": "person_id"},
+                ],
+                {"hogql_val_0": "$browser", "hogql_val_1": "custom"},
+            ),
+        ],
+    )
+    def test_serialize_hogql_query(self, _name, query, expected_fields, expected_values):
+        prepared = prepare_query(query, self.team.pk)
+        serializer = self._make_serializer()
+
+        result = serializer.serialize_hogql_query_to_batch_export_schema(prepared)
+
+        assert result["fields"] == expected_fields
+        assert result["values"] == expected_values
+        assert "hogql_query" in result
+
+    def test_serialize_hogql_query_escapes_injected_alias(self):
+        """An alias containing SQL injection attempts is escaped with backticks."""
+        query = "SELECT uuid AS `x, (SELECT query FROM another_table LIMIT 100) AS leaked` FROM events"
+        prepared = prepare_query(query, self.team.pk)
+        serializer = self._make_serializer()
+
+        result = serializer.serialize_hogql_query_to_batch_export_schema(prepared)
+
+        assert len(result["fields"]) == 1
+        field = result["fields"][0]
+        # The alias must be wrapped in backticks, keeping the malicious string as a single identifier
+        assert field["alias"] == "`x, (SELECT query FROM another_table LIMIT 100) AS leaked`"
+        assert field["expression"] == "events.uuid"

--- a/posthog/api/test/batch_exports/test_test.py
+++ b/posthog/api/test/batch_exports/test_test.py
@@ -25,6 +25,7 @@ from products.batch_exports.backend.api.destination_tests.snowflake import Snowf
 
 pytestmark = [
     pytest.mark.django_db,
+    pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
 
 

--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -29,6 +29,7 @@ from posthog.temporal.common.codec import EncryptionCodec
 
 pytestmark = [
     pytest.mark.django_db,
+    pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
 
 


### PR DESCRIPTION
## Problem

Our batch export test fixtures could be better organised and faster.

## Changes

- Remove use of `autouse` fixture for temporal worker and cleanup, and add to any test modules that need access to it -> this should speed up tests that do not need Temporal
- Add some other tests

## How did you test this code?

This is test code.
