### PR TITLE
fix(dags): filter pre-epoch timestamps in duckling backfill sensors

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -407,7 +407,7 @@ def _set_table_partitioning(
         conn: DuckDB connection with catalog attached.
         alias: Catalog alias.
         table: Table name (must be alphanumeric/underscore only).
-        partition_expr: Partition expression (e.g., "year(timestamp), month(timestamp)").
+        partition_expr: Partition expression (e.g., "year(timestamp), month(timestamp), day(timestamp)").
         context: Dagster asset execution context.
         team_id: Team ID for logging.
 
@@ -466,7 +466,7 @@ def ensure_events_table_exists(
             context.log.info("Events table already exists in duckling catalog")
             # Ensure partitioning is set even on existing tables (idempotent)
             _set_table_partitioning(
-                conn, alias, "events", "year(timestamp), month(timestamp)", context, catalog.team_id
+                conn, alias, "events", "year(timestamp), month(timestamp), day(timestamp)", context, catalog.team_id
             )
             return False
 
@@ -483,7 +483,7 @@ def ensure_events_table_exists(
                 context.log.info("Events table was created by another worker")
                 # Ensure partitioning is set even when another worker created the table
                 _set_table_partitioning(
-                    conn, alias, "events", "year(timestamp), month(timestamp)", context, catalog.team_id
+                    conn, alias, "events", "year(timestamp), month(timestamp), day(timestamp)", context, catalog.team_id
                 )
                 return False
             # Real error - log and re-raise
@@ -492,8 +492,10 @@ def ensure_events_table_exists(
 
         context.log.info("Successfully created events table")
 
-        # Set partitioning by year/month for efficient querying
-        _set_table_partitioning(conn, alias, "events", "year(timestamp), month(timestamp)", context, catalog.team_id)
+        # Set partitioning by year/month/day for efficient querying
+        _set_table_partitioning(
+            conn, alias, "events", "year(timestamp), month(timestamp), day(timestamp)", context, catalog.team_id
+        )
 
         logger.info(
             "duckling_events_table_created",

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -284,7 +284,7 @@ def get_earliest_event_date_for_team(team_id: int) -> datetime | None:
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
     def query_earliest(client: Client) -> datetime | None:
-        # Filter timestamp > '1970-01-01' to avoid toDate() overflow on pre-epoch timestamps.
+        # Filter timestamp >= '1970-01-01' to avoid toDate() overflow on pre-epoch timestamps.
         # ClickHouse's Date type is UInt16 (days since 1970-01-01), so negative timestamps
         # overflow to the max date (2149-06-06), breaking the backfill sensor logic.
         result = client.execute(
@@ -292,7 +292,7 @@ def get_earliest_event_date_for_team(team_id: int) -> datetime | None:
             SELECT toDate(min(timestamp)) as earliest_date
             FROM events
             WHERE team_id = %(team_id)s
-              AND timestamp > '1970-01-01'
+              AND timestamp >= '1970-01-01'
             """,
             {"team_id": team_id},
         )
@@ -324,7 +324,7 @@ def get_earliest_person_date_for_team(team_id: int) -> datetime | None:
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
     def query_earliest(client: Client) -> datetime | None:
-        # Filter _timestamp > '1970-01-01' to avoid toDate() overflow on pre-epoch timestamps.
+        # Filter _timestamp >= '1970-01-01' to avoid toDate() overflow on pre-epoch timestamps.
         # ClickHouse's Date type is UInt16 (days since 1970-01-01), so negative timestamps
         # overflow to the max date (2149-06-06), breaking the backfill sensor logic.
         result = client.execute(
@@ -332,7 +332,7 @@ def get_earliest_person_date_for_team(team_id: int) -> datetime | None:
             SELECT toDate(min(_timestamp)) as earliest_date
             FROM person
             WHERE team_id = %(team_id)s
-              AND _timestamp > '1970-01-01'
+              AND _timestamp >= '1970-01-01'
             """,
             {"team_id": team_id},
         )

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -284,11 +284,15 @@ def get_earliest_event_date_for_team(team_id: int) -> datetime | None:
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
     def query_earliest(client: Client) -> datetime | None:
+        # Filter timestamp > '1970-01-01' to avoid toDate() overflow on pre-epoch timestamps.
+        # ClickHouse's Date type is UInt16 (days since 1970-01-01), so negative timestamps
+        # overflow to the max date (2149-06-06), breaking the backfill sensor logic.
         result = client.execute(
             """
             SELECT toDate(min(timestamp)) as earliest_date
             FROM events
             WHERE team_id = %(team_id)s
+              AND timestamp > '1970-01-01'
             """,
             {"team_id": team_id},
         )
@@ -320,11 +324,15 @@ def get_earliest_person_date_for_team(team_id: int) -> datetime | None:
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
     def query_earliest(client: Client) -> datetime | None:
+        # Filter _timestamp > '1970-01-01' to avoid toDate() overflow on pre-epoch timestamps.
+        # ClickHouse's Date type is UInt16 (days since 1970-01-01), so negative timestamps
+        # overflow to the max date (2149-06-06), breaking the backfill sensor logic.
         result = client.execute(
             """
             SELECT toDate(min(_timestamp)) as earliest_date
             FROM person
             WHERE team_id = %(team_id)s
+              AND _timestamp > '1970-01-01'
             """,
             {"team_id": team_id},
         )


### PR DESCRIPTION
## Summary
- Fix duckling full backfill sensor incorrectly marking itself as "completed" without creating any jobs
- Filter out pre-epoch timestamps (before 1970-01-01) in earliest date queries

## Problem
ClickHouse's `Date` type is a `UInt16` storing days since 1970-01-01. When `toDate()` is called on pre-epoch timestamps (negative Unix time), it overflows to the max date value: **June 6, 2149**.

Example from production:
```sql
SELECT min(timestamp) FROM events WHERE team_id = 50689
-- Returns: December 31, 1969, 9:23 PM (negative Unix timestamp)

SELECT toDate(min(timestamp)) FROM events WHERE team_id = 50689  
-- Returns: June 6, 2149 (overflow!)
```

This caused the sensor to compute an "earliest date" far in the future, resulting in an empty partition list (`all_months = []`), and the sensor marking itself as "completed" without creating any backfill jobs.

## Solution
Filter `timestamp > '1970-01-01'` in both:
- `get_earliest_event_date_for_team()`
- `get_earliest_person_date_for_team()` (for consistency)

## Test plan
- [ ] Reset the `duckling_full_backfill_sensor` cursor in Dagster UI
- [ ] Preview tick should now show partitions being created (not "Skipped")
- [ ] Verify the computed cursor shows `{"team_id": ..., "next_month": ...}` instead of `{"completed": ...}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)