### PR TITLE
feat(product tours): allow moving sidebar to either side of the screen

### DIFF
--- a/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
+++ b/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
-import { IconCheck, IconCursorClick, IconExternal, IconPlay, IconPlus, IconX } from '@posthog/icons'
+import { IconCheck, IconCursorClick, IconExternal, IconPlay, IconPlus, IconSidebarClose, IconX } from '@posthog/icons'
 import { LemonButton, LemonInput, Link } from '@posthog/lemon-ui'
 
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
@@ -33,6 +33,7 @@ export function ProductToursSidebar(): JSX.Element | null {
         isPreviewing,
         pendingEditInPostHog,
         sessionRecordingConsent,
+        sidebarPosition,
     } = useValues(productToursLogic)
     const {
         selectTour,
@@ -46,6 +47,7 @@ export function ProductToursSidebar(): JSX.Element | null {
         updateRects,
         setSidebarTransitioning,
         setSessionRecordingConsent,
+        toggleSidebarPosition,
     } = useActions(productToursLogic)
 
     const steps = tourForm?.steps || []
@@ -111,8 +113,9 @@ export function ProductToursSidebar(): JSX.Element | null {
 
     useEffect(() => {
         if (selectedTourId !== null) {
-            document.body.style.transition = `margin-right ${PRODUCT_TOURS_SIDEBAR_TRANSITION_MS}ms ease-out`
-            document.body.style.marginRight = `${SIDEBAR_WIDTH}px`
+            document.body.style.transition = `margin ${PRODUCT_TOURS_SIDEBAR_TRANSITION_MS}ms ease-out`
+            document.body.style.marginLeft = sidebarPosition === 'left' ? `${SIDEBAR_WIDTH}px` : ''
+            document.body.style.marginRight = sidebarPosition === 'right' ? `${SIDEBAR_WIDTH}px` : ''
 
             const timer = setTimeout(() => {
                 setSidebarTransitioning(false)
@@ -121,10 +124,12 @@ export function ProductToursSidebar(): JSX.Element | null {
 
             return () => {
                 clearTimeout(timer)
+                document.body.style.marginLeft = ''
                 document.body.style.marginRight = ''
+                document.body.style.transition = ''
             }
         }
-    }, [selectedTourId, updateRects, setSidebarTransitioning])
+    }, [selectedTourId, sidebarPosition, updateRects, setSidebarTransitioning])
 
     if (selectedTourId === null) {
         return null
@@ -141,12 +146,16 @@ export function ProductToursSidebar(): JSX.Element | null {
                 style={{
                     position: 'fixed',
                     top: 0,
-                    right: 0,
+                    [sidebarPosition]: 0,
                     bottom: 0,
                     width: SIDEBAR_WIDTH,
                     backgroundColor: 'var(--color-bg-3000)',
-                    borderLeft: '1px solid var(--border-bold-3000)',
-                    boxShadow: '-4px 0 24px rgba(0, 0, 0, 0.4)',
+                    borderLeft: sidebarPosition === 'right' ? '1px solid var(--border-bold-3000)' : 'none',
+                    borderRight: sidebarPosition === 'left' ? '1px solid var(--border-bold-3000)' : 'none',
+                    boxShadow:
+                        sidebarPosition === 'right'
+                            ? '-4px 0 24px rgba(0, 0, 0, 0.4)'
+                            : '4px 0 24px rgba(0, 0, 0, 0.4)',
                     zIndex: 2147483019,
                     pointerEvents: 'auto',
                     color: 'var(--text-3000)',
@@ -156,13 +165,26 @@ export function ProductToursSidebar(): JSX.Element | null {
                 <div className="p-4 border-b border-border-bold-3000 bg-bg-light">
                     <div className="flex items-center justify-between mb-3">
                         <h2 className="m-0 text-sm font-semibold">{isNewTour ? 'New tour' : 'Edit tour'}</h2>
-                        <button
-                            type="button"
-                            onClick={() => selectTour(null)}
-                            className="p-1 rounded border-none bg-transparent cursor-pointer text-muted-3000 hover:text-text-3000 flex items-center justify-center"
-                        >
-                            <IconX className="w-4 h-4" />
-                        </button>
+                        <div className="flex items-center gap-1">
+                            <button
+                                type="button"
+                                onClick={toggleSidebarPosition}
+                                className="p-1 rounded border-none bg-transparent cursor-pointer text-muted-3000 hover:text-text-3000 flex items-center justify-center"
+                                title={`Move to ${sidebarPosition === 'right' ? 'left' : 'right'}`}
+                            >
+                                <IconSidebarClose
+                                    className="w-4 h-4"
+                                    style={{ transform: sidebarPosition === 'right' ? 'scaleX(-1)' : undefined }}
+                                />
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => selectTour(null)}
+                                className="p-1 rounded border-none bg-transparent cursor-pointer text-muted-3000 hover:text-text-3000 flex items-center justify-center"
+                            >
+                                <IconX className="w-4 h-4" />
+                            </button>
+                        </div>
                     </div>
 
                     <LemonInput

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -199,6 +199,9 @@ export const productToursLogic = kea<productToursLogicType>([
 
         // Sidebar transition state (hide highlights during animation)
         setSidebarTransitioning: (transitioning: boolean) => ({ transitioning }),
+
+        // Sidebar position toggle
+        toggleSidebarPosition: true,
     }),
 
     loaders(() => ({
@@ -314,6 +317,13 @@ export const productToursLogic = kea<productToursLogicType>([
             { persist: true },
             {
                 setSessionRecordingConsent: (_, { consent }) => consent,
+            },
+        ],
+        sidebarPosition: [
+            'right' as 'left' | 'right',
+            { persist: true },
+            {
+                toggleSidebarPosition: (state) => (state === 'right' ? 'left' : 'right'),
             },
         ],
     }),


### PR DESCRIPTION
## Problem

the sidebar is a fixed-position element which means it'll collide with other users' fixed position elements

this is a hard problem to solve, because we don't want to try to detect & reposition everything

so... let users just move it to the left or right as needed :)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

https://screen.studio/share/D4PN2kGk

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
