### PR TITLE
fix(persons): bind Split ID modal visibility to logic state to fix close issue

### DIFF
--- a/frontend/src/scenes/persons/MergeSplitPerson.tsx
+++ b/frontend/src/scenes/persons/MergeSplitPerson.tsx
@@ -11,14 +11,15 @@ import { mergeSplitPersonLogic } from './mergeSplitPersonLogic'
 import { personsLogic } from './personsLogic'
 
 export function MergeSplitPerson({ person }: { person: PersonType }): JSX.Element {
-    const { urlId } = useValues(personsLogic)
+    // We explicitly pull the modal state from personsLogic
+    const { urlId, splitMergeModalShown } = useValues(personsLogic)
     const logicProps = { person, urlId: urlId ?? '' }
     const { executedLoading } = useValues(mergeSplitPersonLogic(logicProps))
     const { execute, cancel } = useActions(mergeSplitPersonLogic(logicProps))
 
     return (
         <LemonModal
-            isOpen
+            isOpen={splitMergeModalShown}  // <--- REPLACED "isOpen" with the variable
             width="40rem"
             title="Split persons"
             footer={


### PR DESCRIPTION
Fixes a bug where the "Split Person" modal would not close when clicking "Cancel" or "Split". The modal's isOpen prop was hardcoded to true (implicit), causing it to ignore the state changes dispatched by mergeSplitPersonLogic.

Changes
Updated MergeSplitPerson.tsx to retrieve splitMergeModalShown from personsLogic.

Bound <LemonModal isOpen={...}> to this state variable instead of being statically open.

Motivation
Resolves Issue #40420. The cancel action in mergeSplitPersonLogic correctly calls setSplitMergeModalShown(false), but the UI component was not listening to this value, leaving the user stuck with an open modal.