### PR TITLE
feat(capture-logs): add batch uuid header to each message produced in log-capture

### DIFF
--- a/rust/capture-logs/src/kafka.rs
+++ b/rust/capture-logs/src/kafka.rs
@@ -241,6 +241,10 @@ impl KafkaSink {
                         key: "created_at",
                         value: Some(&created_at),
                     })
+                    .insert(Header {
+                        key: "batch_uuid",
+                        value: Some(&uuid::Uuid::new_v4().to_string()),
+                    })
             }),
         }) {
             Err((err, _)) => Err(anyhow!(format!("kafka error: {err}"))),


### PR DESCRIPTION
## Problem

we have messages produced by capture, these are read and re-produced by ingestion

currently we have no way to correlate these messages to compare them for debugging

## Changes

add a uuid header to each message produced, these will get persisted by ingestion so we can correlate messages between capture/ingestion
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
