### PR TITLE
fix(cyclotron): fix source for cyclotron metric collection

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-cyclotron-shadow-worker.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-shadow-worker.consumer.ts
@@ -25,7 +25,7 @@ export class CdpCyclotronShadowWorker extends CdpCyclotronWorker {
         const shadowHub: CdpCyclotronWorkerHub = {
             ...hub,
             CYCLOTRON_DATABASE_URL: hub.CYCLOTRON_SHADOW_DATABASE_URL,
-            CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: 'postgres',
+            CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: 'shadow',
             CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING: '*:postgres',
         }
         super(shadowHub)

--- a/nodejs/src/cdp/services/job-queue/job-queue.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.ts
@@ -248,20 +248,12 @@ export class CyclotronJobQueue {
 
         if (this.shadowPostgres && Date.now() >= this.shadowCircuitOpenUntil) {
             const hogInvocations = invocations.filter((x) => x.queue === 'hog')
-            const allQueues = [...new Set(invocations.map((x) => x.queue))]
-            logger.info('Shadow write check', {
-                totalInvocations: invocations.length,
-                hogInvocations: hogInvocations.length,
-                allQueues,
-            })
             if (!hogInvocations.length) {
-                logger.info('Shadow write skipped - no hog invocations', { allQueues })
                 return
             }
             void this.shadowPostgres
                 .queueInvocations(hogInvocations)
                 .then(() => {
-                    logger.info('Shadow write succeeded', { count: hogInvocations.length })
                     this.shadowFailures = 0
                 })
                 .catch((err) => {

--- a/nodejs/src/cdp/services/job-queue/job-queue.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.ts
@@ -75,7 +75,7 @@ export class CyclotronJobQueue {
             this.consumeBatch(invocations, 'delay')
         )
         this.jobQueuePostgres = new CyclotronJobQueuePostgres(this.config, this.queue, (invocations) =>
-            this.consumeBatch(invocations, 'postgres')
+            this.consumeBatch(invocations, this.consumerMode === 'shadow' ? 'shadow' : 'postgres')
         )
 
         if (this.config.CDP_CYCLOTRON_SHADOW_WRITE_ENABLED && this.config.CYCLOTRON_SHADOW_DATABASE_URL) {
@@ -164,7 +164,7 @@ export class CyclotronJobQueue {
         // The consumer always needs the producers as well
         await this.startAsProducer()
 
-        if (this.consumerMode === 'postgres') {
+        if (this.consumerMode === 'postgres' || this.consumerMode === 'shadow') {
             await this.jobQueuePostgres.startAsConsumer()
         } else if (this.consumerMode === 'kafka') {
             await this.jobQueueKafka.startAsConsumer()
@@ -191,7 +191,7 @@ export class CyclotronJobQueue {
     }
 
     public isHealthy() {
-        if (this.consumerMode === 'postgres') {
+        if (this.consumerMode === 'postgres' || this.consumerMode === 'shadow') {
             return this.jobQueuePostgres.isHealthy()
         } else if (this.consumerMode === 'kafka') {
             return this.jobQueueKafka.isHealthy()

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -258,7 +258,7 @@ export const CYCLOTRON_INVOCATION_JOB_QUEUES = [
 ] as const
 export type CyclotronJobQueueKind = (typeof CYCLOTRON_INVOCATION_JOB_QUEUES)[number]
 
-export const CYCLOTRON_JOB_QUEUE_SOURCES = ['postgres', 'kafka', 'delay'] as const
+export const CYCLOTRON_JOB_QUEUE_SOURCES = ['postgres', 'kafka', 'delay', 'shadow'] as const
 export type CyclotronJobQueueSource = (typeof CYCLOTRON_JOB_QUEUE_SOURCES)[number]
 
 // Agnostic job invocation type


### PR DESCRIPTION
## Problem

Shadow worker was emitting metrics with `source="postgres"`, same as the main cyclotron worker, causing shadow data to pollute production dashboards.                                                                        

### Changes
  - Added `'shadow'` to `CyclotronJobQueueSource`                                                                                                                                                                                                    
  - Shadow worker now uses `consumer_mode: 'shadow'` instead of `'postgres`                                                                                                                                    
  - Metrics emit with `{source="shadow"}` so dashboards can filter them out