### PR TITLE
fix(lemon-table): prevent auto scroll on mount

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -211,8 +211,19 @@ export function LemonTable<T extends Record<string, any>>({
     }, [dataSource, currentSorting, columns])
 
     const paginationState = usePagination(sortedDataSource, pagination, id)
+    const previousPageRef = useRef<number | null>(null)
 
     useEffect(() => {
+        // Don't auto-scroll on initial mount
+        if (previousPageRef.current === null) {
+            previousPageRef.current = paginationState.currentPage
+            return
+        }
+        if (previousPageRef.current === paginationState.currentPage) {
+            return
+        }
+        previousPageRef.current = paginationState.currentPage
+
         // When the current page changes, scroll back to the top of the table
         if (scrollRef.current) {
             const realTableOffsetTop = scrollRef.current.getBoundingClientRect().top - 320 // Extra breathing room


### PR DESCRIPTION
## Problem

Dashboards containing an SQL insight with table view are jumping around during scroll, see https://posthog.slack.com/archives/C0368RPHLQH/p1770159720239519.

Turns out LemonTable has autoscroll behaviour that scrolls to the table top on mount. Before https://github.com/PostHog/posthog/pull/46426 this was a no-op on dashboards, as we'd scroll the outer window instead of the inner container. Now that the behaviour was changed to scroll the main container, we have this jumping behaviour.

## Changes

The autoscroll was meant for the LemonTable to scroll to the top when changing the page e.g. on the feature flags page. I've added an early return so that it doesn't fire on initial mount.

## How did you test this code?

- Created a dashboard that has an SQL insight with table view in the middle and verified the issue is present before these changes, and gone after
- Verified that the feature flags page still jumps to the top