### PR TITLE
feat(tags): autosave tags on insights/dashboard

### DIFF
--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -51,7 +51,11 @@ export function ScenePanelActionsSection({ children }: { children: React.ReactNo
     return <div className="scene-panel-actions-section flex flex-col gap-px -ml-1 pl-1">{children}</div>
 }
 
-export function ScenePanelLabel({ children, title, ...props }: PropsWithChildren<LabelProps>): JSX.Element {
+export function ScenePanelLabel({
+    children,
+    title,
+    ...props
+}: PropsWithChildren<Omit<LabelProps, 'title'> & { title: React.ReactNode }>): JSX.Element {
     return (
         <div className="flex flex-col gap-0">
             <Label intent="menu" {...props}>

--- a/frontend/src/lib/components/Scenes/SceneTags.tsx
+++ b/frontend/src/lib/components/Scenes/SceneTags.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 
 import { ScenePanelLabel } from '~/layout/scenes/SceneLayout'
@@ -13,6 +14,7 @@ type SceneTagsProps = SceneCanEditProps &
         onSave?: (value: string[]) => void
         tags?: string[]
         tagsAvailable?: string[]
+        loading?: boolean
     }
 
 export const SceneTags = ({
@@ -21,6 +23,7 @@ export const SceneTags = ({
     tagsAvailable,
     dataAttrKey,
     canEdit = true,
+    loading,
 }: SceneTagsProps): JSX.Element => {
     const [localTags, setLocalTags] = useState(tags)
     const [localIsEditing, setLocalIsEditing] = useState(false)
@@ -35,9 +38,16 @@ export const SceneTags = ({
         setLocalTags(tags)
     }, [tags])
 
+    const label = (
+        <span className="flex items-center gap-1.5">
+            Tags
+            {loading ? <Spinner className="text-sm" /> : null}
+        </span>
+    )
+
     return localIsEditing ? (
         <div className="flex flex-col gap-1">
-            <ScenePanelLabel htmlFor="new-tag-input" title="Tags">
+            <ScenePanelLabel htmlFor="new-tag-input" title={label}>
                 <LemonInputSelect
                     mode="multiple"
                     allowCustomValues
@@ -55,7 +65,7 @@ export const SceneTags = ({
             </ScenePanelLabel>
         </div>
     ) : (
-        <ScenePanelLabel title="Tags">
+        <ScenePanelLabel title={label}>
             <ButtonPrimitive
                 className="hyphens-auto flex gap-1 items-center"
                 lang="en"

--- a/frontend/src/lib/components/Scenes/SceneTags.tsx
+++ b/frontend/src/lib/components/Scenes/SceneTags.tsx
@@ -35,8 +35,10 @@ export const SceneTags = ({
     }
 
     useEffect(() => {
-        setLocalTags(tags)
-    }, [tags])
+        if (!localIsEditing) {
+            setLocalTags(tags)
+        }
+    }, [tags, localIsEditing])
 
     const label = (
         <span className="flex items-center gap-1.5">

--- a/frontend/src/lib/components/Scenes/SceneTags.tsx
+++ b/frontend/src/lib/components/Scenes/SceneTags.tsx
@@ -6,7 +6,7 @@ import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { ScenePanelLabel } from '~/layout/scenes/SceneLayout'
 
 import { ObjectTags } from '../ObjectTags/ObjectTags'
-import { SceneCanEditProps, SceneDataAttrKeyProps, SceneSaveCancelButtons } from './utils'
+import { SceneCanEditProps, SceneDataAttrKeyProps } from './utils'
 
 type SceneTagsProps = SceneCanEditProps &
     SceneDataAttrKeyProps & {
@@ -24,32 +24,27 @@ export const SceneTags = ({
 }: SceneTagsProps): JSX.Element => {
     const [localTags, setLocalTags] = useState(tags)
     const [localIsEditing, setLocalIsEditing] = useState(false)
-    const [hasChanged, setHasChanged] = useState(false)
 
-    const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
-        e.preventDefault()
-        onSave?.(localTags ?? [])
-        setHasChanged(false)
-        setLocalIsEditing(false)
+    const handleTagsChange = (newTags: string[]): void => {
+        setLocalTags(newTags)
+        // Autosave on change
+        onSave?.(newTags)
     }
-
-    useEffect(() => {
-        setHasChanged(localTags !== tags)
-    }, [localTags, tags])
 
     useEffect(() => {
         setLocalTags(tags)
     }, [tags])
 
     return localIsEditing ? (
-        <form onSubmit={handleSubmit} name="page-tags" className="flex flex-col gap-1">
+        <div className="flex flex-col gap-1">
             <ScenePanelLabel htmlFor="new-tag-input" title="Tags">
                 <LemonInputSelect
                     mode="multiple"
                     allowCustomValues
                     value={localTags}
                     options={tagsAvailable?.map((t) => ({ key: t, label: t }))}
-                    onChange={setLocalTags}
+                    onChange={handleTagsChange}
+                    onBlur={() => setLocalIsEditing(false)}
                     loading={false}
                     data-attr={`${dataAttrKey}-new-tag-input`}
                     placeholder='try "official"'
@@ -58,16 +53,7 @@ export const SceneTags = ({
                     className="max-w-full"
                 />
             </ScenePanelLabel>
-            <SceneSaveCancelButtons
-                name="tags"
-                onCancel={() => {
-                    setLocalTags(tags)
-                    setLocalIsEditing(false)
-                }}
-                hasChanged={hasChanged}
-                dataAttrKey={dataAttrKey}
-            />
-        </form>
+        </div>
     ) : (
         <ScenePanelLabel title="Tags">
             <ButtonPrimitive

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -85,8 +85,9 @@ export function DashboardHeader(): JSX.Element | null {
         apiUrl,
         showTextTileModal,
         textTileId,
+        isSavingTags,
     } = useValues(dashboardLogic)
-    const { setDashboardMode, triggerDashboardUpdate, loadDashboard } = useActions(dashboardLogic)
+    const { setDashboardMode, loadDashboard, updateDashboardTags } = useActions(dashboardLogic)
     const { asDashboardTemplate, effectiveEditBarFilters, effectiveDashboardVariableOverrides, tiles } =
         useValues(dashboardLogic)
     const { updateDashboard, pinDashboard, unpinDashboard } = useActions(dashboardsModel)
@@ -104,7 +105,6 @@ export function DashboardHeader(): JSX.Element | null {
     const { showDeleteDashboardModal } = useActions(deleteDashboardLogic)
 
     const { tags } = useValues(tagsModel)
-    const { dashboardLoading: isDashboardUpdating } = useValues(dashboardsModel)
 
     const { push } = useActions(router)
 
@@ -209,13 +209,13 @@ export function DashboardHeader(): JSX.Element | null {
                 <ScenePanelInfoSection>
                     <SceneTags
                         onSave={(tags) => {
-                            triggerDashboardUpdate({ tags })
+                            updateDashboardTags(tags)
                         }}
                         canEdit={canEditDashboard}
                         tags={dashboard?.tags}
                         tagsAvailable={tags.filter((tag) => !dashboard?.tags?.includes(tag))}
                         dataAttrKey={RESOURCE_TYPE}
-                        loading={isDashboardUpdating}
+                        loading={isSavingTags}
                     />
 
                     <SceneFile dataAttrKey={RESOURCE_TYPE} />

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -104,6 +104,7 @@ export function DashboardHeader(): JSX.Element | null {
     const { showDeleteDashboardModal } = useActions(deleteDashboardLogic)
 
     const { tags } = useValues(tagsModel)
+    const { dashboardLoading: isDashboardUpdating } = useValues(dashboardsModel)
 
     const { push } = useActions(router)
 
@@ -214,6 +215,7 @@ export function DashboardHeader(): JSX.Element | null {
                         tags={dashboard?.tags}
                         tagsAvailable={tags.filter((tag) => !dashboard?.tags?.includes(tag))}
                         dataAttrKey={RESOURCE_TYPE}
+                        loading={isDashboardUpdating}
                     />
 
                     <SceneFile dataAttrKey={RESOURCE_TYPE} />

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -239,6 +239,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setAccessDeniedToDashboard: true,
         /** Update the dashboard in dashboardsModel with given payload. */
         triggerDashboardUpdate: (payload) => ({ payload }),
+        updateDashboardTags: (tags: string[]) => ({ tags }),
         /** Update page visibility for virtualized rendering. */
         setPageVisibility: (visible: boolean) => ({ visible }),
         setSubscriptionMode: (enabled: boolean, id?: number | 'new') => ({ enabled, id }),
@@ -868,6 +869,16 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     breakdown_filter: undefined,
                     explicitDate: undefined,
                 }),
+            },
+        ],
+        isSavingTags: [
+            false,
+            {
+                updateDashboardTags: () => true,
+                [dashboardsModel.actionTypes.updateDashboardSuccess]: (state, { dashboard }) => {
+                    return dashboard && dashboard.id === props.id ? false : state
+                },
+                [dashboardsModel.actionTypes.updateDashboardFailure]: () => false,
             },
         ],
     })),
@@ -1888,7 +1899,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 id: props.id,
                 last_refresh: lastDashboardRefresh.toISOString(),
                 discardResult: true,
+                allowUndo: false,
             })
+        },
+        updateDashboardTags: ({ tags }: { tags: string[] }) => {
+            actions.triggerDashboardUpdate({ tags })
         },
         setTileOverride: ({ tile }) => {
             const tileLogicProps = { dashboardId: props.id, tileId: tile.id, filtersOverrides: tile.filters_overrides }

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -253,6 +253,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             tagsAvailable={allExistingTags}
                             dataAttrKey={RESOURCE_TYPE}
                             canEdit={canEditInsight}
+                            loading={insightSaving}
                         />
 
                         <SceneFile dataAttrKey={RESOURCE_TYPE} />

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -98,6 +98,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         insight,
         insightChanged,
         insightSaving,
+        isSavingTags,
         hasDashboardItemId,
         insightLoading,
         derivedName,
@@ -253,7 +254,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             tagsAvailable={allExistingTags}
                             dataAttrKey={RESOURCE_TYPE}
                             canEdit={canEditInsight}
-                            loading={insightSaving}
+                            loading={isSavingTags}
                         />
 
                         <SceneFile dataAttrKey={RESOURCE_TYPE} />

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -337,6 +337,14 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 saveInsightFailure: () => false,
             },
         ],
+        isSavingTags: [
+            false,
+            {
+                setInsightMetadata: (_, { metadataUpdate }) => !!metadataUpdate.tags,
+                setInsightMetadataSuccess: () => false,
+                setInsightMetadataFailure: () => false,
+            },
+        ],
         previousQuery: [
             null as Node | null,
             {


### PR DESCRIPTION
## Problem
https://posthog.slack.com/archives/C045L1VEG87/p1770111660039839

Currently when editing tags on insights/dashboards, the save/undo buttons as blocked by the tags dropdown

## Changes
Made the tag changes autosave
Also removed the form wrapper since we don't need it now.

https://github.com/user-attachments/assets/5f7cd3e1-7432-4dcc-9756-bc931609582d


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
