### PR TITLE
fix(onboarding): filter out send events for SR

### DIFF
--- a/docs/onboarding/session-replay/_snippets/create-session-replay-steps.tsx
+++ b/docs/onboarding/session-replay/_snippets/create-session-replay-steps.tsx
@@ -9,8 +9,12 @@ export function createSessionReplayStepsFromPA(
     const { snippets } = ctx
     const SessionReplayFinalSteps = snippets?.SessionReplayFinalSteps
 
+    const installationSteps = getClientStepsPA(ctx).filter(
+        (step: StepDefinition) => step.title !== 'Send events'
+    )
+
     return [
-        ...getClientStepsPA(ctx),
+        ...installationSteps,
         {
             title: 'Watch session recordings',
             badge: 'recommended',


### PR DESCRIPTION
## Problem

session replay onboarding was showing send events step for web SDKs, but this step needs filtered out. I forgot to add the filter :') 

## Changes

filter out send events step, matching the experiments onboarding pattern

## How did you test this code?

ran the app locally to verify, verified against pattern in experiments

## Publish to changelog?

no
