### PR TITLE
fix(modeling): center DAG view after initial layout completes

### DIFF
--- a/frontend/src/scenes/data-warehouse/DataWarehouseScene.tsx
+++ b/frontend/src/scenes/data-warehouse/DataWarehouseScene.tsx
@@ -1,4 +1,5 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
+import { combineUrl, router } from 'kea-router'
 
 import { IconPlusSmall } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
@@ -32,7 +33,7 @@ export const scene: SceneExport = {
 export function DataWarehouseScene(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const { activeTab } = useValues(dataWarehouseSceneLogic)
-    const { setActiveTab } = useActions(dataWarehouseSceneLogic)
+    const { searchParams } = useValues(router)
 
     if (!featureFlags[FEATURE_FLAGS.DATA_WAREHOUSE_SCENE]) {
         return <NotFound object="Data warehouse" />
@@ -74,23 +75,25 @@ export function DataWarehouseScene(): JSX.Element {
             />
             <LemonTabs
                 activeKey={activeTab}
-                onChange={(newKey) => setActiveTab(newKey)}
                 sceneInset
                 tabs={[
                     {
                         key: DataWarehouseTab.OVERVIEW,
                         label: 'Overview',
                         content: <OverviewTab />,
+                        link: urls.dataWarehouse(),
                     },
                     {
                         key: DataWarehouseTab.SOURCES,
                         label: 'Sources',
                         content: <SourcesTab />,
+                        link: combineUrl(urls.dataWarehouse(), { ...searchParams, tab: DataWarehouseTab.SOURCES }).url,
                     },
                     {
                         key: DataWarehouseTab.VIEWS,
                         label: 'Views',
                         content: <ViewsTab />,
+                        link: combineUrl(urls.dataWarehouse(), { ...searchParams, tab: DataWarehouseTab.VIEWS }).url,
                     },
                     ...(featureFlags[FEATURE_FLAGS.DATA_MODELING_TAB]
                         ? [
@@ -98,6 +101,10 @@ export function DataWarehouseScene(): JSX.Element {
                                   key: DataWarehouseTab.MODELING,
                                   label: 'Modeling',
                                   content: <DataModelingTab />,
+                                  link: combineUrl(urls.dataWarehouse(), {
+                                      ...searchParams,
+                                      tab: DataWarehouseTab.MODELING,
+                                  }).url,
                               },
                           ]
                         : []),

--- a/frontend/src/scenes/data-warehouse/dataWarehouseSceneLogic.ts
+++ b/frontend/src/scenes/data-warehouse/dataWarehouseSceneLogic.ts
@@ -1,11 +1,12 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { router } from 'kea-router'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 import posthog from 'posthog-js'
 
 import api, { PaginatedResponse } from 'lib/api'
 import { billingLogic } from 'scenes/billing/billingLogic'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
+import { urls } from 'scenes/urls'
 
 import { DatabaseSchemaDataWarehouseTable } from '~/queries/schema/schema-general'
 import {
@@ -313,4 +314,25 @@ export const dataWarehouseSceneLogic = kea<dataWarehouseSceneLogicType>([
         actions.loadJobStats({ days: 7 })
         actions.loadBilling()
     }),
+    urlToAction(({ actions, values }) => ({
+        [urls.dataWarehouse()]: (_, searchParams) => {
+            const tab = searchParams.tab as DataWarehouseTab | undefined
+            if (tab && Object.values(DataWarehouseTab).includes(tab) && tab !== values.activeTab) {
+                actions.setActiveTab(tab)
+            } else if (!tab && values.activeTab !== DataWarehouseTab.OVERVIEW) {
+                actions.setActiveTab(DataWarehouseTab.OVERVIEW)
+            }
+        },
+    })),
+    actionToUrl(({ values }) => ({
+        setActiveTab: () => {
+            const searchParams = { ...router.values.searchParams }
+            if (values.activeTab === DataWarehouseTab.OVERVIEW) {
+                delete searchParams.tab
+            } else {
+                searchParams.tab = values.activeTab
+            }
+            return [urls.dataWarehouse(), searchParams]
+        },
+    })),
 ])

--- a/frontend/src/scenes/data-warehouse/scene/dataModelingNodesLogic.ts
+++ b/frontend/src/scenes/data-warehouse/scene/dataModelingNodesLogic.ts
@@ -10,6 +10,28 @@ import { dataModelingEditorLogic } from './modeling/dataModelingEditorLogic'
 
 export const PAGE_SIZE = 10
 
+export type SearchMode = 'search' | 'upstream' | 'downstream' | 'all'
+
+export interface ParsedSearch {
+    mode: SearchMode
+    baseName: string
+}
+
+/** Parse search term for +name (upstream), name+ (downstream), or +name+ (both) syntax */
+export function parseSearchTerm(searchTerm: string): ParsedSearch {
+    const trimmed = searchTerm.trim()
+    if (trimmed.startsWith('+') && trimmed.endsWith('+') && trimmed.length > 2) {
+        return { mode: 'all', baseName: trimmed.slice(1, -1) }
+    }
+    if (trimmed.startsWith('+') && trimmed.length > 1) {
+        return { mode: 'upstream', baseName: trimmed.slice(1) }
+    }
+    if (trimmed.endsWith('+') && trimmed.length > 1) {
+        return { mode: 'downstream', baseName: trimmed.slice(0, -1) }
+    }
+    return { mode: 'search', baseName: trimmed }
+}
+
 export const dataModelingNodesLogic = kea<dataModelingNodesLogicType>([
     path(['scenes', 'data-warehouse', 'scene', 'dataModelingNodesLogic']),
     actions({
@@ -50,13 +72,18 @@ export const dataModelingNodesLogic = kea<dataModelingNodesLogicType>([
         ],
     }),
     selectors({
+        parsedSearch: [
+            (s) => [s.debouncedSearchTerm],
+            (debouncedSearchTerm: string): ParsedSearch => parseSearchTerm(debouncedSearchTerm),
+        ],
         filteredNodes: [
             (s) => [s.nodes, s.searchTerm],
             (nodes: DataModelingNode[], searchTerm: string): DataModelingNode[] => {
                 if (!searchTerm) {
                     return nodes
                 }
-                return nodes.filter((n) => n.name.toLowerCase().includes(searchTerm.toLowerCase()))
+                const { baseName } = parseSearchTerm(searchTerm)
+                return nodes.filter((n) => n.name.toLowerCase().includes(baseName.toLowerCase()))
             },
         ],
         viewNodes: [


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

not a prob really, just some nits and UX that i like

## Changes

- the view didn't properly center when loading the nodes - now we wait for them to load and then call setView
- when nodes are highlighted - we make the other ones opaque, making it easier to focus on the highlighted ones
- add the tab to the data warehouse scene URL - so that a refresh keeps you in the tab you're on
- introduce `+` syntax to the search - so we can highlight upstream and downstream nodes
    - appreciate we might not want to do this in the frontend as we have an APi for it, but just putting it out here, and then I can adjust the implementation if this is something we want to keep

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

**Before**

[modeling-canvas-before.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/f7cbbd3d-b84b-43d8-839b-487403e4bcba.mov" />](https://app.graphite.com/user-attachments/video/f7cbbd3d-b84b-43d8-839b-487403e4bcba.mov)

After

## [modeling-canvas-edits.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/268c8de6-07a3-49f2-bdfb-359339ebfa89.mov" />](https://app.graphite.com/user-attachments/video/268c8de6-07a3-49f2-bdfb-359339ebfa89.mov)

## How did you test this code?

- played around locally

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

nah

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->