### PR TITLE
fix(temporal): reduce realtime cohorts concurrency to prevent ClickHouse overload

### DIFF
--- a/posthog/temporal/messaging/schedule.py
+++ b/posthog/temporal/messaging/schedule.py
@@ -25,8 +25,8 @@ from posthog.temporal.messaging.realtime_cohort_calculation_workflow_coordinator
 )
 
 # Default configuration for realtime cohort calculation coordinator
-DEFAULT_COORDINATOR_PARALLELISM = 10
-DEFAULT_WORKFLOWS_PER_BATCH = 5
+DEFAULT_COORDINATOR_PARALLELISM = 6
+DEFAULT_WORKFLOWS_PER_BATCH = 2
 DEFAULT_BATCH_DELAY_MINUTES = 5
 
 # PostHog team ID for realtime cohort calculation processing


### PR DESCRIPTION
## Problem

PostHog production is experiencing ClickHouse query overload with error "Too many simultaneous queries for all users. Current: 504/506, maximum: 500".

## Changes

Reduced realtime cohort calculation concurrency parameters to alleviate ClickHouse query pressure:
- `DEFAULT_COORDINATOR_PARALLELISM`: 10 → 6 (40% reduction)
- `DEFAULT_WORKFLOWS_PER_BATCH`: 5 → 2 (60% reduction)

These changes maintain realtime cohort functionality while significantly reducing the number of concurrent ClickHouse queries generated by the temporal workflow coordinator.

## How did you test this code?

Testing will be conducted in production by monitoring ClickHouse query load metrics after deployment. Key metrics to monitor:
- Current/maximum simultaneous query counts
- Query failure rates

## Publish to changelog?

No