### PR TITLE
chore: Inkeep trigger only on merge

### DIFF
--- a/.github/workflows/inkeep-agent.yml
+++ b/.github/workflows/inkeep-agent.yml
@@ -2,7 +2,7 @@ name: Inkeep Agent
 
 on:
     pull_request:
-        types: [opened, synchronize]
+        types: [closed]
 
     issue_comment:
         types: [created]
@@ -14,8 +14,10 @@ permissions:
 
 jobs:
     trigger-agent:
-        # Agent will trigger if a PR is created or a comment including `@inkeep` is left on a PR.
-        if: github.event_name != 'issue_comment' || (github.event.issue.pull_request && contains(github.event.comment.body, '@inkeep'))
+        # Agent will trigger if a PR is merged or a comment including `@inkeep` is left on a PR.
+        if: |
+            (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+            (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@inkeep'))
         runs-on: ubuntu-latest
         steps:
             - name: Trigger Inkeep Agent


### PR DESCRIPTION
## Problem

Inkeep will trigger on synchronize and on open which is annoying

## Changes

This makes it only open on merged PRs, which I think is what we want.

## How did you test this code?

😢 Boo github workflows

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
NO