### PR TITLE
fix(destinations): handle non-string values in meta ads parseValueIfArray

### DIFF
--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -35,11 +35,14 @@ if (not empty(inputs.eventSourceUrl)) {
 
 // Helper function to parse JSON arrays from string values
 fn parseValueIfArray(value) {
-    if (typeof(value) == 'string' and startsWith(trim(value), '[')) {
-        try {
-            return jsonParse(trim(value))
-        } catch {
-            return value
+    if (typeof(value) == 'string') {
+        let trimmed := trim(value)
+        if (startsWith(trimmed, '[')) {
+            try {
+                return jsonParse(trimmed)
+            } catch {
+                return value
+            }
         }
     }
     return value

--- a/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
@@ -118,3 +118,21 @@ class TestTemplateMetaAds(BaseHogFunctionTemplateTest):
         assert user_data["external_id"] == ["user123", "crm456"]
         assert custom_data["content_ids"] == ["product123", "product456"]
         assert custom_data["contents"] == [{"id": "product123", "quantity": 2}]
+
+    def test_function_handles_numeric_values_in_custom_data(self):
+        self.mock_fetch_response = lambda *args: {"status": 200, "body": {"ok": True}}  # type: ignore
+        inputs = self._inputs(
+            customData={
+                "currency": "EUR",
+                "value": 99.8,
+                "quantity": 2,
+            }
+        )
+        self.run_function(inputs)
+
+        call = self.get_mock_fetch_calls()[0]
+        custom_data = call[1]["body"]["data"][0]["custom_data"]
+
+        assert custom_data["currency"] == "EUR"
+        assert custom_data["value"] == 99.8
+        assert custom_data["quantity"] == 2


### PR DESCRIPTION
## Problem

The parseValueIfArray function was calling trim() on all values, including numbers. Since Hog bytecode doesn't short-circuit the `and` operator, trim(value) was evaluated even when typeof(value) was not 'string', causing TypeError: str.slice is not a function.

## Changes

Fix: Use nested conditionals to ensure trim() is only called on strings. Numbers like 99.8 now pass through unchanged.

## How did you test this code?

- Added test `test_function_handles_numeric_values_in_custom_data`
- All 5 Meta Ads template tests pass

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
