### PR TITLE
fix(cdp): properly cache persons with ":" in distinct ID

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.consumer.ts
@@ -27,7 +27,6 @@ export class CdpCyclotronWorkerHogFlow extends CdpCyclotronWorker<CdpCyclotronWo
 
     @instrumented('cdpConsumer.handleEachBatch.executeInvocations')
     public async processInvocations(invocations: CyclotronJobInvocation[]): Promise<CyclotronJobInvocationResult[]> {
-        this.personsManager.clear() // We want to load persons fresh each time
         const loadedInvocations = await this.loadHogFlows(invocations)
         return await Promise.all(loadedInvocations.map((item) => this.hogFlowExecutor.execute(item)))
     }

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.test.ts
@@ -249,26 +249,6 @@ describe('CdpCyclotronWorkerHogFlow', () => {
             ])
         })
 
-        it('should clear the cache each time', async () => {
-            const personManagerSpy = jest.spyOn(processor['personsManager'] as any, 'fetchPersons')
-            await processor.processInvocations(invocations)
-            expect(personManagerSpy).toHaveBeenCalledTimes(1)
-            expect(personManagerSpy.mock.calls[0][0]).toEqual([
-                `${team.id}:distinct_A_1`,
-                `${team.id}:distinct_A_2`,
-                `${team2.id}:distinct_A_1`,
-                `${team2.id}:missing_person`,
-            ])
-            await processor.processInvocations(invocations)
-            expect(personManagerSpy).toHaveBeenCalledTimes(2)
-            expect(personManagerSpy.mock.calls[1][0]).toEqual([
-                `${team.id}:distinct_A_1`,
-                `${team.id}:distinct_A_2`,
-                `${team2.id}:distinct_A_1`,
-                `${team2.id}:missing_person`,
-            ])
-        })
-
         it('should skip invocations when workflow is disabled after being queued', async () => {
             // Scenario: workflow is active, invocations are queued, then workflow is disabled
             // Remaining invocations should be skipped

--- a/nodejs/src/cdp/services/managers/persons-manager.service.test.ts
+++ b/nodejs/src/cdp/services/managers/persons-manager.service.test.ts
@@ -106,6 +106,64 @@ describe('PersonsManager', () => {
         ])
     })
 
+    it('returns the persons requested when distinct IDs contain colons', async () => {
+        const TIMESTAMP = DateTime.fromISO('2000-10-14T11:42:06.502Z').toUTC()
+        const result1 = await personRepository.createPerson(
+            TIMESTAMP,
+            { foo: '1' },
+            {},
+            {},
+            team.id,
+            null,
+            true,
+            new UUIDT().toString(),
+            { distinctId: 'foo:distinct_id_A_1' }
+        )
+        if (!result1.success) {
+            throw new Error('Failed to create person')
+        }
+        const person1 = result1.person
+        const result2 = await personRepository.createPerson(
+            TIMESTAMP,
+            { foo: '2' },
+            {},
+            {},
+            team.id,
+            null,
+            true,
+            new UUIDT().toString(),
+            { distinctId: 'foo:bar:distinct_id_B_1' }
+        )
+        if (!result2.success) {
+            throw new Error('Failed to create person')
+        }
+        const person2 = result2.person
+
+        const res = await Promise.all([
+            manager.get({ teamId: team.id, distinctId: 'foo:distinct_id_A_1' }),
+            manager.get({ teamId: team.id, distinctId: 'foo:bar:distinct_id_B_1' }),
+        ])
+
+        expect(res).toEqual([
+            {
+                distinct_id: 'foo:distinct_id_A_1',
+                id: person1.uuid,
+                properties: {
+                    foo: '1',
+                },
+                team_id: team.id,
+            },
+            {
+                distinct_id: 'foo:bar:distinct_id_B_1',
+                id: person2.uuid,
+                properties: {
+                    foo: '2',
+                },
+                team_id: team.id,
+            },
+        ])
+    })
+
     it('returns the different persons for different teams', async () => {
         const res = await Promise.all([
             manager.get({ teamId: team.id, distinctId: 'distinct_id_A_1' }),

--- a/nodejs/src/cdp/services/managers/persons-manager.service.ts
+++ b/nodejs/src/cdp/services/managers/persons-manager.service.ts
@@ -35,7 +35,7 @@ export class PersonsManagerService {
         this.lazyLoader = new LazyLoader({
             name: 'person_manager',
             loader: async (ids) => await this.fetchPersons(ids),
-            refreshAgeMs: 1000 * 60 * 5, // 5 minutes
+            refreshAgeMs: 1000 * 60, // 1 minute
         })
     }
 

--- a/nodejs/src/cdp/services/managers/persons-manager.service.ts
+++ b/nodejs/src/cdp/services/managers/persons-manager.service.ts
@@ -17,8 +17,8 @@ export type BatchPersonGetArgs = {
 const toKey = (args: PersonGetArgs): string => `${args.teamId}:${args.distinctId}`
 
 const fromKey = (key: string): PersonGetArgs => {
-    const [teamId, distinctId] = key.split(':')
-    return { teamId: parseInt(teamId), distinctId }
+    const [teamId, ...distinctIdParts] = key.split(':')
+    return { teamId: parseInt(teamId), distinctId: distinctIdParts.join(':') }
 }
 
 export type PersonManagerPerson = {

--- a/nodejs/src/cdp/services/managers/persons-manager.service.ts
+++ b/nodejs/src/cdp/services/managers/persons-manager.service.ts
@@ -35,7 +35,7 @@ export class PersonsManagerService {
         this.lazyLoader = new LazyLoader({
             name: 'person_manager',
             loader: async (ids) => await this.fetchPersons(ids),
-            refreshAgeMs: 1000 * 60, // 1 minute
+            refreshAgeMs: 1000 * 60, // 1 minute, so that we don't hold stale person data for too long
         })
     }
 

--- a/nodejs/src/cdp/services/managers/persons-manager.service.ts
+++ b/nodejs/src/cdp/services/managers/persons-manager.service.ts
@@ -35,6 +35,7 @@ export class PersonsManagerService {
         this.lazyLoader = new LazyLoader({
             name: 'person_manager',
             loader: async (ids) => await this.fetchPersons(ids),
+            refreshAgeMs: 1000 * 60 * 5, // 5 minutes
         })
     }
 

--- a/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
+++ b/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
@@ -106,7 +106,7 @@ export const EmailSetupModal = (props: EmailSetupModalLogicProps): JSX.Element =
                                 <thead>
                                     <tr className="border-b">
                                         <th className="py-2 text-left">Type</th>
-                                        <th className="py-2 text-left">Target</th>
+                                        <th className="py-2 text-left">Name</th>
                                         <th className="py-2 text-left">Value</th>
                                         <th className="py-2 text-left">Status</th>
                                     </tr>


### PR DESCRIPTION
## Problem

If a customer identifies users with `:` in a distinct ID, our persons manager will never be able to find them due to how we form our redis cache key

## Changes

- Make the cache key agnostic to which characters are used (team ID will never include a colon as its a numerical key)
- While investigating we noticed poor person lazy loader cache usage:
<img width="1318" height="431" alt="image" src="https://github.com/user-attachments/assets/8f02b7c1-7fa3-437f-b3ff-f1fbc769ee68" />
  - to address this we're removing the `lazyLoader.clear()` on the hogflow executor, and using a 1 minute TTL instead.

## How did you test this code?

Added a test to verify behavior

## Publish to changelog?

no