### PR TITLE
fix(duckling): skip existing partitions in full backfill sensor

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1833,7 +1833,6 @@ def duckling_full_backfill_sensor(context: SensorEvaluationContext) -> SensorRes
             run_requests.append(
                 RunRequest(
                     partition_key=partition_key,
-                    run_key=f"{partition_key}_full_backfill",
                 )
             )
             current_month = month


### PR DESCRIPTION
## Summary

- Removes deterministic `run_key` from `duckling_full_backfill_sensor` RunRequests

**Problem:** The sensor used `run_key=f"{partition_key}_full_backfill"` which is deterministic per partition. Dagster deduplicates run requests by `run_key` forever — once a run_key is used, it can never schedule another run with that key. If the sensor cursor drifts back (e.g., cursor didn't persist after a prior tick), the sensor re-generates the same partition keys and run_keys. Partitions get added (idempotent), but runs get silently dropped (deduplicated). Result: partitions exist but no runs are scheduled.

**Fix:** Remove `run_key` so Dagster always creates runs. Cursor advancement prevents duplicates in normal operation. The jobs are idempotent anyway (via `cleanup_existing_partition_data`).

## Test plan

- [ ] Preview tick in Dagster UI with the stuck cursor — should now show run requests alongside partition adds
- [ ] Verify `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)