### PR TITLE
fix: Add missing Action perms needed in private repo

### DIFF
--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -15,6 +15,7 @@ jobs:
         name: Determine if sandbox image needs to be built
         permissions:
             contents: read
+            pull-requests: read
         outputs:
             sandbox_image: ${{ steps.filter.outputs.sandbox_image }}
         steps:

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
     contents: read
+    pull-requests: read
 
 env:
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -23,6 +23,9 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         name: Determine need to run Hog checks
+        permissions:
+            contents: read
+            pull-requests: read
         # Set job outputs to values from filter step
         outputs:
             hog: ${{ steps.filter.outputs.hog || 'true' }}

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -9,6 +9,7 @@ jobs:
     changes:
         permissions:
             contents: read
+            pull-requests: read
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         name: Determine need to run MCP checks

--- a/.github/workflows/ci-migrations-service-separation-check.yml
+++ b/.github/workflows/ci-migrations-service-separation-check.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
     contents: read
+    pull-requests: read
 
 jobs:
     check-migration-service-separation:

--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -17,6 +17,7 @@ jobs:
         runs-on: ubuntu-24.04
         permissions:
             contents: read
+            pull-requests: read
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog' && github.event_name != 'merge_group'
         name: Determine need to run node Docker build

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -27,6 +27,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         name: Determine need to run Node.js checks
+        permissions:
+            contents: read
+            pull-requests: read
         outputs:
             nodejs: ${{ steps.filter.outputs.nodejs || 'true' }}
         steps:

--- a/.github/workflows/ci-proto.yml
+++ b/.github/workflows/ci-proto.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
     contents: read
+    pull-requests: read
 
 jobs:
     changes:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
     contents: read
+    pull-requests: read
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -18,6 +18,9 @@ jobs:
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
         name: Determine need to run Rust checks
+        permissions:
+            contents: read
+            pull-requests: read
         # Set job outputs to values from filter step
         outputs:
             rust: ${{ steps.filter.outputs.rust || 'true' }}

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -14,6 +14,9 @@ jobs:
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog' && github.event_name != 'merge_group'
         name: Determine need to run Docker checks
+        permissions:
+            contents: read
+            pull-requests: read
         # Set job outputs to values from filter step
         outputs:
             docker_files: ${{ steps.filter.outputs.docker_files }}

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -7,6 +7,7 @@ on:
     workflow_dispatch:
 permissions:
     contents: read
+    pull-requests: read
     id-token: write
 
 jobs:

--- a/.github/workflows/pr-updated.yml
+++ b/.github/workflows/pr-updated.yml
@@ -11,6 +11,9 @@ jobs:
     lint-pr:
         name: Validate PR title against Conventional Commits
         runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+            pull-requests: read
         steps:
             - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
               env:


### PR DESCRIPTION
We're testing a private fork of this repo, and it needs these perms to be able to read PRs.