### PR TITLE
fix(ui): restrict table view editing to that view's creators only

### DIFF
--- a/frontend/src/queries/nodes/DataTable/TableView/TableViewSelector.tsx
+++ b/frontend/src/queries/nodes/DataTable/TableView/TableViewSelector.tsx
@@ -26,23 +26,24 @@ export interface TableViewSelectorProps {
 export function TableViewSelector({ contextKey, query, setQuery }: TableViewSelectorProps): JSX.Element {
     const tableViewLogicProps = { contextKey, query, setQuery }
     const logic = tableViewLogic(tableViewLogicProps)
-    const { views, currentView, hasUnsavedChanges, viewsLoading } = useValues(logic)
+    const { views, currentView, hasUnsavedChanges, viewsLoading, canEditCurrentView, user } = useValues(logic)
     const { applyView, updateView, setShowDeleteConfirm, setIsCreating } = useActions(logic)
 
     const menuItems: LemonMenuItems = [
         {
-            items: views.map(
-                (view) =>
-                    ({
-                        label: view.name,
-                        icon:
-                            view.visibility === 'private' ? (
-                                <Tooltip title="This view is private. Only you can see and use it.">
-                                    <IconPerson className="text-muted" />
-                                </Tooltip>
-                            ) : undefined,
-                        active: currentView?.id === view.id,
-                        onClick: () => applyView(view),
+            items: views.map((view) => {
+                const canEditView = view.created_by === user?.id
+                return {
+                    label: view.name,
+                    icon:
+                        view.visibility === 'private' ? (
+                            <Tooltip title="This view is private. Only you can see and use it.">
+                                <IconPerson className="text-muted" />
+                            </Tooltip>
+                        ) : undefined,
+                    active: currentView?.id === view.id,
+                    onClick: () => applyView(view),
+                    ...(canEditView && {
                         sideAction: {
                             icon: <IconGear />,
                             tooltip: 'Manage view',
@@ -75,8 +76,9 @@ export function TableViewSelector({ contextKey, query, setQuery }: TableViewSele
                                 ),
                             },
                         },
-                    }) as LemonMenuItem
-            ),
+                    }),
+                } as LemonMenuItem
+            }),
         },
         {
             items: [
@@ -109,7 +111,7 @@ export function TableViewSelector({ contextKey, query, setQuery }: TableViewSele
                     </LemonButton>
                 )}
 
-                {currentView && hasUnsavedChanges && (
+                {currentView && hasUnsavedChanges && canEditCurrentView && (
                     <LemonButton
                         icon={<IconDownload />}
                         size="small"

--- a/frontend/src/queries/nodes/DataTable/TableView/TableViewSelector.tsx
+++ b/frontend/src/queries/nodes/DataTable/TableView/TableViewSelector.tsx
@@ -111,15 +111,17 @@ export function TableViewSelector({ contextKey, query, setQuery }: TableViewSele
                     </LemonButton>
                 )}
 
-                {currentView && hasUnsavedChanges && canEditCurrentView && (
+                {currentView && hasUnsavedChanges && (
                     <LemonButton
                         icon={<IconDownload />}
                         size="small"
                         type="secondary"
                         tooltip="Update current view with changes"
+                        disabledReason={!canEditCurrentView ? 'You can only edit views you created' : undefined}
                         loading={viewsLoading}
                         onClick={() => {
-                            updateView(currentView.id, {}) // Empty object triggers update with current state
+                            // Empty object triggers update with current state
+                            updateView(currentView.id, {})
                         }}
                     >
                         Update "{currentView.name}"

--- a/frontend/src/queries/nodes/DataTable/TableView/tableViewLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/TableView/tableViewLogic.ts
@@ -5,11 +5,11 @@ import { lazyLoaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
-import { userLogic } from 'scenes/userLogic'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { GROUPS_LIST_DEFAULT_QUERY } from 'scenes/groups/groupsListLogic'
 import { PERSON_EVENTS_CONTEXT_KEY } from 'scenes/persons/personsLogic'
 import { PEOPLE_LIST_CONTEXT_KEY, PEOPLE_LIST_DEFAULT_QUERY } from 'scenes/persons/personsSceneLogic'
+import { userLogic } from 'scenes/userLogic'
 
 import { ActorsQuery, EventsQuery, GroupsQuery } from '~/queries/schema/schema-general'
 import { isEventsQuery } from '~/queries/utils'
@@ -200,7 +200,6 @@ export const tableViewLogic = kea<tableViewLogicType>([
                 if (!currentView || !user) {
                     return false
                 }
-                // Only the creator of the view can edit it
                 return currentView.created_by === user.id
             },
         ],


### PR DESCRIPTION
i visited the persons scene and a config was already in place called "Column configuration"

<img width="1980" height="268" alt="CleanShot 2026-02-04 at 19 41 41@2x" src="https://github.com/user-attachments/assets/015bb8e3-0c6b-4308-85b2-569ada2b53ef" />

I got an `Update "Column configuration"` button

I clicked it

<img width="960" height="482" alt="CleanShot 2026-02-04 at 19 41 47@2x" src="https://github.com/user-attachments/assets/67f20fe1-2bdb-45ec-b8b1-8c6fb293da60" />

I can't update it
I can only update my own views

so, don't let me try to update others
