### PR TITLE
feat(deduplicator): ensure in-flight exports cancel ASAP as import cycle starts

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/error.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/error.rs
@@ -1,0 +1,53 @@
+use std::fmt;
+
+/// Error indicating an upload operation was cancelled (e.g., due to rebalance or shutdown).
+/// Use anyhow's downcast_ref::<UploadCancelledError>() to detect this error type.
+#[derive(Debug)]
+pub struct UploadCancelledError {
+    pub reason: String,
+}
+
+impl fmt::Display for UploadCancelledError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Upload cancelled: {}", self.reason)
+    }
+}
+
+impl std::error::Error for UploadCancelledError {}
+
+/// Error indicating a download operation was cancelled (e.g., due to rebalance or shutdown).
+/// Use anyhow's downcast_ref::<DownloadCancelledError>() to detect this error type.
+#[derive(Debug)]
+pub struct DownloadCancelledError {
+    pub reason: String,
+}
+
+impl fmt::Display for DownloadCancelledError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Download cancelled: {}", self.reason)
+    }
+}
+
+impl std::error::Error for DownloadCancelledError {}
+
+/// Error indicating a checkpoint import operation timed out.
+/// This prevents exceeding Kafka's max poll interval during long imports.
+/// Use anyhow's downcast_ref::<ImportTimeoutError>() to detect this error type.
+#[derive(Debug)]
+pub struct ImportTimeoutError {
+    pub topic: String,
+    pub partition: i32,
+    pub timeout_secs: u64,
+}
+
+impl fmt::Display for ImportTimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Checkpoint import timed out after {}s for {}:{}",
+            self.timeout_secs, self.topic, self.partition
+        )
+    }
+}
+
+impl std::error::Error for ImportTimeoutError {}

--- a/rust/kafka-deduplicator/src/checkpoint/import.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/import.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use super::error::{DownloadCancelledError, ImportTimeoutError};
 use super::{CheckpointDownloader, CheckpointMetadata};
 use crate::metrics_const::{
     CHECKPOINT_IMPORT_ATTEMPT_DURATION_HISTOGRAM, CHECKPOINT_IMPORT_DURATION_HISTOGRAM,
@@ -136,10 +137,12 @@ impl CheckpointImporter {
                 );
                 metrics::histogram!(CHECKPOINT_IMPORT_DURATION_HISTOGRAM, "result" => "timeout")
                     .record(start_time.elapsed().as_secs_f64());
-                Err(anyhow::anyhow!(
-                    "Checkpoint import timed out after {}s for topic:{topic} partition:{partition_number}",
-                    self.import_timeout.as_secs()
-                ))
+                Err(ImportTimeoutError {
+                    topic: topic.to_string(),
+                    partition: partition_number,
+                    timeout_secs: self.import_timeout.as_secs(),
+                }
+                .into())
             }
         }
     }
@@ -189,7 +192,10 @@ impl CheckpointImporter {
                     );
                     metrics::histogram!(CHECKPOINT_IMPORT_DURATION_HISTOGRAM, "result" => "cancelled")
                         .record(start_time.elapsed().as_secs_f64());
-                    return Err(anyhow::anyhow!("Checkpoint import cancelled"));
+                    return Err(DownloadCancelledError {
+                        reason: "import cancelled before attempt".to_string(),
+                    }
+                    .into());
                 }
             }
 
@@ -433,7 +439,10 @@ mod tests {
         ) -> Result<()> {
             if let Some(token) = cancel_token {
                 if token.is_cancelled() {
-                    return Err(anyhow::anyhow!("Download cancelled"));
+                    return Err(DownloadCancelledError {
+                        reason: "test mock".to_string(),
+                    }
+                    .into());
                 }
             }
             tokio::fs::write(local_filepath, b"mock file content").await?;
@@ -513,7 +522,10 @@ mod tests {
             // Check cancellation before starting
             if let Some(token) = cancel_token {
                 if token.is_cancelled() {
-                    return Err(anyhow::anyhow!("Download cancelled"));
+                    return Err(DownloadCancelledError {
+                        reason: "test mock".to_string(),
+                    }
+                    .into());
                 }
             }
 
@@ -530,7 +542,10 @@ mod tests {
             // Check cancellation before starting
             if let Some(token) = cancel_token {
                 if token.is_cancelled() {
-                    return Err(anyhow::anyhow!("Download cancelled"));
+                    return Err(DownloadCancelledError {
+                        reason: "test mock".to_string(),
+                    }
+                    .into());
                 }
             }
 
@@ -578,9 +593,11 @@ mod tests {
             .await;
 
         assert!(result.is_err());
+        let err = result.unwrap_err();
         assert!(
-            result.unwrap_err().to_string().contains("cancelled"),
-            "Error should mention cancellation"
+            err.downcast_ref::<DownloadCancelledError>().is_some(),
+            "Error should be DownloadCancelledError: {}",
+            err
         );
     }
 
@@ -605,9 +622,11 @@ mod tests {
             .await;
 
         assert!(result.is_err());
+        let err = result.unwrap_err();
         assert!(
-            result.unwrap_err().to_string().contains("cancelled"),
-            "Error should mention cancellation"
+            err.downcast_ref::<DownloadCancelledError>().is_some(),
+            "Error should be DownloadCancelledError: {}",
+            err
         );
     }
 

--- a/rust/kafka-deduplicator/src/checkpoint/mod.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/mod.rs
@@ -1,6 +1,7 @@
 pub mod client;
 pub mod config;
 pub mod downloader;
+pub mod error;
 pub mod export;
 pub mod import;
 pub mod metadata;
@@ -22,3 +23,5 @@ pub use s3_downloader::S3Downloader;
 pub use s3_uploader::S3Uploader;
 pub use uploader::CheckpointUploader;
 pub use worker::CheckpointWorker;
+
+pub use error::{DownloadCancelledError, ImportTimeoutError, UploadCancelledError};

--- a/rust/kafka-deduplicator/src/checkpoint/worker.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/worker.rs
@@ -93,24 +93,32 @@ impl CheckpointWorker {
         store: &DeduplicationStore,
         previous_metadata: Option<&CheckpointMetadata>,
     ) -> Result<Option<CheckpointInfo>> {
-        self.checkpoint_partition_cancellable(store, previous_metadata, None)
+        self.checkpoint_partition_cancellable(store, previous_metadata, None, None)
             .await
     }
 
     /// Perform a complete checkpoint operation with cancellation support.
     /// If cancel_token is provided and cancelled during export, returns an error early.
+    ///
+    /// The optional `cancel_cause` is used for metrics when cancelled (e.g., "rebalance" or "shutdown").
     pub async fn checkpoint_partition_cancellable(
         &self,
         store: &DeduplicationStore,
         previous_metadata: Option<&CheckpointMetadata>,
         cancel_token: Option<&CancellationToken>,
+        cancel_cause: Option<&str>,
     ) -> Result<Option<CheckpointInfo>> {
         // Create the local checkpoint
         let rocks_metadata = self.create_checkpoint(store).await?;
 
         // Export checkpoint with cancellation support
         let result = self
-            .export_checkpoint_cancellable(&rocks_metadata, previous_metadata, cancel_token)
+            .export_checkpoint_cancellable(
+                &rocks_metadata,
+                previous_metadata,
+                cancel_token,
+                cancel_cause,
+            )
             .await;
 
         // Clean up temp checkpoint directory (skip in test mode to allow verification)
@@ -257,6 +265,7 @@ impl CheckpointWorker {
         rocks_metadata: &LocalCheckpointInfo,
         previous_metadata: Option<&CheckpointMetadata>,
         cancel_token: Option<&CancellationToken>,
+        cancel_cause: Option<&str>,
     ) -> Result<Option<CheckpointInfo>> {
         let local_attempt_path_tag = self.get_local_attempt_path().to_string_lossy().to_string();
         let attempt_type = if previous_metadata.is_some() {
@@ -313,7 +322,7 @@ impl CheckpointWorker {
 
                 // Export checkpoint using the plan with cancellation support
                 match exporter
-                    .export_checkpoint_with_plan_cancellable(&plan, cancel_token)
+                    .export_checkpoint_with_plan_cancellable(&plan, cancel_token, cancel_cause)
                     .await
                 {
                     Ok(()) => {

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -1,3 +1,19 @@
+//! Checkpoint manager for coordinating periodic checkpoint operations.
+//!
+//! This module handles scheduling and execution of checkpoint export workers, which
+//! persist deduplication store state to S3 for recovery.
+//!
+//! # Export Suppression During Rebalancing
+//!
+//! When a Kafka rebalance occurs, checkpoint imports (downloads from S3) need S3
+//! bandwidth to quickly restore partition state. To prevent exports from competing
+//! for this bandwidth, workers obtain a rebalance-scoped cancellation token from
+//! `RebalanceTracker::get_export_token()`.
+//!
+//! This token is cancelled when any rebalance starts (0->1 transition) and recreated
+//! when all rebalances complete (1->0 transition). Workers check this token before
+//! expensive I/O and pass it to the exporter for cancellation during S3 uploads.
+
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{
@@ -231,7 +247,10 @@ impl CheckpointManager {
                             let worker_store_manager = store_manager.clone();
                             let worker_exporter = exporter.as_ref().map(|e| e.clone());
                             let worker_offset_tracker = offset_tracker.clone();
-                            let worker_cancel_token = cancel_submit_loop_token.child_token();
+                            // Shutdown token - child of main loop token, cancelled on graceful shutdown
+                            let worker_shutdown_token = cancel_submit_loop_token.child_token();
+                            // Rebalance token - cancelled when any rebalance starts, to free S3 bandwidth for imports
+                            let worker_rebalance_token = store_manager.rebalance_tracker().get_export_token();
                             let attempt_timestamp = Utc::now();
                             let worker_local_base_dir = Path::new(&submit_loop_config.local_checkpoint_dir);
                             let worker_full_upload_interval = submit_loop_config.checkpoint_full_upload_interval;
@@ -253,10 +272,22 @@ impl CheckpointManager {
                             // for now, we don't bother to track the handles of spawned workers
                             // because each worker represents one best-effort checkpoint attempt
                             let _result = tokio::spawn(async move {
-                                // best effort to bail if the checkpoint manager shut
-                                // down before the worker thread started executing...
-                                if tokio::time::timeout(Duration::from_millis(1), worker_cancel_token.cancelled()).await.is_ok() {
-                                    info!(partition = partition_tag, "Checkpoint worker thread: inner submit loop shutting down, skipping worker execution");
+                                // Best-effort bail if shutdown requested before worker started
+                                if tokio::time::timeout(Duration::from_millis(1), worker_shutdown_token.cancelled()).await.is_ok() {
+                                    info!(partition = partition_tag, "Checkpoint worker thread: shutdown requested, skipping worker execution");
+                                    {
+                                        let mut is_checkpointing_guard = worker_is_checkpointing.lock().await;
+                                        is_checkpointing_guard.remove(&partition);
+                                    }
+                                    return Ok(None);
+                                }
+
+                                // Best-effort bail if rebalance started before worker started
+                                // (frees S3 bandwidth for checkpoint imports)
+                                if worker_rebalance_token.is_cancelled() {
+                                    let tags = [("result", "skipped"), ("cause", "rebalance_before_start")];
+                                    metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
+                                    info!(partition = partition_tag, "Checkpoint worker thread: rebalance token cancelled, skipping worker execution");
                                     {
                                         let mut is_checkpointing_guard = worker_is_checkpointing.lock().await;
                                         is_checkpointing_guard.remove(&partition);
@@ -306,11 +337,11 @@ impl CheckpointManager {
                                         "Checkpoint worker thread: performing incremental checkpoint");
                                 }
 
-                                // Re-verify conditions before expensive I/O (may have changed during scheduling)
-                                if worker_store_manager.rebalance_tracker().is_rebalancing() {
-                                    let tags = [("result", "skipped"), ("cause", "rebalancing_worker")];
+                                // Re-verify rebalance token before expensive I/O (may have been cancelled during scheduling)
+                                if worker_rebalance_token.is_cancelled() {
+                                    let tags = [("result", "skipped"), ("cause", "rebalance_before_export")];
                                     metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
-                                    warn!(partition = partition_tag, "Checkpoint worker: rebalancing started, skipping checkpoint");
+                                    warn!(partition = partition_tag, "Checkpoint worker: rebalance token cancelled, skipping checkpoint");
                                     {
                                         let mut is_checkpointing_guard = worker_is_checkpointing.lock().await;
                                         is_checkpointing_guard.remove(&partition);
@@ -329,12 +360,14 @@ impl CheckpointManager {
                                     return Ok(None);
                                 }
 
-                                // Execute checkpoint operation with previous metadata for deduplication
-                                // Pass the cancel token for cancellation support during export
+                                // Execute checkpoint operation with previous metadata for deduplication.
+                                // Pass the rebalance token for cancellation during S3 upload - this frees
+                                // bandwidth for imports when a rebalance occurs.
                                 let result = worker.checkpoint_partition_cancellable(
                                     &target_store,
                                     incremental_or_full,
-                                    Some(&worker_cancel_token),
+                                    Some(&worker_rebalance_token),
+                                    Some("rebalance"),
                                 ).await;
 
                                 // handle releasing locks and reporting outcome
@@ -451,9 +484,14 @@ impl CheckpointManager {
                 self.offset_tracker.clone(),
             );
 
-            // Use cancellable variant with the manager's cancel token
+            // Use cancellable variant with the manager's cancel token (shutdown)
             worker
-                .checkpoint_partition_cancellable(&store, None, Some(&self.cancel_token))
+                .checkpoint_partition_cancellable(
+                    &store,
+                    None,
+                    Some(&self.cancel_token),
+                    Some("shutdown"),
+                )
                 .await?;
         }
 
@@ -1069,5 +1107,153 @@ mod tests {
 
         // The manager should have handled this gracefully without panicking
         // We just verify it completes without error
+    }
+
+    // ============================================
+    // EXPORT SUPPRESSION TOKEN TESTS
+    // ============================================
+
+    #[tokio::test]
+    async fn test_rebalance_token_cancelled_stops_in_flight_workers() {
+        // This test verifies that when a rebalance starts, workers using the
+        // rebalance token from get_export_token() will see it cancelled.
+        let store_manager = create_test_store_manager();
+        let tracker = store_manager.rebalance_tracker();
+
+        // Get a token before rebalance
+        let worker_token = tracker.get_export_token();
+        assert!(
+            !worker_token.is_cancelled(),
+            "Token should not be cancelled initially"
+        );
+
+        // Simulate rebalance starting
+        tracker.start_rebalancing();
+
+        // Token should now be cancelled
+        assert!(
+            worker_token.is_cancelled(),
+            "Token should be cancelled when rebalance starts"
+        );
+
+        tracker.finish_rebalancing();
+    }
+
+    #[tokio::test]
+    async fn test_fresh_token_after_rebalance_complete() {
+        // This test verifies that after a rebalance completes, new export tokens
+        // obtained from get_export_token() are NOT cancelled.
+        let store_manager = create_test_store_manager();
+        let tracker = store_manager.rebalance_tracker();
+
+        // Start and complete a rebalance
+        tracker.start_rebalancing();
+        tracker.finish_rebalancing();
+
+        // New token should be fresh (not cancelled)
+        let new_token = tracker.get_export_token();
+        assert!(
+            !new_token.is_cancelled(),
+            "New token should not be cancelled after rebalance completes"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_worker_tokens_survive_shutdown_but_not_rebalance() {
+        // Verify that the shutdown token and rebalance token behave differently
+        let store_manager = create_test_store_manager();
+        let store = create_test_store("token_test", 0);
+
+        // Add an event
+        let event = create_test_event();
+        let key = TimestampKey::from(&event);
+        let metadata = TimestampMetadata::new(&event);
+        store.put_timestamp_record(&key, &metadata).unwrap();
+
+        let partition = Partition::new("token_test".to_string(), 0);
+        store_manager.stores().insert(partition, store);
+
+        let tmp_checkpoint_dir = TempDir::new().unwrap();
+        let config = CheckpointConfig {
+            checkpoint_interval: Duration::from_millis(500), // Long interval to control timing
+            local_checkpoint_dir: tmp_checkpoint_dir.path().to_string_lossy().to_string(),
+            ..Default::default()
+        };
+
+        let mut manager = CheckpointManager::new(config.clone(), store_manager.clone(), None);
+        manager.start();
+
+        // The manager should be running
+        assert!(manager.checkpoint_task.is_some());
+
+        // Get a rebalance token - it should NOT be cancelled yet
+        let rebalance_token = store_manager.rebalance_tracker().get_export_token();
+        assert!(!rebalance_token.is_cancelled());
+
+        // Start a rebalance - rebalance token should be cancelled
+        store_manager.rebalance_tracker().start_rebalancing();
+        assert!(
+            rebalance_token.is_cancelled(),
+            "Rebalance token should be cancelled when rebalance starts"
+        );
+
+        // But shutdown token should NOT be cancelled yet (manager still running)
+        assert!(
+            !manager.cancel_token.is_cancelled(),
+            "Shutdown token should not be cancelled while manager is running"
+        );
+
+        // Finish rebalancing
+        store_manager.rebalance_tracker().finish_rebalancing();
+
+        // Now stop the manager - shutdown token should be cancelled
+        manager.stop().await;
+        assert!(
+            manager.cancel_token.is_cancelled(),
+            "Shutdown token should be cancelled after manager stops"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_overlapping_rebalances_keep_exports_suppressed() {
+        // Verify that during overlapping rebalances, exports stay suppressed
+        let store_manager = create_test_store_manager();
+        let tracker = store_manager.rebalance_tracker();
+
+        // Get initial token
+        let token1 = tracker.get_export_token();
+        assert!(!token1.is_cancelled());
+
+        // Start first rebalance - token should be cancelled
+        tracker.start_rebalancing();
+        assert!(token1.is_cancelled());
+
+        // Get another token during rebalance - should already be cancelled
+        let token2 = tracker.get_export_token();
+        assert!(
+            token2.is_cancelled(),
+            "Tokens during rebalance should be pre-cancelled"
+        );
+
+        // Start second overlapping rebalance
+        tracker.start_rebalancing();
+        let token3 = tracker.get_export_token();
+        assert!(token3.is_cancelled());
+
+        // First rebalance finishes - tokens should STILL be cancelled (count > 0)
+        tracker.finish_rebalancing();
+        let token4 = tracker.get_export_token();
+        assert!(
+            token4.is_cancelled(),
+            "Tokens should stay cancelled while any rebalance is in progress"
+        );
+
+        // Second rebalance finishes - NOW tokens should be fresh
+        tracker.finish_rebalancing();
+        let token5 = tracker.get_export_token();
+        assert!(
+            !token5.is_cancelled(),
+            "Tokens should be fresh after all rebalances complete"
+        );
     }
 }

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -70,10 +70,12 @@ pub const CHECKPOINT_WORKER_STATUS_COUNTER: &str = "checkpoint_worker_status";
 
 /// Histogram for checkpoint upload duration
 /// Tags: result=success|error|cancelled
+/// When result=cancelled, additional tag: cause=rebalance|shutdown|unknown
 pub const CHECKPOINT_UPLOAD_DURATION_HISTOGRAM: &str = "checkpoint_upload_duration_seconds";
 
 /// Counter for checkpoint upload outcome status
 /// Tags: result=success|error|cancelled|unavailable
+/// When result=cancelled, additional tag: cause=rebalance|shutdown|unknown
 pub const CHECKPOINT_UPLOADS_COUNTER: &str = "checkpoint_upload_status";
 
 /// Counter for checkpoint file downloads outcome status

--- a/rust/kafka-deduplicator/src/rebalance_tracker.rs
+++ b/rust/kafka-deduplicator/src/rebalance_tracker.rs
@@ -12,24 +12,28 @@
 //! - `ProcessorRebalanceHandler`: Calls `start_rebalancing()` when partitions are assigned
 //! - `StoreManager`: Checks `is_rebalancing()` to skip cleanup during rebalance
 //! - `OffsetTracker`: Checks `is_rebalancing()` to block offset commits during rebalance
-//! - `CheckpointManager`: Checks `is_rebalancing()` to skip checkpoint work during rebalance
+//! - `CheckpointManager`: Uses `get_export_token()` to obtain cancellation tokens for export
+//!   workers. These tokens are cancelled when rebalancing starts, freeing S3 bandwidth for
+//!   the more critical checkpoint imports.
 //!
 //! # Counter Semantics
 //!
-//! - `start_rebalancing()`: Increments the counter. Called synchronously in the rdkafka
-//!   callback before async work is queued.
-//! - `finish_rebalancing()`: Decrements the counter. Called when async work completes
-//!   (typically via the RAII `RebalancingGuard`).
+//! - `start_rebalancing()`: Increments the counter. On 0->1 transition, cancels the export
+//!   suppression token to immediately stop in-flight checkpoint exports.
+//! - `finish_rebalancing()`: Decrements the counter. On 1->0 transition, creates a fresh
+//!   export suppression token so checkpoint exports can resume.
 //! - `is_rebalancing()`: Returns true if counter > 0.
+//! - `get_export_token()`: Returns a child of the export suppression token. Workers use this
+//!   to check if they should bail out of S3 uploads.
 //!
 //! The counter supports overlapping rebalances:
-//! - Rebalance A starts: counter = 1
-//! - Rebalance B starts before A finishes: counter = 2
-//! - Rebalance A finishes: counter = 1 (still rebalancing!)
-//! - Rebalance B finishes: counter = 0 (safe to proceed)
+//! - Rebalance A starts: counter = 1, export token cancelled
+//! - Rebalance B starts before A finishes: counter = 2 (token already cancelled)
+//! - Rebalance A finishes: counter = 1 (still rebalancing, exports still suppressed!)
+//! - Rebalance B finishes: counter = 0, fresh export token created (exports can resume)
 
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use dashmap::mapref::entry::Entry;
 use dashmap::{DashMap, DashSet};
@@ -69,6 +73,7 @@ struct PartitionSetupTask {
 /// It provides the single source of truth for:
 /// - Whether a rebalance is in progress (counter-based for overlapping rebalances)
 /// - Which partitions are currently owned by this consumer
+/// - Export suppression during rebalancing (to prioritize imports)
 pub struct RebalanceTracker {
     /// Counter tracking the number of in-progress rebalances.
     /// Using a counter (not bool) correctly handles overlapping rebalances.
@@ -83,15 +88,23 @@ pub struct RebalanceTracker {
     /// - Shared<JoinHandle> allows multiple async_setup calls to await the same task
     /// - CancellationToken allows cancelling ONLY this partition's S3 download on revoke
     partition_setup_tasks: DashMap<Partition, PartitionSetupTask>,
+
+    /// Token for suppressing checkpoint exports during rebalancing.
+    /// Cancelled when rebalancing starts (count 0->1), recreated when complete (count 1->0).
+    /// CheckpointManager workers use child tokens from this via `get_export_token()`.
+    /// This ensures S3 bandwidth is available for checkpoint imports during rebalance.
+    export_suppression_token: RwLock<CancellationToken>,
 }
 
 impl RebalanceTracker {
     /// Create a new tracker with the counter initialized to 0 and no owned partitions.
+    /// Export suppression token starts fresh (uncancelled).
     pub fn new() -> Self {
         Self {
             rebalancing_count: AtomicUsize::new(0),
             owned_partitions: DashSet::new(),
             partition_setup_tasks: DashMap::new(),
+            export_suppression_token: RwLock::new(CancellationToken::new()),
         }
     }
 
@@ -101,10 +114,22 @@ impl RebalanceTracker {
     /// to ensure no gap where cleanup could run.
     ///
     /// While counter > 0, operations like orphan cleanup and offset commits are blocked.
+    ///
+    /// On the 0->1 transition (first rebalance starts), cancels the export suppression
+    /// token to immediately stop all in-flight checkpoint exports. This frees S3
+    /// bandwidth for the more critical checkpoint imports.
     pub fn start_rebalancing(&self) {
         let prev = self.rebalancing_count.fetch_add(1, Ordering::SeqCst);
         let new_count = prev + 1;
         metrics::gauge!(REBALANCING_COUNT).set(new_count as f64);
+
+        // Cancel export token on FIRST rebalance (0 -> 1 transition)
+        if prev == 0 {
+            let token = self.export_suppression_token.read().unwrap();
+            token.cancel();
+            info!("Export suppression: cancelled all in-flight exports (rebalance started)");
+        }
+
         info!(
             previous_count = prev,
             new_count = new_count,
@@ -116,13 +141,21 @@ impl RebalanceTracker {
     ///
     /// Typically called via the `RebalancingGuard` RAII pattern to ensure cleanup
     /// even on panic or cancellation.
+    ///
+    /// On the 1->0 transition (all rebalances complete), creates a fresh export
+    /// suppression token so checkpoint exports can resume normally.
     pub fn finish_rebalancing(&self) {
         let prev = self.rebalancing_count.fetch_sub(1, Ordering::SeqCst);
         let new_count = prev.saturating_sub(1);
         metrics::gauge!(REBALANCING_COUNT).set(new_count as f64);
+
         if prev == 0 {
             warn!("finish_rebalancing called when counter was already 0");
         } else if new_count == 0 {
+            // Create fresh token when ALL rebalances complete (1 -> 0 transition)
+            let mut token = self.export_suppression_token.write().unwrap();
+            *token = CancellationToken::new();
+            info!("Export suppression: created fresh token (all rebalances complete)");
             info!("All rebalances completed, counter returned to 0");
         } else {
             info!(
@@ -138,6 +171,18 @@ impl RebalanceTracker {
     /// Returns true if the counter is greater than 0.
     pub fn is_rebalancing(&self) -> bool {
         self.rebalancing_count.load(Ordering::SeqCst) > 0
+    }
+
+    /// Get a child token for checkpoint export suppression.
+    ///
+    /// CheckpointManager calls this when spawning export workers. The returned
+    /// child token will be cancelled when any rebalance starts, allowing workers
+    /// to bail out of S3 uploads early and free bandwidth for imports.
+    ///
+    /// Returns a child of the current export suppression token. If a rebalance
+    /// is in progress, the returned token will already be cancelled.
+    pub fn get_export_token(&self) -> CancellationToken {
+        self.export_suppression_token.read().unwrap().child_token()
     }
 
     /// Get a guard that will decrement the counter when dropped.
@@ -696,5 +741,161 @@ mod tests {
 
         assert!(!tracker.has_setup_task(&p0));
         assert!(tracker.get_setup_task(&p0).is_none());
+    }
+
+    // ============================================
+    // EXPORT SUPPRESSION TOKEN TESTS
+    // ============================================
+
+    #[test]
+    fn test_export_token_not_cancelled_on_new_tracker() {
+        let tracker = RebalanceTracker::new();
+        let token = tracker.get_export_token();
+        assert!(
+            !token.is_cancelled(),
+            "Export token should NOT be cancelled on fresh tracker"
+        );
+    }
+
+    #[test]
+    fn test_export_token_cancelled_on_first_rebalance() {
+        let tracker = RebalanceTracker::new();
+
+        // Get child token before rebalance starts
+        let token = tracker.get_export_token();
+        assert!(!token.is_cancelled(), "Token should not be cancelled yet");
+
+        // Start first rebalance (0 -> 1 transition)
+        tracker.start_rebalancing();
+
+        // Token should be cancelled now
+        assert!(
+            token.is_cancelled(),
+            "Export token should be cancelled when first rebalance starts"
+        );
+    }
+
+    #[test]
+    fn test_export_token_stays_cancelled_during_overlapping_rebalances() {
+        let tracker = RebalanceTracker::new();
+
+        // Start first rebalance
+        tracker.start_rebalancing();
+        let token_during_first = tracker.get_export_token();
+        assert!(
+            token_during_first.is_cancelled(),
+            "Token should be cancelled during first rebalance"
+        );
+
+        // Start second overlapping rebalance
+        tracker.start_rebalancing();
+        assert_eq!(tracker.rebalancing_count(), 2);
+
+        // Token should still be cancelled
+        let token_during_second = tracker.get_export_token();
+        assert!(
+            token_during_second.is_cancelled(),
+            "Token should stay cancelled during overlapping rebalances"
+        );
+
+        // First rebalance finishes
+        tracker.finish_rebalancing();
+        assert_eq!(tracker.rebalancing_count(), 1);
+
+        // Token should STILL be cancelled (count is still > 0)
+        let token_after_first_finish = tracker.get_export_token();
+        assert!(
+            token_after_first_finish.is_cancelled(),
+            "Token should stay cancelled while any rebalance is in progress"
+        );
+    }
+
+    #[test]
+    fn test_export_token_refreshed_when_all_rebalances_complete() {
+        let tracker = RebalanceTracker::new();
+
+        // Get initial token
+        let initial_token = tracker.get_export_token();
+        assert!(!initial_token.is_cancelled());
+
+        // Start and complete a rebalance
+        tracker.start_rebalancing();
+        assert!(initial_token.is_cancelled(), "Token cancelled on rebalance");
+
+        tracker.finish_rebalancing();
+
+        // Initial token should STILL be cancelled (it's a child of the old cancelled token)
+        assert!(
+            initial_token.is_cancelled(),
+            "Old child tokens stay cancelled after refresh"
+        );
+
+        // But NEW tokens should NOT be cancelled
+        let new_token = tracker.get_export_token();
+        assert!(
+            !new_token.is_cancelled(),
+            "New tokens should not be cancelled after all rebalances complete"
+        );
+    }
+
+    #[test]
+    fn test_export_token_multiple_rebalance_cycles() {
+        let tracker = RebalanceTracker::new();
+
+        // Cycle 1
+        let token1 = tracker.get_export_token();
+        tracker.start_rebalancing();
+        assert!(token1.is_cancelled());
+        tracker.finish_rebalancing();
+
+        // After cycle 1, new token should work
+        let token2 = tracker.get_export_token();
+        assert!(!token2.is_cancelled());
+
+        // Cycle 2
+        tracker.start_rebalancing();
+        assert!(token2.is_cancelled());
+        tracker.finish_rebalancing();
+
+        // After cycle 2, new token should work
+        let token3 = tracker.get_export_token();
+        assert!(!token3.is_cancelled());
+    }
+
+    #[test]
+    fn test_export_token_child_inherits_cancelled_state() {
+        let tracker = RebalanceTracker::new();
+
+        // Start rebalance to cancel the token
+        tracker.start_rebalancing();
+
+        // Child tokens obtained during rebalance should already be cancelled
+        let child = tracker.get_export_token();
+        assert!(
+            child.is_cancelled(),
+            "Child tokens obtained during rebalance should be pre-cancelled"
+        );
+    }
+
+    #[test]
+    fn test_export_token_with_guard() {
+        let tracker = Arc::new(RebalanceTracker::new());
+
+        let token = tracker.get_export_token();
+        assert!(!token.is_cancelled());
+
+        tracker.start_rebalancing();
+        {
+            let _guard = tracker.rebalancing_guard();
+            // Token cancelled during rebalance
+            assert!(token.is_cancelled());
+        } // guard drops, calls finish_rebalancing
+
+        // Token should STAY cancelled (it was a child of the old parent)
+        assert!(token.is_cancelled());
+
+        // New token should NOT be cancelled
+        let new_token = tracker.get_export_token();
+        assert!(!new_token.is_cancelled());
     }
 }

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -718,7 +718,7 @@ async fn test_export_cancellation_via_minio() -> Result<()> {
 
     let start = Instant::now();
     let result = worker_1
-        .checkpoint_partition_cancellable(&store, None, Some(&pre_cancelled_token))
+        .checkpoint_partition_cancellable(&store, None, Some(&pre_cancelled_token), Some("test"))
         .await;
     let elapsed = start.elapsed();
 
@@ -849,7 +849,7 @@ async fn test_export_cancellation_via_minio() -> Result<()> {
 
     let active_token = CancellationToken::new();
     let result = worker_3
-        .checkpoint_partition_cancellable(&store, None, Some(&active_token))
+        .checkpoint_partition_cancellable(&store, None, Some(&active_token), None)
         .await?;
 
     assert!(
@@ -961,7 +961,7 @@ async fn test_export_mid_upload_cancellation() -> Result<()> {
 
     let start = Instant::now();
     let result = worker
-        .checkpoint_partition_cancellable(&store, None, Some(&cancel_token))
+        .checkpoint_partition_cancellable(&store, None, Some(&cancel_token), Some("test"))
         .await;
     let elapsed = start.elapsed();
 

--- a/rust/kafka-deduplicator/tests/checkpoint_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_tests.rs
@@ -626,7 +626,7 @@ async fn test_checkpoint_with_pre_cancelled_token_fails() {
 
     // Checkpoint should fail with cancellation error
     let result = worker
-        .checkpoint_partition_cancellable(&store, None, Some(&cancel_token))
+        .checkpoint_partition_cancellable(&store, None, Some(&cancel_token), Some("test"))
         .await;
 
     assert!(result.is_err(), "Checkpoint should fail when pre-cancelled");
@@ -694,7 +694,7 @@ async fn test_checkpoint_with_active_token_succeeds() {
 
     // Checkpoint should succeed with active token
     let result = worker
-        .checkpoint_partition_cancellable(&store, None, Some(&cancel_token))
+        .checkpoint_partition_cancellable(&store, None, Some(&cancel_token), None)
         .await;
 
     assert!(


### PR DESCRIPTION
## Problem
We need to use our S3 bandwidth carefully and prioritize imports when a rebalance is triggered over export activity that may be inflight
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* More aggressive cancellation of in-flight export work during pause-resume rebalance cycles
* Related updates to test suites & coverage
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
