### PR TITLE
feat(customers): Gate power users revenue fields behind feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -354,6 +354,7 @@ export const FEATURE_FLAGS = {
     REPLAY_WAIT_FOR_IFRAME_READY: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay
     REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW: 'replay-x-llm-analytics-conversation-view', // owner: @pauldambra #team-replay
     REORDER_PLATFORM_ADDON_BILLING_SECTION: 'reorder-platform-addon-billing-section', // owner: @reece #team-platform-features
+    REVENUE_FIELDS_IN_POWER_USERS_TABLE: 'revenue-fields-in-power-users-table', // owner: @arthurdedeus #team-customer-analytics
     SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE: 'schedule-feature-flag-variants-update', // owner: @gustavo #team-feature-flags
     SCHEMA_MANAGEMENT: 'schema-management', // owner: @aspicer
     SEEKBAR_PREVIEW_SCRUBBING: 'seekbar-preview-scrubbing', // owner: @pauldambra #team-replay

--- a/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
@@ -2,6 +2,7 @@ import { useValues } from 'kea'
 
 import { LemonBanner, LemonButton, Tooltip } from '@posthog/lemon-ui'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { urls } from 'scenes/urls'
 
 import { Query } from '~/queries/Query/Query'
@@ -54,6 +55,7 @@ export function ActiveUsersInsights(): JSX.Element {
 function PowerUsersTable(): JSX.Element {
     const { businessType, customerLabel, dauSeries, selectedGroupType, tabId } = useValues(customerAnalyticsSceneLogic)
     const { isRevenueAnalyticsEnabled, baseCurrency } = useValues(revenueAnalyticsLogic)
+    const revenueFieldsEnabled = useFeatureFlag('REVENUE_FIELDS_IN_POWER_USERS_TABLE')
     const uniqueKey = `power-users-${tabId}`
     const insightProps: InsightLogicProps<InsightVizNode> = {
         dataNodeCollectionId: CUSTOMER_ANALYTICS_DATA_COLLECTION_NODE_ID,
@@ -63,7 +65,7 @@ function PowerUsersTable(): JSX.Element {
     const isB2c = businessType === 'b2c'
     const buttonTo = isB2c ? urls.persons() : urls.groups(selectedGroupType)
     const tooltip = isB2c ? 'Open people list' : `Open ${customerLabel.plural} list`
-    const revenueFields = isRevenueAnalyticsEnabled ? ['$virt_mrr', '$virt_revenue'] : []
+    const revenueFields = isRevenueAnalyticsEnabled && revenueFieldsEnabled ? ['$virt_mrr', '$virt_revenue'] : []
 
     const query = {
         kind: NodeKind.DataTableNode,


### PR DESCRIPTION
## Problem

We need to control the rollout of revenue fields (`$virt_mrr`, `$virt_revenue`) in the Power Users table within Customer Analytics. This allows us to gate the feature behind a feature flag for gradual rollout.

## Changes

- Added `REVENUE_FIELDS_IN_POWER_USERS_TABLE` feature flag to `frontend/src/lib/constants.tsx`
- Updated `PowerUsersTable` component to check the feature flag before displaying revenue columns
- Revenue fields now only appear when both `isRevenueAnalyticsEnabled` AND the feature flag are enabled

## How did you test this code?

- With flag disabled: Power Users table does not show MRR/Revenue columns
- With flag enabled + revenue analytics enabled: Power Users table shows MRR/Revenue columns
- With flag enabled + revenue analytics disabled: Power Users table does not show columns (existing behavior preserved)

## Publish to changelog?

no