### PR TITLE
feat(llma): drop ORDER BY rand() and add window offset for trace summarization

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -13,6 +13,7 @@ DEFAULT_MAX_ITEMS_PER_WINDOW = (
 DEFAULT_BATCH_SIZE = 3  # Number of traces to process in parallel (reduced to avoid rate limits)
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)
+DEFAULT_WINDOW_OFFSET_MINUTES = 30  # Offset window into the past so traces have time to fully complete
 DEFAULT_MODEL = OpenAIModel.GPT_4_1_NANO
 
 # Max text representation length (in characters)

--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -56,11 +56,9 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
         query = TracesQuery(
             dateRange=DateRange(date_from=window_start, date_to=window_end),
             limit=max_items,
-            randomOrder=True,
         )
 
         # Use QUERY_ASYNC limit context to get 600s timeout instead of default 60s
-        # This prevents timeouts for high-volume teams with many AI events
         runner = TracesQueryRunner(team=team, query=query, limit_context=LimitContext.QUERY_ASYNC)
         response = runner.calculate()
 

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -111,6 +111,10 @@ class TestSampleItemsInWindowActivity:
             assert result[0].trace_id == "trace_0"
             assert result[49].trace_id == "trace_49"
 
+            # Verify randomOrder is not used (defaults to timestamp DESC ordering)
+            query = mock_runner_class.call_args.kwargs["query"]
+            assert query.randomOrder is None
+
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.asyncio
     async def test_sample_items_empty(self, mock_team):

--- a/posthog/temporal/llm_analytics/trace_summarization/workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/workflow.py
@@ -26,6 +26,7 @@ from posthog.temporal.llm_analytics.trace_summarization.constants import (
     DEFAULT_MODE,
     DEFAULT_MODEL,
     DEFAULT_WINDOW_MINUTES,
+    DEFAULT_WINDOW_OFFSET_MINUTES,
     GENERATE_SUMMARY_TIMEOUT_SECONDS,
     MAX_TEXT_REPR_LENGTH,
     SAMPLE_TIMEOUT_SECONDS,
@@ -152,8 +153,9 @@ class BatchTraceSummarizationWorkflow(PostHogWorkflow):
             window_end = inputs.window_end
         else:
             now = temporalio.workflow.now()
-            window_end = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-            window_start = (now - timedelta(minutes=inputs.window_minutes)).strftime("%Y-%m-%dT%H:%M:%SZ")
+            offset = timedelta(minutes=DEFAULT_WINDOW_OFFSET_MINUTES)
+            window_end = (now - offset).strftime("%Y-%m-%dT%H:%M:%SZ")
+            window_start = (now - offset - timedelta(minutes=inputs.window_minutes)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
         # Prepare inputs with computed window
         inputs_with_window = BatchSummarizationInputs(


### PR DESCRIPTION
## Problem

The trace summarization workflow times out for high-volume teams (e.g., team 2) because `TracesQueryRunner` uses `ORDER BY rand()` when `randomOrder=True`. This requires materializing all matching rows before sorting, causing the sampling activity to exceed its 15-minute timeout. The workflow task itself also times out repeatedly trying to handle the activity failure.

Additionally, traces near the end of the query window may still have in-flight spans, leading to incomplete summaries.

## Changes

- Remove `randomOrder=True` from the sampling activity's `TracesQuery`, falling back to the default `ORDER BY max(timestamp) DESC` which can leverage ClickHouse's timestamp index
- Add a 30-minute window offset (`DEFAULT_WINDOW_OFFSET_MINUTES`) so the query window is shifted into the past (e.g., at 14:00 the window becomes 12:30-13:30 instead of 13:00-14:00), giving traces time to fully complete before summarization
- Add test assertion verifying `randomOrder` is no longer used

## How did you test this code?

- Existing workflow tests pass (`pytest posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py`)
- Added assertion in `test_sample_items_success` to verify `randomOrder` is not set on the query
- Manual verification needed in prod for team 2 query performance

## Publish to changelog?

Do not publish to changelog.