### PR TITLE
feat(llma): add observability tracking to clusters tab

### DIFF
--- a/products/llm_analytics/frontend/clusters/ClusterCard.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterCard.tsx
@@ -40,7 +40,11 @@ export function ClusterCard({
             }`}
         >
             {/* Card Header */}
-            <div className="p-4 cursor-pointer hover:bg-surface-secondary transition-colors" onClick={onToggleExpand}>
+            <div
+                className="p-4 cursor-pointer hover:bg-surface-secondary transition-colors"
+                onClick={onToggleExpand}
+                data-attr="clusters-card-header"
+            >
                 <div className="flex items-start justify-between gap-2">
                     <div className="flex-1 min-w-0">
                         <div className="flex items-baseline gap-2 mb-2">
@@ -48,6 +52,7 @@ export function ClusterCard({
                                 to={urls.llmAnalyticsCluster(runId, cluster.cluster_id)}
                                 className="font-semibold text-base truncate hover:underline"
                                 onClick={(e) => e.stopPropagation()}
+                                data-attr="clusters-card-title-link"
                             >
                                 {cluster.title}
                             </Link>
@@ -82,6 +87,7 @@ export function ClusterCard({
                         <Link
                             to={urls.llmAnalyticsCluster(runId, cluster.cluster_id)}
                             className="text-link hover:underline text-sm font-medium"
+                            data-attr="clusters-view-all-link"
                         >
                             View all {Object.keys(cluster.traces).length} {itemLabel} →
                         </Link>

--- a/products/llm_analytics/frontend/clusters/ClusterTraceList.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusterTraceList.tsx
@@ -102,6 +102,7 @@ function TraceListItem({
                               }
                     )}
                     className="text-xs text-link hover:underline shrink-0"
+                    data-attr="clusters-view-trace-link"
                 >
                     {clusteringLevel === 'generation' ? 'View generation →' : 'View trace →'}
                 </Link>
@@ -117,6 +118,7 @@ function TraceListItem({
                                 type="secondary"
                                 icon={showFlow ? <IconChevronDown /> : <IconChevronRight />}
                                 onClick={() => setShowFlow(!showFlow)}
+                                data-attr="clusters-trace-flow-toggle"
                             >
                                 Flow
                             </LemonButton>
@@ -127,6 +129,7 @@ function TraceListItem({
                                 type="secondary"
                                 icon={showBullets ? <IconChevronDown /> : <IconChevronRight />}
                                 onClick={() => setShowBullets(!showBullets)}
+                                data-attr="clusters-trace-summary-toggle"
                             >
                                 Summary
                             </LemonButton>
@@ -137,6 +140,7 @@ function TraceListItem({
                                 type="secondary"
                                 icon={showNotes ? <IconChevronDown /> : <IconChevronRight />}
                                 onClick={() => setShowNotes(!showNotes)}
+                                data-attr="clusters-trace-notes-toggle"
                             >
                                 Notes
                             </LemonButton>

--- a/products/llm_analytics/frontend/clusters/ClusteringAdminModal.tsx
+++ b/products/llm_analytics/frontend/clusters/ClusteringAdminModal.tsx
@@ -19,14 +19,29 @@ export function ClusteringAdminModal(): JSX.Element {
             description="Configure and trigger a clustering workflow with custom parameters for experimentation."
             footer={
                 <>
-                    <LemonButton type="secondary" onClick={resetParams} disabled={isRunning}>
+                    <LemonButton
+                        type="secondary"
+                        onClick={resetParams}
+                        disabled={isRunning}
+                        data-attr="clusters-admin-reset"
+                    >
                         Reset to defaults
                     </LemonButton>
                     <div className="flex-1" />
-                    <LemonButton type="secondary" onClick={closeModal} disabled={isRunning}>
+                    <LemonButton
+                        type="secondary"
+                        onClick={closeModal}
+                        disabled={isRunning}
+                        data-attr="clusters-admin-cancel"
+                    >
                         Cancel
                     </LemonButton>
-                    <LemonButton type="primary" onClick={triggerClusteringRun} loading={isRunning}>
+                    <LemonButton
+                        type="primary"
+                        onClick={triggerClusteringRun}
+                        loading={isRunning}
+                        data-attr="clusters-admin-run"
+                    >
                         Run clustering
                     </LemonButton>
                 </>
@@ -44,6 +59,7 @@ export function ClusteringAdminModal(): JSX.Element {
                             { value: 'generation', label: 'Generations' },
                         ]}
                         fullWidth
+                        data-attr="clusters-admin-level"
                     />
                     <div className="text-xs text-muted mt-2">
                         <strong>Traces:</strong> Cluster entire conversation traces. <strong>Generations:</strong>{' '}
@@ -62,6 +78,7 @@ export function ClusteringAdminModal(): JSX.Element {
                             onChange={(value) => setParams({ run_label: value })}
                             placeholder="e.g., pca-100-l2-test"
                             fullWidth
+                            data-attr="clusters-admin-run-label"
                         />
                         <div className="text-xs text-muted mt-1">
                             Optional label added as suffix to run ID for tracking experiments
@@ -107,6 +124,7 @@ export function ClusteringAdminModal(): JSX.Element {
                                 value={params.lookback_days}
                                 onChange={(value) => setParams({ lookback_days: Number(value) })}
                                 fullWidth
+                                data-attr="clusters-admin-lookback-days"
                             />
                             <div className="text-xs text-muted mt-1">
                                 Days of traces to analyze (default: {DEFAULT_CLUSTERING_PARAMS.lookback_days})
@@ -121,6 +139,7 @@ export function ClusteringAdminModal(): JSX.Element {
                                 value={params.max_samples}
                                 onChange={(value) => setParams({ max_samples: Number(value) })}
                                 fullWidth
+                                data-attr="clusters-admin-max-samples"
                             />
                             <div className="text-xs text-muted mt-1">
                                 Maximum traces to cluster (default: {DEFAULT_CLUSTERING_PARAMS.max_samples})
@@ -142,6 +161,7 @@ export function ClusteringAdminModal(): JSX.Element {
                                 { value: 'l2', label: 'L2 normalize' },
                             ]}
                             fullWidth
+                            data-attr="clusters-admin-normalization"
                         />
                         <div className="text-xs text-muted mt-1">
                             L2 normalization can help with embeddings of varying magnitudes
@@ -164,6 +184,7 @@ export function ClusteringAdminModal(): JSX.Element {
                                     { value: 'pca', label: 'PCA' },
                                 ]}
                                 fullWidth
+                                data-attr="clusters-admin-dim-reduction"
                             />
                             <div className="text-xs text-muted mt-1">UMAP is slower but better for clustering</div>
                         </div>
@@ -177,6 +198,7 @@ export function ClusteringAdminModal(): JSX.Element {
                                 onChange={(value) => setParams({ dimensionality_reduction_ndims: Number(value) })}
                                 fullWidth
                                 disabled={params.dimensionality_reduction_method === 'none'}
+                                data-attr="clusters-admin-target-dims"
                             />
                             <div className="text-xs text-muted mt-1">
                                 Number of dimensions (default:{' '}
@@ -199,6 +221,7 @@ export function ClusteringAdminModal(): JSX.Element {
                                 { value: 'kmeans', label: 'K-means (centroid-based)' },
                             ]}
                             fullWidth
+                            data-attr="clusters-admin-clustering-method"
                         />
                         <div className="text-xs text-muted mt-1">
                             HDBSCAN auto-determines clusters and identifies outliers. K-means uses silhouette score to
@@ -298,6 +321,7 @@ export function ClusteringAdminModal(): JSX.Element {
                                 { value: 'tsne', label: 't-SNE' },
                             ]}
                             fullWidth
+                            data-attr="clusters-admin-visualization"
                         />
                         <div className="text-xs text-muted mt-1">
                             Method for reducing cluster embeddings to 2D for the scatter plot visualization

--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -121,6 +121,7 @@ export function ClustersView(): JSX.Element {
                                     { value: 'generation', label: 'Generations' },
                                 ]}
                                 size="small"
+                                data-attr="clusters-level-toggle"
                             />
                         </span>
                     </Tooltip>
@@ -130,6 +131,7 @@ export function ClustersView(): JSX.Element {
                         icon={<IconRefresh />}
                         onClick={loadClusteringRuns}
                         tooltip="Refresh clustering runs"
+                        data-attr="clusters-refresh-runs"
                     />
                 </div>
 
@@ -165,6 +167,7 @@ export function ClustersView(): JSX.Element {
                                     { value: 'generation', label: 'Generations' },
                                 ]}
                                 size="small"
+                                data-attr="clusters-level-toggle"
                             />
                         </span>
                     </Tooltip>
@@ -179,6 +182,7 @@ export function ClustersView(): JSX.Element {
                                     label: run.label,
                                 }))}
                                 placeholder="Select a run"
+                                data-attr="clusters-run-select"
                             />
                         </span>
                     </Tooltip>
@@ -188,6 +192,7 @@ export function ClustersView(): JSX.Element {
                         icon={<IconRefresh />}
                         onClick={loadClusteringRuns}
                         tooltip="Refresh clustering runs"
+                        data-attr="clusters-refresh-runs"
                     />
                 </div>
 
@@ -238,6 +243,7 @@ export function ClustersView(): JSX.Element {
                             icon={<IconGear />}
                             onClick={openModal}
                             tooltip="Run clustering with custom parameters"
+                            data-attr="clusters-run-clustering-button"
                         >
                             Run clustering
                         </LemonButton>
@@ -258,6 +264,7 @@ export function ClustersView(): JSX.Element {
                     <div
                         className="p-4 cursor-pointer hover:bg-surface-secondary transition-colors"
                         onClick={toggleScatterPlotExpanded}
+                        data-attr="clusters-scatter-plot-toggle"
                     >
                         <div className="flex items-center gap-4">
                             <ClusterDistributionBar clusters={sortedClusters} runId={effectiveRunId || ''} />

--- a/products/llm_analytics/frontend/clusters/LLMAnalyticsClusterScene.tsx
+++ b/products/llm_analytics/frontend/clusters/LLMAnalyticsClusterScene.tsx
@@ -73,7 +73,7 @@ export function LLMAnalyticsClusterScene(): JSX.Element {
                 resourceType={{ type: 'llm_analytics' }}
                 actions={
                     <Link to={urls.llmAnalyticsClusters()}>
-                        <LemonButton type="secondary" size="small">
+                        <LemonButton type="secondary" size="small" data-attr="clusters-back-button">
                             Back to clusters
                         </LemonButton>
                     </Link>
@@ -123,6 +123,7 @@ export function LLMAnalyticsClusterScene(): JSX.Element {
                             icon={<IconChevronLeft />}
                             disabled={currentPage === 1}
                             onClick={() => setPage(currentPage - 1)}
+                            data-attr="clusters-detail-prev-page"
                         />
                         <span className="text-sm">
                             Page {currentPage} of {totalPages}
@@ -133,6 +134,7 @@ export function LLMAnalyticsClusterScene(): JSX.Element {
                             icon={<IconChevronRight />}
                             disabled={currentPage === totalPages}
                             onClick={() => setPage(currentPage + 1)}
+                            data-attr="clusters-detail-next-page"
                         />
                     </div>
                 </div>
@@ -182,6 +184,7 @@ export function LLMAnalyticsClusterScene(): JSX.Element {
                             icon={<IconChevronLeft />}
                             disabled={currentPage === 1}
                             onClick={() => setPage(currentPage - 1)}
+                            data-attr="clusters-detail-prev-page"
                         />
                         <span className="text-sm">
                             Page {currentPage} of {totalPages}
@@ -192,6 +195,7 @@ export function LLMAnalyticsClusterScene(): JSX.Element {
                             icon={<IconChevronRight />}
                             disabled={currentPage === totalPages}
                             onClick={() => setPage(currentPage + 1)}
+                            data-attr="clusters-detail-next-page"
                         />
                     </div>
                 </div>
@@ -239,6 +243,7 @@ function TraceListItem({
                         ...(traceInfo.timestamp ? { timestamp: traceInfo.timestamp } : {}),
                     })}
                     className="text-sm text-link hover:underline shrink-0"
+                    data-attr="clusters-view-trace-link"
                 >
                     {clusteringLevel === 'generation' ? 'View generation →' : 'View trace →'}
                 </Link>
@@ -254,6 +259,7 @@ function TraceListItem({
                                 type="secondary"
                                 icon={showFlow ? <IconChevronDown /> : <IconChevronRight />}
                                 onClick={() => setShowFlow(!showFlow)}
+                                data-attr="clusters-trace-flow-toggle"
                             >
                                 Flow
                             </LemonButton>
@@ -264,6 +270,7 @@ function TraceListItem({
                                 type="secondary"
                                 icon={showBullets ? <IconChevronDown /> : <IconChevronRight />}
                                 onClick={() => setShowBullets(!showBullets)}
+                                data-attr="clusters-trace-summary-toggle"
                             >
                                 Summary
                             </LemonButton>
@@ -274,6 +281,7 @@ function TraceListItem({
                                 type="secondary"
                                 icon={showNotes ? <IconChevronDown /> : <IconChevronRight />}
                                 onClick={() => setShowNotes(!showNotes)}
+                                data-attr="clusters-trace-notes-toggle"
                             >
                                 Notes
                             </LemonButton>

--- a/products/llm_analytics/frontend/clusters/clusterDetailLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clusterDetailLogic.ts
@@ -294,7 +294,7 @@ export const clusterDetailLogic = kea<clusterDetailLogicType>([
         ],
     }),
 
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, props }) => ({
         loadClusterDataSuccess: async () => {
             // Load summaries for the first page of traces
             await actions.setPage(1)

--- a/products/llm_analytics/frontend/clusters/clusterDetailLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clusterDetailLogic.ts
@@ -1,6 +1,7 @@
 import { actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { urlToAction } from 'kea-router'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { getSeriesColor } from 'lib/colors'
@@ -299,7 +300,12 @@ export const clusterDetailLogic = kea<clusterDetailLogicType>([
             await actions.setPage(1)
         },
 
-        setPage: async () => {
+        setPage: async ({ page }) => {
+            posthog.capture('llma clusters page changed', {
+                page,
+                cluster_id: props.clusterId,
+                run_id: props.runId,
+            })
             // Load trace summaries for the current page
             const traceIds = values.paginatedTraceIds
             const { windowStart, windowEnd, clusteringLevel } = values

--- a/products/llm_analytics/frontend/clusters/clustersAdminLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clustersAdminLogic.ts
@@ -1,5 +1,6 @@
 import { actions, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -99,7 +100,16 @@ export const clustersAdminLogic = kea<clustersAdminLogicType>([
         isRunning: [(s) => [s.clusteringRunLoading], (loading): boolean => loading],
     }),
 
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
+        triggerClusteringRun: () => {
+            posthog.capture('llma clusters admin run triggered', {
+                level: values.params.analysis_level,
+                method: values.params.clustering_method,
+                normalization: values.params.embedding_normalization,
+                lookback_days: values.params.lookback_days,
+            })
+        },
+
         triggerClusteringRunSuccess: ({ clusteringRun }) => {
             lemonToast.success(`Clustering workflow started`, {
                 toastId: `clustering-run-${clusteringRun?.workflow_id}`,

--- a/products/llm_analytics/frontend/clusters/clustersLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clustersLogic.ts
@@ -1,6 +1,7 @@
 import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { actionToUrl, urlToAction } from 'kea-router'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { getSeriesColor } from 'lib/colors'
@@ -335,7 +336,8 @@ export const clustersLogic = kea<clustersLogicType>([
     }),
 
     listeners(({ actions, values }) => ({
-        setClusteringLevel: () => {
+        setClusteringLevel: ({ level }) => {
+            posthog.capture('llma clusters level changed', { level })
             // Reload runs when level changes
             actions.loadClusteringRuns()
         },
@@ -366,6 +368,10 @@ export const clustersLogic = kea<clustersLogicType>([
         },
 
         toggleClusterExpanded: async ({ clusterId }) => {
+            posthog.capture('llma clusters cluster expanded', {
+                cluster_id: clusterId,
+                run_id: values.effectiveRunId,
+            })
             // Load summaries when expanding a cluster (fallback for lazy loading)
             if (values.expandedClusterIds.has(clusterId)) {
                 const run = values.currentRun
@@ -418,8 +424,15 @@ export const clustersLogic = kea<clustersLogicType>([
             }
         },
 
+        toggleScatterPlotExpanded: () => {
+            posthog.capture('llma clusters scatter plot toggled', {
+                expanded: values.isScatterPlotExpanded,
+            })
+        },
+
         setSelectedRunId: ({ runId }) => {
             if (runId) {
+                posthog.capture('llma clusters run selected', { run_id: runId })
                 actions.loadClusteringRun(runId)
             }
         },


### PR DESCRIPTION
## Problem

The LLM Analytics Clusters tab has almost no usage tracking -- only 1 data-attr exists and 0 custom event captures. This makes it impossible to monitor adoption, engagement, or performance for the feature.

## Changes

- Add `data-attr` attributes to all interactive elements across 5 component files (toggles, buttons, links, selects, form controls in the admin modal)
- Add 6 custom `posthog.capture()` events to 3 kea logic files:
  - `llma clusters level changed` (traces/generations toggle)
  - `llma clusters run selected` (run dropdown)
  - `llma clusters cluster expanded` (card expand/collapse)
  - `llma clusters scatter plot toggled` (scatter plot expand/collapse)
  - `llma clusters page changed` (cluster detail pagination)
  - `llma clusters admin run triggered` (admin modal run button)
- Created a [LLM Analytics Clusters Usage dashboard](https://us.posthog.com/project/2/dashboard/1200360) with 12 tiles: WAU/DAU bold numbers, adoption trends, funnels (tab -> detail, tab -> trace), interaction volume, level breakdown pie, spinner load time percentiles, and admin run tracking

## How did you test this code?

- Ran `pnpm prettier` on all modified files -- no formatting issues
- Ran `pnpm typescript:check` -- no new TS errors (all errors are pre-existing in unrelated files)
- Verified dashboard renders at https://us.posthog.com/project/2/dashboard/1200360

## Publish to changelog?

No