### PR TITLE
feat(surveys): add thumb response viz, llma link from response table

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -24,6 +24,7 @@ import { HTMLEditor } from './SurveyAppearanceUtils'
 import { SurveyDragHandle } from './SurveyDragHandle'
 import { NewSurvey, SCALE_OPTIONS, SURVEY_RATING_SCALE, SurveyQuestionLabel } from './constants'
 import { surveyLogic } from './surveyLogic'
+import { isThumbQuestion } from './utils'
 
 type SurveyQuestionHeaderProps = {
     index: number
@@ -148,10 +149,6 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
     const canSkipSubmitButton = canQuestionSkipSubmitButton(question)
     const shouldShowNpsCheckbox =
         question.type === SurveyQuestionType.Rating && question.scale === SURVEY_RATING_SCALE.NPS_10_POINT
-    const isThumbSurvey =
-        question.type === SurveyQuestionType.Rating &&
-        question.display === 'emoji' &&
-        question.scale === SURVEY_RATING_SCALE.THUMB_2_POINT
 
     const confirmQuestionTypeChange = (
         index: number,
@@ -301,7 +298,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                 />
                             </LemonField>
                         </div>
-                        {!isThumbSurvey && (
+                        {!isThumbQuestion(question) && (
                             <div className="flex flex-row gap-4">
                                 <LemonField name="lowerBoundLabel" label="Lower bound label" className="w-1/2">
                                     <LemonInput value={question.lowerBoundLabel || ''} />

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -1,10 +1,10 @@
 import './SurveyView.scss'
 
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
-import { IconArchive, IconGraph, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonDivider } from '@posthog/lemon-ui'
+import { IconArchive, IconGraph, IconLlmAnalytics, IconThumbsDown, IconThumbsUp, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonDialog, LemonDivider, Tooltip } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
@@ -40,6 +40,7 @@ import {
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { Query } from '~/queries/Query/Query'
+import { QueryContextColumn } from '~/queries/types'
 import {
     AccessControlLevel,
     AccessControlResourceType,
@@ -55,8 +56,27 @@ import {
 
 import { SurveyHeadline } from './SurveyHeadline'
 import { SurveysDisabledBanner } from './SurveySettings'
+import { getSurveyResponse, isThumbQuestion } from './utils'
 
 const RESOURCE_TYPE = 'survey'
+
+const getTraceIdFromRecord = (record: unknown): string | null => {
+    if (!Array.isArray(record)) {
+        return null
+    }
+    const event = record[0] as { properties?: { $ai_trace_id?: string } } | undefined
+    return event?.properties?.$ai_trace_id ?? null
+}
+
+const getThumbIcon = (value: unknown): JSX.Element | null => {
+    if (value == '1') {
+        return <IconThumbsUp className="text-brand-blue" />
+    }
+    if (value == '2') {
+        return <IconThumbsDown className="text-warning" />
+    }
+    return null
+}
 
 export function SurveyView({ id }: { id: string }): JSX.Element {
     const { survey, surveyLoading } = useValues(surveyLogic)
@@ -365,6 +385,7 @@ function SurveyResponsesByQuestionV2(): JSX.Element {
 
 export function SurveyResult({ disableEventsTable }: { disableEventsTable?: boolean }): JSX.Element {
     const {
+        survey,
         dataTableQuery,
         surveyLoading,
         surveyAsInsightURL,
@@ -373,6 +394,60 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
         archivedResponseUuids,
         isSurveyHeadlineEnabled,
     } = useValues(surveyLogic)
+
+    /**
+     * custom column renderer that does:
+     * - shows LLM trace button on the first question, if the event has an $ai_trace_id
+     * - shows thumbs up/down icons instead of the raw '1'/'2' data for thumb questions
+     */
+    const surveyColumnRenderers = useMemo(() => {
+        const columns: Record<string, QueryContextColumn> = {}
+
+        survey.questions.forEach((question, index) => {
+            const isThumb = isThumbQuestion(question)
+            const isFirstQuestion = index === 0
+
+            if (!isThumb && !isFirstQuestion) {
+                return
+            }
+
+            const columnName = getSurveyResponse(question, index)
+            columns[columnName] = {
+                render: ({ value, record }) => {
+                    const traceId = isFirstQuestion ? getTraceIdFromRecord(record) : null
+
+                    return (
+                        <span className="flex items-center gap-2">
+                            {/* show LLM trace button on the first question if we have $ai_trace_id */}
+                            {traceId && (
+                                <Tooltip title="View LLM trace">
+                                    <LemonButton
+                                        size="xsmall"
+                                        icon={
+                                            <IconLlmAnalytics className="text-[var(--color-product-llm-analytics-light)]" />
+                                        }
+                                        to={urls.llmAnalyticsTrace(traceId)}
+                                    />
+                                </Tooltip>
+                            )}
+
+                            {/* replace '1' and '2' with thumb icon+text if it's a thumb question */}
+                            {isThumb ? (
+                                <span className="flex items-center gap-1">
+                                    {getThumbIcon(value)}
+                                    Thumbs {value == '1' ? 'up' : 'down'}
+                                </span>
+                            ) : (
+                                value
+                            )}
+                        </span>
+                    )
+                },
+            }
+        })
+
+        return columns
+    }, [survey.questions])
 
     const atLeastOneResponse = !!processedSurveyStats?.[SurveyEventName.SENT].total_count
     return (
@@ -400,6 +475,7 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
                                 <Query
                                     query={dataTableQuery}
                                     context={{
+                                        columns: surveyColumnRenderers,
                                         rowProps: (record: unknown) => {
                                             // "mute" archived records
                                             if (typeof record !== 'object' || !record || !('result' in record)) {

--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -28,6 +28,12 @@ function QuestionTitle({
     questionIndex,
     totalResponses = 0,
 }: Props & { totalResponses?: number }): JSX.Element {
+    // only show analzye button if there's text to analyze
+    const shouldShowAnalyzeButton =
+        question.type === SurveyQuestionType.Open ||
+        (question.type === SurveyQuestionType.SingleChoice && question.hasOpenChoice) ||
+        (question.type === SurveyQuestionType.MultipleChoice && question.hasOpenChoice)
+
     return (
         <div className="flex flex-col">
             <div className="inline-flex gap-1 max-w-fit font-semibold text-secondary items-center">
@@ -57,7 +63,8 @@ function QuestionTitle({
                 <h3 className="text-xl font-bold mb-0">
                     Question {questionIndex + 1}: {question.question}
                 </h3>
-                <AnalyzeResponsesButton />
+
+                {shouldShowAnalyzeButton && <AnalyzeResponsesButton />}
             </div>
         </div>
     )

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -4,7 +4,7 @@ import posthog from 'posthog-js'
 
 import { dayjs } from 'lib/dayjs'
 import { dateStringToDayJs } from 'lib/utils'
-import { NEW_SURVEY, NewSurvey, SURVEY_CREATED_SOURCE } from 'scenes/surveys/constants'
+import { NEW_SURVEY, NewSurvey, SURVEY_CREATED_SOURCE, SURVEY_RATING_SCALE } from 'scenes/surveys/constants'
 import { SurveyRatingResults } from 'scenes/surveys/surveyLogic'
 
 import {
@@ -658,4 +658,12 @@ export function duplicateExistingSurvey(survey: Survey | NewSurvey): Partial<Sur
         targeting_flag_filters: survey.targeting_flag?.filters ?? NEW_SURVEY.targeting_flag_filters,
         linked_flag_id: survey.linked_flag?.id ?? NEW_SURVEY.linked_flag_id,
     }
+}
+
+export const isThumbQuestion = (question: SurveyQuestion): boolean => {
+    return (
+        question.type === SurveyQuestionType.Rating &&
+        question.display === 'emoji' &&
+        question.scale === SURVEY_RATING_SCALE.THUMB_2_POINT
+    )
 }


### PR DESCRIPTION
## Problem

- thumb questions do not have good viz right now (it's broken)
- not easy to link from survey response -> llm trace

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- adds legit viz for thumb questions
- adds llma button on first question column if the event has `$ai_trace_id`
- updates `generate_random_surveys`
  - adds thumb questions
  - adds `--with-trace-ids` option to attach fake trace IDs to `survey sent` events

![Screenshot 2026-02-02 at 1.54.26 PM.png](https://app.graphite.com/user-attachments/assets/cc28e841-9a89-4488-8ae3-1c3a35a70596.png)

![Screenshot 2026-02-02 at 2.00.43 PM.png](https://app.graphite.com/user-attachments/assets/4c975bc3-f11d-46cd-a232-d1d819339d47.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
manual testing
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
sure