### PR TITLE
feat: Detect browser extension errors in ErrorBoundary

### DIFF
--- a/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -5,8 +5,20 @@ import { useActions, useValues } from 'kea'
 import { PostHogErrorBoundary, type PostHogErrorBoundaryFallbackProps } from 'posthog-js/react'
 
 import { SupportTicketExceptionEvent, supportLogic } from 'lib/components/Support/supportLogic'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { teamLogic } from 'scenes/teamLogic'
+
+const DOM_MUTATION_PATTERNS = [
+    "Failed to execute 'removeChild' on 'Node'",
+    "Failed to execute 'insertBefore' on 'Node'",
+    "Failed to execute 'appendChild' on 'Node'",
+]
+
+function isDOMModificationError(error: Error): boolean {
+    const message = error.message || ''
+    return DOM_MUTATION_PATTERNS.some((pattern) => message.includes(pattern))
+}
 
 interface ErrorBoundaryProps {
     children?: React.ReactNode
@@ -37,6 +49,8 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
 
                 const exceptionEvent = props.exceptionEvent as SupportTicketExceptionEvent
 
+                const isBrowserExtensionError = isDOMModificationError(normalizedError)
+
                 return (
                     <div className={clsx('ErrorBoundary', className)}>
                         <h2>An error has occurred</h2>
@@ -54,23 +68,46 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
                         {exceptionEvent?.uuid && (
                             <div className="text-muted text-xs mb-2">Exception ID: {exceptionEvent.uuid}</div>
                         )}
-                        Please help us resolve the issue by sending a screenshot of this message.
-                        <LemonButton
-                            type="primary"
-                            fullWidth
-                            center
-                            onClick={() => {
-                                openSupportForm({
-                                    kind: 'bug',
-                                    isEmailFormOpen: true,
-                                    exception_event: exceptionEvent ?? null,
-                                })
-                            }}
-                            targetBlank
-                            className="mt-2"
-                        >
-                            Email an engineer
-                        </LemonButton>
+                        {isBrowserExtensionError ? (
+                            <LemonBanner
+                                type="warning"
+                                className="mt-2"
+                                action={{
+                                    children: 'Email an engineer',
+                                    onClick: () => {
+                                        openSupportForm({
+                                            kind: 'bug',
+                                            isEmailFormOpen: true,
+                                            exception_event: exceptionEvent ?? null,
+                                        })
+                                    },
+                                }}
+                            >
+                                This error is commonly caused by browser extensions (such as translation or ad-blocking
+                                extensions) that modify the page. Try disabling your browser extension(s) and reloading
+                                the page to avoid this error in the future.
+                            </LemonBanner>
+                        ) : (
+                            <>
+                                Please help us resolve the issue by sending a screenshot of this message.
+                                <LemonButton
+                                    type="primary"
+                                    fullWidth
+                                    center
+                                    onClick={() => {
+                                        openSupportForm({
+                                            kind: 'bug',
+                                            isEmailFormOpen: true,
+                                            exception_event: exceptionEvent ?? null,
+                                        })
+                                    }}
+                                    targetBlank
+                                    className="mt-2"
+                                >
+                                    Email an engineer
+                                </LemonButton>
+                            </>
+                        )}
                     </div>
                 )
             }}

--- a/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -54,24 +54,10 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
                 return (
                     <div className={clsx('ErrorBoundary', className)}>
                         <h2>An error has occurred</h2>
-                        <pre>
-                            <code>
-                                {stack || (
-                                    <>
-                                        {name}
-                                        <br />
-                                        {message}
-                                    </>
-                                )}
-                            </code>
-                        </pre>
-                        {exceptionEvent?.uuid && (
-                            <div className="text-muted text-xs mb-2">Exception ID: {exceptionEvent.uuid}</div>
-                        )}
-                        {isBrowserExtensionError ? (
+                        {isBrowserExtensionError && (
                             <LemonBanner
                                 type="warning"
-                                className="mt-2"
+                                className="mb-2"
                                 action={{
                                     children: 'Email an engineer',
                                     onClick: () => {
@@ -87,7 +73,22 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
                                 extensions) that modify the page. Try disabling your browser extension(s) and reloading
                                 the page to avoid this error in the future.
                             </LemonBanner>
-                        ) : (
+                        )}
+                        <pre>
+                            <code>
+                                {stack || (
+                                    <>
+                                        {name}
+                                        <br />
+                                        {message}
+                                    </>
+                                )}
+                            </code>
+                        </pre>
+                        {exceptionEvent?.uuid && (
+                            <div className="text-muted text-xs mb-2">Exception ID: {exceptionEvent.uuid}</div>
+                        )}
+                        {!isBrowserExtensionError && (
                             <>
                                 Please help us resolve the issue by sending a screenshot of this message.
                                 <LemonButton


### PR DESCRIPTION
## Problem

In support, we're seeing errors like `Failed to execute 'removeChild' on 'Node'` reported more often. There's not loads we can do about them (possibly some improvements in React 19), so let's detect them and give users a more informative error screen.

https://github.com/PostHog/posthog/issues/46669

## Changes

Add a warning banner to give the user some useful info about how to fix/avoid:

<img width="1361" height="443" alt="CleanShot 2026-02-03 at 16 58 05" src="https://github.com/user-attachments/assets/2001a564-574e-49fb-b944-1962e51fb893" />
