### PR TITLE
fix(batch-exports): Fix bug displaying day name in backfill modal

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillModalLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillModalLogic.tsx
@@ -180,8 +180,7 @@ export const batchExportBackfillModalLogic = kea<batchExportBackfillModalLogicTy
                 if (dayOfWeek === null) {
                     return null
                 }
-                let dayOfWeekName = dayOptions[dayOfWeek].label
-                return dayOfWeekName
+                return dayOptions[dayOfWeek].label
             },
         ],
         hourOffset: [

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillModalLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillModalLogic.tsx
@@ -177,7 +177,11 @@ export const batchExportBackfillModalLogic = kea<batchExportBackfillModalLogicTy
         dayOfWeekName: [
             (s) => [s.dayOfWeek],
             (dayOfWeek: number | null): string | null => {
-                return dayOfWeek ? dayOptions[dayOfWeek].label : null
+                if (dayOfWeek === null) {
+                    return null
+                }
+                let dayOfWeekName = dayOptions[dayOfWeek].label
+                return dayOfWeekName
             },
         ],
         hourOffset: [


### PR DESCRIPTION
## Problem

Is the `dayOfWeek` is `0` then we currently don't display the day name properly.

## Changes

Fix this.

## How did you test this code?

Local stack.
