### PR TITLE
fix(flags): simplify readiness probe to prevent cascade failures

### DIFF
--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -117,7 +117,7 @@ pub async fn serve<F>(
     let health = HealthRegistry::new("liveness");
 
     // Liveness checks only verify the process is alive (simple heartbeat loop).
-    // Readiness checks (in router.rs) verify DB connectivity before accepting traffic.
+    // Readiness checks (in router.rs) verify the pod isn't shutting down via a preStop marker file.
     let simple_loop = health
         .register(
             "simple_loop".to_string(),


### PR DESCRIPTION
## Problem

During high load, the `/_readiness` endpoint blocks on `pool.acquire()` for all 4 database pools. This can timeout and cause pods to be pulled from Kubernetes rotation—exactly when we need them most. This creates a cascade failure where busy pods are removed, increasing load on remaining pods.

Readiness should answer "can this pod serve traffic?" not "are all dependencies up?" During DB outages, keeping pods in rotation (returning fast errors) is better than removing them entirely.

## Changes

- Replace the custom `readiness()` function with the shared `readiness_handler` from the `health` crate, matching the pattern used by capture, personhog-router, and personhog-replica
- The new handler only checks for a preStop shutdown marker file (`/tmp/shutdown`) — no database connections acquired
- Pool warmup still happens at startup via the `/_startup` probe, which is unchanged

### Probe behavior after this change

| Probe | Behavior |
|-------|----------|
| `/_startup` | Warms DB pools (best-effort, never blocks startup) |
| `/_readiness` | Checks for `/tmp/shutdown` marker file only |
| `/_liveness` | Heartbeat loop |

## How did you test this code?

- Existing unit tests for `test_pool_connection`, `startup`, and aliased pool handling all pass
- Manual verification:
  ```bash
  # Readiness returns 200 normally
  curl -v http://localhost:3001/_readiness

  # Readiness returns 503 when shutdown marker exists
  touch /tmp/shutdown
  curl -v http://localhost:3001/_readiness
  rm /tmp/shutdown

  # Readiness still returns 200 with Postgres stopped
  docker stop posthog-db-1
  curl -v http://localhost:3001/_readiness
  docker start posthog-db-1
  ```

## Publish to changelog?

Do not publish to changelog

Fixes #46457