### PR TITLE
fix(flags): Exclude remote config flags from PostgreSQL fallback

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -76,10 +76,15 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     wrapped in a dict that HyperCache can serialize. The actual flag data is in the
     "flags" key as a list of flag dictionaries.
 
+    Remote config flags (is_remote_configuration=True) are excluded since they
+    are served via a separate API.
+
     Returns:
         dict: {"flags": [...]} where flags is a list of flag dictionaries
     """
     flags = get_feature_flags(team=team)
+    # Exclude remote config flags - they are served via a separate API
+    flags = [f for f in flags if not f.is_remote_configuration]
     flags_data = serialize_feature_flags(flags)
 
     logger.info(
@@ -100,6 +105,9 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     This avoids N+1 queries by loading all flags for all teams at once,
     then grouping them by team_id.
 
+    Remote config flags (is_remote_configuration=True) are excluded since they
+    are served via a separate API.
+
     Args:
         teams: List of Team objects to load flags for
 
@@ -112,11 +120,12 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     # Load all flags for all teams in one query with evaluation tags pre-loaded.
     # Include disabled flags (active=False) so flag dependencies can reference them
     # and evaluate them as false, rather than raising DependencyNotFound errors.
+    # Exclude remote config flags - they are served via a separate API.
     # Note: We intentionally don't select_related("team") here because we only need
     # team_id (already on the model) for grouping, and the Team objects are already
     # loaded by the caller. Avoiding the join saves memory.
     all_flags = list(
-        FeatureFlag.objects.filter(team__in=teams, deleted=False).annotate(
+        FeatureFlag.objects.filter(~Q(is_remote_configuration=True), team__in=teams, deleted=False).annotate(
             evaluation_tag_names_agg=ArrayAgg(
                 "evaluation_tags__tag__name",
                 filter=Q(evaluation_tags__isnull=False),

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -135,6 +135,36 @@ class TestServiceFlagsCache(BaseTest):
         inactive_flag = next(f for f in flags if f["key"] == "inactive-flag")
         assert inactive_flag["active"] is False
 
+    def test_get_feature_flags_for_service_excludes_remote_config(self):
+        """Test that remote config flags are excluded from cache.
+
+        Remote config flags (is_remote_configuration=True) are served via a
+        separate API and should not appear in /flags responses.
+        """
+        # Create regular feature flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="regular-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Create remote config flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="remote-config-flag",
+            created_by=self.user,
+            is_remote_configuration=True,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = _get_feature_flags_for_service(self.team)
+        flags = result["flags"]
+
+        # Only the regular flag should be included
+        assert len(flags) == 1
+        assert flags[0]["key"] == "regular-flag"
+
     def test_get_feature_flags_for_teams_batch_includes_inactive(self):
         """Test that batch function includes inactive flags for dependency resolution.
 
@@ -169,6 +199,36 @@ class TestServiceFlagsCache(BaseTest):
         # Verify the inactive flag has active=False
         inactive_flag = next(f for f in flags if f["key"] == "inactive-flag")
         assert inactive_flag["active"] is False
+
+    def test_get_feature_flags_for_teams_batch_excludes_remote_config(self):
+        """Test that batch function excludes remote config flags.
+
+        This tests the same behavior as test_get_feature_flags_for_service_excludes_remote_config
+        but for the batch function used in management commands and cache warming.
+        """
+        # Create regular feature flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="regular-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Create remote config flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="remote-config-flag",
+            created_by=self.user,
+            is_remote_configuration=True,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = _get_feature_flags_for_teams_batch([self.team])
+        flags = result[self.team.id]["flags"]
+
+        # Only the regular flag should be included
+        assert len(flags) == 1
+        assert flags[0]["key"] == "regular-flag"
 
     def test_get_flags_from_cache_redis_hit(self):
         """Test getting flags from Redis cache."""

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -102,6 +102,7 @@ impl FeatureFlagList {
               LEFT JOIN posthog_tag AS tag ON (et.tag_id = tag.id)
             WHERE t.id = $1
               AND f.deleted = false
+              AND (f.is_remote_configuration IS NULL OR f.is_remote_configuration = false)
             GROUP BY f.id, f.team_id, f.name, f.key, f.filters, f.deleted, f.active, 
                      f.ensure_experience_continuity, f.version, f.evaluation_runtime
         "#;
@@ -346,6 +347,54 @@ mod tests {
         for flag in &flags_from_pg {
             assert_eq!(flag.team_id, team.id);
         }
+    }
+
+    #[tokio::test]
+    async fn test_remote_config_flags_excluded_from_pg() {
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team");
+
+        // Insert a regular feature flag using the helper (is_remote_configuration defaults to NULL)
+        let regular_flag = context
+            .insert_flag(team.id, None)
+            .await
+            .expect("Failed to insert regular flag");
+
+        // Insert a remote config flag via raw SQL since FeatureFlagRow doesn't have
+        // is_remote_configuration field
+        let remote_config_flag_id = rand::thread_rng().gen_range(1_000_000..100_000_000);
+        let mut conn = context
+            .non_persons_writer
+            .get_connection()
+            .await
+            .expect("Failed to get connection");
+        sqlx::query(
+            r#"INSERT INTO posthog_featureflag
+            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+             is_remote_configuration, created_at)
+            VALUES ($1, $2, $3, $4, $5, false, true, false, true, '2024-06-17')"#,
+        )
+        .bind(remote_config_flag_id)
+        .bind(team.id)
+        .bind("Remote Config Flag")
+        .bind("remote_config_flag")
+        .bind(serde_json::json!({"groups": [{"properties": [], "rollout_percentage": 100}]}))
+        .execute(&mut *conn)
+        .await
+        .expect("Failed to insert remote config flag");
+
+        let flags_from_pg = FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.id)
+            .await
+            .expect("Failed to fetch flags from pg");
+
+        // Only the regular flag should be returned, remote config flag should be excluded
+        assert_eq!(flags_from_pg.len(), 1);
+        let flag = flags_from_pg.first().expect("Should have one flag");
+        assert_eq!(flag.key, regular_flag.key);
+        assert_eq!(flag.id, regular_flag.id);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Remote config flags (`is_remote_configuration=true`) were incorrectly included in `/flags` endpoint responses when the Rust feature-flags service fell back to PostgreSQL on cache miss.

The Python hypercache already filters out remote config flags via `~Q(is_remote_configuration=True)` in `_get_flags_for_local_evaluation`, but this filtering was missing from the Rust PostgreSQL fallback path, causing inconsistent behavior.

## Changes

Added `is_remote_configuration` filtering to the PostgreSQL query in `rust/feature-flags/src/flags/feature_flag_list.rs`:

```sql
AND (f.is_remote_configuration IS NULL OR f.is_remote_configuration = false)
```

Also added a test to verify remote config flags are excluded from PostgreSQL query results.

## How did you test this code?

- Manual smoke test
- Added unit test `test_remote_config_flags_excluded_from_pg` that inserts both a regular flag and a remote config flag, then verifies only the regular flag is returned
- Ran all 21 `feature_flag_list` tests - all pass
- Ran `cargo clippy` and `cargo fmt` - no warnings

## Publish to changelog?

No - this is a bug fix for internal consistency, not a user-facing feature.
