### PR TITLE
fix(tests): create posthog schema before running DDL tests

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -357,6 +357,9 @@ def ensure_events_table_exists(
             context.log.info("Events table already exists in duckling catalog")
             return False
 
+        context.log.info("Creating posthog schema if it doesn't exist...")
+        conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
+
         context.log.info("Creating events table in duckling catalog...")
         ddl = EVENTS_TABLE_DDL.format(catalog=alias)
         try:
@@ -405,6 +408,9 @@ def ensure_persons_table_exists(
         if table_exists(conn, alias, "posthog", "persons"):
             context.log.info("Persons table already exists in duckling catalog")
             return False
+
+        context.log.info("Creating posthog schema if it doesn't exist...")
+        conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
 
         context.log.info("Creating persons table in duckling catalog...")
         ddl = PERSONS_TABLE_DDL.format(catalog=alias)

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -133,6 +133,7 @@ class TestTableExists:
 class TestEventsDDL:
     def test_events_ddl_is_valid_sql(self):
         conn = duckdb.connect()
+        conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
         ddl = EVENTS_TABLE_DDL.format(catalog="memory")
         conn.execute(ddl)
 
@@ -145,6 +146,7 @@ class TestEventsDDL:
 
     def test_events_ddl_is_idempotent(self):
         conn = duckdb.connect()
+        conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
         ddl = EVENTS_TABLE_DDL.format(catalog="memory")
         # Should not raise on second execution
         conn.execute(ddl)
@@ -155,6 +157,7 @@ class TestEventsDDL:
 class TestPersonsDDL:
     def test_persons_ddl_is_valid_sql(self):
         conn = duckdb.connect()
+        conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
         ddl = PERSONS_TABLE_DDL.format(catalog="memory")
         conn.execute(ddl)
 
@@ -167,6 +170,7 @@ class TestPersonsDDL:
 
     def test_persons_ddl_is_idempotent(self):
         conn = duckdb.connect()
+        conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
         ddl = PERSONS_TABLE_DDL.format(catalog="memory")
         # Should not raise on second execution
         conn.execute(ddl)


### PR DESCRIPTION
## Summary
- Fixes test failures in `test_events_backfill_to_duckling.py` caused by missing `posthog` schema
- Adds `CREATE SCHEMA IF NOT EXISTS memory.posthog` before DDL tests run
- Required after #46592 changed DDL to use `posthog` schema instead of `main`

## Test plan
- [x] All 34 tests pass locally
- [x] CI should pass after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)