### PR TITLE
feat(llma): clustering replace hardcoded team allowlists with dynamic discovery

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10,7 +10,10 @@
                 "$ai_metric",
                 "$ai_feedback",
                 "$ai_evaluation",
-                "$ai_trace_summary"
+                "$ai_trace_summary",
+                "$ai_generation_summary",
+                "$ai_trace_clusters",
+                "$ai_generation_clusters"
             ],
             "type": "string"
         },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3950,6 +3950,9 @@ export type AIEventType =
     | '$ai_feedback'
     | '$ai_evaluation'
     | '$ai_trace_summary'
+    | '$ai_generation_summary'
+    | '$ai_trace_clusters'
+    | '$ai_generation_clusters'
 
 export interface LLMTraceEvent {
     id: string

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -24,6 +24,9 @@ class AIEventType(StrEnum):
     FIELD_AI_FEEDBACK = "$ai_feedback"
     FIELD_AI_EVALUATION = "$ai_evaluation"
     FIELD_AI_TRACE_SUMMARY = "$ai_trace_summary"
+    FIELD_AI_GENERATION_SUMMARY = "$ai_generation_summary"
+    FIELD_AI_TRACE_CLUSTERS = "$ai_trace_clusters"
+    FIELD_AI_GENERATION_CLUSTERS = "$ai_generation_clusters"
 
 
 class MathGroupTypeIndex(float, Enum):

--- a/posthog/tasks/llm_analytics_usage_report.py
+++ b/posthog/tasks/llm_analytics_usage_report.py
@@ -1,4 +1,3 @@
-import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -24,7 +23,6 @@ from posthog.tasks.utils import CeleryQueue
 from posthog.utils import get_instance_region, get_previous_day
 
 logger = structlog.get_logger(__name__)
-logger.setLevel(logging.INFO)
 
 
 @cached(cache={})

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -93,7 +93,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 00:00:00'
     AND timestamp < '2022-01-10 02:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -105,7 +105,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 02:00:00'
     AND timestamp < '2022-01-10 04:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -117,7 +117,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 04:00:00'
     AND timestamp < '2022-01-10 06:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -129,7 +129,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 06:00:00'
     AND timestamp < '2022-01-10 08:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -141,7 +141,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 08:00:00'
     AND timestamp < '2022-01-10 10:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -153,7 +153,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 10:00:00'
     AND timestamp < '2022-01-10 12:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -179,7 +179,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 12:00:00'
     AND timestamp < '2022-01-10 14:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -191,7 +191,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 14:00:00'
     AND timestamp < '2022-01-10 16:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -203,7 +203,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 16:00:00'
     AND timestamp < '2022-01-10 18:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -215,7 +215,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 18:00:00'
     AND timestamp < '2022-01-10 20:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -227,7 +227,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 20:00:00'
     AND timestamp < '2022-01-10 22:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -239,7 +239,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 22:00:00'
     AND timestamp < '2022-01-10 23:59:59'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
   GROUP BY team_id
   '''
 # ---
@@ -251,7 +251,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 00:00:00'
     AND timestamp < '2022-01-10 02:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -265,7 +265,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 02:00:00'
     AND timestamp < '2022-01-10 04:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -279,7 +279,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 04:00:00'
     AND timestamp < '2022-01-10 06:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -293,7 +293,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 06:00:00'
     AND timestamp < '2022-01-10 08:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -321,7 +321,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 08:00:00'
     AND timestamp < '2022-01-10 10:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -335,7 +335,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 10:00:00'
     AND timestamp < '2022-01-10 12:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -349,7 +349,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 12:00:00'
     AND timestamp < '2022-01-10 14:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -363,7 +363,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 14:00:00'
     AND timestamp < '2022-01-10 16:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -377,7 +377,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 16:00:00'
     AND timestamp < '2022-01-10 18:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -391,7 +391,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 18:00:00'
     AND timestamp < '2022-01-10 20:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -405,7 +405,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 20:00:00'
     AND timestamp < '2022-01-10 22:00:00'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -419,7 +419,7 @@
   FROM events
   WHERE timestamp >= '2022-01-10 22:00:00'
     AND timestamp < '2022-01-10 23:59:59'
-    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+    AND event NOT IN ['$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception', '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND person_mode IN ('full',
                         'force_upgrade')
   GROUP BY team_id
@@ -931,7 +931,7 @@
   SELECT team_id,
          COUNT() as count
   FROM events
-  WHERE event IN ['$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary']
+  WHERE event IN ['$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric', '$ai_feedback', '$ai_evaluation', '$ai_trace_summary', '$ai_generation_summary', '$ai_trace_clusters', '$ai_generation_clusters']
     AND timestamp >= '2022-01-10 00:00:00'
     AND timestamp < '2022-01-10 23:59:59'
   GROUP BY team_id

--- a/posthog/temporal/llm_analytics/__init__.py
+++ b/posthog/temporal/llm_analytics/__init__.py
@@ -9,6 +9,7 @@ from posthog.temporal.llm_analytics.run_evaluation import (
     increment_trial_eval_count_activity,
     update_key_state_activity,
 )
+from posthog.temporal.llm_analytics.team_discovery import get_team_ids_for_llm_analytics
 from posthog.temporal.llm_analytics.trace_clustering import (
     DailyTraceClusteringWorkflow,
     TraceClusteringCoordinatorWorkflow,
@@ -48,6 +49,9 @@ WORKFLOWS = [
 ]
 
 ACTIVITIES = [
+    # Team discovery
+    get_team_ids_for_llm_analytics,
+    # Summarization activities
     sample_items_in_window_activity,
     generate_and_save_summary_activity,
     generate_and_save_generation_summary_activity,

--- a/posthog/temporal/llm_analytics/team_discovery.py
+++ b/posthog/temporal/llm_analytics/team_discovery.py
@@ -36,10 +36,15 @@ GUARANTEED_TEAM_IDS: list[int] = [
 # 0.0 = only guaranteed teams, 0.1 = 10% of remaining, 1.0 = all teams with AI events.
 SAMPLE_PERCENTAGE: float = 0.1
 
+# How far back to look for teams with AI events. Intentionally wider than any
+# individual workflow's data window (e.g. 7 days for clustering, 60 min for
+# summarization) so we discover teams that have been active recently.
+DISCOVERY_LOOKBACK_DAYS: int = 30
+
 
 @dataclasses.dataclass
 class TeamDiscoveryInput:
-    lookback_days: int = 30
+    lookback_days: int = DISCOVERY_LOOKBACK_DAYS
     sample_percentage: float = SAMPLE_PERCENTAGE
 
 

--- a/posthog/temporal/llm_analytics/team_discovery.py
+++ b/posthog/temporal/llm_analytics/team_discovery.py
@@ -1,0 +1,90 @@
+"""
+Team discovery activity for LLM analytics workflows.
+
+Provides dynamic team discovery that combines a guaranteed allowlist
+with a configurable random sample of teams that have AI events.
+"""
+
+import math
+import random
+import asyncio
+import dataclasses
+from datetime import datetime, timedelta
+
+import structlog
+import temporalio.activity
+
+from posthog.temporal.common.heartbeat import Heartbeater
+
+logger = structlog.get_logger(__name__)
+
+# Guaranteed teams that are always included (the original hardcoded allowlist).
+# Single source of truth for both clustering and summarization workflows.
+GUARANTEED_TEAM_IDS: list[int] = [
+    1,  # Local development
+    2,  # Internal PostHog project
+    # Dogfooding projects
+    112495,
+    148051,
+    140227,
+    237906,
+    294356,
+    21999,
+]
+
+# Default sample percentage for gradual rollout.
+# 0.0 = only guaranteed teams, 0.1 = 10% of remaining, 1.0 = all teams with AI events.
+SAMPLE_PERCENTAGE: float = 0.1
+
+
+@dataclasses.dataclass
+class TeamDiscoveryInput:
+    lookback_days: int = 30
+    sample_percentage: float = SAMPLE_PERCENTAGE
+
+
+@temporalio.activity.defn
+async def get_team_ids_for_llm_analytics(inputs: TeamDiscoveryInput) -> list[int]:
+    """
+    Discover teams for LLM analytics workflows.
+
+    Returns guaranteed allowlist teams + a random sample of other teams with AI events.
+    On failure, falls back to guaranteed teams only.
+    """
+    async with Heartbeater():
+        guaranteed = set(GUARANTEED_TEAM_IDS)
+
+        try:
+            end = datetime.now()
+            begin = end - timedelta(days=inputs.lookback_days)
+
+            from posthog.tasks.llm_analytics_usage_report import get_teams_with_ai_events
+
+            ai_event_teams = await asyncio.to_thread(get_teams_with_ai_events, begin, end)
+
+            remaining = [t for t in ai_event_teams if t not in guaranteed]
+
+            sample_size = math.ceil(len(remaining) * inputs.sample_percentage)
+            sampled = random.sample(remaining, min(sample_size, len(remaining)))
+
+            result = sorted(guaranteed | set(sampled))
+
+            logger.info(
+                "Team discovery completed",
+                guaranteed_count=len(guaranteed),
+                ai_event_teams_count=len(ai_event_teams),
+                remaining_count=len(remaining),
+                sampled_count=len(sampled),
+                total_count=len(result),
+                sample_percentage=inputs.sample_percentage,
+            )
+
+            return result
+
+        except Exception:
+            logger.warning(
+                "Team discovery failed, falling back to guaranteed teams",
+                exc_info=True,
+                guaranteed_count=len(guaranteed),
+            )
+            return sorted(guaranteed)

--- a/posthog/temporal/llm_analytics/team_discovery.py
+++ b/posthog/temporal/llm_analytics/team_discovery.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 
 import structlog
 import temporalio.activity
+from temporalio.common import RetryPolicy
 
 from posthog.temporal.common.heartbeat import Heartbeater
 
@@ -40,6 +41,10 @@ SAMPLE_PERCENTAGE: float = 0.1
 # individual workflow's data window (e.g. 7 days for clustering, 60 min for
 # summarization) so we discover teams that have been active recently.
 DISCOVERY_LOOKBACK_DAYS: int = 30
+
+# Activity timeout and retry policy for team discovery.
+DISCOVERY_ACTIVITY_TIMEOUT = timedelta(seconds=60)
+DISCOVERY_ACTIVITY_RETRY_POLICY = RetryPolicy(maximum_attempts=2)
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/llm_analytics/test_team_discovery.py
+++ b/posthog/temporal/llm_analytics/test_team_discovery.py
@@ -1,4 +1,5 @@
 import math
+from contextlib import asynccontextmanager
 
 import pytest
 from unittest.mock import patch
@@ -12,6 +13,12 @@ from posthog.temporal.llm_analytics.team_discovery import (
 )
 
 
+@asynccontextmanager
+async def _noop_heartbeater(*args, **kwargs):
+    yield
+
+
+@patch("posthog.temporal.llm_analytics.team_discovery.Heartbeater", _noop_heartbeater)
 @pytest.mark.asyncio
 class TestGetTeamIdsForLlmAnalytics:
     @parameterized.expand(

--- a/posthog/temporal/llm_analytics/test_team_discovery.py
+++ b/posthog/temporal/llm_analytics/test_team_discovery.py
@@ -22,7 +22,7 @@ class TestGetTeamIdsForLlmAnalytics:
             ("hundred_percent", 1.0),
         ]
     )
-    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
     async def test_guaranteed_teams_always_included(self, _name, sample_pct, mock_get_teams):
         mock_get_teams.return_value = [9999, 8888]
         inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=sample_pct)
@@ -32,7 +32,7 @@ class TestGetTeamIdsForLlmAnalytics:
         for team_id in GUARANTEED_TEAM_IDS:
             assert team_id in result
 
-    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
     async def test_no_duplicates_when_guaranteed_in_ai_events(self, mock_get_teams):
         mock_get_teams.return_value = [GUARANTEED_TEAM_IDS[0], 9999]
         inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=1.0)
@@ -41,7 +41,7 @@ class TestGetTeamIdsForLlmAnalytics:
 
         assert len(result) == len(set(result))
 
-    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
     async def test_result_is_sorted(self, mock_get_teams):
         mock_get_teams.return_value = [9999, 5555, 3333]
         inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=1.0)
@@ -50,7 +50,7 @@ class TestGetTeamIdsForLlmAnalytics:
 
         assert result == sorted(result)
 
-    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
     async def test_zero_sample_returns_only_guaranteed(self, mock_get_teams):
         extra_teams = [9999, 8888, 7777]
         mock_get_teams.return_value = extra_teams
@@ -60,7 +60,7 @@ class TestGetTeamIdsForLlmAnalytics:
 
         assert set(result) == set(GUARANTEED_TEAM_IDS)
 
-    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
     async def test_full_sample_returns_all(self, mock_get_teams):
         extra_teams = [9999, 8888, 7777]
         mock_get_teams.return_value = extra_teams
@@ -70,7 +70,7 @@ class TestGetTeamIdsForLlmAnalytics:
 
         assert set(result) == set(GUARANTEED_TEAM_IDS) | set(extra_teams)
 
-    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
     async def test_sampling_math(self, mock_get_teams):
         extra_teams = list(range(10000, 10100))  # 100 non-guaranteed teams
         mock_get_teams.return_value = extra_teams
@@ -82,7 +82,7 @@ class TestGetTeamIdsForLlmAnalytics:
         expected_sample_size = math.ceil(len(extra_teams) * 0.1)
         assert len(sampled_non_guaranteed) == expected_sample_size
 
-    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
     async def test_empty_ai_events_returns_guaranteed(self, mock_get_teams):
         mock_get_teams.return_value = []
         inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.1)
@@ -91,7 +91,7 @@ class TestGetTeamIdsForLlmAnalytics:
 
         assert set(result) == set(GUARANTEED_TEAM_IDS)
 
-    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
     async def test_fallback_on_exception(self, mock_get_teams):
         mock_get_teams.side_effect = Exception("ClickHouse down")
         inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.1)

--- a/posthog/temporal/llm_analytics/test_team_discovery.py
+++ b/posthog/temporal/llm_analytics/test_team_discovery.py
@@ -1,0 +1,101 @@
+import math
+
+import pytest
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from posthog.temporal.llm_analytics.team_discovery import (
+    GUARANTEED_TEAM_IDS,
+    TeamDiscoveryInput,
+    get_team_ids_for_llm_analytics,
+)
+
+
+@pytest.mark.asyncio
+class TestGetTeamIdsForLlmAnalytics:
+    @parameterized.expand(
+        [
+            ("zero_percent", 0.0),
+            ("ten_percent", 0.1),
+            ("fifty_percent", 0.5),
+            ("hundred_percent", 1.0),
+        ]
+    )
+    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    async def test_guaranteed_teams_always_included(self, _name, sample_pct, mock_get_teams):
+        mock_get_teams.return_value = [9999, 8888]
+        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=sample_pct)
+
+        result = await get_team_ids_for_llm_analytics(inputs)
+
+        for team_id in GUARANTEED_TEAM_IDS:
+            assert team_id in result
+
+    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    async def test_no_duplicates_when_guaranteed_in_ai_events(self, mock_get_teams):
+        mock_get_teams.return_value = [GUARANTEED_TEAM_IDS[0], 9999]
+        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=1.0)
+
+        result = await get_team_ids_for_llm_analytics(inputs)
+
+        assert len(result) == len(set(result))
+
+    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    async def test_result_is_sorted(self, mock_get_teams):
+        mock_get_teams.return_value = [9999, 5555, 3333]
+        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=1.0)
+
+        result = await get_team_ids_for_llm_analytics(inputs)
+
+        assert result == sorted(result)
+
+    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    async def test_zero_sample_returns_only_guaranteed(self, mock_get_teams):
+        extra_teams = [9999, 8888, 7777]
+        mock_get_teams.return_value = extra_teams
+        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.0)
+
+        result = await get_team_ids_for_llm_analytics(inputs)
+
+        assert set(result) == set(GUARANTEED_TEAM_IDS)
+
+    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    async def test_full_sample_returns_all(self, mock_get_teams):
+        extra_teams = [9999, 8888, 7777]
+        mock_get_teams.return_value = extra_teams
+        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=1.0)
+
+        result = await get_team_ids_for_llm_analytics(inputs)
+
+        assert set(result) == set(GUARANTEED_TEAM_IDS) | set(extra_teams)
+
+    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    async def test_sampling_math(self, mock_get_teams):
+        extra_teams = list(range(10000, 10100))  # 100 non-guaranteed teams
+        mock_get_teams.return_value = extra_teams
+        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.1)
+
+        result = await get_team_ids_for_llm_analytics(inputs)
+
+        sampled_non_guaranteed = [t for t in result if t not in GUARANTEED_TEAM_IDS]
+        expected_sample_size = math.ceil(len(extra_teams) * 0.1)
+        assert len(sampled_non_guaranteed) == expected_sample_size
+
+    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    async def test_empty_ai_events_returns_guaranteed(self, mock_get_teams):
+        mock_get_teams.return_value = []
+        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.1)
+
+        result = await get_team_ids_for_llm_analytics(inputs)
+
+        assert set(result) == set(GUARANTEED_TEAM_IDS)
+
+    @patch("posthog.temporal.llm_analytics.team_discovery.get_teams_with_ai_events")
+    async def test_fallback_on_exception(self, mock_get_teams):
+        mock_get_teams.side_effect = Exception("ClickHouse down")
+        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.1)
+
+        result = await get_team_ids_for_llm_analytics(inputs)
+
+        assert set(result) == set(GUARANTEED_TEAM_IDS)

--- a/posthog/temporal/llm_analytics/trace_clustering/README.md
+++ b/posthog/temporal/llm_analytics/trace_clustering/README.md
@@ -316,21 +316,17 @@ if results:
 
 The coordinator workflow (`llma-trace-clustering-coordinator`) runs on a schedule and:
 
-1. Processes teams from the `ALLOWED_TEAM_IDS` allowlist
+1. Discovers teams dynamically via `get_team_ids_for_llm_analytics` (guaranteed teams + a random sample of teams with AI events)
 2. Spawns clustering workflow for each team in parallel
 3. Handles failures gracefully (individual team failures don't affect others)
 
-Team allowlist in `constants.py`:
+Team discovery is configured in `team_discovery.py`:
 
-```python
-ALLOWED_TEAM_IDS: list[int] = [
-    1,      # Local development
-    2,      # Internal PostHog project
-    112495, # Dogfooding project
-]
-```
+- `GUARANTEED_TEAM_IDS` — always included (development, internal, dogfooding teams)
+- `SAMPLE_PERCENTAGE` — fraction of remaining teams to sample (default 10%)
+- `DISCOVERY_LOOKBACK_DAYS` — how far back to look for AI events (default 30 days)
 
-To add new teams, simply add their IDs to this list.
+If discovery fails, the coordinator falls back to guaranteed teams only.
 
 ## Configuration
 
@@ -356,7 +352,8 @@ Key constants in `constants.py`:
 | `DEFAULT_UMAP_MIN_DIST`             | 0.0                               | UMAP min distance (tighter for clustering)    |
 | `NOISE_CLUSTER_ID`                  | -1                                | HDBSCAN noise/outlier cluster ID              |
 | `LLMA_TRACE_DOCUMENT_TYPE`          | llm-trace-summary-detailed        | Document type filter for embeddings           |
-| `ALLOWED_TEAM_IDS`                  | [1, 2, 112495]                    | Teams to process (allowlist approach)         |
+| `GUARANTEED_TEAM_IDS`               | [1, 2, 112495, ...]               | Teams always included (in team_discovery.py)  |
+| `SAMPLE_PERCENTAGE`                 | 0.1                               | Fraction of discovered teams to sample        |
 
 ## Processing Flow
 

--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -76,19 +76,6 @@ LLMA_TRACE_RENDERING_LEGACY = "llma_trace_detailed"
 # Product for LLM trace summaries (matches sorting key in posthog_document_embeddings)
 LLMA_TRACE_PRODUCT = "llm-analytics"
 
-# Team allowlist (empty list = no teams processed)
-ALLOWED_TEAM_IDS: list[int] = [
-    1,  # Local development
-    2,  # Internal PostHog project
-    # Dogfooding projects
-    112495,
-    148051,
-    140227,
-    237906,
-    294356,
-    21999,
-]
-
 # Cluster labeling agent configuration
 LABELING_AGENT_MODEL = "gpt-5.2"  # OpenAI GPT-5.2 for reasoning
 LABELING_AGENT_MAX_ITERATIONS = 50  # Max agent iterations before forced finalization

--- a/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
@@ -86,7 +86,7 @@ class TraceClusteringCoordinatorWorkflow(PostHogWorkflow):
         # Discover teams dynamically via activity
         team_ids = await temporalio.workflow.execute_activity(
             get_team_ids_for_llm_analytics,
-            TeamDiscoveryInput(lookback_days=30, sample_percentage=SAMPLE_PERCENTAGE),
+            TeamDiscoveryInput(sample_percentage=SAMPLE_PERCENTAGE),
             start_to_close_timeout=timedelta(seconds=60),
             retry_policy=RetryPolicy(maximum_attempts=2),
         )

--- a/posthog/temporal/llm_analytics/trace_clustering/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/schedule.py
@@ -22,10 +22,10 @@ from posthog.temporal.llm_analytics.trace_clustering.coordinator import TraceClu
 async def create_trace_clustering_coordinator_schedule(client: Client):
     """Create or update the schedule for the trace clustering coordinator.
 
-    The coordinator processes traces for teams in the ALLOWED_TEAM_IDS list
+    The coordinator processes traces for teams in the dynamically discovered team list
     and spawns child workflows to cluster traces for each team.
 
-    This schedule runs daily. Teams are defined in the ALLOWED_TEAM_IDS constant.
+    This schedule runs daily. Teams are discovered dynamically via the team discovery activity.
     """
     coordinator_schedule = Schedule(
         action=ScheduleActionStartWorkflow(
@@ -66,10 +66,10 @@ async def create_generation_clustering_coordinator_schedule(client: Client):
     """Create or update the schedule for the generation clustering coordinator.
 
     The coordinator processes generations (individual LLM calls) for teams in the
-    ALLOWED_TEAM_IDS list and spawns child workflows to cluster generations for each team.
+    dynamically discovered team list and spawns child workflows to cluster generations for each team.
     Uses the same coordinator workflow as trace clustering but with analysis_level="generation".
 
-    This schedule runs daily. Teams are defined in the ALLOWED_TEAM_IDS constant.
+    This schedule runs daily. Teams are discovered dynamically via the team discovery activity.
     """
     coordinator_schedule = Schedule(
         action=ScheduleActionStartWorkflow(

--- a/posthog/temporal/llm_analytics/trace_summarization/README.md
+++ b/posthog/temporal/llm_analytics/trace_summarization/README.md
@@ -4,7 +4,7 @@ Hourly Temporal workflow that generates summaries and embeddings of LLM traces f
 
 ## How It Works
 
-1. Coordinator workflow runs hourly, spawning child workflows for each team in `ALLOWED_TEAM_IDS`
+1. Coordinator workflow runs hourly, discovering teams dynamically (guaranteed teams + sampled teams with AI events)
 2. Per-team workflow queries recent traces (default: last 60 min, max 100 traces)
 3. For each trace: fetch data → generate text repr → call LLM → emit `$ai_trace_summary` event → queue embedding via Kafka
 4. Embeddings processed asynchronously by Rust worker, stored in `document_embeddings` table
@@ -30,7 +30,7 @@ tests/
 
 ### Coordinator: `llma-trace-summarization-coordinator`
 
-Spawns child workflows for teams in `ALLOWED_TEAM_IDS` (configured in `constants.py`).
+Discovers teams dynamically via `get_team_ids_for_llm_analytics` (guaranteed teams + a random sample of teams with AI events, configured in `team_discovery.py`).
 
 **Inputs** (`BatchTraceSummarizationCoordinatorInputs`): `max_traces`, `batch_size`, `mode`, `window_minutes`, `model` - all optional with sensible defaults.
 
@@ -99,9 +99,9 @@ temporal workflow start \
 
 The coordinator runs hourly via Temporal schedule (configured in `schedule.py`). Verify at http://localhost:8233 → schedule: `llma-trace-summarization-coordinator-schedule`.
 
-### Team Allowlist
+### Team Discovery
 
-Edit `ALLOWED_TEAM_IDS` in `constants.py`. Empty list = coordinator skips all teams. Manual triggers can target any team.
+Teams are discovered dynamically via `team_discovery.py`. Guaranteed teams (in `GUARANTEED_TEAM_IDS`) are always included, plus a configurable random sample of teams with AI events. Manual triggers can target any team.
 
 ## Configuration
 

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -53,20 +53,6 @@ GENERATION_DOCUMENT_TYPE = "llm-generation-summary-detailed"  # For generation-l
 # Generation-level configuration
 DEFAULT_MAX_GENERATIONS_PER_WINDOW = 50  # Higher than traces - generations are simpler units
 
-# Team allowlist - only these teams will be processed by the coordinator
-# Empty list means no teams will be processed (coordinator skips)
-ALLOWED_TEAM_IDS: list[int] = [
-    1,  # Local development
-    2,  # Internal PostHog project
-    # Dogfooding projects
-    112495,
-    148051,
-    140227,
-    237906,
-    294356,
-    21999,
-]
-
 # Temporal configuration
 WORKFLOW_NAME = "llma-trace-summarization"
 COORDINATOR_WORKFLOW_NAME = "llma-trace-summarization-coordinator"

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -13,7 +13,6 @@ from datetime import timedelta
 
 import structlog
 import temporalio
-from temporalio.common import RetryPolicy
 
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.llm_analytics.trace_summarization import constants
@@ -39,6 +38,8 @@ from products.llm_analytics.backend.summarization.models import SummarizationMod
 
 with temporalio.workflow.unsafe.imports_passed_through():
     from posthog.temporal.llm_analytics.team_discovery import (
+        DISCOVERY_ACTIVITY_RETRY_POLICY,
+        DISCOVERY_ACTIVITY_TIMEOUT,
         SAMPLE_PERCENTAGE,
         TeamDiscoveryInput,
         get_team_ids_for_llm_analytics,
@@ -93,8 +94,8 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
         team_ids = await temporalio.workflow.execute_activity(
             get_team_ids_for_llm_analytics,
             TeamDiscoveryInput(sample_percentage=SAMPLE_PERCENTAGE),
-            start_to_close_timeout=timedelta(seconds=60),
-            retry_policy=RetryPolicy(maximum_attempts=2),
+            start_to_close_timeout=DISCOVERY_ACTIVITY_TIMEOUT,
+            retry_policy=DISCOVERY_ACTIVITY_RETRY_POLICY,
         )
 
         if not team_ids:

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -92,7 +92,7 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
         # Discover teams dynamically via activity
         team_ids = await temporalio.workflow.execute_activity(
             get_team_ids_for_llm_analytics,
-            TeamDiscoveryInput(lookback_days=30, sample_percentage=SAMPLE_PERCENTAGE),
+            TeamDiscoveryInput(sample_percentage=SAMPLE_PERCENTAGE),
             start_to_close_timeout=timedelta(seconds=60),
             retry_policy=RetryPolicy(maximum_attempts=2),
         )

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -40,6 +40,7 @@ with temporalio.workflow.unsafe.imports_passed_through():
     from posthog.temporal.llm_analytics.team_discovery import (
         DISCOVERY_ACTIVITY_RETRY_POLICY,
         DISCOVERY_ACTIVITY_TIMEOUT,
+        GUARANTEED_TEAM_IDS,
         SAMPLE_PERCENTAGE,
         TeamDiscoveryInput,
         get_team_ids_for_llm_analytics,
@@ -90,23 +91,18 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
             window_minutes=inputs.window_minutes,
         )
 
-        # Discover teams dynamically via activity
-        team_ids = await temporalio.workflow.execute_activity(
-            get_team_ids_for_llm_analytics,
-            TeamDiscoveryInput(sample_percentage=SAMPLE_PERCENTAGE),
-            start_to_close_timeout=DISCOVERY_ACTIVITY_TIMEOUT,
-            retry_policy=DISCOVERY_ACTIVITY_RETRY_POLICY,
-        )
-
-        if not team_ids:
-            logger.info("No teams discovered")
-            return CoordinatorResult(
-                teams_processed=0,
-                teams_failed=0,
-                failed_team_ids=[],
-                total_items=0,
-                total_summaries=0,
+        # Discover teams dynamically via activity, falling back to guaranteed
+        # teams if the activity fails (e.g. ClickHouse timeout).
+        try:
+            team_ids = await temporalio.workflow.execute_activity(
+                get_team_ids_for_llm_analytics,
+                TeamDiscoveryInput(sample_percentage=SAMPLE_PERCENTAGE),
+                start_to_close_timeout=DISCOVERY_ACTIVITY_TIMEOUT,
+                retry_policy=DISCOVERY_ACTIVITY_RETRY_POLICY,
             )
+        except Exception:
+            logger.warning("Team discovery activity failed, falling back to guaranteed teams", exc_info=True)
+            team_ids = sorted(GUARANTEED_TEAM_IDS)
 
         logger.info("Processing discovered teams", team_count=len(team_ids), team_ids=team_ids)
 

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_coordinator.py
@@ -1,10 +1,8 @@
 """Tests for batch trace summarization coordinator workflow."""
 
 import pytest
-from unittest.mock import patch
 
 from posthog.temporal.llm_analytics.trace_summarization.constants import (
-    ALLOWED_TEAM_IDS,
     DEFAULT_BATCH_SIZE,
     DEFAULT_MAX_ITEMS_PER_WINDOW,
     DEFAULT_MODE,
@@ -14,29 +12,9 @@ from posthog.temporal.llm_analytics.trace_summarization.constants import (
 from posthog.temporal.llm_analytics.trace_summarization.coordinator import (
     BatchTraceSummarizationCoordinatorInputs,
     BatchTraceSummarizationCoordinatorWorkflow,
-    get_allowed_team_ids,
 )
 
 from products.llm_analytics.backend.summarization.models import SummarizationMode
-
-
-class TestGetAllowedTeamIds:
-    """Tests for get_allowed_team_ids function."""
-
-    def test_returns_copy_of_allowed_team_ids(self):
-        """Test that function returns a copy of ALLOWED_TEAM_IDS."""
-        result = get_allowed_team_ids()
-        assert result == ALLOWED_TEAM_IDS
-        assert result is not ALLOWED_TEAM_IDS
-
-    def test_returns_empty_list_when_no_teams_configured(self):
-        """Test that function returns empty list when ALLOWED_TEAM_IDS is empty."""
-        with patch(
-            "posthog.temporal.llm_analytics.trace_summarization.coordinator.ALLOWED_TEAM_IDS",
-            [],
-        ):
-            result = get_allowed_team_ids()
-            assert result == []
 
 
 class TestBatchTraceSummarizationCoordinatorWorkflow:
@@ -96,7 +74,6 @@ class TestBatchTraceSummarizationCoordinatorWorkflow:
         ],
     )
     def test_parse_inputs(self, inputs, expected):
-        """Test parsing of workflow inputs."""
         result = BatchTraceSummarizationCoordinatorWorkflow.parse_inputs(inputs)
 
         assert result.analysis_level == expected.analysis_level


### PR DESCRIPTION
## Problem

Both the trace clustering and trace summarization coordinator workflows use identical hardcoded `ALLOWED_TEAM_IDS` lists. Adding new teams requires a code change and deploy. There is no path to gradually roll out to all teams with AI events.

## Changes

- New `team_discovery.py` with a shared Temporal activity (`get_team_ids_for_llm_analytics`) that:
  - Always includes a guaranteed allowlist (the current hardcoded teams)
  - Queries all teams with AI events via `get_teams_with_ai_events()`
  - Randomly samples a configurable percentage (default 10%) of the remaining teams
  - Falls back to guaranteed teams on failure
- Both clustering and summarization coordinators now call this activity instead of reading a static list
- Removed duplicate `ALLOWED_TEAM_IDS` from both `trace_clustering/constants.py` and `trace_summarization/constants.py`
- Removed `get_allowed_team_ids()` helper functions from both coordinators
- Registered the new activity in the LLMA task queue worker

Scaling: adjust `SAMPLE_PERCENTAGE` in `team_discovery.py` (0.0 = guaranteed only, 0.1 = 10%, 1.0 = all).

Note: each coordinator run samples independently, so clustering and summarization may process different non-guaranteed teams on a given run. Over time all teams accumulate coverage since summarization runs hourly.

## How did you test this code?

- Added unit tests for the team discovery activity covering: guaranteed teams always included, deduplication, sorting, sampling math, empty AI events, and exception fallback
- Updated existing coordinator tests to remove references to deleted `ALLOWED_TEAM_IDS` and `get_allowed_team_ids`

## Publish to changelog?

No