### PR TITLE
fix(hobby): skip shadow worker when CYCLOTRON_SHADOW_DATABASE_URL not…

### DIFF
--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -241,11 +241,21 @@ export class PluginServer {
             }
 
             if (capabilities.cdpCyclotronShadowWorker) {
-                serviceLoaders.push(async () => {
-                    const worker = new CdpCyclotronShadowWorker(hub)
-                    await worker.start()
-                    return worker.service
-                })
+                // Only start the shadow worker if CYCLOTRON_SHADOW_DATABASE_URL is explicitly configured
+                // (not just using the default value). This prevents crashes in hobby/dev deployments
+                // that don't have the shadow database set up.
+                if (process.env.CYCLOTRON_SHADOW_DATABASE_URL) {
+                    serviceLoaders.push(async () => {
+                        const worker = new CdpCyclotronShadowWorker(hub)
+                        await worker.start()
+                        return worker.service
+                    })
+                } else {
+                    logger.info(
+                        '⏭️',
+                        'Skipping CdpCyclotronShadowWorker - CYCLOTRON_SHADOW_DATABASE_URL not configured'
+                    )
+                }
             }
 
             if (capabilities.cdpCyclotronWorkerHogFlow) {


### PR DESCRIPTION
… configured

## Problem

Hobby deployments crash-loop because the added `cdpCyclotronShadowWorker: true` is a default. The shadow worker tries to connect to a `cyclotron_shadow` database that doesn't exist in hobby deployments, causing repeated connection failures and container restarts.

## Changes

**NOTE** We could also probably just [default to to false](https://github.com/PostHog/posthog/blob/936a4614e12a2a84cf81fbe724a9a0377ad807d0/nodejs/src/capabilities.ts#L14) but I wasn't sure if that would impact existing "live" deployments

Skip starting `CdpCyclotronShadowWorker` when `CYCLOTRON_SHADOW_DATABASE_URL` is not explicitly set as an environment variable. This preserves the intended behavior for local dev (shadow worker runs when the env var is configured) while preventing crashes in hobby deployments that don't have the shadow database set up.

A log message is emitted when the shadow worker is skipped to help developers understand the behavior.

## How did you test this code?

- built local image with fix
- deploy to local hobby vm that was previously crash-looping
- verified plugins container starts with log: `⏭️ Skipping CdpCyclotronShadowWorker - CYCLOTRON_SHADOW_DATABASE_URL not configured`
- verified container was stable

## Publish to changelog?

no
