### PR TITLE
fix(session-replay): Fix text selection in Session Replay comment form

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -267,7 +267,7 @@ export function PurePlayer({ noMeta = false, noBorder = false }: PurePlayerProps
                                     </div>
                                     <div
                                         className="SessionRecordingPlayer__body"
-                                        draggable={draggable}
+                                        draggable={draggable && !isCommenting}
                                         {...elementProps}
                                     >
                                         <PlayerFrame />


### PR DESCRIPTION
## Problem
Users are unable to select text in the Session Replay comment form
https://github.com/user-attachments/assets/10881b7e-b818-4f63-ae01-492ac6d48676


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Disable dragging when a user is commenting.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
