### PR TITLE
feat(vercel): use NEXT_PUBLIC_ env var names for PostHog secrets

### DIFF
--- a/ee/api/vercel/test/test_vercel_resource.py
+++ b/ee/api/vercel/test/test_vercel_resource.py
@@ -287,10 +287,10 @@ class TestVercelResourceAPI(VercelTestBase):
         self.assertEqual(len(secrets), 2)
 
         secret_names = [s["name"] for s in secrets]
-        self.assertIn("POSTHOG_PROJECT_API_KEY", secret_names)
-        self.assertIn("POSTHOG_HOST", secret_names)
+        self.assertIn("NEXT_PUBLIC_POSTHOG_KEY", secret_names)
+        self.assertIn("NEXT_PUBLIC_POSTHOG_HOST", secret_names)
 
-        api_key_secret = next(s for s in secrets if s["name"] == "POSTHOG_PROJECT_API_KEY")
+        api_key_secret = next(s for s in secrets if s["name"] == "NEXT_PUBLIC_POSTHOG_KEY")
         self.assertEqual(api_key_secret["value"], self.team.api_token)
 
     def test_rotate_secrets_requires_system_auth(self):

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -520,11 +520,11 @@ class VercelIntegration:
     def _build_secrets(team: Team) -> list[dict[str, str]]:
         return [
             {
-                "name": "POSTHOG_PROJECT_API_KEY",
+                "name": "NEXT_PUBLIC_POSTHOG_KEY",
                 "value": team.api_token,
             },
             {
-                "name": "POSTHOG_HOST",
+                "name": "NEXT_PUBLIC_POSTHOG_HOST",
                 "value": absolute_uri(),
             },
         ]

--- a/ee/vercel/test/test_integration.py
+++ b/ee/vercel/test/test_integration.py
@@ -531,9 +531,9 @@ class TestVercelIntegration(TestCase):
         secrets = VercelIntegration._build_secrets(team)
 
         assert len(secrets) == 2
-        assert secrets[0]["name"] == "POSTHOG_PROJECT_API_KEY"
+        assert secrets[0]["name"] == "NEXT_PUBLIC_POSTHOG_KEY"
         assert secrets[0]["value"] == "test_api_token"
-        assert secrets[1]["name"] == "POSTHOG_HOST"
+        assert secrets[1]["name"] == "NEXT_PUBLIC_POSTHOG_HOST"
         assert secrets[1]["value"].startswith(("https://", "http://"))
 
     @parameterized.expand(
@@ -1154,8 +1154,8 @@ class TestPushSecretsToVercel(TestCase):
 
         secrets = call_args[1]["secrets"]
         assert len(secrets) == 2
-        assert any(s["name"] == "POSTHOG_PROJECT_API_KEY" for s in secrets)
-        assert any(s["name"] == "POSTHOG_HOST" for s in secrets)
+        assert any(s["name"] == "NEXT_PUBLIC_POSTHOG_KEY" for s in secrets)
+        assert any(s["name"] == "NEXT_PUBLIC_POSTHOG_HOST" for s in secrets)
 
     @patch("ee.vercel.integration.VercelAPIClient")
     def test_push_secrets_sends_current_api_token(self, mock_client_class):
@@ -1167,7 +1167,7 @@ class TestPushSecretsToVercel(TestCase):
 
         call_args = mock_client.update_resource_secrets.call_args
         secrets = call_args[1]["secrets"]
-        api_key_secret = next(s for s in secrets if s["name"] == "POSTHOG_PROJECT_API_KEY")
+        api_key_secret = next(s for s in secrets if s["name"] == "NEXT_PUBLIC_POSTHOG_KEY")
         assert api_key_secret["value"] == self.team.api_token
 
     @patch("ee.vercel.integration.VercelAPIClient")

--- a/ee/vercel/test/test_vercel_client.py
+++ b/ee/vercel/test/test_vercel_client.py
@@ -127,7 +127,7 @@ class TestVercelAPIClient:
 
     @patch("ee.vercel.client.requests.Session.request")
     def test_update_resource_secrets(self, mock_request, client, test_ids):
-        secrets = [{"name": "POSTHOG_PROJECT_API_KEY", "value": "test_key"}]
+        secrets = [{"name": "NEXT_PUBLIC_POSTHOG_KEY", "value": "test_key"}]
         self.assert_successful_request(
             mock_request,
             "PUT",
@@ -142,7 +142,7 @@ class TestVercelAPIClient:
     def test_update_resource_secrets_handles_errors(self, mock_request, client, test_ids):
         mock_request.return_value = self.ErrorFactory.http(400, "Bad Request")
 
-        secrets = [{"name": "POSTHOG_PROJECT_API_KEY", "value": "test_key"}]
+        secrets = [{"name": "NEXT_PUBLIC_POSTHOG_KEY", "value": "test_key"}]
         result = client.update_resource_secrets(test_ids["integration_config_id"], test_ids["resource_id"], secrets)
 
         assert not result.success


### PR DESCRIPTION
## Problem

The Vercel integration injects `POSTHOG_PROJECT_API_KEY` and `POSTHOG_HOST`, but:

1. **These vars are not available on the frontend** - In Next.js, only env vars prefixed with `NEXT_PUBLIC_` are exposed to the browser ([Next.js docs](https://nextjs.org/docs/pages/guides/environment-variables#exposing-environment-variables-to-the-browser)). Without this prefix, client-side PostHog (analytics, session recording) won't work.
2. [PostHog's official Next.js docs](https://posthog.com/docs/libraries/next-js) recommend `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST`
3. The [Vercel Flags SDK + PostHog template](https://vercel.com/templates/next.js/posthog-with-flags-sdk-and-next-js) expects `NEXT_PUBLIC_*` env vars (see [.env.example](https://github.com/vercel/examples/blob/main/flags-sdk/posthog/.env.example))
4. Users following standard PostHog setup guides can't use the injected vars without manual copying

This causes friction when deploying the PostHog + Vercel Flags SDK template, and makes client-side PostHog impossible without manual env var duplication.

Context: [Slack thread](https://posthog.slack.com/archives/C08LYBQ58N5/p1770154736205909?thread_ts=1769647976.280949&cid=C08LYBQ58N5)

## Changes

Switch the injected env var names from:
- `POSTHOG_PROJECT_API_KEY` → `NEXT_PUBLIC_POSTHOG_KEY`
- `POSTHOG_HOST` → `NEXT_PUBLIC_POSTHOG_HOST`

`NEXT_PUBLIC_*` vars are available in **both** client and server environments in Next.js, so this works for all use cases:
- ✅ Client-side posthog-js (analytics, session recording)
- ✅ Server-side posthog-node (feature flags, server events)
- ✅ Edge middleware (Vercel Flags SDK)

This matches what [Sentry does with their Vercel integration](https://docs.sentry.io/organization/integrations/deployment/vercel/) (`NEXT_PUBLIC_SENTRY_DSN`).

## How did you test this code?

- Updated all related tests to use new env var names
- CI will run full test suite

## Changelog

Yes - this is a breaking change for existing Vercel integrations that reference `POSTHOG_PROJECT_API_KEY` by name. Users will need to update their code to use the new env var names.

🤖 Generated with [Claude Code](https://claude.ai/code)