### PR TITLE
Add customizable back button text for multi-step surveys

### DIFF
--- a/frontend/src/queries/schema/schema-surveys.ts
+++ b/frontend/src/queries/schema/schema-surveys.ts
@@ -96,6 +96,7 @@ export interface SurveyAppearanceSchema {
     thankYouMessageDescription?: string
     thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType
     thankYouMessageCloseButtonText?: string
+    backButtonText?: string
     shuffleQuestions?: boolean
     surveyPopupDelaySeconds?: number
     widgetType?: SurveyWidgetType

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -88,6 +88,7 @@ export const defaultSurveyAppearance = {
     borderRadius: '10px',
     shuffleQuestions: false,
     surveyPopupDelaySeconds: undefined,
+    backButtonText: 'Back',
 } as const satisfies SurveyAppearance
 
 export const defaultSurveyFieldValues = {

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceModal.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceModal.tsx
@@ -10,6 +10,7 @@ import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { defaultSurveyAppearance } from 'scenes/surveys/constants'
 import {
+    SurveyButtonTextAppearance,
     SurveyColorsAppearance,
     SurveyContainerAppearance,
 } from 'scenes/surveys/survey-appearance/SurveyAppearanceSections'
@@ -193,6 +194,16 @@ export function SurveyAppearanceModal({
                             customizeRatingButtons={hasRatingButtons}
                             customizePlaceholderText={hasPlaceholderText}
                         />
+                        {survey.questions.length > 1 && (
+                            <>
+                                <LemonDivider />
+                                <SurveyButtonTextAppearance
+                                    appearance={survey.appearance || defaultSurveyAppearance}
+                                    onAppearanceChange={onAppearanceChange}
+                                    validationErrors={validationErrors}
+                                />
+                            </>
+                        )}
                     </div>
                     <SurveyPreview
                         survey={survey}

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
@@ -304,3 +304,20 @@ export function SurveyColorsAppearance({
         </SurveyOptionsGroup>
     )
 }
+
+export function SurveyButtonTextAppearance({
+    appearance,
+    onAppearanceChange,
+}: CommonProps): JSX.Element {
+    return (
+        <SurveyOptionsGroup sectionTitle="Button text customization">
+            <SurveyAppearanceInput
+                value={appearance.backButtonText}
+                onChange={(backButtonText) => onAppearanceChange({ backButtonText })}
+                label="Back button text"
+                placeholder="Back"
+                info="Customize the text shown on the back button in multi-step surveys. Useful for localization."
+            />
+        </SurveyOptionsGroup>
+    )
+}

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.tsx
@@ -8,6 +8,7 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { defaultSurveyAppearance } from 'scenes/surveys/constants'
 import { SurveyAppearanceModal } from 'scenes/surveys/survey-appearance/SurveyAppearanceModal'
 import {
+    SurveyButtonTextAppearance,
     SurveyColorsAppearance,
     SurveyContainerAppearance,
 } from 'scenes/surveys/survey-appearance/SurveyAppearanceSections'
@@ -68,6 +69,16 @@ export function Customization({
                     customizeRatingButtons={hasRatingButtons}
                     customizePlaceholderText={hasPlaceholderText}
                 />
+                {survey.questions.length > 1 && (
+                    <>
+                        <LemonDivider />
+                        <SurveyButtonTextAppearance
+                            appearance={surveyAppearance}
+                            onAppearanceChange={onAppearanceChange}
+                            validationErrors={validationErrors}
+                        />
+                    </>
+                )}
                 <LemonDivider />
                 <div className="flex flex-col gap-1">
                     <LemonCheckbox

--- a/frontend/src/scenes/surveys/surveyActivityDescriber.tsx
+++ b/frontend/src/scenes/surveys/surveyActivityDescriber.tsx
@@ -182,6 +182,7 @@ const surveyActionsMapping: Record<
             thankYouMessageDescription: 'thank you message description',
             thankYouMessageDescriptionContentType: 'thank you message content type',
             thankYouMessageCloseButtonText: 'thank you message close button text',
+            backButtonText: 'back button text',
             autoDisappear: 'auto-disappear option',
             position: 'survey position',
             tabPosition: 'survey button position',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3613,6 +3613,8 @@ export interface SurveyAppearance {
     thankYouMessageDescription?: string
     thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType
     thankYouMessageCloseButtonText?: string
+    // Custom text for the back button on multi-step surveys. Defaults to "Back".
+    backButtonText?: string
     autoDisappear?: boolean
     position?: SurveyPosition
     tabPosition?: SurveyTabPosition


### PR DESCRIPTION
## Problem

Multi-step surveys need localization support for the back button text. Currently, the back button uses a hardcoded "Back" label, which doesn't support different languages or custom messaging.

## Changes

- Added `backButtonText` property to `SurveyAppearance` interface with a default value of "Back"
- Created new `SurveyButtonTextAppearance` component for customizing button text in the appearance editor
- Integrated button text customization into both `SurveyAppearanceModal` and `SurveyCustomization` components
- Only displays the back button customization section when surveys have multiple questions
- Updated survey activity describer to track changes to `backButtonText`

## How did you test this code?

- Verified the new `backButtonText` field is properly initialized with the default value
- Confirmed the customization UI only appears for multi-step surveys (2+ questions)
- Checked that the appearance changes are properly tracked in survey activity logs
- Validated the component integrations in both modal and customization views

## Publish to changelog?

Yes - this adds a new feature for survey localization and customization.

https://claude.ai/code/session_016DYUpwucmazPvNBNZHyB5b