### PR TITLE
fix(deduplicator): bug in producer creation when disabled

### DIFF
--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -220,10 +220,24 @@ impl KafkaDeduplicatorService {
             return Err(anyhow::anyhow!("Service already initialized"));
         }
 
+        // Normalize empty strings to None for optional topic configs
+        let output_topic = self
+            .config
+            .output_topic
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .cloned();
+        let duplicate_events_topic = self
+            .config
+            .duplicate_events_topic
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .cloned();
+
         // Create deduplication config (store config already in store_manager)
         let dedup_config = DeduplicationConfig {
-            output_topic: self.config.output_topic.clone(),
-            duplicate_events_topic: self.config.duplicate_events_topic.clone(),
+            output_topic: output_topic.clone(),
+            duplicate_events_topic: duplicate_events_topic.clone(),
             producer_config: self.config.build_producer_config(),
             store_config: DeduplicationStoreConfig {
                 path: self.config.store_path_buf(),
@@ -248,7 +262,7 @@ impl KafkaDeduplicatorService {
         };
 
         // Create main producer for output topic if configured
-        let main_producer = match &self.config.output_topic {
+        let main_producer = match &output_topic {
             Some(topic) => {
                 info!("Creating Kafka producer for output topic: {}", topic);
 
@@ -267,11 +281,14 @@ impl KafkaDeduplicatorService {
 
                 Some(Arc::new(producer))
             }
-            None => None,
+            None => {
+                info!("Output topic not configured, skipping main producer creation");
+                None
+            }
         };
 
         // Create duplicate events producer if configured
-        let duplicate_producer = match &self.config.duplicate_events_topic {
+        let duplicate_producer = match &duplicate_events_topic {
             Some(topic) => {
                 info!(
                     "Creating Kafka producer for duplicate events topic: {}",
@@ -302,7 +319,12 @@ impl KafkaDeduplicatorService {
                     Arc::new(producer),
                 )?)
             }
-            None => None,
+            None => {
+                info!(
+                    "Duplicate events topic not configured, skipping duplicate producer creation"
+                );
+                None
+            }
         };
 
         // Create a processor with the store manager and both producers
@@ -442,7 +464,7 @@ impl KafkaDeduplicatorService {
 
         info!(
             "Initialized consumer for topic '{}', publishing to '{:?}'",
-            self.config.kafka_consumer_topic, self.config.output_topic
+            self.config.kafka_consumer_topic, output_topic
         );
 
         // Register health check for the service


### PR DESCRIPTION
## Problem
We tried to disable production of duplicate events yesterday to avoid high volume ingest into ClickHouse, but the producer creation conditions had a bug causing downstream errors in the service
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Fix producer creation bug at app startup
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, CI, smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
