### PR TITLE
chore: Add Claude Code for web test setup guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
   - Auto-detect flox environment before running terminal commands
   - If flox is available, and you run into trouble executing commands, try with `flox activate -- bash -c "<command>"` pattern
     - Never use `flox activate` in interactive sessions (it hangs if you try)
-  - **Claude Code for web**: If flox is unavailable and `uv sync` fails due to Python version constraints, see `CLAUDE_CODE_WEB.md` for alternative setup instructions
+  - **Claude Code for web**: See `CLAUDE_CODE_WEB.md` for environment setup instructions
 - Tests:
   - All tests: `pytest`
   - Single test: `pytest path/to/test.py::TestClass::test_method`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
   - Auto-detect flox environment before running terminal commands
   - If flox is available, and you run into trouble executing commands, try with `flox activate -- bash -c "<command>"` pattern
     - Never use `flox activate` in interactive sessions (it hangs if you try)
+  - **Claude Code for web**: If flox is unavailable and `uv sync` fails due to Python version constraints, see `CLAUDE_CODE_WEB.md` for alternative setup instructions
 - Tests:
   - All tests: `pytest`
   - Single test: `pytest path/to/test.py::TestClass::test_method`

--- a/CLAUDE_CODE_WEB.md
+++ b/CLAUDE_CODE_WEB.md
@@ -7,6 +7,7 @@ If you get stuck following these instructions, please bail out to the user and s
 ## Problem
 
 The project requires a specific Python version pinned in `pyproject.toml` (check `requires-python`), but:
+
 - Claude Code for web environments may have a different system Python version
 - `uv python install <version>` may fail if the version isn't yet indexed by uv
 - `uv sync` enforces the exact version constraint and will fail with the wrong Python version
@@ -128,6 +129,7 @@ sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 ## Pytest Configuration
 
 The `pytest.ini` sets:
+
 - `pythonpath = . common`
 - `DJANGO_SETTINGS_MODULE = posthog.settings`
 - `DEBUG=1`, `TEST=1`
@@ -137,6 +139,7 @@ Default ignores: `--ignore=posthog/user_scripts --ignore=services/llm-gateway --
 ## Debugging Installation Issues
 
 If you encounter issues with the test setup, refer to [`.github/workflows/ci-backend.yml`](.github/workflows/ci-backend.yml) for the authoritative CI configuration. This file shows:
+
 - Exact Python version used in CI
 - System dependencies installed
 - Environment variables set

--- a/CLAUDE_CODE_WEB.md
+++ b/CLAUDE_CODE_WEB.md
@@ -81,21 +81,13 @@ curl -sL "https://api.github.com/repos/astral-sh/python-build-standalone/release
 
 ## Docker Services
 
-Most tests require backend services running. If Docker is available:
+Most tests require backend services running. If Docker is available, start them with:
 
 ```bash
 docker compose -f docker-compose.dev.yml up -d
 ```
 
-Key services for tests:
-- **PostgreSQL** (port 5432): Django database
-- **ClickHouse** (port 8123, 9000): Analytics database
-- **Redis** (port 6379): Caching and Celery broker
-- **Kafka** (port 9092): Event streaming
-- **Zookeeper** (port 2181): Kafka coordination
-- **Object Storage/MinIO** (port 19000): S3-compatible storage
-
-Some test directories have specific service requirements documented in their own `cargo.yaml`, `package.json`, or similar configuration files.
+See `docker-compose.dev.yml` for the full list of services and ports. Some test directories have specific service requirements documented in their own configuration files.
 
 ### Hosts file setup
 

--- a/CLAUDE_CODE_WEB.md
+++ b/CLAUDE_CODE_WEB.md
@@ -104,25 +104,7 @@ echo "127.0.0.1 kafka clickhouse clickhouse-coordinator objectstorage" | sudo te
 
 ## Environment Variables
 
-Tests expect certain environment variables. These are defined in [`.github/workflows/ci-backend.yml`](.github/workflows/ci-backend.yml):
-
-```bash
-export SECRET_KEY='6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
-export DATABASE_URL='postgres://posthog:posthog@localhost:5432/posthog'
-export REDIS_URL='redis://localhost'
-export CLICKHOUSE_HOST='localhost'
-export CLICKHOUSE_SECURE='False'
-export CLICKHOUSE_VERIFY='False'
-export TEST=1
-export DEBUG=1
-export OBJECT_STORAGE_ENABLED='True'
-export OBJECT_STORAGE_ENDPOINT='http://localhost:19000'
-export OBJECT_STORAGE_ACCESS_KEY_ID='object_storage_root_user'
-export OBJECT_STORAGE_SECRET_ACCESS_KEY='object_storage_root_password'
-export DJANGO_SETTINGS_MODULE='posthog.settings'
-```
-
-You can also copy `.env.example` to `.env` for local development defaults.
+Tests require environment variables defined in [`.github/workflows/ci-backend.yml`](.github/workflows/ci-backend.yml) (see the `env:` section at the top of the file). You can also copy `.env.example` to `.env` for local development defaults.
 
 ## Additional Setup
 
@@ -189,14 +171,8 @@ uv sync --python /tmp/python-install/python/bin/python3.12
 # Create frontend placeholders
 mkdir -p frontend/dist && touch frontend/dist/{index,layout,exporter}.html
 
-# Set required environment variables
-export SECRET_KEY='6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
-export DATABASE_URL='postgres://posthog:posthog@localhost:5432/posthog'
-export REDIS_URL='redis://localhost'
-export CLICKHOUSE_HOST='localhost'
-export TEST=1
-export DEBUG=1
-export DJANGO_SETTINGS_MODULE='posthog.settings'
+# Set environment variables (see .github/workflows/ci-backend.yml for full list)
+cp .env.example .env
 
 # Run a specific test
 .venv/bin/pytest posthog/api/test/test_utils.py -v

--- a/CLAUDE_CODE_WEB.md
+++ b/CLAUDE_CODE_WEB.md
@@ -2,6 +2,8 @@
 
 This document describes how to set up and run Python tests in a Claude Code for web environment, where flox is not available.
 
+If you get stuck following these instructions, please bail out to the user and seek their guidance. Please suggest that they update this guide.
+
 ## Problem
 
 The project requires a specific Python version pinned in `pyproject.toml` (check `requires-python`), but:

--- a/CLAUDE_CODE_WEB.md
+++ b/CLAUDE_CODE_WEB.md
@@ -1,0 +1,160 @@
+# Claude Code for Web - Test Setup
+
+This document describes how to set up and run Python tests in a Claude Code for web environment, where flox is not available and Python 3.12.12 cannot be easily downloaded.
+
+## Problem
+
+The project requires Python 3.12.12 exactly (pinned in `pyproject.toml`), but:
+- Claude Code for web environments typically have Python 3.12.3 (from system packages)
+- Python 3.12.12 is not available in python-build-standalone (used by `uv`)
+- External downloads may be restricted
+- `uv sync` enforces the exact version constraint and will fail
+
+## Solution
+
+Use `uv pip install` instead of `uv sync` to install dependencies into a manually created virtualenv. This bypasses the `requires-python` version check.
+
+### Step 1: Create a virtualenv with system Python
+
+```bash
+/usr/bin/python3.12 -m venv /tmp/posthog-venv
+```
+
+### Step 2: Install dependencies using uv pip
+
+```bash
+# Install main dependencies
+uv pip install -p /tmp/posthog-venv --requirements /home/user/posthog/pyproject.toml
+
+# Install dev dependencies (includes pytest, etc.)
+uv pip install -p /tmp/posthog-venv --group dev --requirements /home/user/posthog/pyproject.toml
+```
+
+### Step 3: Run tests
+
+```bash
+# Set PYTHONPATH and use the virtualenv's pytest
+PYTHONPATH=/home/user/posthog:/home/user/posthog/common \
+  /tmp/posthog-venv/bin/pytest path/to/test.py::TestClass::test_method
+```
+
+## Docker Services
+
+Most tests require backend services running. If Docker is available:
+
+```bash
+docker compose -f docker-compose.dev.yml up -d
+```
+
+Key services for tests:
+- **PostgreSQL** (port 5432): Django database
+- **ClickHouse** (port 8123, 9000): Analytics database
+- **Redis** (port 6379): Caching and Celery broker
+- **Kafka** (port 9092): Event streaming
+- **Zookeeper** (port 2181): Kafka coordination
+- **Object Storage/MinIO** (port 19000): S3-compatible storage
+
+Some test directories have specific service requirements documented in their own `cargo.yaml`, `package.json`, or similar configuration files.
+
+### Hosts file setup
+
+Tests expect certain hostnames to resolve to localhost:
+
+```bash
+echo "127.0.0.1 kafka clickhouse clickhouse-coordinator objectstorage" | sudo tee -a /etc/hosts
+```
+
+## Environment Variables
+
+Tests expect certain environment variables. The CI uses these (from `.github/workflows/ci-backend.yml`):
+
+```bash
+export SECRET_KEY='6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
+export DATABASE_URL='postgres://posthog:posthog@localhost:5432/posthog'
+export REDIS_URL='redis://localhost'
+export CLICKHOUSE_HOST='localhost'
+export CLICKHOUSE_SECURE='False'
+export CLICKHOUSE_VERIFY='False'
+export TEST=1
+export DEBUG=1
+export OBJECT_STORAGE_ENABLED='True'
+export OBJECT_STORAGE_ENDPOINT='http://localhost:19000'
+export OBJECT_STORAGE_ACCESS_KEY_ID='object_storage_root_user'
+export OBJECT_STORAGE_SECRET_ACCESS_KEY='object_storage_root_password'
+export DJANGO_SETTINGS_MODULE='posthog.settings'
+```
+
+You can also copy `.env.example` to `.env` for local development defaults.
+
+## Additional Setup
+
+### Frontend dist placeholders
+
+Some tests require frontend build artifacts to exist (even if empty):
+
+```bash
+mkdir -p frontend/dist
+touch frontend/dist/index.html
+touch frontend/dist/layout.html
+touch frontend/dist/exporter.html
+```
+
+### SAML dependencies (if needed)
+
+For SAML-related functionality:
+
+```bash
+sudo apt-get update
+sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+```
+
+## Pytest Configuration
+
+The `pytest.ini` sets:
+- `pythonpath = . common`
+- `DJANGO_SETTINGS_MODULE = posthog.settings`
+- `DEBUG=1`, `TEST=1`
+
+Default ignores: `--ignore=posthog/user_scripts --ignore=services/llm-gateway --ignore=common/ingestion/acceptance_tests`
+
+## Limitations
+
+- **Python 3.12.3 vs 3.12.12**: Minor version difference, most tests should work
+- **Docker unavailable**: Tests requiring services will fail without Docker
+- **Network restrictions**: Some tests may fail in restricted environments
+- **Temporal tests**: Require additional Temporal service setup
+
+## Quick Reference
+
+```bash
+# One-time setup
+/usr/bin/python3.12 -m venv /tmp/posthog-venv
+uv pip install -p /tmp/posthog-venv --requirements pyproject.toml
+uv pip install -p /tmp/posthog-venv --group dev --requirements pyproject.toml
+
+# Create frontend placeholders
+mkdir -p frontend/dist && touch frontend/dist/{index,layout,exporter}.html
+
+# Set required environment variables
+export SECRET_KEY='6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
+export DATABASE_URL='postgres://posthog:posthog@localhost:5432/posthog'
+export REDIS_URL='redis://localhost'
+export CLICKHOUSE_HOST='localhost'
+export TEST=1
+export DEBUG=1
+export DJANGO_SETTINGS_MODULE='posthog.settings'
+
+# Run a specific test
+PYTHONPATH=.:/home/user/posthog/common /tmp/posthog-venv/bin/pytest posthog/api/test/test_utils.py -v
+
+# Run tests without services (unit tests only)
+PYTHONPATH=.:/home/user/posthog/common /tmp/posthog-venv/bin/pytest posthog/hogql/test/ -v
+```
+
+## Checking Docker availability
+
+```bash
+docker --version && docker compose version
+```
+
+If Docker is not available, you can only run unit tests that don't require external services. Many HogQL tests, for example, can run without services.

--- a/CLAUDE_CODE_WEB.md
+++ b/CLAUDE_CODE_WEB.md
@@ -33,9 +33,9 @@ The following example shows how to install Python 3.12.12. Adjust the version nu
 mkdir -p /tmp/python-install && cd /tmp/python-install
 
 # Download Python 3.12.12 from python-build-standalone
-# Note: Replace version and release tag as needed
+# Note: This URL is an example. Replace the version and <RELEASE_TAG> with a valid release from GitHub Releases.
 curl -L -o python.tar.gz \
-  "https://github.com/astral-sh/python-build-standalone/releases/download/20260203/cpython-3.12.12%2B20260203-x86_64-unknown-linux-gnu-install_only.tar.gz"
+  "https://github.com/astral-sh/python-build-standalone/releases/download/<RELEASE_TAG>/cpython-3.12.12%2B<RELEASE_TAG>-x86_64-unknown-linux-gnu-install_only.tar.gz"
 
 # Extract
 tar -xzf python.tar.gz

--- a/CLAUDE_CODE_WEB.md
+++ b/CLAUDE_CODE_WEB.md
@@ -52,14 +52,17 @@ uv sync --python /tmp/python-install/python/bin/python3.12
 
 This creates a `.venv` directory with all dependencies installed using the correct Python version.
 
-#### Step 3: Run tests
+#### Step 3: Activate the venv and run tests
 
 ```bash
+# Activate the virtual environment
+source .venv/bin/activate
+
 # Run a specific test
-.venv/bin/pytest path/to/test.py::TestClass::test_method -v
+pytest path/to/test.py::TestClass::test_method -v
 
 # Run all tests in a directory
-.venv/bin/pytest posthog/hogql/test/ -v
+pytest posthog/hogql/test/ -v
 ```
 
 ### Finding the correct download URL
@@ -174,11 +177,14 @@ mkdir -p frontend/dist && touch frontend/dist/{index,layout,exporter}.html
 # Set environment variables (see .github/workflows/ci-backend.yml for full list)
 cp .env.example .env
 
+# Activate the virtual environment
+source .venv/bin/activate
+
 # Run a specific test
-.venv/bin/pytest posthog/api/test/test_utils.py -v
+pytest posthog/api/test/test_utils.py -v
 
 # Run tests without services (unit tests only)
-.venv/bin/pytest posthog/hogql/test/ -v
+pytest posthog/hogql/test/ -v
 ```
 
 ## Checking Docker availability


### PR DESCRIPTION
## Problem

I got fed up of claude code web not being to actually run tests, so I made it figure out how to do so, and then better instructions for its future self. The rest of this PR was written by claude, with my help and review.

Claude:

Claude Code for web environments don't have access to flox, and may have a different system Python version than what's pinned in `pyproject.toml`. When `uv sync` fails due to Python version constraints, users have no guidance on how to proceed with running tests.

This creates friction for contributors trying to run tests in Claude Code for web environments.

## Changes

- Added `CLAUDE_CODE_WEB.md` with comprehensive setup instructions for running tests in Claude Code for web environments
- Updated `AGENTS.md` to reference the new guide when flox is unavailable and `uv sync` fails
- Documented the python-build-standalone approach as a solution for obtaining the correct Python version
- Included Docker service setup, environment configuration, and debugging guidance
- Provided quick reference commands for common tasks

## How did you test this code?

This is documentation-only, so no automated tests apply. The instructions have been written based on the project's existing CI configuration (`.github/workflows/ci-backend.yml`) and should be validated by users attempting to run tests in Claude Code for web environments.

## Publish to changelog?