### PR TITLE
feat(signals): Store cluster centroids in Redis to reduce Temporal payload size

### DIFF
--- a/posthog/temporal/ai/video_segment_clustering/activities/a6_persist_reports.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/a6_persist_reports.py
@@ -42,193 +42,203 @@ async def persist_reports_activity(inputs: PersistReportsActivityInputs) -> Pers
     workflow_id = get_workflow_id_from_activity()
     cached_centroids = await get_centroids(workflow_id) if inputs.new_clusters else None
 
-    team = await Team.objects.aget(id=inputs.team_id)
+    # Validate centroids are available for new clusters (consistent with a4_match_clusters.py)
+    if inputs.new_clusters and cached_centroids is None:
+        raise ValueError("Centroids not found in cache for new clusters - clustering activity may not have run")
 
-    segment_lookup = {s.document_id: s for s in inputs.segments}
+    try:
+        team = await Team.objects.aget(id=inputs.team_id)
 
-    report_ids: list[str] = []
-    reports_created = 0
-    reports_updated = 0
+        segment_lookup = {s.document_id: s for s in inputs.segments}
 
-    # Build cluster_to_report mapping as we create reports
-    cluster_to_report: dict[int, str] = {}
+        report_ids: list[str] = []
+        reports_created = 0
+        reports_updated = 0
 
-    # 1. Create new SignalReports for new clusters
-    for cluster in inputs.new_clusters:
-        label = inputs.labels.get(cluster.cluster_id)
-        if not label:
-            logger.warning("No label found for new cluster, skipping", cluster_id=cluster.cluster_id)
-            continue
+        # Build cluster_to_report mapping as we create reports
+        cluster_to_report: dict[int, str] = {}
 
-        # Get centroid from Redis cache
-        centroid = cached_centroids.get(cluster.cluster_id) if cached_centroids else None
-        if centroid is None:
-            logger.warning("No centroid found for cluster, skipping", cluster_id=cluster.cluster_id)
-            continue
+        # 1. Create new SignalReports for new clusters
+        for cluster in inputs.new_clusters:
+            label = inputs.labels.get(cluster.cluster_id)
+            if not label:
+                logger.warning("No label found for new cluster, skipping", cluster_id=cluster.cluster_id)
+                continue
 
-        cluster_segments = [segment_lookup[sid] for sid in cluster.segment_ids if sid in segment_lookup]
-        metrics = await calculate_task_metrics(team, cluster_segments)
+            # Get centroid from Redis cache
+            centroid = cached_centroids.get(cluster.cluster_id) if cached_centroids else None
+            if centroid is None:
+                logger.warning("No centroid found for cluster, skipping", cluster_id=cluster.cluster_id)
+                continue
 
-        # Use total_weight for priority (based on user count via logarithmic scoring)
-        total_weight = calculate_priority_score(
-            relevant_user_count=metrics["relevant_user_count"],
-        )
+            cluster_segments = [segment_lookup[sid] for sid in cluster.segment_ids if sid in segment_lookup]
+            metrics = await calculate_task_metrics(team, cluster_segments)
 
-        report = await SignalReport.objects.acreate(
-            team=team,
-            title=label.title,
-            summary=label.description,
-            status=SignalReport.Status.READY,
-            cluster_centroid=centroid,
-            cluster_centroid_updated_at=django_timezone.now(),
-            total_weight=total_weight,
-            signal_count=metrics["occurrence_count"],
-            relevant_user_count=metrics["relevant_user_count"],
-        )
-
-        report_ids.append(str(report.id))
-        cluster_to_report[cluster.cluster_id] = str(report.id)
-        reports_created += 1
-
-        logger.info(
-            "Created report from cluster",
-            report_id=str(report.id),
-            cluster_id=cluster.cluster_id,
-            cluster_size=cluster.size,
-        )
-
-    # 2. Update existing SignalReports for matched clusters (idempotent - only count new segments)
-    for match in inputs.matched_clusters:
-        try:
-            report = await SignalReport.objects.aget(id=match.report_id)
-        except SignalReport.DoesNotExist:
-            logger.warning("Matched report not found", report_id=match.report_id)
-            continue
-
-        cluster_to_report[match.cluster_id] = match.report_id
-
-        # Find segments for this matched cluster from segment_to_cluster
-        matched_segment_ids = [doc_id for doc_id, cid in inputs.segment_to_cluster.items() if cid == match.cluster_id]
-        cluster_segments = [segment_lookup[sid] for sid in matched_segment_ids if sid in segment_lookup]
-
-        if cluster_segments:
-            # Check which segments already have artefacts for this report (idempotency)
-            existing_artefacts = [
-                artefact
-                async for artefact in SignalReportArtefact.objects.filter(
-                    report_id=match.report_id, type="video_segment"
-                ).only("content")
-            ]
-            existing_refs: set[str] = set()
-            for artefact in existing_artefacts:
-                try:
-                    content_bytes = (
-                        bytes(artefact.content) if isinstance(artefact.content, memoryview) else artefact.content
-                    )
-                    content = json.loads(content_bytes.decode("utf-8"))
-                    existing_refs.add(
-                        f"{content.get('session_id')}:{content.get('start_time')}:{content.get('end_time')}"
-                    )
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    pass
-
-            # Filter to only NEW segments (not already linked to this report)
-            new_segments = []
-            existing_distinct_ids: set[str] = set()
-            for artefact in existing_artefacts:
-                try:
-                    content_bytes = (
-                        bytes(artefact.content) if isinstance(artefact.content, memoryview) else artefact.content
-                    )
-                    content = json.loads(content_bytes.decode("utf-8"))
-                    if content.get("distinct_id"):
-                        existing_distinct_ids.add(content["distinct_id"])
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    pass
-
-            for seg in cluster_segments:
-                session_start = parse_datetime_as_utc(seg.session_start_time)
-                abs_start = session_start + timedelta(seconds=parse_timestamp_to_seconds(seg.start_time))
-                abs_end = session_start + timedelta(seconds=parse_timestamp_to_seconds(seg.end_time))
-                ref_key = f"{seg.session_id}:{abs_start.isoformat()}:{abs_end.isoformat()}"
-                if ref_key not in existing_refs:
-                    new_segments.append(seg)
-
-            if new_segments:
-                # Get all distinct_ids from existing artefacts + new segments for accurate user count
-                new_distinct_ids = {seg.distinct_id for seg in new_segments}
-                relevant_user_count = await sync_to_async(count_distinct_persons)(
-                    team, list(existing_distinct_ids | new_distinct_ids)
-                )
-
-                report.relevant_user_count = relevant_user_count
-                report.signal_count = (report.signal_count or 0) + len(new_segments)
-
-                # Update total_weight for priority scoring
-                report.total_weight = calculate_priority_score(
-                    relevant_user_count=report.relevant_user_count,
-                )
-
-                await report.asave()
-                reports_updated += 1
-
-                logger.info(
-                    "Updated report from matched cluster",
-                    report_id=str(report.id),
-                    cluster_id=match.cluster_id,
-                    new_segments=len(new_segments),
-                    skipped_existing=len(cluster_segments) - len(new_segments),
-                )
-
-        report_ids.append(str(report.id))
-
-    # 3. Create SignalReportArtefact records in bulk (idempotent via ignore_conflicts)
-    artefacts_to_create: list[SignalReportArtefact] = []
-
-    for segment in inputs.segments:
-        cluster_id = inputs.segment_to_cluster.get(segment.document_id)
-        if cluster_id is None:
-            continue
-
-        report_id = cluster_to_report.get(cluster_id)
-        if not report_id:
-            continue
-
-        session_start_time = parse_datetime_as_utc(segment.session_start_time)
-        segment_start_time = session_start_time + timedelta(seconds=parse_timestamp_to_seconds(segment.start_time))
-        segment_end_time = session_start_time + timedelta(seconds=parse_timestamp_to_seconds(segment.end_time))
-
-        artefact_content = json.dumps(
-            {
-                "session_id": segment.session_id,
-                "start_time": segment_start_time.isoformat(),
-                "end_time": segment_end_time.isoformat(),
-                "distinct_id": segment.distinct_id,
-                "content": segment.content,
-            }
-        ).encode("utf-8")
-
-        artefacts_to_create.append(
-            SignalReportArtefact(
-                team=team,
-                report_id=report_id,
-                type="video_segment",
-                content=artefact_content,
+            # Use total_weight for priority (based on user count via logarithmic scoring)
+            total_weight = calculate_priority_score(
+                relevant_user_count=metrics["relevant_user_count"],
             )
+
+            report = await SignalReport.objects.acreate(
+                team=team,
+                title=label.title,
+                summary=label.description,
+                status=SignalReport.Status.READY,
+                cluster_centroid=centroid,
+                cluster_centroid_updated_at=django_timezone.now(),
+                total_weight=total_weight,
+                signal_count=metrics["occurrence_count"],
+                relevant_user_count=metrics["relevant_user_count"],
+            )
+
+            report_ids.append(str(report.id))
+            cluster_to_report[cluster.cluster_id] = str(report.id)
+            reports_created += 1
+
+            logger.info(
+                "Created report from cluster",
+                report_id=str(report.id),
+                cluster_id=cluster.cluster_id,
+                cluster_size=cluster.size,
+            )
+
+        # 2. Update existing SignalReports for matched clusters (idempotent - only count new segments)
+        for match in inputs.matched_clusters:
+            try:
+                report = await SignalReport.objects.aget(id=match.report_id)
+            except SignalReport.DoesNotExist:
+                logger.warning("Matched report not found", report_id=match.report_id)
+                continue
+
+            cluster_to_report[match.cluster_id] = match.report_id
+
+            # Find segments for this matched cluster from segment_to_cluster
+            matched_segment_ids = [
+                doc_id for doc_id, cid in inputs.segment_to_cluster.items() if cid == match.cluster_id
+            ]
+            cluster_segments = [segment_lookup[sid] for sid in matched_segment_ids if sid in segment_lookup]
+
+            if cluster_segments:
+                # Check which segments already have artefacts for this report (idempotency)
+                existing_artefacts = [
+                    artefact
+                    async for artefact in SignalReportArtefact.objects.filter(
+                        report_id=match.report_id, type="video_segment"
+                    ).only("content")
+                ]
+                existing_refs: set[str] = set()
+                for artefact in existing_artefacts:
+                    try:
+                        content_bytes = (
+                            bytes(artefact.content) if isinstance(artefact.content, memoryview) else artefact.content
+                        )
+                        content = json.loads(content_bytes.decode("utf-8"))
+                        existing_refs.add(
+                            f"{content.get('session_id')}:{content.get('start_time')}:{content.get('end_time')}"
+                        )
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        pass
+
+                # Filter to only NEW segments (not already linked to this report)
+                new_segments = []
+                existing_distinct_ids: set[str] = set()
+                for artefact in existing_artefacts:
+                    try:
+                        content_bytes = (
+                            bytes(artefact.content) if isinstance(artefact.content, memoryview) else artefact.content
+                        )
+                        content = json.loads(content_bytes.decode("utf-8"))
+                        if content.get("distinct_id"):
+                            existing_distinct_ids.add(content["distinct_id"])
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        pass
+
+                for seg in cluster_segments:
+                    session_start = parse_datetime_as_utc(seg.session_start_time)
+                    abs_start = session_start + timedelta(seconds=parse_timestamp_to_seconds(seg.start_time))
+                    abs_end = session_start + timedelta(seconds=parse_timestamp_to_seconds(seg.end_time))
+                    ref_key = f"{seg.session_id}:{abs_start.isoformat()}:{abs_end.isoformat()}"
+                    if ref_key not in existing_refs:
+                        new_segments.append(seg)
+
+                if new_segments:
+                    # Get all distinct_ids from existing artefacts + new segments for accurate user count
+                    new_distinct_ids = {seg.distinct_id for seg in new_segments}
+                    relevant_user_count = await sync_to_async(count_distinct_persons)(
+                        team, list(existing_distinct_ids | new_distinct_ids)
+                    )
+
+                    report.relevant_user_count = relevant_user_count
+                    report.signal_count = (report.signal_count or 0) + len(new_segments)
+
+                    # Update total_weight for priority scoring
+                    report.total_weight = calculate_priority_score(
+                        relevant_user_count=report.relevant_user_count,
+                    )
+
+                    await report.asave()
+                    reports_updated += 1
+
+                    logger.info(
+                        "Updated report from matched cluster",
+                        report_id=str(report.id),
+                        cluster_id=match.cluster_id,
+                        new_segments=len(new_segments),
+                        skipped_existing=len(cluster_segments) - len(new_segments),
+                    )
+
+            report_ids.append(str(report.id))
+
+        # 3. Create SignalReportArtefact records in bulk (idempotent via ignore_conflicts)
+        artefacts_to_create: list[SignalReportArtefact] = []
+
+        for segment in inputs.segments:
+            cluster_id = inputs.segment_to_cluster.get(segment.document_id)
+            if cluster_id is None:
+                continue
+
+            report_id = cluster_to_report.get(cluster_id)
+            if not report_id:
+                continue
+
+            session_start_time = parse_datetime_as_utc(segment.session_start_time)
+            segment_start_time = session_start_time + timedelta(seconds=parse_timestamp_to_seconds(segment.start_time))
+            segment_end_time = session_start_time + timedelta(seconds=parse_timestamp_to_seconds(segment.end_time))
+
+            artefact_content = json.dumps(
+                {
+                    "session_id": segment.session_id,
+                    "start_time": segment_start_time.isoformat(),
+                    "end_time": segment_end_time.isoformat(),
+                    "distinct_id": segment.distinct_id,
+                    "content": segment.content,
+                }
+            ).encode("utf-8")
+
+            artefacts_to_create.append(
+                SignalReportArtefact(
+                    team=team,
+                    report_id=report_id,
+                    type="video_segment",
+                    content=artefact_content,
+                )
+            )
+
+        if artefacts_to_create:
+            created_artefacts = await SignalReportArtefact.objects.abulk_create(
+                artefacts_to_create, ignore_conflicts=True
+            )
+            artefacts_created = len(created_artefacts)
+        else:
+            artefacts_created = 0
+
+        return PersistReportsResult(
+            reports_created=reports_created,
+            reports_updated=reports_updated,
+            report_ids=report_ids,
+            artefacts_created=artefacts_created,
         )
-
-    if artefacts_to_create:
-        created_artefacts = await SignalReportArtefact.objects.abulk_create(artefacts_to_create, ignore_conflicts=True)
-        artefacts_created = len(created_artefacts)
-    else:
-        artefacts_created = 0
-
-    # Cleanup centroid cache now that we've persisted everything
-    await delete_centroids(workflow_id)
-
-    return PersistReportsResult(
-        reports_created=reports_created,
-        reports_updated=reports_updated,
-        report_ids=report_ids,
-        artefacts_created=artefacts_created,
-    )
+    finally:
+        # Cleanup centroid cache regardless of success or failure
+        if inputs.new_clusters:
+            await delete_centroids(workflow_id)

--- a/posthog/temporal/ai/video_segment_clustering/activities/a6_persist_reports.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/a6_persist_reports.py
@@ -240,5 +240,4 @@ async def persist_reports_activity(inputs: PersistReportsActivityInputs) -> Pers
         )
     finally:
         # Cleanup centroid cache regardless of success or failure
-        if inputs.new_clusters:
-            await delete_centroids(workflow_id)
+        await delete_centroids(workflow_id)

--- a/posthog/temporal/ai/video_segment_clustering/centroid_cache.py
+++ b/posthog/temporal/ai/video_segment_clustering/centroid_cache.py
@@ -33,8 +33,10 @@ async def store_centroids(
     cluster_ids = np.array(list(centroids.keys()), dtype=np.int32)
     embeddings = np.array(list(centroids.values()), dtype=np.float32)
 
-    await redis_client.setex(_cache_key(workflow_id, "ids"), ttl, cluster_ids.tobytes())
-    await redis_client.setex(_cache_key(workflow_id, "embeddings"), ttl, embeddings.tobytes())
+    pipeline = redis_client.pipeline(transaction=True)
+    pipeline.setex(_cache_key(workflow_id, "ids"), ttl, cluster_ids.tobytes())
+    pipeline.setex(_cache_key(workflow_id, "embeddings"), ttl, embeddings.tobytes())
+    await pipeline.execute()
 
 
 async def get_centroids(workflow_id: str) -> dict[int, list[float]] | None:

--- a/posthog/temporal/ai/video_segment_clustering/centroid_cache.py
+++ b/posthog/temporal/ai/video_segment_clustering/centroid_cache.py
@@ -1,0 +1,64 @@
+"""Redis-based centroid cache for video segment clustering workflow.
+
+Uses NumPy binary format (float32) for efficient storage:
+- JSON: 3072 floats × ~20 bytes = 62KB per centroid
+- Binary float32: 3072 × 4 bytes = 12KB per centroid (5x smaller)
+"""
+
+import numpy as np
+from temporalio import activity
+
+from posthog.redis import get_async_client
+
+CENTROID_CACHE_TTL_SECONDS = 4 * 60 * 60  # 4 hours
+EMBEDDING_DIM = 3072
+
+
+def _cache_key(workflow_id: str, suffix: str) -> str:
+    return f"video_segment_clustering:centroids:{workflow_id}:{suffix}"
+
+
+async def store_centroids(
+    workflow_id: str,
+    centroids: dict[int, list[float]],
+    ttl: int = CENTROID_CACHE_TTL_SECONDS,
+) -> None:
+    """Store cluster centroids in Redis using NumPy binary format."""
+    if not centroids:
+        return
+
+    redis_client = get_async_client()
+
+    # Store as two arrays: cluster_ids (int32) and embeddings (float32)
+    cluster_ids = np.array(list(centroids.keys()), dtype=np.int32)
+    embeddings = np.array(list(centroids.values()), dtype=np.float32)
+
+    await redis_client.setex(_cache_key(workflow_id, "ids"), ttl, cluster_ids.tobytes())
+    await redis_client.setex(_cache_key(workflow_id, "embeddings"), ttl, embeddings.tobytes())
+
+
+async def get_centroids(workflow_id: str) -> dict[int, list[float]] | None:
+    """Retrieve cluster centroids from Redis."""
+    redis_client = get_async_client()
+
+    ids_data = await redis_client.get(_cache_key(workflow_id, "ids"))
+    emb_data = await redis_client.get(_cache_key(workflow_id, "embeddings"))
+
+    if not ids_data or not emb_data:
+        return None
+
+    cluster_ids = np.frombuffer(ids_data, dtype=np.int32)
+    embeddings = np.frombuffer(emb_data, dtype=np.float32).reshape(-1, EMBEDDING_DIM)
+
+    return {int(cid): emb.tolist() for cid, emb in zip(cluster_ids, embeddings)}
+
+
+async def delete_centroids(workflow_id: str) -> None:
+    """Delete centroid cache for a workflow."""
+    redis_client = get_async_client()
+    await redis_client.delete(_cache_key(workflow_id, "ids"), _cache_key(workflow_id, "embeddings"))
+
+
+def get_workflow_id_from_activity() -> str:
+    """Get workflow ID from within an activity context."""
+    return activity.info().workflow_id

--- a/posthog/temporal/ai/video_segment_clustering/models.py
+++ b/posthog/temporal/ai/video_segment_clustering/models.py
@@ -61,11 +61,14 @@ class ClusterContext:
 
 @dataclass
 class Cluster:
-    """A cluster of similar video segments."""
+    """A cluster of similar video segments.
+
+    Note: Centroids are stored in Redis via centroid_cache module to avoid
+    large Temporal payloads. Use centroid_cache.get_centroids() to retrieve.
+    """
 
     cluster_id: int
     segment_ids: list[str]  # document_ids of segments in this cluster
-    centroid: list[float]  # 3072-dim embedding centroid
     size: int
 
 


### PR DESCRIPTION
## Problem

The video segment clustering workflow is experiencing performance issues due to large Temporal payloads. Cluster centroids (3072-dimensional embeddings) are being passed between activities:
                                                                                       
- Each centroid: 3072 floats × ~20 bytes JSON encoding = **~62KB per centroid** when JSON-serialized
- Temporal limit of data output: 4MB
- 4 MB = just 66 clusters
                       
## Changes

Cluster centroids are now stored in and retrieved from Redis, separately from Temporal payloads. Uses NumPy's binary format, reducing centroid size from ~62KB to ~12KB.

Removed centroids from the `Cluster` Pydantic model, as now they're stored externally.

## How did you test this code?

Basically posthog/temporal/ai/video_segment_clustering/tests/test_workflow.py added in #46566 now passed.

## Publish to changelog?

No