### PR TITLE
fix(lemon-ui): prevent LemonInputSelect from toggling off value on search-click

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.test.tsx
@@ -286,4 +286,35 @@ describe('LemonInputSelect', () => {
         expect(testButtons.length).toBeGreaterThanOrEqual(1)
         expect(addTestButtons.length).toBe(0)
     })
+
+    it('multiple-select mode: clicking option matching search text does not toggle it off', async () => {
+        const onChange = jest.fn()
+
+        const { container } = render(
+            <LemonInputSelect<string>
+                mode="multiple"
+                options={[
+                    { key: 'alice@example.com', label: 'alice@example.com' },
+                    { key: 'bob@example.com', label: 'bob@example.com' },
+                ]}
+                value={[]}
+                onChange={onChange}
+                allowCustomValues
+            />
+        )
+
+        const input = await openDropdown(container)
+
+        // Type a value that exactly matches an option
+        await userEvent.type(input, 'alice@example.com')
+
+        // Click the matching option in the dropdown
+        const optionButton = await findDropdownButtonByText('alice@example.com')
+        expect(optionButton).toBeInTheDocument()
+        await userEvent.click(optionButton!)
+
+        // The final onChange call should ADD the value, not remove it
+        const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1]
+        expect(lastCall[0]).toContain('alice@example.com')
+    })
 })

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -492,9 +492,10 @@ export function LemonInputSelect<T = string>({
             popoverFocusRef.current = false
             inputRef.current?.focus()
             _onFocus()
-            if (hasCustomValue) {
-                _onActionItem(inputValue.trim(), null)
-            }
+            // Don't add custom values here - if the user clicked on a popover option,
+            // the click handler will handle the selection. Adding it here causes a
+            // double-fire: the value gets added by _onBlur, the component re-renders,
+            // and then the click handler sees it already exists and removes it.
             return
         }
         if (hasCustomValue) {


### PR DESCRIPTION
## Problem

When using search to find and select a value in property filters (e.g., email filter on LLM analytics dashboard), the selected value is immediately cleared. The URL briefly includes the filter, then resets to no filter value.

This affects any property filter using `LemonInputSelect` with `allowCustomValues` in multiple mode (which includes the `exact` operator). Reported by a customer on the LLM analytics dashboard.

## Changes

The bug is a race condition in `LemonInputSelect._onBlur`:

1. User types search text matching a dropdown option (e.g., "andy@example.com")
2. User clicks the matching option
3. `mousedown` causes input blur -> `_onBlur` fires with `popoverFocusRef.current=true`
4. `_onBlur` adds the search text as a custom value via `_onActionItem`
5. React re-renders with the new value (kea updates synchronously)
6. `click` fires -> `_onActionItem` finds value already in `stringKeys` -> toggles it OFF via `_removeItem`
7. Filter is cleared

Fix: remove the `_onActionItem` call from the `popoverFocusRef.current === true` path in `_onBlur`. When blur is caused by clicking inside the popover, the click handler handles the selection. The blur handler should not also try to commit a custom value.

## How did you test this code?

- Added a regression test: `multiple-select mode: clicking option matching search text does not toggle it off`
- All 10 LemonInputSelect tests pass
- Verified other paths unaffected: clicking outside popover still commits custom values, Enter key still works, single-select mode unchanged

## Publish to changelog?

No