### PR TITLE
fix(sql-editor): do not reload queries

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
@@ -6,6 +6,7 @@ import type { editor as importedEditor } from 'monaco-editor'
 import { useMemo, useRef, useState } from 'react'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { DatabaseTree } from '~/layout/panel-layout/DatabaseTree/DatabaseTree'
@@ -125,6 +126,8 @@ export function EditorScene({ tabId }: { tabId?: string }): JSX.Element {
     }
 
     const { loadData } = useActions(dataNodeLogic(dataNodeLogicProps))
+
+    useAttachedLogic(dataNodeLogic(dataNodeLogicProps), logic)
 
     const variablesLogicProps: VariablesLogicProps = {
         key: dataVisualizationLogicProps.key,

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -1281,17 +1281,11 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                         insight.query &&
                         !searchParams.open_query
                     ) {
-                        dataNodeLogic({
-                            key: values.dataLogicKey,
-                            query: (insight.query as DataVisualizationNode).source,
-                        }).mount()
+                        const mountedDataLogic = dataNodeLogic.findMounted({ key: values.dataLogicKey })
+                        const response = mountedDataLogic?.values.response
+                        const responseLoading = mountedDataLogic?.values.responseLoading ?? false
 
-                        const response = dataNodeLogic({
-                            key: values.dataLogicKey,
-                            query: (insight.query as DataVisualizationNode).source,
-                        }).values.response
-
-                        if (!response) {
+                        if (!responseLoading && !response) {
                             actions.runQuery()
                         }
                     } else {


### PR DESCRIPTION
## Problem

We seem to cancel running SQL queries when switching between SQL editor tabs.

## Changes

Fixes that by
- attaching the dataNodeLogic to the multiTabEditorLogic
- reusing a data node instead of creating a new one (probably fixing a leak in the process)

## How did you test this code?

Turned on the "slug throttle" (1kbit/sec) and made 2 queries in 2 tabs. They were not cancelled. They also ran one after the other (the 2nd SQL query I started waited for the first to finish)

![2026-02-05 01 38 12](https://github.com/user-attachments/assets/dfb8f6ec-454f-4061-be05-c1e42593a9d4)
