### PR TITLE
fix(storybook): make networkidle timeout non-fatal

### DIFF
--- a/common/storybook/.storybook/test-runner.ts
+++ b/common/storybook/.storybook/test-runner.ts
@@ -50,6 +50,7 @@ declare module '@storybook/types' {
             viewport?: { width: number; height: number }
             /**
              * Skip waiting for iframes to load. Useful for stories with external iframes that fail in CI.
+             * Also skips waiting for networkidle, which is useful for stories with background network activity.
              * @default false
              */
             skipIframeWait?: boolean
@@ -466,7 +467,11 @@ async function waitForPageReady(page: Page, skipNetworkIdle = false): Promise<vo
     await page.waitForLoadState('load')
 
     if (process.env.CI && !skipNetworkIdle) {
-        await page.waitForLoadState('networkidle')
+        // networkidle can be flaky in CI due to background requests - don't fail on timeout
+        await page.waitForLoadState('networkidle').catch(() => {
+            // eslint-disable-next-line no-console
+            console.warn('[test-runner] networkidle timeout - proceeding anyway')
+        })
     }
 
     await page.evaluate(() => document.fonts.ready)


### PR DESCRIPTION
Storybook CI has intermittent failures due to networkidle timeouts. The page.waitForLoadState('networkidle') check times out after 10s when there's sporadic background network activity in CI.

Catch the timeout and log a warning instead of failing. The snapshot comparison still validates the page rendered correctly.