### PR TITLE
chore: update 2fa reset timeout to 24 hours

### DIFF
--- a/posthog/api/test/test_two_factor_reset.py
+++ b/posthog/api/test/test_two_factor_reset.py
@@ -91,13 +91,13 @@ class TestTwoFactorReset(APIBaseTest):
         self.assertEqual(response.json()["error"], "You must log in with your credentials first.")
 
     def test_cannot_validate_with_expired_half_auth_session(self):
-        """Test that validation fails when half-auth session has expired (1 hour for reset flow)."""
+        """Test that validation fails when half-auth session has expired (24 hours for reset flow)."""
         token = self._setup_2fa_reset()
 
-        # Set up session with an old timestamp (more than 1 hour ago)
+        # Set up session with an old timestamp (more than 24 hours ago)
         session = self.client.session
         session["user_authenticated_but_no_2fa"] = self.user.pk
-        session["user_authenticated_time"] = int(time.time()) - 3700  # 1 hour + 100 seconds ago
+        session["user_authenticated_time"] = int(time.time()) - 86500  # 24 hours + 100 seconds ago
         session.save()
 
         response = self.client.get(f"/api/reset_2fa/{self.user.uuid}/?token={token}")
@@ -117,11 +117,11 @@ class TestTwoFactorReset(APIBaseTest):
         self.assertEqual(response.json()["error"], "This reset link is invalid or has expired.")
 
     def test_cannot_validate_expired_token(self):
-        """Test that tokens expire after 1 hour."""
+        """Test that tokens expire after 24 hours."""
         token = self._setup_2fa_reset()
 
-        # Move time forward by more than 1 hour
-        with freeze_time(timezone.now() + datetime.timedelta(hours=1, minutes=1)):
+        # Move time forward by more than 24 hours
+        with freeze_time(timezone.now() + datetime.timedelta(hours=24, minutes=1)):
             self._setup_half_auth_session()
             response = self.client.get(f"/api/reset_2fa/{self.user.uuid}/?token={token}")
 


### PR DESCRIPTION
## Problem

The expiration window for the 2fa reset links is too short and people often miss it. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Update 2fa reset link expiration time from 1 hour to 24 hours.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
