### PR TITLE
fix(persons): allow split ID modal to be closed

### DIFF
--- a/frontend/src/scenes/persons/MergeSplitPerson.tsx
+++ b/frontend/src/scenes/persons/MergeSplitPerson.tsx
@@ -1,82 +1,83 @@
-import { BindLogic, useActions, useValues } from 'kea'
+                import { BindLogic, useActions, useValues } from 'kea'
 
-import { LemonButton, LemonModal, LemonSelect } from '@posthog/lemon-ui'
+                import { LemonButton, LemonModal, LemonSelect } from '@posthog/lemon-ui'
 
-import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
-import { pluralize } from 'lib/utils'
+                import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+                import { pluralize } from 'lib/utils'
 
-import { PersonType } from '~/types'
+                import { PersonType } from '~/types'
 
-import { mergeSplitPersonLogic } from './mergeSplitPersonLogic'
-import { personsLogic } from './personsLogic'
+                import { mergeSplitPersonLogic } from './mergeSplitPersonLogic'
+                import { personsLogic } from './personsLogic'
 
-export function MergeSplitPerson({ person }: { person: PersonType }): JSX.Element {
-    const { urlId } = useValues(personsLogic)
-    const logicProps = { person, urlId: urlId ?? '' }
-    const { executedLoading } = useValues(mergeSplitPersonLogic(logicProps))
-    const { execute, cancel } = useActions(mergeSplitPersonLogic(logicProps))
+                export function MergeSplitPerson({ person, onClose }: { person: PersonType; onClose: () => void }): JSX.Element {
 
-    return (
-        <LemonModal
-            isOpen
-            width="40rem"
-            title="Split persons"
-            footer={
-                <div className="flex items-center gap-2">
-                    <LemonButton onClick={cancel} disabledReason={executedLoading && 'Splitting the user'}>
-                        Cancel
-                    </LemonButton>
-                    <LemonButton type="primary" onClick={execute} loading={executedLoading}>
-                        Split persons
-                    </LemonButton>
-                </div>
-            }
-            onClose={cancel}
-        >
-            {person.distinct_ids.length < 2 ? (
-                'Only persons with more than two distinct IDs can be split.'
-            ) : (
-                <BindLogic logic={mergeSplitPersonLogic} props={logicProps}>
-                    <SplitPerson />
-                </BindLogic>
-            )}
-        </LemonModal>
-    )
-}
+                    const { urlId, splitMergeModalShown } = useValues(personsLogic)
+                    const logicProps = { person, urlId: urlId ?? '' }
+                    const { executedLoading } = useValues(mergeSplitPersonLogic(logicProps))
+                    const { execute, cancel } = useActions(mergeSplitPersonLogic(logicProps))
 
-function SplitPerson(): JSX.Element | null {
-    const { person, selectedPersonToAssignSplit, executedLoading } = useValues(mergeSplitPersonLogic)
-    const { setSelectedPersonToAssignSplit } = useActions(mergeSplitPersonLogic)
+                    return (
+                        <LemonModal
+                            isOpen={splitMergeModalShown}  
+                            width="40rem"
+                            title="Split persons"
+                            footer={
+                                <div className="flex items-center gap-2">
+                                    <LemonButton onClick={onClose} disabledReason={executedLoading && 'Splitting the user'}>
+                                        Cancel
+                                    </LemonButton>
+                                    <LemonButton type="primary" onClick={execute} loading={executedLoading}>
+                                        Split persons
+                                    </LemonButton>
+                                </div>
+                            }
+                            onClose={onClose}
+                        >
+                            {person.distinct_ids.length < 2 ? (
+                                'Only persons with more than two distinct IDs can be split.'
+                            ) : (
+                                <BindLogic logic={mergeSplitPersonLogic} props={logicProps}>
+                                    <SplitPerson />
+                                </BindLogic>
+                            )}
+                        </LemonModal>
+                    )
+                }
 
-    if (!person) {
-        return null
-    }
+                function SplitPerson(): JSX.Element | null {
+                    const { person, selectedPersonToAssignSplit, executedLoading } = useValues(mergeSplitPersonLogic)
+                    const { setSelectedPersonToAssignSplit } = useActions(mergeSplitPersonLogic)
 
-    const options = person.distinct_ids.map((distinctId: string) => ({
-        label: distinctId,
-        value: distinctId,
-    }))
+                    if (!person) {
+                        return null
+                    }
 
-    return (
-        <>
-            <p>This will split all Distinct IDs for this person into unique persons.</p>
-            <p>
-                You can select a distinct ID for which all the current properties will be assigned (<i>optional</i>).
-                All other new users will start without any properties.
-            </p>
-            <LemonSelect
-                fullWidth
-                options={options}
-                placeholder="Select a distinct ID to which to assign all properties (optional)"
-                disabledReason={executedLoading && 'Splitting user'}
-                value={selectedPersonToAssignSplit}
-                onChange={(value) => setSelectedPersonToAssignSplit(value as string)}
-            />
-            <LemonBanner type="warning" className="mt-4">
-                This will create <strong>{person.distinct_ids.length - 1}</strong>{' '}
-                {pluralize(person.distinct_ids.length - 1, 'new person', undefined, false)}. This might change the
-                numbers in your charts, even historically. Please be certain.
-            </LemonBanner>
-        </>
-    )
-}
+                    const options = person.distinct_ids.map((distinctId: string) => ({
+                        label: distinctId,
+                        value: distinctId,
+                    }))
+
+                    return (
+                        <>
+                            <p>This will split all Distinct IDs for this person into unique persons.</p>
+                            <p>
+                                You can select a distinct ID for which all the current properties will be assigned (<i>optional</i>).
+                                All other new users will start without any properties.
+                            </p>
+                            <LemonSelect
+                                fullWidth
+                                options={options}
+                                placeholder="Select a distinct ID to which to assign all properties (optional)"
+                                disabledReason={executedLoading && 'Splitting user'}
+                                value={selectedPersonToAssignSplit}
+                                onChange={(value) => setSelectedPersonToAssignSplit(value as string)}
+                            />
+                            <LemonBanner type="warning" className="mt-4">
+                                This will create <strong>{person.distinct_ids.length - 1}</strong>{' '}
+                                {pluralize(person.distinct_ids.length - 1, 'new person', undefined, false)}. This might change the
+                                numbers in your charts, even historically. Please be certain.
+                            </LemonBanner>
+                        </>
+                    )
+                }

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -416,7 +416,12 @@ export function PersonScene(): JSX.Element | null {
                 ]}
             />
 
-            {splitMergeModalShown && person && <MergeSplitPerson person={person} />}
+            {splitMergeModalShown && person && (
+                <MergeSplitPerson
+                    person={person}
+                    onClose={() => setSplitMergeModalShown(false)}
+                />
+            )}
         </SceneContent>
     )
 }


### PR DESCRIPTION
Description:

Problem: The Split IDs modal was missing an onClose handler, causing it to remain open even when clicking "Cancel" or clicking outside. Fix:

Updated MergeSplitPerson component to accept an onClose prop.

Updated PersonScene to pass the state setter setSplitMergeModalShown(false) to the component.

Related Issue: Fixes #40420 (Split ID modal won't close without refresh)