### PR TITLE
fix: better disposal of monaco code editor

### DIFF
--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -186,16 +186,20 @@ export function CodeEditor({
             monacoDisposables.current.forEach((d) => d?.dispose())
             monacoDisposables.current = []
 
-            // 2. Clear codeEditorLogic reference from model to break kea reference chain
+            // 2. Disconnect and clear mutation observer to fully release DOM references
+            mutationObserver.current?.disconnect()
+            mutationObserver.current = null
+
+            // 3. Clear codeEditorLogic reference from model to break kea reference chain
             const model = editorRef.current?.getModel()
             if (model) {
                 ;(model as any).codeEditorLogic = undefined
             }
 
-            // 3. Clear state to release React's reference to the editor
+            // 4. Clear state to release React's reference to the editor
             setMonacoAndEditor(null)
 
-            // 4. Now safe to remove monacoRoot - editor disposal happens via @monaco-editor/react
+            // 5. Now safe to remove monacoRoot - editor disposal happens via @monaco-editor/react
             // but our cleanup ran first, breaking the reference chains
             monacoRoot?.remove()
         }

--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -141,6 +141,9 @@ export function CodeEditor({
     )
     const [monaco, editor] = monacoAndEditor ?? []
 
+    // Keep a ref to the editor for cleanup - ensures we can dispose it even if state is stale
+    const editorRef = useRef<importedEditor.IStandaloneCodeEditor | null>(null)
+
     const [realKey] = useState(() => codeEditorIndex++)
     const builtCodeEditorLogic = codeEditorLogic({
         key: queryKey ?? `new/${realKey}`,
@@ -170,8 +173,32 @@ export function CodeEditor({
         return monacoRoot
     }, [])
 
+    // Using useRef, not useState, as we don't want to reload the component when this changes.
+    const monacoDisposables = useRef([] as IDisposable[])
+    const mutationObserver = useRef<MutationObserver | null>(null)
+
+    // Consolidated cleanup: dispose editor and its resources BEFORE removing monacoRoot from DOM.
+    // This prevents Monaco's internal services (hoverService, contextViewService) from holding
+    // references to detached DOM nodes.
     useOnMountEffect(() => {
-        return () => monacoRoot?.remove()
+        return () => {
+            // 1. Dispose all custom disposables (actions, observers, etc.)
+            monacoDisposables.current.forEach((d) => d?.dispose())
+            monacoDisposables.current = []
+
+            // 2. Clear codeEditorLogic reference from model to break kea reference chain
+            const model = editorRef.current?.getModel()
+            if (model) {
+                ;(model as any).codeEditorLogic = undefined
+            }
+
+            // 3. Clear state to release React's reference to the editor
+            setMonacoAndEditor(null)
+
+            // 4. Now safe to remove monacoRoot - editor disposal happens via @monaco-editor/react
+            // but our cleanup ran first, breaking the reference chains
+            monacoRoot?.remove()
+        }
     })
 
     useEffect(() => {
@@ -204,15 +231,6 @@ export function CodeEditor({
         })
     }, [monaco, schema])
 
-    // Using useRef, not useState, as we don't want to reload the component when this changes.
-    const monacoDisposables = useRef([] as IDisposable[])
-    const mutationObserver = useRef<MutationObserver | null>(null)
-    useOnMountEffect(() => {
-        return () => {
-            monacoDisposables.current.forEach((d) => d?.dispose())
-        }
-    })
-
     const editorOptions: editor.IStandaloneEditorConstructionOptions = {
         minimap: {
             enabled: false,
@@ -240,6 +258,7 @@ export function CodeEditor({
     }
 
     const editorOnMount = (editor: importedEditor.IStandaloneCodeEditor, monaco: Monaco): void => {
+        editorRef.current = editor
         setMonacoAndEditor([monaco, editor])
         initEditor(monaco, editor, editorProps, options ?? {}, builtCodeEditorLogic)
 
@@ -328,6 +347,7 @@ export function CodeEditor({
         // If originalValue is provided, we render a diff editor instead
         const diffEditorOnMount = (diff: importedEditor.IStandaloneDiffEditor, monaco: Monaco): void => {
             const modifiedEditor = diff.getModifiedEditor()
+            editorRef.current = modifiedEditor
             setMonacoAndEditor([monaco, modifiedEditor])
 
             if (editorProps.onChange) {

--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -2,7 +2,7 @@ import { Monaco } from '@monaco-editor/react'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import type { IDisposable, editor as importedEditor } from 'monaco-editor'
+import type { editor as importedEditor } from 'monaco-editor'
 import { useEffect, useRef, useState } from 'react'
 
 import { IconMagicWand } from '@posthog/icons'
@@ -81,11 +81,11 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
             editor,
         })
     )
-    // Using useRef, not useState, as we don't want to reload the component when this changes.
-    const monacoDisposables = useRef([] as IDisposable[])
+
+    // Clear editor state on unmount to avoid holding references to disposed editor
     useOnMountEffect(() => {
         return () => {
-            monacoDisposables.current.forEach((d) => d?.dispose())
+            setMonacoAndEditor(null)
         }
     })
 

--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
@@ -5,6 +5,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import type { editor as importedEditor } from 'monaco-editor'
 import { useMemo, useRef, useState } from 'react'
 
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { DatabaseTree } from '~/layout/panel-layout/DatabaseTree/DatabaseTree'
@@ -73,6 +74,13 @@ export function EditorScene({ tabId }: { tabId?: string }): JSX.Element {
         null as [Monaco, importedEditor.IStandaloneCodeEditor] | null
     )
     const [monaco, editor] = monacoAndEditor ?? []
+
+    // Clear editor state on unmount to avoid holding references to disposed editor
+    useOnMountEffect(() => {
+        return () => {
+            setMonacoAndEditor(null)
+        }
+    })
 
     const logic = multitabEditorLogic({
         tabId: tabId || '',


### PR DESCRIPTION
each new code editor phAB is leaking at least 16MB of detached monaco elements and any data that they keep alive

this _should_ help release those

(NB it is not the full story as even with this i can see posthog-js keeping something alive so am going to follow-up there as well)

related to #32479