### PR TITLE
feat(capture-logs): don't produce empty batches to kafka

### DIFF
--- a/rust/capture-logs/src/kafka.rs
+++ b/rust/capture-logs/src/kafka.rs
@@ -195,6 +195,10 @@ impl KafkaSink {
         rows: Vec<KafkaLogRow>,
         uncompressed_bytes: u64,
     ) -> Result<(), anyhow::Error> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
         let schema = Schema::parse_str(AVRO_SCHEMA)?;
         let mut writer = Writer::with_codec(
             &schema,

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -88,10 +88,6 @@ pub fn parse_otel_message(json_bytes: &Bytes) -> Result<ExportLogsServiceRequest
         merged_request.resource_logs.extend(request.resource_logs);
     }
 
-    if merged_request.resource_logs.is_empty() {
-        return Err(anyhow::anyhow!("No valid log data found in request"));
-    }
-
     Ok(merged_request)
 }
 


### PR DESCRIPTION
## Problem

we had a poison pill issue due to an empty batch - there's no reason to write these so lets just return success

we were previously checking for empty resource_logs and returning a 400.

However, this did not check for actual logs deeper down in the resource_logs object, and _also_ this breaks the spec - we are supposed to silently accept empty requests per the spec

## Changes

noop the kafka consumer on an empty batch

## How did you test this code?


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
