### PR TITLE
fix(llma): increase sample activity timeout and use start_to_close

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -24,7 +24,7 @@ MAX_TEXT_REPR_LENGTH = 2_000_000
 SCHEDULE_INTERVAL_HOURS = 1  # How often the coordinator runs
 
 # Timeout configuration (in seconds)
-SAMPLE_TIMEOUT_SECONDS = 300  # 5 minutes for sampling query
+SAMPLE_TIMEOUT_SECONDS = 900  # 15 minutes for sampling query (buffer above QUERY_ASYNC 600s ClickHouse timeout)
 GENERATE_SUMMARY_TIMEOUT_SECONDS = 300  # 5 minutes per summary generation (increased for LLM API latency/rate limits)
 
 # Workflow-level timeouts (in minutes)

--- a/posthog/temporal/llm_analytics/trace_summarization/workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/workflow.py
@@ -174,7 +174,7 @@ class BatchTraceSummarizationWorkflow(PostHogWorkflow):
         items = await temporalio.workflow.execute_activity(
             sample_items_in_window_activity,
             inputs_with_window,
-            schedule_to_close_timeout=timedelta(seconds=SAMPLE_TIMEOUT_SECONDS),
+            start_to_close_timeout=timedelta(seconds=SAMPLE_TIMEOUT_SECONDS),
             retry_policy=constants.SAMPLE_RETRY_POLICY,
         )
         metrics.items_queried = len(items)


### PR DESCRIPTION
## Problem

The `sample_items_in_window_activity` in the trace summarization workflow is timing out for high-volume teams (e.g. team 2). The Temporal activity timeout (5 min) is shorter than the ClickHouse `QUERY_ASYNC` timeout (10 min), so the activity gets killed before the query can finish. Additionally, `schedule_to_close_timeout` shares the timeout budget across all retry attempts, so if the first attempt consumes the full 5 minutes, retries get `RETRY_STATE_NON_RETRYABLE_FAILURE`.

## Changes

- Bump `SAMPLE_TIMEOUT_SECONDS` from 300s to 900s (15 min) to give buffer above the 600s ClickHouse timeout
- Switch from `schedule_to_close_timeout` to `start_to_close_timeout` so each retry attempt gets its own timeout window

## How did you test this code?

Verified against the failing workflow run in Temporal Cloud (`llma-trace-summarization-team-2-2026-02-03T10:00:21`). The activity was consistently hitting the 5-minute wall. With these changes, the activity gets 15 minutes per attempt with up to 3 attempts.

## Publish to changelog?

No