### PR TITLE
feat(llma): add evaluation summary to early adopters flag

### DIFF
--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -110,9 +110,7 @@ export function EvaluationSummaryPanel({ runsLookup }: EvaluationSummaryPanelPro
         summaryExpanded,
     } = useValues(llmEvaluationLogic)
     const { toggleSummaryExpanded } = useActions(llmEvaluationLogic)
-    const hasSummaryFlag = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
-    const isEarlyAdopter = useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
-    const showSummaryFeature = hasSummaryFlag || isEarlyAdopter
+    const showSummaryFeature = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY') || useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
 
     if (!showSummaryFeature) {
         return null

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -56,7 +56,9 @@ export function EvaluationSummaryControls(): JSX.Element | null {
         setEvaluationSummaryFilter,
         trackSummarizeClicked,
     } = useActions(llmEvaluationLogic)
-    const showSummaryFeature = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY') || useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
+    const flag1 = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
+    const flag2 = useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
+    const showSummaryFeature = flag1 || flag2
 
     if (!showSummaryFeature || !runsSummary || runsSummary.total === 0) {
         return null
@@ -110,7 +112,9 @@ export function EvaluationSummaryPanel({ runsLookup }: EvaluationSummaryPanelPro
         summaryExpanded,
     } = useValues(llmEvaluationLogic)
     const { toggleSummaryExpanded } = useActions(llmEvaluationLogic)
-    const showSummaryFeature = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY') || useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
+    const flag1 = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
+    const flag2 = useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
+    const showSummaryFeature = flag1 || flag2
 
     if (!showSummaryFeature) {
         return null

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -56,9 +56,7 @@ export function EvaluationSummaryControls(): JSX.Element | null {
         setEvaluationSummaryFilter,
         trackSummarizeClicked,
     } = useActions(llmEvaluationLogic)
-    const hasSummaryFlag = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
-    const isEarlyAdopter = useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
-    const showSummaryFeature = hasSummaryFlag || isEarlyAdopter
+    const showSummaryFeature = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY') || useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
 
     if (!showSummaryFeature || !runsSummary || runsSummary.total === 0) {
         return null

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -41,6 +41,12 @@ const BASE_FILTER_OPTIONS: FilterOption[] = [
 
 const NA_FILTER_OPTION: FilterOption = { value: 'na', label: 'N/A' }
 
+function useShowEvaluationSummary(): boolean {
+    const summaryFlag = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
+    const earlyAdoptersFlag = useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
+    return summaryFlag || earlyAdoptersFlag
+}
+
 export function EvaluationSummaryControls(): JSX.Element | null {
     const {
         evaluation,
@@ -56,9 +62,7 @@ export function EvaluationSummaryControls(): JSX.Element | null {
         setEvaluationSummaryFilter,
         trackSummarizeClicked,
     } = useActions(llmEvaluationLogic)
-    const flag1 = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
-    const flag2 = useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
-    const showSummaryFeature = flag1 || flag2
+    const showSummaryFeature = useShowEvaluationSummary()
 
     if (!showSummaryFeature || !runsSummary || runsSummary.total === 0) {
         return null
@@ -112,9 +116,7 @@ export function EvaluationSummaryPanel({ runsLookup }: EvaluationSummaryPanelPro
         summaryExpanded,
     } = useValues(llmEvaluationLogic)
     const { toggleSummaryExpanded } = useActions(llmEvaluationLogic)
-    const flag1 = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
-    const flag2 = useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
-    const showSummaryFeature = flag1 || flag2
+    const showSummaryFeature = useShowEvaluationSummary()
 
     if (!showSummaryFeature) {
         return null

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationSummaryPanel.tsx
@@ -56,7 +56,9 @@ export function EvaluationSummaryControls(): JSX.Element | null {
         setEvaluationSummaryFilter,
         trackSummarizeClicked,
     } = useActions(llmEvaluationLogic)
-    const showSummaryFeature = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
+    const hasSummaryFlag = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
+    const isEarlyAdopter = useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
+    const showSummaryFeature = hasSummaryFlag || isEarlyAdopter
 
     if (!showSummaryFeature || !runsSummary || runsSummary.total === 0) {
         return null
@@ -110,7 +112,9 @@ export function EvaluationSummaryPanel({ runsLookup }: EvaluationSummaryPanelPro
         summaryExpanded,
     } = useValues(llmEvaluationLogic)
     const { toggleSummaryExpanded } = useActions(llmEvaluationLogic)
-    const showSummaryFeature = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
+    const hasSummaryFlag = useFeatureFlag('LLM_ANALYTICS_EVALUATIONS_SUMMARY')
+    const isEarlyAdopter = useFeatureFlag('LLM_ANALYTICS_EARLY_ADOPTERS')
+    const showSummaryFeature = hasSummaryFlag || isEarlyAdopter
 
     if (!showSummaryFeature) {
         return null


### PR DESCRIPTION
## Problem

LLM analytics early adopters need access to the evaluation summary feature to test and provide feedback on AI-powered pattern analysis of evaluation runs.

## Changes

Updated `EvaluationSummaryPanel.tsx` to show the evaluation summary feature when either:
- `LLM_ANALYTICS_EVALUATIONS_SUMMARY` flag is enabled, OR
- `LLM_ANALYTICS_EARLY_ADOPTERS` flag is enabled

## How did you test this code?

Ran existing tests: `pnpm --filter=@posthog/frontend jest products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts` - all 35 tests pass.

## Publish to changelog?

No