### PR TITLE
fix(surveys): fix broken types in getSurveyResponse

### DIFF
--- a/posthog/hogql/functions/survey.py
+++ b/posthog/hogql/functions/survey.py
@@ -76,13 +76,15 @@ def _build_index_based_key(question_index: int) -> str:
 
 
 def _build_property_access(key: str | ast.Expr) -> ast.Expr:
-    """Build property access expression. Uses ast.Field for static keys (enables materialization)."""
-    if isinstance(key, str):
-        return ast.Field(chain=["properties", key])
-    # Dynamic key - must use JSONExtractString
+    """Build property access expression.
+
+    Always uses JSONExtractString to ensure consistent String return type.
+    This avoids type mismatches when PropertySwapper would wrap ast.Field
+    accesses with type conversion functions (e.g., toFloat for Numeric properties).
+    """
     return ast.Call(
         name="JSONExtractString",
-        args=[ast.Field(chain=["properties"]), key],
+        args=[ast.Field(chain=["properties"]), _key_as_expr(key)],
     )
 
 

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -55,6 +55,7 @@ from posthog.clickhouse.client.execute import sync_execute
 from posthog.models import PropertyDefinition
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.exchange_rate.sql import EXCHANGE_RATE_DICTIONARY_NAME
+from posthog.models.property_definition import PropertyType
 from posthog.models.team.team import WeekStartDay
 from posthog.settings.data_stores import CLICKHOUSE_DATABASE
 
@@ -2575,34 +2576,72 @@ class TestPrinter(BaseTest):
 
     def test_get_survey_response(self):
         # Test with just question index (0) - dynamic key
-        printed = self._print(
-            "select getSurveyResponse(0) from events",
-            settings=HogQLGlobalSettings(max_execution_time=10),
+        result = execute_hogql_query(
+            team=self.team,
+            query="SELECT getSurveyResponse(0) FROM events",
         )
+        assert result.clickhouse is not None
         # Dynamic key (no question_id) uses concat for key construction
-        self.assertIn("coalesce", printed)
-        self.assertIn("nullIf", printed)
-        self.assertIn("concat", printed)
+        self.assertIn("coalesce", result.clickhouse)
+        self.assertIn("nullIf", result.clickhouse)
+        self.assertIn("concat", result.clickhouse)
+        # Always uses JSONExtractString for consistent String return type
+        self.assertIn("JSONExtractString", result.clickhouse)
 
-        # Test with question index and specific ID - static key uses ast.Field
-        printed = self._print(
-            "select getSurveyResponse(1, 'question123') from events",
-            settings=HogQLGlobalSettings(max_execution_time=10),
+        # Test with question index and specific ID - static key
+        result = execute_hogql_query(
+            team=self.team,
+            query="SELECT getSurveyResponse(1, 'question123') FROM events",
         )
-        # Static key uses ast.Field which resolves to JSONExtractRaw (enables materialization)
-        self.assertIn("coalesce", printed)
-        self.assertIn("nullIf", printed)
-        self.assertIn("JSONExtractRaw", printed)
+        assert result.clickhouse is not None
+        # Static key also uses JSONExtractString for type consistency
+        self.assertIn("coalesce", result.clickhouse)
+        self.assertIn("nullIf", result.clickhouse)
+        self.assertIn("JSONExtractString", result.clickhouse)
 
         # Test with multiple choice question
-        printed = self._print(
-            "select getSurveyResponse(2, 'abc123', true) from events",
-            settings=HogQLGlobalSettings(max_execution_time=10),
+        result = execute_hogql_query(
+            team=self.team,
+            query="SELECT getSurveyResponse(2, 'abc123', true) FROM events",
         )
+        assert result.clickhouse is not None
         # Multiple choice uses if() with JSONHas and JSONExtractArrayRaw
-        self.assertIn("JSONHas", printed)
-        self.assertIn("JSONExtractArrayRaw", printed)
-        self.assertIn("if(", printed)
+        self.assertIn("JSONHas", result.clickhouse)
+        self.assertIn("JSONExtractArrayRaw", result.clickhouse)
+        self.assertIn("if(", result.clickhouse)
+
+    def test_get_survey_response_with_numeric_property_type(self):
+        """Test that getSurveyResponse returns consistent types even when property has Numeric type.
+
+        Regression test for a bug where PropertySwapper would wrap the index-based
+        property access with toFloat() when $survey_response had type=Numeric in
+        PropertyDefinition, causing a ClickHouse type mismatch error:
+        "There is no supertype for types String, Float64"
+        """
+        PropertyDefinition.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            name="$survey_response",
+            property_type=PropertyType.Numeric,
+            type=PropertyDefinition.Type.EVENT,
+        )
+
+        # This should NOT raise a ClickHouse error about type mismatch
+        # Before the fix, this would fail with:
+        # "There is no supertype for types String, Float64 because some of them
+        # are String/FixedString/Enum and some of them are not"
+        result = execute_hogql_query(
+            team=self.team,
+            query="SELECT getSurveyResponse(0) FROM events",
+        )
+
+        # Query should execute successfully (even with no results)
+        assert result.clickhouse is not None
+        # Both branches of coalesce should return String type (via JSONExtractString)
+        self.assertIn("JSONExtractString", result.clickhouse)
+        # Should NOT contain Float64 casting which would cause type mismatch
+        self.assertNotIn("accurateCastOrNull", result.clickhouse)
+        self.assertNotIn("Float64", result.clickhouse)
 
     def test_unique_survey_submissions_filter(self):
         printed = self._print(


### PR DESCRIPTION
## Problem

`getSurveyResponse` hogql function fails when `$survey_response_n` properties are numeric type

in the past, this function used `JSONExtractString` for all properties - [this refactor](https://github.com/PostHog/posthog/commit/0f1c02324ff2dc3e68568fb15342794ea88525c3#diff-e39caadf813834ed88e9b55685fe1d7fa83e16b99d7db4c66f969f9017538f7e) uses `ast.Field` which goes through `PropertySwapper`, meaning any numeric properties are cast to float, resulting in a clickhouse type error in `coalesce(string, float64)`

sample error ([ticket](https://posthoghelp.zendesk.com/agent/tickets/48741)):

```
There is no supertype for types String, Float64 because some of them are String/FixedString/Enum and some of them are not: In scope SELECT if(has(e.person_properties_map_custom, 'name'), e.person_properties_map_custom['name'], NULL) AS Name, nullIf(nullIf(e.mat_distinct_id, ''), 'null') AS Email FROM events AS e WHERE (e.team_id = 86439) AND (e.event = 'survey sent') AND (e.`mat_$survey_id` = '019a2bf3-7a8a-0000-5072-d431482caad7') AND ifNull(coalesce(nullIf(JSONExtractString(e.properties, concat('$survey_response_', ifNull(toString(JSONExtractString(JSONExtractArrayRaw(e.properties, '$survey_questions')[1], 'id')), ''))), ''), nullIf(accurateCastOrNull(nullIf(nullIf(e.`mat_$survey_response`, ''), 'null'), 'Float64'), '')) > 0, 0) ORDER BY toTimeZone(e.timestamp, 'UTC') DESC LIMIT 0, 101 SETTINGS readonly = 2, max_execution_time = 600, allow_experimental_object_type = 1, format_csv_allow_double_quotes = 0, max_ast_elements = 4000000, max_expanded_ast_elements = 4000000, max_bytes_before_external_group_by = 0, allow_experimental_analyzer = 1, transform_null_in = 1, optimize_min_equality_disjunction_chain_length = 4294967295, allow_experimental_join_condition = 1, use_hive_partitioning = 0.
```

i think we lose the materialization optimization here, but need to mitigate the impact before optimizing :p 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
