### PR TITLE
fix(signup): limit organization_name to 64 characters

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -80,7 +80,7 @@ class SignupSerializer(serializers.Serializer):
     last_name: serializers.Field = serializers.CharField(max_length=128, required=False, allow_blank=True)
     email: serializers.Field = serializers.EmailField()
     password: serializers.Field = serializers.CharField(allow_null=True, required=False, allow_blank=True)
-    organization_name: serializers.Field = serializers.CharField(max_length=128, required=False, allow_blank=True)
+    organization_name: serializers.Field = serializers.CharField(max_length=64, required=False, allow_blank=True)
     role_at_organization: serializers.Field = serializers.CharField(
         max_length=128, required=False, allow_blank=True, default=""
     )
@@ -163,7 +163,8 @@ class SignupSerializer(serializers.Serializer):
 
         is_instance_first_user: bool = not User.objects.exists()
 
-        organization_name = validated_data.pop("organization_name", f"{validated_data['first_name']}'s Organization")
+        default_org_name = f"{validated_data['first_name']}'s Organization"[:64]
+        organization_name = validated_data.pop("organization_name", default_org_name)
         role_at_organization = validated_data.pop("role_at_organization", "")
         referral_source = validated_data.pop("referral_source", "")
 
@@ -511,7 +512,7 @@ class SocialSignupSerializer(serializers.Serializer):
     Pre-processes information not obtained from SSO provider to create organization.
     """
 
-    organization_name: serializers.Field = serializers.CharField(max_length=128)
+    organization_name: serializers.Field = serializers.CharField(max_length=64)
     first_name: serializers.Field = serializers.CharField(max_length=128)
     role_at_organization: serializers.Field = serializers.CharField(max_length=123, required=False, default="")
 


### PR DESCRIPTION
## Problem

Users signing up with long organization names (65+ characters) encounter a database error:
```
StringDataRightTruncation: value too long for type character varying(64)
```
[Link to issue](https://us.posthog.com/project/2/error_tracking/019c2365-7968-79f1-993b-638e31ab9c44?fingerprint=332b8d20b2c696eeea5e94d776a729fedadf773cca95f8141cc29ac2f806d6a65c3f83168b2d1357e2f869aca5adadbadf94c42ee27bee19a29704a3181c46a4&timestamp=2026-02-03T04%3A08%3A46.141000-08%3A00)

This happens because the signup API serializers allowed `organization_name` up to 128 characters, but the `Organization.name` model field is limited to 64 characters. The mismatch causes a database-level exception instead of a proper validation error.

## Changes

- Reduced `max_length` for `organization_name` from 128 to 64 in `SignupSerializer`
- Reduced `max_length` for `organization_name` from 128 to 64 in `SocialSignupSerializer`
- Added truncation to the auto-generated default organization name (`"{first_name}'s Organization"`) to handle users with very long first names

## How did you test this code?

- Manually

## Publish to changelog?

No 