### PR TITLE
chore(llma): add team IDs 117964 and 153418 to guaranteed dogfooders

### DIFF
--- a/posthog/temporal/llm_analytics/team_discovery.py
+++ b/posthog/temporal/llm_analytics/team_discovery.py
@@ -31,6 +31,8 @@ GUARANTEED_TEAM_IDS: list[int] = [
     237906,
     294356,
     21999,
+    117964,
+    153418,
 ]
 
 # Default sample percentage for gradual rollout.


### PR DESCRIPTION
## Problem

We need additional teams included in the guaranteed team list for LLM analytics trace/generation summarization and clustering workflows so they are always processed.

## Changes

Added team IDs 117964 and 153418 to `GUARANTEED_TEAM_IDS` in `posthog/temporal/llm_analytics/team_discovery.py`.

## How did you test this code?

Config-only change. No logic changes.

## Publish to changelog?

No