### PR TITLE
fix(phai): mixed id retrieval of dashboards

### DIFF
--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -391,8 +391,13 @@ class UpsertDashboardTool(MaxTool):
 
     async def _get_dashboard(self, dashboard_id: Any) -> Dashboard:
         """Get the dashboard and sorted tiles for the given dashboard ID."""
+        # LLMs sometimes output IDs as floats (e.g., "642161.0"), so we parse to int
         try:
-            dashboard = await Dashboard.objects.aget(id=dashboard_id, team=self._team, deleted=False)
+            parsed_id = int(float(dashboard_id))
+        except (ValueError, TypeError):
+            raise MaxToolFatalError(DASHBOARD_NOT_FOUND_PROMPT.format(dashboard_id=dashboard_id))
+        try:
+            dashboard = await Dashboard.objects.aget(id=parsed_id, team=self._team, deleted=False)
         except Dashboard.DoesNotExist:
             raise MaxToolFatalError(DASHBOARD_NOT_FOUND_PROMPT.format(dashboard_id=dashboard_id))
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -20491,7 +20491,7 @@
                     "type": ["string", "null"]
                 },
                 "id": {
-                    "type": "number"
+                    "$ref": "#/definitions/integer"
                 },
                 "name": {
                     "type": "string"
@@ -20770,7 +20770,7 @@
                     "$ref": "#/definitions/DashboardFilter"
                 },
                 "id": {
-                    "type": "number"
+                    "$ref": "#/definitions/integer"
                 },
                 "insights": {
                     "items": {

--- a/frontend/src/scenes/max/maxTypes.ts
+++ b/frontend/src/scenes/max/maxTypes.ts
@@ -27,7 +27,7 @@ export interface MaxInsightContext {
 
 export interface MaxDashboardContext {
     type: MaxContextType.DASHBOARD
-    id: number
+    id: integer
     name?: string | null
     description?: string | null
     insights: MaxInsightContext[]
@@ -43,7 +43,7 @@ export interface MaxEventContext {
 
 export interface MaxActionContext {
     type: MaxContextType.ACTION
-    id: number
+    id: integer
     name: string
     description?: string | null
 }

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2383,16 +2383,6 @@ class MatchingEventsResponse(BaseModel):
     results: list[MatchedRecordingEvent]
 
 
-class MaxActionContext(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    description: str | None = None
-    id: float
-    name: str
-    type: Literal["action"] = "action"
-
-
 class MaxAddonInfo(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -5414,6 +5404,16 @@ class MatchedRecording(BaseModel):
     )
     events: list[MatchedRecordingEvent]
     session_id: str | None = None
+
+
+class MaxActionContext(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str | None = None
+    id: int
+    name: str
+    type: Literal["action"] = "action"
 
 
 class MaxBillingContextBillingPeriod(BaseModel):
@@ -18649,7 +18649,7 @@ class MaxDashboardContext(BaseModel):
     )
     description: str | None = None
     filters: DashboardFilter
-    id: float
+    id: int
     insights: list[MaxInsightContext]
     name: str | None = None
     type: Literal["dashboard"] = "dashboard"


### PR DESCRIPTION
## Problem

The dashboard context was using a number type in JavaScript, which converts to a float. This was breaking the dashboard retrieval in some edge cases.

[Ref](https://us.posthog.com/project/2/llm-analytics/traces/51d163ec-ff2c-48c3-92eb-ebe8d48aeb23?event=c64cd8fa-e8f7-4cd2-8212-11d5543f9c90&timestamp=2026-02-02T15:10:29Z)

## Changes

- Used `integer` in the schema.
- Converted float to int.


