### PR TITLE
fix: fix non array frames

### DIFF
--- a/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
+++ b/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
@@ -42,7 +42,7 @@ export function ExceptionRenderer({
             return false
         }
 
-        if (!stackTrace.frames || stackTrace.frames.length === 0) {
+        if (!Array.isArray(stackTrace.frames) || stackTrace.frames.length === 0) {
             return false
         }
 

--- a/frontend/src/lib/components/Errors/errorPropertiesLogic.ts
+++ b/frontend/src/lib/components/Errors/errorPropertiesLogic.ts
@@ -91,7 +91,10 @@ export const errorPropertiesLogic = kea<errorPropertiesLogicType>([
         frames: [
             (s) => [s.exceptionList],
             (exceptionList: ErrorTrackingException[]) => {
-                return exceptionList.flatMap((e) => e.stacktrace?.frames ?? []) as ErrorTrackingStackFrame[]
+                return exceptionList.flatMap((e) => {
+                    const frames = e.stacktrace?.frames
+                    return Array.isArray(frames) ? frames : []
+                }) as ErrorTrackingStackFrame[]
             },
         ],
         uuid: [(_, props) => [props.id], (id: ErrorEventId) => id],

--- a/frontend/src/lib/components/Errors/utils.ts
+++ b/frontend/src/lib/components/Errors/utils.ts
@@ -12,7 +12,10 @@ import {
 } from './types'
 
 export function stacktraceHasInAppFrames(stacktrace: ErrorTrackingException['stacktrace']): boolean {
-    return stacktrace?.frames?.some(({ in_app }) => in_app) ?? false
+    if (!stacktrace?.frames || !Array.isArray(stacktrace.frames)) {
+        return false
+    }
+    return stacktrace.frames.some(({ in_app }) => in_app)
 }
 
 export function getRuntimeFromLib(lib?: string | null): ErrorTrackingRuntime {
@@ -243,7 +246,8 @@ export function formatResolvedName(
 }
 
 export function formatType(exception: Pick<ErrorTrackingException, 'module' | 'type' | 'stacktrace'>): string {
-    const hasJavaFrames = exception.stacktrace?.frames?.some((frame) => frame.lang === 'java')
+    const frames = exception.stacktrace?.frames
+    const hasJavaFrames = Array.isArray(frames) && frames.some((frame) => frame.lang === 'java')
     return exception.module && hasJavaFrames ? `${exception.module}.${exception.type}` : exception.type
 }
 


### PR DESCRIPTION
Fixes case when frames is a truthy non-array value. Now we can properly display error message and a missing stack trace banner

<img width="1076" height="361" alt="image" src="https://github.com/user-attachments/assets/083227e9-6598-4be4-8f2f-b902dbf44cb9" />
