### PR TITLE
perf(customer-analytics): Make group profile truly tab aware

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -655,6 +655,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                 loadData: () => null,
             },
         ],
+        shouldCalculateCount: [false, { loadTotalCount: () => true, loadFilteredCount: () => true }],
     })),
     lazyLoaders(({ values }) => ({
         totalCount: [
@@ -680,7 +681,8 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         filteredCount: [
             null as number | null,
             {
-                loadFilteredCount: async () => {
+                loadFilteredCount: async (_, breakpoint) => {
+                    await breakpoint(300)
                     const query = values.filteredCountQuery
                     if (!query) {
                         return null
@@ -688,7 +690,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
 
                     try {
                         const response = await performQuery(query)
-                        // Extract count from first row, first column
+                        breakpoint()
                         return response?.results?.[0]?.[0] || 0
                     } catch (error) {
                         posthog.captureException(error, { action: 'load filtered count in dataNodeLogic' })
@@ -1169,6 +1171,11 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
             if (!dataLoading) {
                 // Clear loading timer when data loading finishes
                 cache.disposables.dispose('loadingTimer')
+            }
+        },
+        filteredCountQuery: () => {
+            if (values.shouldCalculateCount) {
+                actions.loadFilteredCount()
             }
         },
     })),

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -1171,9 +1171,6 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                 cache.disposables.dispose('loadingTimer')
             }
         },
-        filteredCountQuery: () => {
-            actions.loadFilteredCount()
-        },
     })),
     afterMount(({ actions, props, cache }) => {
         cache.localResults = {}

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -263,6 +263,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         setLoadingTime: (seconds: number) => ({ seconds }),
         resetLoadingTimer: true,
         setQueryLogQueryId: (queryId: string) => ({ queryId }),
+        loadFilteredCount: true,
     }),
     loaders(({ actions, cache, values, props }) => ({
         response: [

--- a/frontend/src/queries/nodes/DataTable/DataTableCount.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableCount.tsx
@@ -1,5 +1,4 @@
-import { useActions, useValues } from 'kea'
-import { useEffect } from 'react'
+import { useValues } from 'kea'
 
 import { pluralize } from 'lib/utils'
 
@@ -9,17 +8,6 @@ import { isActorsQuery, isEventsQuery, isGroupsQuery, isSessionsQuery } from '~/
 export function DataTableCount(): JSX.Element | null {
     const { totalCount, totalCountLoading, filteredCount, filteredCountLoading, hasActiveFilters, query } =
         useValues(dataNodeLogic)
-    const { loadTotalCount, loadFilteredCount } = useActions(dataNodeLogic)
-
-    useEffect(() => {
-        if (totalCount === null && !totalCountLoading) {
-            loadTotalCount()
-        }
-
-        if (hasActiveFilters && filteredCount === null && !filteredCountLoading) {
-            loadFilteredCount()
-        }
-    }, [query, hasActiveFilters])
 
     const loading = totalCountLoading || filteredCountLoading
 

--- a/frontend/src/queries/nodes/DataTable/DataTableCount.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableCount.tsx
@@ -1,4 +1,5 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
 
 import { pluralize } from 'lib/utils'
 
@@ -8,6 +9,17 @@ import { isActorsQuery, isEventsQuery, isGroupsQuery, isSessionsQuery } from '~/
 export function DataTableCount(): JSX.Element | null {
     const { totalCount, totalCountLoading, filteredCount, filteredCountLoading, hasActiveFilters, query } =
         useValues(dataNodeLogic)
+    const { loadTotalCount, loadFilteredCount } = useActions(dataNodeLogic)
+
+    useEffect(() => {
+        if (totalCount === null && !totalCountLoading) {
+            loadTotalCount()
+        }
+
+        if (hasActiveFilters && filteredCount === null && !filteredCountLoading) {
+            loadFilteredCount()
+        }
+    }, [query, hasActiveFilters])
 
     const loading = totalCountLoading || filteredCountLoading
 

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
@@ -60,11 +60,11 @@ export function Group({ tabId }: { tabId?: string }): JSX.Element {
     if (!tabId) {
         throw new Error('GroupScene rendered with no tabId')
     }
-
+    const mountedGroupLogic = useMountedLogic(groupLogic)
     const { logicProps, groupData, groupDataLoading, groupTypeName, groupType, groupTab, groupEventsQuery } =
-        useValues(groupLogic)
+        useValues(mountedGroupLogic)
     const { groupKey, groupTypeIndex } = logicProps
-    const { setGroupEventsQuery, editProperty, deleteProperty } = useActions(groupLogic)
+    const { setGroupEventsQuery, editProperty, deleteProperty } = useActions(mountedGroupLogic)
     const { currentTeam } = useValues(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { aggregationLabel } = useValues(groupsModel)
@@ -111,7 +111,13 @@ export function Group({ tabId }: { tabId?: string }): JSX.Element {
                               {
                                   key: GroupsTabType.PROFILE,
                                   label: <span data-attr="groups-profile-tab">Profile</span>,
-                                  content: <GroupProfileCanvas group={groupData} tabId={tabId} />,
+                                  content: (
+                                      <GroupProfileCanvas
+                                          group={groupData}
+                                          tabId={tabId}
+                                          attachTo={mountedGroupLogic}
+                                      />
+                                  ),
                               },
                           ]
                         : []),

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.tsx
@@ -9,6 +9,7 @@ import { NotFound } from 'lib/components/NotFound'
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
+import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { formatCurrency } from 'lib/utils/geography/currency'
 import stringWithWBR from 'lib/utils/stringWithWBR'
 import { groupLogic } from 'scenes/groups/groupLogic'
@@ -28,6 +29,11 @@ import { calculateMRRData, getPaidProducts } from './utils'
 
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeGroupAttributes>): JSX.Element => {
     const { id, groupTypeIndex, tabId, title } = attributes
+    const mountedGroupLogic = groupLogic({
+        groupKey: id,
+        groupTypeIndex,
+        tabId,
+    })
     const {
         groupData,
         groupDataLoading,
@@ -35,14 +41,10 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeGroupAttributes
         groupRevenueAnalyticsDataLoading,
         effectiveMRR,
         effectiveLifetimeValue,
-    } = useValues(
-        groupLogic({
-            groupKey: id,
-            groupTypeIndex,
-            tabId,
-        })
-    )
+    } = useValues(mountedGroupLogic)
     const { setActions, insertAfter, setTitlePlaceholder } = useActions(notebookNodeLogic)
+    const { notebookLogic } = useValues(notebookNodeLogic)
+    useAttachedLogic(mountedGroupLogic, notebookLogic)
 
     const groupDisplay = groupData ? groupDisplayId(groupData.group_key, groupData.group_properties) : 'Group'
     const inGroupFeed = title === 'Info'

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -9,7 +9,6 @@ import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { createPostHogWidgetNode } from 'scenes/notebooks/Nodes/NodeWrapper'
-import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
 import { urls } from 'scenes/urls'
 
 import { Query } from '~/queries/Query/Query'
@@ -47,7 +46,7 @@ const Component = ({
 }: NotebookNodeProps<NotebookNodeQueryAttributes>): JSX.Element | null => {
     const { query, nodeId } = attributes
     const nodeLogic = useMountedLogic(notebookNodeLogic)
-    const { expanded } = useValues(nodeLogic)
+    const { expanded, notebookLogic } = useValues(nodeLogic)
     const { setTitlePlaceholder } = useActions(nodeLogic)
     const summarizeInsight = useSummarizeInsight()
     const { canvasFiltersOverride } = useValues(notebookLogic)
@@ -128,6 +127,7 @@ const Component = ({
                         // use separate keys for the settings and visualization to avoid conflicts with insightProps
                         uniqueKey={nodeId + '-component'}
                         query={modifiedQuery}
+                        attachTo={notebookLogic}
                         setQuery={(t) => {
                             updateAttributes({
                                 query: {
@@ -157,6 +157,8 @@ export const Settings = ({
     updateAttributes,
 }: NotebookNodeAttributeProperties<NotebookNodeQueryAttributes>): JSX.Element => {
     const { query, isDefaultFilterApplied } = attributes
+    const nodeLogic = useMountedLogic(notebookNodeLogic)
+    const { notebookLogic } = useValues(nodeLogic)
     const { canvasFiltersOverride } = useValues(notebookLogic)
 
     const modifiedQuery = useMemo(() => {
@@ -252,6 +254,7 @@ export const Settings = ({
             <Query
                 // use separate keys for the settings and visualization to avoid conflicts with insightProps
                 uniqueKey={attributes.nodeId + '-settings'}
+                attachTo={notebookLogic}
                 query={modifiedQuery}
                 setQuery={(t) => {
                     updateAttributes({


### PR DESCRIPTION
## Problem
Same as https://github.com/PostHog/posthog/pull/46881 but for groups profile.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/45359
## Changes
On top of what was done similarly as in [person profiles](https://github.com/PostHog/posthog/pull/46881), this one touched dataNodeLogic to fix the counts queries being triggered unnecessarily.

I moved the trigger of count and filtered count queries over to DataTableCount component, so that we only trigger those when they're actually going to be used.

https://www.loom.com/share/d4d8646f8e6f4128a7c1be9a906968bf
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Loom abbove
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
