### PR TITLE
chore(flags): add source field to feature flag created analytics

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -853,8 +853,9 @@ class FeatureFlagSerializer(
 
         analytics_metadata = instance.get_analytics_metadata()
         analytics_metadata["creation_context"] = creation_context
-        # SessionAuthentication is the default (and only) authentication class for web requests
-        # If that ever changes (seems unlikely), we'll need to update this.
+        # SessionAuthentication is used for standard browser-based web UI requests.
+        # All other authentication methods (API keys, OAuth tokens, toolbar tokens, etc.)
+        # are classified as "api" for analytics purposes.
         is_web_auth = isinstance(request.successful_authenticator, SessionAuthentication)
         analytics_metadata["source"] = "web" if is_web_auth else "api"
         report_user_action(request.user, "feature flag created", analytics_metadata)

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -34,7 +34,12 @@ from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSet
 from posthog.api.utils import ClassicBehaviorBooleanFieldSerializer, action
 from posthog.approvals.decorators import approval_gate
 from posthog.approvals.mixins import ApprovalHandlingMixin
-from posthog.auth import PersonalAPIKeyAuthentication, ProjectSecretAPIKeyAuthentication, TemporaryTokenAuthentication
+from posthog.auth import (
+    PersonalAPIKeyAuthentication,
+    ProjectSecretAPIKeyAuthentication,
+    SessionAuthentication,
+    TemporaryTokenAuthentication,
+)
 from posthog.constants import PRODUCT_TOUR_TARGETING_FLAG_PREFIX, SURVEY_TARGETING_FLAG_PREFIX, FlagRequestType
 from posthog.date_util import thirty_days_ago
 from posthog.event_usage import report_user_action
@@ -848,6 +853,10 @@ class FeatureFlagSerializer(
 
         analytics_metadata = instance.get_analytics_metadata()
         analytics_metadata["creation_context"] = creation_context
+        # SessionAuthentication is the default (and only) authentication class for web requests
+        # If that ever changes (seems unlikely), we'll need to update this.
+        is_web_auth = isinstance(request.successful_authenticator, SessionAuthentication)
+        analytics_metadata["source"] = "web" if is_web_auth else "api"
         report_user_action(request.user, "feature flag created", analytics_metadata)
 
         return instance

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -122,6 +122,7 @@ class TestSurvey(APIBaseTest):
                 "aggregating_by_groups": False,
                 "payload_count": 0,
                 "creation_context": "surveys",
+                "source": "web",
             },
         )
 

--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -72,6 +72,7 @@ class TestWebExperiment(APIBaseTest):
                 "aggregating_by_groups": False,
                 "payload_count": 0,
                 "creation_context": "web_experiments",
+                "source": "web",
             },
         )
 

--- a/products/early_access_features/backend/test/test_early_access_feature.py
+++ b/products/early_access_features/backend/test/test_early_access_feature.py
@@ -652,6 +652,7 @@ class TestEarlyAccessFeature(APIBaseTest):
                 "aggregating_by_groups": False,
                 "payload_count": 0,
                 "creation_context": "early_access_features",
+                "source": "web",
             },
         )
 


### PR DESCRIPTION
## Problem

We have no idea how many flags are created by the API vs the UI other than its possible to create invalid flags via the API.

## Changes

Adds a "source" field to the "feature flag created" analytics event.

## How did you test this code?

Unit Test

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No. It's an observability improvement.