### PR TITLE
chore(batch-exports): add keyless S3 authentication support

### DIFF
--- a/posthog/settings/batch_exports.py
+++ b/posthog/settings/batch_exports.py
@@ -92,3 +92,6 @@ BATCH_EXPORTS_ENABLE_BILLING_CHECK: bool = get_from_env(
 BATCH_EXPORTS_PERSONS_LIMITED_EXPORT_TEAM_IDS: list[str] = get_list(
     os.getenv("BATCH_EXPORTS_PERSONS_LIMITED_EXPORT_TEAM_IDS", "")
 )
+# Temporary setting to rollout keyless S3 authentication for batch exports.
+# TODO: Remove after testing.
+BATCH_EXPORT_USE_KEYLESS_S3_AUTH: bool = get_from_env("BATCH_EXPORT_USE_KEYLESS_S3_AUTH", False, type_cast=str_to_bool)

--- a/products/batch_exports/backend/temporal/sql.py
+++ b/products/batch_exports/backend/temporal/sql.py
@@ -16,7 +16,10 @@ def get_s3_function_call(s3_folder: str, s3_key: str | None, s3_secret: str | No
     """
     s3_url = f"{s3_folder}/export_{{{{_partition_id}}}}.arrow"
     if s3_key is not None and s3_secret is not None:
-        s3_call = f"s3('{s3_url}', '{s3_key}', '{s3_secret}', 'ArrowStream')"
+        # Escape single quotes by doubling them (ClickHouse SQL escaping)
+        escaped_key = s3_key.replace("'", "''")
+        escaped_secret = s3_secret.replace("'", "''")
+        s3_call = f"s3('{s3_url}', '{escaped_key}', '{escaped_secret}', 'ArrowStream')"
     else:
         s3_call = f"s3('{s3_url}', 'ArrowStream')"
 

--- a/products/batch_exports/backend/temporal/sql.py
+++ b/products/batch_exports/backend/temporal/sql.py
@@ -4,6 +4,26 @@ from posthog.hogql import ast
 from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.parser import parse_expr
 
+
+def get_s3_function_call(s3_folder: str, s3_key: str | None, s3_secret: str | None, num_partitions: int) -> str:
+    """Generate the s3() function call for ClickHouse INSERT queries.
+
+    When using keyless S3 auth (IAM roles), we omit credentials and ClickHouse uses the
+    default credential provider chain. Otherwise, we pass the access key and secret.
+
+    Note: We use %% for the modulo operator because the ClickHouse client uses % for
+    parameter substitution, so %% produces a literal % in the final query.
+    """
+    s3_url = f"{s3_folder}/export_{{{{_partition_id}}}}.arrow"
+    if s3_key is not None and s3_secret is not None:
+        s3_call = f"s3('{s3_url}', '{s3_key}', '{s3_secret}', 'ArrowStream')"
+    else:
+        s3_call = f"s3('{s3_url}', 'ArrowStream')"
+
+    return f"""{s3_call}
+    PARTITION BY rand() %% {num_partitions}"""
+
+
 SELECT_FROM_PERSONS = """
 SELECT
     persons.team_id AS team_id,
@@ -506,14 +526,7 @@ SELECT_FROM_SESSIONS_HOGQL = ast.SelectQuery(
 
 EXPORT_TO_S3_FROM_DISTRIBUTED_EVENTS_RECENT = Template(
     """
-INSERT INTO FUNCTION
-   s3(
-       '$s3_folder/export_{{_partition_id}}.arrow',
-       '$s3_key',
-       '$s3_secret',
-       'ArrowStream'
-    )
-    PARTITION BY rand() %% $num_partitions
+INSERT INTO FUNCTION $s3_function
 SELECT
     $fields
 FROM (
@@ -554,14 +567,7 @@ SETTINGS
 
 EXPORT_TO_S3_FROM_EVENTS_RECENT = Template(
     """
-INSERT INTO FUNCTION
-   s3(
-       '$s3_folder/export_{{_partition_id}}.arrow',
-       '$s3_key',
-       '$s3_secret',
-       'ArrowStream'
-    )
-    PARTITION BY rand() %% $num_partitions
+INSERT INTO FUNCTION $s3_function
 SELECT
     $fields
 FROM (
@@ -601,14 +607,7 @@ SETTINGS
 
 EXPORT_TO_S3_FROM_EVENTS_UNBOUNDED = Template(
     """
-INSERT INTO FUNCTION
-   s3(
-       '$s3_folder/export_{{_partition_id}}.arrow',
-       '$s3_key',
-       '$s3_secret',
-       'ArrowStream'
-    )
-    PARTITION BY rand() %% $num_partitions
+INSERT INTO FUNCTION $s3_function
 SELECT
     $fields
 FROM (
@@ -647,14 +646,7 @@ SETTINGS
 
 EXPORT_TO_S3_FROM_EVENTS_BACKFILL = Template(
     """
-INSERT INTO FUNCTION
-   s3(
-       '$s3_folder/export_{{_partition_id}}.arrow',
-       '$s3_key',
-       '$s3_secret',
-       'ArrowStream'
-    )
-    PARTITION BY rand() %% $num_partitions
+INSERT INTO FUNCTION $s3_function
 SELECT
     $fields
 FROM (
@@ -692,14 +684,7 @@ SETTINGS
 
 EXPORT_TO_S3_FROM_EVENTS_WORKFLOWS = Template(
     """
-INSERT INTO FUNCTION
-   s3(
-       '$s3_folder/export_{{_partition_id}}.arrow',
-       '$s3_key',
-       '$s3_secret',
-       'ArrowStream'
-    )
-    PARTITION BY rand() %% $num_partitions
+INSERT INTO FUNCTION $s3_function
 SELECT
     $fields
 FROM
@@ -720,14 +705,7 @@ SETTINGS
 )
 EXPORT_TO_S3_FROM_EVENTS = Template(
     """
-INSERT INTO FUNCTION
-   s3(
-       '$s3_folder/export_{{_partition_id}}.arrow',
-       '$s3_key',
-       '$s3_secret',
-       'ArrowStream'
-    )
-    PARTITION BY rand() %% $num_partitions
+INSERT INTO FUNCTION $s3_function
 SELECT
     $fields
 FROM (
@@ -767,14 +745,7 @@ SETTINGS
 )
 
 EXPORT_TO_S3_FROM_PERSONS_BACKFILL = Template("""
-INSERT INTO FUNCTION
-   s3(
-       '$s3_folder/export_{{_partition_id}}.arrow',
-       '$s3_key',
-       '$s3_secret',
-       'ArrowStream'
-    )
-    PARTITION BY rand() %% $num_partitions
+INSERT INTO FUNCTION $s3_function
 SELECT
     pd.team_id AS team_id,
     pd.distinct_id AS distinct_id,
@@ -841,14 +812,7 @@ SETTINGS
 
 
 EXPORT_TO_S3_FROM_PERSONS = Template("""
-INSERT INTO FUNCTION
-    s3(
-        '$s3_folder/export_{{_partition_id}}.arrow',
-        '$s3_key',
-        '$s3_secret',
-        'ArrowStream'
-    )
-    PARTITION BY rand() %% $num_partitions
+INSERT INTO FUNCTION $s3_function
 SELECT
     persons.team_id AS team_id,
     persons.distinct_id AS distinct_id,


### PR DESCRIPTION
## Problem

Batch exports currently require explicit AWS credentials (access key ID and secret) for writing to the internal S3 staging bucket. In our production environments this is less secure than using IAM roles.

## Changes

- Add `BATCH_EXPORT_USE_KEYLESS_S3_AUTH` setting to enable gradual rollout
- When keyless auth is enabled, generate ClickHouse s3() calls with 2 params (url, format) instead of 4 (url, key, secret, format)
- Continue to use AWS credentials in local and test environments.

## How did you test this code?

- Added unit test for keyless auth s3() function generation
- Local testing with MinIO still uses explicit credentials (keyless only enabled in non-DEBUG/TEST environments)
- ~Will test changes on dev first~ - worked on dev 🙂 
