### PR TITLE
fix(ph-ai): fix notebooks data tables convertion

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -63,8 +63,8 @@ import {
     PlanningStep,
     PlanningStepStatus,
 } from '~/queries/schema/schema-assistant-messages'
-import { DataVisualizationNode, InsightVizNode } from '~/queries/schema/schema-general'
-import { isHogQLQuery } from '~/queries/utils'
+import { DataTableNode, DataVisualizationNode, InsightVizNode } from '~/queries/schema/schema-general'
+import { isDataTableNode, isHogQLQuery } from '~/queries/utils'
 import { PendingApproval, Region } from '~/types'
 
 import { ContextSummary } from './Context'
@@ -1145,7 +1145,7 @@ const Visualization = React.memo(function Visualization({
     collapsed,
     editingChildren,
 }: {
-    query: InsightVizNode | DataVisualizationNode
+    query: InsightVizNode | DataVisualizationNode | DataTableNode
     collapsed?: boolean
     editingChildren?: React.ReactNode
 }): JSX.Element | null {
@@ -1184,7 +1184,7 @@ const Visualization = React.memo(function Visualization({
                     />
                 </div>
             </div>
-            {isSummaryShown && (
+            {isSummaryShown && !isDataTableNode(query) && (
                 <>
                     <SeriesSummary query={query.source} heading={null} />
                     {!isHogQLQuery(query.source) && (
@@ -1215,7 +1215,7 @@ export function MultiVisualizationAnswer({ message, className }: MultiVisualizat
                 }
                 return null
             })
-            .filter(Boolean) as Array<{ query: InsightVizNode | DataVisualizationNode; title: string }>
+            .filter(Boolean) as Array<{ query: InsightVizNode | DataVisualizationNode | DataTableNode; title: string }>
     }, [visualizations])
 
     const openModal = (): void => {
@@ -1296,7 +1296,7 @@ export function MultiVisualizationAnswer({ message, className }: MultiVisualizat
 
 // Modal for detailed view
 interface MultiVisualizationModalProps {
-    insights: Array<{ query: InsightVizNode | DataVisualizationNode; title: string }>
+    insights: Array<{ query: InsightVizNode | DataVisualizationNode | DataTableNode; title: string }>
 }
 
 function MultiVisualizationModal({ insights: messages }: MultiVisualizationModalProps): JSX.Element {

--- a/frontend/src/scenes/max/messages/NotebookArtifactAnswer.tsx
+++ b/frontend/src/scenes/max/messages/NotebookArtifactAnswer.tsx
@@ -32,7 +32,7 @@ import {
     VisualizationBlock,
 } from '~/queries/schema/schema-assistant-artifacts'
 import { NotebookArtifactContent } from '~/queries/schema/schema-assistant-messages'
-import { DataVisualizationNode, InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
+import { DataTableNode, DataVisualizationNode, InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { isFunnelsQuery, isHogQLQuery, isInsightVizNode } from '~/queries/utils'
 
 import { MarkdownMessage } from '../MarkdownMessage'
@@ -192,7 +192,7 @@ function VisualizationBlockPreview({ block }: { block: VisualizationBlock }): JS
                     </span>
                 </LemonButton>
                 <LemonButton
-                    to={urls.insightNew({ query: query as InsightVizNode | DataVisualizationNode })}
+                    to={urls.insightNew({ query: query as InsightVizNode | DataVisualizationNode | DataTableNode })}
                     icon={<IconOpenInNew />}
                     size="xsmall"
                     tooltip="Open as new insight"
@@ -301,7 +301,7 @@ function blocksToTiptapContent(blocks: DocumentBlock[]): JSONContent[] {
                 // Create a ph-query node that the notebook can render
                 const source = castAssistantQuery(block.query)
                 const query = isHogQLQuery(source)
-                    ? { kind: NodeKind.DataVisualizationNode, source }
+                    ? { kind: NodeKind.DataTableNode, source }
                     : { kind: NodeKind.InsightVizNode, source }
 
                 result.push({

--- a/frontend/src/scenes/max/messages/VisualizationArtifactAnswer.tsx
+++ b/frontend/src/scenes/max/messages/VisualizationArtifactAnswer.tsx
@@ -23,7 +23,7 @@ import {
     ArtifactSource,
     VisualizationArtifactContent,
 } from '~/queries/schema/schema-assistant-messages'
-import { DataVisualizationNode, InsightVizNode } from '~/queries/schema/schema-general'
+import { DataTableNode, DataVisualizationNode, InsightVizNode } from '~/queries/schema/schema-general'
 import { isFunnelsQuery, isHogQLQuery, isInsightVizNode } from '~/queries/utils'
 import { InsightShortId } from '~/types'
 
@@ -142,7 +142,7 @@ export const VisualizationArtifactAnswer = React.memo(function VisualizationArti
                                 isSavedInsight
                                     ? urls.insightView(message.artifact_id as InsightShortId)
                                     : urls.insightNew({
-                                          query: query as InsightVizNode | DataVisualizationNode,
+                                          query: query as InsightVizNode | DataVisualizationNode | DataTableNode,
                                       })
                             }
                             icon={<IconOpenInNew />}

--- a/frontend/src/scenes/max/utils.ts
+++ b/frontend/src/scenes/max/utils.ts
@@ -25,7 +25,7 @@ import {
 } from '~/queries/schema/schema-assistant-messages'
 import {
     DashboardFilter,
-    DataVisualizationNode,
+    DataTableNode,
     HogQLVariable,
     InsightVizNode,
     NodeKind,
@@ -287,7 +287,7 @@ export const visualizationTypeToQuery = (
 ): QuerySchema | null => {
     const source = castAssistantQuery('answer' in visualization ? visualization.answer : visualization.query)
     if (isHogQLQuery(source)) {
-        return { kind: NodeKind.DataVisualizationNode, source: source } satisfies DataVisualizationNode
+        return { kind: NodeKind.DataTableNode, source: source } satisfies DataTableNode
     }
     if (isInsightQueryNode(source)) {
         return { kind: NodeKind.InsightVizNode, source, showHeader: true } satisfies InsightVizNode


### PR DESCRIPTION
## Problem
When converting HogQL queries to data blocks in PostHog AI, we're currently using `DataVisualizationNode`, it should be `DataTableNode`.

## Changes
Added support for `DataTableNode` type to properly represent HogQL query results in the PostHog AI interface. This change:

- Updates type signatures to include `DataTableNode` where visualization nodes are used
- Conditionally hides the series summary for data table nodes
- Changes HogQL query visualization to use `DataTableNode` instead of `DataVisualizationNode`

## How did you test this code?
Locally

## Publish to changelog?
No