### PR TITLE
fix(session-replay): Fix comment editing in session replay

### DIFF
--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
@@ -106,6 +106,16 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
             actions.setRecordingCommentValue('commentId', comment.commentId)
             // opening to edit also sets the player timestamp, which will update the timestamps in the form
             actions.setIsCommenting(true)
+
+            if (values.richContentEditor && comment.richContent) {
+                values.richContentEditor.setContent(comment.richContent)
+            }
+        },
+        setRichContentEditor: ({ editor }) => {
+            const richContent = values.recordingComment.richContent
+            if (richContent && values.recordingComment.commentId) {
+                editor.setContent(richContent)
+            }
         },
         setIsCommenting: ({ isCommenting }) => {
             if (!isCommenting) {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1038,6 +1038,15 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             console.log('caughtAssetErrorFromIframe', errorDetails)
         },
         [playerCommentModel.actionTypes.startCommenting]: async ({ comment }) => {
+            const mode = props.mode ?? SessionRecordingPlayerMode.Standard
+            if (!ModesWithInteractions.includes(mode)) {
+                return
+            }
+
+            if (comment?.recordingId && comment.recordingId !== props.sessionRecordingId) {
+                return
+            }
+
             actions.setIsCommenting(true)
             if (comment) {
                 // and we need a short wait until the logic is mounted after calling setIsCommenting


### PR DESCRIPTION
## Problem
Trying to edit a comment in Session Replay would result in two error toasts.
<img width="642" height="494" alt="image" src="https://github.com/user-attachments/assets/fc6aa519-2fab-45bf-8c5e-ef059e09553b" />

The root issue was that `startCommenting` was dispatched globally and all mounted player logic instances received it. Players in non-interactive modes or players showing different recordings would try to enter comment mode and fail.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
 Added two guards in the `startCommenting` listener:
  1. Skip for non-interactive modes (Preview, Screenshot, Video, Kiosk, Sharing)
  2. Skip if the comment's `recordingId` doesn't match the player's `sessionRecordingId`
  
 Added logic to set the editor content programmatically since when edit began working again, the existing text wasn't pre-populated.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
