### PR TITLE
fix: fix slow join on sync distinct ids job

### DIFF
--- a/posthog/temporal/sync_person_distinct_ids/activities.py
+++ b/posthog/temporal/sync_person_distinct_ids/activities.py
@@ -180,7 +180,9 @@ async def lookup_pg_distinct_ids(inputs: LookupPgDistinctIdsInputs) -> LookupPgD
                 pdi.distinct_id,
                 COALESCE(pdi.version, 0) as version
             FROM posthog_person p
-            JOIN posthog_persondistinctid pdi ON pdi.person_id = p.id
+            JOIN posthog_persondistinctid pdi
+                ON pdi.person_id = p.id
+                AND pdi.team_id = p.team_id
             WHERE p.team_id = %s
               AND p.uuid IN (SELECT unnest(%s::uuid[]))
             ORDER BY p.uuid, pdi.id


### PR DESCRIPTION
## Problem

The sync job times out because the join on distinct ids table does a sequential scan.

## Changes

Adds team id to the join clause.

## How did you test this code?

Regression tests