### PR TITLE
chore(ux): new account menu makeover

### DIFF
--- a/frontend/src/layout/GlobalShortcuts.tsx
+++ b/frontend/src/layout/GlobalShortcuts.tsx
@@ -23,7 +23,7 @@ export function GlobalShortcuts(): null {
     const { toggleZenMode } = useActions(navigation3000Logic)
     const { toggleCommand } = useActions(commandLogic)
     const { toggleHelpMenu } = useActions(helpMenuLogic)
-    const { toggleAccountMenu } = useActions(newAccountMenuLogic)
+    const { toggleAccountMenu, toggleProjectSwitcher, toggleOrgSwitcher } = useActions(newAccountMenuLogic)
     const { openSuperpowers } = useActions(superpowersLogic)
     const { toggleHealthMenu } = useActions(healthMenuLogic)
 
@@ -106,6 +106,22 @@ export function GlobalShortcuts(): null {
         intent: 'Toggle new account menu',
         interaction: 'function',
         callback: () => toggleAccountMenu(),
+    })
+
+    useAppShortcut({
+        name: 'toggle-project-switcher',
+        keybind: [keyBinds.projectSwitcher],
+        intent: 'Toggle project switcher',
+        interaction: 'function',
+        callback: () => toggleProjectSwitcher(),
+    })
+
+    useAppShortcut({
+        name: 'toggle-org-switcher',
+        keybind: [keyBinds.orgSwitcher],
+        intent: 'Toggle organization switcher',
+        interaction: 'function',
+        callback: () => toggleOrgSwitcher(),
     })
 
     return null

--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -122,7 +122,7 @@ export const SIDE_PANEL_TABS: Record<
         Content: SidePanelHealth,
     },
     [SidePanelTab.Info]: {
-        label: 'Info & actions',
+        label: 'Actions',
         Icon: SidePanelInfoIcon,
         Content: SidePanelInfo,
     },

--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanelNavigation.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanelNavigation.tsx
@@ -33,73 +33,70 @@ export function SidePanelNavigation({ activeTab, onTabChange, children }: SidePa
             value={activeTab}
             onValueChange={(value) => onTabChange(value as SidePanelTab)}
         >
-            {/* Header with close button */}
-            <div className="h-[50px] flex items-center justify-between gap-2 pl-2 pr-1.5 border-b border-primary shrink-0">
-                {/* Tab buttons */}
-                <Tabs.List className="relative z-0 flex gap-1 grow">
-                    {[
-                        ...(scenePanelIsPresent ? [SidePanelTab.Info] : []),
-                        SidePanelTab.Max,
-                        SidePanelTab.Discussion,
-                        SidePanelTab.AccessControl,
-                        SidePanelTab.Notebooks,
-                    ]
-                        .filter((tab) => tab === SidePanelTab.Info || visibleTabs.includes(tab))
-                        .map((tab) => {
-                            const { Icon, label } = SIDE_PANEL_TABS[tab]!
-                            return (
-                                <Tabs.Tab
-                                    key={tab}
-                                    value={tab}
-                                    render={(props) => (
-                                        <ButtonPrimitive
-                                            {...props}
-                                            onClick={() => openSidePanel(tab as SidePanelTab)}
-                                            tooltip={label}
-                                            className="size-[33px] @[600px]/side-panel:w-auto hover:bg-transparent group justify-center @[600px]/side-panel:justify-normal"
-                                        >
-                                            {tab === SidePanelTab.Max ? (
-                                                <IconSparkles
-                                                    className={cn(
-                                                        'text-accent size-4 group-hover:text-accent-hover -mt-[1px] ml-[2px]'
-                                                    )}
-                                                />
-                                            ) : (
-                                                <Icon
-                                                    className={cn(
-                                                        'size-4 text-tertiary group-hover:text-primary',
-                                                        activeTab === tab ? 'text-primary' : 'text-tertiary'
-                                                    )}
-                                                />
-                                            )}
-                                            <span
+            {/* Tab buttons */}
+            <Tabs.List className="h-[50px] flex items-center justify-between gap-1 pl-2 pr-1.5 border-b border-primary shrink-0 relative z-0 grow overflow-x-auto">
+                {[
+                    ...(scenePanelIsPresent ? [SidePanelTab.Info] : []),
+                    SidePanelTab.Max,
+                    SidePanelTab.Discussion,
+                    SidePanelTab.AccessControl,
+                    SidePanelTab.Notebooks,
+                ]
+                    .filter((tab) => tab === SidePanelTab.Info || visibleTabs.includes(tab))
+                    .map((tab) => {
+                        const { Icon, label } = SIDE_PANEL_TABS[tab]!
+                        return (
+                            <Tabs.Tab
+                                key={tab}
+                                value={tab}
+                                render={(props) => (
+                                    <ButtonPrimitive
+                                        {...props}
+                                        onClick={() => openSidePanel(tab as SidePanelTab)}
+                                        tooltip={label}
+                                        className="size-[33px] @[600px]/side-panel:w-auto hover:bg-transparent group justify-center @[600px]/side-panel:justify-normal"
+                                    >
+                                        {tab === SidePanelTab.Max ? (
+                                            <IconSparkles
                                                 className={cn(
-                                                    'hidden @[600px]/side-panel:block text-tertiary group-hover:text-primary',
+                                                    'text-accent size-4 group-hover:text-accent-hover -mt-[1px] ml-[2px]'
+                                                )}
+                                            />
+                                        ) : (
+                                            <Icon
+                                                className={cn(
+                                                    'size-4 text-tertiary group-hover:text-primary',
                                                     activeTab === tab ? 'text-primary' : 'text-tertiary'
                                                 )}
-                                            >
-                                                {label}
-                                            </span>
-                                        </ButtonPrimitive>
-                                    )}
-                                />
-                            )
-                        })}
-                    <Tabs.Indicator className="transform-gpu absolute top-1/2 left-0 z-[-1] h-[33px] w-[var(--active-tab-width)] translate-x-[var(--active-tab-left)] -translate-y-1/2 rounded bg-[var(--color-bg-fill-button-tertiary-active)] transition-all duration-200 ease-in-out" />
+                                            />
+                                        )}
+                                        <span
+                                            className={cn(
+                                                'hidden @[600px]/side-panel:block text-tertiary group-hover:text-primary',
+                                                activeTab === tab ? 'text-primary' : 'text-tertiary'
+                                            )}
+                                        >
+                                            {label}
+                                        </span>
+                                    </ButtonPrimitive>
+                                )}
+                            />
+                        )
+                    })}
+                <Tabs.Indicator className="transform-gpu absolute top-1/2 left-0 z-[-1] h-[33px] w-[var(--active-tab-width)] translate-x-[var(--active-tab-left)] -translate-y-1/2 rounded bg-[var(--color-bg-fill-button-tertiary-active)] transition-all duration-200 ease-in-out" />
 
-                    <ButtonPrimitive
-                        onClick={() => {
-                            closeSidePanel()
-                        }}
-                        tooltip="Close side panel"
-                        tooltipPlacement="bottom-end"
-                        iconOnly
-                        className="group size-[33px] ml-auto"
-                    >
-                        <IconX className="text-tertiary size-3 group-hover:text-primary z-10" />
-                    </ButtonPrimitive>
-                </Tabs.List>
-            </div>
+                <ButtonPrimitive
+                    onClick={() => {
+                        closeSidePanel()
+                    }}
+                    tooltip="Close side panel"
+                    tooltipPlacement="bottom-end"
+                    iconOnly
+                    className="group size-[33px] ml-auto"
+                >
+                    <IconX className="text-tertiary size-3 group-hover:text-primary z-10" />
+                </ButtonPrimitive>
+            </Tabs.List>
 
             {/* Content area */}
             <Tabs.Panel

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -24,6 +24,8 @@ import { Link } from '@posthog/lemon-ui'
 import { AccountMenu } from 'lib/components/Account/AccountMenu'
 import { NewAccountMenu } from 'lib/components/Account/NewAccountMenu'
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
+import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
+import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
 import { commandLogic } from 'lib/components/Command/commandLogic'
 import { DebugNotice } from 'lib/components/DebugNotice'
 import { HealthMenu } from 'lib/components/HealthMenu/HealthMenu'
@@ -147,6 +149,16 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
 
         return false
     }
+
+    useAppShortcut({
+        name: 'collapse-left-navigation',
+        keybind: [keyBinds.toggleLeftNav],
+        intent: 'Collapse left navigation',
+        interaction: 'function',
+        callback: () => {
+            toggleLayoutNavCollapsed(!isLayoutNavCollapsed)
+        },
+    })
 
     const navItems: {
         identifier: string

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -40,7 +40,7 @@ export function SceneTitlePanelButton({ inPanel = false }: { inPanel?: boolean }
         return (
             <AppShortcut
                 name="OpenSidePanel"
-                keybind={[keyBinds.openSidePanel]}
+                keybind={[keyBinds.toggleRightNav]}
                 intent="Open side panel"
                 interaction="click"
             >

--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -1,24 +1,16 @@
+import { Menu } from '@base-ui/react/menu'
 import { useActions, useValues } from 'kea'
 
-import { IconCopy, IconEllipsis, IconGear, IconLeave, IconPlusSmall, IconReceipt } from '@posthog/icons'
+import { IconCopy, IconGear, IconLeave, IconPlusSmall, IconReceipt } from '@posthog/icons'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { Link } from 'lib/lemon-ui/Link/Link'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture/ProfilePicture'
 import { UploadedLogo } from 'lib/lemon-ui/UploadedLogo/UploadedLogo'
+import { IconBlank } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuGroup,
-    DropdownMenuItem,
-    DropdownMenuSeparator,
-    DropdownMenuSub,
-    DropdownMenuSubContent,
-    DropdownMenuSubTrigger,
-    DropdownMenuTrigger,
-} from 'lib/ui/DropdownMenu/DropdownMenu'
+import { DropdownMenuSeparator } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { Label } from 'lib/ui/Label/Label'
 import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
@@ -36,8 +28,9 @@ import { AccessLevelIndicator } from '~/layout/navigation/AccessLevelIndicator'
 
 import { RenderKeybind } from '../AppShortcuts/AppShortcutMenu'
 import { keyBinds } from '../AppShortcuts/shortcuts'
-import { OrgCombobox } from './OrgCombobox'
-import { ProjectCombobox } from './ProjectCombobox'
+import { ScrollableShadows } from '../ScrollableShadows/ScrollableShadows'
+import { OrgModal } from './OrgModal'
+import { ProjectModal } from './ProjectModal'
 import { newAccountMenuLogic } from './newAccountMenuLogic'
 
 interface AccountMenuProps {
@@ -56,7 +49,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
     const { logout } = useActions(userLogic)
     const { currentTeam } = useValues(teamLogic)
     const { isAccountMenuOpen } = useValues(newAccountMenuLogic)
-    const { setAccountMenuOpen } = useActions(newAccountMenuLogic)
+    const { setAccountMenuOpen, openProjectSwitcher, openOrgSwitcher } = useActions(newAccountMenuLogic)
 
     const projectNameStartsWithEmoji = currentTeam?.name?.match(/^\p{Emoji}/u) !== null
     const projectNameWithoutFirstEmoji = projectNameStartsWithEmoji
@@ -64,261 +57,321 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
         : currentTeam?.name
 
     return (
-        <DropdownMenu open={isAccountMenuOpen} onOpenChange={setAccountMenuOpen}>
-            <DropdownMenuTrigger asChild>
-                <ButtonPrimitive
-                    tooltip={
-                        <div className="flex flex-col gap-1">
-                            <p className="m-0">Organization: {currentOrganization?.name}</p>
-                            <p className="m-0">Project: {currentTeam?.name}</p>
-                            <p className="m-0">
-                                <RenderKeybind keybind={[keyBinds.newAccountMenu]} />
-                            </p>
-                        </div>
-                    }
-                    tooltipPlacement="right"
-                    iconOnly={isLayoutNavCollapsed}
-                    className={cn('flex-1', {
-                        'pl-[3px] gap-[6px]': !isLayoutNavCollapsed,
-                    })}
-                    variant="panel"
-                    data-attr="menu-item-me"
-                >
-                    {isAuthenticatedTeam(currentTeam) && (
-                        <>
-                            <div
-                                className={cn(
-                                    'Lettermark bg-[var(--color-bg-fill-button-tertiary-active)] size-5 dark:text-tertiary',
-                                    {
-                                        'size-[30px] rounded': isLayoutNavCollapsed,
-                                    }
-                                )}
-                            >
-                                {String.fromCodePoint(currentTeam.name.codePointAt(0)!).toLocaleUpperCase()}
-                            </div>
-                            {!isLayoutNavCollapsed && (
-                                <span className="truncate">{projectNameWithoutFirstEmoji ?? 'Project'}</span>
-                            )}
-                        </>
-                    )}
-                    {!isLayoutNavCollapsed && <MenuOpenIndicator />}
-                </ButtonPrimitive>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-                side="bottom"
-                align="start"
-                collisionPadding={{ bottom: 0 }}
-                className="min-w-[var(--project-panel-width)]"
-            >
-                <DropdownMenuGroup>
-                    <Label intent="menu" className="px-2">
-                        Signed in as
-                    </Label>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem asChild>
-                        <Link
-                            to={urls.settings(user?.organization?.id ? 'user' : 'user-danger-zone')}
-                            buttonProps={{
-                                className: 'flex items-center gap-2 h-fit',
-                                menuItem: true,
-                                truncate: true,
-                            }}
-                            tooltip="Account settings"
-                            tooltipPlacement="right"
-                            data-attr="top-menu-account-owner"
-                        >
-                            <ProfilePicture user={user} size="xs" />
-                            <span className="flex flex-col truncate">
-                                <span className="font-semibold truncate">{user?.first_name}</span>
-                                <span className="text-tertiary text-xs truncate">{user?.email}</span>
-                            </span>
-                            <div className="ml-auto">
-                                <IconGear className="text-tertiary" />
-                            </div>
-                        </Link>
-                    </DropdownMenuItem>
-
-                    <Label intent="menu" className="px-2 mt-2">
-                        Projects
-                    </Label>
-                    <DropdownMenuSeparator />
-
-                    {isAuthenticatedTeam(currentTeam) && (
-                        <DropdownMenuItem asChild>
-                            <Link
-                                to={urls.settings('project')}
-                                buttonProps={{
-                                    className: 'flex items-center gap-2',
-                                    menuItem: true,
-                                    truncate: true,
-                                }}
-                                tooltip="Project settings"
-                                tooltipPlacement="right"
-                                data-attr="top-menu-project-settings"
-                            >
-                                <div className="Lettermark bg-[var(--color-bg-fill-button-tertiary-active)] size-4 dark:text-tertiary text-[8px]">
-                                    {String.fromCodePoint(currentTeam.name.codePointAt(0)!).toLocaleUpperCase()}
-                                </div>
-                                <span className="truncate font-semibold">
-                                    {currentTeam ? projectNameWithoutFirstEmoji : 'Select project'}
-                                </span>
-                                {currentTeam && (
-                                    <div className="ml-auto flex items-center gap-1">
-                                        <IconGear className="text-tertiary" />
-                                    </div>
-                                )}
-                            </Link>
-                        </DropdownMenuItem>
-                    )}
-
-                    <DropdownMenuItem asChild>
+        <>
+            <Menu.Root open={isAccountMenuOpen} onOpenChange={setAccountMenuOpen}>
+                <Menu.Trigger
+                    render={(props) => (
                         <ButtonPrimitive
-                            onClick={() => {
-                                showInviteModal()
-                                reportInviteMembersButtonClicked()
-                            }}
-                            menuItem
-                            tooltip="Invite members"
-                            tooltipPlacement="right"
-                            data-attr="top-menu-invite-team-members"
+                            {...props}
+                            iconOnly={isLayoutNavCollapsed}
+                            className={cn('flex-1', {
+                                'pl-[3px] gap-[6px]': !isLayoutNavCollapsed,
+                            })}
+                            variant="panel"
+                            data-attr="menu-item-me"
                         >
-                            <IconPlusSmall />
-                            Invite members
+                            {isAuthenticatedTeam(currentTeam) && (
+                                <>
+                                    <div
+                                        className={cn(
+                                            'Lettermark bg-[var(--color-bg-fill-button-tertiary-active)] size-5 dark:text-tertiary',
+                                            {
+                                                'size-[30px] rounded': isLayoutNavCollapsed,
+                                            }
+                                        )}
+                                    >
+                                        {String.fromCodePoint(currentTeam.name.codePointAt(0)!).toLocaleUpperCase()}
+                                    </div>
+                                    {!isLayoutNavCollapsed && (
+                                        <span className="truncate">{projectNameWithoutFirstEmoji ?? 'Project'}</span>
+                                    )}
+                                </>
+                            )}
+                            {!isLayoutNavCollapsed && <MenuOpenIndicator />}
                         </ButtonPrimitive>
-                    </DropdownMenuItem>
+                    )}
+                />
 
-                    <DropdownMenuSub>
-                        <DropdownMenuSubTrigger asChild>
-                            <ButtonPrimitive menuItem>
-                                <IconEllipsis className="text-tertiary p-px" />
-                                Other
-                                <MenuOpenIndicator intent="sub" />
-                            </ButtonPrimitive>
-                        </DropdownMenuSubTrigger>
-                        <DropdownMenuSubContent className="min-w-[var(--project-panel-width)]">
-                            <ProjectCombobox />
-                        </DropdownMenuSubContent>
-                    </DropdownMenuSub>
+                <Menu.Portal>
+                    <Menu.Backdrop />
 
-                    <Label intent="menu" className="px-2 mt-2">
-                        Organizations
-                    </Label>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem asChild>
-                        <Link
-                            to={urls.settings('organization')}
-                            buttonProps={{
-                                className: 'flex items-center gap-2',
-                                menuItem: true,
-                                truncate: true,
-                            }}
-                            tooltip="Organization settings"
-                            tooltipPlacement="right"
-                            data-attr="top-menu-organization-settings"
-                        >
-                            {currentOrganization ? (
-                                <UploadedLogo
-                                    name={currentOrganization.name}
-                                    entityId={currentOrganization.id}
-                                    mediaId={currentOrganization.logo_media_id}
-                                    size="xsmall"
-                                />
-                            ) : (
-                                <UploadedLogo name="?" entityId="" mediaId="" size="xsmall" />
-                            )}
-                            <span className="truncate font-semibold">
-                                {currentOrganization ? currentOrganization.name : 'Select organization'}
-                            </span>
-                            {currentOrganization && (
-                                <div className="ml-auto flex items-center gap-1">
-                                    <AccessLevelIndicator organization={currentOrganization} />
-                                    <IconGear className="text-tertiary" />
-                                </div>
-                            )}
-                        </Link>
-                    </DropdownMenuItem>
-
-                    {isCloudOrDev ? (
-                        <DropdownMenuItem asChild>
-                            <Link
-                                to={
-                                    featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]
-                                        ? urls.organizationBillingSection('overview')
-                                        : urls.organizationBilling()
-                                }
-                                buttonProps={{
-                                    className: 'flex items-center gap-2',
-                                    menuItem: true,
-                                    truncate: true,
-                                }}
+                    <Menu.Positioner className="z-[var(--z-popover)]" sideOffset={4}>
+                        <Menu.Popup className="primitive-menu-content max-h-[calc(var(--available-height)-4px)] min-w-[250px] w-full">
+                            <ScrollableShadows
+                                direction="vertical"
+                                styledScrollbars
+                                className="flex flex-col gap-px overflow-x-hidden"
+                                innerClassName="primitive-menu-content-inner p-1 "
                             >
-                                <IconReceipt />
-                                {featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS] ? 'Billing & Usage' : 'Billing'}
-                            </Link>
-                        </DropdownMenuItem>
-                    ) : null}
-
-                    <DropdownMenuSub>
-                        <DropdownMenuSubTrigger asChild>
-                            <ButtonPrimitive menuItem>
-                                <IconEllipsis className="text-tertiary p-px" />
-                                Other
-                                <MenuOpenIndicator intent="sub" />
-                            </ButtonPrimitive>
-                        </DropdownMenuSubTrigger>
-                        <DropdownMenuSubContent className="min-w-[var(--project-panel-width)]">
-                            <OrgCombobox />
-                        </DropdownMenuSubContent>
-                    </DropdownMenuSub>
-
-                    <DropdownMenuSeparator />
-
-                    {isDev ||
-                        (billing?.account_owner?.email && billing?.account_owner?.name && (
-                            <>
-                                <Label intent="menu" className="px-2 mt-2">
-                                    YOUR POSTHOG HUMAN
+                                <Label intent="menu" className="px-2">
+                                    Signed in as
                                 </Label>
                                 <DropdownMenuSeparator />
-                                <DropdownMenuItem asChild>
-                                    <ButtonPrimitive
-                                        menuItem
-                                        onClick={() => {
-                                            void copyToClipboard(billing?.account_owner?.email || '', 'email')
-                                            reportAccountOwnerClicked({
-                                                name: billing?.account_owner?.name || '',
-                                                email: billing?.account_owner?.email || '',
-                                            })
-                                        }}
-                                        tooltip="This is your dedicated PostHog human. Click to copy their email. They can help you with trying out new products, solving problems, and reducing your spend."
-                                        tooltipPlacement="right"
-                                        data-attr="top-menu-account-owner"
-                                    >
-                                        <ProfilePicture
-                                            user={{
-                                                first_name: billing.account_owner.name,
-                                                email: billing.account_owner.email,
+                                <Menu.Item
+                                    render={(props) => (
+                                        <Link
+                                            {...props}
+                                            to={urls.settings(user?.organization?.id ? 'user' : 'user-danger-zone')}
+                                            buttonProps={{
+                                                className: 'flex items-center gap-2 h-fit',
+                                                menuItem: true,
+                                                truncate: true,
                                             }}
-                                            size="xs"
-                                        />
-                                        <span className="truncate font-semibold">{billing.account_owner.name}</span>
-                                        <div className="ml-auto">
-                                            <IconCopy />
-                                        </div>
-                                    </ButtonPrimitive>
-                                </DropdownMenuItem>
-                                <DropdownMenuSeparator />
-                            </>
-                        ))}
+                                            tooltip="Account settings"
+                                            tooltipPlacement="right"
+                                            data-attr="top-menu-account-owner"
+                                        >
+                                            <ProfilePicture user={user} size="xs" />
+                                            <span className="flex flex-col truncate">
+                                                <span className="font-semibold truncate">{user?.first_name}</span>
+                                                <span className="text-tertiary text-xs truncate">{user?.email}</span>
+                                            </span>
+                                            <div className="ml-auto">
+                                                <IconGear className="text-tertiary" />
+                                            </div>
+                                        </Link>
+                                    )}
+                                />
 
-                    <DropdownMenuItem asChild>
-                        <ButtonPrimitive menuItem onClick={logout} data-attr="top-menu-item-logout">
-                            <IconLeave />
-                            Log out
-                        </ButtonPrimitive>
-                    </DropdownMenuItem>
-                </DropdownMenuGroup>
-            </DropdownMenuContent>
-        </DropdownMenu>
+                                <Label intent="menu" className="px-2 mt-2">
+                                    Projects
+                                </Label>
+                                <DropdownMenuSeparator />
+
+                                {isAuthenticatedTeam(currentTeam) && (
+                                    <Menu.Item
+                                        render={(props) => (
+                                            <Link
+                                                {...props}
+                                                to={urls.settings('project')}
+                                                buttonProps={{
+                                                    className: 'flex items-center gap-2',
+                                                    menuItem: true,
+                                                    truncate: true,
+                                                }}
+                                                tooltip="Project settings"
+                                                tooltipPlacement="right"
+                                                data-attr="top-menu-project-settings"
+                                            >
+                                                <div className="Lettermark bg-[var(--color-bg-fill-button-tertiary-active)] size-4 dark:text-tertiary text-[8px]">
+                                                    {String.fromCodePoint(
+                                                        currentTeam.name.codePointAt(0)!
+                                                    ).toLocaleUpperCase()}
+                                                </div>
+                                                <span className="truncate font-semibold">
+                                                    {currentTeam ? projectNameWithoutFirstEmoji : 'Select project'}
+                                                </span>
+                                                {currentTeam && (
+                                                    <div className="ml-auto flex items-center gap-1">
+                                                        <IconGear className="text-tertiary" />
+                                                    </div>
+                                                )}
+                                            </Link>
+                                        )}
+                                    />
+                                )}
+
+                                <Menu.Item
+                                    render={(props) => (
+                                        <ButtonPrimitive
+                                            {...props}
+                                            onClick={() => {
+                                                showInviteModal()
+                                                reportInviteMembersButtonClicked()
+                                            }}
+                                            menuItem
+                                            tooltip="Invite members"
+                                            tooltipPlacement="right"
+                                            data-attr="top-menu-invite-team-members"
+                                        >
+                                            <IconPlusSmall />
+                                            Invite members
+                                        </ButtonPrimitive>
+                                    )}
+                                />
+
+                                <Menu.Item
+                                    render={(props) => (
+                                        <ButtonPrimitive
+                                            {...props}
+                                            menuItem
+                                            onClick={openProjectSwitcher}
+                                            data-attr="top-menu-all-projects"
+                                        >
+                                            <IconBlank />
+                                            All projects
+                                            <span className="ml-auto text-tertiary text-xs">
+                                                <RenderKeybind keybind={[keyBinds.projectSwitcher]} />
+                                            </span>
+                                        </ButtonPrimitive>
+                                    )}
+                                />
+
+                                <Label intent="menu" className="px-2 mt-2">
+                                    Organizations
+                                </Label>
+                                <DropdownMenuSeparator />
+                                <Menu.Item
+                                    render={(props) => (
+                                        <Link
+                                            {...props}
+                                            to={urls.settings('organization')}
+                                            buttonProps={{
+                                                className: 'flex items-center gap-2',
+                                                menuItem: true,
+                                                truncate: true,
+                                            }}
+                                            tooltip="Organization settings"
+                                            tooltipPlacement="right"
+                                            data-attr="top-menu-organization-settings"
+                                        >
+                                            {currentOrganization ? (
+                                                <UploadedLogo
+                                                    name={currentOrganization.name}
+                                                    entityId={currentOrganization.id}
+                                                    mediaId={currentOrganization.logo_media_id}
+                                                    size="xsmall"
+                                                />
+                                            ) : (
+                                                <UploadedLogo name="?" entityId="" mediaId="" size="xsmall" />
+                                            )}
+                                            <span className="truncate font-semibold">
+                                                {currentOrganization ? currentOrganization.name : 'Select organization'}
+                                            </span>
+                                            {currentOrganization && (
+                                                <div className="ml-auto flex items-center gap-1">
+                                                    <AccessLevelIndicator organization={currentOrganization} />
+                                                    <IconGear className="text-tertiary" />
+                                                </div>
+                                            )}
+                                        </Link>
+                                    )}
+                                />
+
+                                {isCloudOrDev ? (
+                                    <Menu.Item
+                                        render={(props) => (
+                                            <Link
+                                                {...props}
+                                                to={
+                                                    featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]
+                                                        ? urls.organizationBillingSection('overview')
+                                                        : urls.organizationBilling()
+                                                }
+                                                buttonProps={{
+                                                    className: 'flex items-center gap-2',
+                                                    menuItem: true,
+                                                    truncate: true,
+                                                }}
+                                            >
+                                                <IconReceipt />
+                                                {featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]
+                                                    ? 'Billing & Usage'
+                                                    : 'Billing'}
+                                            </Link>
+                                        )}
+                                    />
+                                ) : null}
+
+                                <Menu.Item
+                                    render={(props) => (
+                                        <ButtonPrimitive
+                                            {...props}
+                                            menuItem
+                                            onClick={() => {
+                                                setAccountMenuOpen(false)
+                                                openOrgSwitcher()
+                                            }}
+                                            data-attr="top-menu-all-organizations"
+                                        >
+                                            <IconBlank />
+                                            All organizations
+                                            <span className="ml-auto text-tertiary text-xs">
+                                                <RenderKeybind keybind={[keyBinds.orgSwitcher]} />
+                                            </span>
+                                        </ButtonPrimitive>
+                                    )}
+                                />
+
+                                <DropdownMenuSeparator />
+
+                                {isDev ||
+                                    (billing?.account_owner?.email && billing?.account_owner?.name && (
+                                        <>
+                                            <Label intent="menu" className="px-2 mt-2">
+                                                YOUR POSTHOG HUMAN
+                                            </Label>
+                                            <DropdownMenuSeparator />
+                                            <Menu.Item
+                                                render={(props) => (
+                                                    <ButtonPrimitive
+                                                        {...props}
+                                                        menuItem
+                                                        onClick={() => {
+                                                            void copyToClipboard(
+                                                                billing?.account_owner?.email || '',
+                                                                'email'
+                                                            )
+                                                            reportAccountOwnerClicked({
+                                                                name: billing?.account_owner?.name || '',
+                                                                email: billing?.account_owner?.email || '',
+                                                            })
+                                                        }}
+                                                        tooltip="This is your dedicated PostHog human. Click to copy their email. They can help you with trying out new products, solving problems, and reducing your spend."
+                                                        tooltipPlacement="right"
+                                                        data-attr="top-menu-account-owner"
+                                                    >
+                                                        <ProfilePicture
+                                                            user={{
+                                                                first_name: billing?.account_owner?.name || '',
+                                                                email: billing?.account_owner?.email || '',
+                                                            }}
+                                                            size="xs"
+                                                        />
+                                                        <span className="truncate font-semibold">
+                                                            {billing?.account_owner?.name || ''}
+                                                        </span>
+                                                        <div className="ml-auto">
+                                                            <IconCopy />
+                                                        </div>
+                                                    </ButtonPrimitive>
+                                                )}
+                                            />
+                                            <DropdownMenuSeparator />
+                                        </>
+                                    ))}
+
+                                <Menu.Item
+                                    render={(props) => (
+                                        <ButtonPrimitive
+                                            {...props}
+                                            menuItem
+                                            onClick={logout}
+                                            data-attr="top-menu-item-logout"
+                                        >
+                                            <IconLeave />
+                                            Log out
+                                        </ButtonPrimitive>
+                                    )}
+                                />
+                            </ScrollableShadows>
+                        </Menu.Popup>
+                    </Menu.Positioner>
+                </Menu.Portal>
+                {/* 
+                <DropdownMenuContent
+                    side="bottom"
+                    align="start"
+                    collisionPadding={{ bottom: 0 }}
+                    className="min-w-[var(--project-panel-width)]"
+                >
+                    <DropdownMenuGroup>
+                    </DropdownMenuGroup>
+                </DropdownMenuContent> */}
+            </Menu.Root>
+
+            <ProjectModal />
+            <OrgModal />
+        </>
     )
 }

--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -172,13 +172,12 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                 )}
 
                                 <Menu.Item
-                                    render={(props) => (
+                                    onClick={() => {
+                                        showInviteModal()
+                                        reportInviteMembersButtonClicked()
+                                    }}
+                                    render={
                                         <ButtonPrimitive
-                                            {...props}
-                                            onClick={() => {
-                                                showInviteModal()
-                                                reportInviteMembersButtonClicked()
-                                            }}
                                             menuItem
                                             tooltip="Invite members"
                                             tooltipPlacement="right"
@@ -187,24 +186,20 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                             <IconPlusSmall />
                                             Invite members
                                         </ButtonPrimitive>
-                                    )}
+                                    }
                                 />
 
                                 <Menu.Item
-                                    render={(props) => (
-                                        <ButtonPrimitive
-                                            {...props}
-                                            menuItem
-                                            onClick={openProjectSwitcher}
-                                            data-attr="top-menu-all-projects"
-                                        >
+                                    onClick={() => openProjectSwitcher()}
+                                    render={
+                                        <ButtonPrimitive menuItem data-attr="top-menu-all-projects">
                                             <IconBlank />
                                             All projects
                                             <span className="ml-auto text-tertiary text-xs">
                                                 <RenderKeybind keybind={[keyBinds.projectSwitcher]} />
                                             </span>
                                         </ButtonPrimitive>
-                                    )}
+                                    }
                                 />
 
                                 <Label intent="menu" className="px-2 mt-2">
@@ -274,23 +269,19 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                 ) : null}
 
                                 <Menu.Item
-                                    render={(props) => (
-                                        <ButtonPrimitive
-                                            {...props}
-                                            menuItem
-                                            onClick={() => {
-                                                setAccountMenuOpen(false)
-                                                openOrgSwitcher()
-                                            }}
-                                            data-attr="top-menu-all-organizations"
-                                        >
+                                    onClick={() => {
+                                        setAccountMenuOpen(false)
+                                        openOrgSwitcher()
+                                    }}
+                                    render={
+                                        <ButtonPrimitive menuItem data-attr="top-menu-all-organizations">
                                             <IconBlank />
                                             All organizations
                                             <span className="ml-auto text-tertiary text-xs">
                                                 <RenderKeybind keybind={[keyBinds.orgSwitcher]} />
                                             </span>
                                         </ButtonPrimitive>
-                                    )}
+                                    }
                                 />
 
                                 <DropdownMenuSeparator />
@@ -303,20 +294,16 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                             </Label>
                                             <DropdownMenuSeparator />
                                             <Menu.Item
-                                                render={(props) => (
+                                                onClick={() => {
+                                                    void copyToClipboard(billing?.account_owner?.email || '', 'email')
+                                                    reportAccountOwnerClicked({
+                                                        name: billing?.account_owner?.name || '',
+                                                        email: billing?.account_owner?.email || '',
+                                                    })
+                                                }}
+                                                render={
                                                     <ButtonPrimitive
-                                                        {...props}
                                                         menuItem
-                                                        onClick={() => {
-                                                            void copyToClipboard(
-                                                                billing?.account_owner?.email || '',
-                                                                'email'
-                                                            )
-                                                            reportAccountOwnerClicked({
-                                                                name: billing?.account_owner?.name || '',
-                                                                email: billing?.account_owner?.email || '',
-                                                            })
-                                                        }}
                                                         tooltip="This is your dedicated PostHog human. Click to copy their email. They can help you with trying out new products, solving problems, and reducing your spend."
                                                         tooltipPlacement="right"
                                                         data-attr="top-menu-account-owner"
@@ -335,24 +322,20 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                                             <IconCopy />
                                                         </div>
                                                     </ButtonPrimitive>
-                                                )}
+                                                }
                                             />
                                             <DropdownMenuSeparator />
                                         </>
                                     ))}
 
                                 <Menu.Item
-                                    render={(props) => (
-                                        <ButtonPrimitive
-                                            {...props}
-                                            menuItem
-                                            onClick={logout}
-                                            data-attr="top-menu-item-logout"
-                                        >
+                                    onClick={() => logout()}
+                                    render={
+                                        <ButtonPrimitive menuItem data-attr="top-menu-item-logout">
                                             <IconLeave />
                                             Log out
                                         </ButtonPrimitive>
-                                    )}
+                                    }
                                 />
                             </ScrollableShadows>
                         </Menu.Popup>

--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -40,7 +40,7 @@ interface AccountMenuProps {
 export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.Element {
     const { user } = useValues(userLogic)
     const { currentOrganization } = useValues(organizationLogic)
-    const { isCloudOrDev, isDev } = useValues(preflightLogic)
+    const { isCloudOrDev } = useValues(preflightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { billing } = useValues(billingLogic)
     const { showInviteModal } = useActions(inviteLogic)
@@ -286,47 +286,46 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
 
                                 <DropdownMenuSeparator />
 
-                                {isDev ||
-                                    (billing?.account_owner?.email && billing?.account_owner?.name && (
-                                        <>
-                                            <Label intent="menu" className="px-2 mt-2">
-                                                YOUR POSTHOG HUMAN
-                                            </Label>
-                                            <DropdownMenuSeparator />
-                                            <Menu.Item
-                                                onClick={() => {
-                                                    void copyToClipboard(billing?.account_owner?.email || '', 'email')
-                                                    reportAccountOwnerClicked({
-                                                        name: billing?.account_owner?.name || '',
-                                                        email: billing?.account_owner?.email || '',
-                                                    })
-                                                }}
-                                                render={
-                                                    <ButtonPrimitive
-                                                        menuItem
-                                                        tooltip="This is your dedicated PostHog human. Click to copy their email. They can help you with trying out new products, solving problems, and reducing your spend."
-                                                        tooltipPlacement="right"
-                                                        data-attr="top-menu-account-owner"
-                                                    >
-                                                        <ProfilePicture
-                                                            user={{
-                                                                first_name: billing?.account_owner?.name || '',
-                                                                email: billing?.account_owner?.email || '',
-                                                            }}
-                                                            size="xs"
-                                                        />
-                                                        <span className="truncate font-semibold">
-                                                            {billing?.account_owner?.name || ''}
-                                                        </span>
-                                                        <div className="ml-auto">
-                                                            <IconCopy />
-                                                        </div>
-                                                    </ButtonPrimitive>
-                                                }
-                                            />
-                                            <DropdownMenuSeparator />
-                                        </>
-                                    ))}
+                                {billing?.account_owner?.email && billing?.account_owner?.name && (
+                                    <>
+                                        <Label intent="menu" className="px-2 mt-2">
+                                            YOUR POSTHOG HUMAN
+                                        </Label>
+                                        <DropdownMenuSeparator />
+                                        <Menu.Item
+                                            onClick={() => {
+                                                void copyToClipboard(billing?.account_owner?.email || '', 'email')
+                                                reportAccountOwnerClicked({
+                                                    name: billing?.account_owner?.name || '',
+                                                    email: billing?.account_owner?.email || '',
+                                                })
+                                            }}
+                                            render={
+                                                <ButtonPrimitive
+                                                    menuItem
+                                                    tooltip="This is your dedicated PostHog human. Click to copy their email. They can help you with trying out new products, solving problems, and reducing your spend."
+                                                    tooltipPlacement="right"
+                                                    data-attr="top-menu-account-owner"
+                                                >
+                                                    <ProfilePicture
+                                                        user={{
+                                                            first_name: billing?.account_owner?.name || '',
+                                                            email: billing?.account_owner?.email || '',
+                                                        }}
+                                                        size="xs"
+                                                    />
+                                                    <span className="truncate font-semibold">
+                                                        {billing?.account_owner?.name || ''}
+                                                    </span>
+                                                    <div className="ml-auto">
+                                                        <IconCopy />
+                                                    </div>
+                                                </ButtonPrimitive>
+                                            }
+                                        />
+                                        <DropdownMenuSeparator />
+                                    </>
+                                )}
 
                                 <Menu.Item
                                     onClick={() => logout()}

--- a/frontend/src/lib/components/Account/OrgModal.tsx
+++ b/frontend/src/lib/components/Account/OrgModal.tsx
@@ -1,0 +1,18 @@
+import { useActions, useValues } from 'kea'
+
+import { DialogPrimitive, DialogPrimitiveTitle } from 'lib/ui/DialogPrimitive/DialogPrimitive'
+
+import { OrgSwitcher } from './OrgSwitcher'
+import { newAccountMenuLogic } from './newAccountMenuLogic'
+
+export function OrgModal(): JSX.Element {
+    const { isOrgSwitcherOpen } = useValues(newAccountMenuLogic)
+    const { closeOrgSwitcher } = useActions(newAccountMenuLogic)
+
+    return (
+        <DialogPrimitive open={isOrgSwitcherOpen} onOpenChange={(open) => !open && closeOrgSwitcher()}>
+            <DialogPrimitiveTitle>Switch organization</DialogPrimitiveTitle>
+            <OrgSwitcher />
+        </DialogPrimitive>
+    )
+}

--- a/frontend/src/lib/components/Account/OrgSwitcher.tsx
+++ b/frontend/src/lib/components/Account/OrgSwitcher.tsx
@@ -1,0 +1,305 @@
+import { Combobox } from '@base-ui/react/combobox'
+import { useActions, useValues } from 'kea'
+import { useCallback, useMemo, useRef, useState } from 'react'
+
+import { IconCheck, IconPlusSmall, IconSearch, IconX } from '@posthog/icons'
+
+import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
+import { UploadedLogo } from 'lib/lemon-ui/UploadedLogo'
+import { IconBlank } from 'lib/lemon-ui/icons'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { userLogic } from 'scenes/userLogic'
+
+import { globalModalsLogic } from '~/layout/GlobalModals'
+import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
+import { AccessLevelIndicator } from '~/layout/navigation/AccessLevelIndicator'
+import { AvailableFeature, OrganizationBasicType } from '~/types'
+
+import { ScrollableShadows } from '../ScrollableShadows/ScrollableShadows'
+import { newAccountMenuLogic } from './newAccountMenuLogic'
+
+interface OrgListItem {
+    type: 'org'
+    id: string
+    org: OrganizationBasicType
+    isCurrent: boolean
+    isDisabled: boolean
+    disabledReason?: string
+}
+
+interface CreateOrgItem {
+    type: 'create'
+    id: 'create-new-org'
+    label: string
+}
+
+type ListItem = OrgListItem | CreateOrgItem
+
+export function OrgSwitcher(): JSX.Element {
+    const { preflight } = useValues(preflightLogic)
+    const { guardAvailableFeature } = useValues(upgradeModalLogic)
+    const { showCreateOrganizationModal } = useActions(globalModalsLogic)
+    const { currentOrganization } = useValues(organizationLogic)
+    const { otherOrganizations } = useValues(userLogic)
+    const { updateCurrentOrganization } = useActions(userLogic)
+    const { closeOrgSwitcher } = useActions(newAccountMenuLogic)
+
+    const [searchValue, setSearchValue] = useState('')
+    const inputRef = useRef<HTMLInputElement>(null!)
+
+    const allOrgItems: OrgListItem[] = useMemo(() => {
+        const items: OrgListItem[] = []
+
+        if (currentOrganization) {
+            items.push({
+                type: 'org',
+                id: currentOrganization.id,
+                org: currentOrganization,
+                isCurrent: true,
+                isDisabled: false,
+            })
+        }
+
+        for (const org of otherOrganizations) {
+            items.push({
+                type: 'org',
+                id: org.id,
+                org,
+                isCurrent: false,
+                isDisabled: org.is_active === false,
+                disabledReason: org.is_not_active_reason || 'Organization is disabled',
+            })
+        }
+
+        return items
+    }, [currentOrganization, otherOrganizations])
+
+    const filteredItems = useMemo(() => {
+        const searchLower = searchValue.trim().toLowerCase()
+
+        // Filter org items
+        const filteredOrgs = searchLower
+            ? allOrgItems.filter((item) => item.org.name.toLowerCase().includes(searchLower))
+            : allOrgItems
+
+        // Create the "create" item - show different label based on search
+        const createItem: CreateOrgItem = {
+            type: 'create',
+            id: 'create-new-org',
+            label: searchValue.trim() ? `Create '${searchValue.trim()}'` : 'New organization',
+        }
+
+        return [...filteredOrgs, createItem] as ListItem[]
+    }, [allOrgItems, searchValue])
+
+    const currentOrgItem = filteredItems.find((o): o is OrgListItem => o.type === 'org' && o.isCurrent)
+    const otherOrgItems = filteredItems
+        .filter((o): o is OrgListItem => o.type === 'org' && !o.isCurrent)
+        .sort((a, b) => a.org.name.localeCompare(b.org.name))
+    const createItem = filteredItems.find((o): o is CreateOrgItem => o.type === 'create')
+
+    const handleItemClick = useCallback(
+        (item: ListItem) => {
+            if (item.type === 'create') {
+                guardAvailableFeature(
+                    AvailableFeature.ORGANIZATIONS_PROJECTS,
+                    () => {
+                        showCreateOrganizationModal()
+                    },
+                    { guardOnCloud: false }
+                )
+                closeOrgSwitcher()
+            } else if (!item.isCurrent && !item.isDisabled) {
+                closeOrgSwitcher()
+                updateCurrentOrganization(item.org.id)
+            }
+        },
+        [closeOrgSwitcher, updateCurrentOrganization, guardAvailableFeature, showCreateOrganizationModal]
+    )
+
+    const getItemString = useCallback((item: ListItem | null): string => {
+        if (!item) {
+            return ''
+        }
+        if (item.type === 'create') {
+            return item.label
+        }
+        return item.org.name
+    }, [])
+
+    const canCreateOrg = preflight?.can_create_org !== false
+
+    return (
+        <Combobox.Root
+            items={filteredItems}
+            filter={null}
+            itemToStringValue={getItemString}
+            inline
+            defaultOpen
+            autoHighlight
+        >
+            <div className="flex flex-col overflow-hidden">
+                {/* Search Input */}
+                <div className="p-2 border-b border-primary">
+                    <label className="group input-like flex gap-1 items-center relative w-full bg-fill-input border border-primary focus-within:ring-primary py-1 px-2">
+                        <Combobox.Icon
+                            className="size-5"
+                            render={<IconSearch className="text-tertiary group-focus-within:text-primary" />}
+                        />
+                        <Combobox.Input
+                            ref={inputRef}
+                            value={searchValue}
+                            onChange={(e) => setSearchValue(e.target.value)}
+                            aria-label="Search organizations"
+                            placeholder="Search organizations..."
+                            className="w-full px-1 py-1 text-sm focus:outline-none border-transparent"
+                            autoFocus
+                        />
+                        {searchValue && (
+                            <Combobox.Clear
+                                render={
+                                    <ButtonPrimitive
+                                        iconOnly
+                                        size="sm"
+                                        onClick={() => setSearchValue('')}
+                                        aria-label="Clear search"
+                                        className="-mr-1"
+                                    >
+                                        <IconX className="size-4 text-tertiary" />
+                                    </ButtonPrimitive>
+                                }
+                            />
+                        )}
+                    </label>
+                </div>
+
+                {/* Results */}
+                <ScrollableShadows
+                    direction="vertical"
+                    styledScrollbars
+                    className="flex-1 overflow-y-auto max-h-[400px]"
+                >
+                    <Combobox.List className="flex flex-col gap-px p-2" tabIndex={-1}>
+                        {/* Current Organization */}
+                        {currentOrgItem && (
+                            <Combobox.Group items={[currentOrgItem]}>
+                                <Combobox.Collection>
+                                    {(item: OrgListItem) => (
+                                        <Combobox.Item
+                                            key={item.id}
+                                            value={item}
+                                            onClick={() => handleItemClick(item)}
+                                            render={(props) => (
+                                                <ButtonPrimitive {...props} menuItem active fullWidth tabIndex={-1}>
+                                                    <IconCheck className="text-tertiary" />
+                                                    <UploadedLogo
+                                                        size="xsmall"
+                                                        name={item.org.name}
+                                                        entityId={item.org.id}
+                                                        mediaId={item.org.logo_media_id}
+                                                    />
+                                                    <span className="truncate">{item.org.name}</span>
+                                                    <div className="ml-auto">
+                                                        <AccessLevelIndicator organization={item.org} />
+                                                    </div>
+                                                </ButtonPrimitive>
+                                            )}
+                                        />
+                                    )}
+                                </Combobox.Collection>
+                            </Combobox.Group>
+                        )}
+
+                        {/* Other Organizations */}
+                        {otherOrgItems.length > 0 && (
+                            <Combobox.Group items={otherOrgItems}>
+                                <Combobox.Collection>
+                                    {(item: OrgListItem) => (
+                                        <Combobox.Item
+                                            key={item.id}
+                                            value={item}
+                                            onClick={() => handleItemClick(item)}
+                                            render={(props) => (
+                                                <ButtonPrimitive
+                                                    {...props}
+                                                    menuItem
+                                                    fullWidth
+                                                    tabIndex={-1}
+                                                    disabled={item.isDisabled}
+                                                    tooltip={item.isDisabled ? item.disabledReason : undefined}
+                                                    tooltipPlacement="right"
+                                                >
+                                                    <IconBlank />
+                                                    <UploadedLogo
+                                                        size="xsmall"
+                                                        name={item.org.name}
+                                                        entityId={item.org.id}
+                                                        mediaId={item.org.logo_media_id}
+                                                    />
+                                                    <span className="truncate">{item.org.name}</span>
+                                                    <div className="ml-auto">
+                                                        <AccessLevelIndicator organization={item.org} />
+                                                    </div>
+                                                </ButtonPrimitive>
+                                            )}
+                                        />
+                                    )}
+                                </Combobox.Collection>
+                            </Combobox.Group>
+                        )}
+
+                        {/* Create New Organization */}
+                        {createItem && (
+                            <Combobox.Group items={[createItem]}>
+                                <Combobox.Collection>
+                                    {(item: CreateOrgItem) => (
+                                        <Combobox.Item
+                                            key={item.id}
+                                            value={item}
+                                            onClick={() => handleItemClick(item)}
+                                            render={(props) => (
+                                                <ButtonPrimitive
+                                                    {...props}
+                                                    menuItem
+                                                    fullWidth
+                                                    tabIndex={-1}
+                                                    disabled={!canCreateOrg}
+                                                    tooltip={
+                                                        !canCreateOrg
+                                                            ? 'You do not have permission to create an organization'
+                                                            : undefined
+                                                    }
+                                                    tooltipPlacement="right"
+                                                >
+                                                    <IconPlusSmall className="text-tertiary" />
+                                                    <span className="truncate">{item.label}</span>
+                                                </ButtonPrimitive>
+                                            )}
+                                        />
+                                    )}
+                                </Combobox.Collection>
+                            </Combobox.Group>
+                        )}
+                    </Combobox.List>
+                </ScrollableShadows>
+
+                {/* Footer */}
+                <div className="menu-legend border-t border-primary p-1">
+                    <div className="px-2 py-1 text-xxs text-tertiary font-medium flex items-center gap-2">
+                        <span>
+                            <KeyboardShortcut arrowup arrowdown preserveOrder /> navigate
+                        </span>
+                        <span>
+                            <KeyboardShortcut enter /> select
+                        </span>
+                        <span>
+                            <KeyboardShortcut escape /> close
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </Combobox.Root>
+    )
+}

--- a/frontend/src/lib/components/Account/OrgSwitcher.tsx
+++ b/frontend/src/lib/components/Account/OrgSwitcher.tsx
@@ -181,7 +181,7 @@ export function OrgSwitcher(): JSX.Element {
                     styledScrollbars
                     className="flex-1 overflow-y-auto max-h-[400px]"
                 >
-                    <Combobox.List className="flex flex-col gap-px p-2" tabIndex={-1}>
+                    <Combobox.List className="flex flex-col gap-px p-2">
                         {/* Current Organization */}
                         {currentOrgItem && (
                             <Combobox.Group items={[currentOrgItem]}>
@@ -191,8 +191,16 @@ export function OrgSwitcher(): JSX.Element {
                                             key={item.id}
                                             value={item}
                                             onClick={() => handleItemClick(item)}
+                                            disabled
                                             render={(props) => (
-                                                <ButtonPrimitive {...props} menuItem active fullWidth tabIndex={-1}>
+                                                <ButtonPrimitive
+                                                    {...props}
+                                                    disabled
+                                                    data-disabled="true"
+                                                    menuItem
+                                                    active
+                                                    fullWidth
+                                                >
                                                     <IconCheck className="text-tertiary" />
                                                     <UploadedLogo
                                                         size="xsmall"
@@ -226,7 +234,6 @@ export function OrgSwitcher(): JSX.Element {
                                                     {...props}
                                                     menuItem
                                                     fullWidth
-                                                    tabIndex={-1}
                                                     disabled={item.isDisabled}
                                                     tooltip={item.isDisabled ? item.disabledReason : undefined}
                                                     tooltipPlacement="right"
@@ -264,7 +271,6 @@ export function OrgSwitcher(): JSX.Element {
                                                     {...props}
                                                     menuItem
                                                     fullWidth
-                                                    tabIndex={-1}
                                                     disabled={!canCreateOrg}
                                                     tooltip={
                                                         !canCreateOrg

--- a/frontend/src/lib/components/Account/OrgSwitcher.tsx
+++ b/frontend/src/lib/components/Account/OrgSwitcher.tsx
@@ -88,7 +88,9 @@ export function OrgSwitcher(): JSX.Element {
         const createItem: CreateOrgItem = {
             type: 'create',
             id: 'create-new-org',
-            label: searchValue.trim() ? `Create '${searchValue.trim()}'` : 'New organization',
+            label: 'New organization',
+            // TODO: Uncomment this when we have a way to create organizations with a name
+            // label: searchValue.trim() ? `Create '${searchValue.trim()}'` : 'New organization',
         }
 
         return [...filteredOrgs, createItem] as ListItem[]

--- a/frontend/src/lib/components/Account/ProjectModal.tsx
+++ b/frontend/src/lib/components/Account/ProjectModal.tsx
@@ -1,0 +1,18 @@
+import { useActions, useValues } from 'kea'
+
+import { DialogPrimitive, DialogPrimitiveTitle } from 'lib/ui/DialogPrimitive/DialogPrimitive'
+
+import { ProjectSwitcher } from './ProjectSwitcher'
+import { newAccountMenuLogic } from './newAccountMenuLogic'
+
+export function ProjectModal(): JSX.Element {
+    const { isProjectSwitcherOpen } = useValues(newAccountMenuLogic)
+    const { closeProjectSwitcher } = useActions(newAccountMenuLogic)
+
+    return (
+        <DialogPrimitive open={isProjectSwitcherOpen} onOpenChange={(open) => !open && closeProjectSwitcher()}>
+            <DialogPrimitiveTitle>Switch project</DialogPrimitiveTitle>
+            <ProjectSwitcher />
+        </DialogPrimitive>
+    )
+}

--- a/frontend/src/lib/components/Account/ProjectSwitcher.tsx
+++ b/frontend/src/lib/components/Account/ProjectSwitcher.tsx
@@ -1,0 +1,292 @@
+import { Combobox } from '@base-ui/react/combobox'
+import { useActions, useValues } from 'kea'
+import { useCallback, useMemo, useRef, useState } from 'react'
+
+import { IconCheck, IconPlusSmall, IconSearch, IconX } from '@posthog/icons'
+
+import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
+import { IconBlank } from 'lib/lemon-ui/icons'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { getProjectSwitchTargetUrl } from 'lib/utils/router-utils'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { isAuthenticatedTeam, teamLogic } from 'scenes/teamLogic'
+
+import { globalModalsLogic } from '~/layout/GlobalModals'
+import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
+import { AvailableFeature, TeamBasicType } from '~/types'
+
+import { ScrollableShadows } from '../ScrollableShadows/ScrollableShadows'
+import { ProjectName } from './ProjectMenu'
+import { newAccountMenuLogic } from './newAccountMenuLogic'
+
+interface ProjectListItem {
+    type: 'project'
+    id: number
+    team: TeamBasicType
+    isCurrent: boolean
+}
+
+interface CreateProjectItem {
+    type: 'create'
+    id: 'create-new-project'
+    label: string
+}
+
+type ListItem = ProjectListItem | CreateProjectItem
+
+export function ProjectSwitcher(): JSX.Element | null {
+    const { preflight } = useValues(preflightLogic)
+    const { guardAvailableFeature } = useValues(upgradeModalLogic)
+    const { showCreateProjectModal } = useActions(globalModalsLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const { currentOrganization, projectCreationForbiddenReason } = useValues(organizationLogic)
+    const { closeProjectSwitcher } = useActions(newAccountMenuLogic)
+
+    const [searchValue, setSearchValue] = useState('')
+    const inputRef = useRef<HTMLInputElement>(null!)
+
+    const allProjectItems: ProjectListItem[] = useMemo(() => {
+        const items: ProjectListItem[] = []
+
+        if (currentOrganization?.teams) {
+            for (const team of currentOrganization.teams) {
+                items.push({
+                    type: 'project',
+                    id: team.id,
+                    team,
+                    isCurrent: team.id === currentTeam?.id,
+                })
+            }
+        }
+
+        return items
+    }, [currentOrganization?.teams, currentTeam?.id])
+
+    const filteredItems = useMemo(() => {
+        const searchLower = searchValue.trim().toLowerCase()
+
+        // Filter project items
+        const filteredProjects = searchLower
+            ? allProjectItems.filter((item) => item.team.name.toLowerCase().includes(searchLower))
+            : allProjectItems
+
+        // Create the "create" item - show different label based on search
+        const createItem: CreateProjectItem = {
+            type: 'create',
+            id: 'create-new-project',
+            label: searchValue.trim() ? `Create '${searchValue.trim()}'` : 'New project',
+        }
+
+        return [...filteredProjects, createItem] as ListItem[]
+    }, [allProjectItems, searchValue])
+
+    const currentProject = filteredItems.find((p): p is ProjectListItem => p.type === 'project' && p.isCurrent)
+    const otherProjects = filteredItems
+        .filter((p): p is ProjectListItem => p.type === 'project' && !p.isCurrent)
+        .sort((a, b) => a.team.name.localeCompare(b.team.name))
+    const createItem = filteredItems.find((p): p is CreateProjectItem => p.type === 'create')
+
+    const handleItemClick = useCallback(
+        (item: ListItem) => {
+            if (item.type === 'create') {
+                guardAvailableFeature(AvailableFeature.ORGANIZATIONS_PROJECTS, showCreateProjectModal, {
+                    currentUsage: currentOrganization?.teams?.length,
+                })
+                closeProjectSwitcher()
+            } else if (!item.isCurrent) {
+                const targetUrl = getProjectSwitchTargetUrl(
+                    location.pathname,
+                    item.team.id,
+                    currentTeam?.project_id,
+                    item.team.project_id
+                )
+                closeProjectSwitcher()
+                window.location.href = targetUrl
+            }
+        },
+        [
+            currentTeam?.project_id,
+            closeProjectSwitcher,
+            guardAvailableFeature,
+            showCreateProjectModal,
+            currentOrganization?.teams?.length,
+        ]
+    )
+
+    const getItemString = useCallback((item: ListItem | null): string => {
+        if (!item) {
+            return ''
+        }
+        if (item.type === 'create') {
+            return item.label
+        }
+        return item.team.name
+    }, [])
+
+    const canCreateProject = preflight?.can_create_org !== false && !projectCreationForbiddenReason
+
+    if (!isAuthenticatedTeam(currentTeam)) {
+        return null
+    }
+
+    return (
+        <Combobox.Root
+            items={filteredItems}
+            filter={null}
+            itemToStringValue={getItemString}
+            inline
+            defaultOpen
+            autoHighlight
+        >
+            <div className="flex flex-col overflow-hidden">
+                {/* Search Input */}
+                <div className="p-2 border-b border-primary">
+                    <label className="group input-like flex gap-1 items-center relative w-full bg-fill-input border border-primary focus-within:ring-primary py-1 px-2">
+                        <Combobox.Icon
+                            className="size-5"
+                            render={<IconSearch className="text-tertiary group-focus-within:text-primary" />}
+                        />
+                        <Combobox.Input
+                            ref={inputRef}
+                            value={searchValue}
+                            onChange={(e) => setSearchValue(e.target.value)}
+                            aria-label="Search projects"
+                            placeholder="Search projects..."
+                            className="w-full px-1 py-1 text-sm focus:outline-none border-transparent"
+                            autoFocus
+                        />
+                        {searchValue && (
+                            <Combobox.Clear
+                                render={
+                                    <ButtonPrimitive
+                                        iconOnly
+                                        size="sm"
+                                        onClick={() => setSearchValue('')}
+                                        aria-label="Clear search"
+                                        className="-mr-1"
+                                    >
+                                        <IconX className="size-4 text-tertiary" />
+                                    </ButtonPrimitive>
+                                }
+                            />
+                        )}
+                    </label>
+                </div>
+
+                {/* Results */}
+                <ScrollableShadows
+                    direction="vertical"
+                    styledScrollbars
+                    className="flex-1 overflow-y-auto max-h-[400px]"
+                >
+                    <Combobox.List className="flex flex-col gap-px p-2" tabIndex={-1}>
+                        {/* Current Project */}
+                        {currentProject && (
+                            <Combobox.Group items={[currentProject]}>
+                                <Combobox.Collection>
+                                    {(item: ProjectListItem) => (
+                                        <Combobox.Item
+                                            key={item.id}
+                                            value={item}
+                                            onClick={() => handleItemClick(item)}
+                                            render={(props) => (
+                                                <ButtonPrimitive
+                                                    {...props}
+                                                    menuItem
+                                                    active
+                                                    className="flex-1"
+                                                    tabIndex={-1}
+                                                    hasSideActionRight
+                                                >
+                                                    <IconCheck className="text-tertiary" />
+                                                    <ProjectName team={item.team} />
+                                                </ButtonPrimitive>
+                                            )}
+                                        />
+                                    )}
+                                </Combobox.Collection>
+                            </Combobox.Group>
+                        )}
+
+                        {/* Other Projects */}
+                        {otherProjects.length > 0 && (
+                            <Combobox.Group items={otherProjects}>
+                                <Combobox.Collection>
+                                    {(item: ProjectListItem) => (
+                                        <Combobox.Item
+                                            key={item.id}
+                                            value={item}
+                                            onClick={() => handleItemClick(item)}
+                                            render={(props) => (
+                                                <ButtonPrimitive
+                                                    {...props}
+                                                    menuItem
+                                                    className="flex-1"
+                                                    tabIndex={-1}
+                                                    hasSideActionRight
+                                                >
+                                                    <IconBlank />
+                                                    <ProjectName team={item.team} />
+                                                </ButtonPrimitive>
+                                            )}
+                                        />
+                                    )}
+                                </Combobox.Collection>
+                            </Combobox.Group>
+                        )}
+
+                        {/* Create New Project */}
+                        {createItem && (
+                            <Combobox.Group items={[createItem]}>
+                                <Combobox.Collection>
+                                    {(item: CreateProjectItem) => (
+                                        <Combobox.Item
+                                            key={item.id}
+                                            value={item}
+                                            onClick={() => handleItemClick(item)}
+                                            render={(props) => (
+                                                <ButtonPrimitive
+                                                    {...props}
+                                                    menuItem
+                                                    fullWidth
+                                                    tabIndex={-1}
+                                                    disabled={!canCreateProject}
+                                                    tooltip={
+                                                        !canCreateProject
+                                                            ? projectCreationForbiddenReason ||
+                                                              'You do not have permission to create a project'
+                                                            : undefined
+                                                    }
+                                                    tooltipPlacement="right"
+                                                >
+                                                    <IconPlusSmall className="text-tertiary" />
+                                                    <span className="truncate">{item.label}</span>
+                                                </ButtonPrimitive>
+                                            )}
+                                        />
+                                    )}
+                                </Combobox.Collection>
+                            </Combobox.Group>
+                        )}
+                    </Combobox.List>
+                </ScrollableShadows>
+
+                {/* Footer */}
+                <div className="menu-legend border-t border-primary p-1">
+                    <div className="px-2 py-1 text-xxs text-tertiary font-medium flex items-center gap-2">
+                        <span>
+                            <KeyboardShortcut arrowup arrowdown preserveOrder /> navigate
+                        </span>
+                        <span>
+                            <KeyboardShortcut enter /> select
+                        </span>
+                        <span>
+                            <KeyboardShortcut escape /> close
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </Combobox.Root>
+    )
+}

--- a/frontend/src/lib/components/Account/ProjectSwitcher.tsx
+++ b/frontend/src/lib/components/Account/ProjectSwitcher.tsx
@@ -75,7 +75,9 @@ export function ProjectSwitcher(): JSX.Element | null {
         const createItem: CreateProjectItem = {
             type: 'create',
             id: 'create-new-project',
-            label: searchValue.trim() ? `Create '${searchValue.trim()}'` : 'New project',
+            label: 'New project',
+            // TODO: Uncomment this when we have a way to create projects with a name
+            // label: searchValue.trim() ? `Create '${searchValue.trim()}'` : 'New project',
         }
 
         return [...filteredProjects, createItem] as ListItem[]

--- a/frontend/src/lib/components/Account/ProjectSwitcher.tsx
+++ b/frontend/src/lib/components/Account/ProjectSwitcher.tsx
@@ -144,8 +144,9 @@ export function ProjectSwitcher(): JSX.Element | null {
                 <div className="p-2 border-b border-primary">
                     <label className="group input-like flex gap-1 items-center relative w-full bg-fill-input border border-primary focus-within:ring-primary py-1 px-2">
                         <Combobox.Icon
-                            className="size-5"
-                            render={<IconSearch className="text-tertiary group-focus-within:text-primary" />}
+                            render={
+                                <IconSearch className="size-4 shrink-0 text-tertiary group-focus-within:text-primary" />
+                            }
                         />
                         <Combobox.Input
                             ref={inputRef}
@@ -190,6 +191,7 @@ export function ProjectSwitcher(): JSX.Element | null {
                                             key={item.id}
                                             value={item}
                                             onClick={() => handleItemClick(item)}
+                                            disabled
                                             render={(props) => (
                                                 <ButtonPrimitive
                                                     {...props}
@@ -197,7 +199,8 @@ export function ProjectSwitcher(): JSX.Element | null {
                                                     active
                                                     className="flex-1"
                                                     tabIndex={-1}
-                                                    hasSideActionRight
+                                                    disabled={true}
+                                                    data-disabled="true"
                                                 >
                                                     <IconCheck className="text-tertiary" />
                                                     <ProjectName team={item.team} />

--- a/frontend/src/lib/components/Account/newAccountMenuLogic.ts
+++ b/frontend/src/lib/components/Account/newAccountMenuLogic.ts
@@ -7,6 +7,14 @@ export const newAccountMenuLogic = kea<newAccountMenuLogicType>([
     actions({
         setAccountMenuOpen: (isOpen: boolean) => ({ isOpen }),
         toggleAccountMenu: true,
+        // Project switcher modal
+        openProjectSwitcher: true,
+        closeProjectSwitcher: true,
+        toggleProjectSwitcher: true,
+        // Org switcher modal
+        openOrgSwitcher: true,
+        closeOrgSwitcher: true,
+        toggleOrgSwitcher: true,
     }),
     reducers({
         isAccountMenuOpen: [
@@ -14,6 +22,22 @@ export const newAccountMenuLogic = kea<newAccountMenuLogicType>([
             {
                 setAccountMenuOpen: (_, { isOpen }) => isOpen,
                 toggleAccountMenu: (state) => !state,
+            },
+        ],
+        isProjectSwitcherOpen: [
+            false,
+            {
+                openProjectSwitcher: () => true,
+                closeProjectSwitcher: () => false,
+                toggleProjectSwitcher: (state) => !state,
+            },
+        ],
+        isOrgSwitcherOpen: [
+            false,
+            {
+                openOrgSwitcher: () => true,
+                closeOrgSwitcher: () => false,
+                toggleOrgSwitcher: (state) => !state,
             },
         ],
     }),

--- a/frontend/src/lib/components/AppShortcuts/shortcuts.ts
+++ b/frontend/src/lib/components/AppShortcuts/shortcuts.ts
@@ -3,10 +3,13 @@ export const baseModifier: string[] = ['command', 'option']
 export const keyBinds: Record<string, string[]> = {
     // Sequence shortcuts: use 'then' between keys (e.g., type "sql" to open SQL editor)
     sqlEditor: ['s', 'then', 'q', 'then', 'l'],
-    openSidePanel: ['g', 'then', 'p'],
+    toggleLeftNav: ['['],
+    toggleRightNav: [']'],
     helpMenu: ['?'],
     healthMenu: ['g', 'then', 'h'],
     newAccountMenu: ['g', 'then', 'a'],
+    projectSwitcher: ['g', 'then', 'p'],
+    orgSwitcher: ['g', 'then', 'o'],
     quickStart: ['g', 'then', 's'],
     recentItems: [...baseModifier, 'y'],
     newTab: [...baseModifier, 't'],

--- a/frontend/src/lib/components/Command/Command.tsx
+++ b/frontend/src/lib/components/Command/Command.tsx
@@ -1,7 +1,8 @@
-import { Dialog } from '@base-ui/react/dialog'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useCallback } from 'react'
+
+import { DialogPrimitive, DialogPrimitiveTitle } from 'lib/ui/DialogPrimitive/DialogPrimitive'
 
 import { Search } from '../Search/Search'
 import { SearchItem } from '../Search/searchLogic'
@@ -26,25 +27,21 @@ export function Command(): JSX.Element {
     }, [closeCommand])
 
     return (
-        <Dialog.Root open={isCommandOpen} onOpenChange={(open) => !open && closeCommand()}>
-            <Dialog.Portal>
-                <Dialog.Backdrop className="fixed inset-0 min-h-screen min-w-screen bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 z-[var(--z-modal)]" />
-                <Dialog.Popup className="fixed top-1/4 left-1/2 w-[640px] max-w-[calc(100vw-3rem)] max-h-[60vh] -translate-x-1/2 rounded-lg bg-surface-secondary shadow-xl border border-primary transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 flex flex-col overflow-hidden z-[var(--z-force-modal-above-popovers)]">
-                    <Search.Root
-                        logicKey="command"
-                        isActive={isCommandOpen}
-                        onItemSelect={handleItemSelect}
-                        onAskAiClick={handleAskAiClick}
-                        showAskAiLink
-                    >
-                        <Search.Input autoFocus />
-                        <Search.Status />
-                        <Search.Separator />
-                        <Search.Results groupLabelClassName="bg-surface-secondary" />
-                        <Search.Footer />
-                    </Search.Root>
-                </Dialog.Popup>
-            </Dialog.Portal>
-        </Dialog.Root>
+        <DialogPrimitive open={isCommandOpen} onOpenChange={(open) => !open && closeCommand()} className="w-[640px]">
+            <DialogPrimitiveTitle>Command</DialogPrimitiveTitle>
+            <Search.Root
+                logicKey="command"
+                isActive={isCommandOpen}
+                onItemSelect={handleItemSelect}
+                onAskAiClick={handleAskAiClick}
+                showAskAiLink
+            >
+                <Search.Input autoFocus />
+                <Search.Status />
+                <Search.Separator />
+                <Search.Results groupLabelClassName="bg-surface-secondary" />
+                <Search.Footer />
+            </Search.Root>
+        </DialogPrimitive>
     )
 }

--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -605,7 +605,7 @@ function SearchResults({
                                     {Array.from({
                                         length: group.category === 'recents' ? RECENTS_LIMIT : 10,
                                     }).map((_, i) => (
-                                        <div key={i} className="px-1">
+                                        <div key={i} className="px-2">
                                             <WrappingLoadingSkeleton fullWidth>
                                                 <ButtonPrimitive fullWidth className="invisible">
                                                     &nbsp;
@@ -638,7 +638,7 @@ function SearchResults({
                                                                 highlightedItemRef.current = item
                                                             }
                                                             return (
-                                                                <div className="px-1">
+                                                                <div className="px-2">
                                                                     <Link
                                                                         to={item.href}
                                                                         buttonProps={{

--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -397,7 +397,7 @@ function SearchRoot({
                     itemToStringValue={(item) => item?.name ?? ''}
                     actionsRef={actionsRef}
                     inline
-                    autoHighlight="always"
+                    autoHighlight
                     openOnInputClick={false}
                     defaultOpen
                 >

--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -457,14 +457,13 @@ function SearchInput({ autoFocus, className }: SearchInputProps): JSX.Element {
     }, [autoFocus, inputRef])
 
     return (
-        <div className={cn('p-1 space-y-2', className)}>
+        <div className={cn('p-2 space-y-2', className)}>
             <label
                 htmlFor="app-autocomplete-search"
                 className="group input-like flex gap-1 items-center relative w-full bg-fill-input border border-primary focus:outline-none focus:ring-2 focus-within:ring-primary py-1 px-2"
             >
                 <Autocomplete.Icon
-                    className="size-5"
-                    render={<IconSearch className="text-tertiary group-focus-within:text-primary" />}
+                    render={<IconSearch className="size-4 shrink-0 text-tertiary group-focus-within:text-primary" />}
                 />
                 {searchValue ? null : (
                     <span className="text-tertiary pointer-events-none absolute left-8 top-1/2 -translate-y-1/2 ">
@@ -595,7 +594,10 @@ function SearchResults({
                         <Autocomplete.Group key={group.category} items={group.items} className="mb-4">
                             <Autocomplete.GroupLabel
                                 render={
-                                    <Label className={cn('px-3 sticky top-0 z-1', groupLabelClassName)} intent="menu">
+                                    <Label
+                                        className={cn('px-3 sticky top-0 z-1 mb-1', groupLabelClassName)}
+                                        intent="menu"
+                                    >
                                         {getCategoryDisplayName(group.category)}
                                     </Label>
                                 }

--- a/frontend/src/lib/ui/Button/ButtonPrimitives.scss
+++ b/frontend/src/lib/ui/Button/ButtonPrimitives.scss
@@ -72,7 +72,6 @@
         &[data-current='true'],
         &[data-state='open'],
         &[data-state='checked'],
-        &[data-highlighted],
         &[aria-expanded='true'],
         &.button-primitive--active {
             background-color: var(--color-bg-fill-button-tertiary-active);
@@ -83,6 +82,7 @@
         }
 
         &[data-focused='true'],
+        &[data-highlighted],
         &:hover {
             background-color: var(--color-bg-fill-button-tertiary-hover);
         }
@@ -103,7 +103,6 @@
         &[data-state='open'],
         &[data-state='checked'],
         &[data-menu-item='true'],
-        &[data-highlighted],
         &[aria-expanded='true'],
         &.button-primitive--active {
             background-color: var(--active-bg-color);
@@ -114,6 +113,7 @@
         }
 
         &[data-focused='true'],
+        &[data-highlighted],
         &:hover {
             background-color: var(--hover-bg-color);
         }
@@ -130,7 +130,6 @@
         &[data-state='open'],
         &[data-state='checked'],
         &[data-menu-item='true'],
-        &[data-highlighted],
         &[aria-expanded='true'],
         &.button-primitive--active {
             background-color: var(--color-bg-fill-error-highlight);
@@ -141,6 +140,7 @@
         }
 
         &[data-focused='true'],
+        &[data-highlighted],
         &:hover {
             background-color: var(--color-bg-fill-error-highlight);
         }
@@ -156,7 +156,6 @@
         &[data-state='open'],
         &[data-state='checked'],
         &[data-menu-item='true'],
-        &[data-highlighted],
         &[aria-expanded='true'],
         &.button-primitive--active {
             background-color: var(--color-bg-fill-button-tertiary-active);
@@ -167,6 +166,7 @@
         }
 
         &[data-focused='true'],
+        &[data-highlighted],
         &:hover {
             background-color: var(--color-bg-fill-button-tertiary-hover);
         }

--- a/frontend/src/lib/ui/DialogPrimitive/DialogPrimitive.tsx
+++ b/frontend/src/lib/ui/DialogPrimitive/DialogPrimitive.tsx
@@ -1,19 +1,28 @@
 import { Dialog } from '@base-ui/react/dialog'
 
+import { cn } from 'lib/utils/css-classes'
+
 function DialogPrimitive({
     children,
     open,
     onOpenChange,
+    className,
 }: {
     children: React.ReactNode
     open: boolean
     onOpenChange: (open: boolean) => void
+    className?: string
 }): JSX.Element {
     return (
         <Dialog.Root open={open} onOpenChange={onOpenChange}>
             <Dialog.Portal>
                 <Dialog.Backdrop className="fixed inset-0 min-h-screen min-w-screen bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 z-[var(--z-modal)]" />
-                <Dialog.Popup className="fixed top-4 left-1/2 w-[400px] max-w-[calc(100vw-3rem)] max-h-[60vh] -translate-x-1/2 rounded-lg bg-surface-secondary shadow-xl border border-primary transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 flex flex-col overflow-hidden z-[var(--z-force-modal-above-popovers)]">
+                <Dialog.Popup
+                    className={cn(
+                        'fixed top-4 left-1/2 w-[400px] max-w-[calc(100vw-3rem)] max-h-[60vh] -translate-x-1/2 rounded-lg bg-surface-secondary shadow-xl border border-primary transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 flex flex-col overflow-hidden z-[var(--z-force-modal-above-popovers)]',
+                        className
+                    )}
+                >
                     {children}
                 </Dialog.Popup>
             </Dialog.Portal>

--- a/frontend/src/lib/ui/DialogPrimitive/DialogPrimitive.tsx
+++ b/frontend/src/lib/ui/DialogPrimitive/DialogPrimitive.tsx
@@ -1,0 +1,34 @@
+import { Dialog } from '@base-ui/react/dialog'
+
+function DialogPrimitive({
+    children,
+    open,
+    onOpenChange,
+}: {
+    children: React.ReactNode
+    open: boolean
+    onOpenChange: (open: boolean) => void
+}): JSX.Element {
+    return (
+        <Dialog.Root open={open} onOpenChange={onOpenChange}>
+            <Dialog.Portal>
+                <Dialog.Backdrop className="fixed inset-0 min-h-screen min-w-screen bg-black opacity-20 transition-all duration-150 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 dark:opacity-70 z-[var(--z-modal)]" />
+                <Dialog.Popup className="fixed top-4 left-1/2 w-[400px] max-w-[calc(100vw-3rem)] max-h-[60vh] -translate-x-1/2 rounded-lg bg-surface-secondary shadow-xl border border-primary transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 flex flex-col overflow-hidden z-[var(--z-force-modal-above-popovers)]">
+                    {children}
+                </Dialog.Popup>
+            </Dialog.Portal>
+        </Dialog.Root>
+    )
+}
+
+function DialogPrimitiveTitle({
+    children,
+    className = 'sr-only',
+}: {
+    children: React.ReactNode
+    className?: string
+}): JSX.Element {
+    return <Dialog.Title className={className}>{children}</Dialog.Title>
+}
+
+export { DialogPrimitive, DialogPrimitiveTitle }

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -1107,7 +1107,8 @@
     }
 
     a:focus-visible,
-    button:focus-visible {
+    button:focus-visible,
+    [data-highlighted]:not(:focus-visible, :hover) {
         outline: 2px solid var(--color-accent);
     }
 

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -1108,7 +1108,7 @@
 
     a:focus-visible,
     button:focus-visible,
-    [data-highlighted]:not(:focus-visible, :hover) {
+    [data-highlighted]:not(:hover) {
         outline: 2px solid var(--color-accent);
     }
 


### PR DESCRIPTION
## Problem
People wanted to be able to switch orgs/projects faster with the new account menu (flagged)
People wanted to collapse main nav (left) and panel (right)

## Changes
* Reworked the new account menu to use `base-ui`
* New `DialogPrimitive` (priming for design system)
* Removed "Other" for both project/org, renamed to "All X"
* "All X" launches a dialog which allows you to switch orgs/projects wicked fast (with shortcuts `g then o` and `g then p` respectively
* Unified props between `Search.tsx` and the new project/org switchers `data-hightlighted`
* Added new global shortcut for collapsing left nav `[`
* Added new global shortcut for collapsing right nav  (side panel) `]`

![2026-02-04 11 00 37](https://github.com/user-attachments/assets/61d7b65b-e08a-469d-b9d6-27c7973bc32a)


---

![2026-02-04 10 56 59](https://github.com/user-attachments/assets/7433eff5-b22e-4a05-8590-6804adee14e2)


## How did you test this code?
Locally

## Publish to changelog?
No