### PR TITLE
fix(dashboards): render card meta during scroll

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -226,35 +226,35 @@ function InsightCardInternal(
             style={{ ...divProps?.style, ...theme?.boxStyle }}
             ref={mergedRefs}
         >
-            {isVisible ? (
-                <ErrorBoundary exceptionProps={{ feature: 'insight' }}>
-                    <BindLogic logic={insightLogic} props={insightLogicProps}>
-                        <InsightMeta
-                            tile={tile}
-                            insight={insight}
-                            ribbonColor={ribbonColor}
-                            dashboardId={dashboardId}
-                            updateColor={updateColor}
-                            removeFromDashboard={removeFromDashboard}
-                            deleteWithUndo={deleteWithUndo}
-                            refresh={refresh}
-                            refreshEnabled={refreshEnabled}
-                            loadingQueued={loadingQueued}
-                            loading={loading}
-                            rename={rename}
-                            duplicate={duplicate}
-                            setOverride={setOverride}
-                            moveToDashboard={moveToDashboard}
-                            areDetailsShown={areDetailsShown}
-                            setAreDetailsShown={setAreDetailsShown}
-                            showEditingControls={showEditingControls}
-                            showDetailsControls={showDetailsControls}
-                            moreButtons={moreButtons}
-                            filtersOverride={filtersOverride}
-                            variablesOverride={variablesOverride}
-                            placement={placement}
-                            surveyOpportunity={surveyOpportunity}
-                        />
+            <ErrorBoundary exceptionProps={{ feature: 'insight' }}>
+                <BindLogic logic={insightLogic} props={insightLogicProps}>
+                    <InsightMeta
+                        tile={tile}
+                        insight={insight}
+                        ribbonColor={ribbonColor}
+                        dashboardId={dashboardId}
+                        updateColor={updateColor}
+                        removeFromDashboard={removeFromDashboard}
+                        deleteWithUndo={deleteWithUndo}
+                        refresh={refresh}
+                        refreshEnabled={refreshEnabled}
+                        loadingQueued={loadingQueued}
+                        loading={loading}
+                        rename={rename}
+                        duplicate={duplicate}
+                        setOverride={setOverride}
+                        moveToDashboard={moveToDashboard}
+                        areDetailsShown={areDetailsShown}
+                        setAreDetailsShown={setAreDetailsShown}
+                        showEditingControls={showEditingControls}
+                        showDetailsControls={showDetailsControls}
+                        moreButtons={moreButtons}
+                        filtersOverride={filtersOverride}
+                        variablesOverride={variablesOverride}
+                        placement={placement}
+                        surveyOpportunity={surveyOpportunity}
+                    />
+                    {isVisible ? (
                         <div className="InsightCard__viz">
                             {BlockingEmptyState ? (
                                 BlockingEmptyState
@@ -273,17 +273,17 @@ function InsightCardInternal(
                                 />
                             )}
                         </div>
-                    </BindLogic>
-                    {showResizeHandles && (
-                        <>
-                            {canResizeWidth ? <ResizeHandle1D orientation="vertical" /> : null}
-                            <ResizeHandle1D orientation="horizontal" />
-                            {canResizeWidth ? <ResizeHandle2D /> : null}
-                        </>
-                    )}
-                    {children /* Extras, specifically resize handles injected by ReactGridLayout */}
-                </ErrorBoundary>
-            ) : null}
+                    ) : null}
+                </BindLogic>
+                {showResizeHandles && (
+                    <>
+                        {canResizeWidth ? <ResizeHandle1D orientation="vertical" /> : null}
+                        <ResizeHandle1D orientation="horizontal" />
+                        {canResizeWidth ? <ResizeHandle2D /> : null}
+                    </>
+                )}
+                {children /* Extras, specifically resize handles injected by ReactGridLayout */}
+            </ErrorBoundary>
         </div>
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -214,6 +214,9 @@ export const LineGraph = ({
             const annotations = goalLines.reduce(
                 (acc, cur, curIndex) => {
                     const line: LineAnnotationOptions = {
+                        borderColor: cur.borderColor ?? getSeriesColor(curIndex),
+                        borderWidth: 1,
+                        borderDash: [5, 8],
                         label: {
                             display: cur.displayLabel ?? true,
                             content: cur.label,


### PR DESCRIPTION
## Problem

We use a resize observer visibility check to show/hide card content on a dashboard as a form of virtualization. Since only the charts are the main elements of concern for performance, and having the titles as a guide when scrolling is helpful, I'd like to render the meta part of the card always.

## Changes

### Before
![2026-02-04 14 18 34](https://github.com/user-attachments/assets/d912157d-a68f-488a-951f-7c4c8cebbc0e)



### After

![2026-02-04 14 17 43](https://github.com/user-attachments/assets/72d9c176-29bb-4160-8a09-eb12d08e1e9a)


## How did you test this code?

👀 