### PR TITLE
fix(hobby): handle detached HEAD in installer

### DIFF
--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -33,6 +33,7 @@ jobs:
         name: Determine need to run hobby checks
         outputs:
             should_run: ${{ steps.filter.outputs.hobby == 'true' || steps.check-label.outputs.has_label == 'true' }}
+            installer_changed: ${{ steps.filter.outputs.installer }}
             label_removed: ${{ steps.check-label.outputs.label_removed }}
         steps:
             - uses: actions/checkout@v6
@@ -46,9 +47,12 @@ jobs:
                         - docker-compose.base.yml
                         - docker-compose.hobby.yml
                         - 'bin/*'
+                        - 'bin/hobby-installer/**'
                         - 'docker/*'
                         - uv.lock
                         - .github/workflows/ci-hobby.yml
+                      installer:
+                        - 'bin/hobby-installer/**'
 
             - name: Check for preview label
               id: check-label
@@ -309,6 +313,7 @@ jobs:
                   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
                   DIGITALOCEAN_TOKEN: ${{ secrets.DIGITAL_OCEAN_HOBBY_TOKEN }}
                   DIGITALOCEAN_SSH_PRIVATE_KEY: ${{ secrets.DO_DEPLOY_SSH_PRIVATE_KEY }}
+                  INSTALLER_CHANGED: ${{ needs.changes.outputs.installer_changed || 'false' }}
             - name: Update comment - Instance created
               if: env.PREVIEW_MODE == 'true' && env.HOBBY_COMMENT_ID
               uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -140,6 +140,7 @@ class HobbyTester:
                 'echo "$LOG_PREFIX Building hobby installer from source (installer code changed)..."',
                 "curl -fsSL https://go.dev/dl/go1.24.0.linux-$(dpkg --print-architecture).tar.gz | tar -C /usr/local -xzf -",
                 "export PATH=$PATH:/usr/local/go/bin",
+                "export GOPATH=/tmp/go",
                 "cd posthog/bin/hobby-installer && go build -o /tmp/hobby-installer . && cd ../../..",
                 "cp /tmp/hobby-installer hobby-installer",
                 "chmod +x hobby-installer",

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -108,6 +108,7 @@ class HobbyTester:
             "fi"
         )
 
+<<<<<<< HEAD
     def _get_resolve_node_tag_script(self):
         """Return bash script to resolve the node image tag.
         The node container build only runs when node-related files change, so
@@ -123,6 +124,23 @@ class HobbyTester:
             "else "
             "  export POSTHOG_NODE_TAG=latest; "
             '  echo "$LOG_PREFIX Node image not found for commit, falling back to tag: latest"; '
+=======
+    def _get_node_image_fallback_script(self):
+        """Return bash script to check if posthog-node image exists on DockerHub.
+
+        If the node image doesn't exist for this commit (it's only built when
+        node files change), rewrite the compose file to use :latest for the
+        plugins service so that docker compose pull doesn't fail.
+        """
+        return (
+            'if curl -sf "https://hub.docker.com/v2/repositories/posthog/posthog-node/tags/$CURRENT_COMMIT" > /dev/null 2>&1; then '
+            '  echo "$LOG_PREFIX posthog-node:$CURRENT_COMMIT found on DockerHub"; '
+            "else "
+            '  echo "$LOG_PREFIX posthog-node:$CURRENT_COMMIT not found, using latest for plugins service"; '
+            "  sed -i "
+            '"s|\\${REGISTRY_URL}-node:\\${POSTHOG_APP_TAG}|posthog/posthog-node:latest|g" '
+            "posthog/docker-compose.hobby.yml; "
+>>>>>>> 80124ba1dd (fix(hobby) pull latest images as fallback so that hobby CI is less flaky)
             "fi"
         )
 
@@ -183,7 +201,11 @@ runcmd:
             "cd ..",
             'echo "$LOG_PREFIX Waiting for docker image to be available on DockerHub..."',
             self._get_wait_for_image_script(),
+<<<<<<< HEAD
             self._get_resolve_node_tag_script(),
+=======
+            self._get_node_image_fallback_script(),
+>>>>>>> 80124ba1dd (fix(hobby) pull latest images as fallback so that hobby CI is less flaky)
             *self._get_installer_commands(),
             'echo "$LOG_PREFIX Starting hobby installer (CI mode)"',
             f"./hobby-installer --ci --domain {safe_hostname} --version $CURRENT_COMMIT",

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -108,23 +108,6 @@ class HobbyTester:
             "fi"
         )
 
-<<<<<<< HEAD
-    def _get_resolve_node_tag_script(self):
-        """Return bash script to resolve the node image tag.
-        The node container build only runs when node-related files change, so
-        posthog/posthog-node:<sha> may not exist for most commits. This checks
-        DockerHub and falls back to 'latest' if the commit-specific tag is missing.
-        Returns a single-line bash command suitable for YAML runcmd.
-        """
-        return (
-            'echo "$LOG_PREFIX Checking if node image exists for commit $CURRENT_COMMIT..."; '
-            'if curl -sf "https://hub.docker.com/v2/repositories/posthog/posthog-node/tags/$CURRENT_COMMIT" > /dev/null 2>&1; then '
-            "  export POSTHOG_NODE_TAG=$CURRENT_COMMIT; "
-            '  echo "$LOG_PREFIX Node image found for commit, using tag: $CURRENT_COMMIT"; '
-            "else "
-            "  export POSTHOG_NODE_TAG=latest; "
-            '  echo "$LOG_PREFIX Node image not found for commit, falling back to tag: latest"; '
-=======
     def _get_node_image_fallback_script(self):
         """Return bash script to check if posthog-node image exists on DockerHub.
 
@@ -142,7 +125,6 @@ class HobbyTester:
             "sed -i "
             "'s|${REGISTRY_URL}-node:${POSTHOG_APP_TAG}|posthog/posthog-node:latest|g' "
             "posthog/docker-compose.hobby.yml; "
->>>>>>> 80124ba1dd (fix(hobby) pull latest images as fallback so that hobby CI is less flaky)
             "fi"
         )
 
@@ -203,11 +185,7 @@ runcmd:
             "cd ..",
             'echo "$LOG_PREFIX Waiting for docker image to be available on DockerHub..."',
             self._get_wait_for_image_script(),
-<<<<<<< HEAD
-            self._get_resolve_node_tag_script(),
-=======
             self._get_node_image_fallback_script(),
->>>>>>> 80124ba1dd (fix(hobby) pull latest images as fallback so that hobby CI is less flaky)
             *self._get_installer_commands(),
             'echo "$LOG_PREFIX Starting hobby installer (CI mode)"',
             f"./hobby-installer --ci --domain {safe_hostname} --version $CURRENT_COMMIT",

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -133,12 +133,14 @@ class HobbyTester:
         plugins service so that docker compose pull doesn't fail.
         """
         return (
-            'if curl -sf "https://hub.docker.com/v2/repositories/posthog/posthog-node/tags/$CURRENT_COMMIT" > /dev/null 2>&1; then '
-            '  echo "$LOG_PREFIX posthog-node:$CURRENT_COMMIT found on DockerHub"; '
+            "if curl -sf "
+            "https://hub.docker.com/v2/repositories/posthog/posthog-node/tags/$CURRENT_COMMIT "
+            "> /dev/null 2>&1; then "
+            "echo posthog-node image found on DockerHub; "
             "else "
-            '  echo "$LOG_PREFIX posthog-node:$CURRENT_COMMIT not found, using latest for plugins service"; '
-            "  sed -i "
-            '"s|\\${REGISTRY_URL}-node:\\${POSTHOG_APP_TAG}|posthog/posthog-node:latest|g" '
+            "echo posthog-node image not found, using latest for plugins service; "
+            "sed -i "
+            "'s|${REGISTRY_URL}-node:${POSTHOG_APP_TAG}|posthog/posthog-node:latest|g' "
             "posthog/docker-compose.hobby.yml; "
 >>>>>>> 80124ba1dd (fix(hobby) pull latest images as fallback so that hobby CI is less flaky)
             "fi"

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -141,6 +141,7 @@ class HobbyTester:
                 "curl -fsSL https://go.dev/dl/go1.24.0.linux-$(dpkg --print-architecture).tar.gz | tar -C /usr/local -xzf -",
                 "export PATH=$PATH:/usr/local/go/bin",
                 "export GOPATH=/tmp/go",
+                "export GOCACHE=/tmp/go-cache",
                 "cd posthog/bin/hobby-installer && go build -o /tmp/hobby-installer . && cd ../../..",
                 "cp /tmp/hobby-installer hobby-installer",
                 "chmod +x hobby-installer",

--- a/bin/hobby-installer/core/git.go
+++ b/bin/hobby-installer/core/git.go
@@ -10,6 +10,12 @@ import (
 
 const posthogRepoURL = "https://github.com/PostHog/posthog.git"
 
+// Function variables for testability - tests swap these to mock command execution
+var (
+	runCmd    = RunCommand
+	runCmdDir = RunCommandWithDir
+)
+
 func ClonePostHog() error {
 	logger := GetLogger()
 
@@ -19,7 +25,7 @@ func ClonePostHog() error {
 	}
 
 	logger.WriteString("Cloning PostHog repository...\n")
-	_, err := RunCommand("git", "clone", "--filter=blob:none", posthogRepoURL)
+	_, err := runCmd("git", "clone", "--filter=blob:none", posthogRepoURL)
 	if err == nil {
 		logger.WriteString("Repository cloned successfully\n")
 	}
@@ -34,26 +40,21 @@ func UpdatePostHog() error {
 	}
 
 	logger.WriteString("Fetching latest changes...\n")
-	_, err := RunCommandWithDir("posthog", "git", "fetch", "--prune")
+	_, err := runCmdDir("posthog", "git", "fetch", "--prune")
 	if err != nil {
 		return err
 	}
 
-	// Check if we're on a branch or detached HEAD
-	branch, err := RunCommandWithDir("posthog", "git", "branch", "--show-current")
-	if err != nil {
-		return err
-	}
-	branch = strings.TrimSpace(branch)
-
-	if branch == "" {
-		// Detached HEAD (e.g., CI checked out a specific commit) - skip pull
-		logger.WriteString("On detached HEAD, skipping pull\n")
+	// Check if on a branch before pulling - detached HEAD can't pull
+	// This happens when CI checks out a specific commit SHA
+	branch, _ := runCmdDir("posthog", "git", "branch", "--show-current")
+	if strings.TrimSpace(branch) == "" {
+		logger.WriteString("On detached HEAD, skipping pull (CheckoutVersion will handle it)\n")
 		return nil
 	}
 
 	logger.WriteString("Pulling updates...\n")
-	_, err = RunCommandWithDir("posthog", "git", "pull")
+	_, err = runCmdDir("posthog", "git", "pull")
 	return err
 }
 
@@ -80,37 +81,37 @@ func CheckoutVersion(version string) error {
 }
 
 func checkoutLatest() error {
-	if _, err := RunCommandWithDir("posthog", "git", "fetch", "origin"); err != nil {
+	if _, err := runCmdDir("posthog", "git", "fetch", "origin"); err != nil {
 		return err
 	}
 
-	branch, err := RunCommandWithDir("posthog", "git", "branch", "--show-current")
+	branch, err := runCmdDir("posthog", "git", "branch", "--show-current")
 	if err != nil {
 		return err
 	}
 	branch = strings.TrimSpace(branch)
 
 	if branch != "" {
-		_, err = RunCommandWithDir("posthog", "git", "reset", "--hard", "origin/"+branch)
+		_, err = runCmdDir("posthog", "git", "reset", "--hard", "origin/"+branch)
 	}
 	return err
 }
 
 func checkoutLatestRelease() error {
-	if _, err := RunCommandWithDir("posthog", "git", "fetch", "--tags"); err != nil {
+	if _, err := runCmdDir("posthog", "git", "fetch", "--tags"); err != nil {
 		return err
 	}
 
-	out, err := RunCommandWithDir("posthog", "git", "describe", "--tags", "--abbrev=0")
+	out, err := runCmdDir("posthog", "git", "describe", "--tags", "--abbrev=0")
 	if err != nil {
-		out, err = RunCommandWithDir("posthog", "sh", "-c", "git describe --tags $(git rev-list --tags --max-count=1)")
+		out, err = runCmdDir("posthog", "sh", "-c", "git describe --tags $(git rev-list --tags --max-count=1)")
 		if err != nil {
 			return fmt.Errorf("no release tags found")
 		}
 	}
 	tag := strings.TrimSpace(out)
 
-	_, err = RunCommandWithDir("posthog", "git", "checkout", tag)
+	_, err = runCmdDir("posthog", "git", "checkout", tag)
 	return err
 }
 
@@ -118,21 +119,21 @@ func checkoutSpecific(version string) error {
 	isCommit := regexp.MustCompile(`^[0-9a-f]{40}$`).MatchString(version)
 
 	if isCommit {
-		_, err := RunCommandWithDir("posthog", "git", "checkout", version)
+		_, err := runCmdDir("posthog", "git", "checkout", version)
 		return err
 	}
 
-	if _, err := RunCommandWithDir("posthog", "git", "fetch", "--tags"); err != nil {
+	if _, err := runCmdDir("posthog", "git", "fetch", "--tags"); err != nil {
 		return err
 	}
 
 	releaseTag := strings.TrimPrefix(version, "release-")
-	_, err := RunCommandWithDir("posthog", "git", "checkout", releaseTag)
+	_, err := runCmdDir("posthog", "git", "checkout", releaseTag)
 	return err
 }
 
 func GetCurrentCommit() (string, error) {
-	out, err := RunCommandWithDir("posthog", "git", "rev-parse", "--short", "HEAD")
+	out, err := runCmdDir("posthog", "git", "rev-parse", "--short", "HEAD")
 	if err != nil {
 		return "", err
 	}

--- a/bin/hobby-installer/core/git_test.go
+++ b/bin/hobby-installer/core/git_test.go
@@ -1,0 +1,206 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+type mockCmdRunner struct {
+	calls     []string
+	responses map[string]mockResponse
+}
+
+type mockResponse struct {
+	output string
+	err    error
+}
+
+func newMockRunner() *mockCmdRunner {
+	return &mockCmdRunner{responses: make(map[string]mockResponse)}
+}
+
+func (m *mockCmdRunner) runCmdDir(dir string, name string, args ...string) (string, error) {
+	key := fmt.Sprintf("%s:%s %s", dir, name, strings.Join(args, " "))
+	m.calls = append(m.calls, key)
+	if resp, ok := m.responses[key]; ok {
+		return resp.output, resp.err
+	}
+	return "", nil
+}
+
+func (m *mockCmdRunner) runCmd(name string, args ...string) (string, error) {
+	key := fmt.Sprintf(":%s %s", name, strings.Join(args, " "))
+	m.calls = append(m.calls, key)
+	if resp, ok := m.responses[key]; ok {
+		return resp.output, resp.err
+	}
+	return "", nil
+}
+
+func (m *mockCmdRunner) on(key string, output string, err error) {
+	m.responses[key] = mockResponse{output: output, err: err}
+}
+
+func (m *mockCmdRunner) assertCalled(t *testing.T, key string) {
+	t.Helper()
+	for _, call := range m.calls {
+		if call == key {
+			return
+		}
+	}
+	t.Errorf("expected call %q not found in %v", key, m.calls)
+}
+
+func (m *mockCmdRunner) assertNotCalled(t *testing.T, key string) {
+	t.Helper()
+	for _, call := range m.calls {
+		if call == key {
+			t.Errorf("unexpected call %q found in %v", key, m.calls)
+			return
+		}
+	}
+}
+
+func setupMock(t *testing.T, m *mockCmdRunner) func() {
+	t.Helper()
+	origRunCmd := runCmd
+	origRunCmdDir := runCmdDir
+	runCmd = m.runCmd
+	runCmdDir = m.runCmdDir
+	return func() {
+		runCmd = origRunCmd
+		runCmdDir = origRunCmdDir
+	}
+}
+
+func setupPosthogDir(t *testing.T) func() {
+	t.Helper()
+	origDir, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll("posthog", 0755); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		if err := os.Chdir(origDir); err != nil {
+			t.Log(err)
+		}
+	}
+}
+
+func TestUpdatePostHog(t *testing.T) {
+	t.Run("on branch pulls successfully", func(t *testing.T) {
+		cleanupDir := setupPosthogDir(t)
+		defer cleanupDir()
+
+		mock := newMockRunner()
+		mock.on("posthog:git branch --show-current", "master\n", nil)
+		cleanupMock := setupMock(t, mock)
+		defer cleanupMock()
+
+		err := UpdatePostHog()
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+
+		mock.assertCalled(t, "posthog:git fetch --prune")
+		mock.assertCalled(t, "posthog:git pull")
+	})
+
+	t.Run("detached HEAD skips pull", func(t *testing.T) {
+		cleanupDir := setupPosthogDir(t)
+		defer cleanupDir()
+
+		mock := newMockRunner()
+		mock.on("posthog:git branch --show-current", "", nil)
+		cleanupMock := setupMock(t, mock)
+		defer cleanupMock()
+
+		err := UpdatePostHog()
+		if err != nil {
+			t.Fatalf("expected no error on detached HEAD, got: %v", err)
+		}
+
+		mock.assertCalled(t, "posthog:git fetch --prune")
+		mock.assertCalled(t, "posthog:git branch --show-current")
+		mock.assertNotCalled(t, "posthog:git pull")
+	})
+
+	t.Run("no posthog dir triggers clone", func(t *testing.T) {
+		origDir, _ := os.Getwd()
+		tmpDir := t.TempDir()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = os.Chdir(origDir) }()
+
+		mock := newMockRunner()
+		mock.on(":git clone --filter=blob:none https://github.com/PostHog/posthog.git", "", fmt.Errorf("clone failed"))
+		cleanupMock := setupMock(t, mock)
+		defer cleanupMock()
+
+		err := UpdatePostHog()
+		if err == nil {
+			t.Fatal("expected clone error")
+		}
+		mock.assertCalled(t, ":git clone --filter=blob:none https://github.com/PostHog/posthog.git")
+		mock.assertNotCalled(t, "posthog:git fetch --prune")
+	})
+}
+
+func TestCheckoutVersion(t *testing.T) {
+	t.Run("specific commit SHA", func(t *testing.T) {
+		cleanupDir := setupPosthogDir(t)
+		defer cleanupDir()
+
+		mock := newMockRunner()
+		cleanupMock := setupMock(t, mock)
+		defer cleanupMock()
+
+		sha := "abc123def456abc123def456abc123def456abc1"
+		err := CheckoutVersion(sha)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		mock.assertCalled(t, fmt.Sprintf("posthog:git checkout %s", sha))
+	})
+
+	t.Run("latest resets to origin branch", func(t *testing.T) {
+		cleanupDir := setupPosthogDir(t)
+		defer cleanupDir()
+
+		mock := newMockRunner()
+		mock.on("posthog:git branch --show-current", "master\n", nil)
+		cleanupMock := setupMock(t, mock)
+		defer cleanupMock()
+
+		err := CheckoutVersion("latest")
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		mock.assertCalled(t, "posthog:git fetch origin")
+		mock.assertCalled(t, "posthog:git reset --hard origin/master")
+	})
+
+	t.Run("no posthog dir returns error", func(t *testing.T) {
+		origDir, _ := os.Getwd()
+		tmpDir := t.TempDir()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = os.Chdir(origDir) }()
+
+		mock := newMockRunner()
+		cleanupMock := setupMock(t, mock)
+		defer cleanupMock()
+
+		err := CheckoutVersion("latest")
+		if err == nil {
+			t.Fatal("expected error when posthog dir doesn't exist")
+		}
+	})
+}

--- a/bin/hobby-installer/core/install.go
+++ b/bin/hobby-installer/core/install.go
@@ -201,7 +201,7 @@ func GetInstallSteps() []InstallStep {
 		{
 			Name: "Wait for PostHog to be ready",
 			Run: func(cfg InstallConfig) InstallResult {
-				if err := WaitForHealth(30 * time.Minute); err != nil {
+				if err := WaitForHealth(45 * time.Minute); err != nil {
 					return InstallResult{Err: err}
 				}
 				return InstallResult{Detail: "PostHog is up!"}


### PR DESCRIPTION
## Problem

The hobby installer (Go TUI) fails in CI with `exit status 1: You are not currently on a branch` when running `git pull` on a detached HEAD. This was introduced in the TUI rewrite (a792d9ab7f) which added a `git pull` step that the old shell script didn't have. CI checks out a specific commit SHA, putting the repo in detached HEAD state, which makes `git pull` fail.

Additionally, changes to the hobby-installer Go code were not tested end-to-end by the hobby CI workflow, since it always downloaded the pre-built binary from GitHub releases.

## Changes

- **`bin/hobby-installer/core/git.go`**: Check `git branch --show-current` before pulling — if empty (detached HEAD), skip `git pull` and let `CheckoutVersion` handle it. Added function variables (`runCmd`/`runCmdDir`) to enable mock-based testing.
- **`bin/hobby-installer/core/git_test.go`**: Added 6 unit tests covering `UpdatePostHog` and `CheckoutVersion` behavior (on branch, detached HEAD, missing directory).
- **`bin/hobby-ci.py`**: Conditionally build the hobby-installer from source when Go code has changed (`INSTALLER_CHANGED` env var), otherwise download from the `hobby-latest` release.
- **`.github/workflows/ci-hobby.yml`**: Added `bin/hobby-installer/**` to the paths filter so hobby e2e tests trigger on installer changes. Added `installer` filter output to detect when Go code changed and pass it to `hobby-ci.py`.

## How did you test this code?

- Unit tests pass: `cd bin/hobby-installer && make test` (6 tests covering the fix)
- Linter passes: `golangci-lint run`
- Verified the detached HEAD test case: without the fix the test expects (and gets) an error, with the fix it expects success and asserts `git pull` is not called

## Publish to changelog?

no
