### PR TITLE
feat: identification form and placeholder for support

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -606,6 +606,11 @@ export interface ConversationsSettings {
     widget_public_token?: string | null
     widget_domains?: string[] | null
     notification_recipients?: number[] | null
+    widget_require_email?: boolean
+    widget_collect_name?: boolean
+    widget_identification_form_title?: string
+    widget_identification_form_description?: string
+    widget_placeholder_text?: string
 }
 
 export interface LogsSettings {

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -2006,6 +2006,27 @@ def team_api_test_factory():
             assert settings["widget_greeting_text"] == "Hello!"
             assert settings["widget_color"] == "#ff0000"
 
+        def test_conversations_identification_settings(self):
+            response = self.client.patch(
+                "/api/environments/@current/",
+                {
+                    "conversations_settings": {
+                        "widget_require_email": True,
+                        "widget_collect_name": True,
+                        "widget_identification_form_title": "Before we start...",
+                        "widget_identification_form_description": "Please provide your details.",
+                        "widget_placeholder_text": "Type your message...",
+                    }
+                },
+            )
+            assert response.status_code == status.HTTP_200_OK
+            settings = response.json()["conversations_settings"]
+            assert settings["widget_require_email"] is True
+            assert settings["widget_collect_name"] is True
+            assert settings["widget_identification_form_title"] == "Before we start..."
+            assert settings["widget_identification_form_description"] == "Please provide your details."
+            assert settings["widget_placeholder_text"] == "Type your message..."
+
         def test_enabling_conversations_auto_generates_token(self):
             self.team.conversations_enabled = False
             self.team.conversations_settings = None

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -280,6 +280,13 @@ class RemoteConfig(UUIDTModel):
                 "token": conv_settings.get("widget_public_token"),
                 # NOTE: domains is cached but stripped out at the api level depending on the caller
                 "domains": conv_settings.get("widget_domains") or [],
+                "requireEmail": conv_settings.get("widget_require_email", False),
+                "collectName": conv_settings.get("widget_collect_name", False),
+                "identificationFormTitle": conv_settings.get("widget_identification_form_title")
+                or "Before we start...",
+                "identificationFormDescription": conv_settings.get("widget_identification_form_description")
+                or "Please provide your details so we can help you better.",
+                "placeholderText": conv_settings.get("widget_placeholder_text") or "Type your message...",
             }
         else:
             config["conversations"] = False

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -155,6 +155,14 @@ class TestRemoteConfig(_RemoteConfigBase):
         assert self.remote_config.config["conversations"]["color"] == "#1d4aff"
         assert self.remote_config.config["conversations"]["token"] == "test_public_token_123"
         assert self.remote_config.config["conversations"]["domains"] == []
+        assert self.remote_config.config["conversations"]["requireEmail"] is False
+        assert self.remote_config.config["conversations"]["collectName"] is False
+        assert self.remote_config.config["conversations"]["identificationFormTitle"] == "Before we start..."
+        assert (
+            self.remote_config.config["conversations"]["identificationFormDescription"]
+            == "Please provide your details so we can help you better."
+        )
+        assert self.remote_config.config["conversations"]["placeholderText"] == "Type your message..."
 
     def test_conversations_enabled_with_custom_config(self):
         self.team.conversations_enabled = True
@@ -164,6 +172,11 @@ class TestRemoteConfig(_RemoteConfigBase):
             "widget_color": "#ff5733",
             "widget_public_token": "custom_token",
             "widget_domains": ["example.com", "test.com"],
+            "widget_require_email": True,
+            "widget_collect_name": True,
+            "widget_identification_form_title": "Let's get started",
+            "widget_identification_form_description": "Tell us about yourself",
+            "widget_placeholder_text": "Ask away...",
         }
         self.team.save()
         self.sync_remote_config()
@@ -172,6 +185,11 @@ class TestRemoteConfig(_RemoteConfigBase):
         assert self.remote_config.config["conversations"]["color"] == "#ff5733"
         assert self.remote_config.config["conversations"]["token"] == "custom_token"
         assert self.remote_config.config["conversations"]["domains"] == ["example.com", "test.com"]
+        assert self.remote_config.config["conversations"]["requireEmail"] is True
+        assert self.remote_config.config["conversations"]["collectName"] is True
+        assert self.remote_config.config["conversations"]["identificationFormTitle"] == "Let's get started"
+        assert self.remote_config.config["conversations"]["identificationFormDescription"] == "Tell us about yourself"
+        assert self.remote_config.config["conversations"]["placeholderText"] == "Ask away..."
 
     def test_conversations_disabled_returns_false(self):
         self.team.conversations_enabled = False

--- a/products/conversations/frontend/scenes/settings/SupportSettingsScene.tsx
+++ b/products/conversations/frontend/scenes/settings/SupportSettingsScene.tsx
@@ -123,6 +123,12 @@ export function SupportSettingsScene(): JSX.Element {
         setWidgetEnabledLoading,
         setGreetingInputValue,
         saveGreetingText,
+        setIdentificationFormTitleValue,
+        saveIdentificationFormTitle,
+        setIdentificationFormDescriptionValue,
+        saveIdentificationFormDescription,
+        setPlaceholderTextValue,
+        savePlaceholderText,
         setNotificationRecipients,
     } = useActions(supportSettingsLogic)
     const {
@@ -131,6 +137,9 @@ export function SupportSettingsScene(): JSX.Element {
         conversationsEnabledLoading,
         widgetEnabledLoading,
         greetingInputValue,
+        identificationFormTitleValue,
+        identificationFormDescriptionValue,
+        placeholderTextValue,
         notificationRecipients,
     } = useValues(supportSettingsLogic)
 
@@ -263,6 +272,127 @@ export function SupportSettingsScene(): JSX.Element {
                                             Save
                                         </LemonButton>
                                     </div>
+                                </div>
+
+                                <div className="flex items-center gap-4 py-2">
+                                    <label className="w-40 shrink-0">Placeholder text</label>
+                                    <div className="flex gap-2 flex-1">
+                                        <LemonInput
+                                            value={
+                                                placeholderTextValue ??
+                                                currentTeam?.conversations_settings?.widget_placeholder_text ??
+                                                'Type your message...'
+                                            }
+                                            placeholder="Enter placeholder text"
+                                            onChange={setPlaceholderTextValue}
+                                            fullWidth
+                                        />
+                                        <LemonButton
+                                            type="primary"
+                                            onClick={savePlaceholderText}
+                                            disabledReason={
+                                                !placeholderTextValue ? 'Enter placeholder text' : undefined
+                                            }
+                                        >
+                                            Save
+                                        </LemonButton>
+                                    </div>
+                                </div>
+
+                                <div className="pt-4">
+                                    <div className="flex items-center gap-4 py-2">
+                                        <label className="w-40 shrink-0">Require email</label>
+                                        <LemonSwitch
+                                            checked={!!currentTeam?.conversations_settings?.widget_require_email}
+                                            onChange={(checked) => {
+                                                updateCurrentTeam({
+                                                    conversations_settings: {
+                                                        ...currentTeam?.conversations_settings,
+                                                        widget_require_email: checked,
+                                                    },
+                                                })
+                                            }}
+                                            label="Show identification form before chat"
+                                            bordered
+                                        />
+                                    </div>
+
+                                    {currentTeam?.conversations_settings?.widget_require_email && (
+                                        <div className="ml-44 flex flex-col gap-2 mt-2 border-l pl-4">
+                                            <div className="flex items-center gap-4 py-2">
+                                                <label className="w-40 shrink-0">Collect name</label>
+                                                <LemonSwitch
+                                                    checked={!!currentTeam?.conversations_settings?.widget_collect_name}
+                                                    onChange={(checked) => {
+                                                        updateCurrentTeam({
+                                                            conversations_settings: {
+                                                                ...currentTeam?.conversations_settings,
+                                                                widget_collect_name: checked,
+                                                            },
+                                                        })
+                                                    }}
+                                                    label="Also ask for user's name"
+                                                    bordered
+                                                />
+                                            </div>
+
+                                            <div className="flex items-center gap-4 py-2">
+                                                <label className="w-40 shrink-0">Form title</label>
+                                                <div className="flex gap-2 flex-1">
+                                                    <LemonInput
+                                                        value={
+                                                            identificationFormTitleValue ??
+                                                            currentTeam?.conversations_settings
+                                                                ?.widget_identification_form_title ??
+                                                            'Before we start...'
+                                                        }
+                                                        placeholder="Enter form title"
+                                                        onChange={setIdentificationFormTitleValue}
+                                                        fullWidth
+                                                    />
+                                                    <LemonButton
+                                                        type="primary"
+                                                        onClick={saveIdentificationFormTitle}
+                                                        disabledReason={
+                                                            !identificationFormTitleValue
+                                                                ? 'Enter form title'
+                                                                : undefined
+                                                        }
+                                                    >
+                                                        Save
+                                                    </LemonButton>
+                                                </div>
+                                            </div>
+
+                                            <div className="flex items-center gap-4 py-2">
+                                                <label className="w-40 shrink-0">Form description</label>
+                                                <div className="flex gap-2 flex-1">
+                                                    <LemonInput
+                                                        value={
+                                                            identificationFormDescriptionValue ??
+                                                            currentTeam?.conversations_settings
+                                                                ?.widget_identification_form_description ??
+                                                            'Please provide your details so we can help you better.'
+                                                        }
+                                                        placeholder="Enter form description"
+                                                        onChange={setIdentificationFormDescriptionValue}
+                                                        fullWidth
+                                                    />
+                                                    <LemonButton
+                                                        type="primary"
+                                                        onClick={saveIdentificationFormDescription}
+                                                        disabledReason={
+                                                            !identificationFormDescriptionValue
+                                                                ? 'Enter form description'
+                                                                : undefined
+                                                        }
+                                                    >
+                                                        Save
+                                                    </LemonButton>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    )}
                                 </div>
 
                                 <div className="pt-8">

--- a/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
+++ b/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
@@ -28,6 +28,13 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         cancelDomainEdit: true,
         setGreetingInputValue: (value: string | null) => ({ value }),
         saveGreetingText: true,
+        // Identification form settings
+        setIdentificationFormTitleValue: (value: string | null) => ({ value }),
+        saveIdentificationFormTitle: true,
+        setIdentificationFormDescriptionValue: (value: string | null) => ({ value }),
+        saveIdentificationFormDescription: true,
+        setPlaceholderTextValue: (value: string | null) => ({ value }),
+        savePlaceholderText: true,
         // Notification recipients
         setNotificationRecipients: (users: UserBasicType[]) => ({ users }),
     }),
@@ -77,6 +84,24 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             null as string | null,
             {
                 setGreetingInputValue: (_, { value }) => value,
+            },
+        ],
+        identificationFormTitleValue: [
+            null as string | null,
+            {
+                setIdentificationFormTitleValue: (_, { value }) => value,
+            },
+        ],
+        identificationFormDescriptionValue: [
+            null as string | null,
+            {
+                setIdentificationFormDescriptionValue: (_, { value }) => value,
+            },
+        ],
+        placeholderTextValue: [
+            null as string | null,
+            {
+                setPlaceholderTextValue: (_, { value }) => value,
             },
         ],
     }),
@@ -140,6 +165,39 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                 },
             })
         },
+        saveIdentificationFormTitle: () => {
+            if (!values.identificationFormTitleValue?.trim()) {
+                return
+            }
+            actions.updateCurrentTeam({
+                conversations_settings: {
+                    ...values.currentTeam?.conversations_settings,
+                    widget_identification_form_title: values.identificationFormTitleValue,
+                },
+            })
+        },
+        saveIdentificationFormDescription: () => {
+            if (!values.identificationFormDescriptionValue?.trim()) {
+                return
+            }
+            actions.updateCurrentTeam({
+                conversations_settings: {
+                    ...values.currentTeam?.conversations_settings,
+                    widget_identification_form_description: values.identificationFormDescriptionValue,
+                },
+            })
+        },
+        savePlaceholderText: () => {
+            if (!values.placeholderTextValue?.trim()) {
+                return
+            }
+            actions.updateCurrentTeam({
+                conversations_settings: {
+                    ...values.currentTeam?.conversations_settings,
+                    widget_placeholder_text: values.placeholderTextValue,
+                },
+            })
+        },
         setNotificationRecipients: ({ users }) => {
             actions.updateCurrentTeam({
                 conversations_settings: {
@@ -150,6 +208,9 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         },
         updateCurrentTeamSuccess: () => {
             actions.setGreetingInputValue(null)
+            actions.setIdentificationFormTitleValue(null)
+            actions.setIdentificationFormDescriptionValue(null)
+            actions.setPlaceholderTextValue(null)
         },
     })),
 ])

--- a/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
+++ b/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
@@ -155,46 +155,50 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             actions.setDomainInputValue(values.conversationsDomains[index])
         },
         saveGreetingText: () => {
-            if (!values.greetingInputValue?.trim()) {
+            const trimmedValue = values.greetingInputValue?.trim()
+            if (!trimmedValue) {
                 return
             }
             actions.updateCurrentTeam({
                 conversations_settings: {
                     ...values.currentTeam?.conversations_settings,
-                    widget_greeting_text: values.greetingInputValue,
+                    widget_greeting_text: trimmedValue,
                 },
             })
         },
         saveIdentificationFormTitle: () => {
-            if (!values.identificationFormTitleValue?.trim()) {
+            const trimmedValue = values.identificationFormTitleValue?.trim()
+            if (!trimmedValue) {
                 return
             }
             actions.updateCurrentTeam({
                 conversations_settings: {
                     ...values.currentTeam?.conversations_settings,
-                    widget_identification_form_title: values.identificationFormTitleValue,
+                    widget_identification_form_title: trimmedValue,
                 },
             })
         },
         saveIdentificationFormDescription: () => {
-            if (!values.identificationFormDescriptionValue?.trim()) {
+            const trimmedValue = values.identificationFormDescriptionValue?.trim()
+            if (!trimmedValue) {
                 return
             }
             actions.updateCurrentTeam({
                 conversations_settings: {
                     ...values.currentTeam?.conversations_settings,
-                    widget_identification_form_description: values.identificationFormDescriptionValue,
+                    widget_identification_form_description: trimmedValue,
                 },
             })
         },
         savePlaceholderText: () => {
-            if (!values.placeholderTextValue?.trim()) {
+            const trimmedValue = values.placeholderTextValue?.trim()
+            if (!trimmedValue) {
                 return
             }
             actions.updateCurrentTeam({
                 conversations_settings: {
                     ...values.currentTeam?.conversations_settings,
-                    widget_placeholder_text: values.placeholderTextValue,
+                    widget_placeholder_text: trimmedValue,
                 },
             })
         },


### PR DESCRIPTION
## Problem

In support widget we can ask for identification and placeholder, but it was missing it the config

## Changes

Added `requireEmail`, `collectName`, `identificationFormTitle`, `identificationFormDescription`, `placeholderText` to the config


