### PR TITLE
feat(cohorts): display query IDs in calculation history UI

### DIFF
--- a/frontend/src/scenes/cohorts/CohortCalculationHistory.tsx
+++ b/frontend/src/scenes/cohorts/CohortCalculationHistory.tsx
@@ -182,6 +182,14 @@ export function CohortCalculationHistory(props: CohortCalculationHistoryProps): 
                                                             {query.written_rows?.toLocaleString()}
                                                         </div>
                                                     </div>
+                                                    {query.query_id && (
+                                                        <div className="mt-2 text-xs">
+                                                            <strong>Query ID:</strong>{' '}
+                                                            <code className="bg-bg-3000 px-1 py-0.5 rounded font-mono select-all">
+                                                                {query.query_id}
+                                                            </code>
+                                                        </div>
+                                                    )}
                                                     {query.query && (
                                                         <details className="mt-2">
                                                             <summary className="cursor-pointer text-primary">

--- a/frontend/src/scenes/cohorts/cohortCalculationHistorySceneLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortCalculationHistorySceneLogic.test.ts
@@ -40,6 +40,7 @@ const mockHistoryRecord: CohortCalculationHistoryRecord = {
     total_read_rows: 1000,
     total_written_rows: 500,
     main_query: { query: 'main query' },
+    main_query_id: 'query-1',
 }
 
 const mockHistoryResponse: CohortCalculationHistoryResponse = {

--- a/frontend/src/scenes/cohorts/cohortCalculationHistorySceneLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortCalculationHistorySceneLogic.ts
@@ -33,6 +33,7 @@ export interface CohortCalculationHistoryRecord {
     total_read_rows: number
     total_written_rows: number
     main_query: any
+    main_query_id: string | null
 }
 
 export interface CohortCalculationHistoryResponse {

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -321,6 +321,7 @@ class CohortCalculationHistorySerializer(serializers.ModelSerializer):
     total_read_rows = serializers.ReadOnlyField()
     total_written_rows = serializers.ReadOnlyField()
     main_query = serializers.ReadOnlyField()
+    main_query_id = serializers.ReadOnlyField()
 
     class Meta:
         model = CohortCalculationHistory
@@ -340,6 +341,7 @@ class CohortCalculationHistorySerializer(serializers.ModelSerializer):
             "total_read_rows",
             "total_written_rows",
             "main_query",
+            "main_query_id",
         ]
 
 


### PR DESCRIPTION
## Problem

Debugging cohort calculation performance issues needs easy access to ClickHouse query IDs, but these aren't currently displayed in the PostHog UI, making it difficult to correlate frontend issues with backend query performance.

## Changes

- **Query ID display** in cohort calculation history expandable rows

## How did you test this code?

Locally

## Publish to changelog?

No - this is a debugging/developer experience improvement, not a user-facing feature.