### PR TITLE
feat(deduplcator): extend session.timeout.ms to avoid churn, delete revoked stores safely

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -26,6 +26,17 @@ pub struct Config {
     #[envconfig(default = "30000")] // 30 seconds
     pub kafka_metadata_max_age_ms: u32,
 
+    // Session timeout: how long broker waits for heartbeats before declaring consumer dead.
+    // With static membership (group.instance.id), broker holds partition assignments for this
+    // duration after a consumer disappears. Should be longer than typical pod restart time.
+    #[envconfig(default = "60000")] // 60 seconds - covers slow pod restarts
+    pub kafka_session_timeout_ms: u32,
+
+    // Heartbeat interval: how often consumer sends heartbeats to broker.
+    // With 60s session timeout and 5s heartbeat, 12 heartbeats can miss before timeout.
+    #[envconfig(default = "5000")] // 5 seconds
+    pub kafka_heartbeat_interval_ms: u32,
+
     // supplied by k8s deploy env, used as part of kafka
     // consumer client ID for sticky partition mappings
     #[envconfig(from = "HOSTNAME")]

--- a/rust/kafka-deduplicator/src/kafka/config.rs
+++ b/rust/kafka-deduplicator/src/kafka/config.rs
@@ -20,7 +20,7 @@ impl ConsumerConfigBuilder {
             .set("enable.auto.offset.store", "false") // Manual store for full control
             .set("enable.auto.commit", "false") // Manual commit for exactly-once semantics
             .set("socket.timeout.ms", "10000")
-            .set("session.timeout.ms", "30000")
+            .set("session.timeout.ms", "60000")
             .set("heartbeat.interval.ms", "5000")
             .set("max.poll.interval.ms", "300000");
 
@@ -100,6 +100,21 @@ impl ConsumerConfigBuilder {
     /// Set maximum time between poll() calls before consumer leaves group
     pub fn with_max_poll_interval_ms(mut self, ms: u32) -> Self {
         self.config.set("max.poll.interval.ms", ms.to_string());
+        self
+    }
+
+    /// Set session timeout: how long broker waits for heartbeats before declaring consumer dead.
+    /// With static membership (group.instance.id), broker holds partition assignments for this
+    /// duration after a consumer disappears. Should be longer than typical pod restart time.
+    pub fn with_session_timeout_ms(mut self, ms: u32) -> Self {
+        self.config.set("session.timeout.ms", ms.to_string());
+        self
+    }
+
+    /// Set heartbeat interval: how often consumer sends heartbeats to broker.
+    /// Should be ~1/3 of session.timeout.ms to allow multiple missed heartbeats before timeout.
+    pub fn with_heartbeat_interval_ms(mut self, ms: u32) -> Self {
+        self.config.set("heartbeat.interval.ms", ms.to_string());
         self
     }
 

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -117,6 +117,12 @@ pub const CHECKPOINT_IMPORT_ATTEMPT_DURATION_HISTOGRAM: &str =
 /// when local store is missing after Kafka rebalances
 pub const REBALANCE_CHECKPOINT_IMPORT_COUNTER: &str = "rebalance_checkpoint_import_total";
 
+/// Counter for immediate cleanup of checkpoint imports after cancellation or ownership loss.
+/// This counts directories cleaned up immediately rather than waiting for orphan cleaner.
+/// Tags: result=success|failed
+pub const CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER: &str =
+    "checkpoint_import_cancelled_cleanup_total";
+
 // ==== Store Manager Diagnostics ====
 /// Histogram for store creation duration (in milliseconds)
 pub const STORE_CREATION_DURATION_MS: &str = "store_creation_duration_ms";

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -374,6 +374,8 @@ impl KafkaDeduplicatorService {
                 )
                 // Consumer group membership settings
                 .with_max_poll_interval_ms(self.config.kafka_max_poll_interval_ms)
+                .with_session_timeout_ms(self.config.kafka_session_timeout_ms)
+                .with_heartbeat_interval_ms(self.config.kafka_heartbeat_interval_ms)
                 .build();
 
         // Create shutdown channel


### PR DESCRIPTION
## Problem
We need to expose `session.timeout.ms` to ensure _graceful departures_ from the consumer group (`LeaveGroup`) do not trigger reassignment churn during deploys. Only failed pods considered dead by the broker should result in reassignments when sticky assignment mode is in use.

Let's also experiment (may be a mistake) with new logic to delete genuinely revoked partition stores after checkpoint import completes, when another rebalance attempt hasn't already claimed the partition (i.e. still in `owned_partitions` due to rebalance overlap, which should happen in sticky assignment rebalances if all is well) 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Expose Kafka heartbeat and session timeouts on the service config with new prod defaults
* Add checkpoint import cleanup on revoke when rebalance attempt is cancelled *and* the partition is no longer owned locally (i.e. another rebalance has not reassigned it here)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Smoke test in PoC env forthcoming
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
