### PR TITLE
fix(phai): flag tools

### DIFF
--- a/ee/hogai/chat_agent/toolkit.py
+++ b/ee/hogai/chat_agent/toolkit.py
@@ -79,6 +79,7 @@ class ChatAgentPlanToolkit(AgentToolkit):
 class ChatAgentToolkit(AgentToolkit):
     @property
     def tools(self) -> list[type[MaxTool]]:
+        # TRICKY: DO NOT EXTEND THE TOOLKIT HERE. THE TOOLS HERE ARE USED ACROSS ALL AGENT MODES.
         tools = list(DEFAULT_TOOLS)
         if has_phai_tasks_feature_flag(self._team, self._user):
             tools.extend(TASK_TOOLS)

--- a/ee/hogai/chat_agent/toolkit.py
+++ b/ee/hogai/chat_agent/toolkit.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from langchain_core.runnables import RunnableConfig
 
-from products.experiments.backend.max_tools import ExperimentSummaryTool
 from products.tasks.backend.max_tools import (
     CreateTaskTool,
     GetTaskRunLogsTool,
@@ -32,7 +31,6 @@ from ee.hogai.tools import (
 from ee.hogai.tools.finalize_plan.tool import FinalizePlanTool
 from ee.hogai.utils.feature_flags import (
     has_create_form_tool_feature_flag,
-    has_experiment_summary_tool_feature_flag,
     has_memory_tool_feature_flag,
     has_phai_tasks_feature_flag,
     has_task_tool_feature_flag,
@@ -90,8 +88,6 @@ class ChatAgentToolkit(AgentToolkit):
             tools.append(ManageMemoriesTool)
         if has_create_form_tool_feature_flag(self._team, self._user):
             tools.append(CreateFormTool)
-        if has_experiment_summary_tool_feature_flag(self._team, self._user):
-            tools.append(ExperimentSummaryTool)
         return tools
 
 

--- a/ee/hogai/core/agent_modes/presets/flags.py
+++ b/ee/hogai/core/agent_modes/presets/flags.py
@@ -2,10 +2,14 @@ from typing import TYPE_CHECKING
 
 from posthog.schema import AgentMode
 
+from products.experiments.backend.max_tools import CreateExperimentTool, ExperimentSummaryTool
+from products.feature_flags.backend.max_tools import CreateFeatureFlagTool
+
 from ee.hogai.chat_agent.executables import ChatAgentPlanExecutable, ChatAgentPlanToolsExecutable
 from ee.hogai.core.agent_modes.factory import AgentModeDefinition
 from ee.hogai.core.agent_modes.toolkit import AgentToolkit
 from ee.hogai.tools.todo_write import TodoWriteExample
+from ee.hogai.utils.feature_flags import has_experiment_summary_tool_feature_flag
 
 if TYPE_CHECKING:
     from ee.hogai.tool import MaxTool
@@ -73,10 +77,9 @@ class FlagsAgentToolkit(AgentToolkit):
 
     @property
     def tools(self) -> list[type["MaxTool"]]:
-        from products.experiments.backend.max_tools import CreateExperimentTool, ExperimentSummaryTool
-        from products.feature_flags.backend.max_tools import CreateFeatureFlagTool
-
-        tools: list[type[MaxTool]] = [CreateFeatureFlagTool, CreateExperimentTool, ExperimentSummaryTool]
+        tools: list[type[MaxTool]] = [CreateFeatureFlagTool, CreateExperimentTool]
+        if has_experiment_summary_tool_feature_flag(self._team, self._user):
+            tools.append(ExperimentSummaryTool)
         return tools
 
 

--- a/ee/hogai/core/agent_modes/presets/test/test_flags_preset.py
+++ b/ee/hogai/core/agent_modes/presets/test/test_flags_preset.py
@@ -1,4 +1,5 @@
 from posthog.test.base import BaseTest
+from unittest.mock import patch
 
 from langchain_core.runnables import RunnableConfig
 
@@ -8,7 +9,8 @@ from ..flags import FlagsAgentToolkit
 
 
 class TestFlagsAgentToolkit(BaseTest):
-    def test_toolkit_includes_all_tools(self):
+    @patch("ee.hogai.core.agent_modes.presets.flags.has_experiment_summary_tool_feature_flag", return_value=True)
+    def test_toolkit_includes_all_tools(self, _mock_flag):
         toolkit = FlagsAgentToolkit(
             team=self.team,
             user=self.user,


### PR DESCRIPTION
## Problem

The experiment summary tool was added to all modes, which should not be the case.

## Changes

- Remove the experiment summary from the chat_agent toolkit.

