### PR TITLE
fix(e2e): Fix broken insights test

### DIFF
--- a/playwright/e2e/product-analytics/insights-list.spec.ts
+++ b/playwright/e2e/product-analytics/insights-list.spec.ts
@@ -32,7 +32,7 @@ test.describe('Insights list', () => {
         })
 
         await test.step('open the insight from the list', async () => {
-            await page.getByText(insightName).click()
+            await page.locator('table tbody tr').first().getByRole('link', { name: insightName }).click()
             await expect(page).toHaveURL(/\/insights\/\w+/)
             await expect(insight.topBarName).toContainText(insightName)
         })


### PR DESCRIPTION
## Problem
Test broke from a merged PR that wasn't up to date
https://posthog.slack.com/archives/C0A7SH71ETY/p1770295983477439

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Use a different selector to open insights

## How did you test this code?
Run tests a few times

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
