### PR TITLE
chore(capture): add dlq headers on reroute

### DIFF
--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -324,8 +324,7 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
             // Unlike with our node code, DLQ step will always be static.
             headers.set_dlq_step("Capture".to_string());
             headers.set_dlq_timestamp(
-                chrono::Utc::now()
-                    .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
             );
 
             (&self.topics.dlq_topic, Some(event_key.as_str()))

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -320,9 +320,9 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
 
             // Set DLQ specific headers
             // DLQ reason cannot be known beyond being triggered by an event restriction.
-            headers.set_dlq_reason("Capture event rerouted due to event restriction.".to_string());
+            headers.set_dlq_reason("event_restriction".to_string());
             // Unlike with our node code, DLQ step will always be static.
-            headers.set_dlq_step("Capture".to_string());
+            headers.set_dlq_step("capture".to_string());
             headers.set_dlq_timestamp(
                 chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
             );
@@ -1535,11 +1535,8 @@ mod tests {
             assert_eq!(records.len(), 1);
             let headers = &records[0].headers;
 
-            assert_eq!(
-                headers.dlq_reason.as_deref(),
-                Some("Capture event rerouted due to event restriction.")
-            );
-            assert_eq!(headers.dlq_step.as_deref(), Some("Capture"));
+            assert_eq!(headers.dlq_reason.as_deref(), Some("event_restriction"));
+            assert_eq!(headers.dlq_step.as_deref(), Some("capture"));
             assert!(
                 headers.dlq_timestamp.is_some(),
                 "dlq_timestamp should be set"

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -317,6 +317,17 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
                 &[("reason", "event_restriction")]
             )
             .increment(1);
+
+            // Set DLQ specific headers
+            // DLQ reason cannot be known beyond being triggered by an event restriction.
+            headers.set_dlq_reason("Capture event rerouted due to event restriction.".to_string());
+            // Unlike with our node code, DLQ step will always be static.
+            headers.set_dlq_step("Capture".to_string());
+            headers.set_dlq_timestamp(
+                chrono::Utc::now()
+                    .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            );
+
             (&self.topics.dlq_topic, Some(event_key.as_str()))
         } else {
             match data_type {
@@ -717,6 +728,9 @@ mod tests {
             now: Some("2023-01-01T12:00:00Z".to_string()),
             force_disable_person_processing: None,
             historical_migration: Some(true),
+            dlq_reason: None,
+            dlq_step: None,
+            dlq_timestamp: None,
         };
 
         let owned_headers: OwnedHeaders = headers_historical.into();
@@ -734,6 +748,9 @@ mod tests {
             now: Some("2023-01-01T12:00:00Z".to_string()),
             force_disable_person_processing: None,
             historical_migration: Some(false),
+            dlq_reason: None,
+            dlq_step: None,
+            dlq_timestamp: None,
         };
 
         let owned_headers: OwnedHeaders = headers_main.into();
@@ -759,6 +776,9 @@ mod tests {
             now: Some(test_now.clone()),
             force_disable_person_processing: None,
             historical_migration: None,
+            dlq_reason: None,
+            dlq_step: None,
+            dlq_timestamp: None,
         };
 
         // Convert to owned headers and back
@@ -769,6 +789,39 @@ mod tests {
         assert_eq!(parsed_headers.now, Some(test_now));
         assert_eq!(parsed_headers.token, Some("test_token".to_string()));
         assert_eq!(parsed_headers.distinct_id, Some("test_id".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_dlq_headers_are_set() {
+        use common_types::CapturedEventHeaders;
+        use rdkafka::message::OwnedHeaders;
+
+        // Test that the 'now' header is correctly set and parsed
+        let test_now = "2024-01-15T10:30:45Z".to_string();
+        let dlq_timestamp = "2025-01-15T10:30:45Z".to_string();
+        let headers = CapturedEventHeaders {
+            token: Some("test_token".to_string()),
+            distinct_id: Some("test_id".to_string()),
+            session_id: None,
+            timestamp: Some("2024-01-15T10:30:00Z".to_string()),
+            event: Some("test_event".to_string()),
+            uuid: Some("test-uuid".to_string()),
+            now: Some(test_now.clone()),
+            force_disable_person_processing: None,
+            historical_migration: None,
+            dlq_reason: Some("test reason".to_string()),
+            dlq_step: Some("test step".to_string()),
+            dlq_timestamp: Some(dlq_timestamp.clone()),
+        };
+
+        // Convert to owned headers and back
+        let owned_headers: OwnedHeaders = headers.into();
+        let parsed_headers = CapturedEventHeaders::from(owned_headers);
+
+        // Verify the 'now' field is preserved
+        assert_eq!(parsed_headers.dlq_reason, Some("test reason".to_string()));
+        assert_eq!(parsed_headers.dlq_step, Some("test step".to_string()));
+        assert_eq!(parsed_headers.dlq_timestamp, Some(dlq_timestamp));
     }
 
     #[cfg(test)]
@@ -1459,6 +1512,65 @@ mod tests {
                 },
             )
             .await;
+        }
+
+        // ==================== DLQ Header Tests ====================
+        // Verify that DLQ-specific headers (reason, step, timestamp) are set
+        // when routing to DLQ, and absent for all other routes.
+
+        #[tokio::test]
+        async fn dlq_headers_set_when_redirect_to_dlq() {
+            let producer = MockKafkaProducer::new();
+            let sink =
+                KafkaSinkBase::with_producer(producer.clone(), create_test_topics(), None, None);
+
+            let event = create_test_event(&EventInput {
+                data_type: DataType::AnalyticsMain,
+                force_overflow: false,
+                skip_person_processing: false,
+                redirect_to_dlq: true,
+            });
+            sink.send(event).await.unwrap();
+
+            let records = producer.get_records();
+            assert_eq!(records.len(), 1);
+            let headers = &records[0].headers;
+
+            assert_eq!(
+                headers.dlq_reason.as_deref(),
+                Some("Capture event rerouted due to event restriction.")
+            );
+            assert_eq!(headers.dlq_step.as_deref(), Some("Capture"));
+            assert!(
+                headers.dlq_timestamp.is_some(),
+                "dlq_timestamp should be set"
+            );
+
+            // Verify the timestamp is a valid RFC 3339 string
+            let ts = headers.dlq_timestamp.as_deref().unwrap();
+            chrono::DateTime::parse_from_rfc3339(ts)
+                .unwrap_or_else(|e| panic!("dlq_timestamp '{ts}' is not valid RFC 3339: {e}"));
+        }
+
+        #[tokio::test]
+        async fn dlq_headers_absent_for_normal_analytics() {
+            let producer = MockKafkaProducer::new();
+            let sink =
+                KafkaSinkBase::with_producer(producer.clone(), create_test_topics(), None, None);
+
+            let event = create_test_event(&EventInput {
+                data_type: DataType::AnalyticsMain,
+                force_overflow: false,
+                skip_person_processing: false,
+                redirect_to_dlq: false,
+            });
+            sink.send(event).await.unwrap();
+
+            let records = producer.get_records();
+            let headers = &records[0].headers;
+            assert_eq!(headers.dlq_reason, None);
+            assert_eq!(headers.dlq_step, None);
+            assert_eq!(headers.dlq_timestamp, None);
         }
     }
 }

--- a/rust/common/types/src/event.rs
+++ b/rust/common/types/src/event.rs
@@ -88,11 +88,26 @@ pub struct CapturedEventHeaders {
     pub now: Option<String>,
     pub force_disable_person_processing: Option<bool>,
     pub historical_migration: Option<bool>,
+    pub dlq_reason: Option<String>,
+    pub dlq_step: Option<String>,
+    pub dlq_timestamp: Option<String>,
 }
 
 impl CapturedEventHeaders {
     pub fn set_force_disable_person_processing(&mut self, value: bool) {
         self.force_disable_person_processing = Some(value);
+    }
+
+    pub fn set_dlq_reason(&mut self, value: String) {
+        self.dlq_reason = Some(value);
+    }
+
+    pub fn set_dlq_step(&mut self, value: String) {
+        self.dlq_step = Some(value);
+    }
+
+    pub fn set_dlq_timestamp(&mut self, value: String) {
+        self.dlq_timestamp = Some(value);
     }
 }
 
@@ -139,6 +154,18 @@ impl From<CapturedEventHeaders> for OwnedHeaders {
                 key: "historical_migration",
                 value: historical_migration_str.as_deref(),
             })
+            .insert(Header {
+                key: "dlq_reason",
+                value: headers.dlq_reason.as_deref(),
+            })
+            .insert(Header {
+                key: "dlq_step",
+                value: headers.dlq_step.as_deref(),
+            })
+            .insert(Header {
+                key: "dlq_timestamp",
+                value: headers.dlq_timestamp.as_deref(),
+            })
     }
 }
 
@@ -167,6 +194,9 @@ impl From<OwnedHeaders> for CapturedEventHeaders {
             historical_migration: headers_map
                 .get("historical_migration")
                 .and_then(|v| v.parse::<bool>().ok()),
+            dlq_reason: headers_map.get("dlq_reason").cloned(),
+            dlq_step: headers_map.get("dlq_step").cloned(),
+            dlq_timestamp: headers_map.get("dlq_timestamp").cloned(),
         }
     }
 }
@@ -223,6 +253,10 @@ impl CapturedEvent {
             } else {
                 None
             },
+            // DLQ headers should only be explicitly set when needed
+            dlq_reason: None,
+            dlq_step: None,
+            dlq_timestamp: None,
         }
     }
 
@@ -534,5 +568,126 @@ mod tests {
 
         let headers = event_without_session.to_headers();
         assert_eq!(headers.session_id, None);
+    }
+
+    #[test]
+    fn test_to_headers_dlq_fields_default_to_none() {
+        let event = CapturedEvent {
+            uuid: Uuid::nil(),
+            distinct_id: "test_user".to_string(),
+            session_id: None,
+            ip: "127.0.0.1".to_string(),
+            data: r#"{"event":"test_event"}"#.to_string(),
+            now: "2023-01-02T10:00:00Z".to_string(),
+            sent_at: None,
+            token: "test_token".to_string(),
+            event: "test_event".to_string(),
+            timestamp: DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            is_cookieless_mode: false,
+            historical_migration: false,
+        };
+
+        let headers = event.to_headers();
+        assert_eq!(headers.dlq_reason, None);
+        assert_eq!(headers.dlq_step, None);
+        assert_eq!(headers.dlq_timestamp, None);
+    }
+
+    #[test]
+    fn test_dlq_setters() {
+        let event = CapturedEvent {
+            uuid: Uuid::nil(),
+            distinct_id: "test_user".to_string(),
+            session_id: None,
+            ip: "127.0.0.1".to_string(),
+            data: r#"{"event":"test_event"}"#.to_string(),
+            now: "2023-01-02T10:00:00Z".to_string(),
+            sent_at: None,
+            token: "test_token".to_string(),
+            event: "test_event".to_string(),
+            timestamp: DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            is_cookieless_mode: false,
+            historical_migration: false,
+        };
+
+        let mut headers = event.to_headers();
+        headers.set_dlq_reason("invalid_payload".to_string());
+        headers.set_dlq_step("tokenization".to_string());
+        headers.set_dlq_timestamp("2023-01-02T10:05:00Z".to_string());
+
+        assert_eq!(headers.dlq_reason, Some("invalid_payload".to_string()));
+        assert_eq!(headers.dlq_step, Some("tokenization".to_string()));
+        assert_eq!(
+            headers.dlq_timestamp,
+            Some("2023-01-02T10:05:00Z".to_string())
+        );
+    }
+
+    #[test]
+    fn test_dlq_fields_round_trip_through_owned_headers() {
+        let event = CapturedEvent {
+            uuid: Uuid::nil(),
+            distinct_id: "test_user".to_string(),
+            session_id: None,
+            ip: "127.0.0.1".to_string(),
+            data: r#"{"event":"test_event"}"#.to_string(),
+            now: "2023-01-02T10:00:00Z".to_string(),
+            sent_at: None,
+            token: "test_token".to_string(),
+            event: "test_event".to_string(),
+            timestamp: DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            is_cookieless_mode: false,
+            historical_migration: false,
+        };
+
+        let mut headers = event.to_headers();
+        headers.set_dlq_reason("quota_exceeded".to_string());
+        headers.set_dlq_step("billing_check".to_string());
+        headers.set_dlq_timestamp("2023-01-02T10:05:00Z".to_string());
+
+        let owned: OwnedHeaders = headers.into();
+        let recovered: CapturedEventHeaders = owned.into();
+
+        assert_eq!(recovered.dlq_reason, Some("quota_exceeded".to_string()));
+        assert_eq!(recovered.dlq_step, Some("billing_check".to_string()));
+        assert_eq!(
+            recovered.dlq_timestamp,
+            Some("2023-01-02T10:05:00Z".to_string())
+        );
+    }
+
+    #[test]
+    fn test_dlq_fields_absent_in_owned_headers_round_trip() {
+        let event = CapturedEvent {
+            uuid: Uuid::nil(),
+            distinct_id: "test_user".to_string(),
+            session_id: None,
+            ip: "127.0.0.1".to_string(),
+            data: r#"{"event":"test_event"}"#.to_string(),
+            now: "2023-01-02T10:00:00Z".to_string(),
+            sent_at: None,
+            token: "test_token".to_string(),
+            event: "test_event".to_string(),
+            timestamp: DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            is_cookieless_mode: false,
+            historical_migration: false,
+        };
+
+        // DLQ fields are None by default from to_headers()
+        let headers = event.to_headers();
+        let owned: OwnedHeaders = headers.into();
+        let recovered: CapturedEventHeaders = owned.into();
+
+        assert_eq!(recovered.dlq_reason, None);
+        assert_eq!(recovered.dlq_step, None);
+        assert_eq!(recovered.dlq_timestamp, None);
     }
 }

--- a/rust/common/types/src/event.rs
+++ b/rust/common/types/src/event.rs
@@ -155,15 +155,15 @@ impl From<CapturedEventHeaders> for OwnedHeaders {
                 value: historical_migration_str.as_deref(),
             })
             .insert(Header {
-                key: "dlq_reason",
+                key: "dlq-reason",
                 value: headers.dlq_reason.as_deref(),
             })
             .insert(Header {
-                key: "dlq_step",
+                key: "dlq-step",
                 value: headers.dlq_step.as_deref(),
             })
             .insert(Header {
-                key: "dlq_timestamp",
+                key: "dlq-timestamp",
                 value: headers.dlq_timestamp.as_deref(),
             })
     }
@@ -194,9 +194,9 @@ impl From<OwnedHeaders> for CapturedEventHeaders {
             historical_migration: headers_map
                 .get("historical_migration")
                 .and_then(|v| v.parse::<bool>().ok()),
-            dlq_reason: headers_map.get("dlq_reason").cloned(),
-            dlq_step: headers_map.get("dlq_step").cloned(),
-            dlq_timestamp: headers_map.get("dlq_timestamp").cloned(),
+            dlq_reason: headers_map.get("dlq-reason").cloned(),
+            dlq_step: headers_map.get("dlq-step").cloned(),
+            dlq_timestamp: headers_map.get("dlq-timestamp").cloned(),
         }
     }
 }


### PR DESCRIPTION
## Problem

recently, dlq specific kafka headers were added to the ingestion workers in https://github.com/PostHog/posthog/blob/master/nodejs/src/worker/ingestion/pipeline-helpers.ts#L240-L243. we need to similarly update the capture dlq handling to maintain parity.

## Changes

- add corresponding dlq headers (step, reason, timestamp) to capture dlq dispatch.
- step and reason are both static (step doesn't translate from node to rust, and the reason will always be due to event restrictions).

## How did you test this code?

- added unit tests and ran cargo test.
- testing in dev (i.e. confirming headers are seen in kafbat ui) still remains.

## Publish to changelog?

no