### PR TITLE
fix(llma): remove broken IS NOT NULL check from sampling queries

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -62,7 +62,6 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
                     AND timestamp >= toDateTime({start_ts}, 'UTC')
                     AND timestamp < toDateTime({end_ts}, 'UTC')
-                    AND properties.$ai_trace_id IS NOT NULL
                     AND properties.$ai_trace_id != ''
                 GROUP BY trace_id
                 HAVING last_generation_id IS NOT NULL
@@ -117,7 +116,6 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
                     AND timestamp >= toDateTime({start_ts}, 'UTC')
                     AND timestamp < toDateTime({end_ts}, 'UTC')
-                    AND properties.$ai_trace_id IS NOT NULL
                     AND properties.$ai_trace_id != ''
                 GROUP BY trace_id
                 ORDER BY first_timestamp DESC


### PR DESCRIPTION
## Problem

The lightweight sampling queries introduced in #46713 return 0 results for all teams because `properties.$ai_trace_id IS NOT NULL` evaluates to `NULL` (not `true`) in HogQL when applied to JSON-extracted properties. This causes the WHERE clause to filter out every row, meaning no traces or generations get summarized.

## Changes

Remove the `IS NOT NULL` check from both the trace-level and generation-level sampling queries in `sampling.py`. The existing `!= ''` check already excludes null and empty values, making `IS NOT NULL` both redundant and broken here.

## How did you test this code?

- Verified via PostHog MCP that the broken query (`IS NOT NULL` + `!= ''`) returns 0 results for team 2
- Verified via PostHog MCP that the fixed query (`!= ''` only) returns 15 traces and 50 generations for team 2 in the same time window
- Confirmed via Temporal worker logs that the sampling activity was returning `num_traces: 0` for all teams
- Existing unit tests pass (9/9)

## Publish to changelog?

no