### PR TITLE
feat(ai): add object-level access control for insights and dashboards

### DIFF
--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -121,7 +121,6 @@ class MaxTool(AssistantContextMixin, AssistantDispatcherMixin, BaseTool):
     # -------------------------------------------------------------------------
     # Access Control (Resource-level)
     # -------------------------------------------------------------------------
-    # TODO: Implement object-level access check after retrieval in the ArtifactManager
 
     @cached_property
     def user_access_control(self) -> UserAccessControl:

--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -17,6 +17,7 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 
 from posthog.models import Dashboard, Team, User
+from posthog.rbac.user_access_control import AccessControlLevel
 from posthog.sync import database_sync_to_async
 
 from ee.hogai.artifacts.types import ModelArtifactResult
@@ -27,7 +28,7 @@ from ee.hogai.context.error_tracking import ErrorTrackingIssueContext
 from ee.hogai.context.insight.context import InsightContext
 from ee.hogai.context.survey import SurveyContext
 from ee.hogai.tool import MaxTool, ToolMessagesArtifact
-from ee.hogai.tool_errors import MaxToolFatalError, MaxToolRetryableError
+from ee.hogai.tool_errors import MaxToolAccessDeniedError, MaxToolFatalError, MaxToolRetryableError
 from ee.hogai.tools.read_billing_tool.tool import ReadBillingTool
 from ee.hogai.tools.read_data.prompts import (
     BILLING_INSUFFICIENT_ACCESS_PROMPT,
@@ -190,6 +191,13 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
             context_manager=context_manager,
         )
 
+    async def _check_object_access(self, obj, required_level: AccessControlLevel, resource: str) -> None:
+        has_access = await database_sync_to_async(self.user_access_control.check_access_level_for_object)(
+            obj, required_level
+        )
+        if not has_access:
+            raise MaxToolAccessDeniedError(resource, required_level, action="read")
+
     async def _arun_impl(self, query: dict) -> tuple[str, ToolMessagesArtifact | None]:
         validated_query = _InternalReadDataToolArgs(query=query).query
         match validated_query:
@@ -229,6 +237,9 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
 
         if result is None:
             raise MaxToolRetryableError(INSIGHT_NOT_FOUND_PROMPT.format(short_id=artifact_or_insight_id))
+
+        if isinstance(result, ModelArtifactResult):
+            await self._check_object_access(result.model, "viewer", "insight")
 
         insight_name = result.content.name or f"Insight {artifact_or_insight_id}"
 
@@ -344,6 +355,8 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
             )
         except (Dashboard.DoesNotExist, ValueError):
             raise MaxToolFatalError(DASHBOARD_NOT_FOUND_PROMPT.format(dashboard_id=dashboard_id))
+
+        await self._check_object_access(dashboard, "viewer", "dashboard")
 
         dashboard_name = dashboard.name or f"Dashboard {dashboard_id}"
         tiles = [


### PR DESCRIPTION
The read_data tool now respects RBAC object-level permissions when fetching insights and dashboards, consistent with the main API.
