### PR TITLE
feat(cohorts): Fix hog function and remote config tests to not make assumptions on the test team's test filters

### DIFF
--- a/posthog/models/test/__snapshots__/test_remote_config.ambr
+++ b/posthog/models/test/__snapshots__/test_remote_config.ambr
@@ -267,7 +267,6 @@
         id: 'SITE_DESTINATION_ID',
         init: function(config) { return     (function() {
           function toString (value) { return __STLToString(value) }
-          function match (str, pattern) { return !str || !pattern ? false : new RegExp(pattern).test(str) }
           function ilike (str, pattern) { return __like(str, pattern, true) }
           function __like(str, pattern, caseInsensitive = false) {
               if (caseInsensitive) {
@@ -382,7 +381,7 @@
                       const inputs = buildInputs(globals);
                       const filterGlobals = { ...globals.groups, ...globals.event, person: globals.person, inputs, pdi: { distinct_id: globals.event.distinct_id, person: globals.person } };
                       let __getGlobal = (key) => filterGlobals[key];
-                      const filterMatches = !!(!ilike(toString(__getProperty(__getProperty(__getGlobal("person"), "properties", true), "email", true)), "%@posthog.com%") && ((!match(toString(__getProperty(__getGlobal("properties"), "$host", true)), "^(localhost|127\\.0\\.0\\.1)($|:)")) ?? 1) && (__getGlobal("event") == "$pageview"));
+                      const filterMatches = !!(!ilike(toString(__getProperty(__getProperty(__getGlobal("person"), "properties", true), "email", true)), "%@posthog.com%") && (__getGlobal("event") == "$pageview"));
                       if (!filterMatches) { return; }
                       ;
                   }

--- a/posthog/models/test/test_hog_function.py
+++ b/posthog/models/test/test_hog_function.py
@@ -38,6 +38,11 @@ class TestHogFunction(TestCase):
         assert json_filters["bytecode"] == ["_H", HOGQL_BYTECODE_VERSION, 29]  # TRUE
 
     def test_hog_function_filters_compilation(self):
+        self.team.test_account_filters = [
+            {"key": "$host", "operator": "not_regex", "value": r"^(localhost|127\.0\.0\.1)($|:)", "type": "event"},
+        ]
+        self.team.save()
+
         action = Action.objects.create(team=self.team, name="Test Action")
         item = HogFunction.objects.create(
             name="Test",
@@ -95,6 +100,11 @@ class TestHogFunction(TestCase):
         }
 
     def test_hog_function_team_filters_only_compilation(self):
+        self.team.test_account_filters = [
+            {"key": "$host", "operator": "not_regex", "value": r"^(localhost|127\.0\.0\.1)($|:)", "type": "event"},
+        ]
+        self.team.save()
+
         item = HogFunction.objects.create(
             name="Test",
             type="destination",

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -41,7 +41,7 @@ class _RemoteConfigBase(BaseTest):
         self.team.recording_domains = ["https://*.example.com"]
         self.team.session_recording_opt_in = True
         self.team.surveys_opt_in = True
-        self.team.test_account_filters = [  # the default test account filters may use a cohort, which aren't supported by hog functions
+        self.team.test_account_filters = [  # the default test account filters may use a cohort, which aren't supported by site functions (real-time filters)
             {
                 "key": "email",
                 "value": "@posthog.com",

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -41,6 +41,14 @@ class _RemoteConfigBase(BaseTest):
         self.team.recording_domains = ["https://*.example.com"]
         self.team.session_recording_opt_in = True
         self.team.surveys_opt_in = True
+        self.team.test_account_filters = [  # the default test account filters may use a cohort, which aren't supported by hog functions
+            {
+                "key": "email",
+                "value": "@posthog.com",
+                "operator": "not_icontains",
+                "type": "person",
+            }
+        ]
         self.team.save()
 
         # There will always be a config thanks to the signal


### PR DESCRIPTION
## Problem

These tests make an assumption that the test org will have event/person property filters for the internal/test filters, and I'd like to change this.

## Changes
Make these test explicitly set their test filters. Also add a test that using a cohort filter throws an exception

## How did you test this code?
It's only tests

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
