### PR TITLE
feat(auth): integrate WorkOS Radar for fraud detection (log-only)

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -37,6 +37,7 @@ from posthog.models.webauthn_credential import WebauthnCredential
 from posthog.permissions import CanCreateOrg
 from posthog.rate_limit import SignupEmailPrecheckThrottle, SignupIPThrottle
 from posthog.utils import get_can_create_org, is_relative_url
+from posthog.workos_radar import RadarAction, RadarAuthMethod, evaluate_auth_attempt
 
 logger = structlog.get_logger(__name__)
 
@@ -160,6 +161,15 @@ class SignupSerializer(serializers.Serializer):
 
         request = self.context["request"]
         passkey_credential = request.session.get(WEBAUTHN_SIGNUP_CREDENTIAL_KEY)
+
+        # Evaluate signup attempt with WorkOS Radar (log-only mode, does not block)
+        auth_method = RadarAuthMethod.PASSKEY if passkey_credential else RadarAuthMethod.PASSWORD
+        evaluate_auth_attempt(
+            request=request._request,
+            email=validated_data["email"],
+            action=RadarAction.SIGNUP,
+            auth_method=auth_method,
+        )
 
         is_instance_first_user: bool = not User.objects.exists()
 
@@ -367,6 +377,17 @@ class InviteSignupSerializer(serializers.Serializer):
             invite: OrganizationInvite = OrganizationInvite.objects.select_related("organization").get(id=invite_id)
         except OrganizationInvite.DoesNotExist:
             raise serializers.ValidationError("The provided invite ID is not valid.")
+
+        # Evaluate signup attempt with WorkOS Radar (log-only mode, does not block)
+        # Only for new users, not existing authenticated users
+        if not user and invite.target_email:
+            auth_method = RadarAuthMethod.PASSKEY if passkey_credential else RadarAuthMethod.PASSWORD
+            evaluate_auth_attempt(
+                request=request._request,
+                email=invite.target_email,
+                action=RadarAction.SIGNUP,
+                auth_method=auth_method,
+            )
 
         # Only check SSO enforcement if we're not already logged in
         if (

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -1,4 +1,4 @@
-from posthog.settings.utils import get_from_env
+from posthog.settings.utils import get_from_env, str_to_bool
 
 HUBSPOT_APP_CLIENT_ID = get_from_env("HUBSPOT_APP_CLIENT_ID", "")
 HUBSPOT_APP_CLIENT_SECRET = get_from_env("HUBSPOT_APP_CLIENT_SECRET", "")
@@ -50,6 +50,10 @@ CLICKUP_APP_CLIENT_SECRET = get_from_env("CLICKUP_APP_CLIENT_SECRET", "")
 
 ATLASSIAN_APP_CLIENT_ID = get_from_env("ATLASSIAN_APP_CLIENT_ID", "")
 ATLASSIAN_APP_CLIENT_SECRET = get_from_env("ATLASSIAN_APP_CLIENT_SECRET", "")
+
+# WorkOS Radar (bot/fraud detection for auth flows)
+WORKOS_RADAR_API_KEY = get_from_env("WORKOS_RADAR_API_KEY", "")
+WORKOS_RADAR_ENABLED = get_from_env("WORKOS_RADAR_ENABLED", False, type_cast=str_to_bool)
 
 # Recall.ai (for desktop recordings product)
 RECALL_AI_API_KEY = get_from_env("RECALL_AI_API_KEY", "")

--- a/posthog/test/test_workos_radar.py
+++ b/posthog/test/test_workos_radar.py
@@ -1,0 +1,269 @@
+"""
+Tests for the WorkOS Radar integration.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory, TestCase, override_settings
+
+import httpx
+
+from posthog.workos_radar import (
+    WORKOS_RADAR_API_URL,
+    RadarAction,
+    RadarAuthMethod,
+    RadarVerdict,
+    _call_radar_api,
+    _get_ip_address,
+    _get_user_agent,
+    _hash_email,
+    _log_radar_event,
+    evaluate_auth_attempt,
+)
+
+
+class TestRadarHelpers(TestCase):
+    def test_hash_email_produces_consistent_hash(self):
+        email = "test@example.com"
+        hash1 = _hash_email(email)
+        hash2 = _hash_email(email)
+        assert hash1 == hash2
+        assert len(hash1) == 16
+
+    def test_hash_email_is_case_insensitive(self):
+        assert _hash_email("Test@Example.Com") == _hash_email("test@example.com")
+
+    def test_get_ip_address_from_x_forwarded_for(self):
+        factory = RequestFactory()
+        request = factory.get("/", HTTP_X_FORWARDED_FOR="1.2.3.4, 5.6.7.8")
+        assert _get_ip_address(request) == "1.2.3.4"
+
+    def test_get_ip_address_from_remote_addr(self):
+        factory = RequestFactory()
+        request = factory.get("/", REMOTE_ADDR="9.8.7.6")
+        assert _get_ip_address(request) == "9.8.7.6"
+
+    def test_get_user_agent(self):
+        factory = RequestFactory()
+        request = factory.get("/", HTTP_USER_AGENT="Mozilla/5.0 TestBrowser")
+        assert _get_user_agent(request) == "Mozilla/5.0 TestBrowser"
+
+
+class TestRadarApiCall(TestCase):
+    @patch("posthog.workos_radar.httpx.post")
+    @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
+    def test_call_radar_api_allow_verdict(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"verdict": "allow"}
+        mock_post.return_value = mock_response
+
+        verdict = _call_radar_api(
+            email="test@example.com",
+            ip_address="1.2.3.4",
+            user_agent="TestBrowser",
+            action=RadarAction.SIGNIN,
+        )
+
+        assert verdict == RadarVerdict.ALLOW
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert call_args[0][0] == WORKOS_RADAR_API_URL
+        assert "Bearer test_api_key" in str(call_args[1]["headers"])
+
+    @patch("posthog.workos_radar.httpx.post")
+    @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
+    def test_call_radar_api_challenge_verdict(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"verdict": "challenge"}
+        mock_post.return_value = mock_response
+
+        verdict = _call_radar_api(
+            email="test@example.com",
+            ip_address="1.2.3.4",
+            user_agent="TestBrowser",
+            action=RadarAction.SIGNIN,
+        )
+
+        assert verdict == RadarVerdict.CHALLENGE
+
+    @patch("posthog.workos_radar.httpx.post")
+    @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
+    def test_call_radar_api_block_verdict(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"verdict": "block"}
+        mock_post.return_value = mock_response
+
+        verdict = _call_radar_api(
+            email="test@example.com",
+            ip_address="1.2.3.4",
+            user_agent="TestBrowser",
+            action=RadarAction.SIGNUP,
+        )
+
+        assert verdict == RadarVerdict.BLOCK
+
+    @patch("posthog.workos_radar.httpx.post")
+    @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
+    def test_call_radar_api_handles_api_error(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_post.return_value = mock_response
+
+        verdict = _call_radar_api(
+            email="test@example.com",
+            ip_address="1.2.3.4",
+            user_agent="TestBrowser",
+            action=RadarAction.SIGNIN,
+        )
+
+        assert verdict == RadarVerdict.ERROR
+
+    @patch("posthog.workos_radar.httpx.post")
+    @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
+    def test_call_radar_api_handles_timeout(self, mock_post):
+        mock_post.side_effect = httpx.TimeoutException("timeout")
+
+        verdict = _call_radar_api(
+            email="test@example.com",
+            ip_address="1.2.3.4",
+            user_agent="TestBrowser",
+            action=RadarAction.SIGNIN,
+        )
+
+        assert verdict == RadarVerdict.ERROR
+
+    @patch("posthog.workos_radar.httpx.post")
+    @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
+    def test_call_radar_api_handles_exception(self, mock_post):
+        mock_post.side_effect = Exception("unexpected error")
+
+        verdict = _call_radar_api(
+            email="test@example.com",
+            ip_address="1.2.3.4",
+            user_agent="TestBrowser",
+            action=RadarAction.SIGNIN,
+        )
+
+        assert verdict == RadarVerdict.ERROR
+
+
+class TestRadarEventLogging(TestCase):
+    @patch("posthog.workos_radar.posthoganalytics.capture")
+    def test_log_radar_event_captures_posthog_event(self, mock_capture):
+        _log_radar_event(
+            email="test@example.com",
+            user_id="user_123",
+            action=RadarAction.SIGNIN,
+            auth_method=RadarAuthMethod.PASSWORD,
+            verdict=RadarVerdict.ALLOW,
+            ip_address="1.2.3.4",
+            user_agent="TestBrowser",
+        )
+
+        mock_capture.assert_called_once()
+        call_args = mock_capture.call_args
+        assert call_args[1]["distinct_id"] == "user_123"
+        assert call_args[1]["event"] == "workos_radar_attempt"
+        props = call_args[1]["properties"]
+        assert props["action"] == "signin"
+        assert props["auth_method"] == "password"
+        assert props["verdict"] == "allow"
+        assert props["would_challenge"] is False
+        assert props["would_block"] is False
+
+    @patch("posthog.workos_radar.posthoganalytics.capture")
+    def test_log_radar_event_with_challenge_verdict(self, mock_capture):
+        _log_radar_event(
+            email="test@example.com",
+            user_id=None,
+            action=RadarAction.SIGNUP,
+            auth_method=RadarAuthMethod.PASSKEY,
+            verdict=RadarVerdict.CHALLENGE,
+            ip_address="1.2.3.4",
+            user_agent="TestBrowser",
+        )
+
+        mock_capture.assert_called_once()
+        call_args = mock_capture.call_args
+        assert "pre_signup_" in call_args[1]["distinct_id"]
+        props = call_args[1]["properties"]
+        assert props["would_challenge"] is True
+        assert props["would_block"] is False
+
+    @patch("posthog.workos_radar.posthoganalytics.capture")
+    def test_log_radar_event_with_block_verdict(self, mock_capture):
+        _log_radar_event(
+            email="test@example.com",
+            user_id=None,
+            action=RadarAction.SIGNUP,
+            auth_method=RadarAuthMethod.PASSWORD,
+            verdict=RadarVerdict.BLOCK,
+            ip_address="1.2.3.4",
+            user_agent="TestBrowser",
+        )
+
+        mock_capture.assert_called_once()
+        props = mock_capture.call_args[1]["properties"]
+        assert props["would_challenge"] is False
+        assert props["would_block"] is True
+
+
+class TestEvaluateAuthAttempt(TestCase):
+    @override_settings(WORKOS_RADAR_ENABLED=False)
+    def test_returns_disabled_when_radar_disabled(self):
+        factory = RequestFactory()
+        request = factory.get("/")
+
+        verdict = evaluate_auth_attempt(
+            request=request,
+            email="test@example.com",
+            action=RadarAction.SIGNIN,
+            auth_method=RadarAuthMethod.PASSWORD,
+        )
+
+        assert verdict == RadarVerdict.DISABLED
+
+    @override_settings(WORKOS_RADAR_ENABLED=True, WORKOS_RADAR_API_KEY="")
+    def test_returns_disabled_when_no_api_key(self):
+        factory = RequestFactory()
+        request = factory.get("/")
+
+        verdict = evaluate_auth_attempt(
+            request=request,
+            email="test@example.com",
+            action=RadarAction.SIGNIN,
+            auth_method=RadarAuthMethod.PASSWORD,
+        )
+
+        assert verdict == RadarVerdict.DISABLED
+
+    @patch("posthog.workos_radar._log_radar_event")
+    @patch("posthog.workos_radar._call_radar_api")
+    @override_settings(WORKOS_RADAR_ENABLED=True, WORKOS_RADAR_API_KEY="test_key")
+    def test_calls_api_and_logs_event_when_enabled(self, mock_call_api, mock_log_event):
+        mock_call_api.return_value = RadarVerdict.ALLOW
+
+        factory = RequestFactory()
+        request = factory.get("/", REMOTE_ADDR="1.2.3.4", HTTP_USER_AGENT="TestBrowser")
+
+        verdict = evaluate_auth_attempt(
+            request=request,
+            email="test@example.com",
+            action=RadarAction.SIGNIN,
+            auth_method=RadarAuthMethod.PASSWORD,
+            user_id="user_123",
+        )
+
+        assert verdict == RadarVerdict.ALLOW
+        mock_call_api.assert_called_once()
+        mock_log_event.assert_called_once()
+
+        log_call_args = mock_log_event.call_args
+        assert log_call_args[1]["email"] == "test@example.com"
+        assert log_call_args[1]["user_id"] == "user_123"
+        assert log_call_args[1]["action"] == RadarAction.SIGNIN
+        assert log_call_args[1]["auth_method"] == RadarAuthMethod.PASSWORD
+        assert log_call_args[1]["verdict"] == RadarVerdict.ALLOW

--- a/posthog/test/test_workos_radar.py
+++ b/posthog/test/test_workos_radar.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from django.test import RequestFactory, TestCase, override_settings
 
-import httpx
+import requests
 
 from posthog.workos_radar import (
     WORKOS_RADAR_API_URL,
@@ -39,7 +39,7 @@ class TestRadarHelpers(TestCase):
 
 
 class TestRadarApiCall(TestCase):
-    @patch("posthog.workos_radar.httpx.post")
+    @patch("posthog.workos_radar.requests.post")
     @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
     def test_call_radar_api_allow_verdict(self, mock_post):
         mock_response = MagicMock()
@@ -61,7 +61,7 @@ class TestRadarApiCall(TestCase):
         assert call_args[0][0] == WORKOS_RADAR_API_URL
         assert "Bearer test_api_key" in str(call_args[1]["headers"])
 
-    @patch("posthog.workos_radar.httpx.post")
+    @patch("posthog.workos_radar.requests.post")
     @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
     def test_call_radar_api_challenge_verdict(self, mock_post):
         mock_response = MagicMock()
@@ -79,7 +79,7 @@ class TestRadarApiCall(TestCase):
 
         assert verdict == RadarVerdict.CHALLENGE
 
-    @patch("posthog.workos_radar.httpx.post")
+    @patch("posthog.workos_radar.requests.post")
     @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
     def test_call_radar_api_block_verdict(self, mock_post):
         mock_response = MagicMock()
@@ -97,7 +97,7 @@ class TestRadarApiCall(TestCase):
 
         assert verdict == RadarVerdict.BLOCK
 
-    @patch("posthog.workos_radar.httpx.post")
+    @patch("posthog.workos_radar.requests.post")
     @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
     def test_call_radar_api_handles_api_error(self, mock_post):
         mock_response = MagicMock()
@@ -114,10 +114,10 @@ class TestRadarApiCall(TestCase):
 
         assert verdict == RadarVerdict.ERROR
 
-    @patch("posthog.workos_radar.httpx.post")
+    @patch("posthog.workos_radar.requests.post")
     @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
     def test_call_radar_api_handles_timeout(self, mock_post):
-        mock_post.side_effect = httpx.TimeoutException("timeout")
+        mock_post.side_effect = requests.exceptions.Timeout("timeout")
 
         verdict = _call_radar_api(
             email="test@example.com",
@@ -129,7 +129,7 @@ class TestRadarApiCall(TestCase):
 
         assert verdict == RadarVerdict.ERROR
 
-    @patch("posthog.workos_radar.httpx.post")
+    @patch("posthog.workos_radar.requests.post")
     @override_settings(WORKOS_RADAR_API_KEY="test_api_key")
     def test_call_radar_api_handles_exception(self, mock_post):
         mock_post.side_effect = Exception("unexpected error")

--- a/posthog/test/test_workos_radar.py
+++ b/posthog/test/test_workos_radar.py
@@ -164,7 +164,7 @@ class TestRadarEventLogging(TestCase):
         assert call_args[1]["distinct_id"] == "user_123"
         assert call_args[1]["event"] == "workos_radar_attempt"
         props = call_args[1]["properties"]
-        assert props["action"] == "signin"
+        assert props["action"] == "login"
         assert props["auth_method"] == "Password"
         assert props["verdict"] == "allow"
         assert props["would_challenge"] is False

--- a/posthog/test/test_workos_radar.py
+++ b/posthog/test/test_workos_radar.py
@@ -63,6 +63,7 @@ class TestRadarApiCall(TestCase):
             ip_address="1.2.3.4",
             user_agent="TestBrowser",
             action=RadarAction.SIGNIN,
+            auth_method=RadarAuthMethod.PASSWORD,
         )
 
         assert verdict == RadarVerdict.ALLOW
@@ -84,6 +85,7 @@ class TestRadarApiCall(TestCase):
             ip_address="1.2.3.4",
             user_agent="TestBrowser",
             action=RadarAction.SIGNIN,
+            auth_method=RadarAuthMethod.PASSWORD,
         )
 
         assert verdict == RadarVerdict.CHALLENGE
@@ -101,6 +103,7 @@ class TestRadarApiCall(TestCase):
             ip_address="1.2.3.4",
             user_agent="TestBrowser",
             action=RadarAction.SIGNUP,
+            auth_method=RadarAuthMethod.PASSWORD,
         )
 
         assert verdict == RadarVerdict.BLOCK
@@ -117,6 +120,7 @@ class TestRadarApiCall(TestCase):
             ip_address="1.2.3.4",
             user_agent="TestBrowser",
             action=RadarAction.SIGNIN,
+            auth_method=RadarAuthMethod.PASSWORD,
         )
 
         assert verdict == RadarVerdict.ERROR
@@ -131,6 +135,7 @@ class TestRadarApiCall(TestCase):
             ip_address="1.2.3.4",
             user_agent="TestBrowser",
             action=RadarAction.SIGNIN,
+            auth_method=RadarAuthMethod.PASSWORD,
         )
 
         assert verdict == RadarVerdict.ERROR
@@ -145,6 +150,7 @@ class TestRadarApiCall(TestCase):
             ip_address="1.2.3.4",
             user_agent="TestBrowser",
             action=RadarAction.SIGNIN,
+            auth_method=RadarAuthMethod.PASSWORD,
         )
 
         assert verdict == RadarVerdict.ERROR
@@ -169,7 +175,7 @@ class TestRadarEventLogging(TestCase):
         assert call_args[1]["event"] == "workos_radar_attempt"
         props = call_args[1]["properties"]
         assert props["action"] == "signin"
-        assert props["auth_method"] == "password"
+        assert props["auth_method"] == "Password"
         assert props["verdict"] == "allow"
         assert props["would_challenge"] is False
         assert props["would_block"] is False

--- a/posthog/workos_radar.py
+++ b/posthog/workos_radar.py
@@ -31,7 +31,7 @@ WORKOS_RADAR_TIMEOUT = 5.0
 
 class RadarAction(StrEnum):
     SIGNUP = "signup"
-    SIGNIN = "signin"
+    SIGNIN = "login"
 
 
 class RadarAuthMethod(StrEnum):
@@ -159,6 +159,7 @@ def _call_radar_api(
             logger.error(
                 "workos_radar_api_error",
                 status_code=response.status_code,
+                response_body=response.text[:500],
                 email_hash=_hash_email(email),
             )
             return RadarVerdict.ERROR

--- a/posthog/workos_radar.py
+++ b/posthog/workos_radar.py
@@ -17,7 +17,7 @@ from typing import Optional
 from django.conf import settings
 from django.http import HttpRequest
 
-import httpx
+import requests
 import structlog
 import posthoganalytics
 
@@ -122,7 +122,7 @@ def _call_radar_api(
     Make the actual API call to WorkOS Radar.
     """
     try:
-        response = httpx.post(
+        response = requests.post(
             WORKOS_RADAR_API_URL,
             headers={
                 "Authorization": f"Bearer {settings.WORKOS_RADAR_API_KEY}",
@@ -163,7 +163,7 @@ def _call_radar_api(
             )
             return RadarVerdict.ERROR
 
-    except httpx.TimeoutException:
+    except requests.exceptions.Timeout:
         logger.warning(
             "workos_radar_timeout",
             email_hash=_hash_email(email),

--- a/posthog/workos_radar.py
+++ b/posthog/workos_radar.py
@@ -32,8 +32,8 @@ class RadarAction(StrEnum):
 
 
 class RadarAuthMethod(StrEnum):
-    PASSWORD = "password"
-    PASSKEY = "passkey"
+    PASSWORD = "Password"
+    PASSKEY = "Passkey"
 
 
 class RadarVerdict(StrEnum):
@@ -101,6 +101,7 @@ def evaluate_auth_attempt(
         ip_address=ip_address,
         user_agent=user_agent,
         action=action,
+        auth_method=auth_method,
     )
 
     _log_radar_event(
@@ -121,12 +122,10 @@ def _call_radar_api(
     ip_address: str,
     user_agent: str,
     action: RadarAction,
+    auth_method: RadarAuthMethod,
 ) -> RadarVerdict:
     """
     Make the actual API call to WorkOS Radar.
-
-    The API specification is based on WorkOS documentation. The request body
-    structure may need adjustment once the full API reference is available.
     """
     try:
         response = httpx.post(
@@ -140,6 +139,7 @@ def _call_radar_api(
                 "ip_address": ip_address,
                 "user_agent": user_agent,
                 "action": action.value,
+                "auth_method": auth_method.value,
             },
             timeout=WORKOS_RADAR_TIMEOUT,
         )

--- a/posthog/workos_radar.py
+++ b/posthog/workos_radar.py
@@ -1,0 +1,228 @@
+"""
+WorkOS Radar integration for bot/fraud detection during authentication flows.
+
+This module provides a client for the WorkOS Radar Attempts API to evaluate
+signup and signin attempts for potential fraud or bot activity.
+
+The integration operates in LOG-ONLY mode - it records the Radar decision as
+a PostHog event but does not actually block or challenge users based on the verdict.
+This allows evaluation of the potential impact before enabling enforcement.
+"""
+
+import hashlib
+from enum import StrEnum
+from typing import Optional
+
+from django.conf import settings
+from django.http import HttpRequest
+
+import httpx
+import structlog
+import posthoganalytics
+
+logger = structlog.get_logger(__name__)
+
+WORKOS_RADAR_API_URL = "https://api.workos.com/radar/attempts"
+WORKOS_RADAR_TIMEOUT = 5.0
+
+
+class RadarAction(StrEnum):
+    SIGNUP = "signup"
+    SIGNIN = "signin"
+
+
+class RadarAuthMethod(StrEnum):
+    PASSWORD = "password"
+    PASSKEY = "passkey"
+
+
+class RadarVerdict(StrEnum):
+    ALLOW = "allow"
+    CHALLENGE = "challenge"
+    BLOCK = "block"
+    ERROR = "error"
+    DISABLED = "disabled"
+
+
+def _hash_email(email: str) -> str:
+    """Hash email for logging purposes to avoid PII in logs."""
+    return hashlib.sha256(email.lower().encode()).hexdigest()[:16]
+
+
+def _get_ip_address(request: HttpRequest) -> str:
+    """Extract client IP address from request."""
+    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+    if x_forwarded_for:
+        return x_forwarded_for.split(",")[0].strip()
+    return request.META.get("REMOTE_ADDR", "")
+
+
+def _get_user_agent(request: HttpRequest) -> str:
+    """Extract user agent from request."""
+    return request.META.get("HTTP_USER_AGENT", "")
+
+
+def evaluate_auth_attempt(
+    request: HttpRequest,
+    email: str,
+    action: RadarAction,
+    auth_method: RadarAuthMethod,
+    user_id: Optional[str] = None,
+) -> RadarVerdict:
+    """
+    Evaluate an authentication attempt using the WorkOS Radar Attempts API.
+
+    This function operates in LOG-ONLY mode - it logs the Radar decision as a
+    PostHog event but always returns the verdict without blocking.
+
+    Args:
+        request: The Django/DRF request object
+        email: The email address being used for auth
+        action: Whether this is a signup or signin attempt
+        auth_method: The authentication method (password or passkey)
+        user_id: Optional user ID if the user already exists (for signin)
+
+    Returns:
+        The Radar verdict (allow, challenge, block, error, or disabled)
+    """
+    if not settings.WORKOS_RADAR_ENABLED:
+        logger.debug("workos_radar_disabled")
+        return RadarVerdict.DISABLED
+
+    if not settings.WORKOS_RADAR_API_KEY:
+        logger.warning("workos_radar_no_api_key")
+        return RadarVerdict.DISABLED
+
+    ip_address = _get_ip_address(request)
+    user_agent = _get_user_agent(request)
+
+    verdict = _call_radar_api(
+        email=email,
+        ip_address=ip_address,
+        user_agent=user_agent,
+        action=action,
+    )
+
+    _log_radar_event(
+        email=email,
+        user_id=user_id,
+        action=action,
+        auth_method=auth_method,
+        verdict=verdict,
+        ip_address=ip_address,
+        user_agent=user_agent,
+    )
+
+    return verdict
+
+
+def _call_radar_api(
+    email: str,
+    ip_address: str,
+    user_agent: str,
+    action: RadarAction,
+) -> RadarVerdict:
+    """
+    Make the actual API call to WorkOS Radar.
+
+    The API specification is based on WorkOS documentation. The request body
+    structure may need adjustment once the full API reference is available.
+    """
+    try:
+        response = httpx.post(
+            WORKOS_RADAR_API_URL,
+            headers={
+                "Authorization": f"Bearer {settings.WORKOS_RADAR_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "email": email,
+                "ip_address": ip_address,
+                "user_agent": user_agent,
+                "action": action.value,
+            },
+            timeout=WORKOS_RADAR_TIMEOUT,
+        )
+
+        if response.status_code == 200:
+            data = response.json()
+            verdict_str = data.get("verdict", "allow").lower()
+
+            if verdict_str == "allow":
+                return RadarVerdict.ALLOW
+            elif verdict_str == "challenge":
+                return RadarVerdict.CHALLENGE
+            elif verdict_str == "block":
+                return RadarVerdict.BLOCK
+            else:
+                logger.warning(
+                    "workos_radar_unknown_verdict",
+                    verdict=verdict_str,
+                    email_hash=_hash_email(email),
+                )
+                return RadarVerdict.ALLOW
+        else:
+            logger.error(
+                "workos_radar_api_error",
+                status_code=response.status_code,
+                email_hash=_hash_email(email),
+            )
+            return RadarVerdict.ERROR
+
+    except httpx.TimeoutException:
+        logger.warning(
+            "workos_radar_timeout",
+            email_hash=_hash_email(email),
+        )
+        return RadarVerdict.ERROR
+    except Exception as e:
+        logger.exception(
+            "workos_radar_exception",
+            email_hash=_hash_email(email),
+            error=str(e),
+        )
+        return RadarVerdict.ERROR
+
+
+def _log_radar_event(
+    email: str,
+    user_id: Optional[str],
+    action: RadarAction,
+    auth_method: RadarAuthMethod,
+    verdict: RadarVerdict,
+    ip_address: str,
+    user_agent: str,
+) -> None:
+    """
+    Log the Radar decision as a PostHog event for analysis.
+
+    This event allows tracking what percentage of users would be
+    challenged or blocked if enforcement were enabled.
+    """
+    distinct_id = user_id or f"pre_signup_{_hash_email(email)}"
+
+    properties = {
+        "action": action.value,
+        "auth_method": auth_method.value,
+        "verdict": verdict.value,
+        "would_challenge": verdict == RadarVerdict.CHALLENGE,
+        "would_block": verdict == RadarVerdict.BLOCK,
+        "is_error": verdict == RadarVerdict.ERROR,
+        "ip_address_hash": hashlib.sha256(ip_address.encode()).hexdigest()[:16],
+        "user_agent": user_agent[:500] if user_agent else "",
+        "email_domain": email.split("@")[-1] if "@" in email else "",
+    }
+
+    posthoganalytics.capture(
+        distinct_id=distinct_id,
+        event="workos_radar_attempt",
+        properties=properties,
+    )
+
+    logger.info(
+        "workos_radar_attempt_logged",
+        action=action.value,
+        auth_method=auth_method.value,
+        verdict=verdict.value,
+        email_hash=_hash_email(email),
+    )


### PR DESCRIPTION
## Summary

- Adds WorkOS Radar Attempts API integration for signup/signin flows
- Log-only mode: records decisions as PostHog events, never blocks users - this is for a test period of 1 week to see how much % we'd theoretically block and then decide how to handle it in practice.
- Covers email/password and passkey auth methods only (excludes SSO/SAML/SCIM)

## Changes

- New `posthog/workos_radar.py` module with Radar client
- Integrated into `SignupSerializer`, `InviteSignupSerializer`, `LoginSerializer`, `WebAuthnLoginViewSet`
- New settings: `WORKOS_RADAR_API_KEY`, `WORKOS_RADAR_ENABLED`
- Logs `workos_radar_attempt` event with verdict info

## Pending

- [k8s secrets PR to add the new env vars](https://github.com/PostHog/charts/pull/8180)

## Test plan

- Unit tests