### PR TITLE
fix: scroll to specific setting when opening side panel settings

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSettings.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSettings.tsx
@@ -38,9 +38,10 @@ export const SidePanelSettings = (): JSX.Element => {
 
     useEffect(() => {
         if (settings.settingId) {
-            setTimeout(() => {
+            const timeout = setTimeout(() => {
                 document.getElementById(settings.settingId!)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-            }, 100)
+            }, 1000 / 60)
+            return () => clearTimeout(timeout)
         }
     }, [settings.settingId])
 

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSettings.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSettings.tsx
@@ -36,6 +36,14 @@ export const SidePanelSettings = (): JSX.Element => {
         })
     }, [selectedSectionId, selectedLevel, setSettings])
 
+    useEffect(() => {
+        if (settings.settingId) {
+            setTimeout(() => {
+                document.getElementById(settings.settingId!)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+            }, 100)
+        }
+    }, [settings.settingId])
+
     const cameFromMax =
         previousTab === SidePanelTab.Max &&
         (selectedSectionId === 'environment-max' || selectedSectionId === ('project-max' as typeof selectedSectionId))

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSettings.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSettings.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { IconArrowLeft, IconExternal } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
@@ -22,6 +22,7 @@ export const SidePanelSettings = (): JSX.Element => {
     const { setSettings, setPreviousTab } = useActions(sidePanelSettingsLogic)
     const { closeSidePanel } = useActions(sidePanelStateLogic)
     const { openAi } = useOpenAi()
+    const scrollContainerRef = useRef<HTMLDivElement | null>(null)
 
     const settingsLogicProps: SettingsLogicProps = {
         ...settings,
@@ -39,7 +40,14 @@ export const SidePanelSettings = (): JSX.Element => {
     useEffect(() => {
         if (settings.settingId) {
             const timeout = setTimeout(() => {
-                document.getElementById(settings.settingId!)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                const container = scrollContainerRef.current
+                if (!container) {
+                    return
+                }
+
+                container
+                    .querySelector<HTMLElement>(`[id="${settings.settingId}"]`)
+                    ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
             }, 1000 / 60)
             return () => clearTimeout(timeout)
         }
@@ -79,7 +87,7 @@ export const SidePanelSettings = (): JSX.Element => {
                     All settings
                 </LemonButton>
             </SidePanelPaneHeader>
-            <div className="flex-1 p-3 overflow-y-auto">
+            <div className="flex-1 p-3 overflow-y-auto" ref={scrollContainerRef}>
                 <Settings hideSections {...settingsLogicProps} />
             </div>
         </div>


### PR DESCRIPTION
## Problem

When clicking the gear icon on "Filter out internal and test users" (or similar setting links on insights), the settings side panel opens at the top of the list. The user has to scroll to find the relevant setting, even though `settingId` is passed through the chain (`openSettingsPanel` → `sidePanelSettingsLogic` → `SidePanelSettings` → `Settings`).

## Changes

Adds a `useEffect` in `SidePanelSettings` that scrolls **within the side panel container** to the element matching the `settingId` (using the existing `id` on the `<h2>` anchor when the full settings list is rendered). This keeps the scroll scoped to the side panel and avoids collisions with the main settings page.

Note: when a `sectionId` forces a single-setting view, there’s nothing to scroll to — the setting is already the only content on screen.

## How did you test this code?

1. Open an insight
2. Click the gear icon next to "Filter out internal and test users"
3. Verify the settings side panel opens scrolled to the "Internal and test user filtering" section rather than the top

## Publish to changelog?
no