### PR TITLE
feat(surveys): integrate with LLMA

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -298,6 +298,7 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_TEXT_VIEW: 'llm-analytics-text-view', // owner: #team-llm-analytics
     LLM_ANALYTICS_TRANSLATION: 'llm-analytics-translation', // owner: #team-llm-analytics
     LLM_ANALYTICS_PROMPTS: 'llm-analytics-prompts', // owner: #team-llm-analytics
+    LLM_ANALYTICS_USER_FEEDBACK: 'llm-analytics-user-feedback', // owner: @adboio #team-surveys
     LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT: 'llm-observability-show-input-output', // owner: #team-llm-analytics
     LOGS: 'logs', // owner: #team-logs
     NEW_LOGS_DATE_RANGE_PICKER: 'new-logs-date-range-picker', // owner: #team-logs

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -645,7 +645,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportSurveyCreated: (
             survey: Survey,
             isDuplicate?: boolean,
-            creationSource?: 'wizard' | 'full_editor' | 'quick_create' | 'template'
+            creationSource?: 'wizard' | 'full_editor' | 'quick_create' | 'template' | 'llm_analytics'
         ) => ({ survey, isDuplicate, creationSource }),
         reportUserFeedbackButtonClicked: (source: SURVEY_CREATED_SOURCE, meta: Record<string, any>) => ({
             source,

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -68,7 +68,7 @@ const getTraceIdFromRecord = (record: unknown): string | null => {
     return event?.properties?.$ai_trace_id ?? null
 }
 
-const getThumbIcon = (value: unknown): JSX.Element | null => {
+export const getThumbIcon = (value: unknown): JSX.Element | null => {
     if (value == '1') {
         return <IconThumbsUp className="text-brand-blue" />
     }

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -694,6 +694,7 @@ export enum SURVEY_CREATED_SOURCE {
     CUSTOMER_ANALYTICS_INSIGHT = 'customer_analytics_insight',
     ERROR_TRACKING = 'error_tracking',
     WEB_ANALYTICS = 'web_analytics',
+    LLM_ANALYTICS = 'llm_analytics',
 }
 
 export enum SURVEY_FORM_INPUT_IDS {

--- a/frontend/src/scenes/surveys/wizard/ColorInput.tsx
+++ b/frontend/src/scenes/surveys/wizard/ColorInput.tsx
@@ -9,6 +9,7 @@ interface ColorInputProps {
     value?: string
     onChange: (value: string) => void
     disabled?: boolean
+    colorList?: string[]
 }
 
 // Survey-appropriate preset colors
@@ -61,7 +62,7 @@ function ColorGlyph({ color }: { color: string }): JSX.Element {
     )
 }
 
-export function ColorInput({ value = '', onChange, disabled }: ColorInputProps): JSX.Element {
+export function ColorInput({ value = '', onChange, disabled, colorList }: ColorInputProps): JSX.Element {
     const [isOpen, setIsOpen] = useState(false)
 
     const showCssVariableWarning = isCssVariable(value)
@@ -75,7 +76,7 @@ export function ColorInput({ value = '', onChange, disabled }: ColorInputProps):
                     overlay={
                         <div className="p-2">
                             <LemonColorList
-                                colors={SURVEY_PRESET_COLORS}
+                                colors={colorList ?? SURVEY_PRESET_COLORS}
                                 selectedColor={value}
                                 onSelectColor={(color) => {
                                     onChange(color)

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -63,6 +63,7 @@ import { EventContentDisplayAsync, EventContentGeneration } from './components/E
 import { FeedbackTag } from './components/FeedbackTag'
 import { MetricTag } from './components/MetricTag'
 import { SaveToDatasetButton } from './datasets/SaveToDatasetButton'
+import { FeedbackViewDisplay } from './feedback-view/FeedbackViewDisplay'
 import { useAIData } from './hooks/useAIData'
 import { llmAnalyticsPlaygroundLogic } from './llmAnalyticsPlaygroundLogic'
 import { EnrichedTraceTreeNode, llmAnalyticsTraceDataLogic } from './llmAnalyticsTraceDataLogic'
@@ -784,6 +785,8 @@ const EventContent = React.memo(
 
         const showClustersTab = !!event && isTraceLevel(event) && featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB]
 
+        const showFeedbackTab = !!event && isTraceLevel(event)
+
         // Check if we're viewing a trace with actual content vs. a pseudo-trace (grouping of generations w/o input/output state)
         const isTopLevelTraceWithoutContent = !event || (!isLLMEvent(event) && !event.inputState && !event.outputState)
 
@@ -1084,6 +1087,22 @@ const EventContent = React.memo(
                                                   </>
                                               ),
                                               content: <ClustersTabContent />,
+                                          },
+                                      ]
+                                    : []),
+                                ...(showFeedbackTab
+                                    ? [
+                                          {
+                                              key: TraceViewMode.Feedback,
+                                              label: (
+                                                  <>
+                                                      Feedback{' '}
+                                                      <LemonTag className="ml-1" type="completion">
+                                                          Beta
+                                                      </LemonTag>
+                                                  </>
+                                              ),
+                                              content: <FeedbackViewDisplay />,
                                           },
                                       ]
                                     : []),

--- a/products/llm_analytics/frontend/feedback-view/FeedbackViewDisplay.tsx
+++ b/products/llm_analytics/frontend/feedback-view/FeedbackViewDisplay.tsx
@@ -1,0 +1,89 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonBanner, LemonCard, LemonSkeleton, LemonSwitch, Link } from '@posthog/lemon-ui'
+
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { SurveyEventProperties } from '~/types'
+
+import { llmAnalyticsTraceLogic } from '../llmAnalyticsTraceLogic'
+import { feedbackViewLogic } from './feedbackViewLogic'
+import { SurveyResponseCard } from './survey-responses/SurveyResponseCard'
+import { groupEventsBySubmission } from './survey-responses/utils'
+import { FeedbackSurveyWizard } from './wizard/FeedbackSurveyWizard'
+
+export function FeedbackViewDisplay(): JSX.Element {
+    const { traceId } = useValues(llmAnalyticsTraceLogic)
+    const { surveyEvents, surveyEventsLoading, surveys, surveysLoading, hasLoadingError } = useValues(
+        feedbackViewLogic({ traceId })
+    )
+    const { currentTeam } = useValues(teamLogic)
+    const { updateCurrentTeam } = useActions(teamLogic)
+
+    if (surveyEventsLoading || surveysLoading) {
+        return <LemonSkeleton className="h-8" />
+    }
+
+    if (hasLoadingError) {
+        return <LemonBanner type="error">Failed to load feedback data</LemonBanner>
+    }
+
+    const surveyResponseEvents = (surveyEvents ?? []).filter((e) => e.event === 'survey sent')
+    const groupedResponses = groupEventsBySubmission(surveyResponseEvents, surveys)
+
+    // survey events are deduped on survey_id (and implicitly trace_id), so we'll
+    // only have 'survey shown' events here if there was no survey response
+    const surveyShownEvents = (surveyEvents ?? []).filter((e) => e.event === 'survey shown')
+
+    const hasSurveyEvents = groupedResponses.length > 0 || surveyShownEvents.length > 0
+
+    // no survey events at all -> survey wizard CTA
+    if (!hasSurveyEvents) {
+        return <FeedbackSurveyWizard />
+    }
+
+    return (
+        <div className="flex flex-col gap-3">
+            {hasSurveyEvents && !currentTeam?.surveys_opt_in && (
+                <LemonBanner type="warning">
+                    <div className="flex items-center justify-between gap-2">
+                        <span>Surveys are disabled for this project. Your feedback surveys won't work.</span>
+                        <LemonSwitch
+                            checked={false}
+                            onChange={(checked) => updateCurrentTeam({ surveys_opt_in: checked })}
+                            label="Enable surveys"
+                            bordered
+                        />
+                    </div>
+                </LemonBanner>
+            )}
+
+            {groupedResponses.map((response) => {
+                const survey = surveys[response.surveyId]
+                if (!survey) {
+                    return null
+                }
+                return <SurveyResponseCard key={response.submissionId} response={response} survey={survey} />
+            })}
+
+            {surveyShownEvents.map((event) => {
+                const survey = surveys[event.properties?.[SurveyEventProperties.SURVEY_ID]]
+                return (
+                    <LemonCard key={event.id} className="p-3" hoverEffect={false}>
+                        <span className="text-secondary">
+                            {survey ? (
+                                <Link to={urls.survey(survey.id)} target="_blank" targetBlankIcon>
+                                    {survey.name}
+                                </Link>
+                            ) : (
+                                'Survey'
+                            )}{' '}
+                            was shown but received no response
+                        </span>
+                    </LemonCard>
+                )
+            })}
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/feedback-view/feedbackViewLogic.ts
+++ b/products/llm_analytics/frontend/feedback-view/feedbackViewLogic.ts
@@ -1,0 +1,114 @@
+import { afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
+
+import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
+
+import { LLMTrace, LLMTraceEvent } from '~/queries/schema/schema-general'
+import { hogql } from '~/queries/utils'
+import { Survey, SurveyEventProperties } from '~/types'
+
+import { llmAnalyticsTraceDataLogic } from '../llmAnalyticsTraceDataLogic'
+import type { feedbackViewLogicType } from './feedbackViewLogicType'
+
+export interface FeedbackViewLogicProps {
+    traceId: string
+}
+
+export const feedbackViewLogic = kea<feedbackViewLogicType>([
+    path(['scenes', 'llm-analytics', 'feedbackViewLogic']),
+    props({} as FeedbackViewLogicProps),
+    key((props) => props.traceId),
+    connect({
+        values: [llmAnalyticsTraceDataLogic, ['trace']],
+    }),
+    loaders(({ props, values }) => ({
+        surveyEvents: [
+            null as LLMTraceEvent[] | null,
+            {
+                loadSurveyEvents: async (createdAt: string) => {
+                    const formattedDate = dayjs.utc(createdAt).format('YYYY-MM-DDTHH:mm:ss')
+                    const response = await api.queryHogQL(
+                        hogql`
+                            SELECT uuid, event, timestamp, properties
+                            FROM events
+                            WHERE (event = 'survey sent' OR event = 'survey shown')
+                                AND properties.$ai_trace_id = ${props.traceId}
+                                AND timestamp >= ${formattedDate}
+                            ORDER BY if(event = 'survey sent', 0, 1)
+                            LIMIT 1 BY properties.$survey_id
+                        `,
+                        { productKey: 'llm_analytics' }
+                    )
+
+                    return response.results.map(([uuid, event, timestamp, properties]: any) => ({
+                        id: uuid,
+                        event,
+                        createdAt: timestamp,
+                        properties: typeof properties === 'string' ? JSON.parse(properties) : properties,
+                    }))
+                },
+            },
+        ],
+        surveys: [
+            {} as Record<string, Survey>,
+            {
+                loadSurveys: async () => {
+                    const surveyIds = values.surveyIds
+                    if (surveyIds.length === 0) {
+                        return {}
+                    }
+                    const surveys = await Promise.all(surveyIds.map((id) => api.surveys.get(id)))
+                    return Object.fromEntries(surveys.map((survey) => [survey.id, survey]))
+                },
+            },
+        ],
+    })),
+    reducers({
+        hasLoadingError: [
+            false,
+            {
+                loadSurveyEventsFailure: () => true,
+                loadSurveysFailure: () => true,
+                loadSurveyEvents: () => false,
+            },
+        ],
+    }),
+    selectors({
+        surveyIds: [
+            (s) => [s.surveyEvents],
+            (surveyEvents): string[] => {
+                if (!surveyEvents) {
+                    return []
+                }
+                const ids = new Set<string>()
+                for (const event of surveyEvents) {
+                    const surveyId = event.properties?.[SurveyEventProperties.SURVEY_ID]
+                    if (surveyId) {
+                        ids.add(surveyId)
+                    }
+                }
+                return Array.from(ids)
+            },
+        ],
+    }),
+    listeners(({ actions }) => ({
+        loadSurveyEventsSuccess: () => {
+            actions.loadSurveys()
+        },
+    })),
+    subscriptions(({ actions, values }) => ({
+        trace: (trace: LLMTrace | undefined) => {
+            if (trace?.createdAt && values.surveyEvents === null && !values.surveyEventsLoading) {
+                actions.loadSurveyEvents(trace.createdAt)
+            }
+        },
+    })),
+    afterMount(({ actions, values }) => {
+        const trace = values.trace
+        if (trace?.createdAt && values.surveyEvents === null && !values.surveyEventsLoading) {
+            actions.loadSurveyEvents(trace.createdAt)
+        }
+    }),
+])

--- a/products/llm_analytics/frontend/feedback-view/survey-responses/ChoiceResponse.tsx
+++ b/products/llm_analytics/frontend/feedback-view/survey-responses/ChoiceResponse.tsx
@@ -1,0 +1,25 @@
+import { SurveyQuestion } from '~/types'
+
+export function ChoiceResponse({ value, question }: { value: unknown; question: SurveyQuestion }): JSX.Element {
+    const choices = Array.isArray(value)
+        ? value
+        : String(value)
+              .split(',')
+              .map((s) => s.trim())
+
+    return (
+        <div className="flex flex-col gap-2">
+            {question.question && <span className="text-xs text-muted">{question.question}</span>}
+            <div className="flex flex-wrap gap-1.5">
+                {choices.map((choice, i) => (
+                    <span
+                        key={i}
+                        className="inline-flex items-center px-2 py-0.5 rounded-md bg-fill-secondary text-sm text-primary"
+                    >
+                        {choice}
+                    </span>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/feedback-view/survey-responses/OpenTextResponse.tsx
+++ b/products/llm_analytics/frontend/feedback-view/survey-responses/OpenTextResponse.tsx
@@ -1,0 +1,12 @@
+import { SurveyQuestion } from '~/types'
+
+export function OpenTextResponse({ value, question }: { value: unknown; question: SurveyQuestion }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-1">
+            {question.question && <span className="text-xs text-muted">{question.question}</span>}
+            <blockquote className="border-l-2 border-border pl-3 text-sm text-primary italic">
+                {String(value)}
+            </blockquote>
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/feedback-view/survey-responses/RatingScale.tsx
+++ b/products/llm_analytics/frontend/feedback-view/survey-responses/RatingScale.tsx
@@ -1,0 +1,31 @@
+import { SURVEY_RATING_SCALE } from 'scenes/surveys/constants'
+
+import { RatingSurveyQuestion } from '~/types'
+
+export function RatingScale({ value, question }: { value: number; question: RatingSurveyQuestion }): JSX.Element {
+    const { scale } = question
+    const isNps = scale === SURVEY_RATING_SCALE.NPS_10_POINT
+    const start = isNps ? 0 : 1
+    const points = Array.from({ length: scale }, (_, i) => start + i)
+
+    return (
+        <div className="flex flex-col gap-1.5">
+            {question.question && <span className="text-xs text-muted">{question.question}</span>}
+            <div className="flex items-center gap-1">
+                {points.map((point) => {
+                    const isSelected = point === value
+                    return (
+                        <span
+                            key={point}
+                            className={`inline-flex items-center justify-center size-6 rounded text-xs font-mono ${
+                                isSelected ? 'bg-brand-blue text-white font-medium' : 'bg-fill-secondary text-muted'
+                            }`}
+                        >
+                            {point}
+                        </span>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/feedback-view/survey-responses/SurveyResponseCard.tsx
+++ b/products/llm_analytics/frontend/feedback-view/survey-responses/SurveyResponseCard.tsx
@@ -1,0 +1,50 @@
+import { Link } from '@posthog/lemon-ui'
+
+import { isThumbQuestion } from 'scenes/surveys/utils'
+import { urls } from 'scenes/urls'
+
+import { RatingSurveyQuestion, Survey, SurveyQuestion, SurveyQuestionType } from '~/types'
+
+import { ChoiceResponse } from './ChoiceResponse'
+import { OpenTextResponse } from './OpenTextResponse'
+import { RatingScale } from './RatingScale'
+import { ThumbsResponse } from './ThumbsResponse'
+import { GroupedResponse } from './utils'
+
+function QuestionResponse({ question, value }: { question: SurveyQuestion; value: unknown }): JSX.Element {
+    if (isThumbQuestion(question)) {
+        return <ThumbsResponse isPositive={value === '1'} question={question} />
+    }
+
+    if (question.type === SurveyQuestionType.Rating) {
+        const numValue = typeof value === 'string' ? parseInt(value, 10) : Number(value)
+        return <RatingScale value={numValue} question={question as RatingSurveyQuestion} />
+    }
+
+    if (question.type === SurveyQuestionType.SingleChoice || question.type === SurveyQuestionType.MultipleChoice) {
+        return <ChoiceResponse value={value} question={question} />
+    }
+
+    return <OpenTextResponse value={value} question={question} />
+}
+
+export function SurveyResponseCard({ response, survey }: { response: GroupedResponse; survey: Survey }): JSX.Element {
+    return (
+        <div className="rounded-lg border border-border bg-bg-light p-3 flex flex-col gap-3">
+            <Link
+                to={urls.survey(survey.id)}
+                className="self-start inline-flex items-center gap-1 text-xs font-medium text-link hover:underline"
+                target="_blank"
+                targetBlankIcon
+            >
+                {survey.name}
+            </Link>
+
+            {response.responses.map((r) => (
+                <QuestionResponse key={r.questionIndex} question={r.question} value={r.value} />
+            ))}
+
+            {!response.isComplete && <span className="text-xs text-muted italic">Partial response</span>}
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/feedback-view/survey-responses/ThumbsResponse.tsx
+++ b/products/llm_analytics/frontend/feedback-view/survey-responses/ThumbsResponse.tsx
@@ -1,0 +1,33 @@
+import { IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+
+import { SurveyQuestion } from '~/types'
+
+export function ThumbsResponse({
+    isPositive,
+    question,
+}: {
+    isPositive: boolean
+    question: SurveyQuestion
+}): JSX.Element {
+    return (
+        <div className="flex items-center gap-3">
+            <span
+                className={`inline-flex items-center justify-center size-8 rounded-md ${
+                    isPositive ? 'bg-[var(--brand-blue-light)]' : 'bg-warning-highlight'
+                }`}
+            >
+                {isPositive ? (
+                    <IconThumbsUp className="size-5 text-brand-blue" />
+                ) : (
+                    <IconThumbsDown className="size-5 text-warning" />
+                )}
+            </span>
+            <div className="flex flex-col">
+                {question.question && <span className="text-xs text-muted">{question.question}</span>}
+                <span className={`text-sm font-medium ${isPositive ? 'text-brand-blue' : 'text-warning'}`}>
+                    {isPositive ? 'Positive' : 'Negative'}
+                </span>
+            </div>
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/feedback-view/survey-responses/utils.ts
+++ b/products/llm_analytics/frontend/feedback-view/survey-responses/utils.ts
@@ -1,0 +1,56 @@
+import { getSurveyResponseValue } from 'scenes/surveys/utils'
+
+import { LLMTraceEvent } from '~/queries/schema/schema-general'
+import { Survey, SurveyEventProperties, SurveyQuestion } from '~/types'
+
+export interface GroupedResponse {
+    submissionId: string
+    surveyId: string
+    responses: { questionIndex: number; question: SurveyQuestion; value: unknown }[]
+    isComplete: boolean
+}
+
+export function groupEventsBySubmission(events: LLMTraceEvent[], surveys: Record<string, Survey>): GroupedResponse[] {
+    const submissionMap = new Map<string, GroupedResponse>()
+
+    for (const event of events) {
+        const props = event.properties || {}
+        const surveyId = props[SurveyEventProperties.SURVEY_ID]
+        const survey = surveyId ? surveys[surveyId] : null
+
+        if (!survey) {
+            continue
+        }
+
+        const submissionId = props[SurveyEventProperties.SURVEY_SUBMISSION_ID] || event.id
+
+        if (!submissionMap.has(submissionId)) {
+            submissionMap.set(submissionId, {
+                submissionId,
+                surveyId,
+                responses: [],
+                isComplete: props[SurveyEventProperties.SURVEY_COMPLETED] === true,
+            })
+        }
+
+        const submission = submissionMap.get(submissionId)!
+
+        for (let i = 0; i < survey.questions.length; i++) {
+            const question = survey.questions[i]
+            const value = getSurveyResponseValue(props, i, question.id)
+
+            if (value != null && value !== '') {
+                const existing = submission.responses.find((r) => r.questionIndex === i)
+                if (!existing) {
+                    submission.responses.push({ questionIndex: i, question, value })
+                }
+            }
+        }
+
+        if (props[SurveyEventProperties.SURVEY_COMPLETED] === true) {
+            submission.isComplete = true
+        }
+    }
+
+    return Array.from(submissionMap.values())
+}

--- a/products/llm_analytics/frontend/feedback-view/wizard/FeedbackPreviewMock.tsx
+++ b/products/llm_analytics/frontend/feedback-view/wizard/FeedbackPreviewMock.tsx
@@ -1,0 +1,147 @@
+import { useValues } from 'kea'
+import { renderSurveysPreview } from 'posthog-js/dist/surveys-preview'
+import { useEffect, useMemo, useRef } from 'react'
+
+import { IconThumbsDown, IconThumbsDownFilled, IconThumbsUp, IconThumbsUpFilled } from '@posthog/icons'
+
+import { UploadedLogo } from 'lib/lemon-ui/UploadedLogo/UploadedLogo'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { Survey, SurveyPosition, SurveyQuestionType, SurveyType } from '~/types'
+
+function BrowserFrame({ children }: { children: React.ReactNode }): JSX.Element {
+    const { currentTeam } = useValues(teamLogic)
+    const { currentOrganization } = useValues(organizationLogic)
+
+    return (
+        <div className="rounded-lg border border-border bg-bg-light overflow-hidden">
+            <div className="bg-fill-secondary px-3 py-2 border-b border-border flex items-center relative">
+                <div className="flex gap-1.5 items-center">
+                    <div className="size-3 rounded-full bg-[#ff5f57]" />
+                    <div className="size-3 rounded-full bg-[#febc2e]" />
+                    <div className="size-3 rounded-full bg-[#28c840]" />
+                </div>
+                <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                    <span className="text-xs font-medium text-muted">{currentTeam?.name || 'Your App'}</span>
+                </div>
+            </div>
+            <div className="p-4 space-y-3">
+                <div className="flex gap-3">
+                    <UploadedLogo
+                        name={currentOrganization?.name || 'Your App'}
+                        entityId={currentOrganization?.id || '1'}
+                        mediaId={currentOrganization?.logo_media_id || null}
+                        size="medium"
+                    />
+                    {children}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export function FeedbackPreviewMock({
+    thumbState,
+    onThumbClick,
+    followUpEnabled,
+    followUpQuestion,
+    surveyAppearance,
+}: {
+    thumbState: 'none' | 'up' | 'down'
+    onThumbClick: (thumb: 'up' | 'down') => void
+    followUpEnabled: boolean
+    followUpQuestion: string
+    surveyAppearance: Survey['appearance']
+}): JSX.Element {
+    const surveyPopupRef = useRef<HTMLDivElement>(null)
+
+    const previewSurvey = useMemo(
+        () => ({
+            id: 'preview',
+            name: 'Follow-up',
+            type: SurveyType.API,
+            questions: [
+                {
+                    type: SurveyQuestionType.Open,
+                    question: followUpQuestion || 'What went wrong?',
+                    optional: true,
+                },
+            ],
+            appearance: {
+                ...surveyAppearance,
+                displayThankYouMessage: false,
+                position: SurveyPosition.NextToTrigger,
+            },
+        }),
+        [followUpQuestion, surveyAppearance]
+    )
+
+    useEffect(() => {
+        if (surveyPopupRef.current && thumbState === 'down' && followUpEnabled) {
+            renderSurveysPreview({
+                survey: previewSurvey,
+                parentElement: surveyPopupRef.current,
+                previewPageIndex: 0,
+                positionStyles: {
+                    position: 'relative',
+                    left: 'unset',
+                    right: 'unset',
+                    top: 'unset',
+                    bottom: 'unset',
+                    transform: 'unset',
+                    maxWidth: '100%',
+                    zIndex: '1',
+                },
+            })
+        }
+    }, [thumbState, followUpEnabled, previewSurvey])
+
+    return (
+        <BrowserFrame>
+            <div className="flex-1 space-y-3">
+                <div className="rounded-lg bg-fill-secondary p-3 text-sm">
+                    You're absolutely right! Click the thumbs below to demo the user feedback flow.
+                </div>
+
+                <div className="flex items-center gap-2">
+                    <span className="text-xs text-muted">Was this helpful?</span>
+                    <div className="flex items-center gap-1">
+                        <button
+                            type="button"
+                            onClick={() => onThumbClick('up')}
+                            className={`p-1.5 rounded transition-colors ${
+                                thumbState === 'up'
+                                    ? 'bg-success-highlight text-success'
+                                    : 'hover:bg-fill-secondary text-muted'
+                            }`}
+                        >
+                            {thumbState === 'up' ? (
+                                <IconThumbsUpFilled className="size-4" />
+                            ) : (
+                                <IconThumbsUp className="size-4" />
+                            )}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => onThumbClick('down')}
+                            className={`p-1.5 rounded transition-colors ${
+                                thumbState === 'down'
+                                    ? 'bg-warning-highlight text-warning'
+                                    : 'hover:bg-fill-secondary text-muted'
+                            }`}
+                        >
+                            {thumbState === 'down' ? (
+                                <IconThumbsDownFilled className="size-4" />
+                            ) : (
+                                <IconThumbsDown className="size-4" />
+                            )}
+                        </button>
+                    </div>
+                </div>
+
+                {thumbState === 'down' && followUpEnabled && <div ref={surveyPopupRef} />}
+            </div>
+        </BrowserFrame>
+    )
+}

--- a/products/llm_analytics/frontend/feedback-view/wizard/FeedbackSurveyWizard.tsx
+++ b/products/llm_analytics/frontend/feedback-view/wizard/FeedbackSurveyWizard.tsx
@@ -1,0 +1,368 @@
+import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
+
+import { IconArrowLeft, IconArrowRight, IconCheck, IconDocument } from '@posthog/icons'
+import { LemonButton, LemonCheckbox, LemonInput, LemonSwitch, LemonTabs, LemonTextArea } from '@posthog/lemon-ui'
+
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { dayjs } from 'lib/dayjs'
+import { ColorInput } from 'scenes/surveys/wizard/ColorInput'
+
+import { Survey, SurveyAppearance } from '~/types'
+
+import { FeedbackPreviewMock } from './FeedbackPreviewMock'
+import { getManualCaptureExample, getReactExample } from './codeExamples'
+import { WizardStep, feedbackSurveyWizardLogic } from './feedbackSurveyWizardLogic'
+
+const SURVEY_PRESET_COLORS = ['#ffffff', '#171717', '#3b82f6', '#22c55e', '#f97316', '#a855f7']
+
+function WizardStepIndicator({ currentStep }: { currentStep: WizardStep }): JSX.Element {
+    const steps: { key: WizardStep; label: string }[] = [
+        { key: 'intro', label: 'Overview' },
+        { key: 'configure', label: 'Configure' },
+        { key: 'implement', label: 'Implement' },
+    ]
+
+    const currentIndex = steps.findIndex((s) => s.key === currentStep)
+
+    return (
+        <div className="flex items-center gap-2">
+            {steps.map((step, index) => {
+                const isCompleted = index < currentIndex
+                const isCurrent = step.key === currentStep
+
+                return (
+                    <div key={step.key} className="flex items-center gap-2">
+                        <div
+                            className={`flex items-center justify-center size-6 rounded-full text-xs font-medium transition-colors ${
+                                isCompleted
+                                    ? 'bg-success text-white'
+                                    : isCurrent
+                                      ? 'bg-primary-3000 text-white'
+                                      : 'bg-fill-secondary text-muted'
+                            }`}
+                        >
+                            {isCompleted ? <IconCheck className="size-3" /> : index + 1}
+                        </div>
+                        <span className={`text-sm ${isCurrent ? 'font-semibold text-primary' : 'text-muted'}`}>
+                            {step.label}
+                        </span>
+                        {index < steps.length - 1 && <div className="w-8 h-px bg-border" />}
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+function ExistingSurveyCard({ survey, onClick }: { survey: Survey; onClick: () => void }): JSX.Element {
+    const hasFollowUp = (survey.questions?.length ?? 0) > 1
+
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="flex flex-col items-start gap-2 p-3 rounded-lg border border-border bg-bg-light hover:border-primary hover:bg-primary/5 transition-colors text-left cursor-pointer"
+        >
+            <div className="flex items-center gap-2">
+                <div className="flex items-center justify-center size-8 rounded bg-fill-secondary">
+                    <IconDocument className="size-4 text-muted" />
+                </div>
+                <span className="font-medium text-sm truncate">{survey.name}</span>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-muted">
+                <span>{hasFollowUp ? 'With follow-up' : 'Thumbs only'}</span>
+                <span>·</span>
+                <span>{dayjs(survey.created_at).fromNow()}</span>
+            </div>
+        </button>
+    )
+}
+
+function IntroStep({ appearance }: { appearance: SurveyAppearance }): JSX.Element {
+    const { eligibleSurveys } = useValues(feedbackSurveyWizardLogic)
+    const { setStep, selectExistingSurvey } = useActions(feedbackSurveyWizardLogic)
+    const [thumbState, setThumbState] = useState<'none' | 'up' | 'down'>('none')
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h3 className="text-lg font-semibold mb-2">Collect user feedback on LLM traces</h3>
+                <p className="text-muted text-sm">
+                    Add thumbs up/down feedback to your AI-powered features, integrated into your own UI.
+                </p>
+            </div>
+
+            <FeedbackPreviewMock
+                thumbState={thumbState}
+                onThumbClick={(thumb) => setThumbState(thumbState === thumb ? 'none' : thumb)}
+                followUpEnabled={true}
+                followUpQuestion="What went wrong?"
+                surveyAppearance={appearance}
+            />
+
+            <div className="flex justify-end">
+                <LemonButton type="primary" onClick={() => setStep('configure')} sideIcon={<IconArrowRight />}>
+                    Create new survey
+                </LemonButton>
+            </div>
+
+            {eligibleSurveys.length > 0 && (
+                <div className="border-t border-border pt-4">
+                    <p className="text-muted text-sm mb-3">or use an existing survey:</p>
+                    <div className="grid grid-cols-3 gap-3">
+                        {eligibleSurveys.map((survey) => (
+                            <ExistingSurveyCard
+                                key={survey.id}
+                                survey={survey}
+                                onClick={() => selectExistingSurvey(survey)}
+                            />
+                        ))}
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}
+
+function ConfigureStep(): JSX.Element {
+    const {
+        surveyName,
+        followUpEnabled,
+        followUpQuestion,
+        appearance,
+        nameIsDuplicate,
+        disabledReason,
+        createdSurveyLoading,
+        surveysNeedEnabling,
+    } = useValues(feedbackSurveyWizardLogic)
+    const { setStep, setSurveyName, setFollowUpEnabled, setFollowUpQuestion, updateAppearance, createSurvey } =
+        useActions(feedbackSurveyWizardLogic)
+
+    const [thumbState, setThumbState] = useState<'none' | 'up' | 'down'>('down')
+
+    useEffect(() => {
+        if (followUpEnabled) {
+            setThumbState('down')
+        }
+    }, [followUpEnabled])
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h3 className="text-lg font-semibold mb-2">Configure your survey</h3>
+                <p className="text-muted text-sm">Just the thumbs, or add a follow-up question on negative feedback.</p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-6">
+                <div className="space-y-4">
+                    <div>
+                        <label className="text-sm font-medium mb-1.5 block">Survey name</label>
+                        <LemonInput
+                            value={surveyName}
+                            onChange={setSurveyName}
+                            placeholder="LLM feedback"
+                            status={nameIsDuplicate ? 'danger' : undefined}
+                        />
+                        {nameIsDuplicate && (
+                            <p className="text-danger text-xs mt-1">A survey with this name already exists</p>
+                        )}
+                    </div>
+
+                    <div className="border border-border rounded-md overflow-hidden">
+                        <div className="p-3 bg-bg-light">
+                            <LemonSwitch
+                                checked={followUpEnabled}
+                                onChange={setFollowUpEnabled}
+                                label="Ask follow-up on thumbs down"
+                                fullWidth
+                            />
+                        </div>
+                        {followUpEnabled && (
+                            <div className="p-3 border-t border-border space-y-4">
+                                <div>
+                                    <label className="text-sm font-medium mb-1.5 block">Follow-up question</label>
+                                    <LemonTextArea
+                                        value={followUpQuestion}
+                                        onChange={setFollowUpQuestion}
+                                        placeholder="What went wrong?"
+                                        minRows={2}
+                                    />
+                                </div>
+
+                                <div className="pt-2 border-t border-border/50 space-y-3">
+                                    <label className="text-xs font-medium text-muted uppercase tracking-wide">
+                                        Popup appearance
+                                    </label>
+                                    <div className="grid grid-cols-3 gap-3">
+                                        <div className="space-y-1">
+                                            <label className="text-xs font-medium">Background</label>
+                                            <ColorInput
+                                                value={appearance.backgroundColor}
+                                                onChange={(backgroundColor) => updateAppearance({ backgroundColor })}
+                                                colorList={SURVEY_PRESET_COLORS}
+                                            />
+                                        </div>
+                                        <div className="space-y-1">
+                                            <label className="text-xs font-medium">Text</label>
+                                            <ColorInput
+                                                value={appearance.textColor}
+                                                onChange={(textColor) => updateAppearance({ textColor })}
+                                                colorList={SURVEY_PRESET_COLORS}
+                                            />
+                                        </div>
+                                        <div className="space-y-1">
+                                            <label className="text-xs font-medium">Button</label>
+                                            <ColorInput
+                                                value={appearance.submitButtonColor}
+                                                onChange={(submitButtonColor) =>
+                                                    updateAppearance({ submitButtonColor })
+                                                }
+                                                colorList={SURVEY_PRESET_COLORS}
+                                            />
+                                        </div>
+                                    </div>
+                                    <LemonCheckbox
+                                        label="Hide PostHog branding"
+                                        checked={appearance.whiteLabel}
+                                        onChange={(checked) => updateAppearance({ whiteLabel: checked })}
+                                        size="small"
+                                    />
+                                </div>
+
+                                <p className="text-muted text-xs">
+                                    Need more? You'll be able to customize further after creating your survey.
+                                </p>
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                <FeedbackPreviewMock
+                    thumbState={thumbState}
+                    onThumbClick={(thumb) => setThumbState(thumbState === thumb ? 'none' : thumb)}
+                    followUpEnabled={followUpEnabled}
+                    followUpQuestion={followUpQuestion}
+                    surveyAppearance={appearance}
+                />
+            </div>
+
+            <div className="flex flex-col gap-2 items-end">
+                <div className="flex justify-between w-full">
+                    <LemonButton
+                        type="secondary"
+                        onClick={() => setStep('intro')}
+                        icon={<IconArrowLeft />}
+                        disabled={createdSurveyLoading}
+                    >
+                        Back
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={createSurvey}
+                        sideIcon={<IconArrowRight />}
+                        loading={createdSurveyLoading}
+                        disabled={!!disabledReason}
+                        disabledReason={disabledReason}
+                    >
+                        Create & continue
+                    </LemonButton>
+                </div>
+                {surveysNeedEnabling && (
+                    <p className="text-muted text-xs">This will also enable surveys for this project.</p>
+                )}
+            </div>
+        </div>
+    )
+}
+
+function ImplementStep(): JSX.Element {
+    const { activeSurvey } = useValues(feedbackSurveyWizardLogic)
+    const { viewSurvey } = useActions(feedbackSurveyWizardLogic)
+
+    const [activeTab, setActiveTab] = useState<'react' | 'other'>('react')
+
+    const followUpEnabled = (activeSurvey?.questions?.length ?? 0) > 1
+    const params = { surveyId: activeSurvey?.id, followUpEnabled }
+    const reactExample = getReactExample(params)
+    const otherExample = getManualCaptureExample(params)
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h3 className="text-lg font-semibold mb-3">Implement in your app</h3>
+                <div className="flex gap-2">
+                    <LemonButton
+                        type="primary"
+                        to="https://posthog.com/docs/ai-engineering"
+                        targetBlank
+                        disableClientSideRouting
+                    >
+                        Read the docs
+                    </LemonButton>
+                    <LemonButton
+                        type="secondary"
+                        to="https://github.com/PostHog/posthog/blob/e332d656667b8906410e93591a0f16633079efbd/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx#L112"
+                        targetBlank
+                        sideIcon={<IconArrowRight />}
+                    >
+                        See a real implementation in our codebase
+                    </LemonButton>
+                </div>
+            </div>
+
+            <LemonTabs
+                activeKey={activeTab}
+                onChange={setActiveTab}
+                tabs={[
+                    {
+                        key: 'react',
+                        label: 'React (useThumbSurvey)',
+                        content: (
+                            <div className="pt-4">
+                                <CodeSnippet language={Language.JSX} wrap>
+                                    {reactExample}
+                                </CodeSnippet>
+                            </div>
+                        ),
+                    },
+                    {
+                        key: 'other',
+                        label: 'Manual capture',
+                        content: (
+                            <div className="pt-4">
+                                <CodeSnippet language={Language.JavaScript} wrap>
+                                    {otherExample}
+                                </CodeSnippet>
+                                <p className="text-xs text-muted mt-2">
+                                    Send survey events directly.
+                                    {followUpEnabled ? " You'll need to build your own follow-up UI." : ''}
+                                </p>
+                            </div>
+                        ),
+                    },
+                ]}
+            />
+
+            <div className="flex justify-end">
+                <LemonButton type="primary" onClick={viewSurvey}>
+                    View survey
+                </LemonButton>
+            </div>
+        </div>
+    )
+}
+
+export function FeedbackSurveyWizard(): JSX.Element {
+    const { step, appearance, activeSurvey } = useValues(feedbackSurveyWizardLogic)
+
+    return (
+        <div className="space-y-6">
+            <WizardStepIndicator currentStep={step} />
+
+            {step === 'intro' && <IntroStep appearance={appearance} />}
+            {step === 'configure' && <ConfigureStep />}
+            {step === 'implement' && activeSurvey && <ImplementStep />}
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/feedback-view/wizard/codeExamples.ts
+++ b/products/llm_analytics/frontend/feedback-view/wizard/codeExamples.ts
@@ -1,0 +1,115 @@
+interface CodeExampleParams {
+    surveyId?: string
+    followUpEnabled: boolean
+}
+
+export function getReactExample({ surveyId = 'your-survey-id', followUpEnabled }: CodeExampleParams): string {
+    return `// requires @posthog/react X.XX.X+ (bundled with posthog-js 1.XXX.X+)
+import { useThumbSurvey } from 'posthog-js/react/surveys'
+
+function HedgehogBotResponse({ traceId }: { traceId: string }) {
+  const { respond, response${followUpEnabled ? ', triggerRef' : ''} } = useThumbSurvey({
+    surveyId: '${surveyId}', // ID for the survey you just created
+    properties: {
+      $ai_trace_id: traceId, // your generated trace ID
+      // add any other custom properties here
+    },
+  })
+
+  return (
+    <div>
+      <ChatBubble>You're absolutely right! I should have been using PostHog all along.</ChatBubble>
+
+      ${followUpEnabled ? '<div ref={triggerRef}> {/* PostHog followup pop-up anchors to triggerRef */}' : '<div>'}
+        <p>Was this response helpful?</p>
+        <button className={response === 'up' ? 'active' : ''} onClick={() => respond('up')}>👍</button>
+        <button className={response === 'down' ? 'active' : ''} onClick={() => respond('down')}>👎</button>
+      </div>
+
+    </div>
+  )
+}`
+}
+
+interface Prop {
+    key: string
+    value: string
+    comment?: string
+}
+
+const generateProps = (props: Prop[], indent = 2): string => {
+    const spaces = ' '.repeat(indent)
+    return props
+        .map(({ key, value, comment }) => `${spaces}${key}: ${value},${comment ? ` // ${comment}` : ''}`)
+        .join('\n')
+}
+
+export function getManualCaptureExample({ surveyId = 'your-survey-id', followUpEnabled }: CodeExampleParams): string {
+    const thumbsProps: Prop[] = [
+        { key: '$survey_id', value: `'${surveyId}'`, comment: 'ID for the survey you just created' },
+        { key: '$survey_response', value: '1', comment: '1 = thumbs up, 2 = thumbs down' },
+        { key: '$ai_trace_id', value: 'traceId', comment: 'your generated trace ID' },
+        ...(followUpEnabled
+            ? [
+                  {
+                      key: '$survey_submission_id',
+                      value: 'submissionId',
+                      comment: 'unique ID to link thumbs + follow-up',
+                  },
+                  {
+                      key: '$survey_completed',
+                      value: 'true',
+                      comment: 'or false if there is negative feedback followup',
+                  },
+              ]
+            : []),
+    ]
+
+    const surveyShownProps: Prop[] = [
+        { key: '$survey_id', value: `'${surveyId}'` },
+        { key: '$ai_trace_id', value: 'traceId' },
+    ]
+
+    const submissionIdLine = followUpEnabled
+        ? `// Generate a unique ID to link \`survey sent\` events into a single user feedback event
+const submissionId = crypto.randomUUID()
+
+`
+        : ''
+
+    const base = `// (Optional) Track when the survey is shown to the user
+posthog.capture('survey shown', {
+${generateProps(surveyShownProps)}
+})
+
+${submissionIdLine}// When user clicks thumbs up/down, send a survey event
+posthog.capture('survey sent', {
+${generateProps(thumbsProps)}
+})`
+
+    if (followUpEnabled) {
+        const followUpProps: Prop[] = [
+            { key: '$survey_id', value: `'${surveyId}'` },
+            { key: '$survey_response_1', value: "'the AI hallucinated hedgehogs everywhere'" },
+            { key: '$ai_trace_id', value: 'traceId' },
+            {
+                key: '$survey_submission_id',
+                value: 'submissionId',
+                comment: "must match the previous event's $survey_submission_id",
+            },
+            { key: '$survey_completed', value: 'true' },
+        ]
+
+        return (
+            base +
+            `
+
+// If the user submitted follow-up text after thumbs down:
+posthog.capture('survey sent', {
+${generateProps(followUpProps)}
+})`
+        )
+    }
+
+    return base
+}

--- a/products/llm_analytics/frontend/feedback-view/wizard/feedbackSurveyWizardLogic.ts
+++ b/products/llm_analytics/frontend/feedback-view/wizard/feedbackSurveyWizardLogic.ts
@@ -1,0 +1,244 @@
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { addProductIntent } from 'lib/utils/product-intents'
+import { SURVEY_CREATED_SOURCE, defaultSurveyAppearance } from 'scenes/surveys/constants'
+import { isThumbQuestion } from 'scenes/surveys/utils'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
+import { Survey, SurveyAppearance, SurveyQuestionBranchingType, SurveyQuestionType, SurveyType } from '~/types'
+
+import type { feedbackSurveyWizardLogicType } from './feedbackSurveyWizardLogicType'
+
+export type WizardStep = 'intro' | 'configure' | 'implement'
+
+const BASE_SURVEY_NAME = 'LLM feedback'
+
+function generateUniqueSurveyName(existingNames: Set<string>): string {
+    if (!existingNames.has(BASE_SURVEY_NAME.toLowerCase())) {
+        return BASE_SURVEY_NAME
+    }
+    let counter = 2
+    while (existingNames.has(`${BASE_SURVEY_NAME} (${counter})`.toLowerCase())) {
+        counter++
+    }
+    return `${BASE_SURVEY_NAME} (${counter})`
+}
+
+export const feedbackSurveyWizardLogic = kea<feedbackSurveyWizardLogicType>([
+    path(['scenes', 'llm-analytics', 'feedbackSurveyWizardLogic']),
+    connect({
+        values: [teamLogic, ['currentTeam']],
+        actions: [teamLogic, ['updateCurrentTeam']],
+    }),
+    actions({
+        setStep: (step: WizardStep) => ({ step }),
+        setSurveyName: (name: string) => ({ name }),
+        setFollowUpEnabled: (enabled: boolean) => ({ enabled }),
+        setFollowUpQuestion: (question: string) => ({ question }),
+        updateAppearance: (updates: Partial<SurveyAppearance>) => ({ updates }),
+        selectExistingSurvey: (survey: Survey) => ({ survey }),
+        viewSurvey: true,
+    }),
+    reducers({
+        step: [
+            'intro' as WizardStep,
+            {
+                setStep: (_, { step }) => step,
+                createSurveySuccess: () => 'implement' as WizardStep,
+                selectExistingSurvey: () => 'implement' as WizardStep,
+            },
+        ],
+        selectedSurvey: [
+            null as Survey | null,
+            {
+                selectExistingSurvey: (_, { survey }) => survey,
+            },
+        ],
+        surveyName: [
+            BASE_SURVEY_NAME as string,
+            {
+                setSurveyName: (_, { name }) => name,
+            },
+        ],
+        followUpEnabled: [
+            true,
+            {
+                setFollowUpEnabled: (_, { enabled }) => enabled,
+            },
+        ],
+        followUpQuestion: [
+            'What went wrong?',
+            {
+                setFollowUpQuestion: (_, { question }) => question,
+            },
+        ],
+        appearance: [
+            {} as SurveyAppearance,
+            {
+                updateAppearance: (state, { updates }) => ({ ...state, ...updates }),
+            },
+        ],
+    }),
+    loaders({
+        allSurveys: [
+            [] as Survey[],
+            {
+                loadAllSurveys: async () => {
+                    const response = await api.surveys.list()
+                    return response.results
+                },
+            },
+        ],
+        createdSurvey: [
+            null as Survey | null,
+            {
+                createSurvey: async () => {
+                    const { surveyName, followUpEnabled, followUpQuestion, appearance, surveysNeedEnabling } =
+                        feedbackSurveyWizardLogic.values
+
+                    // Enable surveys if not already enabled
+                    if (surveysNeedEnabling) {
+                        teamLogic.actions.updateCurrentTeam({ surveys_opt_in: true })
+                    }
+
+                    const questions: Survey['questions'] = [
+                        {
+                            type: SurveyQuestionType.Rating,
+                            question: 'Was this response helpful?', // not actually displayed, so not user-configurable
+                            display: 'emoji',
+                            scale: 2,
+                            lowerBoundLabel: '', // unused for thumb surveys
+                            upperBoundLabel: '', // unused for thumb surveys
+                            skipSubmitButton: true,
+                            ...(followUpEnabled
+                                ? {
+                                      branching: {
+                                          type: SurveyQuestionBranchingType.ResponseBased,
+                                          responseValues: {
+                                              positive: SurveyQuestionBranchingType.End,
+                                              negative: 1,
+                                          },
+                                      },
+                                  }
+                                : {}),
+                        },
+                    ]
+
+                    if (followUpEnabled) {
+                        questions.push({
+                            type: SurveyQuestionType.Open,
+                            question: followUpQuestion,
+                            optional: true,
+                        })
+                    }
+
+                    const survey = await api.surveys.create({
+                        name: surveyName || BASE_SURVEY_NAME,
+                        type: SurveyType.API,
+                        questions,
+                        appearance: followUpEnabled ? appearance : undefined,
+                        start_date: dayjs().toISOString(),
+                    })
+
+                    eventUsageLogic.actions.reportSurveyCreated(survey, false, 'llm_analytics')
+                    addProductIntent({
+                        product_type: ProductKey.SURVEYS,
+                        intent_context: ProductIntentContext.SURVEY_CREATED,
+                        metadata: {
+                            survey_id: survey.id,
+                            source: SURVEY_CREATED_SOURCE.LLM_ANALYTICS,
+                            created_successfully: true,
+                        },
+                    })
+
+                    return survey
+                },
+            },
+        ],
+    }),
+    selectors({
+        defaultAppearance: [
+            (s) => [s.currentTeam],
+            (currentTeam): SurveyAppearance => ({
+                ...defaultSurveyAppearance,
+                ...currentTeam?.survey_config?.appearance,
+            }),
+        ],
+        existingSurveyNames: [
+            (s) => [s.allSurveys],
+            (allSurveys): Set<string> => new Set(allSurveys.map((survey) => survey.name.toLowerCase())),
+        ],
+        nameIsDuplicate: [
+            (s) => [s.surveyName, s.existingSurveyNames],
+            (surveyName, existingSurveyNames): boolean =>
+                surveyName.trim() !== '' && existingSurveyNames.has(surveyName.trim().toLowerCase()),
+        ],
+        canCreateSurvey: [
+            (s) => [s.surveyName, s.nameIsDuplicate, s.followUpEnabled, s.followUpQuestion],
+            (surveyName, nameIsDuplicate, followUpEnabled, followUpQuestion): boolean =>
+                surveyName.trim() !== '' && !nameIsDuplicate && (!followUpEnabled || followUpQuestion.trim() !== ''),
+        ],
+        disabledReason: [
+            (s) => [s.surveyName, s.nameIsDuplicate, s.followUpEnabled, s.followUpQuestion],
+            (surveyName, nameIsDuplicate, followUpEnabled, followUpQuestion): string | undefined => {
+                if (nameIsDuplicate) {
+                    return 'A survey with this name already exists'
+                }
+                if (!surveyName.trim()) {
+                    return 'Survey name is required'
+                }
+                if (followUpEnabled && !followUpQuestion.trim()) {
+                    return 'Follow-up question is required'
+                }
+                return undefined
+            },
+        ],
+        eligibleSurveys: [
+            (s) => [s.allSurveys],
+            (allSurveys): Survey[] => {
+                return allSurveys
+                    .filter((survey) => {
+                        const firstQuestion = survey.questions?.[0]
+                        return survey.type === SurveyType.API && firstQuestion && isThumbQuestion(firstQuestion)
+                    })
+                    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+                    .slice(0, 3)
+            },
+        ],
+        activeSurvey: [
+            (s) => [s.createdSurvey, s.selectedSurvey],
+            (createdSurvey, selectedSurvey): Survey | null => createdSurvey ?? selectedSurvey,
+        ],
+        surveysNeedEnabling: [(s) => [s.currentTeam], (currentTeam): boolean => !currentTeam?.surveys_opt_in],
+    }),
+    listeners(({ actions, values }) => ({
+        loadAllSurveysSuccess: ({ allSurveys }) => {
+            const existingNames = new Set(allSurveys.map((s: Survey) => s.name.toLowerCase()))
+            actions.setSurveyName(generateUniqueSurveyName(existingNames))
+        },
+        createSurveySuccess: () => {
+            lemonToast.success('Survey created!')
+        },
+        createSurveyFailure: () => {
+            lemonToast.error('Failed to create survey')
+        },
+        viewSurvey: () => {
+            if (values.activeSurvey?.id) {
+                router.actions.push(urls.survey(values.activeSurvey.id))
+            }
+        },
+    })),
+    afterMount(({ actions, values }) => {
+        actions.loadAllSurveys()
+        actions.updateAppearance(values.defaultAppearance)
+    }),
+])

--- a/products/llm_analytics/frontend/llmAnalyticsTraceLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsTraceLogic.ts
@@ -42,6 +42,7 @@ export enum TraceViewMode {
     Summary = 'summary',
     Evals = 'evals',
     Clusters = 'clusters',
+    Feedback = 'feedback',
 }
 
 export interface LLMAnalyticsTraceDataNodeLogicParams {
@@ -129,6 +130,9 @@ export const llmAnalyticsTraceLogic = kea<llmAnalyticsTraceLogicType>([
                     }
                     if (tab === 'clusters') {
                         return TraceViewMode.Clusters
+                    }
+                    if (tab === 'feedback') {
+                        return TraceViewMode.Feedback
                     }
                     return TraceViewMode.Conversation
                 },


### PR DESCRIPTION
## Problem
we want to enable customers to collect user feedback for llm traces, and nicely integrate that feedback into llma

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

adds new survey workflow natively within llma

depends on updates to `useThumbSurvey`: https://github.com/PostHog/posthog-js/pull/3034

slightly outdated demo: https://screen.studio/share/YP18MYkC?state=uploading

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
yes? maybe? it's behind ff lol