### PR TITLE
chore(llm-analytics): move clustering run label to tooltip on select

### DIFF
--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -169,16 +169,19 @@ export function ClustersView(): JSX.Element {
                         </span>
                     </Tooltip>
                     <span className="text-muted">|</span>
-                    <label className="font-medium whitespace-nowrap">Clustering run:</label>
-                    <LemonSelect
-                        value={effectiveRunId || undefined}
-                        onChange={(value) => setSelectedRunId(value || null)}
-                        options={clusteringRuns.map((run: { runId: string; label: string }) => ({
-                            value: run.runId,
-                            label: run.label,
-                        }))}
-                        placeholder="Select a run"
-                    />
+                    <Tooltip title="Clustering run">
+                        <span>
+                            <LemonSelect
+                                value={effectiveRunId || undefined}
+                                onChange={(value) => setSelectedRunId(value || null)}
+                                options={clusteringRuns.map((run: { runId: string; label: string }) => ({
+                                    value: run.runId,
+                                    label: run.label,
+                                }))}
+                                placeholder="Select a run"
+                            />
+                        </span>
+                    </Tooltip>
                     <LemonButton
                         type="secondary"
                         size="small"


### PR DESCRIPTION
## Problem

The "Clustering run:" label in the LLM analytics clusters tab takes up horizontal space without adding much value.

## Changes

Removed the explicit label and moved it to a tooltip on the run selection dropdown instead.

## How did you test this code?

Manual review of the component change.