### PR TITLE
fix: allow filters_override instead of variables still

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,7 +56,6 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
-                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -80,7 +79,6 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
-                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -97,7 +95,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND (("pmat_email" ILIKE '%g0%'
+                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -1449,7 +1449,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         else:
             # SECURITY: For materialized endpoints with required variables, those variables MUST be provided.
             # Without this check, omitting a variable would return ALL data instead of filtered data.
-            if is_materialized:
+            # Exception: filters_override is the deprecated way to provide filters for insight endpoints
+            if is_materialized and data.filters_override is None:
                 required_var = self._get_required_variable_for_materialized(query, version)
                 if required_var:
                     raise ValidationError(f"Required variable '{required_var}' not provided")

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -1450,7 +1450,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             # SECURITY: For materialized endpoints with required variables, those variables MUST be provided.
             # Without this check, omitting a variable would return ALL data instead of filtered data.
             # Exception: filters_override is the deprecated way to provide filters for insight endpoints
-            if is_materialized and data.filters_override is None:
+            if is_materialized and not (data.filters_override and data.filters_override.properties):
                 required_var = self._get_required_variable_for_materialized(query, version)
                 if required_var:
                     raise ValidationError(f"Required variable '{required_var}' not provided")


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
when an insight-based endpoint is materialized, we still want to allow filters_override (at least for now)
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- add an exception to the condition before we raise an error
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- unit and locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
