### PR TITLE
fix(Insights): SQL Insight - number shouldn't flash

### DIFF
--- a/frontend/src/scenes/insights/views/BoldNumber/Textfit.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/Textfit.tsx
@@ -10,7 +10,7 @@ export type TextfitProps = {
 export const Textfit = ({ min, max, children }: TextfitProps): JSX.Element => {
     const parentRef = useRef<HTMLDivElement>(null)
     const childRef = useRef<HTMLDivElement>(null)
-    const fontSizeRef = useRef<number>(min)
+    const fontSizeRef = useRef<number>(max)
 
     let resizeTimer: NodeJS.Timeout
 

--- a/frontend/src/scenes/insights/views/BoldNumber/Textfit.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/Textfit.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import useResizeObserver from 'use-resize-observer'
 
 export type TextfitProps = {
@@ -10,65 +10,48 @@ export type TextfitProps = {
 export const Textfit = ({ min, max, children }: TextfitProps): JSX.Element => {
     const parentRef = useRef<HTMLDivElement>(null)
     const childRef = useRef<HTMLDivElement>(null)
-    const fontSizeRef = useRef<number>(max)
 
-    let resizeTimer: NodeJS.Timeout
+    const calculateFontSize = (): void => {
+        const parent = parentRef.current
+        const child = childRef.current
 
-    const updateFontSize = (size: number): void => {
-        fontSizeRef.current = size
-        childRef.current!.style.fontSize = `${size}px`
+        if (!parent || !child) {
+            return
+        }
+
+        let low = min
+        let high = max
+
+        while (low <= high) {
+            const mid = Math.floor((low + high) / 2)
+            child.style.fontSize = `${mid}px`
+
+            const childFitsParent =
+                child.getBoundingClientRect().width <= parent.getBoundingClientRect().width &&
+                child.getBoundingClientRect().height <= parent.getBoundingClientRect().height
+
+            if (childFitsParent) {
+                low = mid + 1
+            } else {
+                high = mid - 1
+            }
+        }
+
+        const finalSize = Math.max(min, Math.min(max, Math.min(low, high)))
+        child.style.fontSize = `${finalSize}px`
     }
 
-    const handleResize = (): void => {
-        clearTimeout(resizeTimer)
-        resizeTimer = setTimeout(() => {
-            const parent = parentRef.current
-            const child = childRef.current
-
-            if (!parent || !child) {
-                return
-            }
-
-            let mid
-            let low = min
-            let high = max
-
-            while (low <= high) {
-                mid = Math.floor((low + high) / 2)
-                updateFontSize(mid)
-                const childRect = child.getBoundingClientRect()
-                const parentRect = parent.getBoundingClientRect()
-
-                const childFitsParent = childRect.width <= parentRect.width && childRect.height <= parentRect.height
-
-                if (childFitsParent) {
-                    low = mid + 1
-                } else {
-                    high = mid - 1
-                }
-            }
-            mid = Math.min(low, high)
-
-            // Ensure we hit the user-supplied limits
-            mid = Math.max(mid, min)
-            mid = Math.min(mid, max)
-
-            updateFontSize(mid)
-        }, 50)
-    }
+    useLayoutEffect(() => {
+        calculateFontSize()
+    }, [children, min, max])
 
     useResizeObserver<HTMLDivElement>({
         ref: parentRef,
-        onResize: () => handleResize(),
+        onResize: calculateFontSize,
     })
 
     return (
-        <div
-            ref={parentRef}
-            className="w-full h-full flex items-center justify-center leading-none"
-            // eslint-disable-next-line react/forbid-dom-props
-            style={{ fontSize: fontSizeRef.current }}
-        >
+        <div ref={parentRef} className="w-full h-full flex items-center justify-center leading-none">
             <div ref={childRef} className="whitespace-nowrap">
                 {children}
             </div>


### PR DESCRIPTION
## Problem
https://posthog.slack.com/archives/C045L1VEG87/p1770206561882419

On a SQL insight, when returning back to a dashboard tab, this bold number would flash small then big. 

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Default to maximum font size gets rid of the sizing changes seen in the video                                                                                                                
                                     

https://github.com/user-attachments/assets/7091bdb2-1cc6-4fdd-a968-e8c722fd4e70


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
