### PR TITLE
feat: hide URL blocklist controls

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/exception_autocapture/IngestionControls.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/exception_autocapture/IngestionControls.tsx
@@ -25,7 +25,6 @@ export function ErrorTrackingIngestionControls({ disabled }: { disabled: boolean
         linkedFeatureFlag,
         eventTriggers,
         urlTriggers,
-        urlBlocklist,
     } = useValues(logic)
     const {
         loadControls,
@@ -35,7 +34,6 @@ export function ErrorTrackingIngestionControls({ disabled }: { disabled: boolean
         setLinkedFeatureFlag,
         setEventTriggers,
         setUrlTriggers,
-        setUrlBlocklist,
     } = useActions(logic)
 
     useEffect(() => {
@@ -80,15 +78,6 @@ export function ErrorTrackingIngestionControls({ disabled }: { disabled: boolean
                             }}
                             title="Enable exception autocapture when URL matches"
                             description="Adding a URL trigger means exception autocapture will only be started when the user visits a page that matches the URL."
-                        />
-                        <UrlConfig
-                            logicProps={{
-                                logicKey: 'error-tracking-url-blocklist',
-                                initialUrlTriggerConfig: urlBlocklist,
-                                onChange: setUrlBlocklist,
-                            }}
-                            title="Pause exception autocapture when URL matches"
-                            description="Used to pause exception autocapture for part of a user journey"
                         />
                         <EventTriggers value={eventTriggers} onChange={setEventTriggers} />
                         <LinkedFlagSelector value={linkedFeatureFlag} onChange={setLinkedFeatureFlag} />

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/exception_autocapture/autoCaptureControlsLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/exception_autocapture/autoCaptureControlsLogic.ts
@@ -107,8 +107,8 @@ export const autoCaptureControlsLogic = kea<autoCaptureControlsLogicType>([
     })),
     selectors({
         triggers: [
-            (s) => [s.sampleRate, s.linkedFeatureFlag, s.eventTriggers, s.urlTriggers, s.urlBlocklist],
-            (sampleRate, linkedFeatureFlag, eventTriggers, urlTriggers, urlBlocklist): Trigger[] => [
+            (s) => [s.sampleRate, s.linkedFeatureFlag, s.eventTriggers, s.urlTriggers],
+            (sampleRate, linkedFeatureFlag, eventTriggers, urlTriggers): Trigger[] => [
                 {
                     type: TriggerType.URL_MATCH,
                     enabled: urlTriggers.length > 0,
@@ -128,11 +128,6 @@ export const autoCaptureControlsLogic = kea<autoCaptureControlsLogicType>([
                     type: TriggerType.SAMPLING,
                     enabled: sampleRate < 1,
                     sampleRate: sampleRate,
-                },
-                {
-                    type: TriggerType.URL_BLOCKLIST,
-                    enabled: urlBlocklist.length > 0,
-                    urls: urlBlocklist,
                 },
             ],
         ],


### PR DESCRIPTION
We've decided to skip URL blocklist for now. I'm not removing backend and migrating the DB because we may decide to add it back.