### PR TITLE
feat(surveys): add redesigned survey view with collapsible sidebar

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -212,6 +212,7 @@ export const FEATURE_FLAGS = {
     SURVEYS_ACTIONS: 'surveys-actions', // owner: #team-surveys
     SURVEYS_ADAPTIVE_LIMITS: 'surveys-adaptive-limits', // owner: #team-surveys
     SURVEYS_GUIDED_EDITOR: 'surveys-guided-editor', // owner: #team-surveys, enables the new simplified survey guided editor
+    SURVEYS_REDESIGNED_VIEW: 'surveys-redesigned-view', // owner: #team-surveys, enables the redesigned survey view with sidebar
     TRACK_MEMORY_USAGE: 'track-memory-usage', // owner: @pauldambra #team-replay
     TRACK_REACT_FRAMERATE: 'track-react-framerate', // owner: @pauldambra #team-replay
     WEB_ANALYTICS_API: 'web-analytics-api', // owner: #team-web-analytics

--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -45,16 +45,14 @@ export function SurveyComponent({ id }: SurveyLogicProps): JSX.Element {
         return <NotFound object="survey" />
     }
 
+    if (!id) {
+        return <LemonSkeleton />
+    }
+
     return (
-        <div>
-            {!id ? (
-                <LemonSkeleton />
-            ) : (
-                <BindLogic logic={surveyLogic} props={{ id }}>
-                    {isEditingSurvey ? <SurveyForm id={id} /> : <SurveyView id={id} />}
-                </BindLogic>
-            )}
-        </div>
+        <BindLogic logic={surveyLogic} props={{ id }}>
+            {isEditingSurvey ? <SurveyForm id={id} /> : <SurveyView id={id} />}
+        </BindLogic>
     )
 }
 

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -10,6 +10,7 @@ import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { SceneDuplicate } from 'lib/components/Scenes/SceneDuplicate'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
@@ -23,6 +24,7 @@ import { SurveyOverview } from 'scenes/surveys/SurveyOverview'
 import { SurveyResponseFilters } from 'scenes/surveys/SurveyResponseFilters'
 import { SurveyResultDemo } from 'scenes/surveys/SurveyResultDemo'
 import { SurveyStatsSummary } from 'scenes/surveys/SurveyStatsSummary'
+import { SurveyViewRedesign } from 'scenes/surveys/SurveyViewRedesign'
 import { LaunchSurveyButton } from 'scenes/surveys/components/LaunchSurveyButton'
 import { SurveyFeedbackButton } from 'scenes/surveys/components/SurveyFeedbackButton'
 import { SurveyQuestionVisualization } from 'scenes/surveys/components/question-visualizations/SurveyQuestionVisualization'
@@ -79,6 +81,16 @@ export const getThumbIcon = (value: unknown): JSX.Element | null => {
 }
 
 export function SurveyView({ id }: { id: string }): JSX.Element {
+    const isRedesignEnabled = useFeatureFlag('SURVEYS_REDESIGNED_VIEW')
+
+    if (isRedesignEnabled) {
+        return <SurveyViewRedesign />
+    }
+
+    return <SurveyViewLegacy id={id} />
+}
+
+function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
     const { survey, surveyLoading } = useValues(surveyLogic)
     const { editingSurvey, updateSurvey, stopSurvey, resumeSurvey, archiveSurvey } = useActions(surveyLogic)
     const { deleteSurvey, duplicateSurvey, setSurveyToDuplicate } = useActions(surveysLogic)

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyDraftContent.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyDraftContent.tsx
@@ -1,0 +1,23 @@
+import { IconRocket } from '@posthog/icons'
+
+import { LaunchSurveyButton } from 'scenes/surveys/components/LaunchSurveyButton'
+
+export function SurveyDraftContent(): JSX.Element {
+    return (
+        <div className="flex flex-col items-center justify-center py-16 gap-6 max-w-lg mx-auto text-center">
+            <div className="flex flex-col items-center gap-4">
+                <div className="w-14 h-14 rounded-full bg-primary-highlight flex items-center justify-center">
+                    <IconRocket className="text-3xl text-primary" />
+                </div>
+                <div>
+                    <h2 className="text-xl font-semibold m-0 mb-2">Ready to launch</h2>
+                    <p className="text-muted m-0">
+                        Your survey is configured and ready to start collecting responses. You can preview how it looks
+                        in the sidebar.
+                    </p>
+                </div>
+                <LaunchSurveyButton>Launch survey</LaunchSurveyButton>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveySidebar.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveySidebar.tsx
@@ -1,0 +1,319 @@
+import { useActions, useValues } from 'kea'
+import { combineUrl } from 'kea-router'
+import { getNextSurveyStep } from 'posthog-js/dist/surveys-preview'
+import { ReactNode, useEffect, useState } from 'react'
+
+import { IconDownload, IconPlus } from '@posthog/icons'
+import { LemonButton, LemonMenu, LemonSelect, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
+import { TZLabel } from 'lib/components/TZLabel'
+import { HogFunctionIcon } from 'scenes/hog-functions/configuration/HogFunctionIcon'
+import { SurveyAppearancePreview } from 'scenes/surveys/SurveyAppearancePreview'
+import { SURVEY_TYPE_LABEL_MAP } from 'scenes/surveys/constants'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { urls } from 'scenes/urls'
+
+import {
+    ExporterFormat,
+    HogFunctionType,
+    PropertyFilterType,
+    PropertyOperator,
+    Survey,
+    SurveyEventName,
+    SurveyEventProperties,
+    SurveyQuestionBranchingType,
+    SurveyType,
+} from '~/types'
+
+// ============================================================================
+// Panel Section - Wrapper for consistent panel styling
+// ============================================================================
+
+interface PanelSectionProps {
+    title: string
+    description?: string
+    children: ReactNode
+}
+
+function PanelSection({ title, description, children }: PanelSectionProps): JSX.Element {
+    return (
+        <div className="flex flex-col gap-3">
+            <div>
+                <div className="text-xs font-semibold uppercase tracking-wide">{title}</div>
+                {description && <p className="text-xs text-muted m-0 mt-1">{description}</p>}
+            </div>
+            {children}
+        </div>
+    )
+}
+
+// ============================================================================
+// Panel Components
+// ============================================================================
+
+export function SurveyDetailsPanel(): JSX.Element {
+    const { survey, selectedPageIndex } = useValues(surveyLogic)
+    const { setSelectedPageIndex } = useActions(surveyLogic)
+    const isNonApiSurvey = survey.type !== SurveyType.API
+
+    return (
+        <div className="flex flex-col gap-6">
+            {/* Preview */}
+            {isNonApiSurvey && (
+                <PanelSection title="Preview">
+                    <div className="flex flex-col gap-3">
+                        <div className="flex justify-center">
+                            <SurveyAppearancePreview
+                                survey={survey as Survey}
+                                previewPageIndex={selectedPageIndex || 0}
+                                onPreviewSubmit={(response) => {
+                                    const nextStep = getNextSurveyStep(survey, selectedPageIndex, response)
+                                    if (
+                                        nextStep === SurveyQuestionBranchingType.End &&
+                                        !survey.appearance?.displayThankYouMessage
+                                    ) {
+                                        return
+                                    }
+                                    setSelectedPageIndex(
+                                        nextStep === SurveyQuestionBranchingType.End
+                                            ? survey.questions.length
+                                            : nextStep
+                                    )
+                                }}
+                            />
+                        </div>
+                        <LemonSelect
+                            size="xsmall"
+                            fullWidth
+                            value={selectedPageIndex || 0}
+                            onChange={(pageIndex) => setSelectedPageIndex(pageIndex)}
+                            options={[
+                                ...survey.questions.map((question, index) => ({
+                                    label: `${index + 1}. ${question.question ?? ''}`,
+                                    value: index,
+                                })),
+                                ...(survey.appearance?.displayThankYouMessage
+                                    ? [{ label: 'Thank you message', value: survey.questions.length }]
+                                    : []),
+                            ]}
+                        />
+                    </div>
+                </PanelSection>
+            )}
+
+            {/* Survey info */}
+            <PanelSection title="Details">
+                <div className="flex flex-col gap-1.5 text-sm">
+                    <div className="flex justify-between">
+                        <span className="text-muted">Type</span>
+                        <span>{SURVEY_TYPE_LABEL_MAP[survey.type]}</span>
+                    </div>
+                    <div className="flex justify-between">
+                        <span className="text-muted">Questions</span>
+                        <span>{survey.questions.length}</span>
+                    </div>
+                    {survey.start_date && (
+                        <div className="flex justify-between">
+                            <span className="text-muted">Started</span>
+                            <TZLabel time={survey.start_date} />
+                        </div>
+                    )}
+                    {survey.end_date && (
+                        <div className="flex justify-between">
+                            <span className="text-muted">Ended</span>
+                            <TZLabel time={survey.end_date} />
+                        </div>
+                    )}
+                    {survey.responses_limit && (
+                        <div className="flex justify-between">
+                            <span className="text-muted">Response limit</span>
+                            <span>{survey.responses_limit}</span>
+                        </div>
+                    )}
+                </div>
+            </PanelSection>
+        </div>
+    )
+}
+
+function newNotificationUrl(surveyId: string): string {
+    const filters = {
+        events: [
+            {
+                id: SurveyEventName.SENT,
+                type: 'events',
+                properties: [
+                    {
+                        key: SurveyEventProperties.SURVEY_ID,
+                        type: PropertyFilterType.Event,
+                        value: surveyId,
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            },
+        ],
+    }
+    return combineUrl(urls.hogFunctionNew('template-webhook'), {}, { configuration: { filters } }).url
+}
+
+function getNotificationDescription(fn: HogFunctionType): string | null {
+    const inputs = fn.inputs
+    if (!inputs) {
+        return null
+    }
+    // Try common destination fields for a useful summary
+    if (inputs.url?.value) {
+        try {
+            return new URL(String(inputs.url.value)).hostname
+        } catch {
+            return String(inputs.url.value)
+        }
+    }
+    if (inputs.channel?.value) {
+        return String(inputs.channel.value)
+    }
+    if (inputs.email?.value) {
+        return String(inputs.email.value)
+    }
+    return null
+}
+
+export function SurveyNotificationsPanel(): JSX.Element {
+    const { survey } = useValues(surveyLogic)
+    const [hogFunctions, setHogFunctions] = useState<HogFunctionType[]>([])
+    const [loading, setLoading] = useState(true)
+
+    const loadFunctions = (): void => {
+        setLoading(true)
+        void api.hogFunctions
+            .list({
+                filter_groups: [
+                    {
+                        events: [
+                            {
+                                id: SurveyEventName.SENT,
+                                type: 'events',
+                                properties: [
+                                    {
+                                        key: SurveyEventProperties.SURVEY_ID,
+                                        type: PropertyFilterType.Event,
+                                        value: survey.id,
+                                        operator: PropertyOperator.Exact,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                types: ['destination'],
+                full: true,
+            })
+            .then((res) => setHogFunctions(res.results))
+            .finally(() => setLoading(false))
+    }
+
+    useEffect(() => {
+        loadFunctions()
+    }, [survey.id])
+
+    const toggleEnabled = (fn: HogFunctionType): void => {
+        const newEnabled = !fn.enabled
+        setHogFunctions((prev) => prev.map((f) => (f.id === fn.id ? { ...f, enabled: newEnabled } : f)))
+        void api.hogFunctions.update(fn.id, { enabled: newEnabled })
+    }
+
+    if (loading) {
+        return (
+            <div className="flex flex-col gap-2">
+                <LemonSkeleton className="h-12" />
+                <LemonSkeleton className="h-12" />
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-3">
+            {hogFunctions.length > 0 ? (
+                <div className="flex flex-col gap-1.5">
+                    {hogFunctions.map((fn) => {
+                        const description = getNotificationDescription(fn)
+                        return (
+                            <div key={fn.id} className="flex items-center gap-2 rounded border p-2">
+                                <HogFunctionIcon src={fn.icon_url} size="small" />
+                                <div className="flex-1 min-w-0">
+                                    <LemonButton
+                                        type="tertiary"
+                                        size="xsmall"
+                                        to={urls.hogFunction(fn.id)}
+                                        className="font-medium p-0 h-auto min-h-0"
+                                        noPadding
+                                    >
+                                        <span className="truncate">{fn.name}</span>
+                                    </LemonButton>
+                                    {description && <div className="text-xs text-muted truncate">{description}</div>}
+                                </div>
+                                <LemonSwitch checked={fn.enabled} onChange={() => toggleEnabled(fn)} size="small" />
+                            </div>
+                        )
+                    })}
+                </div>
+            ) : (
+                <p className="text-xs text-muted m-0">No notifications configured yet.</p>
+            )}
+            <LemonButton type="secondary" size="small" icon={<IconPlus />} to={newNotificationUrl(survey.id)} fullWidth>
+                New notification
+            </LemonButton>
+        </div>
+    )
+}
+
+export function SurveyExportPanel(): JSX.Element {
+    const { survey, dataTableQuery } = useValues(surveyLogic)
+    const { startExport } = useActions(exportsLogic)
+
+    const handleExport = (format: ExporterFormat): void => {
+        if (!dataTableQuery) {
+            return
+        }
+        startExport({
+            export_format: format,
+            export_context: {
+                source: dataTableQuery,
+                filename: `survey-${survey.name}-responses`,
+            },
+        })
+    }
+
+    return (
+        <PanelSection title="Export" description="Download survey responses">
+            {dataTableQuery ? (
+                <LemonMenu
+                    items={[
+                        {
+                            label: 'Export as CSV',
+                            onClick: () => handleExport(ExporterFormat.CSV),
+                        },
+                        {
+                            label: 'Export as Excel',
+                            onClick: () => handleExport(ExporterFormat.XLSX),
+                        },
+                    ]}
+                >
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        fullWidth
+                        icon={<IconDownload />}
+                        data-attr="export-survey-responses"
+                    >
+                        Export responses
+                    </LemonButton>
+                </LemonMenu>
+            ) : (
+                <p className="text-xs text-muted m-0">No responses to export yet.</p>
+            )}
+        </PanelSection>
+    )
+}

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -1,0 +1,423 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconArchive, IconGraph, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonDialog, LemonDivider } from '@posthog/lemon-ui'
+
+import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
+import { SceneDuplicate } from 'lib/components/Scenes/SceneDuplicate'
+import { SceneFile } from 'lib/components/Scenes/SceneFile'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { userHasAccess } from 'lib/utils/accessControlUtils'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { DuplicateToProjectModal } from 'scenes/surveys/DuplicateToProjectModal'
+import { SurveyHeadline } from 'scenes/surveys/SurveyHeadline'
+import { SurveyNoResponsesBanner } from 'scenes/surveys/SurveyNoResponsesBanner'
+import { SurveyResponseFilters } from 'scenes/surveys/SurveyResponseFilters'
+import { SurveyStatsSummary } from 'scenes/surveys/SurveyStatsSummary'
+import { LaunchSurveyButton } from 'scenes/surveys/components/LaunchSurveyButton'
+import { SurveyFeedbackButton } from 'scenes/surveys/components/SurveyFeedbackButton'
+import { SurveyQuestionVisualization } from 'scenes/surveys/components/question-visualizations/SurveyQuestionVisualization'
+import { canDeleteSurvey, openArchiveSurveyDialog, openDeleteSurveyDialog } from 'scenes/surveys/surveyDialogs'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { getSurveyStatus, surveysLogic } from 'scenes/surveys/surveysLogic'
+import { urls } from 'scenes/urls'
+
+import {
+    ScenePanel,
+    ScenePanelActionsSection,
+    ScenePanelDivider,
+    ScenePanelInfoSection,
+} from '~/layout/scenes/SceneLayout'
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { Query } from '~/queries/Query/Query'
+import {
+    AccessControlLevel,
+    AccessControlResourceType,
+    ActivityScope,
+    ProgressStatus,
+    Survey,
+    SurveyEventName,
+    SurveyQuestionType,
+    SurveyType,
+} from '~/types'
+
+import { SurveyDraftContent } from './SurveyDraftContent'
+import { SurveyDetailsPanel, SurveyExportPanel, SurveyNotificationsPanel } from './SurveySidebar'
+
+const RESOURCE_TYPE = 'survey'
+
+export function SurveyViewRedesign(): JSX.Element {
+    const { survey, surveyLoading } = useValues(surveyLogic)
+    const { editingSurvey, updateSurvey, archiveSurvey } = useActions(surveyLogic)
+    const { deleteSurvey, duplicateSurvey, setSurveyToDuplicate } = useActions(surveysLogic)
+    const { guidedEditorEnabled } = useValues(surveysLogic)
+    const { currentOrganization } = useValues(organizationLogic)
+
+    const hasMultipleProjects = currentOrganization?.teams && currentOrganization.teams.length > 1
+    const [tabKey, setTabKey] = useState('summary')
+    const [panelTabKey, setPanelTabKey] = useState('details')
+    const status = getSurveyStatus(survey)
+    const isDraft = status === ProgressStatus.Draft
+
+    if (surveyLoading) {
+        return <LemonSkeleton />
+    }
+
+    return (
+        <SceneContent className="gap-y-4 flex-1 min-h-full">
+            <ScenePanel>
+                <ScenePanelInfoSection>
+                    <SceneFile dataAttrKey={RESOURCE_TYPE} />
+                </ScenePanelInfoSection>
+                <ScenePanelDivider />
+                <ScenePanelActionsSection>
+                    <SceneDuplicate
+                        dataAttrKey={RESOURCE_TYPE}
+                        onClick={() => {
+                            const existingSurvey = survey as Survey
+                            if (hasMultipleProjects) {
+                                setSurveyToDuplicate(existingSurvey)
+                            } else {
+                                duplicateSurvey(existingSurvey)
+                            }
+                        }}
+                    />
+                    {!survey.archived && (
+                        <AccessControlAction
+                            resourceType={AccessControlResourceType.Survey}
+                            minAccessLevel={AccessControlLevel.Editor}
+                            userAccessLevel={survey.user_access_level}
+                        >
+                            <ButtonPrimitive
+                                menuItem
+                                data-attr={`${RESOURCE_TYPE}-archive`}
+                                onClick={() => openArchiveSurveyDialog(survey, archiveSurvey)}
+                            >
+                                <IconArchive />
+                                Archive
+                            </ButtonPrimitive>
+                        </AccessControlAction>
+                    )}
+                    {canDeleteSurvey(survey) && (
+                        <AccessControlAction
+                            resourceType={AccessControlResourceType.Survey}
+                            minAccessLevel={AccessControlLevel.Editor}
+                            userAccessLevel={survey.user_access_level}
+                        >
+                            <ButtonPrimitive
+                                menuItem
+                                variant="danger"
+                                data-attr={`${RESOURCE_TYPE}-delete`}
+                                onClick={() => openDeleteSurveyDialog(survey, () => deleteSurvey(survey.id))}
+                            >
+                                <IconTrash />
+                                Delete permanently
+                            </ButtonPrimitive>
+                        </AccessControlAction>
+                    )}
+                </ScenePanelActionsSection>
+                <ScenePanelDivider />
+
+                {/* Survey-specific panels as sub-tabs */}
+                <LemonTabs
+                    size="small"
+                    activeKey={panelTabKey}
+                    onChange={(key) => setPanelTabKey(key)}
+                    tabs={[
+                        {
+                            key: 'details',
+                            label: 'Details',
+                            content: <SurveyDetailsPanel />,
+                        },
+                        {
+                            key: 'notifications',
+                            label: 'Notifications',
+                            content: <SurveyNotificationsPanel />,
+                        },
+                        ...(!isDraft
+                            ? [
+                                  {
+                                      key: 'export',
+                                      label: 'Export',
+                                      content: <SurveyExportPanel />,
+                                  },
+                              ]
+                            : []),
+                    ]}
+                />
+            </ScenePanel>
+
+            <SceneTitleSection
+                name={survey.name}
+                description={survey.description}
+                resourceType={{ type: 'survey' }}
+                canEdit={userHasAccess(
+                    AccessControlResourceType.Survey,
+                    AccessControlLevel.Editor,
+                    survey.user_access_level
+                )}
+                saveOnBlur
+                onNameChange={(name) => updateSurvey({ id: survey.id, name })}
+                onDescriptionChange={(description) => updateSurvey({ id: survey.id, description })}
+                renameDebounceMs={0}
+                isLoading={surveyLoading}
+                actions={
+                    <>
+                        <SurveyFeedbackButton />
+                        <AccessControlAction
+                            resourceType={AccessControlResourceType.Survey}
+                            minAccessLevel={AccessControlLevel.Editor}
+                            userAccessLevel={survey.user_access_level}
+                        >
+                            <LemonButton
+                                data-attr="edit-survey"
+                                onClick={
+                                    guidedEditorEnabled && survey.type === SurveyType.Popover
+                                        ? undefined
+                                        : () => editingSurvey(true)
+                                }
+                                to={
+                                    guidedEditorEnabled && survey.type === SurveyType.Popover
+                                        ? urls.surveyWizard(survey.id)
+                                        : undefined
+                                }
+                                type="secondary"
+                                size="small"
+                            >
+                                Edit
+                            </LemonButton>
+                        </AccessControlAction>
+                        <SurveyStatusAction />
+                    </>
+                }
+            />
+
+            {/* Main content */}
+            <div className="-m-4 flex-1 min-h-0">
+                <LemonTabs
+                    activeKey={tabKey}
+                    onChange={(key) => setTabKey(key)}
+                    barClassName="pl-4 [&::before]:!bg-transparent border-b"
+                    tabs={[
+                        {
+                            key: 'summary',
+                            label: 'Summary',
+                            content: isDraft ? (
+                                <SurveyDraftContent />
+                            ) : (
+                                <SurveySummaryContent onViewResponses={() => setTabKey('responses')} />
+                            ),
+                        },
+                        ...(!isDraft
+                            ? [
+                                  {
+                                      key: 'responses',
+                                      label: 'Responses',
+                                      content: <SurveyResponsesContent />,
+                                  },
+                              ]
+                            : []),
+                        {
+                            key: 'history',
+                            label: 'History',
+                            content: (
+                                <div className="px-4 pb-4 max-w-4xl mx-auto">
+                                    <ActivityLog scope={ActivityScope.SURVEY} id={survey.id} />
+                                </div>
+                            ),
+                        },
+                    ]}
+                />
+            </div>
+
+            <DuplicateToProjectModal />
+        </SceneContent>
+    )
+}
+
+function SurveyStatusAction(): JSX.Element | null {
+    const { survey } = useValues(surveyLogic)
+    const { stopSurvey, resumeSurvey } = useActions(surveyLogic)
+    const status = getSurveyStatus(survey)
+
+    if (status === ProgressStatus.Draft) {
+        return <LaunchSurveyButton />
+    }
+
+    if (survey.archived) {
+        return null
+    }
+
+    if (status === ProgressStatus.Complete) {
+        return (
+            <AccessControlAction
+                resourceType={AccessControlResourceType.Survey}
+                minAccessLevel={AccessControlLevel.Editor}
+                userAccessLevel={survey.user_access_level}
+            >
+                <LemonButton
+                    type="secondary"
+                    size="small"
+                    onClick={() => {
+                        LemonDialog.open({
+                            title: 'Resume this survey?',
+                            content: (
+                                <div className="text-sm text-secondary">
+                                    Once resumed, the survey will be visible to your users again.
+                                </div>
+                            ),
+                            primaryButton: {
+                                children: 'Resume',
+                                type: 'primary',
+                                onClick: () => resumeSurvey(),
+                                size: 'small',
+                            },
+                            secondaryButton: {
+                                children: 'Cancel',
+                                type: 'tertiary',
+                                size: 'small',
+                            },
+                        })
+                    }}
+                >
+                    Resume
+                </LemonButton>
+            </AccessControlAction>
+        )
+    }
+
+    return (
+        <AccessControlAction
+            resourceType={AccessControlResourceType.Survey}
+            minAccessLevel={AccessControlLevel.Editor}
+            userAccessLevel={survey.user_access_level}
+        >
+            <LemonButton
+                data-attr="stop-survey"
+                type="secondary"
+                status="danger"
+                size="small"
+                onClick={() => {
+                    LemonDialog.open({
+                        title: 'Stop this survey?',
+                        content: (
+                            <div className="text-sm text-secondary">
+                                The survey will no longer be displayed to users.
+                            </div>
+                        ),
+                        primaryButton: {
+                            children: 'Stop',
+                            type: 'primary',
+                            onClick: () => stopSurvey(),
+                            size: 'small',
+                        },
+                        secondaryButton: {
+                            children: 'Cancel',
+                            type: 'tertiary',
+                            size: 'small',
+                        },
+                    })
+                }}
+            >
+                Stop
+            </LemonButton>
+        </AccessControlAction>
+    )
+}
+
+function SurveySummaryContent({ onViewResponses }: { onViewResponses: () => void }): JSX.Element {
+    const { survey, isAnyResultsLoading, processedSurveyStats, isSurveyHeadlineEnabled } = useValues(surveyLogic)
+
+    const atLeastOneResponse = !!processedSurveyStats?.[SurveyEventName.SENT].total_count
+
+    if (!isAnyResultsLoading && !atLeastOneResponse) {
+        return (
+            <div className="space-y-4 px-4 pb-4">
+                <SurveyResponseFilters />
+                <SurveyStatsSummary />
+                <SurveyNoResponsesBanner type="survey" />
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-4 px-4 pb-4">
+            <SurveyResponseFilters />
+            <SurveyStatsSummary />
+            {isSurveyHeadlineEnabled && <SurveyHeadline />}
+
+            {/* Question visualizations */}
+            <div className="flex flex-col gap-2">
+                {survey.questions.map((question, i) => {
+                    if (!question.id || question.type === SurveyQuestionType.Link) {
+                        return null
+                    }
+                    return (
+                        <div key={question.id} className="flex flex-col gap-2">
+                            <SurveyQuestionVisualization question={question} questionIndex={i} />
+                            <LemonDivider />
+                        </div>
+                    )
+                })}
+            </div>
+            <LemonButton
+                type="tertiary"
+                data-attr="survey-results-view-responses"
+                onClick={onViewResponses}
+                size="small"
+            >
+                Looking for all responses?
+            </LemonButton>
+        </div>
+    )
+}
+
+function SurveyResponsesContent(): JSX.Element {
+    const { dataTableQuery, surveyLoading, archivedResponseUuids, surveyAsInsightURL } = useValues(surveyLogic)
+
+    if (surveyLoading) {
+        return (
+            <div className="px-4 pb-4">
+                <LemonSkeleton />
+            </div>
+        )
+    }
+
+    return (
+        <div className="px-4 pb-4 space-y-4">
+            <LemonButton
+                type="primary"
+                data-attr="survey-results-explore"
+                icon={<IconGraph />}
+                to={surveyAsInsightURL}
+                size="small"
+            >
+                View insights for this survey
+            </LemonButton>
+            <div className="survey-table-results">
+                <Query
+                    query={dataTableQuery}
+                    context={{
+                        rowProps: (record: unknown) => {
+                            if (typeof record !== 'object' || !record || !('result' in record)) {
+                                return {}
+                            }
+                            const result = record.result
+                            if (!Array.isArray(result)) {
+                                return {}
+                            }
+                            return {
+                                className: archivedResponseUuids.has(result[0].uuid) ? 'opacity-50' : undefined,
+                            }
+                        },
+                    }}
+                />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/index.ts
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/index.ts
@@ -1,0 +1,1 @@
+export { SurveyViewRedesign } from './SurveyViewRedesign'


### PR DESCRIPTION
## Problem

The current survey view is a flat tab-based layout that doesn't scale well as we add more survey management features. Details, preview, notifications, exports, and AI insights all compete for space.

## Changes

- Add a new `SurveyViewRedesign` component behind the `SURVEYS_REDESIGNED_VIEW` feature flag
- Implement a collapsible sidebar with vertical icon tabs (details, notifications, AI insights, export)
- Add a draft state screen with a launch CTA when the survey hasn't started yet
- Extract sidebar panels (details, preview, notifications, export) into composable components
- Simplify the `SurveyComponent` wrapper by using an early return instead of nested ternary
- No changes to the existing view — gated entirely behind the feature flag

## How did you test this code?

Manual testing with the feature flag enabled/disabled, verifying both the legacy and redesigned views render correctly.

All changes are behind a feature flag so we can merge this safely.

## Publish to changelog?

no