### PR TITLE
fix(ci): fetch base branch before migration detection in Node.js CI

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -241,7 +241,7 @@ jobs:
               id: check_migrations
               if: github.event_name == 'pull_request'
               run: |
-                  if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '(migrations/|rust/.*migrate)'; then
+                  if git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E '(migrations/|rust/.*migrate)'; then
                     echo "has_migrations=true" >> $GITHUB_OUTPUT
                   else
                     echo "has_migrations=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -233,6 +233,10 @@ jobs:
                   docker compose -f docker-compose.dev.yml up kafka redis7 clickhouse maildev -d --wait
                   bin/check_kafka_clickhouse_up
 
+            - name: Fetch base branch for diff
+              if: github.event_name == 'pull_request'
+              run: git fetch origin ${{ github.base_ref }} --depth=1
+
             - name: Check for migrations in this PR
               id: check_migrations
               if: github.event_name == 'pull_request'


### PR DESCRIPTION
The migration detection step was failing silently because `origin/master` (or the base branch) wasn't fetched in the shallow clone. This caused the fast path to always be taken, restoring the schema artifact from master even when the PR contains migrations.

CI throws an error:
```
Run if git diff --name-only origin/master...HEAD | grep -E '(migrations/|rust/.*migrate)'; then                                    
  fatal: ambiguous argument 'origin/master...HEAD': unknown revision or path not in the working tree.                                       
  Use '--' to separate paths from revisions, like this:                                                                                         
  'git <command> [<revision>...] -- [<file>...]'
  ```

Add a fetch step to retrieve the base branch before running git diff.
