### PR TITLE
feat: allow hiding total on piechart insights

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -23,6 +23,7 @@ import { ScalePicker } from 'scenes/insights/EditorFilters/ScalePicker'
 import { ShowAlertThresholdLinesFilter } from 'scenes/insights/EditorFilters/ShowAlertThresholdLinesFilter'
 import { ShowLegendFilter } from 'scenes/insights/EditorFilters/ShowLegendFilter'
 import { ShowMultipleYAxesFilter } from 'scenes/insights/EditorFilters/ShowMultipleYAxesFilter'
+import { ShowPieTotalFilter } from 'scenes/insights/EditorFilters/ShowPieTotalFilter'
 import { ShowTrendLinesFilter } from 'scenes/insights/EditorFilters/ShowTrendLinesFilter'
 import { ValueOnSeriesFilter } from 'scenes/insights/EditorFilters/ValueOnSeriesFilter'
 import { RetentionDatePicker } from 'scenes/insights/RetentionDatePicker'
@@ -109,6 +110,7 @@ export function InsightDisplayConfig(): JSX.Element {
                           ...(supportsValueOnSeries ? [{ label: () => <ValueOnSeriesFilter /> }] : []),
                           ...(supportsPercentStackView ? [{ label: () => <PercentStackViewFilter /> }] : []),
                           ...(hasLegend ? [{ label: () => <ShowLegendFilter /> }] : []),
+                          ...(display === ChartDisplayType.ActionsPie ? [{ label: () => <ShowPieTotalFilter /> }] : []),
                           ...(showAlertThresholdLinesConfig
                               ? [{ label: () => <ShowAlertThresholdLinesFilter /> }]
                               : []),

--- a/frontend/src/scenes/insights/EditorFilters/ShowPieTotalFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ShowPieTotalFilter.tsx
@@ -1,0 +1,37 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonCheckbox } from '@posthog/lemon-ui'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
+
+import { ChartDisplayType } from '~/types'
+
+import { insightVizDataLogic } from '../insightVizDataLogic'
+
+export function ShowPieTotalFilter(): JSX.Element | null {
+    const { insightProps } = useValues(insightLogic)
+    const { pieChartVizOptions } = useValues(trendsDataLogic(insightProps))
+    const { updateVizSpecificOptions } = useActions(insightVizDataLogic(insightProps))
+
+    const showTotal = !pieChartVizOptions?.hideAggregation
+
+    const toggleShowTotal = (): void => {
+        updateVizSpecificOptions({
+            [ChartDisplayType.ActionsPie]: {
+                ...pieChartVizOptions,
+                hideAggregation: showTotal,
+            },
+        })
+    }
+
+    return (
+        <LemonCheckbox
+            className="p-1 px-2"
+            onChange={toggleShowTotal}
+            checked={showTotal}
+            label={<span className="font-normal">Show total below chart</span>}
+            size="small"
+        />
+    )
+}

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -41,6 +41,7 @@ import {
     TrendsFilter,
     TrendsFormulaNode,
     TrendsQuery,
+    VizSpecificOptions,
 } from '~/queries/schema/schema-general'
 import {
     filterForQuery,
@@ -122,6 +123,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         setDetailedResultsAggregationType: (detailedResultsAggregationType: AggregationType) => ({
             detailedResultsAggregationType,
         }),
+        updateVizSpecificOptions: (vizSpecificOptions: VizSpecificOptions) => ({ vizSpecificOptions }),
     }),
 
     reducers({
@@ -650,6 +652,16 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
             actions.updateInsightFilter({
                 detailedResultsAggregationType: detailedResultsAggregationType,
             })
+        },
+
+        updateVizSpecificOptions: ({ vizSpecificOptions }) => {
+            actions.setQuery({
+                ...values.query,
+                vizSpecificOptions: {
+                    ...values.vizSpecificOptions,
+                    ...vizSpecificOptions,
+                },
+            } as Node)
         },
 
         // data loading side effects i.e. displaying loading screens for queries with longer duration

--- a/frontend/src/scenes/trends/viz/ActionsPie.scss
+++ b/frontend/src/scenes/trends/viz/ActionsPie.scss
@@ -10,12 +10,17 @@
         flex: 1;
         min-width: 33%;
         padding: 1rem;
+        overflow: hidden;
 
         .ActionsPie__chart {
             position: relative;
             width: 100%;
-            height: calc(100% - 4.5rem); // 4.5rem is the height of the number below the chart
+            height: calc(100% - 4.5rem);
             transition: height 0.5s;
+
+            &.ActionsPie__chart--full-height {
+                height: 100%;
+            }
         }
 
         h3 {

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -118,7 +118,7 @@ export function ActionsPie({ inSharedMode, showPersonsModal = true, context }: C
         data[0] && data[0].labels ? (
             <div className="ActionsPie">
                 <div className="ActionsPie__component">
-                    <div className="ActionsPie__chart">
+                    <div className={`ActionsPie__chart ${!showAggregation ? 'ActionsPie__chart--full-height' : ''}`}>
                         <PieChart
                             data-attr="trend-pie-graph"
                             type={GraphType.Pie}


### PR DESCRIPTION
a user reports they'd like to hide the total below piechart insights

turns out we have all the code for this for some programmatic uses, it's just not wired up to the UI...

well, it is now!

![CleanShot 2026-02-03 at 21.03.19.gif](https://app.graphite.com/user-attachments/assets/835333db-ad09-4b74-a328-532527e4242b.gif)

it's piechart specific config so i only show it when piechart is the type to avoid having to cope with UI states as people switch around between types when creating