### PR TITLE
fix: Soft delete orphaned tables and joins

### DIFF
--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -574,10 +574,12 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             .all()
         )
 
-        # Soft-delete source + schemas atomically first so DB state is consistent
-        # even if the external cleanup below fails
+        # Soft-delete source, schemas, and tables atomically first so DB state
+        # is consistent even if the external cleanup below fails
         with transaction.atomic():
             for schema in schemas:
+                if schema.table:
+                    schema.table.soft_delete()
                 schema.soft_delete()
             instance.soft_delete()
 

--- a/products/data_warehouse/backend/migrations/0019_fix_orphaned_tables.py
+++ b/products/data_warehouse/backend/migrations/0019_fix_orphaned_tables.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+from django.db.models import Q
+from django.db.models.functions import Now
+
+
+def fix_orphaned_tables(apps, schema_editor):
+    DataWarehouseTable = apps.get_model("data_warehouse", "DataWarehouseTable")
+    DataWarehouseJoin = apps.get_model("data_warehouse", "DataWarehouseJoin")
+
+    orphaned_tables = DataWarehouseTable.objects.filter(
+        external_data_source__deleted=True,
+        deleted=False,
+    )
+
+    orphaned_table_names = list(orphaned_tables.values_list("name", "team_id"))
+
+    for name, team_id in orphaned_table_names:
+        DataWarehouseJoin.objects.filter(
+            Q(team_id=team_id) & (Q(source_table_name=name) | Q(joining_table_name=name)),
+            deleted=False,
+        ).update(deleted=True, deleted_at=Now())
+
+    orphaned_tables.update(deleted=True, deleted_at=Now())
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("data_warehouse", "0018_fix_orphaned_schemas"),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_orphaned_tables, migrations.RunPython.noop),
+    ]

--- a/products/data_warehouse/backend/migrations/max_migration.txt
+++ b/products/data_warehouse/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0018_fix_orphaned_schemas
+0019_fix_orphaned_tables

--- a/products/data_warehouse/backend/models/external_data_schema.py
+++ b/products/data_warehouse/backend/models/external_data_schema.py
@@ -271,7 +271,9 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
             except Exception as e:
                 capture_exception(e)
 
-            self.table.soft_delete()
+            if not self.table.deleted:
+                self.table.soft_delete()
+
             self.table_id = None
             self.last_synced_at = None
             self.status = None


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/46250 where I didn't account for `DataWarehouseTable` or `DataWarehouseJoin` in the migration.

https://posthog.slack.com/archives/C0A6L24BU0P/p1770040423708429

## Changes

- add another migration to delete orphaned `DataWarehouseTable` and `DataWarehouseJoin` (the numbers of these in US and EU are low 100s)
- add `schema.table.soft_delete()` to the atomic transaction block to avoid getting into a bad state in the future. `DataWarehouseJoin`s also get deleted via the table's `soft_delete` method.

## How did you test this code?

Added a test to check `DataWarehouseTable`s get soft deleted via the destroy method.