### PR TITLE
fix(batch-exports): Fix bug related to race condition in building sessions model query

### DIFF
--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -7,6 +7,7 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.hogql import ast
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
+from posthog.hogql.visitor import clone_expr
 
 from posthog.batch_exports.service import BatchExportModel, BatchExportSchema
 from posthog.clickhouse import query_tagging
@@ -86,7 +87,7 @@ class SessionsRecordBatchModel(RecordBatchModel):
         self, data_interval_start: dt.datetime | None, data_interval_end: dt.datetime
     ) -> ast.SelectQuery:
         """Return the HogQLQuery used for the sessions model."""
-        hogql_query = sql.SELECT_FROM_SESSIONS_HOGQL
+        hogql_query = clone_expr(sql.SELECT_FROM_SESSIONS_HOGQL)
 
         where_and = ast.And(
             exprs=[

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -94,6 +94,16 @@ async def ateam(aorganization):
     await sync_to_async(team.delete)()
 
 
+@pytest_asyncio.fixture
+async def another_ateam(aorganization):
+    name = f"BatchExportsTestTeam-{random.randint(1, 99999)}"
+    team = await sync_to_async(Team.objects.create)(organization=aorganization, name=name)
+
+    yield team
+    await sync_to_async(delete_batch_exports)(team_ids=[team.pk])
+    await sync_to_async(team.delete)()
+
+
 @pytest.fixture
 def activity_environment():
     """Return a testing temporal ActivityEnvironment."""


### PR DESCRIPTION
## Problem

There's a race condition that can occur if two separate batch exports are running concurrently and trying to export sessions models. We do not clone the base HogQL query we're using, which means one batch export can overwrite the where clause of another.

## Changes

- Use `clone_expr` to ensure we return a separate instance of the base HogQL expression

## How did you test this code?

- Added some tests to reproduce the issue and ensure they now pass

