### PR TITLE
feat(llma): stagger generation summarization schedule by 30 minutes

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,7 +56,6 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
-                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -80,7 +79,6 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
-                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -97,7 +95,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND (("pmat_email" ILIKE '%g0%'
+                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/posthog/temporal/llm_analytics/trace_summarization/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/schedule.py
@@ -73,7 +73,14 @@ async def create_batch_generation_summarization_schedule(client: Client):
             id=GENERATION_COORDINATOR_SCHEDULE_ID,
             task_queue=settings.LLMA_TASK_QUEUE,
         ),
-        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(hours=SCHEDULE_INTERVAL_HOURS))]),
+        spec=ScheduleSpec(
+            intervals=[
+                ScheduleIntervalSpec(
+                    every=timedelta(hours=SCHEDULE_INTERVAL_HOURS),
+                    offset=timedelta(minutes=30),
+                )
+            ]
+        ),
     )
 
     if await a_schedule_exists(client, GENERATION_COORDINATOR_SCHEDULE_ID):


### PR DESCRIPTION
## Problem

The trace and generation summarization coordinator workflows are both scheduled at the top of each hour, competing for the same LLM API and ClickHouse resources simultaneously. This doubles peak resource contention unnecessarily since the two coordinators are independent.

## Changes

Added `offset=timedelta(minutes=30)` to the generation coordinator's `ScheduleIntervalSpec` so it runs at `:30` instead of `:00`, alternating with the trace coordinator. Single-line change in `schedule.py`.

- Trace coordinator: runs at `:00` (unchanged)
- Generation coordinator: runs at `:30` (new offset)

## How did you test this code?

- All 152 existing `posthog/temporal/llm_analytics/` tests pass
- Verified `ScheduleIntervalSpec(every=..., offset=...)` is the correct Temporal SDK API
- After deploy, verify in Temporal UI that the generation coordinator schedule shows the 30-min offset

## Publish to changelog?

No