### PR TITLE
chore(ux): sidepanel 13 - exports and searchable entities

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,6 +56,7 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
+                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -79,6 +80,7 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
+                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -95,7 +97,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
+                         AND (("pmat_email" ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -11,6 +11,7 @@ import {
     IconDashboard,
     IconDatabase,
     IconDecisionTree,
+    IconDownload,
     IconExternal,
     IconFeatures,
     IconFlask,
@@ -303,6 +304,9 @@ const iconTypes: Record<FileSystemIconType, { icon: JSX.Element; iconColor?: Fil
     llm_clusters: {
         icon: <IconPeople />,
         iconColor: ['var(--color-product-llm-clusters-light)'],
+    },
+    exports: {
+        icon: <IconDownload />,
     },
 }
 

--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -4,9 +4,12 @@ import { router } from 'kea-router'
 
 import api from 'lib/api'
 import { TriggerExportProps, downloadBlob, downloadExportedAsset } from 'lib/components/ExportButton/exporter'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { delay } from 'lib/utils'
+import { newInternalTab } from 'lib/utils/newInternalTab'
 import { SessionRecordingPlayerMode } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { urls } from 'scenes/urls'
 
@@ -60,6 +63,7 @@ export const exportsLogic = kea<exportsLogicType>([
     }),
 
     connect(() => ({
+        values: [featureFlagLogic, ['featureFlags']],
         actions: [sidePanelStateLogic, ['openSidePanel']],
     })),
 
@@ -110,8 +114,18 @@ export const exportsLogic = kea<exportsLogicType>([
             actions.createExport({ exportData })
         },
         createExportSuccess: () => {
-            actions.openSidePanel(SidePanelTab.Exports)
-            lemonToast.info('Export starting...')
+            if (featureFlagLogic.findMounted()?.values.featureFlags?.[FEATURE_FLAGS.UX_REMOVE_SIDEPANEL]) {
+                lemonToast.info('Export starting...', {
+                    button: {
+                        label: 'View exports',
+                        action: () => newInternalTab(urls.exports()),
+                    },
+                    autoClose: false,
+                })
+            } else {
+                actions.openSidePanel(SidePanelTab.Exports)
+                lemonToast.info('Export starting...')
+            }
             actions.loadExports()
         },
         loadExportsSuccess: async (_, breakpoint) => {

--- a/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
+++ b/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
@@ -7,7 +7,6 @@ import {
     IconDownload,
     IconEllipsis,
     IconExpand45,
-    IconFeatures,
     IconGear,
     IconLive,
     IconOpenSidebar,
@@ -38,7 +37,6 @@ import { userLogic } from 'scenes/userLogic'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
-import { SidePanelStatusIcon } from '~/layout/navigation-3000/sidepanel/panels/SidePanelStatus'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { SidePanelTab } from '~/types'
 
@@ -137,15 +135,16 @@ export function HelpMenu(): JSX.Element {
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>
                         <Link
-                            targetBlankIcon
-                            target="_blank"
+                            tooltip="View your exports"
+                            tooltipPlacement="right"
                             buttonProps={{ menuItem: true }}
-                            to="https://posthogstatus.com"
+                            to={urls.exports()}
                         >
-                            <SidePanelStatusIcon className="flex" size="xsmall" />
-                            PostHog status
+                            <IconDownload />
+                            Exports
                         </Link>
                     </DropdownMenuItem>
+
                     <DropdownMenuItem asChild>
                         <Link
                             tooltip="View our changelog"
@@ -159,31 +158,7 @@ export function HelpMenu(): JSX.Element {
                             Changelog
                         </Link>
                     </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                        <Link
-                            tooltip="View your exports"
-                            tooltipPlacement="right"
-                            buttonProps={{ menuItem: true }}
-                            to={urls.exports()}
-                        >
-                            <IconDownload />
-                            Exports
-                        </Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                        <Link
-                            to={urls.settings('user-feature-previews')}
-                            buttonProps={{
-                                menuItem: true,
-                            }}
-                            data-attr="top-menu-feature-previews"
-                            tooltip="View and access upcoming features"
-                            tooltipPlacement="right"
-                        >
-                            <IconFeatures />
-                            Feature previews
-                        </Link>
-                    </DropdownMenuItem>
+
                     {user?.is_staff && <></>}
                     {!isCloud && (
                         <DropdownMenuItem asChild>

--- a/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
+++ b/frontend/src/lib/components/HelpMenu/HelpMenu.tsx
@@ -4,6 +4,7 @@ import {
     IconBook,
     IconConfetti,
     IconDatabase,
+    IconDownload,
     IconEllipsis,
     IconExpand45,
     IconFeatures,
@@ -156,6 +157,17 @@ export function HelpMenu(): JSX.Element {
                         >
                             <IconLive />
                             Changelog
+                        </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                        <Link
+                            tooltip="View your exports"
+                            tooltipPlacement="right"
+                            buttonProps={{ menuItem: true }}
+                            to={urls.exports()}
+                        >
+                            <IconDownload />
+                            Exports
                         </Link>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -1,7 +1,7 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import { IconClock } from '@posthog/icons'
+import { IconClock, IconDownload } from '@posthog/icons'
 
 import api from 'lib/api'
 import { commandLogic } from 'lib/components/Command/commandLogic'
@@ -523,6 +523,47 @@ export const searchLogic = kea<searchLogicType>([
                 })
             },
         ],
+        healthItems: [
+            (s) => [s.sceneLogViewsByRef],
+            (sceneLogViewsByRef): SearchItem[] => [
+                {
+                    id: 'health-pipeline-status',
+                    name: 'Pipeline status',
+                    displayName: 'Pipeline status',
+                    category: 'health',
+                    href: urls.pipelineStatus(),
+                    itemType: 'pipeline_status',
+                    lastViewedAt: sceneLogViewsByRef['PipelineStatus'] ?? null,
+                    record: { type: 'pipeline_status', iconType: 'pipeline_status' },
+                },
+                {
+                    id: 'health-sdk-doctor',
+                    name: 'SDK doctor',
+                    displayName: 'SDK doctor',
+                    category: 'health',
+                    href: urls.sdkDoctor(),
+                    itemType: 'sdk_doctor',
+                    lastViewedAt: sceneLogViewsByRef['SdkDoctor'] ?? null,
+                    record: { type: 'sdk_doctor', iconType: 'sdk_doctor' },
+                },
+            ],
+        ],
+        miscItems: [
+            (s) => [s.sceneLogViewsByRef],
+            (sceneLogViewsByRef): SearchItem[] => [
+                {
+                    id: 'misc-exports',
+                    name: 'Exports',
+                    displayName: 'Exports',
+                    category: 'misc',
+                    href: urls.exports(),
+                    icon: <IconDownload />,
+                    itemType: null,
+                    lastViewedAt: sceneLogViewsByRef['Exports'] ?? null,
+                    record: { type: 'exports' },
+                },
+            ],
+        ],
         settingsItems: [
             (s) => [s.featureFlags],
             (featureFlags): SearchItem[] => {
@@ -713,6 +754,8 @@ export const searchLogic = kea<searchLogicType>([
                 s.recentItems,
                 s.appsItems,
                 s.dataManagementItems,
+                s.healthItems,
+                s.miscItems,
                 s.settingsItems,
                 s.newItems,
                 s.personItems,
@@ -726,6 +769,8 @@ export const searchLogic = kea<searchLogicType>([
                 recentItems: SearchItem[],
                 appsItems: SearchItem[],
                 dataManagementItems: SearchItem[],
+                healthItems: SearchItem[],
+                miscItems: SearchItem[],
                 settingsItems: SearchItem[],
                 newItems: SearchItem[],
                 personItems: SearchItem[],
@@ -798,6 +843,26 @@ export const searchLogic = kea<searchLogicType>([
                         key: 'data-management',
                         items: isAppsLoading ? [] : filteredDataManagement,
                         isLoading: isAppsLoading,
+                    })
+                }
+
+                // Show health items if searching with matching results
+                const filteredHealth = filterBySearch(healthItems)
+                if (hasSearch && filteredHealth.length > 0) {
+                    categories.push({
+                        key: 'health',
+                        items: filteredHealth,
+                        isLoading: false,
+                    })
+                }
+
+                // Show misc items if searching with matching results
+                const filteredMisc = filterBySearch(miscItems)
+                if (hasSearch && filteredMisc.length > 0) {
+                    categories.push({
+                        key: 'misc',
+                        items: filteredMisc,
+                        isLoading: false,
                     })
                 }
 

--- a/frontend/src/lib/components/Search/utils.ts
+++ b/frontend/src/lib/components/Search/utils.ts
@@ -28,6 +28,8 @@ export const getCategoryDisplayName = (category: string): string => {
         property_definition: 'Property definitions',
         session_recording_playlist: 'Session recording filter',
         hog_flow: 'Workflows',
+        health: 'Health',
+        misc: 'Misc',
     }
 
     return displayNames[category] || category

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -15672,7 +15672,8 @@
                 "llm_evaluations",
                 "llm_datasets",
                 "llm_prompts",
-                "llm_clusters"
+                "llm_clusters",
+                "exports"
             ],
             "type": "string"
         },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2899,6 +2899,7 @@ export type FileSystemIconType =
     | 'llm_datasets'
     | 'llm_prompts'
     | 'llm_clusters'
+    | 'exports'
 
 export interface FileSystemImport extends Omit<FileSystemEntry, 'id'> {
     id?: string

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -98,6 +98,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.Health]: () => import('./health/HealthScene'),
     [Scene.PipelineStatus]: () => import('./health/pipelineStatus/PipelineStatusScene'),
     [Scene.SdkDoctor]: () => import('./onboarding/sdks/SdkDoctorScene'),
+    [Scene.Exports]: () => import('./exports/ExportsScene'),
     [Scene.SessionAttributionExplorer]: () =>
         import('scenes/web-analytics/SessionAttributionExplorer/SessionAttributionExplorerScene'),
     [Scene.SessionProfile]: () => import('./sessions/SessionProfileScene'),

--- a/frontend/src/scenes/exports/ExportsScene.tsx
+++ b/frontend/src/scenes/exports/ExportsScene.tsx
@@ -1,0 +1,178 @@
+import { useActions, useValues } from 'kea'
+
+import { IconDownload, IconPencil, IconRefresh, IconWarning } from '@posthog/icons'
+import { LemonButton, LemonSelect, LemonTable, LemonTag, Spinner, lemonToast } from '@posthog/lemon-ui'
+import { LemonTableColumns } from '@posthog/lemon-ui'
+
+import { downloadExportedAsset, exportedAssetBlob } from 'lib/components/ExportButton/exporter'
+import { takeScreenshotLogic } from 'lib/components/TakeScreenshot/takeScreenshotLogic'
+import { dayjs } from 'lib/dayjs'
+import { Scene, SceneExport } from 'scenes/sceneTypes'
+import { sceneConfigurations } from 'scenes/scenes'
+
+import { sidePanelExportsLogic } from '~/layout/navigation-3000/sidepanel/panels/exports/sidePanelExportsLogic'
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { ExportedAssetType, ExporterFormat } from '~/types'
+
+import { exportsSceneLogic } from './exportsSceneLogic'
+
+const ROW_LIMIT_IN_THOUSANDS = 300
+
+export const scene: SceneExport = {
+    component: ExportsScene,
+    logic: exportsSceneLogic,
+}
+
+function ExportActions({ asset }: { asset: ExportedAssetType }): JSX.Element {
+    const { freshUndownloadedExports } = useValues(sidePanelExportsLogic)
+    const { removeFresh } = useActions(sidePanelExportsLogic)
+    const { setBlob } = useActions(takeScreenshotLogic({ screenshotKey: 'exports' }))
+
+    const isNotDownloaded = freshUndownloadedExports.some((fresh) => fresh.id === asset.id)
+    const stillCalculating = !asset.has_content && !asset.exception
+    let disabledReason: string | undefined = undefined
+    if (asset.exception) {
+        disabledReason = asset.exception
+    } else if (!asset.has_content) {
+        disabledReason = 'Export not ready yet'
+    }
+
+    const handleEdit = async (): Promise<void> => {
+        const r = await exportedAssetBlob(asset)
+        if (!r) {
+            lemonToast.error('Cannot get the file. Please try again.')
+            return
+        }
+        setBlob(r)
+    }
+
+    return (
+        <div className="flex gap-2 justify-end">
+            {asset.export_format === ExporterFormat.PNG && (
+                <LemonButton
+                    tooltip="Edit"
+                    size="xsmall"
+                    data-attr="export-editor"
+                    disabledReason={disabledReason}
+                    type={isNotDownloaded ? 'primary' : 'secondary'}
+                    icon={<IconPencil />}
+                    onClick={() => {
+                        void handleEdit()
+                    }}
+                />
+            )}
+            <LemonButton
+                tooltip="Download"
+                size="xsmall"
+                type={isNotDownloaded ? 'primary' : 'secondary'}
+                data-attr="export-download"
+                disabledReason={disabledReason}
+                onClick={() => {
+                    removeFresh(asset)
+                    void downloadExportedAsset(asset)
+                }}
+                sideIcon={
+                    stillCalculating ? (
+                        <Spinner />
+                    ) : asset.has_content ? (
+                        <IconDownload className="text-link" />
+                    ) : (
+                        <IconWarning className="text-link" />
+                    )
+                }
+            />
+        </div>
+    )
+}
+
+export function ExportsScene(): JSX.Element {
+    const { exports, exportsLoading, assetFormat } = useValues(sidePanelExportsLogic)
+    const { loadExports, setAssetFormat } = useActions(sidePanelExportsLogic)
+
+    const columns: LemonTableColumns<ExportedAssetType> = [
+        {
+            title: 'Filename',
+            dataIndex: 'filename',
+            render: (_, asset) => <span className="font-medium">{asset.filename}</span>,
+        },
+        {
+            title: 'Format',
+            dataIndex: 'export_format',
+            render: (_, asset) => (
+                <div className="flex items-center gap-1">
+                    <LemonTag>{asset.export_format}</LemonTag>
+                    {asset.export_format === ExporterFormat.CSV && (
+                        <span className="text-xs text-secondary">{ROW_LIMIT_IN_THOUSANDS}k row limit</span>
+                    )}
+                </div>
+            ),
+        },
+        {
+            title: 'Created',
+            dataIndex: 'created_at',
+            render: (_, asset) => (asset.created_at ? dayjs(asset.created_at).fromNow() : '–'),
+            sorter: (a, b) => dayjs(a.created_at).unix() - dayjs(b.created_at).unix(),
+        },
+        {
+            title: 'Expires',
+            dataIndex: 'expires_after',
+            render: (_, asset) => (asset.expires_after ? dayjs(asset.expires_after).fromNow() : '–'),
+        },
+        {
+            title: '',
+            width: 0,
+            render: (_, asset) => <ExportActions asset={asset} />,
+        },
+    ]
+
+    return (
+        <SceneContent>
+            <SceneTitleSection
+                name={sceneConfigurations[Scene.Exports].name}
+                description={sceneConfigurations[Scene.Exports].description}
+                resourceType={{ type: 'exports' }}
+                actions={
+                    <LemonButton
+                        onClick={loadExports}
+                        type="primary"
+                        size="small"
+                        icon={<IconRefresh />}
+                        loading={exportsLoading}
+                        data-attr="export-refresh"
+                    >
+                        Refresh
+                    </LemonButton>
+                }
+            />
+
+            <div className="flex justify-end mb-2">
+                <div className="flex items-center gap-2">
+                    <span className="text-sm">Format</span>
+                    <LemonSelect
+                        size="small"
+                        options={[
+                            { label: 'All', value: null },
+                            ...Object.entries(ExporterFormat).map(([key, value]) => ({
+                                label: key,
+                                value: value,
+                            })),
+                        ]}
+                        value={assetFormat}
+                        onChange={setAssetFormat}
+                        disabledReason={exportsLoading ? 'Loading exports...' : undefined}
+                    />
+                </div>
+            </div>
+
+            <LemonTable
+                columns={columns}
+                dataSource={exports}
+                loading={exportsLoading}
+                rowKey="id"
+                emptyState="No exports matching current filters"
+                defaultSorting={{ columnKey: 'created_at', order: -1 }}
+            />
+        </SceneContent>
+    )
+}

--- a/frontend/src/scenes/exports/exportsSceneLogic.tsx
+++ b/frontend/src/scenes/exports/exportsSceneLogic.tsx
@@ -1,0 +1,26 @@
+import { kea, path, selectors } from 'kea'
+
+import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
+import { Scene } from 'scenes/sceneTypes'
+import { sceneConfigurations } from 'scenes/scenes'
+
+import { Breadcrumb } from '~/types'
+
+import type { exportsSceneLogicType } from './exportsSceneLogicType'
+
+export const exportsSceneLogic = kea<exportsSceneLogicType>([
+    path(['scenes', 'exports', 'exportsSceneLogic']),
+    tabAwareScene(),
+    selectors({
+        breadcrumbs: [
+            () => [],
+            (): Breadcrumb[] => [
+                {
+                    key: Scene.Exports,
+                    name: sceneConfigurations[Scene.Exports].name,
+                    iconType: sceneConfigurations[Scene.Exports].iconType || 'default_icon_type',
+                },
+            ],
+        ],
+    }),
+])

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -54,6 +54,7 @@ export enum Scene {
     EventDefinitionEdit = 'EventDefinitionEdit',
     Experiment = 'Experiment',
     Experiments = 'Experiments',
+    Exports = 'Exports',
     ExperimentsSharedMetric = 'ExperimentsSharedMetric',
     ExperimentsSharedMetrics = 'ExperimentsSharedMetrics',
     ExploreEvents = 'ExploreEvents',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -507,6 +507,13 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
             'Monitor and maintain your PostHog SDK integrations by automatically detecting version issues, configuration problems, and implementation patterns across your applications.',
         defaultDocsPath: '/docs/sdk-doctor',
     },
+    [Scene.Exports]: {
+        projectBased: true,
+        name: 'Exports',
+        iconType: 'exports',
+        description:
+            'Retrieve your exports here. Exports are generated asynchronously and may take a few seconds to complete.',
+    },
     [Scene.SessionAttributionExplorer]: { projectBased: true, name: 'Session attribution explorer (beta)' },
     [Scene.SessionProfile]: { projectBased: true, name: 'Session profile' },
     [Scene.Settings]: { projectBased: true, name: 'Settings' },
@@ -905,6 +912,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.health()]: [Scene.Health, 'health'],
     [urls.pipelineStatus()]: [Scene.PipelineStatus, 'pipelineStatus'],
     [urls.sdkDoctor()]: [Scene.SdkDoctor, 'sdkDoctor'],
+    [urls.exports()]: [Scene.Exports, 'exports'],
     [urls.startups()]: [Scene.StartupProgram, 'startupProgram'],
     [urls.startups(':referrer')]: [Scene.StartupProgram, 'startupProgramWithReferrer'],
     [urls.oauthAuthorize()]: [Scene.OAuthAuthorize, 'oauthAuthorize'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -231,6 +231,7 @@ export const urls = {
     health: (): string => '/health',
     pipelineStatus: (): string => '/health/pipeline-status',
     sdkDoctor: (): string => '/health/sdk-doctor',
+    exports: (): string => '/exports',
 }
 
 export interface UrlMatcher {

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1318,6 +1318,10 @@ class MyFlagsResponseSerializer(serializers.Serializer):
     value = serializers.JSONField()
 
 
+class MyFlagsResponseListSerializer(serializers.ListSerializer):
+    child = MyFlagsResponseSerializer()
+
+
 class LocalEvaluationResponseSerializer(serializers.Serializer):
     flags: serializers.ListSerializer = serializers.ListSerializer(child=MinimalFeatureFlagSerializer())
     group_type_mapping = serializers.DictField(child=serializers.CharField())
@@ -1743,7 +1747,7 @@ class FeatureFlagViewSet(
     @validated_request(
         query_serializer=MyFlagsQuerySerializer,
         responses={
-            200: OpenApiResponse(response=MyFlagsResponseSerializer(many=True)),
+            200: OpenApiResponse(response=MyFlagsResponseListSerializer),
         },
     )
     @action(methods=["GET"], detail=False, pagination_class=None)

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1318,10 +1318,6 @@ class MyFlagsResponseSerializer(serializers.Serializer):
     value = serializers.JSONField()
 
 
-class MyFlagsResponseListSerializer(serializers.ListSerializer):
-    child = MyFlagsResponseSerializer()
-
-
 class LocalEvaluationResponseSerializer(serializers.Serializer):
     flags: serializers.ListSerializer = serializers.ListSerializer(child=MinimalFeatureFlagSerializer())
     group_type_mapping = serializers.DictField(child=serializers.CharField())
@@ -1747,7 +1743,7 @@ class FeatureFlagViewSet(
     @validated_request(
         query_serializer=MyFlagsQuerySerializer,
         responses={
-            200: OpenApiResponse(response=MyFlagsResponseListSerializer),
+            200: OpenApiResponse(response=MyFlagsResponseSerializer(many=True)),
         },
     )
     @action(methods=["GET"], detail=False, pagination_class=None)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1749,6 +1749,7 @@ class FileSystemIconType(StrEnum):
     LLM_DATASETS = "llm_datasets"
     LLM_PROMPTS = "llm_prompts"
     LLM_CLUSTERS = "llm_clusters"
+    EXPORTS = "exports"
 
 
 class FileSystemViewLogEntry(BaseModel):


### PR DESCRIPTION
## Problem

- Exports were last item to move from side panel
- previous pr's introduced new scenes SDK doctor and Pipeline status, and these weren't searchable in `cmd k`
- Posthog status was in helpmenu and should be in Health menu


## Changes

- Add new exports scene
- `If openSidePanel(Exports) and flag`, we show a Toast instead of opening the the sidepanel
- Add SDK, Pipeline status, and exports to search
- Move posthog status to Health menu

![2026-02-05 21 04 43](https://github.com/user-attachments/assets/fee24f67-ea2a-4eb0-aaa5-4b81808848e4)

![2026-02-05 21 05 53](https://github.com/user-attachments/assets/6ee1322f-c3f3-434b-a446-c0d8cf8f2845)

<img width="1078" height="842" alt="image" src="https://github.com/user-attachments/assets/a4afca78-0c40-4a75-b705-9655a1ea33b5" />


## How did you test this code?
Locally

## Publish to changelog?
No