### PR TITLE
fix(billing): Implement a proxy for usage signals to avoid CH timeouts

### DIFF
--- a/ee/billing/dags/productled_outbound_targets.py
+++ b/ee/billing/dags/productled_outbound_targets.py
@@ -8,7 +8,6 @@ import polars as pl
 import dagster
 from dagster import AssetKey, JsonMetadataValue, MetadataValue
 
-from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.query import execute_hogql_query
 
@@ -66,13 +65,6 @@ TEAM_PRODUCT_SCHEMA = {
     "autocapture_exceptions_opt_in": pl.Boolean,
 }
 
-PRODUCT_EVENT_MAP = {
-    "session_recording_opt_in": ("$snapshot", "session_recording"),
-    "surveys_opt_in": ("survey sent", "surveys"),
-    "heatmaps_opt_in": ("$heatmap", "heatmaps"),
-    "autocapture_exceptions_opt_in": ("$exception", "autocapture_exceptions"),
-}
-
 
 def build_team_product_df(org_ids: list[str]) -> pl.DataFrame:
     """Fetch team-level product flags from ClickHouse ETL table for the given orgs."""
@@ -87,7 +79,7 @@ def build_team_product_df(org_ids: list[str]) -> pl.DataFrame:
             surveys_opt_in,
             heatmaps_opt_in,
             autocapture_exceptions_opt_in
-        FROM posthog_team
+        FROM models.posthog_team
         WHERE organization_id IN %(org_ids)s
     """
     results = sync_execute(query, {"org_ids": org_ids})
@@ -123,54 +115,88 @@ def compute_multi_product_usage(team_df: pl.DataFrame) -> dict[str, int]:
     )
 
 
-def compute_event_growth(team_df: pl.DataFrame) -> dict[str, float | None]:
-    """Compute month-over-month event growth percentage per org."""
-    if len(team_df) == 0:
-        return {}
+def fetch_org_usage(org_ids: list[str]) -> pl.DataFrame:
+    """Fetch current billing period usage data from ClickHouse ETL table for the given orgs.
 
-    team_ids = team_df["team_id"].to_list()
-    team = Team.objects.get(id=PLO_TEAM_ID)
+    Returns a DataFrame with columns: organization_id, event_count, recording_count,
+    survey_count, exception_count.
+    """
+    if not org_ids:
+        return pl.DataFrame(
+            schema={
+                "organization_id": pl.Utf8,
+                "event_count": pl.Int64,
+                "recording_count": pl.Int64,
+                "survey_count": pl.Int64,
+                "exception_count": pl.Int64,
+            }
+        )
 
     query = """
         SELECT
-            properties.$team_id as team_id,
-            countIf(timestamp >= now() - interval 30 day) as current_count,
-            countIf(timestamp >= now() - interval 60 day AND timestamp < now() - interval 30 day) as prior_count
-        FROM events
-        WHERE properties.$team_id IN {team_ids}
-          AND timestamp >= now() - interval 60 day
-        GROUP BY team_id
+            toString(id) as organization_id,
+            JSONExtractInt(usage, 'events', 'usage') as event_count,
+            JSONExtractInt(usage, 'recordings', 'usage') as recording_count,
+            JSONExtractInt(usage, 'survey_responses', 'usage') as survey_count,
+            JSONExtractInt(usage, 'exceptions', 'usage') as exception_count
+        FROM models.posthog_organization
+        WHERE toString(id) IN %(org_ids)s
+          AND usage IS NOT NULL
+        ORDER BY _inserted_at DESC
+        LIMIT 1 BY id
     """
+    results = sync_execute(query, {"org_ids": org_ids})
 
-    response = execute_hogql_query(
-        query=query,
-        team=team,
-        query_type="plo_event_growth",
-        limit_context=LimitContext.SAVED_QUERY,
-        placeholders={"team_ids": ast.Tuple(exprs=[ast.Constant(value=t) for t in team_ids])},
+    if not results:
+        return pl.DataFrame(
+            schema={
+                "organization_id": pl.Utf8,
+                "event_count": pl.Int64,
+                "recording_count": pl.Int64,
+                "survey_count": pl.Int64,
+                "exception_count": pl.Int64,
+            }
+        )
+
+    return pl.DataFrame(
+        results,
+        schema=["organization_id", "event_count", "recording_count", "survey_count", "exception_count"],
+        orient="row",
     )
 
-    # Build team_id → org_id mapping
-    team_to_org = dict(zip(team_df["team_id"].to_list(), team_df["organization_id"].to_list()))
 
-    # Aggregate per org
-    org_current: dict[str, int] = {}
-    org_prior: dict[str, int] = {}
-    for row in response.results or []:
-        tid, current, prior = row[:3]
-        org_id = team_to_org.get(tid)
-        if org_id:
-            org_current[org_id] = org_current.get(org_id, 0) + current
-            org_prior[org_id] = org_prior.get(org_id, 0) + prior
+# @FIXME-AT: This is a workaround until we have a stable way to query MoM growth without scanning events table in CH.
+# Threshold for considering an org as having "significant" event activity.
+# Orgs above this threshold qualify for the event_growth_pct signal.
+# This replaces the prior MoM growth calculation which required scanning the events table.
+HIGH_EVENT_VOLUME_THRESHOLD = 10000
+
+
+def compute_event_growth(org_ids: list[str]) -> dict[str, float | None]:
+    """Check for high event volume as a proxy for growth signal.
+
+    Since we cannot efficiently compute MoM growth without scanning the events table,
+    we use current billing period event count from Organization.usage as a threshold signal.
+    Orgs with event_count > HIGH_EVENT_VOLUME_THRESHOLD are considered to have significant activity.
+
+    Returns a dict mapping org_id to a synthetic "growth" value:
+    - 100.0 for orgs above threshold (will pass the >30% filter)
+    - 0.0 for orgs below threshold
+    """
+    if not org_ids:
+        return {}
+
+    usage_df = fetch_org_usage(org_ids)
+    if len(usage_df) == 0:
+        return {}
 
     result: dict[str, float | None] = {}
-    for org_id in org_current.keys() | org_prior.keys():
-        current = org_current.get(org_id, 0)
-        prior = org_prior.get(org_id, 0)
-        if prior == 0:
-            result[org_id] = None
-        else:
-            result[org_id] = (current - prior) / prior * 100
+    for row in usage_df.iter_rows(named=True):
+        org_id = row["organization_id"]
+        event_count = row["event_count"] or 0
+        # Return 100.0 (passes >30% filter) if above threshold, else 0.0
+        result[org_id] = 100.0 if event_count > HIGH_EVENT_VOLUME_THRESHOLD else 0.0
+
     return result
 
 
@@ -192,64 +218,42 @@ def compute_new_users_30d(org_ids: list[str]) -> dict[str, int]:
     return {str(row["organization_id"]): row["new_user_count"] for row in rows}
 
 
-def compute_new_product_this_month(team_df: pl.DataFrame) -> dict[str, str]:
-    """Detect products newly adopted this month (events this month but not last month, with flag on)."""
-    if len(team_df) == 0:
+def compute_active_products(org_ids: list[str]) -> dict[str, str]:
+    """Detect products with actual usage in the current billing period.
+
+    Uses Organization.usage data from the ClickHouse ETL table to identify
+    products that have non-zero usage. This replaces the prior event-scanning
+    approach which was too slow for production.
+
+    Returns a dict mapping org_id to comma-separated list of active product names.
+    """
+    if not org_ids:
         return {}
 
-    team_ids = team_df["team_id"].to_list()
-    team = Team.objects.get(id=PLO_TEAM_ID)
+    usage_df = fetch_org_usage(org_ids)
+    if len(usage_df) == 0:
+        return {}
 
-    all_events = [ev for ev, _ in PRODUCT_EVENT_MAP.values()]
+    # Map usage columns to product names
+    usage_to_product = {
+        "recording_count": "session_recording",
+        "survey_count": "surveys",
+        "exception_count": "autocapture_exceptions",
+    }
 
-    query = """
-        SELECT
-            properties.$team_id as team_id,
-            event,
-            countIf(timestamp >= toStartOfMonth(now())) as this_month,
-            countIf(timestamp >= toStartOfMonth(now()) - interval 1 month AND timestamp < toStartOfMonth(now())) as prior_month
-        FROM events
-        WHERE properties.$team_id IN {team_ids}
-          AND event IN {events}
-          AND timestamp >= toStartOfMonth(now()) - interval 1 month
-        GROUP BY team_id, event
-    """
+    result: dict[str, str] = {}
+    for row in usage_df.iter_rows(named=True):
+        org_id = row["organization_id"]
+        active_products: list[str] = []
 
-    response = execute_hogql_query(
-        query=query,
-        team=team,
-        query_type="plo_new_product",
-        limit_context=LimitContext.SAVED_QUERY,
-        placeholders={
-            "team_ids": ast.Tuple(exprs=[ast.Constant(value=t) for t in team_ids]),
-            "events": ast.Tuple(exprs=[ast.Constant(value=e) for e in all_events]),
-        },
-    )
+        for usage_col, product_name in usage_to_product.items():
+            if (row[usage_col] or 0) > 0:
+                active_products.append(product_name)
 
-    # Build team_id → (org_id, flags) mapping
-    team_to_org: dict[Any, str] = {}
-    team_flags: dict[Any, dict[str, bool]] = {}
-    for row in team_df.to_dicts():
-        tid = row["team_id"]
-        team_to_org[tid] = row["organization_id"]
-        team_flags[tid] = {f: row[f] for f in PRODUCT_FLAGS}
+        if active_products:
+            result[org_id] = ",".join(sorted(active_products))
 
-    # Event → flag mapping (reverse of PRODUCT_EVENT_MAP)
-    event_to_flag = {ev: flag for flag, (ev, _) in PRODUCT_EVENT_MAP.items()}
-
-    # Collect new products per org
-    org_new_products: dict[str, set[str]] = {}
-    for row in response.results or []:
-        tid, event, this_month, prior_month = row[:4]
-        if this_month > 0 and prior_month == 0:
-            flag = event_to_flag.get(event)
-            if flag and team_flags.get(tid, {}).get(flag, False):
-                org_id = team_to_org.get(tid)
-                if org_id:
-                    _, product_name = PRODUCT_EVENT_MAP[flag]
-                    org_new_products.setdefault(org_id, set()).add(product_name)
-
-    return {org_id: ",".join(sorted(products)) for org_id, products in org_new_products.items()}
+    return result
 
 
 def fetch_org_users(org_ids: list[str]) -> dict[str, list[dict[str, Any]]]:
@@ -396,17 +400,17 @@ def qualify_signals(
     multi_product = compute_multi_product_usage(team_df)
     context.log.info("Computed multi-product usage for %d orgs", len(multi_product))
 
-    # Signal 2: Event growth MoM
-    event_growth = compute_event_growth(team_df)
-    context.log.info("Computed event growth for %d orgs", len(event_growth))
+    # Signal 2: High event volume (proxy for growth)
+    event_growth = compute_event_growth(org_ids)
+    context.log.info("Computed event volume signal for %d orgs", len(event_growth))
 
     # Signal 3: New users in last 30 days
     new_users = compute_new_users_30d(org_ids)
     context.log.info("Computed new users for %d orgs", len(new_users))
 
-    # Signal 4: New product this month
-    new_products = compute_new_product_this_month(team_df)
-    context.log.info("Computed new products for %d orgs", len(new_products))
+    # Signal 4: Active products with usage
+    new_products = compute_active_products(org_ids)
+    context.log.info("Computed active products for %d orgs", len(new_products))
 
     # Join signals onto base targets
     org_id_list = plo_base_targets["organization_id"].to_list()

--- a/ee/billing/dags/test_productled_outbound_targets.py
+++ b/ee/billing/dags/test_productled_outbound_targets.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import cast
 
-import pytest
 from unittest.mock import MagicMock, patch
 
 import polars as pl
@@ -12,9 +11,9 @@ from parameterized import parameterized
 from ee.billing.dags.productled_outbound_targets import (
     TEAM_PRODUCT_SCHEMA,
     build_team_product_df,
+    compute_active_products,
     compute_event_growth,
     compute_multi_product_usage,
-    compute_new_product_this_month,
     compute_new_users_30d,
     dataframe_to_plo_clay_payload,
     fetch_org_users,
@@ -216,49 +215,44 @@ class TestComputeEventGrowth:
     @parameterized.expand(
         [
             (
-                "growth_above_30pct",
-                [(1, 1000, 500)],
-                pl.DataFrame({"team_id": [1], "organization_id": ["org-1"]}),
-                {"org-1": 100.0},
+                "high_event_volume_passes",
+                [("org-1", 50000, 0, 0, 0)],  # 50k events > 10k threshold
+                {"org-1": 100.0},  # Returns 100.0 to pass the >30% filter
             ),
             (
-                "no_events",
-                [],
-                pl.DataFrame({"team_id": [1], "organization_id": ["org-1"]}),
+                "low_event_volume_fails",
+                [("org-1", 5000, 0, 0, 0)],  # 5k events < 10k threshold
+                {"org-1": 0.0},  # Returns 0.0, won't pass the >30% filter
+            ),
+            (
+                "no_usage_data",
+                [],  # No usage data returned
                 {},
             ),
             (
-                "decline",
-                [(1, 200, 500)],
-                pl.DataFrame({"team_id": [1], "organization_id": ["org-1"]}),
-                {"org-1": -60.0},
+                "exactly_at_threshold",
+                [("org-1", 10000, 0, 0, 0)],  # Exactly 10k, not above
+                {"org-1": 0.0},
             ),
             (
-                "new_org_zero_prior",
-                [(1, 500, 0)],
-                pl.DataFrame({"team_id": [1], "organization_id": ["org-1"]}),
-                {"org-1": None},
-            ),
-            (
-                "multiple_teams_same_org",
-                [(1, 300, 200), (2, 400, 100)],
-                pl.DataFrame({"team_id": [1, 2], "organization_id": ["org-1", "org-1"]}),
-                {"org-1": pytest.approx(133.33, abs=0.01)},
+                "multiple_orgs_mixed",
+                [("org-1", 50000, 0, 0, 0), ("org-2", 5000, 0, 0, 0)],
+                {"org-1": 100.0, "org-2": 0.0},
             ),
         ]
     )
-    @patch("ee.billing.dags.productled_outbound_targets.execute_hogql_query")
-    @patch("ee.billing.dags.productled_outbound_targets.Team")
-    def test_event_growth(self, name, hogql_results, team_df, expected, mock_team, mock_hogql):
-        mock_team.objects.get.return_value = MagicMock()
-        mock_response = MagicMock()
-        mock_response.results = hogql_results
-        mock_hogql.return_value = mock_response
+    @patch("ee.billing.dags.productled_outbound_targets.fetch_org_usage")
+    def test_event_growth(self, name, usage_data, expected, mock_fetch_usage):
+        mock_fetch_usage.return_value = pl.DataFrame(
+            usage_data,
+            schema=["organization_id", "event_count", "recording_count", "survey_count", "exception_count"],
+            orient="row",
+        )
 
-        result = compute_event_growth(team_df)
+        org_ids = [row[0] for row in usage_data] if usage_data else ["org-1"]
+        result = compute_event_growth(org_ids)
 
-        for org_id, val in expected.items():
-            assert result[org_id] == val
+        assert result == expected
 
 
 class TestComputeNewUsers30d:
@@ -323,80 +317,41 @@ class TestFetchOrgUsers:
         assert result == {}
 
 
-class TestComputeNewProductThisMonth:
+class TestComputeActiveProducts:
     @parameterized.expand(
         [
             (
-                "new_product_detected",
-                [(1, "$snapshot", 50, 0)],
-                pl.DataFrame(
-                    {
-                        "team_id": [1],
-                        "organization_id": ["org-1"],
-                        "session_recording_opt_in": [True],
-                        "surveys_opt_in": [False],
-                        "heatmaps_opt_in": [False],
-                        "autocapture_exceptions_opt_in": [False],
-                    }
-                ),
+                "single_product_with_usage",
+                [("org-1", 1000, 500, 0, 0)],  # org_id, events, recordings, surveys, exceptions
                 {"org-1": "session_recording"},
             ),
             (
-                "existing_product_not_new",
-                [(1, "$snapshot", 50, 30)],
-                pl.DataFrame(
-                    {
-                        "team_id": [1],
-                        "organization_id": ["org-1"],
-                        "session_recording_opt_in": [True],
-                        "surveys_opt_in": [False],
-                        "heatmaps_opt_in": [False],
-                        "autocapture_exceptions_opt_in": [False],
-                    }
-                ),
+                "multiple_products_with_usage",
+                [("org-1", 1000, 500, 100, 50)],
+                {"org-1": "autocapture_exceptions,session_recording,surveys"},
+            ),
+            (
+                "no_products_with_usage",
+                [("org-1", 1000, 0, 0, 0)],  # Only events, no product usage
                 {},
             ),
             (
-                "flag_off_ignored",
-                [(1, "$snapshot", 50, 0)],
-                pl.DataFrame(
-                    {
-                        "team_id": [1],
-                        "organization_id": ["org-1"],
-                        "session_recording_opt_in": [False],
-                        "surveys_opt_in": [False],
-                        "heatmaps_opt_in": [False],
-                        "autocapture_exceptions_opt_in": [False],
-                    }
-                ),
-                {},
-            ),
-            (
-                "multiple_new_products",
-                [(1, "$snapshot", 10, 0), (1, "survey sent", 5, 0)],
-                pl.DataFrame(
-                    {
-                        "team_id": [1],
-                        "organization_id": ["org-1"],
-                        "session_recording_opt_in": [True],
-                        "surveys_opt_in": [True],
-                        "heatmaps_opt_in": [False],
-                        "autocapture_exceptions_opt_in": [False],
-                    }
-                ),
-                {"org-1": "session_recording,surveys"},
+                "multiple_orgs",
+                [("org-1", 1000, 500, 0, 0), ("org-2", 2000, 0, 100, 0)],
+                {"org-1": "session_recording", "org-2": "surveys"},
             ),
         ]
     )
-    @patch("ee.billing.dags.productled_outbound_targets.execute_hogql_query")
-    @patch("ee.billing.dags.productled_outbound_targets.Team")
-    def test_new_product(self, name, hogql_results, team_df, expected, mock_team, mock_hogql):
-        mock_team.objects.get.return_value = MagicMock()
-        mock_response = MagicMock()
-        mock_response.results = hogql_results
-        mock_hogql.return_value = mock_response
+    @patch("ee.billing.dags.productled_outbound_targets.fetch_org_usage")
+    def test_active_products(self, name, usage_data, expected, mock_fetch_usage):
+        mock_fetch_usage.return_value = pl.DataFrame(
+            usage_data,
+            schema=["organization_id", "event_count", "recording_count", "survey_count", "exception_count"],
+            orient="row",
+        )
 
-        result = compute_new_product_this_month(team_df)
+        org_ids = [row[0] for row in usage_data]
+        result = compute_active_products(org_ids)
 
         assert result == expected
 
@@ -671,7 +626,7 @@ class TestGetPloPriorHashes:
 
 
 class TestQualifySignals:
-    @patch("ee.billing.dags.productled_outbound_targets.compute_new_product_this_month")
+    @patch("ee.billing.dags.productled_outbound_targets.compute_active_products")
     @patch("ee.billing.dags.productled_outbound_targets.compute_new_users_30d")
     @patch("ee.billing.dags.productled_outbound_targets.compute_event_growth")
     @patch("ee.billing.dags.productled_outbound_targets.compute_multi_product_usage")
@@ -783,14 +738,12 @@ class TestFilterQualifiedBoundaries:
 
 
 class TestEmptyDataFramePaths:
-    def test_compute_event_growth_empty_dataframe(self):
-        empty_df = pl.DataFrame(schema={"team_id": pl.Int64, "organization_id": pl.Utf8})
-        result = compute_event_growth(empty_df)
+    def test_compute_event_growth_empty_org_ids(self):
+        result = compute_event_growth([])
         assert result == {}
 
-    def test_compute_new_product_this_month_empty_dataframe(self):
-        empty_df = pl.DataFrame(schema=TEAM_PRODUCT_SCHEMA)
-        result = compute_new_product_this_month(empty_df)
+    def test_compute_active_products_empty_org_ids(self):
+        result = compute_active_products([])
         assert result == {}
 
     @patch("ee.billing.dags.productled_outbound_targets.OrganizationMembership")


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
The qualification [asset](https://posthog.dagster.plus/prod-us/selection/all-assets/assets/qualify_signals) we deployed doesn't actually run because CH queries timeout. I replaced these with simpler proxies that can complete and will work on infrastructure to aggregate and distribute such metrics in: https://github.com/PostHog/posthog/pull/45695#discussion_r2745535210

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Introduce simplified proxies for Event growth MoM and Active products with usage signals

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
I ran all the queries in Metabase (`prod-us` and `prod-eu`) and verified they actually complete with results

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no
