### PR TITLE
feat(llma): reset eval keys on delete

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,7 +56,6 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
-                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -80,7 +79,6 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
-                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -97,7 +95,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND (("pmat_email" ILIKE '%g0%'
+                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/products/llm_analytics/backend/api/provider_keys.py
+++ b/products/llm_analytics/backend/api/provider_keys.py
@@ -269,10 +269,18 @@ class LLMProviderKeyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     {"detail": "Replacement key must be from the same provider"}, status=status.HTTP_400_BAD_REQUEST
                 )
 
-            LLMModelConfiguration.objects.filter(provider_key=instance).update(provider_key=replacement_key)
+            LLMModelConfiguration.objects.filter(provider_key=instance, team_id=self.team_id).update(
+                provider_key=replacement_key
+            )
         else:
-            model_config_ids = LLMModelConfiguration.objects.filter(provider_key=instance).values_list("id", flat=True)
-            Evaluation.objects.filter(model_configuration_id__in=model_config_ids, deleted=False).update(enabled=False)
+            model_config_ids = list(
+                LLMModelConfiguration.objects.filter(provider_key=instance, team_id=self.team_id).values_list(
+                    "id", flat=True
+                )
+            )
+            Evaluation.objects.filter(
+                model_configuration_id__in=model_config_ids, team_id=self.team_id, deleted=False
+            ).update(enabled=False)
 
         return super().destroy(request, *args, **kwargs)
 

--- a/products/llm_analytics/backend/api/provider_keys.py
+++ b/products/llm_analytics/backend/api/provider_keys.py
@@ -16,6 +16,8 @@ from posthog.models import User
 
 from ..llm.client import Client
 from ..models.evaluation_config import EvaluationConfig
+from ..models.evaluations import Evaluation
+from ..models.model_configuration import LLMModelConfiguration
 from ..models.provider_keys import LLMProvider, LLMProviderKey
 
 
@@ -217,8 +219,61 @@ class LLMProviderKeyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def partial_update(self, request, *args, **kwargs):
         return super().partial_update(request, *args, **kwargs)
 
+    @action(detail=True, methods=["get"])
+    @monitor(feature=None, endpoint="llma_provider_keys_dependent_configs", method="GET")
+    def dependent_configs(self, request: Request, **_kwargs) -> Response:
+        """Get evaluations using this key and alternative keys for replacement."""
+        instance = self.get_object()
+
+        model_configs = LLMModelConfiguration.objects.filter(provider_key=instance).prefetch_related("evaluations")
+
+        evaluations = []
+        for config in model_configs:
+            for evaluation in config.evaluations.filter(deleted=False):
+                evaluations.append(
+                    {
+                        "id": str(evaluation.id),
+                        "name": evaluation.name,
+                        "model_configuration_id": str(config.id),
+                    }
+                )
+
+        alternative_keys = LLMProviderKey.objects.filter(
+            team_id=self.team_id,
+            provider=instance.provider,
+            state=LLMProviderKey.State.OK,
+        ).exclude(id=instance.id)
+
+        return Response(
+            {
+                "evaluations": evaluations,
+                "alternative_keys": [
+                    {"id": str(key.id), "name": key.name, "provider": key.provider} for key in alternative_keys
+                ],
+            }
+        )
+
     @monitor(feature=None, endpoint="llma_provider_keys_destroy", method="DELETE")
     def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        replacement_key_id = request.query_params.get("replacement_key_id")
+
+        if replacement_key_id:
+            try:
+                replacement_key = LLMProviderKey.objects.get(id=replacement_key_id, team_id=self.team_id)
+            except LLMProviderKey.DoesNotExist:
+                return Response({"detail": "Replacement key not found"}, status=status.HTTP_400_BAD_REQUEST)
+
+            if replacement_key.provider != instance.provider:
+                return Response(
+                    {"detail": "Replacement key must be from the same provider"}, status=status.HTTP_400_BAD_REQUEST
+                )
+
+            LLMModelConfiguration.objects.filter(provider_key=instance).update(provider_key=replacement_key)
+        else:
+            model_config_ids = LLMModelConfiguration.objects.filter(provider_key=instance).values_list("id", flat=True)
+            Evaluation.objects.filter(model_configuration_id__in=model_config_ids, deleted=False).update(enabled=False)
+
         return super().destroy(request, *args, **kwargs)
 
 

--- a/products/llm_analytics/backend/api/test/test_provider_keys.py
+++ b/products/llm_analytics/backend/api/test/test_provider_keys.py
@@ -518,7 +518,7 @@ class TestLLMProviderKeyDependentConfigs(APIBaseTest):
         self.assertEqual(model_config.provider_key, key2)
         self.assertEqual(LLMProviderKey.objects.filter(id=key1.id).count(), 0)
 
-    def test_delete_without_replacement_nullifies_model_configs_and_disables_evaluations(self):
+    def test_delete_without_replacement_disables_evaluations(self):
         key = LLMProviderKey.objects.create(
             team=self.team,
             provider="openai",

--- a/products/llm_analytics/backend/api/test/test_provider_keys.py
+++ b/products/llm_analytics/backend/api/test/test_provider_keys.py
@@ -8,6 +8,8 @@ from rest_framework import status
 from posthog.models import Organization, Project, Team, User
 
 from products.llm_analytics.backend.models.evaluation_config import EvaluationConfig
+from products.llm_analytics.backend.models.evaluations import Evaluation
+from products.llm_analytics.backend.models.model_configuration import LLMModelConfiguration
 from products.llm_analytics.backend.models.provider_keys import LLMProviderKey
 
 
@@ -359,3 +361,260 @@ class TestLLMProviderKeyValidationViewSet(APIBaseTest):
             {},
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class TestLLMProviderKeyDependentConfigs(APIBaseTest):
+    def test_dependent_configs_returns_evaluations_using_key(self):
+        key = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="My Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-test-key"},
+            created_by=self.user,
+        )
+        model_config = LLMModelConfiguration.objects.create(
+            team=self.team,
+            provider="openai",
+            model="gpt-5-mini",
+            provider_key=key,
+        )
+        evaluation = Evaluation.objects.create(
+            team=self.team,
+            name="Test Evaluation",
+            evaluation_type="llm_judge",
+            evaluation_config={"prompt": "Is this good?"},
+            output_type="boolean",
+            model_configuration=model_config,
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_analytics/provider_keys/{key.id}/dependent_configs/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["evaluations"]), 1)
+        self.assertEqual(response.data["evaluations"][0]["id"], str(evaluation.id))
+        self.assertEqual(response.data["evaluations"][0]["name"], "Test Evaluation")
+
+    def test_dependent_configs_excludes_deleted_evaluations(self):
+        key = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="My Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-test-key"},
+            created_by=self.user,
+        )
+        model_config = LLMModelConfiguration.objects.create(
+            team=self.team,
+            provider="openai",
+            model="gpt-5-mini",
+            provider_key=key,
+        )
+        Evaluation.objects.create(
+            team=self.team,
+            name="Deleted Evaluation",
+            evaluation_type="llm_judge",
+            evaluation_config={"prompt": "Is this good?"},
+            output_type="boolean",
+            model_configuration=model_config,
+            deleted=True,
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_analytics/provider_keys/{key.id}/dependent_configs/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["evaluations"]), 0)
+
+    def test_dependent_configs_returns_alternative_keys_for_same_provider(self):
+        key1 = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="Key 1",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-key1"},
+            created_by=self.user,
+        )
+        key2 = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="Key 2",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-key2"},
+            created_by=self.user,
+        )
+        LLMProviderKey.objects.create(
+            team=self.team,
+            provider="anthropic",
+            name="Anthropic Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-ant-key"},
+            created_by=self.user,
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_analytics/provider_keys/{key1.id}/dependent_configs/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["alternative_keys"]), 1)
+        self.assertEqual(response.data["alternative_keys"][0]["id"], str(key2.id))
+        self.assertEqual(response.data["alternative_keys"][0]["provider"], "openai")
+
+    def test_dependent_configs_excludes_invalid_alternative_keys(self):
+        key1 = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="Key 1",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-key1"},
+            created_by=self.user,
+        )
+        LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="Invalid Key",
+            state=LLMProviderKey.State.INVALID,
+            encrypted_config={"api_key": "sk-invalid"},
+            created_by=self.user,
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_analytics/provider_keys/{key1.id}/dependent_configs/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["alternative_keys"]), 0)
+
+    def test_delete_with_replacement_updates_model_configs(self):
+        key1 = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="Key 1",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-key1"},
+            created_by=self.user,
+        )
+        key2 = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="Key 2",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-key2"},
+            created_by=self.user,
+        )
+        model_config = LLMModelConfiguration.objects.create(
+            team=self.team,
+            provider="openai",
+            model="gpt-5-mini",
+            provider_key=key1,
+        )
+
+        response = self.client.delete(
+            f"/api/environments/{self.team.id}/llm_analytics/provider_keys/{key1.id}/?replacement_key_id={key2.id}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        model_config.refresh_from_db()
+        self.assertEqual(model_config.provider_key, key2)
+        self.assertEqual(LLMProviderKey.objects.filter(id=key1.id).count(), 0)
+
+    def test_delete_without_replacement_nullifies_model_configs_and_disables_evaluations(self):
+        key = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="My Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-key"},
+            created_by=self.user,
+        )
+        model_config = LLMModelConfiguration.objects.create(
+            team=self.team,
+            provider="openai",
+            model="gpt-5-mini",
+            provider_key=key,
+        )
+        evaluation = Evaluation.objects.create(
+            team=self.team,
+            name="Test Evaluation",
+            evaluation_type="llm_judge",
+            evaluation_config={"prompt": "Is this good?"},
+            output_type="boolean",
+            model_configuration=model_config,
+            enabled=True,
+        )
+
+        response = self.client.delete(f"/api/environments/{self.team.id}/llm_analytics/provider_keys/{key.id}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        model_config.refresh_from_db()
+        self.assertIsNone(model_config.provider_key)
+
+        evaluation.refresh_from_db()
+        self.assertFalse(evaluation.enabled)
+
+    def test_delete_with_mismatched_provider_replacement_fails(self):
+        openai_key = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="OpenAI Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-openai"},
+            created_by=self.user,
+        )
+        anthropic_key = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="anthropic",
+            name="Anthropic Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-ant-key"},
+            created_by=self.user,
+        )
+
+        response = self.client.delete(
+            f"/api/environments/{self.team.id}/llm_analytics/provider_keys/{openai_key.id}/?replacement_key_id={anthropic_key.id}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("same provider", response.data["detail"])
+        self.assertEqual(LLMProviderKey.objects.filter(id=openai_key.id).count(), 1)
+
+    def test_delete_with_nonexistent_replacement_fails(self):
+        key = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="My Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-key"},
+            created_by=self.user,
+        )
+
+        response = self.client.delete(
+            f"/api/environments/{self.team.id}/llm_analytics/provider_keys/{key.id}/?replacement_key_id=00000000-0000-0000-0000-000000000000"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("not found", response.data["detail"])
+        self.assertEqual(LLMProviderKey.objects.filter(id=key.id).count(), 1)
+
+    def test_delete_with_other_teams_replacement_key_fails(self):
+        other_team = _setup_team()
+        key = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="My Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-key"},
+            created_by=self.user,
+        )
+        other_key = LLMProviderKey.objects.create(
+            team=other_team,
+            provider="openai",
+            name="Other Team Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-other"},
+            created_by=self.user,
+        )
+
+        response = self.client.delete(
+            f"/api/environments/{self.team.id}/llm_analytics/provider_keys/{key.id}/?replacement_key_id={other_key.id}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(LLMProviderKey.objects.filter(id=key.id).count(), 1)

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -315,8 +315,8 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 const provider = evaluation.model_configuration?.provider || 'openai'
                 let keyId = evaluation.model_configuration?.provider_key_id || null
 
-                // For new evals without a key, auto-select user's first key if available
-                if (!keyId && !evaluation.id) {
+                // Auto-select user's first key if none set (for new OR existing evals)
+                if (!keyId) {
                     const keysForProvider = values.providerKeysByProvider[provider] || []
                     if (keysForProvider.length > 0) {
                         keyId = keysForProvider[0].id
@@ -329,14 +329,24 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
         },
 
         loadProviderKeysSuccess: () => {
-            // When provider keys finish loading after evaluation, auto-select key for new evals
             const evaluation = values.evaluation
+
+            // For new evals without a key, auto-select first key
             if (evaluation && !evaluation.id && !values.selectedKeyId) {
                 const keysForProvider = values.providerKeysByProvider[values.selectedProvider] || []
                 if (keysForProvider.length > 0) {
                     const keyId = keysForProvider[0].id
                     actions.setSelectedKeyId(keyId)
                     actions.loadAvailableModels({ provider: values.selectedProvider, keyId })
+                }
+            }
+
+            // For existing evals, if selected key no longer exists, reload evaluation to get fresh data
+            if (evaluation && evaluation.id && values.selectedKeyId) {
+                const keysForProvider = values.providerKeysByProvider[values.selectedProvider] || []
+                const keyExists = keysForProvider.some((key) => key.id === values.selectedKeyId)
+                if (!keyExists) {
+                    actions.loadEvaluation()
                 }
             }
         },

--- a/products/llm_analytics/frontend/generated/api.ts
+++ b/products/llm_analytics/frontend/generated/api.ts
@@ -557,6 +557,24 @@ export const llmAnalyticsProviderKeysDestroy = async (
     })
 }
 
+/**
+ * Get evaluations using this key and alternative keys for replacement.
+ */
+export const getLlmAnalyticsProviderKeysDependentConfigsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/environments/${projectId}/llm_analytics/provider_keys/${id}/dependent_configs/`
+}
+
+export const llmAnalyticsProviderKeysDependentConfigsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<LLMProviderKeyApi> => {
+    return apiMutator<LLMProviderKeyApi>(getLlmAnalyticsProviderKeysDependentConfigsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
 export const getLlmAnalyticsProviderKeysValidateCreateUrl = (projectId: string, id: string) => {
     return `/api/environments/${projectId}/llm_analytics/provider_keys/${id}/validate/`
 }

--- a/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
@@ -388,11 +388,12 @@ function DeleteKeyModal({
     const hasEvaluations = (dependentConfigs?.evaluations.length ?? 0) > 0
     const hasAlternatives = (dependentConfigs?.alternative_keys.length ?? 0) > 0
 
+    const firstAlternativeKeyId = dependentConfigs?.alternative_keys[0]?.id
     useEffect(() => {
-        if (hasAlternatives && dependentConfigs?.alternative_keys[0]) {
-            setReplacementKeyId(dependentConfigs.alternative_keys[0].id)
+        if (hasAlternatives && firstAlternativeKeyId) {
+            setReplacementKeyId(firstAlternativeKeyId)
         }
-    }, [hasAlternatives, dependentConfigs])
+    }, [hasAlternatives, firstAlternativeKeyId])
 
     const handleClose = (): void => {
         setKeyToDelete(null)

--- a/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react'
 import { IconPlus, IconRefresh, IconTrash } from '@posthog/icons'
 import {
     LemonButton,
-    LemonDialog,
     LemonInput,
     LemonModal,
     LemonSelect,
@@ -19,6 +18,8 @@ import { IconKey } from 'lib/lemon-ui/icons'
 
 import { TrialUsageMeterDisplay } from './TrialUsageMeter'
 import {
+    AlternativeKey,
+    DependentConfigsResponse,
     KeyValidationResult,
     LLMProvider,
     LLMProviderKey,
@@ -371,6 +372,117 @@ function EditKeyModal({ keyToEdit }: { keyToEdit: LLMProviderKey }): JSX.Element
     )
 }
 
+function DeleteKeyModal({
+    keyToDelete,
+    dependentConfigs,
+    dependentConfigsLoading,
+}: {
+    keyToDelete: LLMProviderKey
+    dependentConfigs: DependentConfigsResponse | null
+    dependentConfigsLoading: boolean
+}): JSX.Element {
+    const { providerKeysLoading } = useValues(llmProviderKeysLogic)
+    const { setKeyToDelete, confirmDelete } = useActions(llmProviderKeysLogic)
+    const [replacementKeyId, setReplacementKeyId] = useState<string | undefined>(undefined)
+
+    const hasEvaluations = (dependentConfigs?.evaluations.length ?? 0) > 0
+    const hasAlternatives = (dependentConfigs?.alternative_keys.length ?? 0) > 0
+
+    useEffect(() => {
+        if (hasAlternatives && dependentConfigs?.alternative_keys[0]) {
+            setReplacementKeyId(dependentConfigs.alternative_keys[0].id)
+        }
+    }, [hasAlternatives, dependentConfigs])
+
+    const handleClose = (): void => {
+        setKeyToDelete(null)
+    }
+
+    const handleDelete = (): void => {
+        confirmDelete(hasEvaluations && hasAlternatives ? replacementKeyId : undefined)
+    }
+
+    const replacementOptions =
+        dependentConfigs?.alternative_keys.map((key: AlternativeKey) => ({
+            value: key.id,
+            label: key.name,
+        })) ?? []
+
+    return (
+        <LemonModal
+            isOpen
+            onClose={handleClose}
+            title="Delete API key?"
+            width={480}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={handleClose}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        status="danger"
+                        onClick={handleDelete}
+                        loading={providerKeysLoading}
+                        disabled={dependentConfigsLoading}
+                    >
+                        Delete key
+                    </LemonButton>
+                </>
+            }
+        >
+            {dependentConfigsLoading ? (
+                <LemonSkeleton className="h-20" />
+            ) : (
+                <div className="space-y-4">
+                    <p>
+                        Are you sure you want to delete "<strong>{keyToDelete.name}</strong>"? This cannot be undone.
+                    </p>
+
+                    {hasEvaluations && (
+                        <div className="bg-bg-light border rounded p-3">
+                            <p className="font-medium mb-2">
+                                {dependentConfigs!.evaluations.length} evaluation
+                                {dependentConfigs!.evaluations.length === 1 ? '' : 's'} using this key:
+                            </p>
+                            <ul className="list-disc pl-4 text-sm text-muted space-y-1">
+                                {dependentConfigs!.evaluations.map((evaluation) => (
+                                    <li key={evaluation.id}>{evaluation.name}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    {hasEvaluations && hasAlternatives && (
+                        <div>
+                            <label className="text-sm font-medium">Replace with another key</label>
+                            <LemonSelect
+                                value={replacementKeyId}
+                                onChange={setReplacementKeyId}
+                                options={replacementOptions}
+                                className="mt-1"
+                                fullWidth
+                            />
+                            <p className="text-xs text-muted mt-1">
+                                The selected key will be used by evaluations that currently use this key.
+                            </p>
+                        </div>
+                    )}
+
+                    {hasEvaluations && !hasAlternatives && (
+                        <div className="bg-warning-highlight border border-warning rounded p-3">
+                            <p className="text-sm">
+                                <strong>No replacement keys available.</strong> These evaluations will be disabled after
+                                deletion.
+                            </p>
+                        </div>
+                    )}
+                </div>
+            )}
+        </LemonModal>
+    )
+}
+
 export function LLMProviderKeysSettings(): JSX.Element {
     const {
         providerKeys,
@@ -379,24 +491,11 @@ export function LLMProviderKeysSettings(): JSX.Element {
         evaluationConfigLoading,
         editingKey,
         validatingKeyId,
+        keyToDelete,
+        dependentConfigs,
+        dependentConfigsLoading,
     } = useValues(llmProviderKeysLogic)
-    const { setNewKeyModalOpen, deleteProviderKey, validateProviderKey, setEditingKey } =
-        useActions(llmProviderKeysLogic)
-
-    const handleDelete = (key: LLMProviderKey): void => {
-        LemonDialog.open({
-            title: 'Delete API key?',
-            description: `Are you sure you want to delete "${key.name}"? This cannot be undone.`,
-            primaryButton: {
-                children: 'Delete',
-                status: 'danger',
-                onClick: () => deleteProviderKey({ id: key.id }),
-            },
-            secondaryButton: {
-                children: 'Cancel',
-            },
-        })
-    }
+    const { setNewKeyModalOpen, validateProviderKey, setEditingKey, setKeyToDelete } = useActions(llmProviderKeysLogic)
 
     const columns: LemonTableColumns<LLMProviderKey> = [
         {
@@ -471,7 +570,7 @@ export function LLMProviderKeysSettings(): JSX.Element {
                         type="secondary"
                         status="danger"
                         icon={<IconTrash />}
-                        onClick={() => handleDelete(key)}
+                        onClick={() => setKeyToDelete(key)}
                     />
                 </div>
             ),
@@ -534,6 +633,13 @@ export function LLMProviderKeysSettings(): JSX.Element {
             </div>
             <AddKeyModal />
             {editingKey && <EditKeyModal keyToEdit={editingKey} />}
+            {keyToDelete && (
+                <DeleteKeyModal
+                    keyToDelete={keyToDelete}
+                    dependentConfigs={dependentConfigs}
+                    dependentConfigsLoading={dependentConfigsLoading}
+                />
+            )}
         </>
     )
 }

--- a/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
@@ -238,7 +238,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                         return values.providerKeys
                     }
                     const url = replacementKeyId
-                        ? `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/?replacement_key_id=${replacementKeyId}`
+                        ? `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/?replacement_key_id=${encodeURIComponent(replacementKeyId)}`
                         : `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/`
                     await api.delete(url)
                     // If deleted key was active, reload config to reflect change

--- a/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
@@ -60,6 +60,23 @@ export interface KeyValidationResult {
     error_message: string | null
 }
 
+export interface DependentEvaluation {
+    id: string
+    name: string
+    model_configuration_id: string
+}
+
+export interface AlternativeKey {
+    id: string
+    name: string
+    provider: LLMProvider
+}
+
+export interface DependentConfigsResponse {
+    evaluations: DependentEvaluation[]
+    alternative_keys: AlternativeKey[]
+}
+
 export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
     path(['products', 'llm_analytics', 'settings', 'llmProviderKeysLogic']),
 
@@ -67,6 +84,8 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
         clearPreValidation: true,
         setNewKeyModalOpen: (open: boolean) => ({ open }),
         setEditingKey: (key: LLMProviderKey | null) => ({ key }),
+        setKeyToDelete: (key: LLMProviderKey | null) => ({ key }),
+        confirmDelete: (replacementKeyId?: string) => ({ replacementKeyId }),
     }),
 
     reducers({
@@ -100,9 +119,34 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                 setEditingKey: () => null,
             },
         ],
+        keyToDelete: [
+            null as LLMProviderKey | null,
+            {
+                setKeyToDelete: (_, { key }) => key,
+                deleteProviderKeySuccess: () => null,
+            },
+        ],
     }),
 
     loaders(({ values, actions }) => ({
+        dependentConfigs: [
+            null as DependentConfigsResponse | null,
+            {
+                loadDependentConfigs: async ({
+                    keyId,
+                }: {
+                    keyId: string
+                }): Promise<DependentConfigsResponse | null> => {
+                    const teamId = teamLogic.values.currentTeamId
+                    if (!teamId) {
+                        return null
+                    }
+                    return await api.get(
+                        `/api/environments/${teamId}/llm_analytics/provider_keys/${keyId}/dependent_configs/`
+                    )
+                },
+            },
+        ],
         preValidationResult: [
             null as KeyValidationResult | null,
             {
@@ -182,12 +226,21 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                     actions.setEditingKey(null)
                     return values.providerKeys.map((key: LLMProviderKey) => (key.id === id ? response : key))
                 },
-                deleteProviderKey: async ({ id }: { id: string }): Promise<LLMProviderKey[]> => {
+                deleteProviderKey: async ({
+                    id,
+                    replacementKeyId,
+                }: {
+                    id: string
+                    replacementKeyId?: string
+                }): Promise<LLMProviderKey[]> => {
                     const teamId = teamLogic.values.currentTeamId
                     if (!teamId) {
                         return values.providerKeys
                     }
-                    await api.delete(`/api/environments/${teamId}/llm_analytics/provider_keys/${id}/`)
+                    const url = replacementKeyId
+                        ? `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/?replacement_key_id=${replacementKeyId}`
+                        : `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/`
+                    await api.delete(url)
                     // If deleted key was active, reload config to reflect change
                     if (values.evaluationConfig?.active_provider_key?.id === id) {
                         actions.loadEvaluationConfig()
@@ -234,7 +287,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
         ],
     }),
 
-    listeners(() => ({
+    listeners(({ actions, values }) => ({
         loadProviderKeysFailure: ({ error }) => {
             lemonToast.error(`Failed to load API keys: ${error || 'Unknown error'}`)
         },
@@ -249,6 +302,16 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
         },
         deleteProviderKeyFailure: ({ error }) => {
             lemonToast.error(`Failed to delete API key: ${error || 'Unknown error'}`)
+        },
+        setKeyToDelete: ({ key }) => {
+            if (key) {
+                actions.loadDependentConfigs({ keyId: key.id })
+            }
+        },
+        confirmDelete: ({ replacementKeyId }) => {
+            if (values.keyToDelete) {
+                actions.deleteProviderKey({ id: values.keyToDelete.id, replacementKeyId })
+            }
         },
     })),
 


### PR DESCRIPTION
This ensures that once a key is deleted, any eval using it gets either disabled or assigned a new key. To add this there's a couple of components involved:
- Endpoint that fetches what evals would be affected by a key removal and what replacement keys exist
- Modify the key deletion dialogue to show this information and allow picking a replacement key
- Modify the backend key delete function to properly replace keys or disable related evals if no replacement key is available