### PR TITLE
fix(error-tracking): validate filterGroup to prevent crash from corrupted localStorage

### DIFF
--- a/products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic.ts
+++ b/products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic.ts
@@ -63,7 +63,8 @@ export const issueFiltersLogic = kea<issueFiltersLogicType>([
             DEFAULT_FILTER_GROUP as UniversalFiltersGroup,
             { persist: true },
             {
-                setFilterGroup: (_, { filterGroup }) => filterGroup,
+                setFilterGroup: (_, { filterGroup }) =>
+                    filterGroup?.values?.length ? filterGroup : DEFAULT_FILTER_GROUP,
             },
         ],
         filterTestAccounts: [


### PR DESCRIPTION
## Summary
- Adds validation to the `filterGroup` reducer to fall back to `DEFAULT_FILTER_GROUP` when the persisted/URL value has an empty `values` array
- Fixes `TypeError: Cannot read properties of undefined (reading '0')` in `FilterGroup.tsx` for users with corrupted localStorage state

## Problem
The `filterGroup` reducer uses `{ persist: true }`, meaning it stores/loads from localStorage. If a user has stale or corrupted state with `values: []`, accessing `filterGroup.values[0]` in the component throws.

This was reported for a single user in Brazil, likely due to:
- Schema migration leaving old persisted format
- Partial localStorage write / corruption
- Manual tampering

## Solution
Validate in the reducer - if `filterGroup?.values?.length` is falsy, return `DEFAULT_FILTER_GROUP` instead. This auto-heals bad state without affecting normal users.

## Test plan
- [x] Verified no existing tests for `issueFiltersLogic` need updating
- [x] Change is backwards compatible - valid filterGroups pass through unchanged