### PR TITLE
fix(ph-ai): better styling for dangerous approvals

### DIFF
--- a/frontend/src/scenes/max/DangerousOperationApprovalCard.tsx
+++ b/frontend/src/scenes/max/DangerousOperationApprovalCard.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 
-import { IconCheck, IconWarning, IconX } from '@posthog/icons'
+import { IconWarning } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
 
 import { DangerousOperationResponse } from '~/queries/schema/schema-assistant-messages'
@@ -34,10 +34,14 @@ export function DangerousOperationApprovalCard({ operation }: DangerousOperation
     // Show pending state while waiting for resolution
     if (!resolvedStatus) {
         return (
-            <div className="flex items-center gap-2 text-muted text-xs">
-                <IconWarning className="size-4" />
-                <span>Awaiting approval...</span>
-                <Spinner className="size-3" />
+            <div className="flex text-xs text-muted">
+                <div className="flex items-center justify-center size-5">
+                    <IconWarning />
+                </div>
+                <div className="flex items-center gap-1 flex-1 min-w-0">
+                    <span>Awaiting approval...</span>
+                    <Spinner className="size-3" />
+                </div>
             </div>
         )
     }
@@ -53,10 +57,13 @@ export function DangerousOperationApprovalCard({ operation }: DangerousOperation
             : `${subject} declined this operation`
 
     return (
-        <div className="flex items-center gap-1 text-xs text-muted">
-            <IconWarning className="size-4" />
-            <span>{text}</span>
-            {isApproved ? <IconCheck className="text-success size-3" /> : <IconX className="text-danger size-3" />}
+        <div className="flex text-xs text-muted">
+            <div className="flex items-center justify-center size-5">
+                <IconWarning />
+            </div>
+            <div className="flex items-center gap-1 flex-1 min-w-0">
+                <span>{text}</span>
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -1631,15 +1631,26 @@ function enhanceThreadToolCalls(
         }
     }
 
-    // Create a set of tool call IDs that have pending approvals
+    // Create sets of tool call IDs based on approval status
     // An approval is truly pending if:
     // 1. It's in pendingApprovalsData with decision_status === 'pending', AND
     // 2. It's NOT in resolvedApprovalStatuses (which takes precedence)
     const toolCallsWithPendingApproval = new Set<string>()
+    // Track tool calls that have been rejected (declined by user)
+    const toolCallsWithRejectedApproval = new Set<string>()
     for (const approval of Object.values(pendingApprovalsData)) {
-        const isResolved = resolvedApprovalStatuses[approval.proposal_id]?.status !== undefined
-        if (approval.original_tool_call_id && approval.decision_status === 'pending' && !isResolved) {
-            toolCallsWithPendingApproval.add(approval.original_tool_call_id)
+        const frontendResolved = resolvedApprovalStatuses[approval.proposal_id]
+        if (approval.original_tool_call_id) {
+            // Frontend resolved status takes precedence over backend status
+            if (frontendResolved?.status) {
+                if (frontendResolved.status === 'rejected' || frontendResolved.status === 'auto_rejected') {
+                    toolCallsWithRejectedApproval.add(approval.original_tool_call_id)
+                }
+            } else if (approval.decision_status === 'pending') {
+                toolCallsWithPendingApproval.add(approval.original_tool_call_id)
+            } else if (approval.decision_status === 'rejected') {
+                toolCallsWithRejectedApproval.add(approval.original_tool_call_id)
+            }
         }
     }
 
@@ -1688,8 +1699,11 @@ function enhanceThreadToolCalls(
                 const isInteractiveTool = toolCall.name === 'create_form'
                 // Tool calls with pending approvals should show as "in progress" (awaiting approval)
                 const hasPendingApproval = toolCallsWithPendingApproval.has(toolCall.id)
+                // Tool calls with rejected approvals should show as "failed" (user declined)
+                const hasRejectedApproval = toolCallsWithRejectedApproval.has(toolCall.id)
                 const isFailed =
-                    !isCompleted && !isInteractiveTool && !hasPendingApproval && (!isFinalGroup || !isLoading)
+                    hasRejectedApproval ||
+                    (!isCompleted && !isInteractiveTool && !hasPendingApproval && (!isFinalGroup || !isLoading))
                 return {
                     ...toolCall,
                     status: isFailed


### PR DESCRIPTION
## Problem
Dangerous approval styling is inconsistent with the rest of the chat.

Before:
![image.png](https://app.graphite.com/user-attachments/assets/1ca37b3d-8106-441e-b0ed-53222c043b51.png)

After:
![image.png](https://app.graphite.com/user-attachments/assets/84bfc11c-ee91-4bea-a6ce-efd0aa1306ba.png)

## Changes
- Tool calls are now correctly marked as failed if the approval is rejected
- No icons next to the approval result alert

## How did you test this code?
Manually + added tests

## Publish to changelog?
No