### PR TITLE
fix(duckling): use BOOLEAN for historical_migration column in DDL

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -148,7 +148,7 @@ CREATE TABLE IF NOT EXISTS {catalog}.posthog.events (
     group3_created_at TIMESTAMPTZ,
     group4_created_at TIMESTAMPTZ,
     person_mode VARCHAR,
-    historical_migration VARCHAR,
+    historical_migration BOOLEAN,
     _inserted_at TIMESTAMPTZ
 )
 """


### PR DESCRIPTION
## Summary

- Changes `historical_migration` column from `VARCHAR` to `BOOLEAN` in `EVENTS_TABLE_DDL`

## Problem

ClickHouse exports `historical_migration` as `BOOLEAN` in Parquet format, but the DuckDB table schema had it as `VARCHAR`. This caused type mismatch errors when registering parquet files:

```
Invalid Input Error: Failed to map column "historical_migration" from file "s3://..." to the column in table "events"
* Expected VARCHAR, found type BOOLEAN
```

## Test plan

- [x] DDL tests pass
- [ ] Re-run duckling backfill job after deployment (with `delete_tables: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)