### PR TITLE
feat(analytics-platform): Create $internal_or_test_user filter for new teams and demo projects

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -30,6 +30,8 @@ export function loadPostHogJS(): void {
             error_tracking: {
                 __capturePostHogExceptions: true,
             },
+            internal_or_test_user_hostname: /^(localhost|127\.0\.0\.1)$/,
+
             loaded: (loadedInstance) => {
                 if (loadedInstance.sessionRecording) {
                     loadedInstance.sessionRecording._forceAllowLocalhostNetworkCapture = true

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -4267,6 +4267,15 @@
             "label": "Insert ID",
             "system": true
         },
+        "$internal_or_test_user": {
+            "description": "Whether this user is an internal team member or test user. Used to filter out internal users from analytics. Learn more in [our documentation](https://posthog.com/tutorials/filter-internal-users).",
+            "examples": [
+                true,
+                false
+            ],
+            "label": "Internal/test user",
+            "type": "Boolean"
+        },
         "$ip": {
             "description": "IP address for this user when the event was sent.",
             "examples": [

--- a/posthog/api/test/test_playwright_setup.py
+++ b/posthog/api/test/test_playwright_setup.py
@@ -24,7 +24,7 @@ class TestPlaywrightSetup(APIBaseTest):
         response = self.client.post("/api/setup_test/organization_with_team/", payload, format="json")
 
         # Check response structure
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
         data = response.json()
 
         self.assertTrue(data["success"])
@@ -70,14 +70,14 @@ class TestPlaywrightSetup(APIBaseTest):
         """Test that the endpoint works in DEBUG mode"""
         payload = {"organization_name": "Debug Org"}
         response = self.client.post("/api/setup_test/organization_with_team/", payload, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
 
     @override_settings(E2E_TESTING=True)
     def test_endpoint_allowed_in_e2e_mode(self):
         """Test that the endpoint works in E2E_TESTING mode"""
         payload = {"organization_name": "E2E Org"}
         response = self.client.post("/api/setup_test/organization_with_team/", payload, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
 
     @override_settings(TEST=True)
     def test_unknown_setup_function(self):

--- a/posthog/demo/matrix/manager.py
+++ b/posthog/demo/matrix/manager.py
@@ -94,7 +94,7 @@ class MatrixManager:
                     role_at_organization="engineering",
                 )
                 team = self.create_team(organization, initiating_user=new_user)
-            # Demo data generation is triggered by create_with_data(is_demo=True) via Celery task
+            self.run_on_team(team, new_user)
             return (organization, team, new_user)
         elif existing_user.is_staff:
             raise exceptions.PermissionDenied("Cannot log in as staff user without password.")
@@ -120,12 +120,13 @@ class MatrixManager:
 
     @staticmethod
     def create_team(organization: Organization, initiating_user: Optional["UserType"] = None, **kwargs) -> Team:
-        # Pass is_demo=True to trigger demo data generation via Celery task
-        # The task calls MatrixManager.run_on_team() which handles all demo setup
+        # Pass is_demo=True but skip automatic demo data generation
+        # MatrixManager handles demo data via run_on_team() which uses the same matrix instance
         return Team.objects.create_with_data(
             organization=organization,
             initiating_user=initiating_user,
             is_demo=True,
+            skip_demo_data_generation=True,
             **kwargs,
         )
 

--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -207,7 +207,7 @@ class HedgeboxMatrix(Matrix):
                 }
             ],
         )
-        real_users_cohort = Cohort.objects.create(
+        Cohort.objects.create(
             team=team,
             name="Real persons",
             description="People who don't belong to the Hedgebox team.",
@@ -225,7 +225,6 @@ class HedgeboxMatrix(Matrix):
                 }
             ],
         )
-        team.test_account_filters = [{"key": "id", "type": "cohort", "value": real_users_cohort.pk}]
 
         # Dashboard: Key metrics (project home)
         key_metrics_dashboard = Dashboard.objects.create(

--- a/posthog/demo/products/hedgebox/models.py
+++ b/posthog/demo/products/hedgebox/models.py
@@ -728,7 +728,11 @@ class HedgeboxPerson(SimPerson):
         )
         self.active_client.capture(EVENT_SIGNED_UP, {"from_invite": False})
         self.advance_timer(self.cluster.random.uniform(0.1, 0.2))
-        self.active_client.identify(self.in_product_id, {"email": self.email, "name": self.name})
+        identify_properties = {"email": self.email, "name": self.name}
+        # First cluster users are marked as internal/test users for filtering demo
+        if self.cluster.index == 0:
+            identify_properties["$internal_or_test_user"] = True
+        self.active_client.identify(self.in_product_id, identify_properties)
         self.active_client.group(
             GROUP_TYPE_ACCOUNT,
             self.account.id,

--- a/posthog/demo/products/hedgebox/models.py
+++ b/posthog/demo/products/hedgebox/models.py
@@ -728,7 +728,7 @@ class HedgeboxPerson(SimPerson):
         )
         self.active_client.capture(EVENT_SIGNED_UP, {"from_invite": False})
         self.advance_timer(self.cluster.random.uniform(0.1, 0.2))
-        identify_properties = {"email": self.email, "name": self.name}
+        identify_properties: dict[str, str | bool] = {"email": self.email, "name": self.name}
         # First cluster users are marked as internal/test users for filtering demo
         if self.cluster.index == 0:
             identify_properties["$internal_or_test_user"] = True

--- a/posthog/demo/test/test_matrix_manager.py
+++ b/posthog/demo/test/test_matrix_manager.py
@@ -4,7 +4,6 @@ from typing import Optional
 from zoneinfo import ZoneInfo
 
 from posthog.test.base import ClickhouseDestroyTablesMixin
-from unittest import mock
 
 from posthog.clickhouse.client import sync_execute
 from posthog.demo.matrix.manager import MatrixManager
@@ -70,8 +69,7 @@ class TestMatrixManager(ClickhouseDestroyTablesMixin):
         # At least one event for each cluster
         assert sync_execute("SELECT count() FROM events WHERE team_id = 0")[0][0] >= 3
 
-    @mock.patch("posthog.models.team.team.Team.kick_off_demo_data_generation")
-    def test_create_team(self, mock_kick_off):
+    def test_create_team(self):
         manager = MatrixManager(self.matrix)
 
         demo_team = manager.create_team(self.organization, initiating_user=self.user)
@@ -79,7 +77,6 @@ class TestMatrixManager(ClickhouseDestroyTablesMixin):
         assert demo_team.organization == self.organization
         assert demo_team.ingested_event
         assert demo_team.is_demo
-        mock_kick_off.assert_called_once_with(self.user)
 
     def test_run_on_team(self):
         manager = MatrixManager(self.matrix)

--- a/posthog/demo/test/test_matrix_manager.py
+++ b/posthog/demo/test/test_matrix_manager.py
@@ -74,6 +74,8 @@ class TestMatrixManager(ClickhouseDestroyTablesMixin):
 
         demo_team = manager.create_team(self.organization, initiating_user=self.user)
 
+        # Refresh from DB to get updates from the Celery task that ran synchronously
+        demo_team.refresh_from_db()
         assert demo_team.organization == self.organization
         assert demo_team.ingested_event
         assert demo_team.is_demo

--- a/posthog/demo/test/test_matrix_manager.py
+++ b/posthog/demo/test/test_matrix_manager.py
@@ -4,6 +4,7 @@ from typing import Optional
 from zoneinfo import ZoneInfo
 
 from posthog.test.base import ClickhouseDestroyTablesMixin
+from unittest import mock
 
 from posthog.clickhouse.client import sync_execute
 from posthog.demo.matrix.manager import MatrixManager
@@ -69,14 +70,16 @@ class TestMatrixManager(ClickhouseDestroyTablesMixin):
         # At least one event for each cluster
         assert sync_execute("SELECT count() FROM events WHERE team_id = 0")[0][0] >= 3
 
-    def test_create_team(self):
+    @mock.patch("posthog.models.team.team.Team.kick_off_demo_data_generation")
+    def test_create_team(self, mock_kick_off):
         manager = MatrixManager(self.matrix)
 
-        demo_team = manager.create_team(self.organization)
+        demo_team = manager.create_team(self.organization, initiating_user=self.user)
 
         assert demo_team.organization == self.organization
         assert demo_team.ingested_event
         assert demo_team.is_demo
+        mock_kick_off.assert_called_once_with(self.user)
 
     def test_run_on_team(self):
         manager = MatrixManager(self.matrix)

--- a/posthog/demo/test/test_matrix_manager.py
+++ b/posthog/demo/test/test_matrix_manager.py
@@ -74,10 +74,9 @@ class TestMatrixManager(ClickhouseDestroyTablesMixin):
 
         demo_team = manager.create_team(self.organization, initiating_user=self.user)
 
-        # Refresh from DB to get updates from the Celery task that ran synchronously
-        demo_team.refresh_from_db()
+        # Verify the team was created with is_demo=True
+        # Note: create_team only creates the team, run_on_team is called separately by ensure_account_and_save
         assert demo_team.organization == self.organization
-        assert demo_team.ingested_event
         assert demo_team.is_demo
 
     def test_run_on_team(self):

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -859,6 +859,45 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
     __repr__ = sane_repr("id", "name", "last_calculation")
 
 
+TEST_USERS_COHORT_NAME = "Test users"
+
+
+def get_or_create_test_users_cohort(team: "Team") -> "Cohort":
+    """
+    Get or create a 'Test users' cohort for the team.
+
+    This cohort contains users with the $test_user person property set to true.
+    Used for filtering out test/internal users from analytics.
+    """
+    test_users_cohort, _ = Cohort.objects.get_or_create(
+        team=team,
+        name=TEST_USERS_COHORT_NAME,
+        defaults={
+            "description": "Cohort containing users with $test_user property set to true. See https://posthog.com/tutorials/filter-internal-users",
+            "is_static": False,
+            "filters": {
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "$test_user",
+                                    "type": "person",
+                                    "value": [True],
+                                    "operator": "exact",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        },
+    )
+    return test_users_cohort
+
+
 class CohortPeople(models.Model):
     id = models.BigAutoField(primary_key=True)
     cohort = models.ForeignKey("Cohort", on_delete=models.DO_NOTHING, db_constraint=False)

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -859,12 +859,12 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
     __repr__ = sane_repr("id", "name", "last_calculation")
 
 
-TEST_USERS_COHORT_NAME = "Test users"
+TEST_USERS_COHORT_NAME = "Internal / Test users"
 
 
-def get_or_create_test_users_cohort(team: "Team") -> "Cohort":
+def get_or_create_internal_test_users_cohort(team: "Team") -> "Cohort":
     """
-    Get or create a 'Test users' cohort for the team.
+    Get or create a 'Internal / Test users' cohort for the team.
 
     This cohort contains users with the $test_user person property set to true.
     Used for filtering out test/internal users from analytics.
@@ -873,7 +873,7 @@ def get_or_create_test_users_cohort(team: "Team") -> "Cohort":
         team=team,
         name=TEST_USERS_COHORT_NAME,
         defaults={
-            "description": "Cohort containing users with $test_user property set to true. See https://posthog.com/tutorials/filter-internal-users",
+            "description": "Cohort containing users with $internal_or_test_user property set to true. See https://posthog.com/tutorials/filter-internal-users",
             "is_static": False,
             "filters": {
                 "properties": {
@@ -883,7 +883,7 @@ def get_or_create_test_users_cohort(team: "Team") -> "Cohort":
                             "type": "AND",
                             "values": [
                                 {
-                                    "key": "$test_user",
+                                    "key": "$internal_or_test_user",
                                     "type": "person",
                                     "value": [True],
                                     "operator": "exact",

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -866,7 +866,7 @@ def get_or_create_internal_test_users_cohort(team: "Team") -> "Cohort":
     """
     Get or create a 'Internal / Test users' cohort for the team.
 
-    This cohort contains users with the $test_user person property set to true.
+    This cohort contains users with the $internal_or_test_user person property set to true.
     Used for filtering out test/internal users from analytics.
     """
     test_users_cohort, _ = Cohort.objects.get_or_create(

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -115,7 +115,9 @@ class TeamManager(models.Manager):
                     ]
         return filters
 
-    def create_with_data(self, *, initiating_user: Optional["User"], **kwargs) -> "Team":
+    def create_with_data(
+        self, *, initiating_user: Optional["User"], skip_demo_data_generation: bool = False, **kwargs
+    ) -> "Team":
         team = cast("Team", self.create(**kwargs))
 
         # Create test users cohort and set test account filters to exclude it
@@ -124,7 +126,7 @@ class TeamManager(models.Manager):
         test_users_cohort = get_or_create_internal_test_users_cohort(team)
         team.test_account_filters = [{"key": "id", "type": "cohort", "value": test_users_cohort.id, "negation": True}]
 
-        if kwargs.get("is_demo"):
+        if kwargs.get("is_demo") and not skip_demo_data_generation:
             if initiating_user is None:
                 raise ValueError("initiating_user must be provided when creating a demo team")
             team.save()

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -128,7 +128,13 @@ class TeamManager(models.Manager):
             if initiating_user is None:
                 raise ValueError("initiating_user must be provided when creating a demo team")
             team.save()
-            team.kick_off_demo_data_generation(initiating_user)
+            # Defer Celery task if we're inside an atomic block (e.g., ensure_account_and_save)
+            # to avoid sending task before transaction commits. In tests, Celery tasks run
+            # synchronously so we can call directly (and on_commit doesn't run in TestCase).
+            if connection.in_atomic_block and not settings.TEST:
+                transaction.on_commit(lambda: team.kick_off_demo_data_generation(initiating_user))
+            else:
+                team.kick_off_demo_data_generation(initiating_user)
             return team  # Return quickly, as the demo data and setup will be created asynchronously
 
         # Get organization to apply defaults

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -45,7 +45,8 @@ from posthog.utils import GenericEmails
 from products.customer_analytics.backend.constants import DEFAULT_ACTIVITY_EVENT
 
 from ...hogql.modifiers import set_default_modifier_values
-from ...schema import CurrencyCode, HogQLQueryModifiers, PathCleaningFilter, PersonsOnEventsMode
+from ...schema import CurrencyCode, HogQLQueryModifiers, PathCleaningFilter, PersonsOnEventsMode, CohortPropertyFilter, \
+    PropertyOperator
 from .team_caching import get_team_in_cache, set_team_in_cache
 
 if TYPE_CHECKING:
@@ -124,7 +125,8 @@ class TeamManager(models.Manager):
         from posthog.models.cohort.cohort import get_or_create_internal_test_users_cohort
 
         test_users_cohort = get_or_create_internal_test_users_cohort(team)
-        team.test_account_filters = [{"key": "id", "type": "cohort", "value": test_users_cohort.id, "negation": True}]
+        cohort_filter = CohortPropertyFilter(cohort_name=test_users_cohort.name, value=test_users_cohort.id, operator=PropertyOperator.NOT_IN)
+        team.test_account_filters = [cohort_filter.model_dump_json()]
 
         if kwargs.get("is_demo") and not skip_demo_data_generation:
             if initiating_user is None:

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -119,9 +119,9 @@ class TeamManager(models.Manager):
         team = cast("Team", self.create(**kwargs))
 
         # Create test users cohort and set test account filters to exclude it
-        from posthog.models.cohort.cohort import get_or_create_test_users_cohort
+        from posthog.models.cohort.cohort import get_or_create_internal_test_users_cohort
 
-        test_users_cohort = get_or_create_test_users_cohort(team)
+        test_users_cohort = get_or_create_internal_test_users_cohort(team)
         team.test_account_filters = [{"key": "id", "type": "cohort", "value": test_users_cohort.id, "negation": True}]
 
         if kwargs.get("is_demo"):

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -134,7 +134,7 @@ class TeamManager(models.Manager):
         cohort_filter = CohortPropertyFilter(
             cohort_name=test_users_cohort.name, value=test_users_cohort.id, operator=PropertyOperator.NOT_IN
         )
-        team.test_account_filters = [cohort_filter.model_dump_json()]
+        team.test_account_filters = [cohort_filter.model_dump()]
 
         if kwargs.get("is_demo") and not skip_demo_data_generation:
             if initiating_user is None:

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -45,8 +45,14 @@ from posthog.utils import GenericEmails
 from products.customer_analytics.backend.constants import DEFAULT_ACTIVITY_EVENT
 
 from ...hogql.modifiers import set_default_modifier_values
-from ...schema import CurrencyCode, HogQLQueryModifiers, PathCleaningFilter, PersonsOnEventsMode, CohortPropertyFilter, \
-    PropertyOperator
+from ...schema import (
+    CohortPropertyFilter,
+    CurrencyCode,
+    HogQLQueryModifiers,
+    PathCleaningFilter,
+    PersonsOnEventsMode,
+    PropertyOperator,
+)
 from .team_caching import get_team_in_cache, set_team_in_cache
 
 if TYPE_CHECKING:
@@ -125,7 +131,9 @@ class TeamManager(models.Manager):
         from posthog.models.cohort.cohort import get_or_create_internal_test_users_cohort
 
         test_users_cohort = get_or_create_internal_test_users_cohort(team)
-        cohort_filter = CohortPropertyFilter(cohort_name=test_users_cohort.name, value=test_users_cohort.id, operator=PropertyOperator.NOT_IN)
+        cohort_filter = CohortPropertyFilter(
+            cohort_name=test_users_cohort.name, value=test_users_cohort.id, operator=PropertyOperator.NOT_IN
+        )
         team.test_account_filters = [cohort_filter.model_dump_json()]
 
         if kwargs.get("is_demo") and not skip_demo_data_generation:

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2155,6 +2155,12 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "type": "Numeric",
             "virtual": True,
         },
+        "$internal_or_test_user": {
+            "label": "Internal/test user",
+            "description": "Whether this user is an internal team member or test user. Used to filter out internal users from analytics. Learn more in [our documentation](https://posthog.com/tutorials/filter-internal-users).",
+            "examples": [True, False],
+            "type": "Boolean",
+        },
     },
     "session_properties": {
         "$session_duration": {

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -106,10 +106,12 @@ class TestTeam(BaseTest):
             team.test_account_filters,
             [
                 {
+                    "cohort_name": TEST_USERS_COHORT_NAME,
                     "key": "id",
+                    "label": None,
+                    "operator": "not_in",
                     "type": "cohort",
                     "value": test_users_cohort.id,
-                    "negation": True,
                 },
             ],
         )

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -75,10 +75,10 @@ class TestTeam(BaseTest):
     def test_create_team_with_test_account_filters(self):
         team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
 
-        # A "Test users" cohort should be created for the team
+        # An "Internal / Test users" cohort should be created for the team
         test_users_cohort = Cohort.objects.get(team=team, name=TEST_USERS_COHORT_NAME)
 
-        # The cohort should have $test_user: true filter
+        # The cohort should have $internal_or_test_user: true filter
         self.assertEqual(
             test_users_cohort.filters,
             {
@@ -89,7 +89,7 @@ class TestTeam(BaseTest):
                             "type": "AND",
                             "values": [
                                 {
-                                    "key": "$test_user",
+                                    "key": "$internal_or_test_user",
                                     "type": "person",
                                     "value": [True],
                                     "operator": "exact",

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -7,7 +7,9 @@ from parameterized import parameterized
 
 from posthog.schema import PersonsOnEventsMode
 
-from posthog.models import Dashboard, DashboardTile, Organization, Team, User
+from posthog.models import Dashboard, DashboardTile, Organization, Team
+from posthog.models.cohort import Cohort
+from posthog.models.cohort.cohort import TEST_USERS_COHORT_NAME
 from posthog.models.instance_setting import override_instance_config
 from posthog.models.project import Project
 from posthog.models.team import get_team_in_cache, util
@@ -72,38 +74,43 @@ class TestTeam(BaseTest):
 
     def test_create_team_with_test_account_filters(self):
         team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
+
+        # A "Test users" cohort should be created for the team
+        test_users_cohort = Cohort.objects.get(team=team, name=TEST_USERS_COHORT_NAME)
+
+        # The cohort should have $test_user: true filter
         self.assertEqual(
-            team.test_account_filters,
-            [
-                {
-                    "key": "email",
-                    "value": "@posthog.com",
-                    "operator": "not_icontains",
-                    "type": "person",
-                },
-                {
-                    "key": "$host",
-                    "operator": "not_regex",
-                    "value": "^(localhost|127\\.0\\.0\\.1)($|:)",
-                    "type": "event",
-                },
-            ],
+            test_users_cohort.filters,
+            {
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "$test_user",
+                                    "type": "person",
+                                    "value": [True],
+                                    "operator": "exact",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
         )
 
-        # test generic emails
-        user = User.objects.create(email="test@gmail.com")
-        organization = Organization.objects.create()
-        organization.members.set([user])
-        team = Team.objects.create_with_data(initiating_user=self.user, organization=organization)
+        # New teams get the Test users cohort filter (with negation to exclude test users)
         self.assertEqual(
             team.test_account_filters,
             [
                 {
-                    "key": "$host",
-                    "operator": "not_regex",
-                    "value": "^(localhost|127\\.0\\.0\\.1)($|:)",
-                    "type": "event",
-                }
+                    "key": "id",
+                    "type": "cohort",
+                    "value": test_users_cohort.id,
+                    "negation": True,
+                },
             ],
         )
 


### PR DESCRIPTION
## Problem

We want new teams to start with a cohort for internal / test users. This uses the property at $test_or_internal_user which can be set by the JS SDK by using the `setInternalOrTestUser()` function or the `internal_or_test_user_hostname` config option

## Changes
Create a cohort with new teams to use as internal/test filters

Also changed the text to nudge people towards doing the right thing. I plan to improve this UI a bit more in a future PR

## How did you test this code?

Updated the tests to work with this new setting.

Demo env:

<img width="1473" height="288" alt="Screenshot 2026-02-05 at 17 15 04" src="https://github.com/user-attachments/assets/facf4f7b-57b8-4319-a5d5-2e189e1e59ec" />


## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
