### PR TITLE
fix(ph-ai): remove duplicate notebook titles

### DIFF
--- a/ee/hogai/tools/create_notebook/helpers.py
+++ b/ee/hogai/tools/create_notebook/helpers.py
@@ -30,7 +30,7 @@ async def create_or_update_notebook_artifact(
     Returns:
         tuple[AgentArtifact, ArtifactStatus] with the artifact and status
     """
-    blocks = parse_notebook_content_for_storage(content)
+    blocks = parse_notebook_content_for_storage(content, title=title)
     artifact_content = StoredNotebookArtifactContent(blocks=blocks, title=title)
 
     artifact = None


### PR DESCRIPTION
## Problem

When creating notebooks, the LLM often generates an H1 heading that duplicates the notebook title, creating redundant information for users.

## Changes

- Added functionality to strip duplicate H1 headings from notebook content when they match the notebook title
- Modified `parse_notebook_content_for_storage` to accept an optional title parameter
- Updated `create_or_update_notebook_artifact` to pass the title to the parsing function
- Added comprehensive tests for the new title stripping functionality

## How did you test this code?
Added tests + verified manually