### PR TITLE
fix(ux): random nits

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -599,7 +599,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                             ) : (
                                 <div
                                     className={cn('flex gap-1', {
-                                        'flex-col items-center': isLayoutNavCollapsed,
+                                        'items-center flex-col-reverse': isLayoutNavCollapsed,
                                     })}
                                 >
                                     <HelpMenu />

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -103,14 +103,6 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
     const { toggleCommand } = useActions(commandLogic)
     const isRemovingSidePanelFlag = useFeatureFlag('UX_REMOVE_SIDEPANEL')
 
-    useAppShortcut({
-        name: 'ToggleLeftNav',
-        keybind: [keyBinds.toggleLeftNav],
-        intent: 'Toggle collapse left navigation',
-        interaction: 'function',
-        callback: toggleLayoutNavCollapsed,
-    })
-
     function handlePanelTriggerClick(item: PanelLayoutNavIdentifier): void {
         if (activePanelIdentifier !== item) {
             setActivePanelIdentifier(item)
@@ -157,6 +149,14 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
 
         return false
     }
+
+    useAppShortcut({
+        name: 'ToggleLeftNav',
+        keybind: [keyBinds.toggleLeftNav],
+        intent: 'Toggle collapse left navigation',
+        interaction: 'function',
+        callback: toggleLayoutNavCollapsed,
+    })
 
     const navItems: {
         identifier: string

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -24,8 +24,6 @@ import { Link } from '@posthog/lemon-ui'
 import { AccountMenu } from 'lib/components/Account/AccountMenu'
 import { NewAccountMenu } from 'lib/components/Account/NewAccountMenu'
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
-import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
-import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
 import { commandLogic } from 'lib/components/Command/commandLogic'
 import { DebugNotice } from 'lib/components/DebugNotice'
 import { HealthMenu } from 'lib/components/HealthMenu/HealthMenu'
@@ -149,16 +147,6 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
 
         return false
     }
-
-    useAppShortcut({
-        name: 'collapse-left-navigation',
-        keybind: [keyBinds.toggleLeftNav],
-        intent: 'Collapse left navigation',
-        interaction: 'function',
-        callback: () => {
-            toggleLayoutNavCollapsed(!isLayoutNavCollapsed)
-        },
-    })
 
     const navItems: {
         identifier: string
@@ -599,7 +587,11 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                     />
                                 </>
                             ) : (
-                                <div className="flex gap-1">
+                                <div
+                                    className={cn('flex gap-1', {
+                                        'flex-col items-center': isLayoutNavCollapsed,
+                                    })}
+                                >
                                     <HelpMenu />
                                     <HealthMenu />
                                 </div>

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -24,6 +24,8 @@ import { Link } from '@posthog/lemon-ui'
 import { AccountMenu } from 'lib/components/Account/AccountMenu'
 import { NewAccountMenu } from 'lib/components/Account/NewAccountMenu'
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
+import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
+import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
 import { commandLogic } from 'lib/components/Command/commandLogic'
 import { DebugNotice } from 'lib/components/DebugNotice'
 import { HealthMenu } from 'lib/components/HealthMenu/HealthMenu'
@@ -100,6 +102,14 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
     const { featureFlags } = useValues(featureFlagLogic)
     const { toggleCommand } = useActions(commandLogic)
     const isRemovingSidePanelFlag = useFeatureFlag('UX_REMOVE_SIDEPANEL')
+
+    useAppShortcut({
+        name: 'toggle collapse left nav',
+        keybind: [keyBinds.toggleLeftNav],
+        intent: 'Toggle collapse left nav',
+        interaction: 'function',
+        callback: toggleLayoutNavCollapsed,
+    })
 
     function handlePanelTriggerClick(item: PanelLayoutNavIdentifier): void {
         if (activePanelIdentifier !== item) {

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -104,9 +104,9 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
     const isRemovingSidePanelFlag = useFeatureFlag('UX_REMOVE_SIDEPANEL')
 
     useAppShortcut({
-        name: 'toggle collapse left nav',
+        name: 'ToggleLeftNav',
         keybind: [keyBinds.toggleLeftNav],
-        intent: 'Toggle collapse left nav',
+        intent: 'Toggle collapse left navigation',
         interaction: 'function',
         callback: toggleLayoutNavCollapsed,
     })

--- a/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
@@ -56,6 +56,7 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
                                         width={width}
                                         originalValue={props.originalValue}
                                         {...props.codeEditorProps}
+                                        autoFocus={true}
                                         options={{
                                             minimap: {
                                                 enabled: false,

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/DatabaseSearchField.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/DatabaseSearchField.tsx
@@ -32,7 +32,6 @@ export function DatabaseSearchField({ placeholder }: TreeSearchFieldProps): JSX.
             onKeyDown={(e) => handleKeyDown(e)}
             onClear={() => clearSearch()}
             onChange={(value) => setSearchTerm(value)}
-            autoFocus={true}
         />
     )
 }

--- a/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
@@ -2,10 +2,14 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useEffect, useRef, useState } from 'react'
 
+import { IconArchive, IconCopy, IconScreen } from '@posthog/icons'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { More } from 'lib/lemon-ui/LemonButton/More'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 
+import { ScenePanel, ScenePanelActionsSection, ScenePanelDivider } from '~/layout/scenes/SceneLayout'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { HogFlowManualTriggerButton } from './hogflows/HogFlowManualTriggerButton'
@@ -31,6 +35,7 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
     const [displayStatus, setDisplayStatus] = useState(workflow?.status)
     const [isTransitioning, setIsTransitioning] = useState(false)
     const prevStatusRef = useRef(workflow?.status)
+    const isRemovingSidePanelFlag = useFeatureFlag('UX_REMOVE_SIDEPANEL')
 
     useEffect(() => {
         // Only transition if status actually changed (not on initial mount)
@@ -87,27 +92,49 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
                                     </span>
                                 </LemonButton>
                                 <LemonDivider vertical />
-                                <More
-                                    size="small"
-                                    overlay={
-                                        <>
-                                            <LemonButton fullWidth onClick={() => duplicate()}>
+                                {isRemovingSidePanelFlag ? (
+                                    <ScenePanel>
+                                        <ScenePanelActionsSection>
+                                            <ButtonPrimitive menuItem onClick={() => duplicate()}>
+                                                <IconCopy />
                                                 Duplicate
-                                            </LemonButton>
-                                            <LemonButton fullWidth onClick={showSaveAsTemplateModal}>
+                                            </ButtonPrimitive>
+                                            <ButtonPrimitive menuItem onClick={showSaveAsTemplateModal}>
+                                                <IconScreen />
                                                 Save as template
-                                            </LemonButton>
-                                            <LemonDivider />
-                                            <LemonButton
-                                                status="danger"
-                                                fullWidth
-                                                onClick={() => archiveWorkflow(workflow)}
-                                            >
+                                            </ButtonPrimitive>
+                                        </ScenePanelActionsSection>
+                                        <ScenePanelDivider />
+                                        <ScenePanelActionsSection>
+                                            <ButtonPrimitive menuItem onClick={() => archiveWorkflow(workflow)}>
+                                                <IconArchive />
                                                 Archive
-                                            </LemonButton>
-                                        </>
-                                    }
-                                />
+                                            </ButtonPrimitive>
+                                        </ScenePanelActionsSection>
+                                    </ScenePanel>
+                                ) : (
+                                    <More
+                                        size="small"
+                                        overlay={
+                                            <>
+                                                <LemonButton fullWidth onClick={() => duplicate()}>
+                                                    Duplicate
+                                                </LemonButton>
+                                                <LemonButton fullWidth onClick={showSaveAsTemplateModal}>
+                                                    Save as template
+                                                </LemonButton>
+                                                <LemonDivider />
+                                                <LemonButton
+                                                    status="danger"
+                                                    fullWidth
+                                                    onClick={() => archiveWorkflow(workflow)}
+                                                >
+                                                    Archive
+                                                </LemonButton>
+                                            </>
+                                        }
+                                    />
+                                )}
                             </>
                         )}
                         {workflowChanged && (

--- a/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
@@ -106,7 +106,11 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
                                         </ScenePanelActionsSection>
                                         <ScenePanelDivider />
                                         <ScenePanelActionsSection>
-                                            <ButtonPrimitive menuItem onClick={() => archiveWorkflow(workflow)}>
+                                            <ButtonPrimitive
+                                                menuItem
+                                                onClick={() => archiveWorkflow(workflow)}
+                                                variant="danger"
+                                            >
                                                 <IconArchive />
                                                 Archive
                                             </ButtonPrimitive>


### PR DESCRIPTION
## Problem
* Navbar
  * `[` shortcut was not working in my last PR somehow
  * Health button was lost when nav was collapsed and scrolled navbar
* Sql editor scene auto focused query tree and not editor
* Workflow scene had two `...` menus

![2026-02-04 15 52 33](https://github.com/user-attachments/assets/67498cdb-cbac-47e0-a431-527d40ef7393)
---
![2026-02-04 15 53 15](https://github.com/user-attachments/assets/33ccf638-e974-4102-91c9-f9e705be9d0d)
---
![2026-02-04 15 53 44](https://github.com/user-attachments/assets/42608636-1981-4dc5-bdf5-9ee2b7396f53)
---
![2026-02-04 15 55 16](https://github.com/user-attachments/assets/e960bea2-ca45-4bdb-b79d-c9f6436e0403)



## Changes
* fix `[` shortcut
* health button now stacked with `flex-col` when nav is collapsed.
* Editor add autofocus, sql tree remove autofocus
* Add `<ScenePanel>` for when `UX SIDEPANEL REMOVAL` is true, getting rid of the first original `...`

## How did you test this code?
Locally

## Publish to changelog?
No