### PR TITLE
fix(experiments): no control breakdown calculations

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -283,6 +283,22 @@ class ExperimentQueryRunner(QueryRunner):
     ) -> ExperimentBreakdownResult:
         """Compute statistics for a single breakdown combination."""
         breakdown_variants = [v for bv, v in variant_results if bv == breakdown_tuple]
+
+        # Ensure all expected variants are present in this breakdown group
+        # Some breakdown groups may not have data for all variants (e.g., no control users with specific browser)
+        variants_present = {v.key for v in breakdown_variants}
+        for expected_variant in self.variants:
+            if expected_variant not in variants_present:
+                # Add missing variant with zero stats to avoid "No control variant found" error
+                breakdown_variants.append(
+                    ExperimentStatsBase(
+                        key=expected_variant,
+                        number_of_samples=0,
+                        sum=0,
+                        sum_squares=0,
+                    )
+                )
+
         stats = self._calculate_statistics_for_variants(breakdown_variants)
 
         return ExperimentBreakdownResult(

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_breakdown.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_breakdown.py
@@ -2121,3 +2121,126 @@ class TestExperimentBreakdown(ExperimentQueryRunnerBaseTest):
             self.assertIsNotNone(breakdown_result.baseline)
             self.assertIsNotNone(breakdown_result.variants)
             self.assertGreater(len(breakdown_result.variants), 0)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_retention_metric_breakdown_with_missing_control_variant(self):
+        """
+        Regression test: Retention metrics with breakdowns should handle cases where
+        some breakdown groups have no data for certain variants (including control).
+
+        This reproduces the "ValueError: No control variant found" bug that occurs
+        when a breakdown group (e.g., specific browser type) has data for test variants
+        but not for the control variant.
+        """
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist", "use_new_query_builder": True}
+        experiment.save()
+
+        metric = ExperimentRetentionMetric(
+            start_event=EventsNode(event="signup"),
+            completion_event=EventsNode(event="login"),
+            retention_window_start=1,
+            retention_window_end=7,
+            retention_window_unit=FunnelConversionWindowTimeUnit.DAY,
+            start_handling=StartHandling.FIRST_SEEN,
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")]),
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Create control users with Chrome only
+        for i in range(2):
+            _create_person(distinct_ids=[f"user_control_{i}"], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=f"user_control_{i}",
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: "control",
+                    "$feature_flag_response": "control",
+                    "$feature_flag": feature_flag.key,
+                    "$browser": "Chrome",
+                },
+            )
+            _create_event(
+                team=self.team,
+                event="signup",
+                distinct_id=f"user_control_{i}",
+                timestamp="2020-01-02T12:01:00Z",
+                properties={feature_flag_property: "control"},
+            )
+            _create_event(
+                team=self.team,
+                event="login",
+                distinct_id=f"user_control_{i}",
+                timestamp="2020-01-05T12:00:00Z",
+                properties={feature_flag_property: "control"},
+            )
+
+        # Create test users with both Chrome AND Safari
+        for browser in ["Chrome", "Safari"]:
+            for i in range(2):
+                _create_person(distinct_ids=[f"user_test_{browser}_{i}"], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=f"user_test_{browser}_{i}",
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: "test",
+                        "$feature_flag_response": "test",
+                        "$feature_flag": feature_flag.key,
+                        "$browser": browser,
+                    },
+                )
+                _create_event(
+                    team=self.team,
+                    event="signup",
+                    distinct_id=f"user_test_{browser}_{i}",
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: "test"},
+                )
+                _create_event(
+                    team=self.team,
+                    event="login",
+                    distinct_id=f"user_test_{browser}_{i}",
+                    timestamp="2020-01-05T12:00:00Z",
+                    properties={feature_flag_property: "test"},
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+
+        # This should NOT raise "ValueError: No control variant found"
+        # Safari breakdown has no control variant data, but should be handled gracefully
+        result = query_runner._calculate()
+
+        # Verify we got breakdown results for both browsers
+        self.assertIsNotNone(result.breakdown_results)
+        assert result.breakdown_results is not None
+        self.assertEqual(len(result.breakdown_results), 2)  # Chrome and Safari
+
+        # Chrome breakdown should have real control data
+        chrome_breakdown = next((br for br in result.breakdown_results if br.breakdown_value == ["Chrome"]), None)
+        self.assertIsNotNone(chrome_breakdown)
+        assert chrome_breakdown is not None
+        self.assertIsNotNone(chrome_breakdown.baseline)
+        self.assertGreater(chrome_breakdown.baseline.number_of_samples, 0)
+
+        # Safari breakdown should have zero-filled control data
+        safari_breakdown = next((br for br in result.breakdown_results if br.breakdown_value == ["Safari"]), None)
+        self.assertIsNotNone(safari_breakdown)
+        assert safari_breakdown is not None
+        self.assertIsNotNone(safari_breakdown.baseline)
+        self.assertEqual(safari_breakdown.baseline.number_of_samples, 0)  # No control users with Safari


### PR DESCRIPTION
## Problem

When processing experiment breakdowns, some breakdown groups had no control variant data, causing `split_baseline_and_test_variants` to fail with `No control variant found`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Before calculating statistics for each breakdown group, ensure all expected variants (including control) are present by adding missing variants with zero stats.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
hogli test:python posthog/hogql_queries/experiments/test/experiment_query_runner/test_breakdown.py
```

![cat-type-small](https://github.com/user-attachments/assets/4cd83619-b123-4dff-be89-ef354b4ade23)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
