### PR TITLE
chore: decrease celery by team to 10

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -95,7 +95,7 @@ def redis_heartbeat() -> None:
 )
 @limit_concurrency(150, limit_name="global")  # Do not go above what CH can handle (max_concurrent_queries)
 @limit_concurrency(
-    50,
+    10,
     key=lambda *args, **kwargs: kwargs.get("team_id") or args[0],
     limit_name="per_team",
 )  # Do not run too many queries at once for the same team


### PR DESCRIPTION
## Problem

Celery queries are a bit unpredictable. Let's keep it under the guard.

## Changes

limit of 50 celery started queries is way too high