### PR TITLE
feat(llma): add person property filters for evaluation triggers

### DIFF
--- a/nodejs/src/evaluation-scheduler/evaluation-scheduler.ts
+++ b/nodejs/src/evaluation-scheduler/evaluation-scheduler.ts
@@ -110,14 +110,37 @@ export async function checkConditionMatch(event: RawKafkaEvent, condition: Evalu
     }
 
     // Build globals for HogVM execution
+    let personProperties = {}
+    let eventProperties = {}
+
+    try {
+        personProperties = parseJSON(event.person_properties || '{}')
+    } catch (e) {
+        logger.warn('Failed to parse person_properties', {
+            conditionId: condition.id,
+            eventUuid: event.uuid,
+            error: e instanceof Error ? e.message : String(e),
+        })
+    }
+
+    try {
+        eventProperties = parseJSON(event.properties || '{}')
+    } catch (e) {
+        logger.warn('Failed to parse event properties', {
+            conditionId: condition.id,
+            eventUuid: event.uuid,
+            error: e instanceof Error ? e.message : String(e),
+        })
+    }
+
     const filterGlobals = {
         event: event.event,
         elements_chain: event.elements_chain || '',
         distinct_id: event.distinct_id,
         person: {
-            properties: parseJSON(event.person_properties || '{}'),
+            properties: personProperties,
         },
-        properties: parseJSON(event.properties || '{}'),
+        properties: eventProperties,
     }
 
     try {

--- a/nodejs/src/evaluation-scheduler/evaluation-scheduler.ts
+++ b/nodejs/src/evaluation-scheduler/evaluation-scheduler.ts
@@ -115,7 +115,7 @@ export async function checkConditionMatch(event: RawKafkaEvent, condition: Evalu
         elements_chain: event.elements_chain || '',
         distinct_id: event.distinct_id,
         person: {
-            properties: {},
+            properties: parseJSON(event.person_properties || '{}'),
         },
         properties: parseJSON(event.properties || '{}'),
     }

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationTriggers.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationTriggers.tsx
@@ -139,10 +139,10 @@ export function EvaluationTriggers(): JSX.Element {
 
                         {/* Property Filters */}
                         <div className="space-y-2">
-                            <label className="block text-sm font-medium">Generation properties</label>
+                            <label className="block text-sm font-medium">Filter conditions</label>
                             <div className="text-sm text-muted mb-2">
-                                Define which generation events should trigger this evaluation. Leave empty to match all
-                                generations.
+                                Filter by generation event properties or person properties to target specific users or
+                                generations. Leave empty to match all generations.
                             </div>
                             <PropertyFilters
                                 propertyFilters={condition.properties}
@@ -151,8 +151,9 @@ export function EvaluationTriggers(): JSX.Element {
                                 taxonomicGroupTypes={[
                                     TaxonomicFilterGroupType.EventProperties,
                                     TaxonomicFilterGroupType.EventMetadata,
+                                    TaxonomicFilterGroupType.PersonProperties,
                                 ]}
-                                addText="Add generation property condition"
+                                addText="Add filter condition"
                                 hasRowOperator={false}
                                 sendAllKeyUpdates
                                 allowRelativeDateOptions={false}
@@ -174,14 +175,14 @@ export function EvaluationTriggers(): JSX.Element {
                 <h4 className="font-semibold mb-2">Examples:</h4>
                 <ul className="space-y-1 text-muted list-disc list-inside">
                     <li>
-                        <strong>10% of all generations:</strong> Set 10% sampling with no property conditions
+                        <strong>10% of all generations:</strong> Set 10% sampling with no filter conditions
                     </li>
                     <li>
                         <strong>5% of GPT-4 generations:</strong> Set 5% sampling with $ai_model_name = "gpt-4"
                     </li>
                     <li>
-                        <strong>20% of custom property generations:</strong> Set 20% sampling with my_custom_property =
-                        "value"
+                        <strong>Exclude internal users:</strong> Set 100% sampling with person property is_internal ≠
+                        true
                     </li>
                     <li>
                         <strong>High-cost generations:</strong> Set 100% sampling with $ai_total_cost_usd &gt; 0.01


### PR DESCRIPTION
## Problem

Users running LLM evaluations want to filter triggers on person properties (e.g., to exclude internal users) rather than just event properties. Currently, the eval triggers only support filtering by generation event properties.

## Changes

- Added `PersonProperties` to the `taxonomicGroupTypes` in `EvaluationTriggers.tsx`, allowing users to select person properties in the filter UI
- Updated the evaluation scheduler to pass `person_properties` from the Kafka event to the HogVM bytecode execution globals
- Added tests to verify person properties are correctly passed to bytecode execution

## How did you test this code?

- Added unit tests for `checkConditionMatch` verifying person properties are passed to HogVM
- Added test for `EvaluationMatcher` verifying person properties flow through the evaluation matching

## Publish to changelog?

no