### PR TITLE
chore(llma): add a project to Llm analytics allow list for clustering 

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -86,6 +86,7 @@ ALLOWED_TEAM_IDS: list[int] = [
     140227,
     237906,
     294356,
+    21999,
 ]
 
 # Cluster labeling agent configuration

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -64,6 +64,7 @@ ALLOWED_TEAM_IDS: list[int] = [
     140227,
     237906,
     294356,
+    21999,
 ]
 
 # Temporal configuration


### PR DESCRIPTION
## Problem

This PR adds team ID `21999` to the allow list for LLM analytics summarization and clustering temporal workflows, enabling this team to utilize these features.

## Changes

Added `21999` to the `ALLOWED_TEAM_IDS` list in:
- `posthog/temporal/llm_analytics/trace_summarization/constants.py`
- `posthog/temporal/llm_analytics/trace_clustering/constants.py`

## How did you test this code?

This is a configuration update. No specific automated tests were added. Manual verification would involve confirming that team `21999` can now access and use the LLM analytics summarization and clustering features.

## Publish to changelog?

no

---
<a href="https://cursor.com/background-agent?bcId=bc-1fc9c399-e43a-48ca-a27d-d6cec4b34328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1fc9c399-e43a-48ca-a27d-d6cec4b34328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

