### PR TITLE
fix(duckling): remove S3 file cleanup that corrupts DuckLake catalog

### DIFF
--- a/posthog/dags/README_DUCKLINGS.md
+++ b/posthog/dags/README_DUCKLINGS.md
@@ -100,7 +100,7 @@ class DucklingBackfillConfig:
     clickhouse_settings: dict | None = None  # Custom ClickHouse settings
     skip_ducklake_registration: bool = False  # Export to S3 only
     skip_schema_validation: bool = False      # Skip pre-flight schema check
-    cleanup_prior_run_files: bool = True      # Remove orphaned files from failed runs
+    cleanup_existing_partition_data: bool = True  # Delete existing DuckLake data before re-processing
     create_tables_if_missing: bool = True     # Auto-create events/persons tables
     delete_tables: bool = False               # DANGER: Drop and recreate tables
     dry_run: bool = False                     # Preview mode, no writes
@@ -137,7 +137,7 @@ The job logs warnings if the duckling table schema differs from expected columns
 
 ### Orphaned files in S3
 
-Failed runs may leave orphaned Parquet files. The `cleanup_prior_run_files` option (enabled by default) removes these on the next successful run for that partition.
+Failed runs may leave orphaned Parquet files in S3. These files are harmless - each run writes to a unique path based on the run ID, and the `cleanup_existing_partition_data` option ensures DuckLake data is cleaned up via DELETE before re-processing. Do NOT delete S3 files that may have been registered with DuckLake, as this causes catalog corruption.
 
 ### Table creation race condition
 


### PR DESCRIPTION
## Summary

- Removes `cleanup_prior_run_files` and `cleanup_full_export_files` functions that delete S3 parquet files during backfill retries
- Removes the `cleanup_prior_run_files` config option from `DucklingBackfillConfig`
- Removes `boto3` and `botocore` imports that were only used by these functions

**Problem:** When a duckling backfill run partially succeeds (exports + registers some files with DuckLake, then fails), the retry run's S3 file cleanup step deletes those already-registered parquet files. This leaves DuckLake with dangling references, corrupting the catalog and breaking queries.

**Solution:** The existing `cleanup_existing_partition_data` mechanism (DELETE SQL via DuckLake) is the correct way to handle idempotent re-processing — it cleanly removes data from the catalog before re-registering. Orphaned S3 files from failed runs are harmless since each run writes to a unique path based on run ID.

## Test plan

- [ ] Verify `ruff check` passes (confirmed locally)
- [ ] Verify existing duckling backfill tests pass
- [ ] Confirm retry runs no longer delete S3 files, relying on `cleanup_existing_partition_data` (DuckLake DELETE) for idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)