### PR TITLE
fix: managed reverse proxy UI status update

### DIFF
--- a/frontend/src/scenes/settings/environment/proxyLogic.ts
+++ b/frontend/src/scenes/settings/environment/proxyLogic.ts
@@ -137,9 +137,7 @@ export const proxyLogic = kea<proxyLogicType>([
     })),
     afterMount(({ actions, cache }) => {
         actions.loadRecords()
-        cache.disposables.add(() => {
-            const timerId = setInterval(() => actions.maybeRefreshRecords(), 5000)
-            return () => clearInterval(timerId)
-        }, 'refreshInterval')
+        const timerId = setInterval(() => actions.maybeRefreshRecords(), 5000)
+        cache.disposables.add(() => clearInterval(timerId), 'refreshInterval')
     }),
 ])


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

When the user creates a managed reverse proxy it stays on waiting even when it is done and will only see the status updated to issued after a page refresh.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
