### PR TITLE
fix(ducklake): update schema naming in copy workflows

### DIFF
--- a/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
@@ -41,7 +41,7 @@ from posthog.temporal.ducklake.metrics import (
 from products.data_warehouse.backend.models.external_data_schema import ExternalDataSchema
 
 LOGGER = get_logger(__name__)
-DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX = "data_imports"
+DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX = "posthog_data_imports"
 
 _IDENTIFIER_SANITIZE_RE = re.compile(r"[^0-9a-zA-Z]+")
 
@@ -191,7 +191,7 @@ async def prepare_data_imports_ducklake_metadata_activity(
                 source_normalized_name=normalized_name,
                 source_table_uri=source_table_uri,
                 ducklake_schema_name=_sanitize_ducklake_identifier(
-                    f"{DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX}_team_{inputs.team_id}",
+                    f"{DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX}",
                     default_prefix=DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX,
                 ),
                 ducklake_table_name=_sanitize_ducklake_identifier(

--- a/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
@@ -38,7 +38,7 @@ from posthog.temporal.ducklake.types import DataModelingDuckLakeCopyInputs, Duck
 from products.data_warehouse.backend.models import DataWarehouseSavedQuery
 
 LOGGER = get_logger(__name__)
-DATA_MODELING_DUCKLAKE_WORKFLOW_PREFIX = "data_modeling"
+DATA_MODELING_DUCKLAKE_WORKFLOW_PREFIX = "posthog_data_modeling"
 
 
 @dataclasses.dataclass
@@ -151,7 +151,7 @@ async def prepare_data_modeling_ducklake_metadata_activity(
                 normalized_name=normalized_name,
                 source_table_uri=model.table_uri,
                 schema_name=_sanitize_ducklake_identifier(
-                    f"{DATA_MODELING_DUCKLAKE_WORKFLOW_PREFIX}_team_{inputs.team_id}",
+                    f"{DATA_MODELING_DUCKLAKE_WORKFLOW_PREFIX}",
                     default_prefix=DATA_MODELING_DUCKLAKE_WORKFLOW_PREFIX,
                 ),
                 table_name=_sanitize_ducklake_identifier(model.model_label or normalized_name, default_prefix="model"),


### PR DESCRIPTION
## Summary
- Add `posthog_` prefix to ducklake schema names
- Simplify schema naming by removing team ID suffix

## Test plan
- [ ] Verify ducklake copy workflows use updated schema names

🤖 Generated with [Claude Code](https://claude.com/claude-code)