### PR TITLE
fix(trends): handle comparing against null in bold number display

### DIFF
--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -166,19 +166,19 @@ function BoldNumberComparison({
             ? null
             : (currentValue - previousValue) / Math.abs(previousValue)
 
-    const percentageDiffDisplay =
-        percentageDiff === null
-            ? 'No data for comparison in the'
-            : percentageDiff > 0
-              ? `Up ${percentage(percentageDiff)} from`
-              : percentageDiff < 0
-                ? `Down ${percentage(-percentageDiff)} from`
-                : 'No change from'
+    const hasComparableDiff = percentageDiff !== null && Number.isFinite(percentageDiff)
+    const percentageDiffDisplay = !hasComparableDiff
+        ? 'No data in the'
+        : percentageDiff > 0
+          ? `Up ${percentage(percentageDiff)} from`
+          : percentageDiff < 0
+            ? `Down ${percentage(-percentageDiff)} from`
+            : 'No change from'
 
     return (
         <LemonRow
             icon={
-                percentageDiff === null ? (
+                !hasComparableDiff ? (
                     <IconFlare />
                 ) : percentageDiff > 0 ? (
                     <IconTrending />
@@ -196,7 +196,7 @@ function BoldNumberComparison({
                 {percentageDiffDisplay}{' '}
                 {currentValue === null ? (
                     'current period'
-                ) : previousValue === null || !showPersonsModal ? (
+                ) : previousValue === null || !showPersonsModal || !hasComparableDiff ? (
                     'previous period'
                 ) : (
                     <Link


### PR DESCRIPTION
## Problem

When you have a bold number insight with the compare against option enabled, but there's no data for the previous period, we would sometimes show it like this:

![Screenshot 2026-02-04 at 17.44.26.png](https://app.graphite.com/user-attachments/assets/9501614f-0408-4a93-9cc8-56448115d345.png)

## Changes

This is because the backend returns a zero, which results in a division by zero. Handling this case solves the issue:


![Screenshot 2026-02-04 at 17.42.07.png](https://app.graphite.com/user-attachments/assets/6ca0efdc-33f4-4de0-962b-d3ece0a1ff36.png)

## How did you test this code?

See above.