### PR TITLE
chore(experiments): Include dagster bg jobs in default hogli setup config for experiments

### DIFF
--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -159,7 +159,15 @@ intents:
 
     experiments:
         description: 'A/B testing and experimentation'
-        capabilities: [event_ingestion, flag_evaluation, property_definitions, celery_workers, nodejs_feature_flags]
+        capabilities:
+            [
+                event_ingestion,
+                flag_evaluation,
+                property_definitions,
+                celery_workers,
+                nodejs_feature_flags,
+                dagster_pipelines,
+            ]
 
     llm_analytics:
         description: 'LLM/AI observability and analytics'


### PR DESCRIPTION
## Problem

When setting up `hogli dev:setup` with the `5 - experiments` intent, it would not include `dagster`, which is needed for calculating the time series of experiments. Since I understand this intent based system as a carefree approach to starting the right services, it should be included by default, and stopped in case it's not needed.

## Changes

<img width="218" height="291" alt="hogli-experiments-dagster" src="https://github.com/user-attachments/assets/3697a57e-ce4b-4766-b09c-cd5042ab5d48" />

## How did you test this code?

Manually going through `hogli dev:setup`

## Publish to changelog?

No