### PR TITLE
fix(ph-ai): thread bug

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -182,7 +182,7 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
                             // Hide UI payload answers that are not renderable to prevent rendering an empty message component
                             if (
                                 isAssistantToolCallMessage(message) &&
-                                (message.ui_payload === undefined ||
+                                (!message.ui_payload ||
                                     !isRenderableUIPayloadTool(Object.keys(message.ui_payload)[0], message.ui_payload))
                             ) {
                                 return null


### PR DESCRIPTION
## Problem
We shipped a bad bug that breaks the conversation UI entirely.

## Changes
Check if ui_payload exists before passing it to Object.keys()

## How did you test this code?
Locally

## Publish to changelog?

No