### PR TITLE
fix(hobby): fix GeoIP database download and mounting for plugins

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -145,14 +145,14 @@ EOF
 
 # Download GeoLite2-City.mmdb if it doesn't exist
 echo "Downloading GeoIP database file"
-apt-get update &&
-apt-get install -y --no-install-recommends curl ca-certificates brotli &&
-mkdir -p ./share &&
+sudo apt-get update &&
+sudo apt-get install -y --no-install-recommends curl ca-certificates brotli &&
+sudo mkdir -p ./share &&
 if [ ! -f ./share/GeoLite2-City.mmdb ]; then
-    curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress --output=./share/GeoLite2-City.mmdb &&
-    echo '{\"date\": \"'"$(date +%Y-%m-%d)"'\"}' > ./share/GeoLite2-City.json;
-    chmod 644 ./share/GeoLite2-City.mmdb &&
-    chmod 644 ./share/GeoLite2-City.json
+    curl -L 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress | sudo tee ./share/GeoLite2-City.mmdb > /dev/null &&
+    echo '{"date": "'"$(date +%Y-%m-%d)"'"}' | sudo tee ./share/GeoLite2-City.json > /dev/null
+    sudo chmod 644 ./share/GeoLite2-City.mmdb &&
+    sudo chmod 644 ./share/GeoLite2-City.json
 fi
 
 # write entrypoint

--- a/bin/hobby-installer/core/git.go
+++ b/bin/hobby-installer/core/git.go
@@ -39,6 +39,19 @@ func UpdatePostHog() error {
 		return err
 	}
 
+	// Check if we're on a branch or detached HEAD
+	branch, err := RunCommandWithDir("posthog", "git", "branch", "--show-current")
+	if err != nil {
+		return err
+	}
+	branch = strings.TrimSpace(branch)
+
+	if branch == "" {
+		// Detached HEAD (e.g., CI checked out a specific commit) - skip pull
+		logger.WriteString("On detached HEAD, skipping pull\n")
+		return nil
+	}
+
 	logger.WriteString("Pulling updates...\n")
 	_, err = RunCommandWithDir("posthog", "git", "pull")
 	return err

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -155,6 +155,8 @@ services:
             PERSONS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             BEHAVIORAL_COHORTS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             OTEL_EXPORTER_OTLP_ENDPOINT: ''
+        volumes:
+            - ./share:/share
         depends_on:
             - db
             - redis7


### PR DESCRIPTION
## Problem
re: https://posthog.com/questions/error-on-post-hog-node-after-instalation

Hobby deployment users are seeing the plugins container crash-loop with the error:

```
ENOENT: no such file or directory, open '../share/GeoLite2-City.mmdb'
```

Additionally, hobby-ci smoke tests fail with:

```
Error: Clone/update PostHog repository failed: exit status 1: You are not currently on a branch.
Please specify which branch you want to merge with.
```

Root causes:

1. GeoIP download step in `bin/deploy-hobby` lacked `sudo`, causing silent failure due to permission denied
2. The plugins service had no volume mount to access the GeoIP file
3. `hobby-installer` runs `git pull` which fails on detached HEAD (CI checks out specific commit SHA)

## Changes

- Add missing `sudo` to GeoIP download commands in `bin/deploy-hobby`
- Use `| sudo tee` pattern for writing files to root-owned directories
- Add missing `./share:/share` volume mount to plugins service in `docker-compose.hobby.yml`
- Skip `git pull` in `hobby-installer` when on detached HEAD (CI mode)

## How did you test this code?

- Fresh hobby deploy exhibited as noted in community post
- Verified GeoIP database downloads successfully to `./share/`
- Verified plugins container loads MMDB without errors

## Note on CI failure

The `hobby-ci` check will fail on this PR because:
- CI downloads the pre-built `hobby-installer` binary from GitHub releases
- The `git.go` fix won't take effect until the binary is rebuilt (only happens on merge)

## Publish to changelog?

no
