### PR TITLE
feat: add copy to clipboard in early access features

### DIFF
--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -678,7 +678,7 @@ function PersonsTableByFilter({ recordingsFilters, properties }: PersonsTableByF
             columns: {
                 person_display_name: {
                     render: ({ value }) => {
-                        const person = value as { id: string; distinct_id: string; display_name: string }
+                        const person = value as { id: string; display_name: string }
                         return (
                             <CopyToClipboardInline
                                 explicitValue={person.display_name}
@@ -687,7 +687,7 @@ function PersonsTableByFilter({ recordingsFilters, properties }: PersonsTableByF
                             >
                                 <PersonDisplay
                                     withIcon
-                                    person={{ id: person.id, distinct_id: person.distinct_id }}
+                                    person={{ id: person.id }}
                                     displayName={person.display_name}
                                     noPopover
                                 />

--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { router } from 'kea-router'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { IconFlag, IconQuestion, IconTrash, IconX } from '@posthog/icons'
 import {
@@ -15,6 +15,7 @@ import {
     Link,
 } from '@posthog/lemon-ui'
 
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { FlagSelector } from 'lib/components/FlagSelector'
 import { NotFound } from 'lib/components/NotFound'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
@@ -27,6 +28,7 @@ import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { JSONEditorInput } from 'scenes/feature-flags/JSONEditorInput'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
+import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -44,6 +46,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { Query } from '~/queries/Query/Query'
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { Node, NodeKind, ProductIntentContext, ProductKey, QuerySchema } from '~/queries/schema/schema-general'
+import { QueryContext } from '~/queries/types'
 import {
     CyclotronJobFiltersType,
     EarlyAccessFeatureStage,
@@ -670,6 +673,33 @@ function PersonsTableByFilter({ recordingsFilters, properties }: PersonsTableByF
 
     const { addProductIntentForCrossSell } = useActions(teamLogic)
 
+    const context: QueryContext = useMemo(
+        () => ({
+            columns: {
+                person_display_name: {
+                    render: ({ value }) => {
+                        const person = value as { id: string; distinct_id: string; display_name: string }
+                        return (
+                            <CopyToClipboardInline
+                                explicitValue={person.display_name}
+                                iconSize="small"
+                                iconStyle={{ color: 'var(--color-accent)' }}
+                            >
+                                <PersonDisplay
+                                    withIcon
+                                    person={{ id: person.id, distinct_id: person.distinct_id }}
+                                    displayName={person.display_name}
+                                    noPopover
+                                />
+                            </CopyToClipboardInline>
+                        )
+                    },
+                },
+            },
+        }),
+        []
+    )
+
     return (
         <div className="relative">
             {/* NOTE: This is a bit of a placement hack - ideally we would be able to add it to the Query */}
@@ -689,7 +719,7 @@ function PersonsTableByFilter({ recordingsFilters, properties }: PersonsTableByF
                     View recordings
                 </LemonButton>
             </div>
-            <Query query={query} setQuery={setQuery} />
+            <Query query={query} setQuery={setQuery} context={context} />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

When working with Early access features you often want to contact the early adopters but for that you need to open each person

## Changes

Add a button to copy email

#### Before
<img width="844" height="366" alt="Screenshot 2026-02-05 at 8 48 09" src="https://github.com/user-attachments/assets/52f91b93-d290-48c9-acdb-6017c3f4245f" />

#### After
<img width="496" height="310" alt="Screenshot 2026-02-05 at 9 09 46" src="https://github.com/user-attachments/assets/3dc14721-c367-40fa-b210-09ad49457f54" />
