### PR TITLE
fix(duckling): cap DuckDB memory and fix DELETE partition pruning for OOM

### DIFF
--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -7,7 +7,6 @@ import duckdb
 from parameterized import parameterized
 
 from posthog.dags.events_backfill_to_duckling import (
-    DUCKDB_MEMORY_LIMIT,
     EVENTS_COLUMNS,
     EVENTS_TABLE_DDL,
     EXPECTED_DUCKLAKE_COLUMNS,

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -474,7 +474,8 @@ class TestDeleteRangePredicate:
             deleted = result[0] if result else 0
             assert deleted == expected_deleted
 
-            remaining = conn.execute("SELECT count(*) FROM events").fetchone()[0]
+            row = conn.execute("SELECT count(*) FROM events").fetchone()
+            remaining = row[0] if row else 0
             assert remaining == expected_remaining
         finally:
             conn.close()


### PR DESCRIPTION
## Summary
- The `duckling_events_backfill_job` was OOMKilled (16Gi pod) while processing a monthly partition for team_id=50689. DuckDB was using ~12.8Gi by default (80% of RAM), and DELETE queries forced full table scans due to misaligned partition predicates.
- Adds `_connect_duckdb()` helper capping DuckDB at 4GB with disk spill support, and fixes DELETE predicates to use range expressions (`timestamp >= $2 AND timestamp < $3`) that enable DuckLake partition pruning.

## Test plan
- [x] All 69 tests pass including 7 new tests for memory limits and date range boundaries
- [ ] Deploy and verify monthly backfill for team_id=50689 completes without OOM
- [ ] Monitor DuckDB memory usage stays within 4GB cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)