### PR TITLE
feat(logs): register LogsQuery in get_query_runner with access control block

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -837,6 +837,19 @@ def get_query_runner(
             limit_context=limit_context,
         )
 
+    # Registered here for server-side CSV export only (ExportedAsset + Celery).
+    # Direct queries are blocked by LogsQueryRunner.validate_query_runner_access.
+    if kind == "LogsQuery":
+        from products.logs.backend.logs_query_runner import LogsQueryRunner
+
+        return LogsQueryRunner(
+            query=query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+        )
+
     raise ValueError(f"Can't get a runner for an unknown query kind: {kind}")
 
 

--- a/products/logs/backend/test/test_logs_query_runner_access.py
+++ b/products/logs/backend/test/test_logs_query_runner_access.py
@@ -1,0 +1,74 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from rest_framework import status
+
+from posthog.schema import DateRange, FilterLogicalOperator, LogsQuery, PropertyGroupFilter
+
+from posthog.rbac.user_access_control import UserAccessControlError
+
+from products.logs.backend.logs_query_runner import LogsQueryRunner
+
+
+def _minimal_query_data() -> dict:
+    return {
+        "dateRange": {"date_from": "2024-01-01T00:00:00Z", "date_to": "2024-01-02T00:00:00Z"},
+        "filterGroup": {"type": "AND", "values": []},
+        "severityLevels": [],
+        "serviceNames": [],
+    }
+
+
+def _build_runner(team) -> LogsQueryRunner:
+    return LogsQueryRunner(
+        team=team,
+        query=LogsQuery(
+            dateRange=DateRange(date_from="2024-01-01T00:00:00Z", date_to="2024-01-02T00:00:00Z"),
+            filterGroup=PropertyGroupFilter(type=FilterLogicalOperator.AND_, values=[]),
+            severityLevels=[],
+            serviceNames=[],
+            kind="LogsQuery",
+        ),
+    )
+
+
+class TestLogsQueryRunnerAccess(APIBaseTest):
+    def test_validate_query_runner_access_always_blocks_with_user(self):
+        runner = _build_runner(self.team)
+
+        with self.assertRaises(UserAccessControlError):
+            runner.validate_query_runner_access(self.user)
+
+    def test_run_without_user_skips_access_check(self):
+        """Celery export tasks call run() without a user — access check must be skipped."""
+        runner = _build_runner(self.team)
+
+        with patch.object(runner, "_calculate") as mock_calculate:
+            from posthog.schema import LogsQueryResponse
+
+            mock_calculate.return_value = LogsQueryResponse(results=[], hasMore=False)
+            response = runner.run()
+            assert response is not None
+
+    def test_run_with_user_raises_access_error(self):
+        """User-initiated queries via the generic endpoint must be blocked."""
+        runner = _build_runner(self.team)
+
+        with self.assertRaises(UserAccessControlError):
+            runner.run(user=self.user)
+
+
+class TestLogsQueryBlockedOnGenericEndpoint(APIBaseTest):
+    def test_generic_query_endpoint_rejects_logs_query(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.pk}/query/",
+            data={
+                "query": {
+                    "kind": "LogsQuery",
+                    **_minimal_query_data(),
+                },
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Access control failure" in response.json()["detail"]


### PR DESCRIPTION
## Problem

Server-side CSV export for logs needs `LogsQuery` registered in the query runner system so the standard `ExportedAsset` + Celery pipeline can process it. However, registering it also exposes `LogsQuery` via the generic `/api/projects/:id/query/` endpoint, which we don't want until the schema is stable.

## Changes

- Register `LogsQuery` in `get_query_runner` for CSV export support
- Override `validate_query_runner_access` in `LogsQueryRunner` to block all user-initiated queries via the generic endpoint
- Celery export tasks (no user context) bypass the check and work as expected

## How did you test this code?

- Unit + integration tests covering all three code paths:
  - `validate_query_runner_access` always raises for any user
  - `run()` without user (Celery) succeeds
  - `POST /api/projects/:id/query/` with `LogsQuery` returns 400
- Manually verified via Postman: generic endpoint blocked, dedicated `/logs/query/` unaffected

## Publish to changelog?

No
