### PR TITLE
fix: column configurator forced stacked, better width

### DIFF
--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.scss
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.scss
@@ -1,33 +1,4 @@
 .ColumnConfiguratorModal {
-    .Columns {
-        display: flex;
-        column-gap: 1rem;
-        width: 1200px;
-        max-width: 90vw;
-        padding: 0.5rem;
-        background-color: var(--color-bg-primary);
-        border-radius: var(--radius);
-
-        @media (max-width: 960px) {
-            display: block;
-            width: auto;
-        }
-    }
-
-    .HalfColumn {
-        &:first-child {
-            width: 40%;
-        }
-
-        &:last-child {
-            width: 60%;
-        }
-
-        @media (max-width: 960px) {
-            width: 100%;
-        }
-    }
-
     .SelectedColumn {
         display: flex;
         align-items: center;

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -181,10 +181,11 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                     </LemonButton>
                 </>
             }
+            className="w-full max-w-248"
         >
             <div className="ColumnConfiguratorModal">
-                <div className="Columns">
-                    <div className="HalfColumn">
+                <div className="flex flex-col gap-4">
+                    <div className="w-full">
                         <h4 className="secondary uppercase text-secondary">
                             Visible columns ({columns.length}) - Drag to reorder
                         </h4>
@@ -212,7 +213,7 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                             </SortableContext>
                         </DndContext>
                     </div>
-                    <div className="HalfColumn">
+                    <div className="w-full">
                         <h4 className="secondary uppercase text-secondary">Available columns</h4>
                         <div className="h-[min(480px,60vh)]">
                             <AutoSizer


### PR DESCRIPTION
## Problem
Column configurator was claustrophobic 

## Changes

Before
<img width="477" height="976" alt="image" src="https://github.com/user-attachments/assets/89d90241-76cf-474d-92ae-08a2b236b8cf" />

<img width="1074" height="732" alt="image" src="https://github.com/user-attachments/assets/12649196-2c7f-430c-bb5b-0a1a995ec018" />


After
<img width="794" height="956" alt="image" src="https://github.com/user-attachments/assets/3c13935e-d282-4afa-aa75-e5f2b2effcef" />


<img width="1027" height="958" alt="image" src="https://github.com/user-attachments/assets/03423ccd-062b-4b10-9ba8-c5d20ff05b8c" />

## How did you test this code?
Locally

## Publish to changelog?
No