### PR TITLE
fix(Insights e2e): Edit insight flaky

### DIFF
--- a/playwright/page-models/insightPage.ts
+++ b/playwright/page-models/insightPage.ts
@@ -169,7 +169,9 @@ class TrendsInsight {
         const searchField = this.page.getByTestId('taxonomic-filter-searchfield')
         await searchField.waitFor({ state: 'visible' })
         await searchField.fill(property)
-        await this.page.locator('.taxonomic-list-row').first().click()
+        const row = this.page.locator('.taxonomic-list-row').first()
+        await row.waitFor({ state: 'visible' })
+        await row.click()
     }
 
     async setFormula(formula: string): Promise<void> {


### PR DESCRIPTION
## Problem

Saw this test be flaky on CI: Edit saved insight and save as new
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Make sure row is loaded before clicking it. 

## How did you test this code?
Run it 10 times locally, passes every time. 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
