### PR TITLE
fix(llma): LLM analytics trace ID null condition

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -62,7 +62,6 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
                     AND timestamp >= toDateTime({start_ts}, 'UTC')
                     AND timestamp < toDateTime({end_ts}, 'UTC')
-                    AND properties.$ai_trace_id IS NOT NULL
                     AND properties.$ai_trace_id != ''
                 GROUP BY trace_id
                 HAVING last_generation_id IS NOT NULL
@@ -117,7 +116,6 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
                     AND timestamp >= toDateTime({start_ts}, 'UTC')
                     AND timestamp < toDateTime({end_ts}, 'UTC')
-                    AND properties.$ai_trace_id IS NOT NULL
                     AND properties.$ai_trace_id != ''
                 GROUP BY trace_id
                 ORDER BY first_timestamp DESC


### PR DESCRIPTION
## Problem

The `IS NOT NULL` condition for `properties.$ai_trace_id` in the LLM analytics trace summarization sampling queries was causing 0 results due to specific interactions between HogQL and ClickHouse. This prevented accurate sampling of traces and generations.

## Changes

Removed the `AND properties.$ai_trace_id IS NOT NULL` clause from both the generation and trace sampling queries in `posthog/temporal/llm_analytics/trace_summarization/sampling.py`. The `properties.$ai_trace_id != ''` check remains to filter out empty trace IDs.

## How did you test this code?

Verified that no existing tests specifically cover the `IS NOT NULL` condition for `trace_id`. The `last_generation_id IS NOT NULL` condition in the HAVING clause was confirmed to be correct.

## Publish to changelog?

no

---
<a href="https://cursor.com/background-agent?bcId=bc-2e6bdf60-0127-42a4-9e40-05201552d083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e6bdf60-0127-42a4-9e40-05201552d083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

