### PR TITLE
feat: support workflow input for ingestion acceptance tests

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/config.py
+++ b/posthog/temporal/ingestion_acceptance_test/config.py
@@ -19,8 +19,8 @@ class Config(BaseSettings):
     project_api_key: str
     project_id: str
     personal_api_key: str
-    event_timeout_seconds: int = Field(default=90)
-    poll_interval_seconds: float = Field(default=10.0)
+    event_timeout_seconds: int = Field(default=300)
+    poll_interval_seconds: float = Field(default=30.0)
     slack_webhook_url: str | None = Field(default=None)
 
     @field_validator("api_host")

--- a/posthog/temporal/ingestion_acceptance_test/schedule.py
+++ b/posthog/temporal/ingestion_acceptance_test/schedule.py
@@ -1,5 +1,6 @@
 """Schedule for ingestion acceptance test workflow."""
 
+import uuid
 from datetime import timedelta
 
 from django.conf import settings
@@ -23,7 +24,7 @@ async def create_ingestion_acceptance_test_schedule(client: Client) -> None:
         action=ScheduleActionStartWorkflow(
             WORKFLOW_NAME,
             IngestionAcceptanceTestInput(),
-            id=f'{WORKFLOW_NAME}-{{{{.ScheduledTime.Format "2006-01-02T15-04-05"}}}}',
+            id=str(uuid.uuid4()),
             task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
             retry_policy=common.RetryPolicy(
                 maximum_attempts=1,  # Don't retry - we want to know immediately if it fails

--- a/posthog/temporal/ingestion_acceptance_test/schedule.py
+++ b/posthog/temporal/ingestion_acceptance_test/schedule.py
@@ -8,6 +8,7 @@ from temporalio import common
 from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, ScheduleIntervalSpec, ScheduleSpec
 
 from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
+from posthog.temporal.ingestion_acceptance_test.types import IngestionAcceptanceTestInput
 
 SCHEDULE_ID = "ingestion-acceptance-test-schedule"
 WORKFLOW_NAME = "ingestion-acceptance-test"
@@ -21,7 +22,7 @@ async def create_ingestion_acceptance_test_schedule(client: Client) -> None:
     schedule = Schedule(
         action=ScheduleActionStartWorkflow(
             WORKFLOW_NAME,
-            None,  # No inputs required
+            IngestionAcceptanceTestInput(),
             id=f'{WORKFLOW_NAME}-{{{{.ScheduledTime.Format "2006-01-02T15-04-05"}}}}',
             task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
             retry_policy=common.RetryPolicy(

--- a/posthog/temporal/ingestion_acceptance_test/types.py
+++ b/posthog/temporal/ingestion_acceptance_test/types.py
@@ -1,0 +1,13 @@
+"""Types for ingestion acceptance test workflow."""
+
+from pydantic import BaseModel
+
+
+class IngestionAcceptanceTestInput(BaseModel):
+    """Input for the ingestion acceptance test workflow.
+
+    Currently empty as no configuration is needed, but follows the standard
+    pattern for Temporal workflows to allow future extensibility.
+    """
+
+    pass

--- a/posthog/temporal/ingestion_acceptance_test/workflows.py
+++ b/posthog/temporal/ingestion_acceptance_test/workflows.py
@@ -9,6 +9,7 @@ from posthog.temporal.common.base import PostHogWorkflow
 
 with temporalio.workflow.unsafe.imports_passed_through():
     from posthog.temporal.ingestion_acceptance_test.activities import run_ingestion_acceptance_tests
+    from posthog.temporal.ingestion_acceptance_test.types import IngestionAcceptanceTestInput
 
 
 @temporalio.workflow.defn(name="ingestion-acceptance-test")
@@ -20,11 +21,11 @@ class IngestionAcceptanceTestWorkflow(PostHogWorkflow):
     """
 
     @staticmethod
-    def parse_inputs(inputs: list[str]) -> None:
-        return None
+    def parse_inputs(inputs: list[str]) -> IngestionAcceptanceTestInput:
+        return IngestionAcceptanceTestInput.model_validate_json(inputs[0]) if inputs else IngestionAcceptanceTestInput()
 
     @temporalio.workflow.run
-    async def run(self, inputs: None) -> dict:
+    async def run(self, inputs: IngestionAcceptanceTestInput) -> dict:
         """Execute ingestion acceptance tests.
 
         Returns:


### PR DESCRIPTION
## Problem

Scheduling the workflow did not work, likely because of discrepancy on what the input type should be (None/null...).

All other workflows have an input type defined, even if that input contains no actual properties.

## Changes

Create an input type and rely on it.

## How did you test this code?
Manually/unit tests

## Publish to changelog?
