### PR TITLE
feat(logs): decouple filter state from logsSceneLogic into logsViewerFiltersLogic

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/AttributesFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/AttributesFilter.tsx
@@ -5,14 +5,12 @@ import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
 
-import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
-
-import { logsSceneLogic } from '../../../logsSceneLogic'
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
 export const AttributesFilter = (): JSX.Element => {
-    const { filterGroup } = useValues(logsSceneLogic)
-    const { setFilterGroup } = useActions(logsSceneLogic)
-    const { setFilter } = useActions(logsViewerConfigLogic)
+    const { filters } = useValues(logsViewerFiltersLogic)
+    const { filterGroup } = filters
+    const { setFilterGroup } = useActions(logsViewerFiltersLogic)
 
     const rootKey = 'logs'
 
@@ -27,7 +25,6 @@ export const AttributesFilter = (): JSX.Element => {
             ]}
             onChange={(filterGroup) => {
                 setFilterGroup(filterGroup)
-                setFilter('filterGroup', filterGroup)
             }}
         >
             <NestedFilterGroup />
@@ -36,7 +33,7 @@ export const AttributesFilter = (): JSX.Element => {
 }
 
 const NestedFilterGroup = (): JSX.Element => {
-    const { openFilterOnInsert } = useValues(logsSceneLogic)
+    const { openFilterOnInsert } = useValues(logsViewerFiltersLogic)
     const { filterGroup } = useValues(universalFiltersLogic)
     const { replaceGroupValue, removeGroupValue } = useActions(universalFiltersLogic)
 

--- a/products/logs/frontend/components/LogsViewer/Filters/DateRangeFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/DateRangeFilter.tsx
@@ -7,9 +7,7 @@ import { DATE_TIME_FORMAT, formatDateRange } from 'lib/utils'
 
 import { DateMappingOption } from '~/types'
 
-import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
-
-import { logsSceneLogic } from '../../../logsSceneLogic'
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
 const dateMapping: DateMappingOption[] = [
     { key: CUSTOM_OPTION_KEY, values: [] },
@@ -56,9 +54,9 @@ const dateMapping: DateMappingOption[] = [
 ]
 
 export const DateRangeFilter = (): JSX.Element => {
-    const { dateRange } = useValues(logsSceneLogic)
-    const { setDateRange } = useActions(logsSceneLogic)
-    const { setFilter } = useActions(logsViewerConfigLogic)
+    const { filters } = useValues(logsViewerFiltersLogic)
+    const { dateRange } = filters
+    const { setDateRange } = useActions(logsViewerFiltersLogic)
 
     return (
         <DateFilter
@@ -68,7 +66,6 @@ export const DateRangeFilter = (): JSX.Element => {
             dateOptions={dateMapping}
             onChange={(changedDateFrom, changedDateTo) => {
                 setDateRange({ date_from: changedDateFrom, date_to: changedDateTo })
-                setFilter('dateRange', { date_from: changedDateFrom, date_to: changedDateTo })
             }}
             allowTimePrecision
             allowFixedRangeWithTime

--- a/products/logs/frontend/components/LogsViewer/Filters/FilterGroup.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/FilterGroup.tsx
@@ -21,9 +21,7 @@ import {
     UniversalFiltersGroup,
 } from '~/types'
 
-import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
-
-import { logsSceneLogic } from '../../../logsSceneLogic'
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
 export const taxonomicFilterLogicKey = 'logs'
 export const taxonomicGroupTypes = [
@@ -33,14 +31,14 @@ export const taxonomicGroupTypes = [
 ]
 
 export const LogsFilterGroup = (): JSX.Element => {
-    const { filterGroup, tabId, utcDateRange, serviceNames } = useValues(logsSceneLogic)
-    const { setFilterGroup } = useActions(logsSceneLogic)
-    const { setFilter } = useActions(logsViewerConfigLogic)
+    const { filters, tabId, utcDateRange } = useValues(logsViewerFiltersLogic)
+    const { filterGroup, serviceNames } = filters
+    const { setFilterGroup } = useActions(logsViewerFiltersLogic)
 
     const endpointFilters = {
         dateRange: { ...utcDateRange, date_to: utcDateRange.date_to ?? dayjs().toISOString() },
         filterGroup,
-        serviceNames: serviceNames,
+        serviceNames,
     }
 
     return (
@@ -50,9 +48,7 @@ export const LogsFilterGroup = (): JSX.Element => {
             taxonomicGroupTypes={taxonomicGroupTypes}
             endpointFilters={endpointFilters}
             onChange={(group) => {
-                const newFilterGroup = { type: FilterLogicalOperator.And, values: [group] }
-                setFilterGroup(newFilterGroup)
-                setFilter('filterGroup', newFilterGroup)
+                setFilterGroup({ type: FilterLogicalOperator.And, values: [group] })
             }}
         >
             <UniversalSearch />
@@ -62,7 +58,7 @@ export const LogsFilterGroup = (): JSX.Element => {
 
 const UniversalSearch = (): JSX.Element => {
     const [visible, setVisible] = useState<boolean>(false)
-    const { utcDateRange, serviceNames, filterGroup: logsFilterGroup } = useValues(logsSceneLogic)
+    const { utcDateRange, filters: logsFilters } = useValues(logsViewerFiltersLogic)
     const { addGroupFilter, setGroupValues } = useActions(universalFiltersLogic)
     const { filterGroup } = useValues(universalFiltersLogic)
 
@@ -79,8 +75,8 @@ const UniversalSearch = (): JSX.Element => {
         taxonomicGroupTypes,
         endpointFilters: {
             dateRange: { ...utcDateRange, date_to: utcDateRange.date_to ?? dayjs().toISOString() },
-            filterGroup: logsFilterGroup,
-            serviceNames: serviceNames,
+            filterGroup: logsFilters.filterGroup,
+            serviceNames: logsFilters.serviceNames,
         },
         onChange: (taxonomicGroup, value, item, originalQuery) => {
             setVisible(false)

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -29,7 +29,7 @@ import {
     UniversalFiltersGroup,
 } from '~/types'
 
-import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
 import { logsSceneLogic } from '../../../../logsSceneLogic'
 import { DateRangeFilter } from '../DateRangeFilter'
@@ -47,8 +47,11 @@ const taxonomicGroupTypes = [
 
 export const LogsFilterBar = (): JSX.Element => {
     const newLogsDateRangePicker = useFeatureFlag('NEW_LOGS_DATE_RANGE_PICKER')
-    const { logsLoading, liveTailRunning, liveTailDisabledReason, dateRange } = useValues(logsSceneLogic)
-    const { runQuery, zoomDateRange, setLiveTailRunning, setDateRange } = useActions(logsSceneLogic)
+    const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsSceneLogic)
+    const { runQuery, zoomDateRange, setLiveTailRunning } = useActions(logsSceneLogic)
+    const { filters } = useValues(logsViewerFiltersLogic)
+    const { setDateRange } = useActions(logsViewerFiltersLogic)
+    const { dateRange } = filters
 
     return (
         <LogsFilterGroup>
@@ -120,14 +123,14 @@ export const LogsFilterBar = (): JSX.Element => {
 }
 
 const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Element => {
-    const { filterGroup, tabId, utcDateRange, serviceNames, filterGroup: logsFilterGroup } = useValues(logsSceneLogic)
-    const { setFilterGroup } = useActions(logsSceneLogic)
-    const { setFilter } = useActions(logsViewerConfigLogic)
+    const { filters, tabId, utcDateRange } = useValues(logsViewerFiltersLogic)
+    const { filterGroup, serviceNames } = filters
+    const { setFilterGroup } = useActions(logsViewerFiltersLogic)
 
     const endpointFilters = {
         dateRange: { ...utcDateRange, date_to: utcDateRange.date_to ?? dayjs().toISOString() },
-        filterGroup: logsFilterGroup,
-        serviceNames: serviceNames,
+        filterGroup,
+        serviceNames,
     }
 
     return (
@@ -137,9 +140,7 @@ const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Eleme
             taxonomicGroupTypes={taxonomicGroupTypes}
             endpointFilters={endpointFilters}
             onChange={(group) => {
-                const newFilterGroup = { type: FilterLogicalOperator.And, values: [group] }
-                setFilterGroup(newFilterGroup)
-                setFilter('filterGroup', newFilterGroup)
+                setFilterGroup({ type: FilterLogicalOperator.And, values: [group] })
             }}
         >
             {children}
@@ -149,7 +150,7 @@ const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Eleme
 
 const LogsFilterSearch = (): JSX.Element => {
     const [visible, setVisible] = useState<boolean>(false)
-    const { utcDateRange, serviceNames, filterGroup: logsFilterGroup } = useValues(logsSceneLogic)
+    const { utcDateRange, filters: logsFilters } = useValues(logsViewerFiltersLogic)
     const { addGroupFilter, setGroupValues } = useActions(universalFiltersLogic)
     const { filterGroup } = useValues(universalFiltersLogic)
 
@@ -166,8 +167,8 @@ const LogsFilterSearch = (): JSX.Element => {
         taxonomicGroupTypes,
         endpointFilters: {
             dateRange: { ...utcDateRange, date_to: utcDateRange.date_to ?? dayjs().toISOString() },
-            filterGroup: logsFilterGroup,
-            serviceNames: serviceNames,
+            filterGroup: logsFilters.filterGroup,
+            serviceNames: logsFilters.serviceNames,
         },
         onChange: (taxonomicGroup, value, item, originalQuery) => {
             if (item.value === undefined) {

--- a/products/logs/frontend/components/LogsViewer/Filters/SearchTermFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SearchTermFilter.tsx
@@ -2,14 +2,12 @@ import { useActions, useValues } from 'kea'
 
 import { LemonInput } from '@posthog/lemon-ui'
 
-import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
-
-import { logsSceneLogic } from '../../../logsSceneLogic'
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
 export const SearchTermFilter = (): JSX.Element => {
-    const { searchTerm } = useValues(logsSceneLogic)
-    const { setSearchTerm } = useActions(logsSceneLogic)
-    const { setFilter } = useActions(logsViewerConfigLogic)
+    const { filters } = useValues(logsViewerFiltersLogic)
+    const { searchTerm } = filters
+    const { setSearchTerm } = useActions(logsViewerFiltersLogic)
 
     return (
         <LemonInput
@@ -17,7 +15,6 @@ export const SearchTermFilter = (): JSX.Element => {
             value={searchTerm}
             onChange={(value) => {
                 setSearchTerm(value)
-                setFilter('searchTerm', value)
             }}
             placeholder="Search logs..."
         />

--- a/products/logs/frontend/components/LogsViewer/Filters/ServiceFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/ServiceFilter.tsx
@@ -7,15 +7,13 @@ import { projectLogic } from 'scenes/projectLogic'
 import { LogsQuery } from '~/queries/schema/schema-general'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
-import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
-
-import { logsSceneLogic } from '../../../logsSceneLogic'
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
 export const ServiceFilter = (): JSX.Element => {
-    const { serviceNames, dateRange } = useValues(logsSceneLogic)
+    const { filters } = useValues(logsViewerFiltersLogic)
+    const { serviceNames, dateRange } = filters
     const { currentProjectId } = useValues(projectLogic)
-    const { setServiceNames } = useActions(logsSceneLogic)
-    const { setFilter } = useActions(logsViewerConfigLogic)
+    const { setServiceNames } = useActions(logsViewerFiltersLogic)
 
     const endpoint = combineUrl(`api/environments/${currentProjectId}/logs/values`, {
         key: 'service.name',
@@ -34,7 +32,6 @@ export const ServiceFilter = (): JSX.Element => {
                 value={serviceNames}
                 onSet={(value: LogsQuery['serviceNames']) => {
                     setServiceNames(value)
-                    setFilter('serviceNames', value)
                 }}
                 placeholder="Service name"
                 preloadValues

--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
@@ -7,9 +7,7 @@ import { capitalizeFirstLetter } from 'lib/utils'
 
 import { LogMessage } from '~/queries/schema/schema-general'
 
-import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
-
-import { logsSceneLogic } from '../../../logsSceneLogic'
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
 const options: Record<LogMessage['severity_text'], string> = {
     trace: 'Trace',
@@ -23,9 +21,9 @@ const options: Record<LogMessage['severity_text'], string> = {
 const ALL_LOG_LEVELS = Object.values(options) as LogMessage['severity_text'][]
 
 export const SeverityLevelsFilter = (): JSX.Element => {
-    const { severityLevels } = useValues(logsSceneLogic)
-    const { setSeverityLevels } = useActions(logsSceneLogic)
-    const { setFilter } = useActions(logsViewerConfigLogic)
+    const { filters } = useValues(logsViewerFiltersLogic)
+    const { severityLevels } = filters
+    const { setSeverityLevels } = useActions(logsViewerFiltersLogic)
 
     const onClick = (level: LogMessage['severity_text']): void => {
         const levels = [...severityLevels]
@@ -39,7 +37,6 @@ export const SeverityLevelsFilter = (): JSX.Element => {
         }
 
         setSeverityLevels(levels)
-        setFilter('severityLevels', levels)
     }
 
     const displayLevels =

--- a/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.test.ts
@@ -1,0 +1,151 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+import { FilterLogicalOperator } from '~/types'
+
+import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
+
+import { logsViewerFiltersLogic } from './logsViewerFiltersLogic'
+
+describe('logsViewerFiltersLogic', () => {
+    let logic: ReturnType<typeof logsViewerFiltersLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = logsViewerFiltersLogic({ id: 'test-tab' })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    describe('individual filter actions', () => {
+        it.each([
+            ['setDateRange', 'dateRange', { date_from: '-24h', date_to: null }],
+            ['setSearchTerm', 'searchTerm', 'error message'],
+            ['setSeverityLevels', 'severityLevels', ['error', 'warn']],
+            ['setServiceNames', 'serviceNames', ['api', 'worker']],
+            [
+                'setFilterGroup',
+                'filterGroup',
+                { type: FilterLogicalOperator.Or, values: [{ type: FilterLogicalOperator.And, values: [] }] },
+            ],
+        ])('%s sets %s', async (action, key, value) => {
+            await expectLogic(logic, () => {
+                ;(logic.actions as any)[action](value)
+            }).toFinishAllListeners()
+
+            expect((logic.values.filters as any)[key]).toEqual(value)
+        })
+
+        it('preserves other filters when setting a single filter', async () => {
+            logic.actions.setSearchTerm('first')
+            logic.actions.setSeverityLevels(['error'])
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.filters.searchTerm).toBe('first')
+            expect(logic.values.filters.severityLevels).toEqual(['error'])
+        })
+    })
+
+    describe('setFilters (bulk)', () => {
+        it('applies partial filter updates without resetting others', async () => {
+            logic.actions.setSearchTerm('existing search')
+            await expectLogic(logic).toFinishAllListeners()
+
+            logic.actions.setFilters({ severityLevels: ['error', 'warn'] })
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.filters.searchTerm).toBe('existing search')
+            expect(logic.values.filters.severityLevels).toEqual(['error', 'warn'])
+        })
+
+        it('applies all filters when fully specified', async () => {
+            const newFilters: LogsViewerFilters = {
+                dateRange: { date_from: '-7d', date_to: null },
+                searchTerm: 'test query',
+                severityLevels: ['info', 'debug'],
+                serviceNames: ['frontend'],
+                filterGroup: {
+                    type: FilterLogicalOperator.And,
+                    values: [{ type: FilterLogicalOperator.And, values: [] }],
+                },
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.setFilters(newFilters)
+            }).toMatchValues({
+                filters: newFilters,
+            })
+        })
+    })
+
+    describe('setFilterGroup fallback', () => {
+        it('falls back to default when given invalid filterGroup', async () => {
+            logic.actions.setFilterGroup(null as any)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.filters.filterGroup).toEqual({
+                type: FilterLogicalOperator.And,
+                values: [{ type: FilterLogicalOperator.And, values: [] }],
+            })
+        })
+    })
+
+    describe('utcDateRange', () => {
+        it.each([
+            {
+                label: 'converts valid absolute dates to ISO strings',
+                dateRange: { date_from: '2024-01-15T10:30:00', date_to: '2024-01-15T12:00:00' },
+                expected: {
+                    date_from: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),
+                    date_to: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),
+                },
+            },
+            {
+                label: 'preserves relative date_from and null date_to',
+                dateRange: { date_from: '-1h', date_to: null },
+                expected: { date_from: '-1h', date_to: null },
+            },
+            {
+                label: 'preserves relative date_from with valid absolute date_to',
+                dateRange: { date_from: '-7d', date_to: '2024-01-15T12:00:00' },
+                expected: {
+                    date_from: '-7d',
+                    date_to: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),
+                },
+            },
+            {
+                label: 'forwards explicitDate unchanged',
+                dateRange: { date_from: '-1h', date_to: null, explicitDate: true },
+                expected: { date_from: '-1h', date_to: null, explicitDate: true },
+            },
+        ])('$label', async ({ dateRange, expected }) => {
+            logic.actions.setDateRange(dateRange)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.utcDateRange).toEqual(expect.objectContaining(expected))
+        })
+    })
+
+    describe('keyed instances', () => {
+        it('maintains separate state for different keys', async () => {
+            const logic1 = logsViewerFiltersLogic({ id: 'tab-1' })
+            const logic2 = logsViewerFiltersLogic({ id: 'tab-2' })
+            logic1.mount()
+            logic2.mount()
+
+            logic1.actions.setSearchTerm('tab 1 search')
+            logic2.actions.setSearchTerm('tab 2 search')
+            await expectLogic(logic1).toFinishAllListeners()
+            await expectLogic(logic2).toFinishAllListeners()
+
+            expect(logic1.values.filters.searchTerm).toBe('tab 1 search')
+            expect(logic2.values.filters.searchTerm).toBe('tab 2 search')
+
+            logic1.unmount()
+            logic2.unmount()
+        })
+    })
+})

--- a/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
@@ -1,0 +1,120 @@
+import { actions, kea, key, path, props, reducers, selectors } from 'kea'
+
+import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
+import { dayjs } from 'lib/dayjs'
+
+import { DateRange, LogSeverityLevel, LogsQuery } from '~/queries/schema/schema-general'
+import { UniversalFiltersGroup } from '~/types'
+
+import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
+
+import type { logsViewerFiltersLogicType } from './logsViewerFiltersLogicType'
+
+export const DEFAULT_DATE_RANGE = { date_from: '-1h', date_to: null }
+const VALID_SEVERITY_LEVELS: readonly LogSeverityLevel[] = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
+export const DEFAULT_SEVERITY_LEVELS = [] as LogsQuery['severityLevels']
+
+export const isValidSeverityLevel = (level: string): level is LogSeverityLevel =>
+    VALID_SEVERITY_LEVELS.includes(level as LogSeverityLevel)
+
+export const DEFAULT_SERVICE_NAMES = [] as LogsQuery['serviceNames']
+
+export interface LogsViewerFiltersLogicProps {
+    id: string
+}
+
+export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
+    path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'Filters', 'logsViewerFiltersLogic']),
+    props({ id: 'default' } as LogsViewerFiltersLogicProps),
+    key((props) => props.id),
+
+    actions({
+        // setting individual filters
+        setDateRange: (dateRange: DateRange) => ({ dateRange }),
+        setSearchTerm: (searchTerm: LogsQuery['searchTerm']) => ({ searchTerm }),
+        setSeverityLevels: (severityLevels: LogsQuery['severityLevels']) => ({ severityLevels }),
+        setServiceNames: (serviceNames: LogsQuery['serviceNames']) => ({ serviceNames }),
+        setFilterGroup: (filterGroup: UniversalFiltersGroup, openFilterOnInsert: boolean = true) => ({
+            filterGroup,
+            openFilterOnInsert,
+        }),
+
+        // setting all filters at once
+        setFilters: (filters: Partial<LogsViewerFilters>, pushToHistory: boolean = true) => ({
+            filters,
+            pushToHistory,
+        }),
+    }),
+
+    reducers({
+        dateRange: [
+            DEFAULT_DATE_RANGE as DateRange,
+            {
+                setDateRange: (_, { dateRange }) => dateRange,
+                setFilters: (state, { filters }) => filters.dateRange ?? state,
+            },
+        ],
+        searchTerm: [
+            '' as LogsQuery['searchTerm'],
+            {
+                setSearchTerm: (_, { searchTerm }) => searchTerm,
+                setFilters: (state, { filters }) => filters.searchTerm ?? state,
+            },
+        ],
+        severityLevels: [
+            DEFAULT_SEVERITY_LEVELS as LogsQuery['severityLevels'],
+            {
+                setSeverityLevels: (_, { severityLevels }) => severityLevels,
+                setFilters: (state, { filters }) => filters.severityLevels ?? state,
+            },
+        ],
+        serviceNames: [
+            DEFAULT_SERVICE_NAMES as LogsQuery['serviceNames'],
+            {
+                setServiceNames: (_, { serviceNames }) => serviceNames,
+                setFilters: (state, { filters }) => filters.serviceNames ?? state,
+            },
+        ],
+        filterGroup: [
+            DEFAULT_UNIVERSAL_GROUP_FILTER as UniversalFiltersGroup,
+            {
+                setFilterGroup: (_, { filterGroup }) =>
+                    filterGroup && filterGroup.values ? filterGroup : DEFAULT_UNIVERSAL_GROUP_FILTER,
+                setFilters: (state, { filters }) =>
+                    filters.filterGroup && filters.filterGroup.values ? filters.filterGroup : state,
+            },
+        ],
+        openFilterOnInsert: [
+            false as boolean,
+            {
+                setFilterGroup: (_, { openFilterOnInsert }) => openFilterOnInsert,
+            },
+        ],
+    }),
+
+    selectors({
+        tabId: [(_, p) => [p.id], (id: string) => id],
+        filters: [
+            (s) => [s.dateRange, s.searchTerm, s.severityLevels, s.serviceNames, s.filterGroup],
+            (
+                dateRange: DateRange,
+                searchTerm: LogsQuery['searchTerm'],
+                severityLevels: LogsQuery['severityLevels'],
+                serviceNames: LogsQuery['serviceNames'],
+                filterGroup: UniversalFiltersGroup
+            ): LogsViewerFilters => ({ dateRange, searchTerm, severityLevels, serviceNames, filterGroup }),
+        ],
+        utcDateRange: [
+            (s) => [s.dateRange],
+            (dateRange: DateRange) => ({
+                date_from: dayjs(dateRange.date_from).isValid()
+                    ? dayjs(dateRange.date_from).toISOString()
+                    : dateRange.date_from,
+                date_to: dayjs(dateRange.date_to).isValid()
+                    ? dayjs(dateRange.date_to).toISOString()
+                    : dateRange.date_to,
+                explicitDate: dateRange.explicitDate,
+            }),
+        ],
+    }),
+])

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -9,6 +9,7 @@ import { DateRange, LogsSparklineBreakdownBy } from '~/queries/schema/schema-gen
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { LogsFilterBar } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar'
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 import { VirtualizedLogsList } from 'products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList'
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
@@ -62,24 +63,26 @@ export function LogsViewer({
     onExpandTimeRange,
 }: LogsViewerProps): JSX.Element {
     return (
-        <BindLogic logic={logsViewerConfigLogic} props={{ id: tabId }}>
-            <BindLogic logic={logDetailsModalLogic} props={{ tabId }}>
-                <BindLogic logic={logsViewerLogic} props={{ tabId, logs, orderBy, onAddFilter }}>
-                    <LogsViewerContent
-                        loading={loading}
-                        totalLogsCount={totalLogsCount}
-                        hasMoreLogsToLoad={hasMoreLogsToLoad}
-                        orderBy={orderBy}
-                        onChangeOrderBy={onChangeOrderBy}
-                        onRefresh={onRefresh}
-                        onLoadMore={onLoadMore}
-                        sparklineData={sparklineData}
-                        sparklineLoading={sparklineLoading}
-                        onDateRangeChange={onDateRangeChange}
-                        sparklineBreakdownBy={sparklineBreakdownBy}
-                        onSparklineBreakdownByChange={onSparklineBreakdownByChange}
-                        onExpandTimeRange={onExpandTimeRange}
-                    />
+        <BindLogic logic={logsViewerFiltersLogic} props={{ id: tabId }}>
+            <BindLogic logic={logsViewerConfigLogic} props={{ id: tabId }}>
+                <BindLogic logic={logDetailsModalLogic} props={{ tabId }}>
+                    <BindLogic logic={logsViewerLogic} props={{ tabId, logs, orderBy, onAddFilter }}>
+                        <LogsViewerContent
+                            loading={loading}
+                            totalLogsCount={totalLogsCount}
+                            hasMoreLogsToLoad={hasMoreLogsToLoad}
+                            orderBy={orderBy}
+                            onChangeOrderBy={onChangeOrderBy}
+                            onRefresh={onRefresh}
+                            onLoadMore={onLoadMore}
+                            sparklineData={sparklineData}
+                            sparklineLoading={sparklineLoading}
+                            onDateRangeChange={onDateRangeChange}
+                            sparklineBreakdownBy={sparklineBreakdownBy}
+                            onSparklineBreakdownByChange={onSparklineBreakdownByChange}
+                            onExpandTimeRange={onExpandTimeRange}
+                        />
+                    </BindLogic>
                 </BindLogic>
             </BindLogic>
         </BindLogic>

--- a/products/logs/frontend/logsSceneLogic.test.ts
+++ b/products/logs/frontend/logsSceneLogic.test.ts
@@ -7,8 +7,9 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { FilterLogicalOperator } from '~/types'
 
+import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
+
 import { logsSceneLogic } from './logsSceneLogic'
-import { LogsFilters } from './types'
 
 jest.mock('@posthog/lemon-ui', () => ({
     ...jest.requireActual('@posthog/lemon-ui'),
@@ -135,7 +136,7 @@ describe('logsSceneLogic', () => {
                 router.actions.push('/logs', { severityLevels: urlValue })
             }).toFinishAllListeners()
 
-            expect(logic.values.severityLevels).toEqual(expected)
+            expect(logic.values.filters.severityLevels).toEqual(expected)
         })
 
         it.each([
@@ -146,7 +147,7 @@ describe('logsSceneLogic', () => {
                 router.actions.push('/logs', { serviceNames: urlValue })
             }).toFinishAllListeners()
 
-            expect(logic.values.serviceNames).toEqual(expected)
+            expect(logic.values.filters.serviceNames).toEqual(expected)
         })
 
         it('filters out malformed JSON as invalid severity level', async () => {
@@ -155,7 +156,7 @@ describe('logsSceneLogic', () => {
             }).toFinishAllListeners()
 
             // parseTagsFilter falls back to comma-separated parsing, then validation filters invalid levels
-            expect(logic.values.severityLevels).toEqual([])
+            expect(logic.values.filters.severityLevels).toEqual([])
         })
 
         it('filters out non-array JSON as invalid severity level', async () => {
@@ -164,7 +165,7 @@ describe('logsSceneLogic', () => {
             }).toFinishAllListeners()
 
             // parseTagsFilter falls back to comma-separated parsing, then validation filters invalid levels
-            expect(logic.values.severityLevels).toEqual([])
+            expect(logic.values.filters.severityLevels).toEqual([])
         })
 
         it('handles comma-separated values via parseTagsFilter', async () => {
@@ -172,7 +173,7 @@ describe('logsSceneLogic', () => {
                 router.actions.push('/logs', { severityLevels: 'error,warn,info' })
             }).toFinishAllListeners()
 
-            expect(logic.values.severityLevels).toEqual(['error', 'warn', 'info'])
+            expect(logic.values.filters.severityLevels).toEqual(['error', 'warn', 'info'])
         })
 
         it.each([
@@ -185,12 +186,12 @@ describe('logsSceneLogic', () => {
                 router.actions.push('/logs', { severityLevels: urlValue })
             }).toFinishAllListeners()
 
-            expect(logic.values.severityLevels).toEqual(expected)
+            expect(logic.values.filters.severityLevels).toEqual(expected)
         })
     })
 
     describe('filter history', () => {
-        const createFilters = (searchTerm: string): LogsFilters => ({
+        const createFilters = (searchTerm: string): LogsViewerFilters => ({
             dateRange: { date_from: '-1h', date_to: null },
             searchTerm,
             severityLevels: [],
@@ -287,8 +288,10 @@ describe('logsSceneLogic', () => {
                 })
                     .toDispatchActions(['restoreFiltersFromHistory', 'setFilters'])
                     .toMatchValues({
-                        searchTerm: 'restored query',
-                        severityLevels: ['error', 'warn'],
+                        filters: expect.objectContaining({
+                            searchTerm: 'restored query',
+                            severityLevels: ['error', 'warn'],
+                        }),
                     })
             })
 

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -21,9 +21,7 @@ import { Params } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 
 import {
-    DateRange,
     LogMessage,
-    LogSeverityLevel,
     LogsQuery,
     LogsSparklineBreakdownBy,
     ProductIntentContext,
@@ -39,17 +37,19 @@ import {
     UniversalFiltersGroupValue,
 } from '~/types'
 
+import {
+    DEFAULT_DATE_RANGE,
+    DEFAULT_SERVICE_NAMES,
+    DEFAULT_SEVERITY_LEVELS,
+    isValidSeverityLevel,
+    logsViewerFiltersLogic,
+} from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
+
 import { zoomDateRange } from './components/LogsViewer/Filters/zoom-utils'
 import type { logsSceneLogicType } from './logsSceneLogicType'
-import { LogsFilters, LogsFiltersHistoryEntry, LogsOrderBy, ParsedLogMessage } from './types'
+import { LogsFiltersHistoryEntry, LogsOrderBy, ParsedLogMessage } from './types'
 
-const DEFAULT_DATE_RANGE = { date_from: '-1h', date_to: null }
-const VALID_SEVERITY_LEVELS: readonly LogSeverityLevel[] = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
-const DEFAULT_SEVERITY_LEVELS = [] as LogsQuery['severityLevels']
-
-const isValidSeverityLevel = (level: string): level is LogSeverityLevel =>
-    VALID_SEVERITY_LEVELS.includes(level as LogSeverityLevel)
-const DEFAULT_SERVICE_NAMES = [] as LogsQuery['serviceNames']
 const DEFAULT_ORDER_BY = 'latest' as LogsQuery['orderBy']
 const DEFAULT_LOGS_PAGE_SIZE: number = 250
 const DEFAULT_INITIAL_LOGS_LIMIT = null as number | null
@@ -76,19 +76,25 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
     props({} as LogsLogicProps),
     path(['products', 'logs', 'frontend', 'logsSceneLogic']),
     tabAwareScene(),
-    connect(() => ({
-        actions: [teamLogic, ['addProductIntent']],
+    connect((props: LogsLogicProps) => ({
+        actions: [
+            teamLogic,
+            ['addProductIntent'],
+            logsViewerFiltersLogic({ id: props.tabId }),
+            ['setDateRange', 'setFilterGroup', 'setFilters', 'setSearchTerm', 'setSeverityLevels', 'setServiceNames'],
+        ],
+        values: [logsViewerFiltersLogic({ id: props.tabId }), ['filters', 'utcDateRange']],
     })),
     tabAwareUrlToAction(({ actions, values }) => {
         const urlToAction = (_: any, params: Params): void => {
-            const filtersFromUrl: Partial<LogsFilters> = {}
+            const filtersFromUrl: Partial<LogsViewerFilters> = {}
             let hasFilterChanges = false
 
             if (params.dateRange) {
                 try {
                     const dateRange =
                         typeof params.dateRange === 'string' ? JSON.parse(params.dateRange) : params.dateRange
-                    if (!equal(dateRange, values.dateRange)) {
+                    if (!equal(dateRange, values.filters.dateRange)) {
                         filtersFromUrl.dateRange = dateRange
                         hasFilterChanges = true
                     }
@@ -96,34 +102,50 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                     // Ignore malformed dateRange JSON in URL
                 }
             }
-            if (params.filterGroup && !equal(params.filterGroup, values.filterGroup)) {
-                filtersFromUrl.filterGroup = params.filterGroup
+            if (params.filterGroup) {
+                if (!equal(params.filterGroup, values.filters.filterGroup)) {
+                    filtersFromUrl.filterGroup = params.filterGroup
+                    hasFilterChanges = true
+                }
+            } else if (!equal(DEFAULT_UNIVERSAL_GROUP_FILTER, values.filters.filterGroup)) {
+                filtersFromUrl.filterGroup = DEFAULT_UNIVERSAL_GROUP_FILTER
                 hasFilterChanges = true
             }
-            if (params.searchTerm && !equal(params.searchTerm, values.searchTerm)) {
-                filtersFromUrl.searchTerm = params.searchTerm
+            if (params.searchTerm) {
+                if (!equal(params.searchTerm, values.filters.searchTerm)) {
+                    filtersFromUrl.searchTerm = params.searchTerm
+                    hasFilterChanges = true
+                }
+            } else if (values.filters.searchTerm !== '') {
+                filtersFromUrl.searchTerm = ''
                 hasFilterChanges = true
             }
             if (params.severityLevels) {
                 const parsed = parseTagsFilter(params.severityLevels)
                 if (parsed) {
                     const levels = parsed.filter(isValidSeverityLevel)
-                    if (levels.length > 0 && !equal(levels, values.severityLevels)) {
+                    if (levels.length > 0 && !equal(levels, values.filters.severityLevels)) {
                         filtersFromUrl.severityLevels = levels
                         hasFilterChanges = true
                     }
                 }
+            } else if (!equal(DEFAULT_SEVERITY_LEVELS, values.filters.severityLevels)) {
+                filtersFromUrl.severityLevels = DEFAULT_SEVERITY_LEVELS
+                hasFilterChanges = true
             }
             if (params.serviceNames) {
                 const names = parseTagsFilter(params.serviceNames)
-                if (names && !equal(names, values.serviceNames)) {
+                if (names && !equal(names, values.filters.serviceNames)) {
                     filtersFromUrl.serviceNames = names
                     hasFilterChanges = true
                 }
+            } else if (!equal(DEFAULT_SERVICE_NAMES, values.filters.serviceNames)) {
+                filtersFromUrl.serviceNames = DEFAULT_SERVICE_NAMES
+                hasFilterChanges = true
             }
 
             if (hasFilterChanges) {
-                actions.setFiltersFromUrl(filtersFromUrl)
+                actions.setFilters(filtersFromUrl, false)
             }
 
             // Non-filter params handled separately
@@ -149,11 +171,11 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             },
         ] => {
             return syncSearchParams(router, (params: Params) => {
-                updateSearchParams(params, 'searchTerm', values.searchTerm, '')
-                updateSearchParams(params, 'filterGroup', values.filterGroup, DEFAULT_UNIVERSAL_GROUP_FILTER)
-                updateSearchParams(params, 'dateRange', values.dateRange, DEFAULT_DATE_RANGE)
-                updateSearchParams(params, 'severityLevels', values.severityLevels, DEFAULT_SEVERITY_LEVELS)
-                updateSearchParams(params, 'serviceNames', values.serviceNames, DEFAULT_SERVICE_NAMES)
+                updateSearchParams(params, 'searchTerm', values.filters.searchTerm, '')
+                updateSearchParams(params, 'filterGroup', values.filters.filterGroup, DEFAULT_UNIVERSAL_GROUP_FILTER)
+                updateSearchParams(params, 'dateRange', values.filters.dateRange, DEFAULT_DATE_RANGE)
+                updateSearchParams(params, 'severityLevels', values.filters.severityLevels, DEFAULT_SEVERITY_LEVELS)
+                updateSearchParams(params, 'serviceNames', values.filters.serviceNames, DEFAULT_SERVICE_NAMES)
                 updateSearchParams(params, 'orderBy', values.orderBy, DEFAULT_ORDER_BY)
                 actions.runQuery()
                 return params
@@ -196,22 +218,12 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
         setLiveTailAbortController: (liveTailAbortController: AbortController | null) => ({
             liveTailAbortController,
         }),
-        setDateRange: (dateRange: DateRange) => ({ dateRange }),
         setOrderBy: (orderBy: LogsOrderBy, source: 'header' | 'toolbar' = 'toolbar') => ({ orderBy, source }),
-        setSearchTerm: (searchTerm: LogsQuery['searchTerm']) => ({ searchTerm }),
-        setSeverityLevels: (severityLevels: LogsQuery['severityLevels']) => ({ severityLevels }),
-        setServiceNames: (serviceNames: LogsQuery['serviceNames']) => ({ serviceNames }),
-        setFilters: (filters: Partial<LogsFilters>, pushToHistory: boolean = true) => ({ filters, pushToHistory }),
-        setFiltersFromUrl: (filters: Partial<LogsFilters>) => ({ filters }),
-        pushToFilterHistory: (filters: LogsFilters) => ({ filters }),
+        pushToFilterHistory: (filters: LogsViewerFilters) => ({ filters }),
         restoreFiltersFromHistory: (index: number) => ({ index }),
         clearFilterHistory: true,
         setLiveLogsCheckpoint: (liveLogsCheckpoint: string | null) => ({ liveLogsCheckpoint }),
 
-        setFilterGroup: (filterGroup: UniversalFiltersGroup, openFilterOnInsert: boolean = true) => ({
-            filterGroup,
-            openFilterOnInsert,
-        }),
         toggleAttributeBreakdown: (key: string) => ({ key }),
         setExpandedAttributeBreaksdowns: (expandedAttributeBreaksdowns: string[]) => ({ expandedAttributeBreaksdowns }),
         zoomDateRange: (multiplier: number) => ({ multiplier }),
@@ -263,53 +275,10 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                 fetchLogsSuccess: () => null,
             },
         ],
-        dateRange: [
-            DEFAULT_DATE_RANGE as DateRange,
-            {
-                setDateRange: (_, { dateRange }) => dateRange,
-                setFilters: (state, { filters }) => filters.dateRange ?? state,
-                setFiltersFromUrl: (state, { filters }) => filters.dateRange ?? state,
-            },
-        ],
         orderBy: [
             DEFAULT_ORDER_BY,
             {
                 setOrderBy: (_, { orderBy }) => orderBy,
-            },
-        ],
-        searchTerm: [
-            '' as LogsQuery['searchTerm'],
-            {
-                setSearchTerm: (_, { searchTerm }) => searchTerm,
-                setFilters: (state, { filters }) => filters.searchTerm ?? state,
-                setFiltersFromUrl: (state, { filters }) => filters.searchTerm ?? state,
-            },
-        ],
-        severityLevels: [
-            DEFAULT_SEVERITY_LEVELS,
-            {
-                setSeverityLevels: (_, { severityLevels }) => severityLevels,
-                setFilters: (state, { filters }) => filters.severityLevels ?? state,
-                setFiltersFromUrl: (state, { filters }) => filters.severityLevels ?? state,
-            },
-        ],
-        serviceNames: [
-            DEFAULT_SERVICE_NAMES,
-            {
-                setServiceNames: (_, { serviceNames }) => serviceNames,
-                setFilters: (state, { filters }) => filters.serviceNames ?? state,
-                setFiltersFromUrl: (state, { filters }) => filters.serviceNames ?? state,
-            },
-        ],
-        filterGroup: [
-            DEFAULT_UNIVERSAL_GROUP_FILTER,
-            {
-                setFilterGroup: (_, { filterGroup }) =>
-                    filterGroup && filterGroup.values ? filterGroup : DEFAULT_UNIVERSAL_GROUP_FILTER,
-                setFilters: (state, { filters }) =>
-                    filters.filterGroup && filters.filterGroup.values ? filters.filterGroup : state,
-                setFiltersFromUrl: (state, { filters }) =>
-                    filters.filterGroup && filters.filterGroup.values ? filters.filterGroup : state,
             },
         ],
         liveLogsCheckpoint: [
@@ -370,12 +339,6 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                 fetchSparkline: () => true,
                 fetchSparklineSuccess: () => false,
                 fetchSparklineFailure: () => true,
-            },
-        ],
-        openFilterOnInsert: [
-            false as boolean,
-            {
-                setFilterGroup: (_, { openFilterOnInsert }) => openFilterOnInsert,
             },
         ],
         expandedAttributeBreaksdowns: [
@@ -451,10 +414,10 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                             limit: values.initialLogsLimit ?? DEFAULT_LOGS_PAGE_SIZE,
                             orderBy: values.orderBy,
                             dateRange: values.utcDateRange,
-                            searchTerm: values.searchTerm,
-                            filterGroup: values.filterGroup as PropertyGroupFilter,
-                            severityLevels: values.severityLevels,
-                            serviceNames: values.serviceNames,
+                            searchTerm: values.filters.searchTerm,
+                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            severityLevels: values.filters.severityLevels,
+                            serviceNames: values.filters.serviceNames,
                         },
                         signal,
                     })
@@ -478,10 +441,10 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                             limit: limit ?? DEFAULT_LOGS_PAGE_SIZE,
                             orderBy: values.orderBy,
                             dateRange: values.utcDateRange,
-                            searchTerm: values.searchTerm,
-                            filterGroup: values.filterGroup as PropertyGroupFilter,
-                            severityLevels: values.severityLevels,
-                            serviceNames: values.serviceNames,
+                            searchTerm: values.filters.searchTerm,
+                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            severityLevels: values.filters.severityLevels,
+                            serviceNames: values.filters.serviceNames,
                             after: values.nextCursor,
                         },
                         signal,
@@ -506,10 +469,10 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                         query: {
                             orderBy: values.orderBy,
                             dateRange: values.utcDateRange,
-                            searchTerm: values.searchTerm,
-                            filterGroup: values.filterGroup as PropertyGroupFilter,
-                            severityLevels: values.severityLevels,
-                            serviceNames: values.serviceNames,
+                            searchTerm: values.filters.searchTerm,
+                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            severityLevels: values.filters.severityLevels,
+                            serviceNames: values.filters.serviceNames,
                             sparklineBreakdownBy: values.sparklineBreakdownBy,
                         },
                         signal,
@@ -524,31 +487,15 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
 
     selectors({
         tabId: [(_, p) => [p.tabId], (tabId: string) => tabId],
-        filters: [
-            (s) => [s.dateRange, s.searchTerm, s.severityLevels, s.serviceNames, s.filterGroup],
-            (
-                dateRange: LogsFilters['dateRange'],
-                searchTerm: LogsFilters['searchTerm'],
-                severityLevels: LogsFilters['severityLevels'],
-                serviceNames: LogsFilters['serviceNames'],
-                filterGroup: LogsFilters['filterGroup']
-            ): LogsFilters => ({
-                dateRange,
-                searchTerm,
-                severityLevels,
-                serviceNames,
-                filterGroup,
-            }),
-        ],
         hasFilterHistory: [
             (s) => [s.filterHistory],
             (filterHistory: LogsFiltersHistoryEntry[]) => filterHistory.length > 0,
         ],
         liveTailDisabledReason: [
-            (s) => [s.orderBy, s.dateRange, s.logsLoading, s.liveTailExpired],
+            (s) => [s.orderBy, s.filters, s.logsLoading, s.liveTailExpired],
             (
                 orderBy: LogsQuery['orderBy'],
-                dateRange: DateRange,
+                filters: LogsViewerFilters,
                 logsLoading: boolean,
                 liveTailExpired: boolean
             ): string | undefined => {
@@ -556,7 +503,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                     return 'Live tail only works with "Latest" ordering'
                 }
 
-                if (dateRange.date_to) {
+                if (filters.dateRange.date_to) {
                     return 'Live tail requires an open-ended time range'
                 }
 
@@ -570,18 +517,6 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
 
                 return undefined
             },
-        ],
-        utcDateRange: [
-            (s) => [s.dateRange],
-            (dateRange) => ({
-                date_from: dayjs(dateRange.date_from).isValid()
-                    ? dayjs(dateRange.date_from).toISOString()
-                    : dateRange.date_from,
-                date_to: dayjs(dateRange.date_to).isValid()
-                    ? dayjs(dateRange.date_to).toISOString()
-                    : dateRange.date_to,
-                explicitDate: dateRange.explicitDate,
-            }),
         ],
         parsedLogs: [
             (s) => [s.logs],
@@ -773,7 +708,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                 return false
             }
 
-            const rootGroup = values.filterGroup?.values?.[0] as UniversalFiltersGroup | undefined
+            const rootGroup = values.filters.filterGroup?.values?.[0] as UniversalFiltersGroup | undefined
             const hasIncompleteFilter =
                 rootGroup?.values?.some((filterValue) => hasIncompleteUniversalFilterValue(filterValue)) ?? false
 
@@ -863,19 +798,16 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             // Track query execution (skip initial page load)
             if (values.hasRunQuery) {
                 posthog.capture('logs query executed', {
-                    has_search_term: !!values.searchTerm,
-                    has_filters: values.filterGroup.values.length > 0,
-                    severity_count: values.severityLevels?.length ?? 0,
-                    service_count: values.serviceNames?.length ?? 0,
+                    has_search_term: !!values.filters.searchTerm,
+                    has_filters: values.filters.filterGroup.values.length > 0,
+                    severity_count: values.filters.severityLevels?.length ?? 0,
+                    service_count: values.filters.serviceNames?.length ?? 0,
                 })
             }
             actions.clearLogs()
             actions.fetchLogs()
             actions.fetchSparkline()
             actions.cancelInProgressLiveTail(null)
-        },
-        setFiltersFromUrl: () => {
-            actions.runQuery()
         },
         restoreFiltersFromHistory: ({ index }) => {
             const entry = values.filterHistory[index]
@@ -925,7 +857,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                 direction: multiplier > 1 ? 'out' : 'in',
                 multiplier,
             })
-            const newDateRange = zoomDateRange(values.dateRange, multiplier)
+            const newDateRange = zoomDateRange(values.filters.dateRange, multiplier)
             actions.setDateRange(newDateRange)
         },
         expireLiveTail: async ({}, breakpoint) => {
@@ -946,7 +878,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             operator: string
             propertyType: PropertyFilterType
         }) => {
-            const currentGroup = values.filterGroup.values[0] as UniversalFiltersGroup
+            const currentGroup = values.filters.filterGroup.values[0] as UniversalFiltersGroup
 
             const newGroup: UniversalFiltersGroup = {
                 ...currentGroup,
@@ -961,7 +893,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                 ],
             }
 
-            actions.setFilterGroup({ ...values.filterGroup, values: [newGroup] }, false)
+            actions.setFilterGroup({ ...values.filters.filterGroup, values: [newGroup] }, false)
         },
         pollForNewLogs: async () => {
             if (!values.liveTailRunning || values.orderBy !== 'latest' || document.hidden) {
@@ -980,10 +912,10 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                         limit: DEFAULT_LOGS_PAGE_SIZE,
                         orderBy: values.orderBy,
                         dateRange: values.utcDateRange,
-                        searchTerm: values.searchTerm,
-                        filterGroup: values.filterGroup as PropertyGroupFilter,
-                        severityLevels: values.severityLevels,
-                        serviceNames: values.serviceNames,
+                        searchTerm: values.filters.searchTerm,
+                        filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                        severityLevels: values.filters.severityLevels,
+                        serviceNames: values.filters.serviceNames,
                         liveLogsCheckpoint: values.liveLogsCheckpoint ?? undefined,
                     },
                     signal,

--- a/products/logs/frontend/types.ts
+++ b/products/logs/frontend/types.ts
@@ -1,17 +1,10 @@
-import { DateRange, LogsQuery } from '~/queries/schema/schema-general'
 import { LogMessage } from '~/queries/schema/schema-general'
-import { JsonType, UniversalFiltersGroup } from '~/types'
+import { JsonType } from '~/types'
 
-export interface LogsFilters {
-    dateRange: DateRange
-    searchTerm: LogsQuery['searchTerm']
-    severityLevels: LogsQuery['severityLevels']
-    serviceNames: LogsQuery['serviceNames']
-    filterGroup: UniversalFiltersGroup
-}
+import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
 
 export interface LogsFiltersHistoryEntry {
-    filters: LogsFilters
+    filters: LogsViewerFilters
     timestamp: number
 }
 


### PR DESCRIPTION
## Problem

The logs viewer component is still coupled with logsScene logic, making it impossible to re-use it outside of the logsScene context

## Changes

- Created a new `logsViewerFiltersLogic` to centralize all logs filter state management
- Migrated filter-related state and actions from `logsSceneLogic` to the new logic
- Updated all filter components to use the new centralized logic
- Removed redundant filter state synchronization with `logsViewerConfigLogic`
- Added comprehensive tests for the new filter logic

## How did you test this code?

- Added unit tests for the new `logsViewerFiltersLogic` covering all filter operations
- Manually tested all filter interactions in the logs viewer to ensure they work as expected
- Verified that filter state is properly maintained when switching between tabs
- Confirmed that URL parameters still correctly sync with filter state

## Publish to changelog?

No