### PR TITLE
feat: add theme toggle to shortcuts menu

### DIFF
--- a/frontend/src/layout/GlobalShortcuts.tsx
+++ b/frontend/src/layout/GlobalShortcuts.tsx
@@ -14,6 +14,7 @@ import { removeProjectIdIfPresent } from 'lib/utils/router-utils'
 import { urls } from 'scenes/urls'
 
 import { navigation3000Logic } from './navigation-3000/navigationLogic'
+import { themeLogic } from './navigation-3000/themeLogic'
 
 export function GlobalShortcuts(): null {
     const { superpowersEnabled } = useValues(superpowersLogic)
@@ -26,6 +27,7 @@ export function GlobalShortcuts(): null {
     const { toggleAccountMenu, toggleProjectSwitcher, toggleOrgSwitcher } = useActions(newAccountMenuLogic)
     const { openSuperpowers } = useActions(superpowersLogic)
     const { toggleHealthMenu } = useActions(healthMenuLogic)
+    const { toggleTheme } = useActions(themeLogic)
 
     useAppShortcut({
         name: 'Search',
@@ -122,6 +124,14 @@ export function GlobalShortcuts(): null {
         intent: 'Toggle organization switcher',
         interaction: 'function',
         callback: () => toggleOrgSwitcher(),
+    })
+
+    useAppShortcut({
+        name: 'toggle-theme',
+        keybind: [keyBinds.theme],
+        intent: 'Toggle theme (dark / light)',
+        interaction: 'function',
+        callback: () => toggleTheme(),
     })
 
     return null

--- a/frontend/src/layout/navigation-3000/themeLogic.ts
+++ b/frontend/src/layout/navigation-3000/themeLogic.ts
@@ -13,6 +13,7 @@ export const themeLogic = kea<themeLogicType>([
     connect(() => ({
         logic: [sceneLogic],
         values: [userLogic, ['themeMode'], featureFlagLogic, ['featureFlags']],
+        actions: [userLogic, ['updateUser']],
     })),
 
     actions({
@@ -21,6 +22,7 @@ export const themeLogic = kea<themeLogicType>([
         saveCustomCss: true,
         setPersistedCustomCss: (css: string | null) => ({ css }),
         setPreviewingCustomCss: (css: string | null) => ({ css }),
+        toggleTheme: true,
     }),
     reducers({
         darkModeSystemPreference: [
@@ -98,6 +100,9 @@ export const themeLogic = kea<themeLogicType>([
         saveCustomCss() {
             actions.setPersistedCustomCss(values.previewingCustomCss)
             actions.setPreviewingCustomCss(null)
+        },
+        toggleTheme() {
+            actions.updateUser({ theme_mode: values.isDarkModeOn ? 'light' : 'dark' })
         },
     })),
     events(({ cache, actions }) => ({

--- a/frontend/src/lib/components/AppShortcuts/shortcuts.ts
+++ b/frontend/src/lib/components/AppShortcuts/shortcuts.ts
@@ -39,4 +39,5 @@ export const keyBinds: Record<string, string[]> = {
     newChat: ['g', 'then', 'n'],
     allChats: ['g', 'then', '1'],
     allApps: ['g', 'then', '2'],
+    theme: ['g', 'then', 't'],
 }


### PR DESCRIPTION
## Problem

Closes #46058. 

## Changes

- Adds theme toggle to the global shortcuts.
- Sets shortcut to `g + t`.

![Screenshot 2026-02-03 at 18.56.39.png](https://app.graphite.com/user-attachments/assets/71cf2969-f23e-4e74-b8f4-44f8bc8aa425.png)

## How did you test this code?

- Tried finding the theme option within the shortcuts by theme, dark and light (it looks up by option name)

## Publish to changelog?

Yes.

This feature allows the theme toggle to be found within the shortcuts bar.
