### PR TITLE
fix(llma): use start_to_close_timeout for summarization activities

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,7 +56,6 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
-                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -80,7 +79,6 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
-                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -97,7 +95,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND (("pmat_email" ILIKE '%g0%'
+                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/posthog/temporal/llm_analytics/trace_summarization/workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/workflow.py
@@ -108,7 +108,7 @@ class BatchTraceSummarizationWorkflow(PostHogWorkflow):
                         max_length,
                     ],
                     activity_id=f"summarize-gen-{item.generation_id}",
-                    schedule_to_close_timeout=timedelta(seconds=GENERATE_SUMMARY_TIMEOUT_SECONDS),
+                    start_to_close_timeout=timedelta(seconds=GENERATE_SUMMARY_TIMEOUT_SECONDS),
                     retry_policy=constants.SUMMARIZE_RETRY_POLICY,
                 )
             else:
@@ -127,7 +127,7 @@ class BatchTraceSummarizationWorkflow(PostHogWorkflow):
                         max_length,
                     ],
                     activity_id=f"summarize-{item.trace_id}",
-                    schedule_to_close_timeout=timedelta(seconds=GENERATE_SUMMARY_TIMEOUT_SECONDS),
+                    start_to_close_timeout=timedelta(seconds=GENERATE_SUMMARY_TIMEOUT_SECONDS),
                     retry_policy=constants.SUMMARIZE_RETRY_POLICY,
                 )
 


### PR DESCRIPTION
## Problem

Trace and generation summarization activities use `schedule_to_close_timeout` (5 min), which is the total time budget across all retry attempts. When the first attempt times out at 5 minutes, there is no time left for retries, so Temporal marks it `RETRY_STATE_NON_RETRYABLE_FAILURE`. The retry policy (4 attempts, exponential backoff) never kicks in.

Observed in prod for team 2: every summarization activity times out once and fails permanently.
Example: https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/llma-trace-summarization-team-2-2026-02-05T12:00:01.810630+00:00/019c2dac-712d-76c1-89ce-3d871e3498aa/history

## Changes

Switch both `generate_and_save_summary_activity` and `generate_and_save_generation_summary_activity` from `schedule_to_close_timeout` to `start_to_close_timeout`. This gives each individual attempt the full 5 minutes, allowing retries to work as intended.

The sampling activity was already fixed in #46657 but the summarization activities were missed.

## How did you test this code?

Verified no other `schedule_to_close_timeout` usages exist in the summarization or clustering workflows. Will monitor next hourly coordinator run in Temporal UI to confirm retry attempts occur on timeout instead of immediate non-retryable failure.

## Publish to changelog?

No