### PR TITLE
fix(llm-analytics): fall back to raw content

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/XMLViewer.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/XMLViewer.tsx
@@ -17,8 +17,8 @@ interface XMLViewerProps {
 export function XMLViewer({ children: xmlContent, collapsed = 3 }: XMLViewerProps): JSX.Element {
     const parsedXML = parseXML(xmlContent)
 
-    if (!parsedXML) {
-        return <span className="font-mono whitespace-pre-wrap text-danger">Invalid XML content</span>
+    if (!parsedXML || parsedXML.length === 0) {
+        return <span className="font-mono whitespace-pre-wrap">{xmlContent}</span>
     }
 
     return (


### PR DESCRIPTION
### Problem

- Tool responses with HTML in them showed "Invalid XML content" when XML highlighting was on.

### Changes

- On parse failure, show the raw content instead of that error.

### How did you test this code?

- Turned on XML highlighting on a trace with a tool response that had HTML; content displayed correctly.

fix: #46759
