### PR TITLE
fix: hide line graph options on non-line graph insights

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -87,8 +87,8 @@ export function InsightDisplayConfig(): JSX.Element {
         ((isTrends || isStickiness) && !(display && NON_TIME_SERIES_DISPLAY_TYPES.includes(display)))
     const showSmoothing =
         isTrends && !isValidBreakdown(breakdownFilter) && (!display || display === ChartDisplayType.ActionsLineGraph)
-    const showMultipleYAxesConfig = isTrends || isStickiness
-    const showAlertThresholdLinesConfig = isTrends
+    const showMultipleYAxesConfig = (isTrends || isStickiness) && !isNonTimeSeriesDisplay
+    const showAlertThresholdLinesConfig = isTrends && !isNonTimeSeriesDisplay
     const isLineGraph = display === ChartDisplayType.ActionsLineGraph || (!display && isTrendsQuery(querySource))
     const isLinearScale = !yAxisScaleType || yAxisScaleType === 'linear'
 
@@ -115,7 +115,9 @@ export function InsightDisplayConfig(): JSX.Element {
                               ? [{ label: () => <ShowAlertThresholdLinesFilter /> }]
                               : []),
                           ...(showMultipleYAxesConfig ? [{ label: () => <ShowMultipleYAxesFilter /> }] : []),
-                          ...(isTrends || isRetention ? [{ label: () => <ShowTrendLinesFilter /> }] : []),
+                          ...((isTrends || isRetention) && !isNonTimeSeriesDisplay
+                              ? [{ label: () => <ShowTrendLinesFilter /> }]
+                              : []),
                       ],
                   },
               ]


### PR DESCRIPTION
i noticed with piecharts we show some options that can never be appropriate like showing a trend line

this change hides several options for several types

the options?

  1. Show alert threshold lines - Horizontal lines       
  showing alert thresholds on the chart                  
  2. Show multiple Y axes - Allows different series to   
  use separate Y axes                                    
  3. Show trend lines - Displays trend/regression lines  
  fitted to the data   

no longer show for non-time-series display types:               
  - Pie charts (ActionsPie)                              
  - Bar value charts (ActionsBarValue)                   
  - Tables (ActionsTable)                                
  - World maps (WorldMap)                                
  - Bold numbers (BoldNumber)                            
  - Calendar heatmaps (CalendarHeatmap)                  
  - 2D heatmaps (TwoDimensionalHeatmap)    

certainly "show trend lines" and "show alert thresholds" are showing across all types

don't apply to those types

and cause the insight to reload when you change them

![CleanShot 2026-02-03 at 21.35.09@2x.png](https://app.graphite.com/user-attachments/assets/dbf1cf00-41f3-4a71-9d10-3a3e363d8cba.png)

