### PR TITLE
chore(flags): pass HashMap parameters by reference in flag matching

### DIFF
--- a/rust/common/types/src/collections.rs
+++ b/rust/common/types/src/collections.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+
+/// Extension trait for HashMap that provides efficient iteration methods.
+pub trait HashMapExt<K, V> {
+    /// Returns an iterator that yields owned key-value pairs by cloning.
+    ///
+    /// This is useful when you need to extend another HashMap from a reference
+    /// without cloning the entire HashMap upfront.
+    ///
+    /// # Example
+    /// ```
+    /// use std::collections::HashMap;
+    /// use common_types::collections::HashMapExt;
+    ///
+    /// let source: HashMap<String, i32> = [("a".to_string(), 1)].into_iter().collect();
+    /// let mut target: HashMap<String, i32> = HashMap::new();
+    ///
+    /// // Instead of: target.extend(source.clone());
+    /// // Use: target.extend(source.iter_owned());
+    /// target.extend(source.iter_owned());
+    /// ```
+    fn iter_owned(&self) -> impl Iterator<Item = (K, V)>
+    where
+        K: Clone,
+        V: Clone;
+}
+
+impl<K, V> HashMapExt<K, V> for HashMap<K, V>
+where
+    K: Eq + Hash,
+{
+    fn iter_owned(&self) -> impl Iterator<Item = (K, V)>
+    where
+        K: Clone,
+        V: Clone,
+    {
+        self.iter().map(|(k, v)| (k.clone(), v.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_iter_owned_extends_hashmap() {
+        let source: HashMap<String, i32> = [("a".to_string(), 1), ("b".to_string(), 2)]
+            .into_iter()
+            .collect();
+        let mut target: HashMap<String, i32> = [("c".to_string(), 3)].into_iter().collect();
+
+        target.extend(source.iter_owned());
+
+        assert_eq!(target.len(), 3);
+        assert_eq!(target.get("a"), Some(&1));
+        assert_eq!(target.get("b"), Some(&2));
+        assert_eq!(target.get("c"), Some(&3));
+    }
+
+    #[test]
+    fn test_iter_owned_overwrites_existing_keys() {
+        let source: HashMap<String, i32> = [("a".to_string(), 100)].into_iter().collect();
+        let mut target: HashMap<String, i32> = [("a".to_string(), 1)].into_iter().collect();
+
+        target.extend(source.iter_owned());
+
+        assert_eq!(target.get("a"), Some(&100));
+    }
+
+    #[test]
+    fn test_iter_owned_empty_source() {
+        let source: HashMap<String, i32> = HashMap::new();
+        let mut target: HashMap<String, i32> = [("a".to_string(), 1)].into_iter().collect();
+
+        target.extend(source.iter_owned());
+
+        assert_eq!(target.len(), 1);
+        assert_eq!(target.get("a"), Some(&1));
+    }
+}

--- a/rust/common/types/src/lib.rs
+++ b/rust/common/types/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod collections;
 mod embeddings;
 mod event;
 mod formats;

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -772,15 +772,14 @@ impl FeatureFlagMatcher {
                 // this shouldn't happen, but it's here to avoid panics
                 let property_overrides = precomputed_property_overrides
                     .get(&flag.key)
-                    .unwrap_or(&None)
-                    .clone();
+                    .and_then(|opt| opt.as_ref());
                 (
                     flag.key.clone(),
                     self.get_match(
                         flag,
                         property_overrides,
-                        hash_key_overrides.clone(),
-                        request_hash_key_override.clone(),
+                        hash_key_overrides.as_ref(),
+                        request_hash_key_override,
                     ),
                 )
             })
@@ -897,9 +896,9 @@ impl FeatureFlagMatcher {
     pub fn get_match(
         &self,
         flag: &FeatureFlag,
-        property_overrides: Option<HashMap<String, Value>>,
-        hash_key_overrides: Option<HashMap<String, String>>,
-        request_hash_key_override: Option<String>,
+        property_overrides: Option<&HashMap<String, Value>>,
+        hash_key_overrides: Option<&HashMap<String, String>>,
+        request_hash_key_override: &Option<String>,
     ) -> Result<FeatureFlagMatch, FlagError> {
         if !flag.active {
             return Ok(FeatureFlagMatch {
@@ -912,7 +911,7 @@ impl FeatureFlagMatcher {
         }
         // Check if this is a group-based flag with missing group
         let hashed_id =
-            self.hashed_identifier(flag, hash_key_overrides.clone(), &request_hash_key_override)?;
+            self.hashed_identifier(flag, hash_key_overrides, request_hash_key_override)?;
         if flag.get_group_type_index().is_some() && hashed_id.is_empty() {
             // This is a group-based flag but we don't have the group key
             return Ok(FeatureFlagMatch {
@@ -964,9 +963,9 @@ impl FeatureFlagMatcher {
             if !super_groups.is_empty() {
                 let super_condition_evaluation = self.is_super_condition_match(
                     flag,
-                    property_overrides.clone(),
-                    hash_key_overrides.clone(),
-                    &request_hash_key_override,
+                    property_overrides,
+                    hash_key_overrides,
+                    request_hash_key_override,
                 )?;
 
                 if super_condition_evaluation.should_evaluate {
@@ -995,7 +994,7 @@ impl FeatureFlagMatcher {
         if let Some(holdout_groups) = &flag.filters.holdout_groups {
             if !holdout_groups.is_empty() {
                 let (is_match, holdout_value, evaluation_reason) =
-                    self.is_holdout_condition_match(flag, &request_hash_key_override)?;
+                    self.is_holdout_condition_match(flag, request_hash_key_override)?;
                 if is_match {
                     let payload = self.get_matching_payload(holdout_value.as_deref(), flag);
                     return Ok(FeatureFlagMatch {
@@ -1016,9 +1015,9 @@ impl FeatureFlagMatcher {
             let (is_match, reason) = self.is_condition_match(
                 flag,
                 condition,
-                property_overrides.clone(),
-                hash_key_overrides.clone(),
-                &request_hash_key_override,
+                property_overrides,
+                hash_key_overrides,
+                request_hash_key_override,
             )?;
 
             // Update highest_match and highest_index
@@ -1050,17 +1049,13 @@ impl FeatureFlagMatcher {
                         // If override isn't valid, fall back to computed variant
                         self.get_matching_variant(
                             flag,
-                            hash_key_overrides.clone(),
-                            &request_hash_key_override,
+                            hash_key_overrides,
+                            request_hash_key_override,
                         )?
                     }
                 } else {
                     // No override, use computed variant
-                    self.get_matching_variant(
-                        flag,
-                        hash_key_overrides.clone(),
-                        &request_hash_key_override,
-                    )?
+                    self.get_matching_variant(flag, hash_key_overrides, request_hash_key_override)?
                 };
                 let payload = self.get_matching_payload(variant.as_deref(), flag);
 
@@ -1114,8 +1109,8 @@ impl FeatureFlagMatcher {
         &self,
         feature_flag: &FeatureFlag,
         condition: &FlagPropertyGroup,
-        property_overrides: Option<HashMap<String, Value>>,
-        hash_key_overrides: Option<HashMap<String, String>>,
+        property_overrides: Option<&HashMap<String, Value>>,
+        hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<(bool, FeatureFlagMatchReason), FlagError> {
         let rollout_percentage = condition.rollout_percentage.unwrap_or(100.0);
@@ -1191,7 +1186,7 @@ impl FeatureFlagMatcher {
     fn get_properties_to_check(
         &self,
         feature_flag: &FeatureFlag,
-        property_overrides: Option<HashMap<String, Value>>,
+        property_overrides: Option<&HashMap<String, Value>>,
     ) -> Result<HashMap<String, Value>, FlagError> {
         match feature_flag.get_group_type_index() {
             Some(group_type_index) => {
@@ -1205,7 +1200,7 @@ impl FeatureFlagMatcher {
     fn get_group_properties(
         &self,
         group_type_index: GroupTypeIndex,
-        property_overrides: Option<HashMap<String, Value>>,
+        property_overrides: Option<&HashMap<String, Value>>,
     ) -> Result<HashMap<String, Value>, FlagError> {
         // Start with DB properties
         let mut merged_properties =
@@ -1213,7 +1208,7 @@ impl FeatureFlagMatcher {
 
         // Merge in overrides (overrides take precedence)
         if let Some(overrides) = property_overrides {
-            merged_properties.extend(overrides);
+            merged_properties.extend(overrides.clone());
         }
 
         // Return all merged properties
@@ -1223,7 +1218,7 @@ impl FeatureFlagMatcher {
     /// Gets person properties by merging DB properties with overrides (overrides take precedence).
     fn get_person_properties(
         &self,
-        property_overrides: Option<HashMap<String, Value>>,
+        property_overrides: Option<&HashMap<String, Value>>,
     ) -> Result<HashMap<String, Value>, FlagError> {
         // Start with DB properties
         let mut merged_properties = self
@@ -1232,7 +1227,7 @@ impl FeatureFlagMatcher {
 
         // Merge in overrides (overrides take precedence)
         if let Some(overrides) = property_overrides {
-            merged_properties.extend(overrides);
+            merged_properties.extend(overrides.clone());
         }
 
         // Populate missing $initial_ properties from their non-initial counterparts.
@@ -1299,8 +1294,8 @@ impl FeatureFlagMatcher {
     fn is_super_condition_match(
         &self,
         feature_flag: &FeatureFlag,
-        property_overrides: Option<HashMap<String, Value>>,
-        hash_key_overrides: Option<HashMap<String, String>>,
+        property_overrides: Option<&HashMap<String, Value>>,
+        hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<SuperConditionEvaluation, FlagError> {
         if let Some(super_condition) = feature_flag
@@ -1323,7 +1318,7 @@ impl FeatureFlagMatcher {
                 let (is_match, _) = self.is_condition_match(
                     feature_flag,
                     super_condition,
-                    Some(merged_properties),
+                    Some(&merged_properties),
                     hash_key_overrides,
                     request_hash_key_override,
                 )?;
@@ -1355,7 +1350,7 @@ impl FeatureFlagMatcher {
     fn hashed_identifier(
         &self,
         feature_flag: &FeatureFlag,
-        hash_key_overrides: Option<HashMap<String, String>>,
+        hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<String, FlagError> {
         if let Some(group_type_index) = feature_flag.get_group_type_index() {
@@ -1419,7 +1414,7 @@ impl FeatureFlagMatcher {
         &self,
         feature_flag: &FeatureFlag,
         salt: &str,
-        hash_key_overrides: Option<HashMap<String, String>>,
+        hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<f64, FlagError> {
         let hashed_identifier =
@@ -1455,7 +1450,7 @@ impl FeatureFlagMatcher {
         &self,
         feature_flag: &FeatureFlag,
         rollout_percentage: f64,
-        hash_key_overrides: Option<HashMap<String, String>>,
+        hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<(bool, FeatureFlagMatchReason), FlagError> {
         if rollout_percentage == 100.0 {
@@ -1478,7 +1473,7 @@ impl FeatureFlagMatcher {
     pub(crate) fn get_matching_variant(
         &self,
         feature_flag: &FeatureFlag,
-        hash_key_overrides: Option<HashMap<String, String>>,
+        hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<Option<String>, FlagError> {
         let hash = self.get_hash(

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -30,6 +30,7 @@ use crate::utils::graph_utils::{
 };
 use anyhow::Result;
 use common_metrics::{inc, timing_guard};
+use common_types::collections::HashMapExt;
 use common_types::{PersonId, TeamId};
 use rayon::prelude::*;
 use serde_json::Value;
@@ -1208,7 +1209,7 @@ impl FeatureFlagMatcher {
 
         // Merge in overrides (overrides take precedence)
         if let Some(overrides) = property_overrides {
-            merged_properties.extend(overrides.clone());
+            merged_properties.extend(overrides.iter_owned());
         }
 
         // Return all merged properties
@@ -1227,7 +1228,7 @@ impl FeatureFlagMatcher {
 
         // Merge in overrides (overrides take precedence)
         if let Some(overrides) = property_overrides {
-            merged_properties.extend(overrides.clone());
+            merged_properties.extend(overrides.iter_owned());
         }
 
         // Populate missing $initial_ properties from their non-initial counterparts.

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -101,7 +101,7 @@ mod tests {
             .await
             .unwrap();
 
-        let match_result = matcher.get_match(&flag, None, None, None).unwrap();
+        let match_result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert!(match_result.matches);
         assert_eq!(match_result.variant, None);
 
@@ -122,7 +122,7 @@ mod tests {
             .await
             .unwrap();
 
-        let match_result = matcher.get_match(&flag, None, None, None).unwrap();
+        let match_result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert!(!match_result.matches);
         assert_eq!(match_result.variant, None);
 
@@ -143,7 +143,7 @@ mod tests {
             .await
             .unwrap();
 
-        let match_result = matcher.get_match(&flag, None, None, None).unwrap();
+        let match_result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         // Expecting false for non-existent distinct_id
         assert!(!match_result.matches);
@@ -1440,7 +1440,7 @@ mod tests {
                     None,
                     None,
                 );
-                matcher.get_match(&flag_clone, None, None, None).unwrap()
+                matcher.get_match(&flag_clone, None, None, &None).unwrap()
             }));
         }
 
@@ -1528,7 +1528,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(result.matches);
     }
@@ -1573,7 +1573,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         // With empty distinct_id and 100% rollout, the flag should match
         // This is consistent with the Python implementation
@@ -1620,14 +1620,14 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(!result.matches);
 
         // Now set the rollout percentage to 100%
         flag.filters.groups[0].rollout_percentage = Some(100.0);
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(result.matches);
     }
@@ -1752,7 +1752,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(!result.matches);
     }
@@ -1816,7 +1816,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         // The match should fail due to invalid data type
         assert!(!result.matches);
@@ -1947,7 +1947,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(result.matches);
     }
@@ -2180,7 +2180,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let result = matcher.get_match(&flag, None, None, None).unwrap();
+            let result = matcher.get_match(&flag, None, None, &None).unwrap();
             assert_eq!(
                 result.matches,
                 should_match,
@@ -2325,12 +2325,12 @@ mod tests {
             .await
             .unwrap();
 
-        let result_test_id = matcher_test_id.get_match(&flag, None, None, None).unwrap();
+        let result_test_id = matcher_test_id.get_match(&flag, None, None, &None).unwrap();
         let result_example_id = matcher_example_id
-            .get_match(&flag, None, None, None)
+            .get_match(&flag, None, None, &None)
             .unwrap();
         let result_another_id = matcher_another_id
-            .get_match(&flag, None, None, None)
+            .get_match(&flag, None, None, &None)
             .unwrap();
 
         assert!(result_test_id.matches);
@@ -2435,7 +2435,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(result.matches);
         assert_eq!(result.reason, FeatureFlagMatchReason::SuperConditionValue);
@@ -2576,12 +2576,12 @@ mod tests {
             .await
             .unwrap();
 
-        let result_test_id = matcher_test_id.get_match(&flag, None, None, None).unwrap();
+        let result_test_id = matcher_test_id.get_match(&flag, None, None, &None).unwrap();
         let result_example_id = matcher_example_id
-            .get_match(&flag, None, None, None)
+            .get_match(&flag, None, None, &None)
             .unwrap();
         let result_another_id = matcher_another_id
-            .get_match(&flag, None, None, None)
+            .get_match(&flag, None, None, &None)
             .unwrap();
 
         assert!(!result_test_id.matches);
@@ -2697,7 +2697,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(result.matches);
     }
@@ -2793,7 +2793,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(result.matches);
     }
@@ -2884,7 +2884,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         // The user matches the cohort, but the flag is set to NotIn, so it should evaluate to false
         assert!(!result.matches);
@@ -3006,7 +3006,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(result.matches);
     }
@@ -3102,7 +3102,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         // The user does not match the cohort, and the flag is set to In, so it should evaluate to false
         assert!(!result.matches);
@@ -3198,7 +3198,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(
             result.matches,
@@ -3281,7 +3281,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(
             !result.matches,
@@ -3369,7 +3369,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(
             result.matches,
@@ -3462,7 +3462,7 @@ mod tests {
             None,
         );
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         assert!(
             !result.matches,
@@ -3886,7 +3886,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
 
         // The condition matches and has a variant override, so it should return "control"
         // regardless of what the hash-based variant computation would return
@@ -3942,7 +3942,7 @@ mod tests {
             .unwrap();
 
         let result_invalid = matcher
-            .get_match(&flag_invalid_override, None, None, None)
+            .get_match(&flag_invalid_override, None, None, &None)
             .unwrap();
 
         // The condition matches but has an invalid variant override,
@@ -4118,7 +4118,7 @@ mod tests {
             .unwrap();
 
         let result = matcher
-            .get_match(&flag_with_holdout, None, None, None)
+            .get_match(&flag_with_holdout, None, None, &None)
             .unwrap();
         assert!(result.matches);
         assert_eq!(result.variant, Some("second-variant".to_string()));
@@ -4146,7 +4146,7 @@ mod tests {
             .unwrap();
 
         let result = matcher2
-            .get_match(&flag_with_holdout, None, None, None)
+            .get_match(&flag_with_holdout, None, None, &None)
             .unwrap();
 
         assert!(result.matches);
@@ -4155,7 +4155,7 @@ mod tests {
 
         // same should hold true for a different feature flag when within holdout
         let result = matcher2
-            .get_match(&other_flag_with_holdout, None, None, None)
+            .get_match(&other_flag_with_holdout, None, None, &None)
             .unwrap();
         assert!(result.matches);
         assert_eq!(result.variant, Some("holdout".to_string()));
@@ -4163,7 +4163,7 @@ mod tests {
 
         // Test with matcher1 (outside holdout) to verify different variants
         let result = matcher
-            .get_match(&other_flag_with_holdout, None, None, None)
+            .get_match(&other_flag_with_holdout, None, None, &None)
             .unwrap();
         assert!(result.matches);
         assert_eq!(result.variant, Some("third-variant".to_string()));
@@ -4171,14 +4171,14 @@ mod tests {
 
         // when holdout exists but is zero, should default to regular flag evaluation
         let result = matcher
-            .get_match(&flag_without_holdout, None, None, None)
+            .get_match(&flag_without_holdout, None, None, &None)
             .unwrap();
         assert!(result.matches);
         assert_eq!(result.variant, Some("second-variant".to_string()));
         assert_eq!(result.reason, FeatureFlagMatchReason::ConditionMatch);
 
         let result = matcher2
-            .get_match(&flag_without_holdout, None, None, None)
+            .get_match(&flag_without_holdout, None, None, &None)
             .unwrap();
         assert!(result.matches);
         assert_eq!(result.variant, Some("second-variant".to_string()));
@@ -4251,7 +4251,7 @@ mod tests {
             None,
             None,
         );
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert_eq!(
             result,
             FeatureFlagMatch {
@@ -4274,7 +4274,7 @@ mod tests {
             None,
             None,
         );
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert_eq!(
             result,
             FeatureFlagMatch {
@@ -4297,7 +4297,7 @@ mod tests {
             None,
             None,
         );
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert_eq!(
             result,
             FeatureFlagMatch {
@@ -4399,7 +4399,7 @@ mod tests {
             .unwrap();
 
         // This should not throw DependencyNotFound because we skip dependency graph evaluation for static cohorts
-        let result = matcher.get_match(&flag, None, None, None);
+        let result = matcher.get_match(&flag, None, None, &None);
         assert!(result.is_ok(), "Should not throw DependencyNotFound error");
 
         let match_result = result.unwrap();
@@ -4536,7 +4536,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result_numeric = matcher_numeric.get_match(&flag, None, None, None).unwrap();
+        let result_numeric = matcher_numeric.get_match(&flag, None, None, &None).unwrap();
 
         // Test with string group key (same value)
         let groups_string = HashMap::from([("organization".to_string(), json!("123"))]);
@@ -4556,7 +4556,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result_string = matcher_string.get_match(&flag, None, None, None).unwrap();
+        let result_string = matcher_string.get_match(&flag, None, None, &None).unwrap();
 
         // Both should match and produce the same result
         assert!(result_numeric.matches, "Numeric group key should match");
@@ -4588,7 +4588,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result_float = matcher_float.get_match(&flag, None, None, None).unwrap();
+        let result_float = matcher_float.get_match(&flag, None, None, &None).unwrap();
         assert!(result_float.matches, "Float group key should match");
 
         // Test with invalid group key type (should use empty string and not match this specific case)
@@ -4609,7 +4609,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result_bool = matcher_bool.get_match(&flag, None, None, None).unwrap();
+        let result_bool = matcher_bool.get_match(&flag, None, None, &None).unwrap();
         // Boolean group key should use empty string identifier, which returns hash 0.0, making flag evaluate to false
         assert!(
             !result_bool.matches,
@@ -4753,7 +4753,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert!(result.matches, "Super condition user should match");
         assert_eq!(
             result.reason,
@@ -4778,7 +4778,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert!(!result.matches, "PostHog user should not match");
         assert_eq!(
             result.reason,
@@ -4803,7 +4803,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = matcher.get_match(&flag, None, None, None).unwrap();
+        let result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert!(!result.matches, "Regular user should not match");
         assert_eq!(
             result.reason,
@@ -4876,7 +4876,7 @@ mod tests {
             .await
             .unwrap();
 
-        let match_result = matcher.get_match(&flag, None, None, None).unwrap();
+        let match_result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert!(match_result.matches);
         assert_eq!(match_result.variant, None);
     }
@@ -4931,7 +4931,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let high_device_result = matcher.get_match(&flag, None, None, None).unwrap();
+        let high_device_result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert!(
             high_device_result.matches,
             "device-high hash should fall inside rollout"
@@ -4953,7 +4953,7 @@ mod tests {
             .await
             .unwrap();
         let same_device_result = matcher_same_device
-            .get_match(&flag, None, None, None)
+            .get_match(&flag, None, None, &None)
             .unwrap();
         assert_eq!(
             high_device_result.matches, same_device_result.matches,
@@ -4975,7 +4975,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let low_device_result = matcher_low.get_match(&flag, None, None, None).unwrap();
+        let low_device_result = matcher_low.get_match(&flag, None, None, &None).unwrap();
         assert!(
             !low_device_result.matches,
             "device-low hash should fall outside rollout"
@@ -5009,7 +5009,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let match_from_distinct = matcher.get_match(&flag, None, None, None).unwrap();
+        let match_from_distinct = matcher.get_match(&flag, None, None, &None).unwrap();
         assert!(
             match_from_distinct.matches,
             "fallback distinct hash should fall inside rollout"
@@ -5030,7 +5030,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let high_distinct_result = matcher_high.get_match(&flag, None, None, None).unwrap();
+        let high_distinct_result = matcher_high.get_match(&flag, None, None, &None).unwrap();
         assert!(
             !high_distinct_result.matches,
             "fallback distinct hash should fall outside rollout"
@@ -5065,7 +5065,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let high_distinct_result = matcher.get_match(&flag, None, None, None).unwrap();
+        let high_distinct_result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert!(
             !high_distinct_result.matches,
             "distinct-id bucketing should ignore device_id input"
@@ -5086,7 +5086,7 @@ mod tests {
             .prepare_flag_evaluation_state(&[&flag])
             .await
             .unwrap();
-        let low_distinct_result = matcher_low.get_match(&flag, None, None, None).unwrap();
+        let low_distinct_result = matcher_low.get_match(&flag, None, None, &None).unwrap();
         assert!(
             low_distinct_result.matches,
             "distinct-id bucketing should follow the distinct hash even when device_id exists"
@@ -5749,7 +5749,7 @@ mod tests {
         user_properties.insert("email".to_string(), json!("specific@example.com"));
 
         let result = matcher
-            .get_match(&flag, Some(user_properties), None, None)
+            .get_match(&flag, Some(&user_properties), None, &None)
             .unwrap();
         assert!(result.matches, "Flag should match for specific user");
         assert_eq!(
@@ -5778,7 +5778,7 @@ mod tests {
         other_properties.insert("email".to_string(), json!("other@example.com"));
 
         let result2 = matcher2
-            .get_match(&flag, Some(other_properties), None, None)
+            .get_match(&flag, Some(&other_properties), None, &None)
             .unwrap();
         assert!(result2.matches, "Flag should match for other user");
         assert_eq!(
@@ -5944,7 +5944,7 @@ mod tests {
             None,
         );
 
-        let match_result = matcher.get_match(&flag, None, None, None).unwrap();
+        let match_result = matcher.get_match(&flag, None, None, &None).unwrap();
         assert!(!match_result.matches, "Disabled flag should not match");
         assert_eq!(
             match_result.reason,

--- a/rust/feature-flags/tests/test_flag_matching_consistency.rs
+++ b/rust/feature-flags/tests/test_flag_matching_consistency.rs
@@ -127,7 +127,7 @@ async fn it_is_consistent_with_rollout_calculation_for_simple_flags() {
             );
             FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None)
         }
-        .get_match(&flags[0], None, None, None)
+        .get_match(&flags[0], None, None, &None)
         .unwrap();
 
         if *result {
@@ -1225,7 +1225,7 @@ async fn it_is_consistent_with_rollout_calculation_for_multivariate_flags() {
             );
             FeatureFlagMatcher::new(distinct_id, None, 1, router, cohort_cache, None, None)
         }
-        .get_match(&flags[0], None, None, None)
+        .get_match(&flags[0], None, None, &None)
         .unwrap();
 
         if let Some(variant) = &result {


### PR DESCRIPTION
## Problem

The feature flag matching code was passing `HashMap` parameters by value, requiring unnecessary `.clone()` calls at each call site. This created extra memory allocations and copies when the functions only need read access to the data.

## Changes

- Changed function signatures in `flag_matching.rs` to accept `Option<&HashMap<...>>` instead of `Option<HashMap<...>>` for:
  - `get_match`
  - `is_condition_match`
  - `get_properties_to_check`
  - `get_group_properties`
  - `get_person_properties`
  - `is_super_condition_match`
  - `hashed_identifier`
  - `get_hash`
  - `is_percentage_match`
  - `get_matching_variant`
- Updated call sites to use `.as_ref()` instead of `.clone()`
- Updated all test code to pass references (`&None` instead of `None` for the `request_hash_key_override` parameter)

## How did you test this code?

- All existing tests pass
- The changes are purely mechanical refactoring with no behavioral changes

## Publish to changelog?

No