### PR TITLE
feat(product-tours): implement archive -> delete workflow like surveys

### DIFF
--- a/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
@@ -15,6 +15,7 @@ import { urls } from 'scenes/urls'
 
 import { ProductTour, ProgressStatus } from '~/types'
 
+import { canDeleteProductTour, openArchiveProductTourDialog, openDeleteProductTourDialog } from '../productTourDialogs'
 import {
     ProductToursTabs,
     getProductTourStatus,
@@ -244,70 +245,40 @@ export function ProductToursTable(): JSX.Element {
                                                     Unarchive
                                                 </LemonButton>
                                             )}
-                                            {tour.end_date && !tour.archived && (
+                                            {tour.start_date && !tour.archived && (
                                                 <LemonButton
                                                     fullWidth
-                                                    onClick={() => {
-                                                        LemonDialog.open({
-                                                            title: 'Archive this product tour?',
-                                                            content: (
-                                                                <div className="text-sm text-secondary">
-                                                                    This action will remove the tour from your active
-                                                                    tours list. It can be restored at any time.
-                                                                </div>
-                                                            ),
-                                                            primaryButton: {
-                                                                children: 'Archive',
-                                                                type: 'primary',
-                                                                onClick: () => {
-                                                                    updateProductTour({
-                                                                        id: tour.id,
-                                                                        updatePayload: {
-                                                                            archived: true,
-                                                                        },
-                                                                    })
-                                                                },
-                                                                size: 'small',
-                                                            },
-                                                            secondaryButton: {
-                                                                children: 'Cancel',
-                                                                type: 'tertiary',
-                                                                size: 'small',
-                                                            },
+                                                    onClick={() =>
+                                                        openArchiveProductTourDialog(tour, () => {
+                                                            const updatePayload: Partial<ProductTour> = {
+                                                                archived: true,
+                                                            }
+                                                            if (isProductTourRunning(tour)) {
+                                                                updatePayload.end_date = dayjs().toISOString()
+                                                            }
+                                                            updateProductTour({
+                                                                id: tour.id,
+                                                                updatePayload,
+                                                            })
                                                         })
-                                                    }}
+                                                    }
                                                 >
                                                     Archive
                                                 </LemonButton>
                                             )}
-                                            <LemonButton
-                                                status="danger"
-                                                onClick={() => {
-                                                    LemonDialog.open({
-                                                        title: 'Delete this product tour?',
-                                                        content: (
-                                                            <div className="text-sm text-secondary">
-                                                                This action cannot be undone. All tour data will be
-                                                                permanently removed.
-                                                            </div>
-                                                        ),
-                                                        primaryButton: {
-                                                            children: 'Delete',
-                                                            type: 'primary',
-                                                            onClick: () => deleteProductTour(tour.id),
-                                                            size: 'small',
-                                                        },
-                                                        secondaryButton: {
-                                                            children: 'Cancel',
-                                                            type: 'tertiary',
-                                                            size: 'small',
-                                                        },
-                                                    })
-                                                }}
-                                                fullWidth
-                                            >
-                                                Delete
-                                            </LemonButton>
+                                            {canDeleteProductTour(tour) && (
+                                                <LemonButton
+                                                    status="danger"
+                                                    onClick={() =>
+                                                        openDeleteProductTourDialog(tour, () =>
+                                                            deleteProductTour(tour.id)
+                                                        )
+                                                    }
+                                                    fullWidth
+                                                >
+                                                    Delete
+                                                </LemonButton>
+                                            )}
                                         </>
                                     }
                                 />

--- a/frontend/src/scenes/product-tours/productTourDialogs.tsx
+++ b/frontend/src/scenes/product-tours/productTourDialogs.tsx
@@ -1,0 +1,80 @@
+import { LemonDialog } from '@posthog/lemon-ui'
+
+import { ProductTour } from '~/types'
+
+import { isProductTourRunning } from './productToursLogic'
+
+export function openDeleteProductTourDialog(
+    tour: Pick<ProductTour, 'start_date'>,
+    onConfirm: () => void
+): void {
+    const isDraft = !tour.start_date
+    LemonDialog.open({
+        title: 'Permanently delete this product tour?',
+        content: isDraft ? (
+            <div className="text-sm text-secondary">
+                <strong>This action cannot be undone.</strong>
+            </div>
+        ) : (
+            <div className="text-sm text-secondary">
+                <p>
+                    <strong>This action cannot be undone.</strong>
+                </p>
+                <p className="mt-2">The tour configuration will be permanently deleted.</p>
+                <p className="mt-2 text-muted">Note: Tour interaction events in your data will not be affected.</p>
+            </div>
+        ),
+        primaryButton: {
+            children: 'Delete permanently',
+            type: 'primary',
+            status: 'danger',
+            onClick: onConfirm,
+            size: 'small',
+        },
+        secondaryButton: {
+            children: 'Cancel',
+            type: 'tertiary',
+            size: 'small',
+        },
+    })
+}
+
+export function openArchiveProductTourDialog(
+    tour: Pick<ProductTour, 'start_date' | 'end_date'>,
+    onConfirm: () => void
+): void {
+    const isRunning = isProductTourRunning(tour)
+    LemonDialog.open({
+        title: 'Archive this product tour?',
+        content: isRunning ? (
+            <div className="text-sm text-secondary">
+                <p>This tour is currently running. Archiving will:</p>
+                <ul className="list-disc ml-4 mt-2">
+                    <li>Stop the tour immediately</li>
+                    <li>Remove it from your active tours list</li>
+                </ul>
+                <p className="mt-2">You can restore this tour at any time from the Archived tab.</p>
+            </div>
+        ) : (
+            <div className="text-sm text-secondary">
+                This will remove the tour from your active tours list. You can restore it at any time from the Archived
+                tab.
+            </div>
+        ),
+        primaryButton: {
+            children: isRunning ? 'Stop and archive' : 'Archive',
+            type: 'primary',
+            onClick: onConfirm,
+            size: 'small',
+        },
+        secondaryButton: {
+            children: 'Cancel',
+            type: 'tertiary',
+            size: 'small',
+        },
+    })
+}
+
+export function canDeleteProductTour(tour: Pick<ProductTour, 'archived' | 'start_date'>): boolean {
+    return tour.archived || !tour.start_date
+}


### PR DESCRIPTION
- Add productTourDialogs.tsx with canDeleteProductTour, openDeleteProductTourDialog, and openArchiveProductTourDialog functions
- Update ProductToursTable.tsx to show Archive button for all launched tours (not just stopped ones), with proper warning for running tours
- Delete button now only shows for draft or archived tours (matching survey behavior)
- Change backend destroy method from soft delete to hard delete (permanent removal)
- Archive is now done via PATCH update (setting archived: true)

This matches the survey workflow where launched tours must be archived first before they can be permanently deleted.

https://claude.ai/code/session_01T3TXuCh9rR8ZHQUXqwJ9Wd

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
