### PR TITLE
feat(deduplicator): ignore no-op rebalance events

### DIFF
--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -175,6 +175,13 @@ pub const BATCH_PROCESSING_ERROR: &str = "batch_processing_error_total";
 /// Counter for Resume commands skipped entirely (no owned partitions)
 pub const REBALANCE_RESUME_SKIPPED_NO_OWNED: &str = "rebalance_resume_skipped_no_owned_total";
 
+/// Counter for empty rebalances skipped (cooperative-sticky no-ops)
+/// Labels: event_type (assign|revoke)
+/// With cooperative-sticky protocol, the broker triggers rebalances for all consumers
+/// when any group membership changes, even if partitions don't move. This tracks
+/// how many of these empty rebalances we short-circuit.
+pub const REBALANCE_EMPTY_SKIPPED: &str = "rebalance_empty_skipped_total";
+
 // ==== Partition Batch Processing Diagnostics ====
 /// Histogram for partition batch processing duration (in milliseconds)
 pub const PARTITION_BATCH_PROCESSING_DURATION_MS: &str = "partition_batch_processing_duration_ms";


### PR DESCRIPTION
## Problem
The deduplicator is tracking a lot of unneeded state changes that are no-ops, skewing our rebalance metrics. In sticky assignment mode, the broker sends one of these no-op events with an empty TopicPartitionList to every pod whenever any pods join or leave the group.

While we have safeguards in place to ensure we're not doing a lot of extra work, the pileup of no-op async tasks and metrics being ticked (including high expected cancellation rates and local rebalance-in-flight counts) is confusing and not needed. In this consumer group mode, these events don't mean anything.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Skip rebalance handling for broker-triggered rebalance events with empty TPL lists
* Related metrics and tests
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI - smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
