### PR TITLE
fix(sql-editor): focus editor textarea when opening new tab

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -633,6 +633,9 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                     actions.setQueryInput(queryObject.query || '')
                 }
             }
+
+            // Focus the editor after creating a new tab
+            props.editor?.focus()
         },
         setSourceQuery: ({ sourceQuery }) => {
             if (!values.activeTab) {

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/DatabaseSearchField.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/DatabaseSearchField.tsx
@@ -32,7 +32,6 @@ export function DatabaseSearchField({ placeholder }: TreeSearchFieldProps): JSX.
             onKeyDown={(e) => handleKeyDown(e)}
             onClear={() => clearSearch()}
             onChange={(value) => setSearchTerm(value)}
-            autoFocus={true}
         />
     )
 }


### PR DESCRIPTION


## Problem

new sql editor tabs don't focus the text editor

## Changes

When a user opens a new tab from the SQL editor, the editor textarea should now be focused instead of the search input in the sidebar.

- Remove autoFocus from DatabaseSearchField component
- Add explicit editor.focus() call when creating a new tab

https://claude.ai/code/session_01BygxQmVQRYCCPFsvs8Sj1X

## How did you test this code?

i didn't

## Publish to changelog?

no
