### PR TITLE
fix(modeling): better errors for does not exist

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -338,9 +338,10 @@ async def handle_model_ready(
 
     try:
         if model.selected is True:
+            job = await database_sync_to_async(DataModelingJob.objects.get)(id=job_id)
+
             team = await database_sync_to_async(Team.objects.get)(id=team_id)
             saved_query = await get_saved_query(team, model.label)
-            job = await database_sync_to_async(DataModelingJob.objects.get)(id=job_id)
 
             await materialize_model(model.label, team, saved_query, job, logger)
             ducklake_model = DuckLakeCopyModelInput(

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -12,6 +12,7 @@ import dataclasses
 import collections.abc
 
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 
 import pyarrow as pa
 import deltalake
@@ -356,6 +357,21 @@ async def handle_model_ready(
     except DataModelingCancelledException as err:
         await logger.aexception("Data modeling run was cancelled for model %s", model.label, job_id=job_id)
         await handle_cancelled(job, model, queue, err, "Data modeling run was cancelled for model %s: %s", logger)
+    except ObjectDoesNotExist as err:
+        error_msg = (
+            f"Object not found (team_id={team_id}, model_label={model.label}, job_id={job_id}): {err}. "
+            "This likely indicates an orphaned Temporal schedule that should be cleaned up."
+        )
+        await logger.aerror(
+            error_msg,
+            team_id=team_id,
+            model_label=model.label,
+            job_id=job_id,
+        )
+        capture_exception(err)
+        wrapped = Exception(error_msg)
+        wrapped.__cause__ = err
+        await handle_error(job, model, queue, wrapped, error_msg, logger)
     except Exception as err:
         await logger.aexception(
             "Failed to materialize model %s due to unexpected error: %s", model.label, str(err), job_id=job_id
@@ -546,6 +562,8 @@ async def materialize_model(
         if delta_table is None:
             error_message = "Query returned no results. Check that the query returns data before materializing."
             raise NonRetryableException(f"Query for model {model_label} failed: {error_message}")
+    except ObjectDoesNotExist:
+        raise
     except Exception as e:
         error_message = str(e)
         await logger.aerror(f"Error materializing model {model_label}: {error_message}")
@@ -1485,6 +1503,16 @@ async def fail_jobs_activity(inputs: FailJobsActivityInputs) -> None:
     await mark_job_as_failed(job, inputs.error, logger)
 
 
+def _format_exception_chain(e: BaseException) -> str:
+    """Walk the exception cause chain and return a detailed error string."""
+    parts = [str(e)]
+    cause = e.__cause__
+    while cause is not None:
+        parts.append(f"Caused by {type(cause).__name__}: {cause}")
+        cause = cause.__cause__
+    return "\n".join(parts)
+
+
 @dataclasses.dataclass
 class RunWorkflowInputs:
     """Inputs to `RunWorkflow`.
@@ -1600,11 +1628,12 @@ class RunWorkflow(PostHogWorkflow):
                 raise
 
             capture_exception(e)
-            temporalio.workflow.logger.error(f"Activity failed during model run: {str(e)}")
+            error_detail = _format_exception_chain(e)
+            temporalio.workflow.logger.error(f"Activity failed during model run: {error_detail}")
 
             await temporalio.workflow.execute_activity(
                 fail_jobs_activity,
-                FailJobsActivityInputs(job_id=job_id, error=str(e), team_id=inputs.team_id),
+                FailJobsActivityInputs(job_id=job_id, error=error_detail, team_id=inputs.team_id),
                 start_to_close_timeout=dt.timedelta(minutes=20),
                 retry_policy=temporalio.common.RetryPolicy(
                     maximum_attempts=3,
@@ -1612,9 +1641,10 @@ class RunWorkflow(PostHogWorkflow):
             )
             raise
         except Exception as e:
+            error_detail = _format_exception_chain(e)
             await temporalio.workflow.execute_activity(
                 fail_jobs_activity,
-                FailJobsActivityInputs(job_id=job_id, error=str(e), team_id=inputs.team_id),
+                FailJobsActivityInputs(job_id=job_id, error=error_detail, team_id=inputs.team_id),
                 start_to_close_timeout=dt.timedelta(minutes=20),
                 retry_policy=temporalio.common.RetryPolicy(
                     maximum_attempts=3,


### PR DESCRIPTION
## Problem

activity tasks fail when django raises a DoesNotExist error for teams, queries, etc. This can happen when teams are deleted but the temporal schedule is not cleaned up.

## Changes

At least make the error better in temporal so i can clean up manually when i see it and i can track it better in error tracking. Future PR will make sure that team deletion includes temporal schedule clean up.

## How did you test this code?

i didn't

## Publish to changelog?

no