### PR TITLE
feat(mcp): add queryable memory system to MCP server

### DIFF
--- a/ee/urls.py
+++ b/ee/urls.py
@@ -45,6 +45,7 @@ def extend_api_router() -> None:
     )
 
     from ee.api import max_tools, session_summaries
+    from products.posthog_ai.backend import api as posthog_ai_api
 
     root_router.register(r"billing", billing.BillingViewset, "billing")
     root_router.register(r"license", license.LicenseViewSet)
@@ -93,6 +94,8 @@ def extend_api_router() -> None:
     environments_router.register(
         r"session_summaries", session_summaries.SessionSummariesViewSet, "environment_session_summaries", ["team_id"]
     )
+
+    environments_router.register(r"memories", posthog_ai_api.AgentMemoryViewSet, "environment_memories", ["team_id"])
 
 
 # The admin interface is disabled on self-hosted instances, as its misuse can be unsafe

--- a/products/posthog_ai/backend/api.py
+++ b/products/posthog_ai/backend/api.py
@@ -2,7 +2,7 @@ import json
 
 from django.db import transaction
 
-from rest_framework import serializers, status
+from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
@@ -66,11 +66,8 @@ class AgentMemoryViewSet(TeamAndOrgViewSetMixin, ModelViewSet):
         return AgentMemory.objects.filter(team=self.team)
 
     def perform_destroy(self, instance):
-        # Soft delete pattern: mark as deleted in embedding, then hard delete
-        instance.metadata = {**instance.metadata, "deleted": True}
-        with transaction.atomic():
-            instance.embed(EMBEDDING_MODEL)
-            instance.delete()
+        # Hard delete - the embedding service will handle cleanup
+        instance.delete()
 
     @action(detail=False, methods=["post"])
     def query(self, request, *args, **kwargs):

--- a/products/posthog_ai/backend/api.py
+++ b/products/posthog_ai/backend/api.py
@@ -1,0 +1,171 @@
+import json
+
+from django.db import transaction
+
+from rest_framework import serializers, status
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.viewsets import ModelViewSet
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+
+from products.posthog_ai.backend.models import AgentMemory
+
+EMBEDDING_MODEL = "text-embedding-3-small-1536"
+
+
+class AgentMemorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AgentMemory
+        fields = ["id", "contents", "metadata", "user_id", "created_at", "updated_at"]
+        read_only_fields = ["id", "user_id", "created_at", "updated_at"]
+
+    def create(self, validated_data):
+        validated_data["team"] = self.context["get_team"]()
+        validated_data["user"] = self.context["request"].user
+        with transaction.atomic():
+            memory = super().create(validated_data)
+            memory.embed(EMBEDDING_MODEL)
+        return memory
+
+    def update(self, instance, validated_data):
+        with transaction.atomic():
+            memory = super().update(instance, validated_data)
+            memory.embed(EMBEDDING_MODEL)
+        return memory
+
+
+class AgentMemoryQuerySerializer(serializers.Serializer):
+    query_text = serializers.CharField(help_text="The search query for finding relevant memories")
+    metadata_filter = serializers.DictField(
+        required=False,
+        default=dict,
+        help_text="Filter by metadata key-value pairs, e.g. {'type': 'preference'}",
+    )
+    user_only = serializers.BooleanField(
+        default=True, help_text="Search only current user's memories, or all team memories"
+    )
+    limit = serializers.IntegerField(default=10, min_value=1, max_value=100, help_text="Maximum number of results")
+
+
+class MemoryQueryResultSerializer(serializers.Serializer):
+    memory_id = serializers.CharField()
+    contents = serializers.CharField()
+    metadata = serializers.DictField()
+    distance = serializers.FloatField()
+
+
+class AgentMemoryViewSet(TeamAndOrgViewSetMixin, ModelViewSet):
+    scope_object = "conversation"
+    serializer_class = AgentMemorySerializer
+    queryset = AgentMemory.objects.all()
+
+    def get_queryset(self):
+        return AgentMemory.objects.filter(team=self.team)
+
+    def perform_destroy(self, instance):
+        # Soft delete pattern: mark as deleted in embedding, then hard delete
+        instance.metadata = {**instance.metadata, "deleted": True}
+        with transaction.atomic():
+            instance.embed(EMBEDDING_MODEL)
+            instance.delete()
+
+    @action(detail=False, methods=["post"])
+    def query(self, request, *args, **kwargs):
+        """Semantic search of memories using embeddings."""
+        serializer = AgentMemoryQuerySerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        query_text = serializer.validated_data["query_text"]
+        metadata_filter = serializer.validated_data.get("metadata_filter", {})
+        user_only = serializer.validated_data.get("user_only", True)
+        limit = serializer.validated_data.get("limit", 10)
+
+        # Build metadata filter conditions
+        metadata_conditions = []
+        metadata_placeholders: dict[str, ast.Expr] = {}
+        if metadata_filter:
+            for i, (key, value) in enumerate(metadata_filter.items()):
+                key_placeholder = f"meta_key_{i}"
+                value_placeholder = f"meta_value_{i}"
+                metadata_conditions.append(
+                    f"JSONExtractString(metadata, {{{key_placeholder}}}) = {{{value_placeholder}}}"
+                )
+                metadata_placeholders[key_placeholder] = ast.Constant(value=key)
+                metadata_placeholders[value_placeholder] = ast.Constant(value=str(value))
+
+        metadata_filter_sql = " AND ".join(metadata_conditions) if metadata_conditions else "1=1"
+
+        query = f"""
+            SELECT
+                document_id,
+                content,
+                metadata,
+                cosineDistance(embedding, embedText({{query_text}}, {{model_name}})) as distance
+            FROM (
+                SELECT
+                    document_id,
+                    argMax(content, inserted_at) as content,
+                    argMax(metadata, inserted_at) as metadata,
+                    argMax(embedding, inserted_at) as embedding
+                FROM document_embeddings
+                WHERE model_name = {{model_name}}
+                  AND product = 'posthog-ai'
+                  AND document_type = 'memory'
+                GROUP BY document_id, model_name, product, document_type, rendering
+            )
+            WHERE ({{skip_user_filter}} OR JSONExtractString(metadata, 'user_id') = {{user_id}})
+              AND NOT JSONExtractBool(metadata, 'deleted')
+              AND ({metadata_filter_sql})
+            ORDER BY distance ASC
+            LIMIT {{limit}}
+        """
+
+        user_id = str(request.user.id) if request.user else ""
+        skip_user_filter = not user_only or not request.user
+
+        result = execute_hogql_query(
+            query_type="AgentMemoryQuery",
+            query=query,
+            team=self.team,
+            placeholders={
+                "query_text": ast.Constant(value=query_text),
+                "model_name": ast.Constant(value=EMBEDDING_MODEL),
+                "user_id": ast.Constant(value=user_id),
+                "skip_user_filter": ast.Constant(value=skip_user_filter),
+                "limit": ast.Constant(value=limit),
+                **metadata_placeholders,
+            },
+        )
+
+        memories = []
+        for row in result.results or []:
+            document_id, content, metadata_str, distance = row
+            try:
+                metadata_dict = json.loads(metadata_str) if isinstance(metadata_str, str) else metadata_str or {}
+            except json.JSONDecodeError:
+                metadata_dict = {}
+
+            memories.append(
+                {
+                    "memory_id": document_id,
+                    "contents": content,
+                    "metadata": metadata_dict,
+                    "distance": distance,
+                }
+            )
+
+        return Response({"results": memories, "count": len(memories)})
+
+    @action(detail=False, methods=["get"])
+    def metadata_keys(self, request, *args, **kwargs):
+        """List all unique metadata keys used across memories in the team."""
+        memories = AgentMemory.objects.filter(team=self.team).values_list("metadata", flat=True)
+        all_keys: set[str] = set()
+        for metadata in memories:
+            if isinstance(metadata, dict):
+                all_keys.update(metadata.keys())
+
+        return Response({"keys": sorted(all_keys)})

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -782,5 +782,75 @@
             "openWorldHint": false,
             "readOnlyHint": true
         }
+    },
+    "memory-create": {
+        "description": "Store a new memory with content and optional metadata tags. Memories are searchable via semantic embedding and can include metadata for categorization. Use this to remember facts about the user's company, product, preferences, and past interactions.",
+        "category": "Memories",
+        "feature": "memories",
+        "summary": "Create a new memory to store facts or preferences.",
+        "title": "Create memory",
+        "required_scopes": ["conversation:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "memory-query": {
+        "description": "Search memories using semantic similarity. Can filter by metadata key-value pairs and choose to search only the current user's memories or all team memories. Use this to find relevant context about the user's product or previous discussions.",
+        "category": "Memories",
+        "feature": "memories",
+        "summary": "Search memories using semantic similarity.",
+        "title": "Query memories",
+        "required_scopes": ["conversation:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "memory-update": {
+        "description": "Update an existing memory's content or metadata by its ID. Use this to correct or enhance stored facts.",
+        "category": "Memories",
+        "feature": "memories",
+        "summary": "Update an existing memory.",
+        "title": "Update memory",
+        "required_scopes": ["conversation:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "memory-delete": {
+        "description": "Delete a memory by its ID. Use this to remove outdated or incorrect facts.",
+        "category": "Memories",
+        "feature": "memories",
+        "summary": "Delete a memory.",
+        "title": "Delete memory",
+        "required_scopes": ["conversation:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "memory-list-metadata-keys": {
+        "description": "Get all available metadata keys used across memories in the team. Useful for discovering the taxonomy of memory categories and understanding how memories are organized.",
+        "category": "Memories",
+        "feature": "memories",
+        "summary": "List all metadata keys used in memories.",
+        "title": "List memory metadata keys",
+        "required_scopes": ["conversation:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
     }
 }

--- a/services/mcp/typescript/src/api/client.ts
+++ b/services/mcp/typescript/src/api/client.ts
@@ -62,7 +62,6 @@ import type {
     AgentMemory,
     CreateMemoryInput,
     MemoryQueryResponse,
-    MemoryQueryResult,
     MetadataKeysResponse,
     QueryMemoryInput,
     UpdateMemoryInput,

--- a/services/mcp/typescript/src/schema/memories.ts
+++ b/services/mcp/typescript/src/schema/memories.ts
@@ -26,10 +26,14 @@ export const QueryMemoryInputSchema = z.object({
 })
 export type QueryMemoryInput = z.infer<typeof QueryMemoryInputSchema>
 
-export const UpdateMemoryInputSchema = z.object({
-    contents: z.string().optional().describe('New content for the memory'),
-    metadata: z.record(z.any()).optional().describe('New metadata for the memory'),
-})
+export const UpdateMemoryInputSchema = z
+    .object({
+        contents: z.string().optional().describe('New content for the memory'),
+        metadata: z.record(z.any()).optional().describe('New metadata for the memory'),
+    })
+    .refine((data) => data.contents !== undefined || data.metadata !== undefined, {
+        message: 'At least one of "contents" or "metadata" must be provided',
+    })
 export type UpdateMemoryInput = z.infer<typeof UpdateMemoryInputSchema>
 
 export const MemoryQueryResultSchema = z.object({

--- a/services/mcp/typescript/src/schema/memories.ts
+++ b/services/mcp/typescript/src/schema/memories.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+
+export const MemoryMetadataSchema = z.record(z.any()).optional()
+
+export const AgentMemorySchema = z.object({
+    id: z.string().uuid(),
+    contents: z.string(),
+    metadata: z.record(z.any()),
+    user_id: z.number().nullable(),
+    created_at: z.string(),
+    updated_at: z.string(),
+})
+export type AgentMemory = z.infer<typeof AgentMemorySchema>
+
+export const CreateMemoryInputSchema = z.object({
+    contents: z.string().describe('The content of the memory to store'),
+    metadata: z.record(z.any()).optional().describe('Optional metadata tags for the memory'),
+})
+export type CreateMemoryInput = z.infer<typeof CreateMemoryInputSchema>
+
+export const QueryMemoryInputSchema = z.object({
+    query_text: z.string().describe('The search query for finding relevant memories'),
+    metadata_filter: z.record(z.any()).optional().describe('Filter by metadata key-value pairs'),
+    user_only: z.boolean().default(true).describe('Search only current user memories, or all team memories'),
+    limit: z.number().default(10).describe('Maximum number of results to return'),
+})
+export type QueryMemoryInput = z.infer<typeof QueryMemoryInputSchema>
+
+export const UpdateMemoryInputSchema = z.object({
+    contents: z.string().optional().describe('New content for the memory'),
+    metadata: z.record(z.any()).optional().describe('New metadata for the memory'),
+})
+export type UpdateMemoryInput = z.infer<typeof UpdateMemoryInputSchema>
+
+export const MemoryQueryResultSchema = z.object({
+    memory_id: z.string(),
+    contents: z.string(),
+    metadata: z.record(z.any()),
+    distance: z.number(),
+})
+export type MemoryQueryResult = z.infer<typeof MemoryQueryResultSchema>
+
+export const MemoryQueryResponseSchema = z.object({
+    results: z.array(MemoryQueryResultSchema),
+    count: z.number(),
+})
+export type MemoryQueryResponse = z.infer<typeof MemoryQueryResponseSchema>
+
+export const MetadataKeysResponseSchema = z.object({
+    keys: z.array(z.string()),
+})
+export type MetadataKeysResponse = z.infer<typeof MetadataKeysResponseSchema>

--- a/services/mcp/typescript/src/schema/tool-inputs.ts
+++ b/services/mcp/typescript/src/schema/tool-inputs.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { CreateActionInputSchema, ListActionsInputSchema, UpdateActionInputSchema } from './actions'
+import { CreateMemoryInputSchema, QueryMemoryInputSchema, UpdateMemoryInputSchema } from './memories'
 import {
     AddInsightToDashboardSchema,
     CreateDashboardInputSchema,
@@ -460,3 +461,19 @@ export const EntitySearchSchema = z.object({
 export const DemoMcpUiAppsSchema = z.object({
     message: z.string().optional().describe('Optional message to include in the demo data'),
 })
+
+// Memories
+export const MemoryCreateSchema = CreateMemoryInputSchema
+
+export const MemoryQuerySchema = QueryMemoryInputSchema
+
+export const MemoryUpdateSchema = z.object({
+    memoryId: z.string().uuid().describe('The ID of the memory to update'),
+    data: UpdateMemoryInputSchema,
+})
+
+export const MemoryDeleteSchema = z.object({
+    memoryId: z.string().uuid().describe('The ID of the memory to delete'),
+})
+
+export const MemoryListMetadataKeysSchema = z.object({})

--- a/services/mcp/typescript/src/tools/index.ts
+++ b/services/mcp/typescript/src/tools/index.ts
@@ -50,6 +50,12 @@ import updateInsight from './insights/update'
 import getLLMCosts from './llmAnalytics/getLLMCosts'
 import logsListAttributeValues from './logs/listAttributeValues'
 import logsListAttributes from './logs/listAttributes'
+// Memories
+import createMemory from './memories/create'
+import deleteMemory from './memories/delete'
+import listMemoryMetadataKeys from './memories/listMetadataKeys'
+import queryMemory from './memories/query'
+import updateMemory from './memories/update'
 // Logs
 import logsQuery from './logs/query'
 // Organizations
@@ -162,6 +168,13 @@ const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
 
     // Search
     'entity-search': entitySearch,
+
+    // Memories
+    'memory-create': createMemory,
+    'memory-query': queryMemory,
+    'memory-update': updateMemory,
+    'memory-delete': deleteMemory,
+    'memory-list-metadata-keys': listMemoryMetadataKeys,
 
     // Demo
     'demo-mcp-ui-apps': demoMcpUiApps,

--- a/services/mcp/typescript/src/tools/memories/create.ts
+++ b/services/mcp/typescript/src/tools/memories/create.ts
@@ -1,0 +1,32 @@
+import type { z } from 'zod'
+
+import { MemoryCreateSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = MemoryCreateSchema
+type Params = z.infer<typeof schema>
+
+export const createHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.memories({ projectId }).create({
+        data: params,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to create memory: ${result.error.message}`)
+    }
+
+    return {
+        message: `Memory created successfully with ID: ${result.data.id}`,
+        memory: result.data,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'memory-create',
+    schema,
+    handler: createHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/memories/delete.ts
+++ b/services/mcp/typescript/src/tools/memories/delete.ts
@@ -1,0 +1,31 @@
+import type { z } from 'zod'
+
+import { MemoryDeleteSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = MemoryDeleteSchema
+type Params = z.infer<typeof schema>
+
+export const deleteHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.memories({ projectId }).delete({
+        memoryId: params.memoryId,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to delete memory: ${result.error.message}`)
+    }
+
+    return {
+        message: `Memory ${params.memoryId} deleted successfully.`,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'memory-delete',
+    schema,
+    handler: deleteHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/memories/listMetadataKeys.ts
+++ b/services/mcp/typescript/src/tools/memories/listMetadataKeys.ts
@@ -1,0 +1,39 @@
+import type { z } from 'zod'
+
+import { MemoryListMetadataKeysSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = MemoryListMetadataKeysSchema
+type Params = z.infer<typeof schema>
+
+export const listMetadataKeysHandler: ToolBase<typeof schema>['handler'] = async (context: Context, _params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.memories({ projectId }).listMetadataKeys()
+
+    if (!result.success) {
+        throw new Error(`Failed to list metadata keys: ${result.error.message}`)
+    }
+
+    const { keys } = result.data
+
+    if (keys.length === 0) {
+        return {
+            message: 'No metadata keys found in any memories.',
+            keys: [],
+        }
+    }
+
+    return {
+        message: `Available metadata keys across all memories: ${keys.join(', ')}`,
+        keys,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'memory-list-metadata-keys',
+    schema,
+    handler: listMetadataKeysHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/memories/query.ts
+++ b/services/mcp/typescript/src/tools/memories/query.ts
@@ -1,0 +1,43 @@
+import type { z } from 'zod'
+
+import { MemoryQuerySchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = MemoryQuerySchema
+type Params = z.infer<typeof schema>
+
+export const queryHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.memories({ projectId }).query({
+        data: params,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to query memories: ${result.error.message}`)
+    }
+
+    const { results, count } = result.data
+
+    if (count === 0) {
+        return {
+            message: 'No memories found matching your query.',
+            results: [],
+            count: 0,
+        }
+    }
+
+    return {
+        message: `Found ${count} relevant memories.`,
+        results,
+        count,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'memory-query',
+    schema,
+    handler: queryHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/memories/update.ts
+++ b/services/mcp/typescript/src/tools/memories/update.ts
@@ -1,0 +1,33 @@
+import type { z } from 'zod'
+
+import { MemoryUpdateSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = MemoryUpdateSchema
+type Params = z.infer<typeof schema>
+
+export const updateHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.memories({ projectId }).update({
+        memoryId: params.memoryId,
+        data: params.data,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to update memory: ${result.error.message}`)
+    }
+
+    return {
+        message: `Memory ${params.memoryId} updated successfully.`,
+        memory: result.data,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'memory-update',
+    schema,
+    handler: updateHandler,
+})
+
+export default tool


### PR DESCRIPTION
## Summary
Adds the queryable memory system used by PostHog AI chat to the MCP server, enabling external systems to create, query, update, and delete memories via MCP tools.

## Changes

### Backend (Django)
- Created `AgentMemoryViewSet` with full CRUD operations
- Added semantic search endpoint using HogQL embeddings (`/query/`)
- Added metadata keys listing endpoint (`/metadata_keys/`)
- Registered routes at `/api/environments/{team_id}/memories/`
- Uses existing `conversation` scope for access control

### MCP Server (TypeScript)
- Added `memories()` API client method with all operations
- Created 5 new MCP tools:
  - `memory-create` - Store facts/preferences
  - `memory-query` - Semantic search with metadata filtering
  - `memory-update` - Update existing memory
  - `memory-delete` - Remove memory
  - `memory-list-metadata-keys` - Discover taxonomy
- Added tool definitions with `conversation:read`/`conversation:write` scopes

## API Endpoints
- `POST /api/environments/{team_id}/memories/` - Create
- `GET /api/environments/{team_id}/memories/{id}/` - Get
- `PATCH /api/environments/{team_id}/memories/{id}/` - Update
- `DELETE /api/environments/{team_id}/memories/{id}/` - Delete
- `POST /api/environments/{team_id}/memories/query/` - Semantic search
- `GET /api/environments/{team_id}/memories/metadata_keys/` - List keys

## Test plan
- [ ] Test creating a memory via MCP tool
- [ ] Test semantic search with various queries
- [ ] Test metadata filtering
- [ ] Verify memories are stored with correct user/team association
- [ ] Check that conversation scope correctly controls access

🤖 Generated with [Claude Code](https://claude.com/claude-code)