### PR TITLE
fix(duckling): use UBIGINT for person_version to match ClickHouse UInt64

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -191,6 +191,7 @@ CREATE TABLE IF NOT EXISTS {catalog}.posthog.events (
 
 # SQL for creating the persons table in DuckLake if it doesn't exist
 # Uses TIMESTAMPTZ because ClickHouse exports DateTime64 as TIMESTAMP WITH TIME ZONE in Parquet.
+# Note: person_version uses UBIGINT to match ClickHouse's UInt64 type.
 PERSONS_TABLE_DDL = """
 CREATE TABLE IF NOT EXISTS {catalog}.posthog.persons (
     team_id BIGINT,
@@ -200,7 +201,7 @@ CREATE TABLE IF NOT EXISTS {catalog}.posthog.persons (
     created_at TIMESTAMPTZ,
     is_identified BOOLEAN,
     person_distinct_id_version BIGINT,
-    person_version BIGINT,
+    person_version UBIGINT,
     _timestamp TIMESTAMPTZ,
     _inserted_at TIMESTAMPTZ
 )


### PR DESCRIPTION
## Summary

Use `UBIGINT` in DuckLake DDL for `person_version` to match ClickHouse's `UInt64` type.

## Problem

DuckLake's `ducklake_add_data_files` was failing with:
```
Expected one of BIGINT, UINTEGER, INTEGER, USMALLINT, SMALLINT, UTINYINT, TINYINT, found type UBIGINT
```

ClickHouse's `person.version` column is `UInt64`, which exports as `UBIGINT` in Parquet, but the DuckLake table had `BIGINT`.

## Solution

Changed `person_version` from `BIGINT` to `UBIGINT` in the persons table DDL to match the Parquet output.

## Test plan

- [x] All 62 unit tests pass
- [ ] Re-run failed persons backfill partitions with `delete_tables=True`

🤖 Generated with [Claude Code](https://claude.ai/code)