### PR TITLE
Fix typo in PostHog AI memory creation message

### DIFF
--- a/frontend/src/scenes/settings/environment/maxSettingsLogic.tsx
+++ b/frontend/src/scenes/settings/environment/maxSettingsLogic.tsx
@@ -53,7 +53,7 @@ export const maxSettingsLogic = kea<maxSettingsLogicType>([
             updateCoreMemory: async (data: CoreMemoryForm) => {
                 if (!values.coreMemory) {
                     const response = await api.coreMemory.create(data)
-                    lemonToast.success('PostHog AI mmory has been created.')
+                    lemonToast.success('PostHog AI memory has been created.')
                     return response
                 }
 


### PR DESCRIPTION
## Problem

There is a typo in the PostHog AI memory creation message:
PostHog AI mmory has been created

This affects the user-facing UI text and should be corrected.

## Changes

Updated the message text from:
PostHog AI mmory has been created

to:
PostHog AI memory has been created

No functional changes.

## How did you test this code?

Verified the updated message renders correctly in the UI after applying the change locally.

No logic was modified.

## Publish to changelog?

no
