### PR TITLE
fix(error-tracking): guard against non-array stacktrace.frames data

### DIFF
--- a/frontend/src/lib/components/Errors/errorPropertiesLogic.ts
+++ b/frontend/src/lib/components/Errors/errorPropertiesLogic.ts
@@ -124,7 +124,9 @@ export const errorPropertiesLogic = kea<errorPropertiesLogicType>([
     }),
 
     afterMount(({ values, actions }) => {
-        const rawIds: string[] = values.exceptionList.flatMap((e) => e.stacktrace?.frames).map((frame) => frame.raw_id)
+        const rawIds: string[] = values.exceptionList
+            .flatMap((e) => (Array.isArray(e.stacktrace?.frames) ? e.stacktrace.frames : []))
+            .map((frame) => frame.raw_id)
         actions.loadFromRawIds(rawIds)
     }),
 ])

--- a/frontend/src/lib/components/Errors/utils.ts
+++ b/frontend/src/lib/components/Errors/utils.ts
@@ -149,8 +149,18 @@ export function getExceptionList(properties: ErrorEventProperties): ErrorTrackin
 
 function processExceptionList(exceptionList: ErrorTrackingException[] = []): ErrorTrackingException[] {
     exceptionList = ensureStringExceptionValues(exceptionList)
+    exceptionList = ensureArrayFrames(exceptionList)
     exceptionList = ensureFrameIdFormat(exceptionList)
     return exceptionList
+}
+
+function ensureArrayFrames(exceptionList: ErrorTrackingException[]): ErrorTrackingException[] {
+    return exceptionList.map((exception) => {
+        if (exception.stacktrace && !Array.isArray(exception.stacktrace.frames)) {
+            return { ...exception, stacktrace: { ...exception.stacktrace, frames: [] } }
+        }
+        return exception
+    })
 }
 
 function ensureFrameIdFormat(exceptionList: ErrorTrackingException[]): ErrorTrackingException[] {


### PR DESCRIPTION
## Changes

Ingested exception events can have `stacktrace.frames` set to a non-array truthy value (e.g. `{}`), which causes a `TypeError: e.frames.some is not a function` when the error tracking UI tries to render them. This only affects a single customer currently, likely due to a `posthog-node` integration sending malformed stacktrace data.

The fix adds an `ensureArrayFrames` sanitization step to `processExceptionList` in `utils.ts`. This follows the existing pattern in the same file where `ensureStringExceptionValues` guards against non-string `exception.value` (which has [the same comment](https://github.com/PostHog/posthog/blob/33d0444047/frontend/src/lib/components/Errors/utils.ts#L198-L202) about runtime data not matching TypeScript types) and where `ensureFrameIdFormat` already checks `Array.isArray(exception.stacktrace.frames)` before operating on frames. Also adds a defensive `Array.isArray` check in the `afterMount` hook in `errorPropertiesLogic.ts` which accesses frames directly and bypasses the processing pipeline.

<!-- Closes #46525 -->

## How did you test this code?

- Existing tests pass (`pnpm --filter=@posthog/frontend jest --testPathPattern="lib/components/Errors"`)
- TypeScript check passes
- Manual verification that the `ensureArrayFrames` step runs before `ensureFrameIdFormat` and coerces non-array frames to `[]`

## Publish to changelog?
no
