### PR TITLE
fix(ph-ai): plan product analytics read only mode

### DIFF
--- a/ee/hogai/chat_agent/executables.py
+++ b/ee/hogai/chat_agent/executables.py
@@ -7,7 +7,7 @@ from ee.hogai.core.plan_mode import PlanModeExecutable, PlanModeToolsExecutable
 from ee.hogai.utils.types.base import CLEAR_SUPERMODE, AssistantState, PartialAssistantState
 
 SWITCH_TO_EXECUTION_MODE_PROMPT = """
-Planning complete. Executing the plan now.
+Planning complete. Switched to execution mode, which defaults to product analytics mode, with access to all tools, like dashboard creation.
 
 You MUST continue executing the plan until it is complete. Do not respond with text only - proceed with tool calls until you have completed the tasks.
 """

--- a/ee/hogai/chat_agent/mode_manager.py
+++ b/ee/hogai/chat_agent/mode_manager.py
@@ -16,6 +16,7 @@ from ee.hogai.core.agent_modes.factory import AgentModeDefinition
 from ee.hogai.core.agent_modes.mode_manager import AgentModeManager
 from ee.hogai.core.agent_modes.presets.error_tracking import chat_agent_plan_error_tracking_agent, error_tracking_agent
 from ee.hogai.core.agent_modes.presets.product_analytics import (
+    chat_agent_plan_product_analytics_agent,
     product_analytics_agent,
     subagent_product_analytics_agent,
 )
@@ -52,6 +53,7 @@ DEFAULT_CHAT_AGENT_MODE_REGISTRY: dict[AgentMode, AgentModeDefinition] = {
 }
 
 DEFAULT_CHAT_AGENT_PLAN_MODE_REGISTRY: dict[AgentMode, AgentModeDefinition] = {
+    AgentMode.PRODUCT_ANALYTICS: chat_agent_plan_product_analytics_agent,
     AgentMode.SQL: chat_agent_plan_sql_agent,
     AgentMode.SESSION_REPLAY: chat_agent_plan_session_replay_agent,
     AgentMode.EXECUTION: execution_agent,
@@ -88,11 +90,13 @@ class ChatAgentModeManager(AgentModeManager):
         self._supermode: AgentMode | None
         if state.agent_mode == AgentMode.PLAN:
             self._supermode = AgentMode.PLAN
-            self._mode = AgentMode.SQL
         else:
             self._supermode = cast(AgentMode | None, state.supermode)
-            default_mode = AgentMode.SQL if self._supermode == AgentMode.PLAN else AgentMode.PRODUCT_ANALYTICS
-            self._mode = state.agent_mode if state.agent_mode in self.mode_registry else default_mode
+        self._mode = (
+            state.agent_mode
+            if state.agent_mode and state.agent_mode in self.mode_registry
+            else AgentMode.PRODUCT_ANALYTICS
+        )
 
     @property
     def mode_registry(self) -> dict[AgentMode, AgentModeDefinition]:

--- a/ee/hogai/chat_agent/test/test_mode_manager.py
+++ b/ee/hogai/chat_agent/test/test_mode_manager.py
@@ -39,7 +39,7 @@ from ee.hogai.chat_agent.prompts import (
 )
 from ee.hogai.chat_agent.toolkit import ChatAgentPlanToolkit, ChatAgentToolkit
 from ee.hogai.context import AssistantContextManager
-from ee.hogai.core.agent_modes.presets.product_analytics import SubagentProductAnalyticsAgentToolkit
+from ee.hogai.core.agent_modes.presets.product_analytics import ReadOnlyProductAnalyticsAgentToolkit
 from ee.hogai.core.agent_modes.presets.survey import SubagentSurveyAgentToolkit
 from ee.hogai.tools.replay.filter_session_recordings import FilterSessionRecordingsTool
 from ee.hogai.utils.tests import FakeChatAnthropic, FakeChatOpenAI
@@ -263,7 +263,7 @@ class TestChatAgentModeManagerPlanMode(BaseTest):
         )
 
         self.assertEqual(mode_manager._supermode, AgentMode.PLAN)
-        self.assertEqual(mode_manager._mode, AgentMode.SQL)
+        self.assertEqual(mode_manager._mode, AgentMode.PRODUCT_ANALYTICS)
 
     def test_plan_mode_uses_plan_mode_registry(self):
         """Test that mode_registry returns plan mode registry when in plan mode"""
@@ -285,7 +285,7 @@ class TestChatAgentModeManagerPlanMode(BaseTest):
         self.assertIn(AgentMode.EXECUTION, mode_names)  # Plan mode has EXECUTION mode
         self.assertIn(AgentMode.SQL, mode_names)  # Plan mode has SQL mode
         self.assertIn(AgentMode.SESSION_REPLAY, mode_names)  # Plan mode has SESSION_REPLAY mode
-        self.assertNotIn(AgentMode.PRODUCT_ANALYTICS, mode_names)  # Plan mode doesn't have PRODUCT_ANALYTICS
+        self.assertIn(AgentMode.PRODUCT_ANALYTICS, mode_names)  # Plan mode now has PRODUCT_ANALYTICS
 
     def test_plan_mode_uses_plan_prompt_builder(self):
         """Test that prompt_builder_class returns ChatAgentPlanPromptBuilder when in plan mode"""
@@ -700,7 +700,7 @@ class TestChatAgentModeManagerSubagent(BaseTest):
         context_manager = AssistantContextManager(
             team=self.team, user=self.user, config=RunnableConfig(configurable={"is_subagent": True})
         )
-        toolkit = SubagentProductAnalyticsAgentToolkit(team=self.team, user=self.user, context_manager=context_manager)
+        toolkit = ReadOnlyProductAnalyticsAgentToolkit(team=self.team, user=self.user, context_manager=context_manager)
         self.assertIn(CreateInsightTool, toolkit.tools)
         self.assertNotIn(CreateDashboardTool, toolkit.tools)
         self.assertNotIn(UpsertDashboardTool, toolkit.tools)

--- a/ee/hogai/core/agent_modes/presets/product_analytics.py
+++ b/ee/hogai/core/agent_modes/presets/product_analytics.py
@@ -5,7 +5,12 @@ import posthoganalytics
 
 from posthog.schema import AgentMode
 
-from ee.hogai.chat_agent.executables import ChatAgentExecutable, ChatAgentToolsExecutable
+from ee.hogai.chat_agent.executables import (
+    ChatAgentExecutable,
+    ChatAgentPlanExecutable,
+    ChatAgentPlanToolsExecutable,
+    ChatAgentToolsExecutable,
+)
 from ee.hogai.tools import CreateDashboardTool, CreateInsightTool, UpsertDashboardTool
 from ee.hogai.tools.todo_write import POSITIVE_TODO_EXAMPLES, TodoWriteExample
 from ee.hogai.utils.feature_flags import has_upsert_dashboard_feature_flag
@@ -85,12 +90,20 @@ product_analytics_agent = AgentModeDefinition(
 )
 
 
-class SubagentProductAnalyticsAgentToolkit(AgentToolkit):
-    """Product analytics toolkit for subagents — excludes UpsertDashboardTool (dangerous operation)."""
+class ReadOnlyProductAnalyticsAgentToolkit(AgentToolkit):
+    """Product analytics toolkit for readonly operations — excludes UpsertDashboardTool (dangerous operation)."""
 
     @property
     def tools(self) -> list[type["MaxTool"]]:
         return [CreateInsightTool]
 
 
-subagent_product_analytics_agent = replace(product_analytics_agent, toolkit_class=SubagentProductAnalyticsAgentToolkit)
+subagent_product_analytics_agent = replace(product_analytics_agent, toolkit_class=ReadOnlyProductAnalyticsAgentToolkit)
+
+chat_agent_plan_product_analytics_agent = AgentModeDefinition(
+    mode=AgentMode.PRODUCT_ANALYTICS,
+    mode_description=MODE_DESCRIPTION,
+    toolkit_class=ReadOnlyProductAnalyticsAgentToolkit,  # Only CreateInsightTool
+    node_class=ChatAgentPlanExecutable,
+    tools_node_class=ChatAgentPlanToolsExecutable,
+)

--- a/ee/hogai/research_agent/test/test_mode_manager.py
+++ b/ee/hogai/research_agent/test/test_mode_manager.py
@@ -66,12 +66,12 @@ class TestResearchAgentModeManager(BaseTest):
 
         self.assertIn("Invalid supermode", str(context.exception))
 
-    def test_init_defaults_agent_mode_to_sql_in_plan_supermode(self):
-        """Default mode is SQL in PLAN supermode (which is the default supermode)"""
+    def test_init_defaults_agent_mode_to_product_analytics_in_plan_supermode(self):
+        """Default mode is PRODUCT_ANALYTICS in PLAN supermode (which is the default supermode)"""
         state = AssistantState(messages=[HumanMessage(content="Test")], agent_mode=None)
         mode_manager = _create_mode_manager(self.team, self.user, state=state)
 
-        self.assertEqual(mode_manager._mode, AgentMode.SQL)
+        self.assertEqual(mode_manager._mode, AgentMode.PRODUCT_ANALYTICS)
 
     def test_init_preserves_explicit_agent_mode(self):
         state = AssistantState(messages=[HumanMessage(content="Test")], agent_mode=AgentMode.SQL)
@@ -86,7 +86,7 @@ class TestResearchAgentModeManager(BaseTest):
 
         plan_registry = mode_manager.supermode_registries[AgentMode.PLAN]
         self.assertIn(AgentMode.RESEARCH, plan_registry)
-        self.assertNotIn(AgentMode.PRODUCT_ANALYTICS, plan_registry)  # Not in PLAN mode
+        self.assertIn(AgentMode.PRODUCT_ANALYTICS, plan_registry)  # Now in PLAN mode
         self.assertIn(AgentMode.SQL, plan_registry)
         self.assertIn(AgentMode.SESSION_REPLAY, plan_registry)
 


### PR DESCRIPTION
## Problem

The current implementation of the chat agent's mode manager defaults to SQL mode when in PLAN mode, which is wrong as the agent needs to have access to the create_insight tool.

## Changes
- Added `chat_agent_plan_product_analytics_agent` to the PLAN mode registry
- Changed default mode to PRODUCT_ANALYTICS instead of SQL for all modes
- Renamed `SubagentProductAnalyticsAgentToolkit` to `ReadOnlyProductAnalyticsAgentToolkit` to better reflect its purpose
- Added PRODUCT_ANALYTICS mode to research agent's PLAN mode registry

## How did you test this code?
Tests + local test

## Publish to changelog?

No