### PR TITLE
chore: Reorganize Claude Code for web setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,6 @@
   - Auto-detect flox environment before running terminal commands
   - If flox is available, and you run into trouble executing commands, try with `flox activate -- bash -c "<command>"` pattern
     - Never use `flox activate` in interactive sessions (it hangs if you try)
-  - **Claude Code for web**: See `CLAUDE_CODE_WEB.md` for environment setup instructions
 - Tests:
   - All tests: `pytest`
   - Single test: `pytest path/to/test.py::TestClass::test_method`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,4 +2,4 @@
 
 See consolidated agents instructions in @AGENTS.md
 
-If you are Claude Code for web (i.e. you are running on platform linux with a working directory of `/home/user/posthog` and flox is not installed), read the setup instructions in `CLAUDE_CODE_WEB.md`.
+If you are Claude Code for web (i.e. you are running on platform linux with a working directory of `/home/user/posthog` and flox is not installed), read the setup instructions in @CLAUDE_CODE_WEB.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
 # PostHog Development Guide
 
 See consolidated agents instructions in @AGENTS.md
+
+If you are Claude Code for web (i.e. you are running on platform linux with a working directory of `/home/user/posthog` and flox is not installed), read the setup instructions in `CLAUDE_CODE_WEB.md`.


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/46978 did not work, turns out that claude doesn't know if it's claude web vs cli.

Again, I asked claude to have a go at fixing this.

Claude:

The setup instructions for Claude Code for web were scattered across multiple documentation files, making them harder to discover and maintain. The reference in AGENTS.md was out of place since it's specific to a particular Claude environment rather than general agent guidance.

## Changes

- Removed the Claude Code for web reference from AGENTS.md (which contains general agent instructions)
- Added a conditional note in CLAUDE.md that directs Claude Code for web users to the setup instructions in CLAUDE_CODE_WEB.md
- This keeps environment-specific setup instructions consolidated in one place while maintaining clear navigation

## How did you test this code?

Documentation-only changes. Verified that:
- The reference to CLAUDE_CODE_WEB.md is still accessible to users who need it
- General agent instructions in AGENTS.md remain focused on their intended audience
- The conditional note in CLAUDE.md clearly identifies when it applies

## Publish to changelog?

No

https://claude.ai/code/session_014b9E29MENPYCztRSJ76mSQ