### PR TITLE
fix: un-crop ai icon on replay

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -34,7 +34,7 @@ export function SessionRecordingsPlaylist({
 
     return (
         <BindLogic logic={sessionRecordingsPlaylistLogic} props={logicProps}>
-            <div className="w-full h-full flex flex-col xl:flex-row xl:gap-2 overflow-hidden">
+            <div className="w-full h-full flex flex-col xl:flex-row xl:gap-2">
                 {isVerticalLayout ? <VerticalLayout {...props} /> : <HorizontalLayout {...props} />}
             </div>
         </BindLogic>
@@ -74,11 +74,11 @@ function HorizontalLayout({
                     'w-3': isPlaylistCollapsed,
                 })}
                 // eslint-disable-next-line react/forbid-dom-props
-                style={isPlaylistCollapsed ? {} : { width: desiredSize ?? 320, minWidth: 240, maxWidth: '50%' }}
+                style={isPlaylistCollapsed ? {} : { width: desiredSize ?? 320, minWidth: 265, maxWidth: '50%' }}
             >
                 <Playlist {...props} />
                 {!isPlaylistCollapsed && (
-                    <Resizer {...resizerLogicProps} visible={false} offset={-4} handleClassName="rounded my-1" />
+                    <Resizer {...resizerLogicProps} visible={false} offset="0.25rem" handleClassName="rounded my-1" />
                 )}
             </div>
             <PlayerWrapper {...props} className="h-full flex-1 shrink min-w-96" />


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Ai icon on replay recordings sidebar was cropped out at top 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
removing `overflow-hidden` to show the icon fully
<img width="865" height="427" alt="Screenshot 2026-02-02 at 17 52 32" src="https://github.com/user-attachments/assets/098f3523-779f-4f6d-81da-81c454e9f3e0" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
