### PR TITLE
fix(experiments): show breakdowns on metric error.

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -57,6 +57,34 @@ import {
 } from './constants'
 import { useAxisScale } from './useAxisScale'
 
+interface BreakdownErrorStateProps {
+    metric: ExperimentMetric
+    isAlternatingRow: boolean
+    onRemoveBreakdown: (index: number) => void
+}
+
+function BreakdownErrorState({ metric, isAlternatingRow, onRemoveBreakdown }: BreakdownErrorStateProps): JSX.Element {
+    return (
+        <tr data-breakdown-row className="hover:bg-bg-hover group [&:last-child>td]:border-b-0">
+            <td colSpan={7} className={`p-0 border-t border-b ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}>
+                <div className="p-1">
+                    <div className="flex items-center gap-2">
+                        {metric.breakdownFilter?.breakdowns?.map((breakdown, index) => (
+                            <BreakdownTag
+                                key={index}
+                                breakdown={breakdown.property}
+                                breakdownType={breakdown.type || 'event'}
+                                onClose={() => onRemoveBreakdown(index)}
+                                size="small"
+                            />
+                        ))}
+                    </div>
+                </div>
+            </td>
+        </tr>
+    )
+}
+
 interface CollapsibleBreakdownSectionProps {
     breakdownResults: any[]
     metric: ExperimentMetric
@@ -66,7 +94,6 @@ interface CollapsibleBreakdownSectionProps {
     isLastMetric: boolean
     isLoading?: boolean
     exposuresLoading?: boolean
-    error?: any
     colors: ReturnType<typeof useChartColors>
     scale: ReturnType<typeof useAxisScale>
     onRemoveBreakdown: (index: number) => void
@@ -83,7 +110,6 @@ function CollapsibleBreakdownSection({
     isAlternatingRow,
     isLoading,
     exposuresLoading,
-    error,
     colors,
     scale,
     onRemoveBreakdown,
@@ -189,7 +215,6 @@ function CollapsibleBreakdownSection({
                                                                         height={CELL_HEIGHT}
                                                                         experimentStarted={!!experiment.start_date}
                                                                         metric={metric}
-                                                                        error={error}
                                                                     />
                                                                 )}
                                                             </td>
@@ -623,51 +648,60 @@ export function MetricRowGroup({
 
     if (isLoading || error || !result || (!hasMinimumExposureForResults && !hasResultWithValidationFailures)) {
         return (
-            <tr
-                className="hover:bg-bg-hover group [&:last-child>td]:border-b-0"
-                style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
-            >
-                {/* Metric column - always visible */}
-                <td
-                    className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
-                        !isLastMetric ? 'border-b' : ''
-                    } ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                    style={{
-                        height: `${CELL_HEIGHT}px`,
-                        maxHeight: `${CELL_HEIGHT}px`,
-                    }}
-                >
-                    <MetricHeader
-                        displayOrder={displayOrder}
-                        metric={metric}
-                        metricType={metricType}
-                        isPrimaryMetric={!isSecondary}
-                        experiment={experiment}
-                        onDuplicateMetricClick={() => onDuplicateMetric?.()}
-                        onBreakdownChange={onBreakdownChange}
-                    />
-                </td>
-
-                {/* Combined columns for loading/error state */}
-                <td
-                    colSpan={6}
-                    className={`p-3 text-center ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${
-                        !isLastMetric ? 'border-b' : ''
-                    }`}
+            <>
+                <tr
+                    className="hover:bg-bg-hover group [&:last-child>td]:border-b-0"
                     style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
                 >
-                    {isLoading || exposuresLoading ? (
-                        <ChartLoadingState height={CELL_HEIGHT} />
-                    ) : (
-                        <ChartEmptyState
-                            height={CELL_HEIGHT}
-                            experimentStarted={!!experiment.start_date}
+                    {/* Metric column - always visible */}
+                    <td
+                        className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
+                            !isLastMetric ? 'border-b' : ''
+                        } ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
+                        style={{
+                            height: `${CELL_HEIGHT}px`,
+                            maxHeight: `${CELL_HEIGHT}px`,
+                        }}
+                    >
+                        <MetricHeader
+                            displayOrder={displayOrder}
                             metric={metric}
-                            error={error}
+                            metricType={metricType}
+                            isPrimaryMetric={!isSecondary}
+                            experiment={experiment}
+                            onDuplicateMetricClick={() => onDuplicateMetric?.()}
+                            onBreakdownChange={onBreakdownChange}
                         />
-                    )}
-                </td>
-            </tr>
+                    </td>
+
+                    {/* Combined columns for loading/error state */}
+                    <td
+                        colSpan={6}
+                        className={`p-3 text-center ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${
+                            !isLastMetric ? 'border-b' : ''
+                        }`}
+                        style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                    >
+                        {isLoading || exposuresLoading ? (
+                            <ChartLoadingState height={CELL_HEIGHT} />
+                        ) : (
+                            <ChartEmptyState
+                                height={CELL_HEIGHT}
+                                experimentStarted={!!experiment.start_date}
+                                metric={metric}
+                                error={error}
+                            />
+                        )}
+                    </td>
+                </tr>
+                {metric.breakdownFilter?.breakdowns && metric.breakdownFilter.breakdowns.length > 0 && (
+                    <BreakdownErrorState
+                        metric={metric}
+                        isAlternatingRow={isAlternatingRow}
+                        onRemoveBreakdown={onRemoveBreakdown}
+                    />
+                )}
+            </>
         )
     }
 
@@ -953,7 +987,6 @@ export function MetricRowGroup({
                     isLastMetric={isLastMetric}
                     isLoading={isLoading}
                     exposuresLoading={exposuresLoading}
-                    error={error}
                     colors={colors}
                     scale={scale}
                     onRemoveBreakdown={onRemoveBreakdown}


### PR DESCRIPTION
## Problem

When a metric fails to load, the breakdowns collapsible panel is not rendered. This breaks the expectation that a metric can be edited when it fails to load. Also, prevents the user from removing the breakdown of it was the cause of the failure.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

| before | after |
| - | - |
| <img width="1379" height="162" alt="image" src="https://github.com/user-attachments/assets/ebf134ba-a5dd-4ad4-b5e5-9c5279c6d7c1" /> | <img width="1373" height="197" alt="image" src="https://github.com/user-attachments/assets/15ec2f9e-94e6-4cb3-a639-40b33960ae93" /> |

We added a new component to display the error breakdown list and allow the user to perform removal operations. We chose this route because implementing `LemonCollapse` would require duplicating too much code.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/e9674c11-2cda-473c-81b4-ac17037e010d)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
