### PR TITLE
fix: display name nudge banner loading state logic

### DIFF
--- a/products/customer_analytics/frontend/components/PersonDisplayNameNudgeBanner.tsx
+++ b/products/customer_analytics/frontend/components/PersonDisplayNameNudgeBanner.tsx
@@ -53,6 +53,7 @@ export function PersonDisplayNameNudgeBanner({ uniqueKey }: PersonDisplayNameNud
         setIsBannerLoading(dataLoading && !isRefresh)
         const persons = getPersonsFromResponse(response as ActorsQueryResponse | null)
         if (!persons.length) {
+            setShowDisplayNameNudge(false)
             return
         }
         const uuidCount = persons.filter((person) => {

--- a/products/customer_analytics/frontend/components/PersonDisplayNameNudgeBanner.tsx
+++ b/products/customer_analytics/frontend/components/PersonDisplayNameNudgeBanner.tsx
@@ -58,7 +58,7 @@ export function PersonDisplayNameNudgeBanner({ uniqueKey }: PersonDisplayNameNud
         const uuidCount = persons.filter((person) => {
             return isUUIDLike(person.display_name)
         }).length
-        const shouldShow = dataLoading || uuidCount / persons.length > UUID_THRESHOLD
+        const shouldShow = uuidCount / persons.length > UUID_THRESHOLD
         setShowDisplayNameNudge(shouldShow)
     }, [response, dataLoading, isRefresh, setIsBannerLoading, setShowDisplayNameNudge])
 
@@ -66,7 +66,7 @@ export function PersonDisplayNameNudgeBanner({ uniqueKey }: PersonDisplayNameNud
         return <LemonSkeleton className="h-14 my-2" />
     }
 
-    if (!showDisplayNameNudge) {
+    if (dataLoading || !showDisplayNameNudge) {
         return null
     }
 


### PR DESCRIPTION
when the persons scene was loading data it would show the "maybe you need to configure display properties" banner
but only because the data is loading, not because i needed to

if i got no results it would also give me the banner

<img width="2544" height="916" alt="CleanShot 2026-02-04 at 21 58 35@2x" src="https://github.com/user-attachments/assets/4e8b27c7-3abc-4e48-a018-eaceea659caf" />

![CleanShot 2026-02-04 at 21 58 55](https://github.com/user-attachments/assets/c4a61061-604d-40c7-b0db-655465b77541)

