### PR TITLE
chore: fix bundle size check patterns in CI workflow

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -156,9 +156,8 @@ jobs:
                   pattern: 'frontend/dist/*.js'
                   # Exclude source maps and chunk files (chunk hashes change every build)
                   exclude: |
-                      frontend/dist/*.js.map
-                      frontend/dist/chunk-*.js
-                      frontend/dist/**/chunk-*.js
+                      **/*.js.map
+                      **/chunk*.js
                   # Only show large changes
                   minimum-change-threshold: 1000
                   order-by: 'Size:desc'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -153,7 +153,7 @@ jobs:
                   install-script: 'pnpm --filter=@posthog/frontend... install'
                   compression: 'none'
                   # Check all JS bundles in the dist folder
-                  pattern: 'frontend/dist/*.js'
+                  pattern: 'frontend/dist/**/*.js'
                   # Exclude source maps and chunk files (chunk hashes change every build)
                   exclude: |
                       **/*.js.map

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -157,7 +157,8 @@ jobs:
                   # Exclude source maps and chunk files (chunk hashes change every build)
                   exclude: |
                       frontend/dist/*.js.map
-                      frontend/dist/chunk*.js
+                      frontend/dist/chunk-*.js
+                      frontend/dist/**/chunk-*.js
                   # Only show large changes
                   minimum-change-threshold: 1000
                   order-by: 'Size:desc'


### PR DESCRIPTION
## Problem

The bundle size check in the CI workflow uses overly specific exclude patterns that only match files in the `frontend/dist/` directory. This limits the flexibility of the workflow and may miss source maps and chunk files in other locations.

## Changes

Updated the exclude patterns in `.github/workflows/ci-frontend.yml` to use glob patterns that match files at any directory level:
- Changed `frontend/dist/*.js.map` to `**/*.js.map`
- Changed `frontend/dist/chunk*.js` to `**/chunk*.js`

This makes the patterns more robust and allows them to catch source maps and chunk files regardless of their location in the dist directory structure.

## How did you test this code?

This is a CI workflow configuration change. The patterns will be validated when the workflow runs on the next commit. The glob patterns `**/*.js.map` and `**/chunk*.js` are standard glob syntax supported by the bundle size check action.

## Publish to changelog?

No

https://claude.ai/code/session_01GcZNwFv68QCA1f4pGBnauY