### PR TITLE
fix: tooltip visibility on goal lines

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -231,10 +231,11 @@ export const LineGraph = ({
                                     annotationsList[`line${curIndex}`].label.content = `${
                                         cur.label
                                     }: ${cur.value.toLocaleString()}`
-                                    const tooltipEl = document.getElementById('InsightTooltipWrapper')
+                                    const tooltipEl = document.querySelector('.InsightTooltipWrapper') as HTMLElement
 
                                     if (tooltipEl) {
-                                        tooltipEl.style.display = 'none'
+                                        tooltipEl.style.opacity = '0'
+                                        tooltipEl.style.pointerEvents = 'none'
                                     }
 
                                     ctx.chart.update()
@@ -250,9 +251,10 @@ export const LineGraph = ({
                                 if (annotationsList[`line${curIndex}`]) {
                                     annotationsList[`line${curIndex}`].label.content = cur.label
 
-                                    const tooltipEl = document.getElementById('InsightTooltipWrapper')
+                                    const tooltipEl = document.querySelector('.InsightTooltipWrapper') as HTMLElement
                                     if (tooltipEl) {
-                                        tooltipEl.style.display = 'block'
+                                        tooltipEl.style.opacity = ''
+                                        tooltipEl.style.pointerEvents = ''
                                     }
 
                                     ctx.chart.update()

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -119,7 +119,7 @@ export const LineGraph = ({
     goalLines = [],
     className,
 }: LineGraphProps): JSX.Element => {
-    const { getTooltip } = useInsightTooltip()
+    const { tooltipId, getTooltip } = useInsightTooltip()
     const { ref: containerRef, height } = useResizeObserver()
 
     const isBarChart =
@@ -231,11 +231,10 @@ export const LineGraph = ({
                                     annotationsList[`line${curIndex}`].label.content = `${
                                         cur.label
                                     }: ${cur.value.toLocaleString()}`
-                                    const tooltipEl = document.querySelector('.InsightTooltipWrapper') as HTMLElement
+                                    const tooltipEl = document.getElementById(`InsightTooltipWrapper-${tooltipId}`)
 
                                     if (tooltipEl) {
-                                        tooltipEl.style.opacity = '0'
-                                        tooltipEl.style.pointerEvents = 'none'
+                                        tooltipEl.classList.add('opacity-0', 'invisible')
                                     }
 
                                     ctx.chart.update()
@@ -251,10 +250,9 @@ export const LineGraph = ({
                                 if (annotationsList[`line${curIndex}`]) {
                                     annotationsList[`line${curIndex}`].label.content = cur.label
 
-                                    const tooltipEl = document.querySelector('.InsightTooltipWrapper') as HTMLElement
+                                    const tooltipEl = document.getElementById(`InsightTooltipWrapper-${tooltipId}`)
                                     if (tooltipEl) {
-                                        tooltipEl.style.opacity = ''
-                                        tooltipEl.style.pointerEvents = ''
+                                        tooltipEl.classList.remove('opacity-0', 'invisible')
                                     }
 
                                     ctx.chart.update()

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -712,6 +712,20 @@ export function LineGraph_({
                                 },
                                 borderWidth: 1,
                                 borderDash: [5, 8],
+                                enter: () => {
+                                    const tooltipEl = document.querySelector('.InsightTooltipWrapper') as HTMLElement
+                                    if (tooltipEl) {
+                                        tooltipEl.style.opacity = '0'
+                                        tooltipEl.style.pointerEvents = 'none'
+                                    }
+                                },
+                                leave: () => {
+                                    const tooltipEl = document.querySelector('.InsightTooltipWrapper') as HTMLElement
+                                    if (tooltipEl) {
+                                        tooltipEl.style.opacity = ''
+                                        tooltipEl.style.pointerEvents = ''
+                                    }
+                                },
                             }
 
                             return acc

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -295,7 +295,7 @@ export function LineGraph_({
 
     const hideTooltipOnScroll = isInsightVizNode(query) ? query.hideTooltipOnScroll : undefined
 
-    const { hideTooltip, getTooltip } = useInsightTooltip()
+    const { tooltipId, hideTooltip, getTooltip } = useInsightTooltip()
 
     const colors = getGraphColors()
     const isHorizontal = type === GraphType.HorizontalBar
@@ -713,17 +713,15 @@ export function LineGraph_({
                                 borderWidth: 1,
                                 borderDash: [5, 8],
                                 enter: () => {
-                                    const tooltipEl = document.querySelector('.InsightTooltipWrapper') as HTMLElement
+                                    const tooltipEl = document.getElementById(`InsightTooltipWrapper-${tooltipId}`)
                                     if (tooltipEl) {
-                                        tooltipEl.style.opacity = '0'
-                                        tooltipEl.style.pointerEvents = 'none'
+                                        tooltipEl.classList.add('opacity-0', 'invisible')
                                     }
                                 },
                                 leave: () => {
-                                    const tooltipEl = document.querySelector('.InsightTooltipWrapper') as HTMLElement
+                                    const tooltipEl = document.getElementById(`InsightTooltipWrapper-${tooltipId}`)
                                     if (tooltipEl) {
-                                        tooltipEl.style.opacity = ''
-                                        tooltipEl.style.pointerEvents = ''
+                                        tooltipEl.classList.remove('opacity-0', 'invisible')
                                     }
                                 },
                             }


### PR DESCRIPTION

![CleanShot 2026-02-03 at 12 20 00](https://github.com/user-attachments/assets/60802651-e351-4110-b779-d85c0e68994e)


## Problem

The insight tooltip was not properly hidden when hovering over line graph annotations, causing visual overlap and interaction issues. The previous implementation used `display: none/block` which could cause layout shifts and didn't prevent pointer events from reaching the tooltip element.

## Changes

- hide the one when you hover the other

## Publish to changelog?

no

https://claude.ai/code/session_01DidKRZ4TZ5VLtyA86DHMt3