### PR TITLE
chore(ph-ai): auto set mode from URL

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -313,7 +313,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
         conversation_id = serializer.validated_data["conversation"]
 
         has_message = serializer.validated_data.get("content") is not None
-        is_deep_research = serializer.validated_data.get("agent_mode") == AgentMode.RESEARCH
+        is_research = serializer.validated_data.get("agent_mode") == AgentMode.RESEARCH
 
         is_new_conversation = False
         # Safely set the lookup kwarg for potential error handling
@@ -334,7 +334,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
             # Use frontend-provided conversation ID
             # Mark conversation as internal if created during an impersonated session (support agents)
             is_impersonated = is_impersonated_session(request)
-            conversation_type = Conversation.Type.DEEP_RESEARCH if is_deep_research else Conversation.Type.ASSISTANT
+            conversation_type = Conversation.Type.DEEP_RESEARCH if is_research else Conversation.Type.ASSISTANT
             conversation = Conversation.objects.create(
                 user=cast(User, request.user),
                 team=self.team,
@@ -348,7 +348,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
         has_message = serializer.validated_data.get("message") is not None
         has_resume_payload = serializer.validated_data.get("resume_payload") is not None
         if conversation.type == Conversation.Type.DEEP_RESEARCH:
-            is_deep_research = True
+            is_research = True
 
         if has_message and not is_idle:
             raise Conflict("Cannot resume streaming with a new message")
@@ -358,7 +358,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
 
         workflow_inputs: ChatAgentWorkflowInputs | ResearchAgentWorkflowInputs
         workflow_class: type[ChatAgentWorkflow] | type[ResearchAgentWorkflow]
-        if is_deep_research:
+        if is_research:
             workflow_inputs = ResearchAgentWorkflowInputs(
                 team_id=self.team_id,
                 user_id=cast(User, request.user).pk,  # Use pk instead of id for User model

--- a/frontend/src/scenes/max/components/ModeSelector.tsx
+++ b/frontend/src/scenes/max/components/ModeSelector.tsx
@@ -142,7 +142,7 @@ function buildGeneralTooltip(description: string, defaultTools: ToolDefinition[]
 
 interface GetModeOptionsParams {
     planModeEnabled: boolean
-    deepResearchEnabled: boolean
+    researchEnabled: boolean
     webSearchEnabled: boolean
     errorTrackingModeEnabled: boolean
     surveyModeEnabled: boolean
@@ -152,7 +152,7 @@ interface GetModeOptionsParams {
 
 function getModeOptions({
     planModeEnabled,
-    deepResearchEnabled,
+    researchEnabled,
     webSearchEnabled,
     errorTrackingModeEnabled,
     surveyModeEnabled,
@@ -185,21 +185,21 @@ function getModeOptions({
         })
     }
 
-    if (deepResearchEnabled && !hasExistingMessages) {
+    if (researchEnabled && !hasExistingMessages) {
         specialOptions.push({
-            value: 'deep_research' as ModeValue,
+            value: 'research' as ModeValue,
             label: (
                 <span className="flex items-center gap-1">
-                    {SPECIAL_MODES.deep_research.name}
-                    {SPECIAL_MODES.deep_research.beta && (
+                    {SPECIAL_MODES.research.name}
+                    {SPECIAL_MODES.research.beta && (
                         <LemonTag size="small" type="warning">
                             BETA
                         </LemonTag>
                     )}
                 </span>
             ),
-            icon: SPECIAL_MODES.deep_research.icon,
-            tooltip: <div>{SPECIAL_MODES.deep_research.description}</div>,
+            icon: SPECIAL_MODES.research.icon,
+            tooltip: <div>{SPECIAL_MODES.research.description}</div>,
         })
     }
 
@@ -241,22 +241,19 @@ function getModeOptions({
 export function ModeSelector(): JSX.Element | null {
     const { agentMode, contextDisabledReason, conversation, threadMessageCount } = useValues(maxThreadLogic)
     const { setAgentMode } = useActions(maxThreadLogic)
-    const deepResearchEnabled = useFeatureFlag('MAX_DEEP_RESEARCH')
+    const researchEnabled = useFeatureFlag('MAX_DEEP_RESEARCH')
     const planModeEnabled = useFeatureFlag('PHAI_PLAN_MODE')
     const webSearchEnabled = useFeatureFlag('PHAI_WEB_SEARCH')
     const errorTrackingModeEnabled = useFeatureFlag('PHAI_ERROR_TRACKING_MODE')
     const surveyModeEnabled = useFeatureFlag('PHAI_SURVEY_MODE')
     const flagsModeEnabled = useFeatureFlag('POSTHOG_AI_FLAGS_MODE')
 
-    const currentValue: ModeValue =
-        agentMode === AgentMode.Research ? 'deep_research' : agentMode === AgentMode.Plan ? 'plan' : agentMode
-
     const hasExistingMessages = threadMessageCount > 0
     const modeOptions = useMemo(
         () =>
             getModeOptions({
                 planModeEnabled,
-                deepResearchEnabled,
+                researchEnabled,
                 webSearchEnabled,
                 errorTrackingModeEnabled,
                 flagsModeEnabled,
@@ -265,7 +262,7 @@ export function ModeSelector(): JSX.Element | null {
             }),
         [
             planModeEnabled,
-            deepResearchEnabled,
+            researchEnabled,
             webSearchEnabled,
             errorTrackingModeEnabled,
             surveyModeEnabled,
@@ -278,26 +275,19 @@ export function ModeSelector(): JSX.Element | null {
     const handleChange = useCallback(
         (value: ModeValue): void => {
             posthog.capture('phai mode switched', {
-                previous_mode: currentValue,
+                previous_mode: agentMode,
                 new_mode: value,
             })
-
-            if (value === 'deep_research') {
-                setAgentMode(AgentMode.Research)
-            } else if (value === 'plan') {
-                setAgentMode(AgentMode.Plan)
-            } else {
-                setAgentMode(value as AgentMode | null)
-            }
+            setAgentMode(value as AgentMode | null)
         },
-        [currentValue, setAgentMode]
+        [agentMode, setAgentMode]
     )
 
     const isDeepResearch = conversation?.type === ConversationType.DeepResearch
 
     return (
         <LemonSelect
-            value={isDeepResearch ? 'deep_research' : currentValue}
+            value={isDeepResearch ? 'research' : agentMode}
             onChange={handleChange}
             options={modeOptions}
             size="xxsmall"

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -1025,7 +1025,7 @@ export const SPECIAL_MODES: Record<string, ModeDefinition> = {
         icon: <IconNotebook />,
         beta: true,
     },
-    deep_research: {
+    research: {
         name: 'Research',
         description:
             'Answers complex questions using advanced reasoning models and more resources, taking more time to provide deeper insights.',

--- a/frontend/src/scenes/max/maxLogic.test.ts
+++ b/frontend/src/scenes/max/maxLogic.test.ts
@@ -3,46 +3,61 @@ import { expectLogic, partial } from 'kea-test-utils'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { useMocks } from '~/mocks/jest'
+import { AgentMode } from '~/queries/schema/schema-assistant-messages'
 import { initKeaTests } from '~/test/init'
+import { SidePanelTab } from '~/types'
 
 import { QUESTION_SUGGESTIONS_DATA, maxLogic } from './maxLogic'
+import { maxThreadLogic } from './maxThreadLogic'
 import { maxMocks } from './testUtils'
 
 describe('maxLogic', () => {
     let logic: ReturnType<typeof maxLogic.build>
+    let threadLogic: ReturnType<typeof maxThreadLogic.build> | null = null
 
     beforeEach(() => {
+        localStorage.clear()
         useMocks(maxMocks)
         initKeaTests()
     })
 
     afterEach(() => {
+        threadLogic?.unmount()
+        threadLogic = null
         sidePanelStateLogic.unmount()
+        // Reset maxLogic state before unmounting to prevent state leaking to next test
+        if (logic?.isMounted()) {
+            logic.actions.startNewConversation()
+        }
         logic?.unmount()
     })
 
     it('sets the question when URL has hash param #panel=max:Foo', async () => {
-        // Set up router with #panel=max:Foo
-        router.actions.push('', {}, { panel: 'max:Foo' })
+        // Set up sidePanelStateLogic with the options before mounting maxLogic
         sidePanelStateLogic.mount()
+        await expectLogic(sidePanelStateLogic, () => {
+            sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, 'Foo')
+        }).toDispatchActions(['openSidePanel'])
 
         // Mount maxLogic after setting up the sidePanelStateLogic state
-        logic = maxLogic({ tabId: 'test' })
+        logic = maxLogic({ tabId: 'sidepanel' })
         logic.mount()
 
-        // Check that the question has been set to "Foo" (via sidePanelStateLogic automatically)
+        // Check that the question has been set to "Foo"
         await expectLogic(logic).toMatchValues({
             question: 'Foo',
         })
     })
 
     it('sets autoRun and question when URL has hash param #panel=max:!Foo', async () => {
-        // Set up router with #panel=max:!Foo
-        router.actions.push('', {}, { panel: 'max:!Foo' })
+        // Set up sidePanelStateLogic with the options before mounting maxLogic
         sidePanelStateLogic.mount()
+        await expectLogic(sidePanelStateLogic, () => {
+            sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, '!Foo')
+        }).toDispatchActions(['openSidePanel'])
 
         // Must create the logic first to spy on its actions
-        logic = maxLogic({ tabId: 'test' })
+        logic = maxLogic({ tabId: 'sidepanel' })
         logic.mount()
 
         // Only mount maxLogic after setting up the router and sidePanelStateLogic
@@ -176,6 +191,199 @@ describe('maxLogic', () => {
             logic.actions.setConversationId('test-conversation-id')
         }).toMatchValues({
             threadLogicKey: 'test-conversation-id',
+        })
+    })
+
+    describe('mode URL parameter', () => {
+        it('parses mode=research:!Question correctly', async () => {
+            sidePanelStateLogic.mount()
+            await expectLogic(sidePanelStateLogic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, 'mode=research:!Question')
+            }).toDispatchActions(['openSidePanel'])
+
+            logic = maxLogic({ tabId: 'sidepanel' })
+            logic.mount()
+
+            await expectLogic(logic).toMatchValues({
+                autoRun: true,
+                question: 'Question',
+            })
+
+            threadLogic = maxThreadLogic({
+                tabId: 'sidepanel',
+                conversationId: logic.values.frontendConversationId,
+                conversation: null,
+            })
+            threadLogic.mount()
+
+            await expectLogic(threadLogic).toMatchValues({
+                agentMode: AgentMode.Research,
+            })
+        })
+
+        it('parses mode=product_analytics:Question correctly', async () => {
+            sidePanelStateLogic.mount()
+            await expectLogic(sidePanelStateLogic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, 'mode=product_analytics:Question')
+            }).toDispatchActions(['openSidePanel'])
+
+            logic = maxLogic({ tabId: 'sidepanel' })
+            logic.mount()
+
+            await expectLogic(logic).toMatchValues({
+                autoRun: false,
+                question: 'Question',
+            })
+
+            threadLogic = maxThreadLogic({
+                tabId: 'sidepanel',
+                conversationId: logic.values.frontendConversationId,
+                conversation: null,
+            })
+            threadLogic.mount()
+
+            await expectLogic(threadLogic).toMatchValues({
+                agentMode: AgentMode.ProductAnalytics,
+            })
+        })
+
+        it('parses mode=sql:!Write a query correctly', async () => {
+            sidePanelStateLogic.mount()
+            await expectLogic(sidePanelStateLogic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, 'mode=sql:!Write a query')
+            }).toDispatchActions(['openSidePanel'])
+
+            logic = maxLogic({ tabId: 'sidepanel' })
+            logic.mount()
+
+            await expectLogic(logic).toMatchValues({
+                autoRun: true,
+                question: 'Write a query',
+            })
+
+            threadLogic = maxThreadLogic({
+                tabId: 'sidepanel',
+                conversationId: logic.values.frontendConversationId,
+                conversation: null,
+            })
+            threadLogic.mount()
+
+            await expectLogic(threadLogic).toMatchValues({
+                agentMode: AgentMode.SQL,
+            })
+        })
+
+        it('parses mode=auto:!Question correctly (null mode)', async () => {
+            // Mount maxLogic first and reset state to ensure clean slate
+            logic = maxLogic({ tabId: 'sidepanel' })
+            logic.mount()
+            logic.actions.startNewConversation()
+
+            // Now set up sidePanelStateLogic with the options
+            sidePanelStateLogic.mount()
+
+            // Dispatch openSidePanel - the listener in maxLogic will process this
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, 'mode=auto:!Question')
+            }).toMatchValues({
+                autoRun: true,
+                question: 'Question',
+            })
+
+            threadLogic = maxThreadLogic({
+                tabId: 'sidepanel',
+                conversationId: logic.values.frontendConversationId,
+                conversation: null,
+            })
+            threadLogic.mount()
+
+            await expectLogic(threadLogic).toMatchValues({
+                agentMode: null,
+            })
+        })
+
+        it('parses mode=research correctly (mode only, no question)', async () => {
+            // Mount maxLogic first and reset state to ensure clean slate
+            logic = maxLogic({ tabId: 'sidepanel' })
+            logic.mount()
+            logic.actions.startNewConversation()
+
+            // Now set up sidePanelStateLogic with the options
+            sidePanelStateLogic.mount()
+
+            // Dispatch openSidePanel - the listener in maxLogic will process this
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, 'mode=research')
+            }).toMatchValues({
+                autoRun: false,
+                question: '',
+            })
+
+            threadLogic = maxThreadLogic({
+                tabId: 'sidepanel',
+                conversationId: logic.values.frontendConversationId,
+                conversation: null,
+            })
+            threadLogic.mount()
+
+            await expectLogic(threadLogic).toMatchValues({
+                agentMode: AgentMode.Research,
+            })
+        })
+
+        it('parses mode=invalid_mode:!Question correctly (ignores invalid mode)', async () => {
+            sidePanelStateLogic.mount()
+            await expectLogic(sidePanelStateLogic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, 'mode=invalid_mode:!Question')
+            }).toDispatchActions(['openSidePanel'])
+
+            logic = maxLogic({ tabId: 'sidepanel' })
+            logic.mount()
+
+            await expectLogic(logic).toMatchValues({
+                autoRun: true,
+                question: 'Question',
+            })
+
+            threadLogic = maxThreadLogic({
+                tabId: 'sidepanel',
+                conversationId: logic.values.frontendConversationId,
+                conversation: null,
+            })
+            threadLogic.mount()
+
+            await expectLogic(threadLogic).toMatchValues({
+                agentMode: null,
+            })
+        })
+
+        it('parses !My question correctly (backwards compatibility)', async () => {
+            // Mount maxLogic first and reset state to ensure clean slate
+            logic = maxLogic({ tabId: 'sidepanel' })
+            logic.mount()
+            logic.actions.startNewConversation()
+
+            // Now set up sidePanelStateLogic with the options
+            sidePanelStateLogic.mount()
+
+            // Dispatch openSidePanel - the listener in maxLogic will process this
+            await expectLogic(logic, () => {
+                sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, '!My question')
+            }).toMatchValues({
+                autoRun: true,
+                question: 'My question',
+            })
+
+            threadLogic = maxThreadLogic({
+                tabId: 'sidepanel',
+                conversationId: logic.values.frontendConversationId,
+                conversation: null,
+            })
+            threadLogic.mount()
+
+            await expectLogic(threadLogic).toMatchValues({
+                agentMode: null,
+            })
         })
     })
 })

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -18,7 +18,7 @@ import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePane
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { actionsModel } from '~/models/actionsModel'
 import { productUrls } from '~/products'
-import { RootAssistantMessage } from '~/queries/schema/schema-assistant-messages'
+import { AgentMode, RootAssistantMessage } from '~/queries/schema/schema-assistant-messages'
 import { Breadcrumb, Conversation, ConversationDetail, ConversationStatus, SidePanelTab } from '~/types'
 
 import { maxContextLogic } from './maxContextLogic'
@@ -67,13 +67,45 @@ const HEADLINES = [
     'What do you want to know today?',
 ]
 
+interface ParsedCommand {
+    mode?: AgentMode | null
+    autoRun: boolean
+    question: string
+}
+
+function parseCommandString(options: string): ParsedCommand {
+    let remaining = options
+
+    // Check for mode parameter (format: mode=<value>:rest), remove it if present
+    if (remaining.startsWith('mode=')) {
+        const colonIndex = remaining.indexOf(':', 5) // After "mode="
+        remaining = colonIndex === -1 ? '' : remaining.slice(colonIndex + 1)
+    }
+
+    // Handle auto-run prefix
+    const autoRun = remaining.startsWith('!')
+    if (autoRun) {
+        remaining = remaining.slice(1)
+    }
+
+    return {
+        autoRun,
+        question: remaining.trim(),
+    }
+}
+
 function handleCommandString(options: string, actions: maxLogicType['actions']): void {
-    if (options.startsWith('!')) {
+    const parsed = parseCommandString(options)
+
+    // Note: The mode parameter is handled directly by maxThreadLogic in its afterMount
+    // to ensure the correct logic instance sets its own mode
+
+    if (parsed.autoRun) {
         actions.setAutoRun(true)
     }
-    const cleanedQuestion = options.replace(/^!/, '')
-    if (cleanedQuestion.trim() !== '') {
-        actions.setQuestion(cleanedQuestion)
+
+    if (parsed.question !== '') {
+        actions.setQuestion(parsed.question)
     }
 }
 
@@ -197,7 +229,7 @@ export const maxLogic = kea<maxLogicType>([
             },
         ],
 
-        autoRun: [false as boolean, { setAutoRun: (_, { autoRun }) => autoRun }],
+        autoRun: [false as boolean, { setAutoRun: (_, { autoRun }) => autoRun, startNewConversation: () => false }],
     }),
 
     selectors({


### PR DESCRIPTION
## Problem
We want to set a URL parameter to automatically set the mode.

You can now do: `app.posthog.com#panel=max:mode=research:!Question` to automatically set the mode and run research with that question.

Also standardized deep_research -> research everywhere except for the Conversation type.

## Changes
- Renamed variables from `is_deep_research` to `is_research` in the backend
- Updated frontend mode selector to use consistent naming for research mode
- Changed mode value from 'deep_research' to 'research' in the UI components
- Added support for URL-based mode setting via the `mode=` parameter
- Added comprehensive tests for the URL mode parameter functionality

## How did you test this code?
Added tests + manually

## Publish to changelog?
No