### PR TITLE
fix: oauth redirect + team scope

### DIFF
--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -273,13 +273,14 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
         if application.is_first_party:
             try:
                 # Auto-approve with all user's accessible teams
-                credentials["scoped_teams"] = []
+                teams = Team.objects.filter(organization__members=request.user).values_list("pk", flat=True)
+                credentials["scoped_teams"] = list(teams)
                 credentials["scoped_organizations"] = []
 
                 uri, headers, body, status_code = self.create_authorization_response(
                     request=request, scopes=" ".join(scopes), credentials=credentials, allow=True
                 )
-                return Response({"redirect_uri": uri})
+                return self.redirect(uri, application)
             except OAuthToolkitError as error:
                 return self.error_response(error, application, state=request.query_params.get("state"))
 
@@ -295,7 +296,7 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
                         uri, headers, body, status_code = self.create_authorization_response(
                             request=request, scopes=" ".join(scopes), credentials=credentials, allow=True
                         )
-                        return Response({"redirect_uri": uri})
+                        return self.redirect(uri, application)
             except OAuthToolkitError as error:
                 return self.error_response(error, application, state=request.query_params.get("state"))
 


### PR DESCRIPTION
## Problem

Currently, first-party OAuth applications don't automatically include the user's teams in the authorization scope, and the redirect flow returns a JSON response instead of performing a proper redirect.

## Changes

- Modified the first-party OAuth flow to automatically include all of the user's accessible teams in the `scoped_teams` credential
- Changed the response handling to use the `redirect` method instead of returning a JSON response with a redirect URI for both first-party and pre-approved applications

## How did you test this code?

Tested the OAuth flow with first-party applications to verify that:
1. All user's teams are properly included in the scoped_teams credential
2. The redirect happens correctly instead of returning a JSON response
3. The flow works correctly for both first-party and pre-approved applications

## Publish to changelog?

No