### PR TITLE
fix(product tours): fix timezone bug in stats calculation

### DIFF
--- a/frontend/src/scenes/product-tours/ProductTourView.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourView.tsx
@@ -220,8 +220,8 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
                                     loading={tourStatsLoading}
                                     headerAction={
                                         <DateFilter
-                                            dateFrom={dateRange.date_from}
-                                            dateTo={dateRange.date_to}
+                                            dateFrom={dateRange?.date_from ?? null}
+                                            dateTo={dateRange?.date_to ?? null}
                                             onChange={(dateFrom, dateTo) =>
                                                 setDateRange({ date_from: dateFrom, date_to: dateTo })
                                             }
@@ -264,7 +264,7 @@ function formatVersionDate(dateString: string): string {
     return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
-function StepsFunnel({ tour, dateRange }: { tour: ProductTour; dateRange: DateRange }): JSX.Element {
+function StepsFunnel({ tour, dateRange }: { tour: ProductTour; dateRange: DateRange | null }): JSX.Element {
     const allSteps = tour.content?.steps || []
     const stepOrderHistory = tour.content?.step_order_history || []
     const hasVersionHistory = stepOrderHistory.length > 1
@@ -289,8 +289,8 @@ function StepsFunnel({ tour, dateRange }: { tour: ProductTour; dateRange: DateRa
     // Calculate date range for this version
     // Start: version's created_at (or tour start_date, or user-selected date_from)
     // End: next version's created_at (or user-selected date_to)
-    const versionDateFrom = selectedVersion?.created_at || dateRange.date_from
-    const versionDateTo = nextVersion?.created_at || dateRange.date_to
+    const versionDateFrom = selectedVersion?.created_at || dateRange?.date_from
+    const versionDateTo = nextVersion?.created_at || dateRange?.date_to
 
     const tourIdFilter = {
         type: PropertyFilterType.Event,
@@ -376,7 +376,7 @@ function StepsFunnel({ tour, dateRange }: { tour: ProductTour; dateRange: DateRa
                     source: funnelsQuery,
                     showTable: false,
                     showLastComputation: true,
-                    showLastComputationRefresh: false,
+                    showLastComputationRefresh: true,
                 }}
                 readOnly
             />

--- a/frontend/src/scenes/product-tours/productTourLogic.ts
+++ b/frontend/src/scenes/product-tours/productTourLogic.ts
@@ -7,6 +7,8 @@ import isEqual from 'lodash.isequal'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
+import { dateStringToDayJs } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { NEW_FLAG } from 'scenes/feature-flags/featureFlagLogic'
 import { Scene } from 'scenes/sceneTypes'
@@ -37,62 +39,40 @@ export const DEFAULT_TARGETING_FILTERS: FeatureFlagType['filters'] = {
     groups: [{ ...NEW_FLAG.filters.groups[0], rollout_percentage: 100 }],
 }
 
-/**
- * Builds a HogQL date filter clause from a DateRange.
- *
- * Handles:
- * - Relative dates like "-30d", "-7d", "-1w", "-1m" → `now() - INTERVAL X UNIT`
- * - ISO dates like "2025-11-10T02:54:31Z" → `toDateTime('2025-11-10 02:54:31')`
- *
- * @param dateRange - The date range to filter by
- * @param timestampColumn - The column name to filter (default: 'timestamp')
- * @returns HogQL WHERE clause fragment (e.g., " AND timestamp >= ...")
- */
-function buildHogQLDateFilter(dateRange: DateRange | null, timestampColumn = 'timestamp'): string {
-    if (!dateRange) {
-        return ''
+const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss'
+
+function getResolvedTourDateRange(
+    tour: Pick<ProductTour, 'start_date' | 'created_at' | 'end_date'>,
+    dateRange?: DateRange | null
+): { fromDate: string; toDate: string } {
+    let fromDate = dayjs
+        .utc(tour.start_date ?? tour.created_at)
+        .startOf('day')
+        .format(DATE_FORMAT)
+    let toDate = tour.end_date
+        ? dayjs.utc(tour.end_date).endOf('day').format(DATE_FORMAT)
+        : dayjs.utc().endOf('day').format(DATE_FORMAT)
+
+    if (dateRange?.date_from && dateRange.date_from !== 'all') {
+        fromDate = dateStringToDayJs(dateRange.date_from)?.startOf('day').format(DATE_FORMAT) ?? fromDate
     }
 
-    const { date_from, date_to } = dateRange
-    let filter = ''
-
-    const formatDate = (dateStr: string): string => {
-        // For ISO dates, convert to YYYY-MM-DD HH:MM:SS format for ClickHouse
-        const date = new Date(dateStr)
-        if (!isNaN(date.getTime())) {
-            return date.toISOString().replace('T', ' ').replace('Z', '').split('.')[0]
-        }
-        return dateStr
+    if (dateRange?.date_to) {
+        toDate = dateStringToDayJs(dateRange.date_to)?.endOf('day').format(DATE_FORMAT) ?? toDate
     }
 
-    const parseRelativeDate = (dateStr: string): { num: number; unit: string } | null => {
-        const match = dateStr.match(/^-(\d+)([dwmqy])$/)
-        if (!match) {
-            return null
-        }
-        const unitMap: Record<string, string> = { d: 'DAY', w: 'WEEK', m: 'MONTH', q: 'QUARTER', y: 'YEAR' }
-        return { num: parseInt(match[1], 10), unit: unitMap[match[2]] || 'DAY' }
-    }
+    return { fromDate, toDate }
+}
 
-    if (date_from) {
-        const relative = parseRelativeDate(date_from)
-        if (relative) {
-            filter += ` AND ${timestampColumn} >= now() - INTERVAL ${relative.num} ${relative.unit}`
-        } else {
-            filter += ` AND ${timestampColumn} >= toDateTime('${formatDate(date_from)}')`
-        }
-    }
+function buildHogQLDateFilter(
+    tour: Pick<ProductTour, 'start_date' | 'created_at' | 'end_date'>,
+    dateRange: DateRange | null,
+    timestampColumn = 'timestamp'
+): string {
+    const { fromDate, toDate } = getResolvedTourDateRange(tour, dateRange)
 
-    if (date_to) {
-        const relative = parseRelativeDate(date_to)
-        if (relative) {
-            filter += ` AND ${timestampColumn} <= now() - INTERVAL ${relative.num} ${relative.unit}`
-        } else {
-            filter += ` AND ${timestampColumn} <= toDateTime('${formatDate(date_to)}')`
-        }
-    }
-
-    return filter
+    return ` AND ${timestampColumn} >= toDateTime('${fromDate}')
+        AND ${timestampColumn} <= toDateTime('${toDate}')`
 }
 
 /**
@@ -187,7 +167,7 @@ export const productTourLogic = kea<productTourLogicType>([
                     return null
                 }
 
-                const dateFilter = buildHogQLDateFilter(values.dateRange)
+                const dateFilter = buildHogQLDateFilter(values.productTour, values.dateRange)
                 const escapedTourId = escapeSqlString(props.id)
 
                 // Query for overall tour stats with unique and total counts
@@ -415,7 +395,7 @@ export const productTourLogic = kea<productTourLogicType>([
             },
         ],
         dateRange: [
-            { date_from: '-30d', date_to: null } as DateRange,
+            null as DateRange | null,
             {
                 setDateRange: (_, { dateRange }) => dateRange,
             },
@@ -507,15 +487,12 @@ export const productTourLogic = kea<productTourLogicType>([
             if (productTour) {
                 actions.reportProductTourViewed(productTour)
             }
-            // Set date range to start from tour's start_date (or keep default -30d)
-            // This will trigger loadTourStats via the setDateRange listener
-            if (productTour?.start_date) {
+            if (!values.dateRange) {
                 actions.setDateRange({
-                    date_from: productTour.start_date,
-                    date_to: null,
+                    date_from: productTour?.start_date || '-30d',
+                    date_to: productTour?.end_date || null,
                 })
             } else {
-                // No start_date, load stats with default date range
                 actions.loadTourStats()
             }
             // Populate form with loaded data


### PR DESCRIPTION
## Problem
- timezone bug in the stats calculation vs. funnel means the stats are under-counting by default
- date range selection is not intuitive (weird defaults)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- fixes timezone bug
- cleans up date range defaulting to match surveys behavior

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
manual testing 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no