### PR TITLE
feat(flags): add /_startup endpoint for database connection warmup

### DIFF
--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -332,8 +332,16 @@ pub async fn startup(database_pools: Arc<DatabasePools>) -> &'static str {
     // Always warm up non-persons pools
     let skip_query = database_pools.test_before_acquire;
     let (reader_result, writer_result) = tokio::join!(
-        test_pool_connection(&database_pools.non_persons_reader, "non_persons_reader", skip_query),
-        test_pool_connection(&database_pools.non_persons_writer, "non_persons_writer", skip_query),
+        test_pool_connection(
+            &database_pools.non_persons_reader,
+            "non_persons_reader",
+            skip_query
+        ),
+        test_pool_connection(
+            &database_pools.non_persons_writer,
+            "non_persons_writer",
+            skip_query
+        ),
     );
 
     // Only warm up persons pools if they're distinct (not aliased)

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -19,6 +19,7 @@ use common_metrics::{setup_metrics_recorder, track_metrics};
 use common_redis::Client as RedisClient;
 use health::HealthRegistry;
 use metrics::gauge;
+use sqlx::PgPool;
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::{
     cors::{AllowHeaders, AllowOrigin, CorsLayer},
@@ -166,14 +167,21 @@ pub fn router(
         .allow_credentials(true)
         .allow_origin(AllowOrigin::mirror_request());
 
-    // liveness/readiness checks
+    // Clone database_pools for the startup route
+    let db_pools_for_startup = state.database_pools.clone();
+
+    // liveness/readiness/startup checks
     let status_router = Router::new()
         .route("/", get(index))
         .route(
             "/_readiness",
             get(move || readiness(db_pools_for_readiness.clone())),
         )
-        .route("/_liveness", get(move || ready(liveness.get_status())));
+        .route("/_liveness", get(move || ready(liveness.get_status())))
+        .route(
+            "/_startup",
+            get(move || startup(db_pools_for_startup.clone())),
+        );
 
     // flags endpoint
     // IP rate limiting is now handled in the endpoint handler for better control and log-only mode support
@@ -257,10 +265,29 @@ fn spawn_rate_limiter_cleanup_task(
     });
 }
 
+/// Tests a single database pool by acquiring a connection and optionally running a test query.
+///
+/// When `skip_query` is true (because `test_before_acquire` is enabled), only connection
+/// acquisition is tested since sqlx already validates connections on acquire.
+async fn test_pool_connection(pool: &PgPool, name: &str, skip_query: bool) -> Result<(), String> {
+    let mut conn = pool
+        .acquire()
+        .await
+        .map_err(|e| format!("{name} pool unavailable: {e}"))?;
+
+    if !skip_query {
+        sqlx::query("SELECT 1")
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| format!("{name} connection test failed: {e}"))?;
+    }
+
+    Ok(())
+}
+
 pub async fn readiness(
     database_pools: Arc<DatabasePools>,
 ) -> Result<&'static str, (StatusCode, String)> {
-    // Check all pools and collect errors
     let pools = [
         ("non_persons_reader", &database_pools.non_persons_reader),
         ("non_persons_writer", &database_pools.non_persons_writer),
@@ -269,25 +296,9 @@ pub async fn readiness(
     ];
 
     for (name, pool) in pools {
-        let mut conn = pool.acquire().await.map_err(|e| {
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                format!("{name} pool unavailable: {e}"),
-            )
-        })?;
-
-        // If test_before_acquire is false, explicitly test the connection
-        if !database_pools.test_before_acquire {
-            sqlx::query("SELECT 1")
-                .execute(&mut *conn)
-                .await
-                .map_err(|e| {
-                    (
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        format!("{name} connection test failed: {e}"),
-                    )
-                })?;
-        }
+        test_pool_connection(pool, name, database_pools.test_before_acquire)
+            .await
+            .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e))?;
     }
 
     Ok("ready")
@@ -295,4 +306,179 @@ pub async fn readiness(
 
 pub async fn index() -> &'static str {
     "feature flags"
+}
+
+/// Startup probe for Kubernetes.
+///
+/// Warms up database connection pools by acquiring and testing connections.
+/// This ensures the first user request doesn't pay connection establishment latency.
+///
+/// Always returns 200 OK - warmup failures are logged but don't block startup.
+/// This preserves the resilience of lazy pool initialization: if the DB is temporarily
+/// unavailable at startup, the pod still starts and will connect on first request.
+pub async fn startup(database_pools: Arc<DatabasePools>) -> &'static str {
+    // Check if persons pools are aliased to non-persons pools
+    // (this happens when persons_db_routing is disabled)
+    let persons_reader_is_distinct = !Arc::ptr_eq(
+        &database_pools.non_persons_reader,
+        &database_pools.persons_reader,
+    );
+    let persons_writer_is_distinct = !Arc::ptr_eq(
+        &database_pools.non_persons_writer,
+        &database_pools.persons_writer,
+    );
+
+    // Best-effort warmup: try pools in parallel, log failures, never block startup
+    // Always warm up non-persons pools
+    let skip_query = database_pools.test_before_acquire;
+    let (reader_result, writer_result) = tokio::join!(
+        test_pool_connection(&database_pools.non_persons_reader, "non_persons_reader", skip_query),
+        test_pool_connection(&database_pools.non_persons_writer, "non_persons_writer", skip_query),
+    );
+
+    // Only warm up persons pools if they're distinct (not aliased)
+    let (persons_reader_result, persons_writer_result) = tokio::join!(
+        async {
+            if persons_reader_is_distinct {
+                test_pool_connection(&database_pools.persons_reader, "persons_reader", skip_query)
+                    .await
+            } else {
+                Ok(()) // Already warmed via non_persons_reader
+            }
+        },
+        async {
+            if persons_writer_is_distinct {
+                test_pool_connection(&database_pools.persons_writer, "persons_writer", skip_query)
+                    .await
+            } else {
+                Ok(()) // Already warmed via non_persons_writer
+            }
+        },
+    );
+
+    // Log results
+    log_warmup_result("non_persons_reader", reader_result);
+    log_warmup_result("non_persons_writer", writer_result);
+
+    if persons_reader_is_distinct {
+        log_warmup_result("persons_reader", persons_reader_result);
+    } else {
+        tracing::info!("persons_reader is aliased to non_persons_reader, already warmed");
+    }
+
+    if persons_writer_is_distinct {
+        log_warmup_result("persons_writer", persons_writer_result);
+    } else {
+        tracing::info!("persons_writer is aliased to non_persons_writer, already warmed");
+    }
+
+    "started"
+}
+
+fn log_warmup_result(name: &str, result: Result<(), String>) {
+    match result {
+        Ok(()) => tracing::info!("{name} pool warmed up successfully"),
+        Err(e) => tracing::warn!("{name} warmup failed (will connect on first use): {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_pool_connection_success() {
+        // This test requires a running database
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or("postgres://posthog:posthog@localhost:5432/test_database".to_string());
+
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy(&database_url)
+            .expect("Failed to create pool");
+
+        let result = test_pool_connection(&pool, "test_pool", false).await;
+
+        // If database is available, connection test should succeed
+        // If not, it will fail - both are acceptable in test environment
+        // This test primarily verifies the function doesn't panic
+        match result {
+            Ok(()) => {
+                // Pool connection test succeeded
+            }
+            Err(e) => {
+                // Expected when no database is running
+                assert!(e.contains("test_pool"));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pool_connection_failure_includes_pool_name() {
+        // Create a pool with an invalid connection string
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(std::time::Duration::from_millis(100))
+            .connect_lazy("postgres://invalid:invalid@localhost:54321/nonexistent")
+            .expect("Failed to create pool");
+
+        let result = test_pool_connection(&pool, "test_pool", false).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("test_pool"),
+            "Error should contain pool name: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_startup_always_returns_started() {
+        // Create pools with invalid connection strings to simulate DB unavailability
+        let invalid_pool = Arc::new(
+            sqlx::postgres::PgPoolOptions::new()
+                .max_connections(1)
+                .acquire_timeout(std::time::Duration::from_millis(100))
+                .connect_lazy("postgres://invalid:invalid@localhost:54321/nonexistent")
+                .expect("Failed to create pool"),
+        );
+
+        let database_pools = Arc::new(DatabasePools {
+            non_persons_reader: invalid_pool.clone(),
+            non_persons_writer: invalid_pool.clone(),
+            persons_reader: invalid_pool.clone(),
+            persons_writer: invalid_pool,
+            test_before_acquire: false,
+        });
+
+        // Startup should always return "started" even if warmup fails
+        let result = startup(database_pools).await;
+        assert_eq!(result, "started");
+    }
+
+    #[tokio::test]
+    async fn test_startup_with_aliased_pools() {
+        // Simulate the common case where persons pools are aliased to non-persons pools
+        // (when persons_db_routing is disabled)
+        let shared_pool = Arc::new(
+            sqlx::postgres::PgPoolOptions::new()
+                .max_connections(1)
+                .acquire_timeout(std::time::Duration::from_millis(100))
+                .connect_lazy("postgres://invalid:invalid@localhost:54321/nonexistent")
+                .expect("Failed to create pool"),
+        );
+
+        // Both persons pools point to the same Arc as non-persons pools
+        let database_pools = Arc::new(DatabasePools {
+            non_persons_reader: shared_pool.clone(),
+            non_persons_writer: shared_pool.clone(),
+            persons_reader: shared_pool.clone(), // Aliased to non_persons_reader
+            persons_writer: shared_pool,         // Aliased to non_persons_writer
+            test_before_acquire: false,
+        });
+
+        // Startup should still return "started" and handle aliased pools gracefully
+        let result = startup(database_pools).await;
+        assert_eq!(result, "started");
+    }
 }


### PR DESCRIPTION
## Problem

With lazy pool initialization (#46606), the first user request pays connection establishment latency (~50-100ms). We need a way to warm up pools before traffic arrives.

## Changes

- Add dedicated `/_startup` probe endpoint for database connection pool warmup
- Warms all 4 pools in parallel (best-effort)
- Logs success/failure for each pool for observability
- Always returns 200 OK to preserve lazy pool resilience—if DB is temporarily unavailable at startup, the pod still starts and will connect on first request (_This ensures high load won't cause new pods to not deploy considering the reason we're deploying them might be to handle the high load._)

This follows Kubernetes probe best practices:
- `/_startup`: "Has the app finished initializing?" (run once at startup)
- `/_readiness`: "Should traffic route here?" (continuous)
- `/_liveness`: "Is the process alive?" (continuous)

## How did you test this code?

- Added unit tests for `startup()` and `warmup_pool()` functions
- Manual verification with `curl -i http://localhost:3001/_startup`

## Publish to changelog?

Do not publish to changelog

## Follow-up

Once this is deployed, I can update charts to start using it before we merge #46606.