### PR TITLE
fix: Sampling rate extra zeros

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -352,7 +352,7 @@ const useTriggers = (currentTeam: TeamType | TeamPublicType, selectedPlatform: '
             {
                 type: TriggerType.SAMPLING,
                 enabled: hasSampling,
-                sampleRate: numericSampleRate,
+                sampleRate: sampleRate ? parseFloat(sampleRate) : null,
             },
             {
                 type: TriggerType.MIN_DURATION,


### PR DESCRIPTION
## Problem

The sampling rate for Session Replay triggers was displayed incorrectly in the summary, showing with two extra zeros (e.g., "9900%" instead of "99%"). This was due to the value being multiplied by 100 twice.

## Changes

This PR modifies `ReplayTriggers.tsx` to pass the raw decimal value of the `session_recording_sample_rate` to the summary component, instead of a pre-multiplied percentage. This ensures consistency with how Error Tracking passes its sample rate and resolves the incorrect display.

Specifically, `ReplayTriggers.tsx` line 355 was changed from `sampleRate: numericSampleRate` to `sampleRate: sampleRate ? parseFloat(sampleRate) : null`.

## How did you test this code?

- Verified the code change by reviewing the modified file.
- Checked for linting errors.
- Manually verified in the UI that the Session Replay sampling rate now displays correctly (e.g., "99%").

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1770112187621819?thread_ts=1770112187.621819&cid=C0ACRAMJUAG)

<a href="https://cursor.com/background-agent?bcId=bc-c020f592-305f-59c5-aa79-06d7a130ee81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c020f592-305f-59c5-aa79-06d7a130ee81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

