### PR TITLE
fix(llma): use correct child workflow ID prefix for generation-level workflows

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -26,6 +26,7 @@ CHILD_WORKFLOW_ID_PREFIX = "llma-trace-clustering-team"
 
 # Generation-level schedule configuration (reuses same coordinator workflow with different inputs)
 GENERATION_COORDINATOR_SCHEDULE_ID = "llma-generation-clustering-coordinator-schedule"
+GENERATION_CHILD_WORKFLOW_ID_PREFIX = "llma-generation-clustering-team"
 
 # Activity timeouts (per activity type)
 COMPUTE_ACTIVITY_TIMEOUT = timedelta(seconds=120)  # Fetch + k-means + distances

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -73,3 +73,4 @@ CHILD_WORKFLOW_ID_PREFIX = "llma-trace-summarization-team"
 
 # Generation-level schedule configuration (reuses same coordinator workflow with different inputs)
 GENERATION_COORDINATOR_SCHEDULE_ID = "llma-generation-summarization-coordinator-schedule"
+GENERATION_CHILD_WORKFLOW_ID_PREFIX = "llma-generation-summarization-team"

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -26,6 +26,7 @@ from posthog.temporal.llm_analytics.trace_summarization.constants import (
     DEFAULT_MODE,
     DEFAULT_MODEL,
     DEFAULT_WINDOW_MINUTES,
+    GENERATION_CHILD_WORKFLOW_ID_PREFIX,
     WORKFLOW_EXECUTION_TIMEOUT_MINUTES,
 )
 from posthog.temporal.llm_analytics.trace_summarization.models import (
@@ -116,6 +117,9 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
         total_items = 0
         total_summaries = 0
         failed_teams = []
+        child_id_prefix = (
+            GENERATION_CHILD_WORKFLOW_ID_PREFIX if inputs.analysis_level == "generation" else CHILD_WORKFLOW_ID_PREFIX
+        )
 
         for team_id in team_ids:
             try:
@@ -130,7 +134,7 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
                         window_minutes=inputs.window_minutes,
                         model=inputs.model,
                     ),
-                    id=f"{CHILD_WORKFLOW_ID_PREFIX}-{team_id}-{temporalio.workflow.now().isoformat()}",
+                    id=f"{child_id_prefix}-{team_id}-{temporalio.workflow.now().isoformat()}",
                     execution_timeout=timedelta(minutes=WORKFLOW_EXECUTION_TIMEOUT_MINUTES),
                     retry_policy=constants.COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY,
                 )


### PR DESCRIPTION
## Problem

The summarization and clustering coordinator workflows use a hardcoded `CHILD_WORKFLOW_ID_PREFIX` with the "trace" prefix for all child workflows, even when running generation-level analysis. This makes it difficult to distinguish trace vs generation child workflows in the Temporal UI.

## Changes

- Added `GENERATION_CHILD_WORKFLOW_ID_PREFIX` constant to both summarization and clustering constants
- Updated both coordinators to select the prefix based on `analysis_level`
- Generation child workflows now use `llma-generation-{summarization,clustering}-team-*` IDs instead of `llma-trace-*`

## How did you test this code?

Existing coordinator unit tests pass. The change is straightforward constant selection based on an existing input field.

## Publish to changelog?

No