### PR TITLE
feat(experiments): Improve UI of timeseries chart

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
@@ -53,10 +53,7 @@ export function VariantTimeseriesChart({
                             ticks: {
                                 callback: (value) => {
                                     const num = Number(value)
-                                    if (Math.abs(num) < 1) {
-                                        return `${(num * 100).toFixed(1)}%`
-                                    }
-                                    return num.toFixed(2)
+                                    return `${(num * 100).toFixed(0)}%`
                                 },
                             },
                             afterBuildTicks: (axis) => {

--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
@@ -35,13 +35,22 @@ export function VariantTimeseriesChart({
                     },
                     scales: {
                         y: {
-                            beginAtZero: true,
                             grid: {
                                 display: true,
-                                color: colors.EXPOSURES_AXIS_LINES,
+                                color: (context) => {
+                                    if (context.tick.value === 0) {
+                                        return colors.ZERO_LINE
+                                    }
+                                    return colors.EXPOSURES_AXIS_LINES
+                                },
+                                lineWidth: (context) => {
+                                    if (context.tick.value === 0) {
+                                        return 1.25
+                                    }
+                                    return 1
+                                },
                             },
                             ticks: {
-                                count: 6,
                                 callback: (value) => {
                                     const num = Number(value)
                                     if (Math.abs(num) < 1) {
@@ -49,6 +58,13 @@ export function VariantTimeseriesChart({
                                     }
                                     return num.toFixed(2)
                                 },
+                            },
+                            afterBuildTicks: (axis) => {
+                                const ticks = axis.ticks.map((t) => t.value)
+                                if (!ticks.includes(0)) {
+                                    axis.ticks.push({ value: 0 })
+                                    axis.ticks.sort((a, b) => a.value - b.value)
+                                }
                             },
                         },
                         x: {
@@ -119,7 +135,7 @@ export function VariantTimeseriesChart({
                 },
             }
         },
-        deps: [data, colors.EXPOSURES_AXIS_LINES, isRatioMetric],
+        deps: [data, colors.EXPOSURES_AXIS_LINES, colors.ZERO_LINE, isRatioMetric],
     })
 
     return (

--- a/frontend/src/scenes/experiments/MetricsView/shared/colors.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/colors.ts
@@ -21,7 +21,7 @@ export function useChartColors(): ChartColors {
     return {
         TICK_TEXT_COLOR: 'var(--color-text-tertiary)',
         BOUNDARY_LINES: 'var(--color-border-primary)',
-        ZERO_LINE: 'var(--border-bold)',
+        ZERO_LINE: isDarkModeOn ? 'rgba(255, 255, 255, 0.6)' : 'var(--border-bold)',
         BAR_NEGATIVE: isDarkModeOn ? '#c32f45' : '#f84257',
         BAR_POSITIVE: isDarkModeOn ? '#12a461' : '#36cd6f',
         BAR_DEFAULT: isDarkModeOn ? 'rgb(121 121 121)' : 'rgb(217 217 217)',

--- a/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
+++ b/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
@@ -295,11 +295,14 @@ export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([
                     // Create a simple approach: just two datasets with segmented colors
                     const datasets: ChartDataset[] = []
 
+                    // We use the same color for upper and lower bound lines for clear association with the variant line
+                    const boundLineColor = variantColor
+
                     // Upper bounds dataset
                     datasets.push({
                         label: 'Upper bound',
                         data: upperBounds,
-                        borderColor: COLORS.BAR_DEFAULT,
+                        borderColor: boundLineColor,
                         borderWidth: 1,
                         fill: false,
                         tension: 0,
@@ -310,7 +313,7 @@ export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([
                     datasets.push({
                         label: 'Lower bound',
                         data: lowerBounds,
-                        borderColor: COLORS.BAR_DEFAULT,
+                        borderColor: boundLineColor,
                         borderWidth: 1,
                         fill: '-1',
                         backgroundColor: (context: any) => {


### PR DESCRIPTION
## Problem

The time series modal didn't draw the 0 line as reference. Also, the axis didn't format large numbers as percent

## Changes

- Add 0-line for reference
- Color the upper/lower bounds with the variant color to distinguish from 0-line and show connection to the variant itself
- Fix formatting large numbers as decimals instead of percent
- Fix not considering dark mode for ZERO_LINE also in other experiments chart

| case | before | after |
| - | - | - |
| dark mode & purple series| <img width="623" height="280" alt="before-dark" src="https://github.com/user-attachments/assets/a5ef5f59-1784-4732-b4f4-d9e04d1b2a4a" /> | <img width="617" height="277" alt="after-dark" src="https://github.com/user-attachments/assets/181709e3-e07e-47a6-914e-5e7a2aae7afb" /> |
| light mode & green series| <img width="637" height="277" alt="before-light" src="https://github.com/user-attachments/assets/8330677a-2868-4437-814d-7e9020ce5b32" /> | <img width="635" height="277" alt="after-light" src="https://github.com/user-attachments/assets/74e835f1-bb88-4ecc-a567-3afebcdc9c41" /> |




## How did you test this code?

Manually

## Publish to changelog?

No