### PR TITLE
feat(signals): Create Task when SignalReport is created

### DIFF
--- a/products/signals/backend/apps.py
+++ b/products/signals/backend/apps.py
@@ -1,7 +1,14 @@
 from django.apps import AppConfig
+from django.db.models.signals import post_save
 
 
 class SignalsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "products.signals.backend"
     label = "signals"
+
+    def ready(self):
+        from .models import SignalReport
+        from .signals import create_task_for_signal_report
+
+        post_save.connect(create_task_for_signal_report, sender=SignalReport)

--- a/products/signals/backend/signals.py
+++ b/products/signals/backend/signals.py
@@ -1,0 +1,81 @@
+from django.db import transaction
+
+import structlog
+
+from posthog.models.integration import GitHubIntegration, Integration
+
+from .models import SignalReport
+
+logger = structlog.get_logger(__name__)
+
+
+def create_task_for_signal_report(sender, instance: SignalReport, created: bool, **kwargs):
+    """
+    When a SignalReport is created, create an AI coding Task to address the issue.
+
+    Only triggers if the team has a GitHub integration with accessible repositories.
+    Uses the top-starred repository from the integration.
+    """
+    if not created:
+        return
+
+    team_id = instance.team_id
+    report_id = str(instance.id)
+    title = instance.title
+    summary = instance.summary
+
+    def do_create_task():
+        from products.tasks.backend.models import Task, TaskRun
+        from products.tasks.backend.temporal.client import execute_task_processing_workflow
+
+        github_integration = Integration.objects.filter(team_id=team_id, kind="github").first()
+
+        if not github_integration:
+            logger.info(
+                "signal_report.no_github_integration",
+                signal_report_id=report_id,
+                team_id=team_id,
+            )
+            return
+
+        gh = GitHubIntegration(github_integration)
+        repository = gh.get_top_starred_repository()
+
+        if not repository:
+            logger.info(
+                "signal_report.no_repositories",
+                signal_report_id=report_id,
+                team_id=team_id,
+            )
+            return
+
+        task_title = title or "Issue from session summary"
+        task_description = summary or "An issue was identified from session summary analysis."
+
+        task = Task.objects.create(
+            team_id=team_id,
+            title=task_title,
+            description=task_description,
+            origin_product=Task.OriginProduct.SESSION_SUMMARIES,
+            github_integration=github_integration,
+            repository=repository,
+        )
+
+        task_run = task.create_run(environment=TaskRun.Environment.CLOUD)
+
+        execute_task_processing_workflow(
+            task_id=str(task.id),
+            run_id=str(task_run.id),
+            team_id=team_id,
+            skip_user_check=True,
+        )
+
+        logger.info(
+            "signal_report.task_created",
+            signal_report_id=report_id,
+            task_id=str(task.id),
+            task_run_id=str(task_run.id),
+            repository=repository,
+        )
+
+    transaction.on_commit(do_create_task)


### PR DESCRIPTION
## Problem

When a SignalReport is created (from session summary analysis), we want to automatically create an AI coding Task to address the identified issue. Very soon this will run via a proper research process instead, where we combine data from multiple sources. Right now, we must validate session summaries alone.

## Changes

Add a `post_save` signal (hehe) on `SignalReport` to automatically create a Task with `origin_product=SESSION_SUMMARIES`.

The interesting bit: We need a GH integration _and_ repo to be set on a task - I propose we simply get the first integration of the team, and use the most starred repo available as a proxy for value. Dirty, but it's a start. We need proper repo routing down the line.

## How did you test this code?

Created some reports.

## Publish to changelog?

No