### PR TITLE
fix(cohorts): add cohort_id to query tagging for better monitoring

### DIFF
--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -223,6 +223,7 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
 
                 with tags_context(
                     team_id=cohort.team_id,
+                    cohort_id=cohort.id,
                     feature=Feature.BEHAVIORAL_COHORTS,
                     product=Product.MESSAGING,
                     query_type="realtime_cohort_calculation",


### PR DESCRIPTION
## Problem

Realtime cohort queries were missing lc_cohort_id in query logs, making debugging difficult.

## Changes

Add cohort_id parameter to tags_context() in realtime cohort calculation workflow.

## How did you test this code?

Tested locally to make sure `lc_cohort_id` is filled.