### PR TITLE
feat(capture-logs): add created_at kafka header

### DIFF
--- a/rust/capture-logs/src/kafka.rs
+++ b/rust/capture-logs/src/kafka.rs
@@ -3,6 +3,7 @@ use crate::log_record::KafkaLogRow;
 use anyhow::anyhow;
 use apache_avro::{Codec, Schema, Writer, ZstandardSettings};
 use capture::config::KafkaConfig;
+use chrono::Utc;
 use health::HealthHandle;
 use metrics::{counter, gauge};
 use rdkafka::error::KafkaError;
@@ -213,7 +214,8 @@ impl KafkaSink {
             partition: None,
             key: None::<Vec<u8>>.as_ref(),
             timestamp: None,
-            headers: Some(
+            headers: Some({
+                let created_at = Utc::now().to_rfc3339();
                 OwnedHeaders::new()
                     .insert(Header {
                         key: "token",
@@ -230,8 +232,12 @@ impl KafkaSink {
                     .insert(Header {
                         key: "record_count",
                         value: Some(&rows.len().to_string()),
-                    }),
-            ),
+                    })
+                    .insert(Header {
+                        key: "created_at",
+                        value: Some(&created_at),
+                    })
+            }),
         }) {
             Err((err, _)) => Err(anyhow!(format!("kafka error: {err}"))),
             Ok(delivery_future) => Ok(delivery_future),


### PR DESCRIPTION
## Problem

for rate limiting we are currently using clock time, which gets messed up if we're catching up lag (if we e.g. are catching up at 10x the rate messages came in, rate limits are effectively temporarily 10x smaller)

set created_at headers on the messages to use as authoritative timestamps for rate limiting. These are already on the individual log lines but easier to have them on the headers so we don't _have_ to open the avro messages

## Changes

add created_at timestamp
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
