### PR TITLE
fix(managed_migrations): fixes interval part creation bug

### DIFF
--- a/products/managed_migrations/frontend/ManagedMigration.tsx
+++ b/products/managed_migrations/frontend/ManagedMigration.tsx
@@ -133,7 +133,7 @@ export function ManagedMigration(): JSX.Element {
                         <div className="flex gap-4">
                             <LemonField name="start_date" label="Start Date" className="flex-1">
                                 <LemonCalendarSelectInput
-                                    granularity="minute"
+                                    granularity={managedMigration.source_type === 'mixpanel' ? 'day' : 'hour'}
                                     value={managedMigration.start_date ? dayjs(managedMigration.start_date) : null}
                                     onChange={(date) =>
                                         setManagedMigrationValue('start_date', date?.format('YYYY-MM-DD HH:mm:ss'))
@@ -143,7 +143,7 @@ export function ManagedMigration(): JSX.Element {
 
                             <LemonField name="end_date" label="End Date" className="flex-1">
                                 <LemonCalendarSelectInput
-                                    granularity="minute"
+                                    granularity={managedMigration.source_type === 'mixpanel' ? 'day' : 'hour'}
                                     value={managedMigration.end_date ? dayjs(managedMigration.end_date) : null}
                                     onChange={(date) =>
                                         setManagedMigrationValue('end_date', date?.format('YYYY-MM-DD HH:mm:ss'))

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9679,6 +9679,7 @@ dependencies = [
  "getrandom 0.3.1",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -124,7 +124,7 @@ tracing = "0.1.40"
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 url = "2.5.0"
-uuid = { version = "1.6.1", features = ["v4", "v7", "serde"] }
+uuid = { version = "1.6.1", features = ["v4", "v5", "v7", "serde"] }
 neon = "1"
 quick_cache = "0.6.9"
 ahash = "0.8.11"

--- a/rust/batch-import-worker/src/parse/content/mixpanel.rs
+++ b/rust/batch-import-worker/src/parse/content/mixpanel.rs
@@ -11,8 +11,7 @@ use uuid::Uuid;
 /// UUID namespace for generating deterministic UUIDs from Mixpanel $insert_id values.
 /// This allows deduplication of events that may be imported multiple times.
 /// Generated using `uuidgen` - this is a random UUID that serves as our namespace.
-const MIXPANEL_INSERT_ID_NAMESPACE: Uuid =
-    Uuid::from_bytes(*b"posthog_mixpanel");
+const MIXPANEL_INSERT_ID_NAMESPACE: Uuid = Uuid::from_bytes(*b"posthog_mixpanel");
 
 use super::TransformContext;
 use crate::parse::format::{extract_between, extract_field_name, UserFacingParseError};
@@ -431,8 +430,12 @@ mod tests {
         };
 
         // Parse the same event twice with the same $insert_id
-        let parser1 =
-            MixpanelEvent::parse_fn(context.clone(), false, Duration::seconds(0), identity_transform);
+        let parser1 = MixpanelEvent::parse_fn(
+            context.clone(),
+            false,
+            Duration::seconds(0),
+            identity_transform,
+        );
         let parser2 =
             MixpanelEvent::parse_fn(context, false, Duration::seconds(0), identity_transform);
 

--- a/rust/batch-import-worker/src/parse/content/mixpanel.rs
+++ b/rust/batch-import-worker/src/parse/content/mixpanel.rs
@@ -8,6 +8,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
+/// UUID namespace for generating deterministic UUIDs from Mixpanel $insert_id values.
+/// This allows deduplication of events that may be imported multiple times.
+/// Generated using `uuidgen` - this is a random UUID that serves as our namespace.
+const MIXPANEL_INSERT_ID_NAMESPACE: Uuid =
+    Uuid::from_bytes(*b"posthog_mixpanel");
+
 use super::TransformContext;
 use crate::parse::format::{extract_between, extract_field_name, UserFacingParseError};
 
@@ -102,7 +108,15 @@ impl MixpanelEvent {
                 (None, false) => Uuid::now_v7().to_string(),
             };
 
-            let event_uuid = Uuid::now_v7();
+            // Generate a deterministic UUID from $insert_id if present, otherwise use random UUIDv7.
+            // This allows deduplication of events that may be imported multiple times.
+            let event_uuid = mx
+                .properties
+                .other
+                .get("$insert_id")
+                .and_then(|v| v.as_str())
+                .map(|insert_id| Uuid::new_v5(&MIXPANEL_INSERT_ID_NAMESPACE, insert_id.as_bytes()))
+                .unwrap_or_else(Uuid::now_v7);
 
             // Was seeing timestamp values come in that were in seconds, not milliseconds
             // Do a quick heuristic check on the size of the timestamp to determine if it's in seconds or milliseconds
@@ -398,6 +412,112 @@ mod tests {
         assert!(
             serialized["now"].is_string(),
             "now must be a string in serialized output"
+        );
+    }
+
+    #[test]
+    fn test_deterministic_uuid_from_insert_id() {
+        let test_job_id = Uuid::now_v7();
+
+        let context = TransformContext {
+            team_id: 123,
+            token: "test_token".to_string(),
+            job_id: test_job_id,
+            identify_cache: std::sync::Arc::new(crate::cache::MockIdentifyCache::new()),
+            group_cache: std::sync::Arc::new(crate::cache::MockGroupCache::new()),
+            import_events: true,
+            generate_identify_events: false,
+            generate_group_identify_events: false,
+        };
+
+        // Parse the same event twice with the same $insert_id
+        let parser1 =
+            MixpanelEvent::parse_fn(context.clone(), false, Duration::seconds(0), identity_transform);
+        let parser2 =
+            MixpanelEvent::parse_fn(context, false, Duration::seconds(0), identity_transform);
+
+        let mut other1 = HashMap::new();
+        other1.insert("$insert_id".to_string(), json!("unique_insert_id_123"));
+        let mx_event1 = MixpanelEvent {
+            event: "test_event".to_string(),
+            properties: MixpanelProperties {
+                timestamp: 1697379000,
+                distinct_id: Some("user123".to_string()),
+                other: other1,
+            },
+        };
+
+        let mut other2 = HashMap::new();
+        other2.insert("$insert_id".to_string(), json!("unique_insert_id_123"));
+        let mx_event2 = MixpanelEvent {
+            event: "test_event".to_string(),
+            properties: MixpanelProperties {
+                timestamp: 1697379000,
+                distinct_id: Some("user123".to_string()),
+                other: other2,
+            },
+        };
+
+        let result1 = parser1(mx_event1).unwrap().unwrap();
+        let result2 = parser2(mx_event2).unwrap().unwrap();
+
+        // Both events should have the same UUID because they have the same $insert_id
+        assert_eq!(
+            result1.inner.uuid, result2.inner.uuid,
+            "Events with the same $insert_id should have the same deterministic UUID"
+        );
+
+        // The UUID should be deterministic (UUID v5), not random
+        let expected_uuid = Uuid::new_v5(&MIXPANEL_INSERT_ID_NAMESPACE, b"unique_insert_id_123");
+        assert_eq!(
+            result1.inner.uuid, expected_uuid,
+            "UUID should be generated using UUID v5 from $insert_id"
+        );
+    }
+
+    #[test]
+    fn test_random_uuid_without_insert_id() {
+        let test_job_id = Uuid::now_v7();
+
+        let mx_event1 = MixpanelEvent {
+            event: "test_event".to_string(),
+            properties: MixpanelProperties {
+                timestamp: 1697379000,
+                distinct_id: Some("user123".to_string()),
+                other: HashMap::new(), // No $insert_id
+            },
+        };
+
+        let mx_event2 = MixpanelEvent {
+            event: "test_event".to_string(),
+            properties: MixpanelProperties {
+                timestamp: 1697379000,
+                distinct_id: Some("user123".to_string()),
+                other: HashMap::new(), // No $insert_id
+            },
+        };
+
+        let context = TransformContext {
+            team_id: 123,
+            token: "test_token".to_string(),
+            job_id: test_job_id,
+            identify_cache: std::sync::Arc::new(crate::cache::MockIdentifyCache::new()),
+            group_cache: std::sync::Arc::new(crate::cache::MockGroupCache::new()),
+            import_events: true,
+            generate_identify_events: false,
+            generate_group_identify_events: false,
+        };
+
+        let parser =
+            MixpanelEvent::parse_fn(context, false, Duration::seconds(0), identity_transform);
+
+        let result1 = parser(mx_event1).unwrap().unwrap();
+        let result2 = parser(mx_event2).unwrap().unwrap();
+
+        // Without $insert_id, UUIDs should be random (different)
+        assert_ne!(
+            result1.inner.uuid, result2.inner.uuid,
+            "Events without $insert_id should have different random UUIDs"
         );
     }
 }


### PR DESCRIPTION
## Problem

Users using the Mixpanel source for managed migrations were reporting duplicate events.

Investigation found that there was a mismatch between the behaviour of the export endpoint and the logic we use to generate the start/end date intervals that we break an export up into.

The APIs use inclusive date ranges - both the start and end parameters include data from those dates/times. For example, Mixpanel's from_date=2025-06-05&to_date=2025-06-06 returns events from June 5 AND June 6. 

The interval logic creates adjacent semi-open intervals like [June 5, June 6) and [June 6, June 7).

When formatted as query parameters without adjustment:                                            
  - Interval 1: from_date=06-05&to_date=06-06 → returns June 5 + June 6 events                       
  - Interval 2: from_date=06-06&to_date=06-07 → returns June 6 + June 7 events
 
This caused June 6 events to be imported twice.

The same issue effects Amplitude imports but to less detrimental effects because:

Amplitude events include a uuid field in the source data. When parsing, we preserve this UUID:     
                                                                                                     
```
  // amplitude.rs                                                                                    
  let event_uuid = amp                                                                               
      .uuid                                                                                          
      .as_ref()                                                                                      
      .and_then(|u| Uuid::parse_str(u).ok())                                                         
      .unwrap_or_else(Uuid::now_v7);       
```                                                          

If the same Amplitude event is fetched twice due to overlapping intervals, it has the same UUID both times (from the source data). Clickhouse deduplication logic recognize these as duplicates and keeps only one copy.  

Whereas Mixpanel events (before this fix) were assigned a random UUIDv7 on every parse:                    
                                                                                                     
```
  // mixpanel.rs (before)                                                                            
  let event_uuid = Uuid::now_v7();               
```                                                


Mixpanel events do have a unique identifier ($insert_id), but we weren't using it because it wasn't in the UUID form. If the same event was fetched twice, it got two different random UUIDs. The deduplication pipeline couldn't recognize them as the same event.

## Changes

- fixed inteval query logic for all date range export sources
- added deterministic UUID generation for mixpanel events

## How did you test this code?

- unit tests for interval adjustment
- unit tests for deterministic UUID