### PR TITLE
fix: don't autoclose survey for export limit reached

### DIFF
--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -235,6 +235,7 @@ export const exportsLogic = kea<exportsLogicType>([
                             if (apiError?.data?.attr === 'export_limit_exceeded') {
                                 actions.setHasReachedExportFullVideoLimit(true)
                                 lemonToast.error(apiError?.data?.detail || 'You reached your export limit.', {
+                                    autoClose: false,
                                     button: {
                                         label: 'I want more',
                                         className: 'replay-export-limit-reached-button',


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/48819 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/51974) 

survey dismisses too quickly

## Changes

don't autoclose the survey

## Publish to changelog?

no 
