### PR TITLE
chore(flags): use lazy pool initialization to prevent startup failures

### DIFF
--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -68,17 +68,17 @@ impl Default for PoolConfig {
 
 /// Legacy function for backward compatibility - uses default production settings
 /// New services should use get_pool_with_config() with their own PoolConfig
-pub async fn get_pool(url: &str, max_connections: u32) -> Result<PgPool, sqlx::Error> {
+pub fn get_pool(url: &str, max_connections: u32) -> Result<PgPool, sqlx::Error> {
     let config = PoolConfig {
         max_connections,
         ..Default::default()
     };
-    get_pool_with_config(url, config).await
+    get_pool_with_config(url, config)
 }
 
 /// Legacy function for backward compatibility - uses default production settings except for timeout
 /// New services should use get_pool_with_config() with their own PoolConfig
-pub async fn get_pool_with_timeout(
+pub fn get_pool_with_timeout(
     url: &str,
     max_connections: u32,
     acquire_timeout: Duration,
@@ -88,12 +88,12 @@ pub async fn get_pool_with_timeout(
         acquire_timeout,
         ..Default::default()
     };
-    get_pool_with_config(url, config).await
+    get_pool_with_config(url, config)
 }
 
 /// Creates a database pool with the provided configuration
 /// This is the recommended function for services to use
-pub async fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPool, sqlx::Error> {
+pub fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPool, sqlx::Error> {
     let mut options = PgPoolOptions::new()
         .min_connections(config.min_connections)
         .max_connections(config.max_connections)
@@ -118,7 +118,7 @@ pub async fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPoo
         });
     }
 
-    options.connect(url).await
+    options.connect_lazy(url)
 }
 
 #[async_trait]

--- a/rust/common/database/src/lib.rs
+++ b/rust/common/database/src/lib.rs
@@ -91,8 +91,15 @@ pub fn get_pool_with_timeout(
     get_pool_with_config(url, config)
 }
 
-/// Creates a database pool with the provided configuration
-/// This is the recommended function for services to use
+/// Creates a database pool with the provided configuration.
+///
+/// This function creates a *lazy* database pool: connections are not
+/// established until they are first acquired from the pool. URL parsing
+/// errors are still detected immediately when this function is called, but
+/// network connectivity and authentication errors will only be surfaced on
+/// the first actual connection use.
+///
+/// This is the recommended function for services to use.
 pub fn get_pool_with_config(url: &str, config: PoolConfig) -> Result<PgPool, sqlx::Error> {
     let mut options = PgPoolOptions::new()
         .min_connections(config.min_connections)

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -469,7 +469,7 @@ mod tests {
     #[tokio::test]
     async fn token_is_returned_correctly() {
         let redis_client = setup_redis_client(None).await;
-        let pg_client = setup_pg_reader_client(None).await;
+        let pg_client = setup_pg_reader_client(None);
         let team = insert_new_team_in_redis(redis_client.clone())
             .await
             .expect("Failed to insert new team in Redis");
@@ -505,7 +505,7 @@ mod tests {
     #[tokio::test]
     async fn test_error_cases() {
         let redis_client = setup_redis_client(None).await;
-        let pg_client = setup_pg_reader_client(None).await;
+        let pg_client = setup_pg_reader_client(None);
         let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
         let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
 

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -171,7 +171,7 @@ mod tests {
     #[tokio::test]
     async fn test_verify_token() {
         let redis_client = setup_redis_client(None).await;
-        let pg_client = setup_pg_reader_client(None).await;
+        let pg_client = setup_pg_reader_client(None);
         let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
         let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
         let team = insert_new_team_in_redis(redis_client.clone())
@@ -198,7 +198,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_team_from_cache_or_pg() {
         let redis_client = setup_redis_client(None).await;
-        let pg_client = setup_pg_reader_client(None).await;
+        let pg_client = setup_pg_reader_client(None);
         let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
         let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
         let team = insert_new_team_in_redis(redis_client.clone())
@@ -251,7 +251,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_flags_from_hypercache() {
         let redis_client = setup_redis_client(None).await;
-        let pg_client = setup_pg_reader_client(None).await;
+        let pg_client = setup_pg_reader_client(None);
         let team = insert_new_team_in_redis(redis_client.clone())
             .await
             .expect("Failed to insert new team in Redis");
@@ -423,7 +423,7 @@ mod tests {
         use common_compression::compress_zstd;
 
         let redis_client = setup_redis_client(None).await;
-        let pg_client = setup_pg_reader_client(None).await;
+        let pg_client = setup_pg_reader_client(None);
         let team = insert_new_team_in_redis(redis_client.clone())
             .await
             .expect("Failed to insert team in Redis");
@@ -540,7 +540,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_flags_falls_back_to_pg_on_hypercache_miss() {
         let redis_client = setup_redis_client(None).await;
-        let pg_client = setup_pg_reader_client(None).await;
+        let pg_client = setup_pg_reader_client(None);
         let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
         let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
         let context = TestContext::new(None).await;

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -129,8 +129,8 @@ fn test_geoip_enabled_local_ip() {
 
 #[tokio::test]
 async fn test_evaluate_feature_flags() {
-    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None).await;
-    let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None).await;
+    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None);
+    let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None);
     let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
     let context = TestContext::new(None).await;
     let team = context
@@ -600,8 +600,8 @@ fn test_decode_form_data_real_world_payload() {
 
 #[tokio::test]
 async fn test_evaluate_feature_flags_multiple_flags() {
-    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None).await;
-    let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None).await;
+    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None);
+    let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None);
     let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
 
     let context = TestContext::new(None).await;
@@ -709,8 +709,8 @@ async fn test_evaluate_feature_flags_multiple_flags() {
 
 #[tokio::test]
 async fn test_evaluate_feature_flags_details() {
-    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None).await;
-    let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None).await;
+    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None);
+    let writer: Arc<dyn Client + Send + Sync> = setup_pg_writer_client(None);
     let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(None).await.unwrap();
@@ -1163,7 +1163,7 @@ fn test_decode_request_content_types() {
 #[tokio::test]
 async fn test_fetch_and_filter_flags() {
     let redis_client = setup_redis_client(None).await;
-    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None).await;
+    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None);
     let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
     let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
     let flag_service = FlagService::new(

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -291,27 +291,25 @@ pub fn create_flag_from_json(json_value: Option<String>) -> Vec<FeatureFlag> {
     flags
 }
 
-pub async fn setup_pg_reader_client(config: Option<&Config>) -> Arc<dyn Client + Send + Sync> {
+pub fn setup_pg_reader_client(config: Option<&Config>) -> Arc<dyn Client + Send + Sync> {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
     Arc::new(
         get_pool(&config.read_database_url, config.max_pg_connections)
-            .await
             .expect("Failed to create Postgres client"),
     )
 }
 
-pub async fn setup_pg_writer_client(config: Option<&Config>) -> Arc<dyn Client + Send + Sync> {
+pub fn setup_pg_writer_client(config: Option<&Config>) -> Arc<dyn Client + Send + Sync> {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
     Arc::new(
         get_pool(&config.write_database_url, config.max_pg_connections)
-            .await
             .expect("Failed to create Postgres client"),
     )
 }
 
 /// Setup dual database clients for tests that need to work with both persons and non-persons databases.
 /// If persons DB routing is not enabled, returns the same client twice.
-pub async fn setup_dual_pg_readers(
+pub fn setup_dual_pg_readers(
     config: Option<&Config>,
 ) -> (Arc<dyn Client + Send + Sync>, Arc<dyn Client + Send + Sync>) {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
@@ -323,12 +321,10 @@ pub async fn setup_dual_pg_readers(
                 &config.get_persons_read_database_url(),
                 config.max_pg_connections,
             )
-            .await
             .expect("Failed to create Postgres persons reader client"),
         );
         let non_persons_reader = Arc::new(
             get_pool(&config.read_database_url, config.max_pg_connections)
-                .await
                 .expect("Failed to create Postgres client"),
         );
         (persons_reader, non_persons_reader)
@@ -336,7 +332,6 @@ pub async fn setup_dual_pg_readers(
         // Same database for both
         let client = Arc::new(
             get_pool(&config.read_database_url, config.max_pg_connections)
-                .await
                 .expect("Failed to create Postgres client"),
         );
         (client.clone(), client)
@@ -345,7 +340,7 @@ pub async fn setup_dual_pg_readers(
 
 /// Setup dual database writers for tests that need to write to both persons and non-persons databases.
 /// If persons DB routing is not enabled, returns the same client twice.
-pub async fn setup_dual_pg_writers(
+pub fn setup_dual_pg_writers(
     config: Option<&Config>,
 ) -> (Arc<dyn Client + Send + Sync>, Arc<dyn Client + Send + Sync>) {
     let config = config.unwrap_or(&DEFAULT_TEST_CONFIG);
@@ -357,12 +352,10 @@ pub async fn setup_dual_pg_writers(
                 &config.get_persons_write_database_url(),
                 config.max_pg_connections,
             )
-            .await
             .expect("Failed to create Postgres persons writer client"),
         );
         let non_persons_writer = Arc::new(
             get_pool(&config.write_database_url, config.max_pg_connections)
-                .await
                 .expect("Failed to create Postgres client"),
         );
         (persons_writer, non_persons_writer)
@@ -370,7 +363,6 @@ pub async fn setup_dual_pg_writers(
         // Same database for both
         let client = Arc::new(
             get_pool(&config.write_database_url, config.max_pg_connections)
-                .await
                 .expect("Failed to create Postgres client"),
         );
         (client.clone(), client)
@@ -942,8 +934,8 @@ impl TestContext {
     pub async fn new(config: Option<&Config>) -> Self {
         let config = config.unwrap_or(&DEFAULT_TEST_CONFIG).clone();
 
-        let (persons_reader, non_persons_reader) = setup_dual_pg_readers(Some(&config)).await;
-        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(Some(&config)).await;
+        let (persons_reader, non_persons_reader) = setup_dual_pg_readers(Some(&config));
+        let (persons_writer, non_persons_writer) = setup_dual_pg_writers(Some(&config));
 
         Self {
             persons_reader,

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -107,9 +107,7 @@ impl ServerHandle {
                 let persons_reader = match get_pool(
                     &config.get_persons_read_database_url(),
                     config.max_pg_connections,
-                )
-                .await
-                {
+                ) {
                     Ok(client) => Arc::new(client),
                     Err(e) => {
                         tracing::error!("Failed to create persons read Postgres client: {}", e);
@@ -119,9 +117,7 @@ impl ServerHandle {
                 let persons_writer = match get_pool(
                     &config.get_persons_write_database_url(),
                     config.max_pg_connections,
-                )
-                .await
-                {
+                ) {
                     Ok(client) => Arc::new(client),
                     Err(e) => {
                         tracing::error!("Failed to create persons write Postgres client: {}", e);
@@ -129,7 +125,7 @@ impl ServerHandle {
                     }
                 };
                 let non_persons_reader =
-                    match get_pool(&config.read_database_url, config.max_pg_connections).await {
+                    match get_pool(&config.read_database_url, config.max_pg_connections) {
                         Ok(client) => Arc::new(client),
                         Err(e) => {
                             tracing::error!(
@@ -140,7 +136,7 @@ impl ServerHandle {
                         }
                     };
                 let non_persons_writer =
-                    match get_pool(&config.write_database_url, config.max_pg_connections).await {
+                    match get_pool(&config.write_database_url, config.max_pg_connections) {
                         Ok(client) => Arc::new(client),
                         Err(e) => {
                             tracing::error!(
@@ -158,22 +154,20 @@ impl ServerHandle {
                 )
             } else {
                 // Same database for both persons and non-persons tables
-                let reader =
-                    match get_pool(&config.read_database_url, config.max_pg_connections).await {
-                        Ok(client) => Arc::new(client),
-                        Err(e) => {
-                            tracing::error!("Failed to create read Postgres client: {}", e);
-                            return;
-                        }
-                    };
-                let writer =
-                    match get_pool(&config.write_database_url, config.max_pg_connections).await {
-                        Ok(client) => Arc::new(client),
-                        Err(e) => {
-                            tracing::error!("Failed to create write Postgres client: {}", e);
-                            return;
-                        }
-                    };
+                let reader = match get_pool(&config.read_database_url, config.max_pg_connections) {
+                    Ok(client) => Arc::new(client),
+                    Err(e) => {
+                        tracing::error!("Failed to create read Postgres client: {}", e);
+                        return;
+                    }
+                };
+                let writer = match get_pool(&config.write_database_url, config.max_pg_connections) {
+                    Ok(client) => Arc::new(client),
+                    Err(e) => {
+                        tracing::error!("Failed to create write Postgres client: {}", e);
+                        return;
+                    }
+                };
                 (
                     reader.clone(),
                     writer.clone(),

--- a/rust/feature-flags/tests/test_flag_matching_consistency.rs
+++ b/rust/feature-flags/tests/test_flag_matching_consistency.rs
@@ -112,8 +112,8 @@ async fn it_is_consistent_with_rollout_calculation_for_simple_flags() {
     ];
 
     for (i, result) in results.iter().enumerate().take(1000) {
-        let reader = setup_pg_reader_client(None).await;
-        let writer = setup_pg_writer_client(None).await;
+        let reader = setup_pg_reader_client(None);
+        let writer = setup_pg_writer_client(None);
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
 
         let distinct_id = format!("distinct_id_{i}");
@@ -1211,8 +1211,8 @@ async fn it_is_consistent_with_rollout_calculation_for_multivariate_flags() {
     ];
 
     for (i, result) in results.iter().enumerate().take(1000) {
-        let reader = setup_pg_reader_client(None).await;
-        let writer = setup_pg_writer_client(None).await;
+        let reader = setup_pg_reader_client(None);
+        let writer = setup_pg_writer_client(None);
         let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
         let distinct_id = format!("distinct_id_{i}");
 

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -3694,7 +3694,7 @@ async fn test_cohort_filter_with_regex_and_negation() -> Result<()> {
     let distinct_id = "test.user".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
+    let pg_client = setup_pg_reader_client(None);
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 
@@ -4395,7 +4395,7 @@ async fn test_nested_cohort_targeting_with_days_since_paid_plan() -> Result<()> 
     let distinct_id = "test_user_with_77_days".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
+    let pg_client = setup_pg_reader_client(None);
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 
@@ -4938,7 +4938,7 @@ async fn test_cohort_with_and_negated_cohort_condition() -> Result<()> {
     let distinct_id = "test_user_and_cohort".to_string();
 
     let client = setup_redis_client(Some(config.redis_url.clone())).await;
-    let pg_client = setup_pg_reader_client(None).await;
+    let pg_client = setup_pg_reader_client(None);
     let team = insert_new_team_in_redis(client.clone()).await.unwrap();
     let token = team.api_token.clone();
 

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -50,7 +50,6 @@ async fn create_storage(config: &Config) -> Arc<PostgresStorage> {
             // Create primary pool
             let primary_pool =
                 get_pool_with_config(&config.primary_database_url, pool_config.clone())
-                    .await
                     .expect("Failed to create primary database pool");
             tracing::info!("Created primary database pool");
 
@@ -61,7 +60,6 @@ async fn create_storage(config: &Config) -> Arc<PostgresStorage> {
                 primary_pool.clone()
             } else {
                 let pool = get_pool_with_config(replica_url, pool_config)
-                    .await
                     .expect("Failed to create replica database pool");
                 tracing::info!("Created separate replica database pool");
                 pool


### PR DESCRIPTION
## Problem

During aggressive scale-ups, many pods try to establish database connections simultaneously. Even with `min_connections: 0`, sqlx's `connect()` function always tries to establish at least one connection at startup to validate the connection string. This can cause cascade failures when the database is temporarily overwhelmed.

## Changes

Use `connect_lazy()` instead of `connect()` for sqlx database pools. This creates the pool without immediately connecting to the database - connections are only established when first needed.

This prevents crashes on transient DB unavailability during startup and allows newly deployed pods more time to establish connections gradually.

Also removed some tests that assert connection count as they're no longer relevant given the lazy connection. Also, the logic of clamping we were testing is pretty trivial.

## How did you test this code?

- Verified the `common-database` crate compiles
- All 25 existing unit tests pass
- Verified dependent crates (`feature-flags`, `personhog-replica`) compile
- Manually tested that `/flags` responds correctly with `curl`.

## Publish to changelog?

no