### PR TITLE
feat(devenv): Add "all" as option to hogli dev:setup

### DIFF
--- a/common/hogli/devenv/wizard.py
+++ b/common/hogli/devenv/wizard.py
@@ -147,9 +147,10 @@ def _show_config_summary(config: DevenvConfig) -> None:
 
 def _setup_from_intents(intent_map: IntentMap) -> DevenvConfig:
     """Set up by selecting specific intents."""
+    select_all = "all"
     click.echo("")
     click.echo(click.style("Products", fg="cyan"))
-    click.echo("Select products (comma-separated numbers).")
+    click.echo(f"Select products (comma-separated numbers, or '{select_all}').")
     click.echo("")
 
     intents = list(intent_map.intents.items())
@@ -158,17 +159,20 @@ def _setup_from_intents(intent_map: IntentMap) -> DevenvConfig:
 
     click.echo("")
 
-    selection = click.prompt("Enter numbers (e.g., 1,3,5)", default="1")
+    selection = click.prompt(f"Enter numbers (e.g., 1,3,5) or '{select_all}'", default="1")
 
     selected_intents = []
-    try:
-        indices = [int(x.strip()) for x in selection.split(",")]
-        for idx in indices:
-            if 1 <= idx <= len(intents):
-                selected_intents.append(intents[idx - 1][0])
-    except ValueError:
-        click.echo("Invalid selection, using product_analytics.")
-        selected_intents = ["product_analytics"]
+    if selection.strip().lower() == select_all:
+        selected_intents = [name for name, _ in intents]
+    else:
+        try:
+            indices = [int(x.strip()) for x in selection.split(",")]
+            for idx in indices:
+                if 1 <= idx <= len(intents):
+                    selected_intents.append(intents[idx - 1][0])
+        except ValueError:
+            click.echo("Invalid selection, using product_analytics.")
+            selected_intents = ["product_analytics"]
 
     if not selected_intents:
         selected_intents = ["product_analytics"]


### PR DESCRIPTION
## Problem

Introduced in https://github.com/PostHog/posthog/pull/45640, `hogli dev:setup` dialogue asks for different services to run, but sometimes when switching branches and contexts, e.g. for reviewing a PR, I simply want the application to run without thinking specifically what services I need. Entering all numbers in this case is tedious.


## Changes

<img width="554" height="456" alt="hogli-all" src="https://github.com/user-attachments/assets/6a6294f4-c117-4837-b108-fc69e35c6d6f" />


## How did you test this code?

Manually starting minimal setup and then using all - it starts the whole stack

## Publish to changelog?

No