### PR TITLE
feat(llma): replace TracesQueryRunner with lightweight sampling queries

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -1,22 +1,18 @@
 """Activity for sampling traces/generations from a time window.
 
-Uses TracesQueryRunner for both trace-level and generation-level sampling.
-For generation-level, samples traces first then queries for the last generation
-per trace - this ensures each generation has its parent trace's first_timestamp
-for navigation.
+Uses lightweight HogQL queries to sample trace IDs and timestamps.
+The full trace data is fetched later by the summarization activity using
+TraceQueryRunner per-item, so sampling only needs IDs and timestamps.
 """
 
 import structlog
 import temporalio
-
-from posthog.schema import DateRange, TracesQuery
 
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.hogql_queries.ai.traces_query_runner import TracesQueryRunner
 from posthog.models.team import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.llm_analytics.trace_summarization.models import BatchSummarizationInputs, SampledItem
@@ -28,18 +24,14 @@ logger = structlog.get_logger(__name__)
 @temporalio.activity.defn
 async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> list[SampledItem]:
     """
-    Sample traces or generations from a time window using TracesQueryRunner.
+    Sample traces or generations from a time window using lightweight queries.
 
     For trace-level (analysis_level="trace"):
         Returns one SampledItem per trace with generation_id=None.
 
     For generation-level (analysis_level="generation"):
-        Samples traces first to get trace context (id, first_timestamp), then
-        queries for the last $ai_generation event per trace.
-        Returns one SampledItem per generation with the parent trace's context.
-
-    This unified approach ensures both levels have access to the trace's
-    first_timestamp, which is needed for navigation in the cluster scatter plot.
+        Directly samples the last generation per trace, returning one SampledItem
+        per generation with the parent trace's first_timestamp for navigation.
 
     Requires window_start and window_end to be set on inputs (computed by workflow
     using deterministic workflow time to avoid race conditions between runs).
@@ -52,54 +44,26 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
     ) -> list[SampledItem]:
         team = Team.objects.get(id=team_id)
 
-        # Step 1: Sample traces using TracesQueryRunner
-        query = TracesQuery(
-            dateRange=DateRange(date_from=window_start, date_to=window_end),
-            limit=max_items,
-        )
-
-        # Use QUERY_ASYNC limit context to get 600s timeout instead of default 60s
-        runner = TracesQueryRunner(team=team, query=query, limit_context=LimitContext.QUERY_ASYNC)
-        response = runner.calculate()
-
-        logger.debug(
-            "traces_query_runner_result",
-            num_traces=len(response.results),
-            analysis_level=analysis_level,
-            window_start=window_start,
-            window_end=window_end,
-            team_id=team_id,
-        )
+        start_dt_str = format_datetime_for_clickhouse(window_start)
+        end_dt_str = format_datetime_for_clickhouse(window_end)
 
         if analysis_level == "generation":
-            # Step 2: For generation-level, query for last generation per trace
-            trace_context = {trace.id: trace.createdAt for trace in response.results}
-
-            if not trace_context:
-                return []
-
-            # Query last generation per trace (with timestamp bounds for efficiency)
-            # Note: We use argMax(uuid, timestamp) to select only the LAST generation
-            # per trace. This means only the most recent generation in each trace
-            # gets summarized, which is intentional to avoid duplicate summaries
-            # and focus on the final output of each trace.
-            trace_ids_tuple = ast.Tuple(exprs=[ast.Constant(value=tid) for tid in trace_context.keys()])
-
-            # Convert ISO format to ClickHouse-compatible format
-            start_dt_str = format_datetime_for_clickhouse(window_start)
-            end_dt_str = format_datetime_for_clickhouse(window_end)
-
+            # Sample generations directly: get the last generation per trace
+            # with the trace's first_timestamp for navigation
             generations_query = parse_select(
                 """
                 SELECT
                     properties.$ai_trace_id as trace_id,
-                    argMax(uuid, timestamp) as last_generation_id
+                    argMax(uuid, timestamp) as last_generation_id,
+                    min(timestamp) as trace_first_timestamp
                 FROM events
-                WHERE event = '$ai_generation'
+                WHERE event IN ('$ai_generation', '$ai_span', '$ai_trace')
                     AND timestamp >= toDateTime({start_ts}, 'UTC')
                     AND timestamp < toDateTime({end_ts}, 'UTC')
-                    AND properties.$ai_trace_id IN {trace_ids}
+                    AND properties.$ai_trace_id IS NOT NULL
                 GROUP BY trace_id
+                ORDER BY trace_first_timestamp DESC
+                LIMIT {limit}
                 """
             )
 
@@ -107,17 +71,17 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 query_type="GenerationsForSampling",
                 query=generations_query,
                 placeholders={
-                    "trace_ids": trace_ids_tuple,
                     "start_ts": ast.Constant(value=start_dt_str),
                     "end_ts": ast.Constant(value=end_dt_str),
+                    "limit": ast.Constant(value=max_items),
                 },
                 team=team,
+                limit_context=LimitContext.QUERY_ASYNC,
             )
 
             logger.debug(
-                "generation_query_result",
+                "generation_sampling_result",
                 num_generations=len(result.results or []),
-                num_trace_ids_queried=len(trace_context),
                 start_ts=start_dt_str,
                 end_ts=end_dt_str,
                 team_id=team_id,
@@ -127,25 +91,63 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
             for row in result.results or []:
                 trace_id = row[0]
                 generation_id = row[1]
-                if trace_id in trace_context:
+                trace_first_timestamp = row[2]
+                if trace_id and generation_id:
                     items.append(
                         SampledItem(
                             trace_id=trace_id,
-                            trace_first_timestamp=trace_context[trace_id],
+                            trace_first_timestamp=str(trace_first_timestamp),
                             generation_id=str(generation_id),
                         )
                     )
 
             return items
         else:
-            # Trace-level: one item per trace
+            # Trace-level: sample trace IDs and first timestamps
+            traces_query = parse_select(
+                """
+                SELECT
+                    properties.$ai_trace_id as trace_id,
+                    min(timestamp) as first_timestamp
+                FROM events
+                WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
+                    AND timestamp >= toDateTime({start_ts}, 'UTC')
+                    AND timestamp < toDateTime({end_ts}, 'UTC')
+                    AND properties.$ai_trace_id IS NOT NULL
+                GROUP BY trace_id
+                ORDER BY first_timestamp DESC
+                LIMIT {limit}
+                """
+            )
+
+            result = execute_hogql_query(
+                query_type="TracesForSampling",
+                query=traces_query,
+                placeholders={
+                    "start_ts": ast.Constant(value=start_dt_str),
+                    "end_ts": ast.Constant(value=end_dt_str),
+                    "limit": ast.Constant(value=max_items),
+                },
+                team=team,
+                limit_context=LimitContext.QUERY_ASYNC,
+            )
+
+            logger.debug(
+                "trace_sampling_result",
+                num_traces=len(result.results or []),
+                start_ts=start_dt_str,
+                end_ts=end_dt_str,
+                team_id=team_id,
+            )
+
             return [
                 SampledItem(
-                    trace_id=trace.id,
-                    trace_first_timestamp=trace.createdAt,
+                    trace_id=row[0],
+                    trace_first_timestamp=str(row[1]),
                     generation_id=None,
                 )
-                for trace in response.results
+                for row in (result.results or [])
+                if row[0]
             ]
 
     items = await database_sync_to_async(_sample_items, thread_sensitive=False)(

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -75,8 +75,7 @@ class TestSampleItemsInWindowActivity:
 
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.asyncio
-    async def test_sample_items_success(self, mock_team):
-        """Test successful item sampling from window."""
+    async def test_sample_traces_success(self, mock_team):
         inputs = BatchSummarizationInputs(
             team_id=mock_team.id,
             max_items=100,
@@ -85,40 +84,46 @@ class TestSampleItemsInWindowActivity:
             window_end="2025-01-15T12:00:00",
         )
 
-        with patch(
-            "posthog.temporal.llm_analytics.trace_summarization.sampling.TracesQueryRunner"
-        ) as mock_runner_class:
-            from posthog.schema import LLMTrace, LLMTracePerson
+        mock_results = [[f"trace_{i}", f"2025-01-15T11:{i:02d}:00+00:00"] for i in range(50)]
 
-            mock_person = LLMTracePerson(
-                uuid=str(uuid.uuid4()),
-                distinct_id="test_user",
-                created_at=datetime.now(UTC).isoformat(),
-                properties={},
-            )
-
-            mock_runner = mock_runner_class.return_value
-            mock_traces = [
-                LLMTrace(id=f"trace_{i}", createdAt=datetime.now(UTC).isoformat(), events=[], person=mock_person)
-                for i in range(50)
-            ]
-            mock_runner.calculate.return_value.results = mock_traces
+        with patch("posthog.temporal.llm_analytics.trace_summarization.sampling.execute_hogql_query") as mock_execute:
+            mock_execute.return_value.results = mock_results
 
             result = await sample_items_in_window_activity(inputs)
 
             assert len(result) == 50
             assert isinstance(result[0], SampledItem)
             assert result[0].trace_id == "trace_0"
+            assert result[0].generation_id is None
             assert result[49].trace_id == "trace_49"
 
-            # Verify randomOrder is not used (defaults to timestamp DESC ordering)
-            query = mock_runner_class.call_args.kwargs["query"]
-            assert query.randomOrder is None
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.asyncio
+    async def test_sample_generations_success(self, mock_team):
+        inputs = BatchSummarizationInputs(
+            team_id=mock_team.id,
+            max_items=50,
+            analysis_level="generation",
+            window_minutes=60,
+            window_start="2025-01-15T11:00:00",
+            window_end="2025-01-15T12:00:00",
+        )
+
+        mock_results = [[f"trace_{i}", f"gen-uuid-{i}", f"2025-01-15T11:{i:02d}:00+00:00"] for i in range(10)]
+
+        with patch("posthog.temporal.llm_analytics.trace_summarization.sampling.execute_hogql_query") as mock_execute:
+            mock_execute.return_value.results = mock_results
+
+            result = await sample_items_in_window_activity(inputs)
+
+            assert len(result) == 10
+            assert isinstance(result[0], SampledItem)
+            assert result[0].trace_id == "trace_0"
+            assert result[0].generation_id == "gen-uuid-0"
 
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.asyncio
     async def test_sample_items_empty(self, mock_team):
-        """Test sampling when no traces found in window."""
         inputs = BatchSummarizationInputs(
             team_id=mock_team.id,
             max_items=100,
@@ -127,11 +132,8 @@ class TestSampleItemsInWindowActivity:
             window_end="2025-01-15T12:00:00",
         )
 
-        with patch(
-            "posthog.temporal.llm_analytics.trace_summarization.sampling.TracesQueryRunner"
-        ) as mock_runner_class:
-            mock_runner = mock_runner_class.return_value
-            mock_runner.calculate.return_value.results = []
+        with patch("posthog.temporal.llm_analytics.trace_summarization.sampling.execute_hogql_query") as mock_execute:
+            mock_execute.return_value.results = []
 
             result = await sample_items_in_window_activity(inputs)
 


### PR DESCRIPTION
## Problem

The `sample_items_in_window_activity` Temporal activity was using `TracesQueryRunner` (the full UI query runner) to sample trace IDs and timestamps. This runner executes a heavy Phase 2 query that aggregates full event properties, person data, costs, and tokens via `groupArrayIf(tuple(uuid, event, timestamp, properties), ...)`. On high-volume teams, this caused ClickHouse OOM errors (`Query has reached the max memory limit`) even for 1-hour windows requesting only 15-50 items.

The sampling activity only needs trace IDs and first timestamps -- all the heavy data is fetched later per-item by the summarization activity using `TraceQueryRunner`.

## Changes

- Replace `TracesQueryRunner` in `sampling.py` with lightweight HogQL queries that only fetch `trace_id` and `min(timestamp)`
- For generation-level sampling, use a single direct query instead of the previous two-step approach (heavy trace query then separate generations query)
- Remove `TracesQueryRunner` import from sampling module
- Update tests to mock `execute_hogql_query` instead of `TracesQueryRunner`

## How did you test this code?

- Ran existing test suite: `pytest posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py` -- all 9 tests pass
- Added new test for generation-level sampling path

## Publish to changelog?

No