### PR TITLE
fix: remove usePresortedEventsTable modifier from db

### DIFF
--- a/posthog/migrations/0999_remove_presorted_events_modifier.py
+++ b/posthog/migrations/0999_remove_presorted_events_modifier.py
@@ -2,47 +2,28 @@ from django.db import migrations
 
 
 def remove_presorted_events_modifier(apps, schema_editor):
-    Insight = apps.get_model("posthog", "Insight")
+    """
+    Remove the deprecated usePresortedEventsTable modifier from insight queries.
+    Uses atomic PostgreSQL JSON operators to avoid race conditions with concurrent edits.
+    """
+    with schema_editor.connection.cursor() as cursor:
+        # Remove from query->modifiers atomically
+        cursor.execute("""
+            UPDATE posthog_dashboarditem
+            SET query = query #- '{modifiers,usePresortedEventsTable}'
+            WHERE query->'modifiers' ? 'usePresortedEventsTable'
+        """)
 
-    # Find all insights that have the usePresortedEventsTable modifier
-    # Check both query->modifiers and query->source->modifiers paths
-    items_to_update = Insight.objects.raw("""
-        SELECT * FROM posthog_dashboarditem
-        WHERE query->'modifiers' ? 'usePresortedEventsTable'
-           OR query->'source'->'modifiers' ? 'usePresortedEventsTable'
-    """)
-
-    batch_size = 1000
-    batch = []
-
-    for item in items_to_update:
-        if not item.query:
-            continue
-
-        modified = False
-
-        # Handle query->modifiers path
-        if "modifiers" in item.query and isinstance(item.query["modifiers"], dict):
-            if "usePresortedEventsTable" in item.query["modifiers"]:
-                del item.query["modifiers"]["usePresortedEventsTable"]
-                modified = True
-
-        # Handle query->source->modifiers path
-        if "source" in item.query and isinstance(item.query["source"], dict):
-            if "modifiers" in item.query["source"] and isinstance(item.query["source"]["modifiers"], dict):
-                if "usePresortedEventsTable" in item.query["source"]["modifiers"]:
-                    del item.query["source"]["modifiers"]["usePresortedEventsTable"]
-                    modified = True
-
-        if modified:
-            batch.append(item)
-
-            if len(batch) >= batch_size:
-                Insight.objects.bulk_update(batch, ["query"])
-                batch = []
-
-    if batch:
-        Insight.objects.bulk_update(batch, ["query"])
+        # Remove from query->source->modifiers atomically
+        cursor.execute("""
+            UPDATE posthog_dashboarditem
+            SET query = jsonb_set(
+                query,
+                '{source}',
+                (query->'source') #- '{modifiers,usePresortedEventsTable}'
+            )
+            WHERE query->'source'->'modifiers' ? 'usePresortedEventsTable'
+        """)
 
 
 def reverse_noop(apps, schema_editor):

--- a/posthog/migrations/0999_remove_presorted_events_modifier.py
+++ b/posthog/migrations/0999_remove_presorted_events_modifier.py
@@ -1,0 +1,62 @@
+from django.db import migrations
+
+
+def remove_presorted_events_modifier(apps, schema_editor):
+    Insight = apps.get_model("posthog", "Insight")
+
+    # Find all insights that have the usePresortedEventsTable modifier
+    # Check both query->modifiers and query->source->modifiers paths
+    items_to_update = Insight.objects.raw("""
+        SELECT * FROM posthog_dashboarditem
+        WHERE query->'modifiers' ? 'usePresortedEventsTable'
+           OR query->'source'->'modifiers' ? 'usePresortedEventsTable'
+    """)
+
+    batch_size = 1000
+    batch = []
+
+    for item in items_to_update:
+        if not item.query:
+            continue
+
+        modified = False
+
+        # Handle query->modifiers path
+        if "modifiers" in item.query and isinstance(item.query["modifiers"], dict):
+            if "usePresortedEventsTable" in item.query["modifiers"]:
+                del item.query["modifiers"]["usePresortedEventsTable"]
+                modified = True
+
+        # Handle query->source->modifiers path
+        if "source" in item.query and isinstance(item.query["source"], dict):
+            if "modifiers" in item.query["source"] and isinstance(item.query["source"]["modifiers"], dict):
+                if "usePresortedEventsTable" in item.query["source"]["modifiers"]:
+                    del item.query["source"]["modifiers"]["usePresortedEventsTable"]
+                    modified = True
+
+        if modified:
+            batch.append(item)
+
+            if len(batch) >= batch_size:
+                Insight.objects.bulk_update(batch, ["query"])
+                batch = []
+
+    if batch:
+        Insight.objects.bulk_update(batch, ["query"])
+
+
+def reverse_noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "0998_team_proactive_tasks_enabled"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_presorted_events_modifier,
+            reverse_noop,
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0998_team_proactive_tasks_enabled
+0999_remove_presorted_events_modifier

--- a/posthog/test/test_migration_0999.py
+++ b/posthog/test/test_migration_0999.py
@@ -90,6 +90,33 @@ class RemovePresortedEventsModifierMigrationTest(NonAtomicTestMigrations):
             query={"kind": "TrendsQuery"},
         )
 
+        # Other query fields preserved
+        self.insights["other_query_fields_preserved"] = Insight.objects.create(
+            team=self.team,
+            name="Other query fields preserved",
+            query={
+                "kind": "TrendsQuery",
+                "series": [{"event": "pageview", "kind": "EventsNode"}],
+                "dateRange": {"date_from": "-7d"},
+                "modifiers": {"usePresortedEventsTable": True},
+            },
+        )
+
+        # Other source fields preserved
+        self.insights["other_source_fields_preserved"] = Insight.objects.create(
+            team=self.team,
+            name="Other source fields preserved",
+            query={
+                "kind": "DataVisualizationNode",
+                "display": "LineChart",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [{"event": "pageview", "kind": "EventsNode"}],
+                    "modifiers": {"usePresortedEventsTable": True},
+                },
+            },
+        )
+
     @parameterized.expand(
         [
             (
@@ -123,6 +150,27 @@ class RemovePresortedEventsModifierMigrationTest(NonAtomicTestMigrations):
             (
                 "no_modifiers_key",
                 {"kind": "TrendsQuery"},
+            ),
+            (
+                "other_query_fields_preserved",
+                {
+                    "kind": "TrendsQuery",
+                    "series": [{"event": "pageview", "kind": "EventsNode"}],
+                    "dateRange": {"date_from": "-7d"},
+                    "modifiers": {},
+                },
+            ),
+            (
+                "other_source_fields_preserved",
+                {
+                    "kind": "DataVisualizationNode",
+                    "display": "LineChart",
+                    "source": {
+                        "kind": "TrendsQuery",
+                        "series": [{"event": "pageview", "kind": "EventsNode"}],
+                        "modifiers": {},
+                    },
+                },
             ),
         ]
     )

--- a/posthog/test/test_migration_0999.py
+++ b/posthog/test/test_migration_0999.py
@@ -1,0 +1,133 @@
+from typing import Any
+
+import pytest
+from posthog.test.base import NonAtomicTestMigrations
+
+from parameterized import parameterized
+
+pytestmark = pytest.mark.skip("old migrations slow overall test run down")
+
+
+class RemovePresortedEventsModifierMigrationTest(NonAtomicTestMigrations):
+    migrate_from = "0998_team_proactive_tasks_enabled"
+    migrate_to = "0999_remove_presorted_events_modifier"
+
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUpBeforeMigration(self, apps: Any) -> None:
+        Organization = apps.get_model("posthog", "Organization")
+        Project = apps.get_model("posthog", "Project")
+        Team = apps.get_model("posthog", "Team")
+        Insight = apps.get_model("posthog", "Insight")
+
+        self.organization = Organization.objects.create(name="Test Organization")
+        self.project = Project.objects.create(organization=self.organization, name="Test Project", id=1000001)
+        self.team = Team.objects.create(
+            organization=self.organization,
+            project=self.project,
+            name="Test Team",
+        )
+        self.Insight = Insight
+
+        self.insights = {}
+
+        # query.modifiers only
+        self.insights["query_modifiers_only"] = Insight.objects.create(
+            team=self.team,
+            name="Query modifiers only",
+            query={"kind": "TrendsQuery", "modifiers": {"usePresortedEventsTable": True}},
+        )
+
+        # query.source.modifiers only
+        self.insights["source_modifiers_only"] = Insight.objects.create(
+            team=self.team,
+            name="Source modifiers only",
+            query={
+                "kind": "DataVisualizationNode",
+                "source": {"kind": "TrendsQuery", "modifiers": {"usePresortedEventsTable": False}},
+            },
+        )
+
+        # Both locations
+        self.insights["both_locations"] = Insight.objects.create(
+            team=self.team,
+            name="Both locations",
+            query={
+                "kind": "DataVisualizationNode",
+                "modifiers": {"usePresortedEventsTable": True},
+                "source": {"kind": "TrendsQuery", "modifiers": {"usePresortedEventsTable": False}},
+            },
+        )
+
+        # Other modifiers preserved
+        self.insights["other_modifiers_preserved"] = Insight.objects.create(
+            team=self.team,
+            name="Other modifiers preserved",
+            query={
+                "kind": "TrendsQuery",
+                "modifiers": {"usePresortedEventsTable": True, "inCohortVia": "subquery"},
+            },
+        )
+
+        # No usePresortedEventsTable modifier (control case)
+        self.insights["no_modifier"] = Insight.objects.create(
+            team=self.team,
+            name="No modifier",
+            query={"kind": "TrendsQuery", "modifiers": {"inCohortVia": "subquery"}},
+        )
+
+        # Empty modifiers
+        self.insights["empty_modifiers"] = Insight.objects.create(
+            team=self.team,
+            name="Empty modifiers",
+            query={"kind": "TrendsQuery", "modifiers": {}},
+        )
+
+        # No modifiers key at all
+        self.insights["no_modifiers_key"] = Insight.objects.create(
+            team=self.team,
+            name="No modifiers key",
+            query={"kind": "TrendsQuery"},
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "query_modifiers_only",
+                {"kind": "TrendsQuery", "modifiers": {}},
+            ),
+            (
+                "source_modifiers_only",
+                {"kind": "DataVisualizationNode", "source": {"kind": "TrendsQuery", "modifiers": {}}},
+            ),
+            (
+                "both_locations",
+                {
+                    "kind": "DataVisualizationNode",
+                    "modifiers": {},
+                    "source": {"kind": "TrendsQuery", "modifiers": {}},
+                },
+            ),
+            (
+                "other_modifiers_preserved",
+                {"kind": "TrendsQuery", "modifiers": {"inCohortVia": "subquery"}},
+            ),
+            (
+                "no_modifier",
+                {"kind": "TrendsQuery", "modifiers": {"inCohortVia": "subquery"}},
+            ),
+            (
+                "empty_modifiers",
+                {"kind": "TrendsQuery", "modifiers": {}},
+            ),
+            (
+                "no_modifiers_key",
+                {"kind": "TrendsQuery"},
+            ),
+        ]
+    )
+    def test_presorted_events_modifier_removed(self, insight_key, expected_query):
+        insight = self.insights[insight_key]
+        insight.refresh_from_db()
+
+        self.assertEqual(insight.query, expected_query)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

There are some errors for insights after I removed the usePresortedEventsTable modfier in https://github.com/PostHog/posthog/pull/46333

```
1 validation error for QuerySchemaRoot\nInsightVizNode.source.TrendsQuery.modifiers.usePresortedEventsTable\n  Extra inputs are not permitted [type=extra_forbidden, input_value=None, input_type=NoneType]\n    For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden
```
from [logs link](https://us.posthog.com/project/2/logs?serviceNames=%5B%22query%22%2C%22posthog-query-django%22%5D&filterGroup=%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22key%22%3A%22message%22%2C%22value%22%3A%22error%22%2C%22operator%22%3A%22icontains%22%2C%22type%22%3A%22log%22%7D%2C%7B%22key%22%3A%22message%22%2C%22value%22%3A%22usePresortedEventsTable%22%2C%22operator%22%3A%22icontains%22%2C%22type%22%3A%22log%22%7D%5D%7D%5D%7D&dateRange=%7B%22date_from%22%3A%222026-02-03T16%3A51%3A50.527Z%22%2C%22date_to%22%3A%222026-02-03T17%3A21%3A23.365Z%22%2C%22explicitDate%22%3Atrue%7D&linkToLogId=019c2485-ee6a-7892-adc5-89fe83308fc3&initialLogsLimit=209)

## Changes

Remove the modifier from db with a migration

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- migration test

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
