### PR TITLE
feat(surveys): polish redesigned view with filters, compact stats, and details

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -57,7 +57,6 @@ import {
 } from '~/types'
 
 import { SurveyHeadline } from './SurveyHeadline'
-import { SurveysDisabledBanner } from './SurveySettings'
 import { getSurveyResponse, isThumbQuestion } from './utils'
 
 const RESOURCE_TYPE = 'survey'
@@ -183,7 +182,6 @@ function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
                         )}
                     </ScenePanel>
 
-                    <SurveysDisabledBanner />
                     <SceneTitleSection
                         name={survey.name}
                         description={survey.description}

--- a/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
+++ b/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
@@ -5,16 +5,21 @@ import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings'
+import { SurveyConditionsList } from 'scenes/surveys/components/SurveyConditions'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
-import { surveysLogic } from 'scenes/surveys/surveysLogic'
-import { doesSurveyHaveDisplayConditions } from 'scenes/surveys/utils'
+import { getSurveyDisplayConditionsSummary } from 'scenes/surveys/utils'
+import { teamLogic } from 'scenes/teamLogic'
 
-import { AccessControlLevel, AccessControlResourceType, SurveyType } from '~/types'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNode }): JSX.Element {
     const { survey, surveyWarnings } = useValues(surveyLogic)
-    const { showSurveysDisabledBanner } = useValues(surveysLogic)
     const { launchSurvey } = useActions(surveyLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const { updateCurrentTeam } = useActions(teamLogic)
+
+    const needsOptIn = !currentTeam?.surveys_opt_in
+    const conditionsSummary = getSurveyDisplayConditionsSummary(survey)
 
     return (
         <AccessControlAction
@@ -25,31 +30,39 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
             <LemonButton
                 type="primary"
                 data-attr="launch-survey"
-                disabledReason={
-                    showSurveysDisabledBanner && survey.type !== SurveyType.API
-                        ? 'Please enable surveys in the banner above before launching'
-                        : undefined
-                }
                 size="small"
                 onClick={() => {
                     LemonDialog.open({
                         title: 'Launch this survey?',
                         content: (
-                            <div>
-                                <div className="text-sm text-secondary">
-                                    The survey will immediately start displaying to{' '}
-                                    {doesSurveyHaveDisplayConditions(survey)
-                                        ? 'users matching the display conditions'
-                                        : 'all your users'}
-                                    .
-                                </div>
+                            <div className="flex flex-col gap-3">
                                 <SdkVersionWarnings warnings={surveyWarnings} />
+                                {conditionsSummary.length > 0 ? (
+                                    <div className="text-sm">
+                                        <div className="text-secondary mb-1">
+                                            This survey will be shown to users who match:
+                                        </div>
+                                        <SurveyConditionsList conditions={conditionsSummary} />
+                                    </div>
+                                ) : (
+                                    <div className="text-sm text-secondary">
+                                        This survey will be shown to all users.
+                                    </div>
+                                )}
+                                {needsOptIn && (
+                                    <div className="text-xs text-muted">This will enable surveys for your project.</div>
+                                )}
                             </div>
                         ),
                         primaryButton: {
                             children: 'Launch',
                             type: 'primary',
-                            onClick: () => launchSurvey(),
+                            onClick: () => {
+                                if (needsOptIn) {
+                                    updateCurrentTeam({ surveys_opt_in: true })
+                                }
+                                launchSurvey()
+                            },
                             size: 'small',
                         },
                         secondaryButton: {

--- a/frontend/src/scenes/surveys/components/StackedBar.tsx
+++ b/frontend/src/scenes/surveys/components/StackedBar.tsx
@@ -21,19 +21,33 @@ export interface StackedBarSegment {
     tooltip?: string
 }
 
-export function StackedBarSkeleton({ className }: { className?: string }): JSX.Element {
+type StackedBarSize = 'md' | 'sm'
+
+const SIZE_CONFIG: Record<StackedBarSize, { bar: string; label: string; legend: string }> = {
+    md: { bar: 'h-10', label: 'leading-10 text-base', legend: 'text-secondary' },
+    sm: { bar: 'h-8', label: 'leading-8 text-sm', legend: 'text-xs text-secondary' },
+}
+
+export function StackedBarSkeleton({
+    className,
+    size = 'md',
+}: {
+    className?: string
+    size?: StackedBarSize
+}): JSX.Element {
+    const sizeClasses = SIZE_CONFIG[size]
     return (
         <div className={clsx('flex flex-col gap-2', className)}>
-            <div className="relative w-full flex mx-auto h-10">
-                <LemonSkeleton className="w-1/4 h-10 rounded-r-none opacity-60" />
-                <LemonSkeleton className="w-1/2 h-10 rounded-none opacity-80" />
-                <LemonSkeleton className="w-1/4 h-10 rounded-l-none opacity-100" />
+            <div className={clsx('relative w-full flex mx-auto', sizeClasses.bar)}>
+                <LemonSkeleton className={clsx('w-1/4 rounded-r-none opacity-60', sizeClasses.bar)} />
+                <LemonSkeleton className={clsx('w-1/2 rounded-none opacity-80', sizeClasses.bar)} />
+                <LemonSkeleton className={clsx('w-1/4 rounded-l-none opacity-100', sizeClasses.bar)} />
             </div>
             <div className="flex items-center gap-4 justify-center">
                 {Array.from({ length: 3 }).map((_, index) => (
                     <div key={index} className="flex items-center gap-2">
                         <LemonSkeleton className="size-3 rounded-full" />
-                        <LemonSkeleton className="h-6 w-24" />
+                        <LemonSkeleton className="h-4 w-20" />
                     </div>
                 ))}
             </div>
@@ -44,10 +58,13 @@ export function StackedBarSkeleton({ className }: { className?: string }): JSX.E
 export function StackedBar({
     segments,
     className,
+    size = 'md',
 }: {
     segments: StackedBarSegment[]
     className?: string
+    size?: StackedBarSize
 }): JSX.Element | null {
+    const sizeClasses = SIZE_CONFIG[size]
     const total = segments.reduce((sum, segment) => sum + segment.count, 0)
     let accumulatedPercentage = 0
 
@@ -57,7 +74,7 @@ export function StackedBar({
 
     return (
         <div className={clsx('flex flex-col gap-2', className)}>
-            <div className="relative w-full mx-auto h-10">
+            <div className={clsx('relative w-full mx-auto', sizeClasses.bar)}>
                 {segments.map(({ count, label, colorClass, tooltip }, index) => {
                     const percentage = (count / total) * 100
                     const left = accumulatedPercentage
@@ -76,7 +93,8 @@ export function StackedBar({
                         >
                             <div
                                 className={clsx(
-                                    'h-10 text-white text-center absolute cursor-pointer',
+                                    'text-white text-center absolute cursor-pointer',
+                                    sizeClasses.bar,
                                     colorClass,
                                     isFirst || isOnly ? 'rounded-l' : '',
                                     isLast || isOnly ? 'rounded-r' : ''
@@ -87,7 +105,12 @@ export function StackedBar({
                                     left: `${left}%`,
                                 }}
                             >
-                                <span className="inline-flex font-semibold max-w-full px-1 truncate leading-10">
+                                <span
+                                    className={clsx(
+                                        'inline-flex font-semibold max-w-full px-1 truncate',
+                                        sizeClasses.label
+                                    )}
+                                >
                                     {formatCount(count, total)}
                                 </span>
                             </div>
@@ -102,7 +125,7 @@ export function StackedBar({
                             count > 0 && (
                                 <div key={`stacked-bar-legend-${label}`} className="flex items-center gap-2">
                                     <div className={clsx('size-3 rounded-full', colorClass)} />
-                                    <span className="font-semibold text-secondary">{`${label} (${(
+                                    <span className={clsx('font-semibold', sizeClasses.legend)}>{`${label} (${(
                                         (count / total) *
                                         100
                                     ).toFixed(1)}%)`}</span>

--- a/frontend/src/scenes/surveys/components/SurveyConditions.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyConditions.tsx
@@ -1,0 +1,42 @@
+import { ComponentType } from 'react'
+
+import {
+    IconBolt,
+    IconClock,
+    IconCode,
+    IconCursorClick,
+    IconFlag,
+    IconGlobe,
+    IconLaptop,
+    IconPerson,
+} from '@posthog/icons'
+
+import { SurveyConditionSummary, SurveyConditionType } from 'scenes/surveys/utils'
+
+export const SURVEY_CONDITION_ICON: Record<SurveyConditionType, ComponentType<{ className?: string }>> = {
+    url: IconGlobe,
+    selector: IconCode,
+    device: IconLaptop,
+    events: IconBolt,
+    actions: IconCursorClick,
+    flag: IconFlag,
+    targeting: IconPerson,
+    wait_period: IconClock,
+}
+
+export function SurveyConditionsList({ conditions }: { conditions: SurveyConditionSummary[] }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-1.5">
+            {conditions.map(({ type, label, value }) => {
+                const Icon = SURVEY_CONDITION_ICON[type]
+                return (
+                    <div key={type} className="flex items-center gap-2 text-sm">
+                        <Icon className="text-muted shrink-0 text-base" />
+                        <span className="text-muted whitespace-nowrap">{label}</span>
+                        <span className="ml-auto text-right truncate">{value}</span>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
@@ -52,14 +52,17 @@ function OpenEndedResponsesSection({
     questionIndex: number
 }): JSX.Element {
     return (
-        <div>
-            <h4 className="font-semibold mb-3 text-sm text-muted-foreground">Open-ended responses:</h4>
+        <div className="space-y-3">
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted">Open-ended responses</h4>
             <OpenQuestionSummaryV2
                 questionId={questionId}
                 questionIndex={questionIndex}
                 totalResponses={openEndedResponses.length}
             />
-            <VirtualizedResponseList responses={toOpenQuestionFormat(openEndedResponses)} />
+            <VirtualizedResponseList
+                responses={toOpenQuestionFormat(openEndedResponses)}
+                className="rounded-md border bg-surface-secondary/60 p-2"
+            />
         </div>
     )
 }

--- a/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
@@ -124,7 +124,7 @@ export function OpenQuestionSummaryV2({
 
     if (loading && !summary) {
         return (
-            <div className="border rounded p-4 mb-4 bg-surface-primary">
+            <div className="mb-4 border rounded p-4 bg-surface-primary">
                 <div className="flex items-center gap-2 mb-3">
                     <IconSparkles className="text-warning" />
                     <span className="font-semibold">Response summary</span>
@@ -140,7 +140,7 @@ export function OpenQuestionSummaryV2({
 
     if (error && !summary) {
         return (
-            <div className="border rounded p-4 mb-2 bg-surface-primary border-danger">
+            <div className="mb-2 border rounded p-4 bg-surface-primary border-danger">
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2 text-danger">
                         <IconSparkles />
@@ -158,7 +158,7 @@ export function OpenQuestionSummaryV2({
         // Waiting for consent or initial load
         if (!dataProcessingAccepted) {
             return (
-                <div className="border rounded p-4 mb-2 bg-surface-primary">
+                <div className="mb-2 border rounded p-4 bg-surface-primary">
                     <div className="flex items-center justify-between">
                         <div className="flex items-center gap-2">
                             <IconSparkles className="text-warning" />
@@ -193,7 +193,7 @@ export function OpenQuestionSummaryV2({
             {/* Collapsible header */}
             <button
                 type="button"
-                className="w-full flex items-center justify-between p-3 hover:bg-surface-secondary transition-colors cursor-pointer"
+                className="w-full flex items-center justify-between transition-colors cursor-pointer p-3 hover:bg-surface-secondary"
                 onClick={() => setIsExpanded(!isExpanded)}
             >
                 <div className="flex items-center gap-2">
@@ -222,11 +222,11 @@ export function OpenQuestionSummaryV2({
                 }`}
             >
                 <div className="px-3 pb-3">
-                    <div className="prose prose-sm max-w-none">
+                    <div className="prose prose-base max-w-none">
                         <LemonMarkdown>{summary.content}</LemonMarkdown>
                     </div>
 
-                    <div className="flex items-center justify-between mt-3 pt-2 border-t text-xs text-muted">
+                    <div className="flex items-center justify-between text-xs text-muted mt-3 pt-2 border-t">
                         <div className="flex items-center gap-2">
                             <span>
                                 Based on {summary.responseCount}

--- a/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionViz.tsx
@@ -18,7 +18,13 @@ export function OpenQuestionViz({ question, questionIndex, responseData, totalRe
                 questionIndex={questionIndex}
                 totalResponses={totalResponses}
             />
-            <VirtualizedResponseList responses={responseData} />
+            <div className="space-y-2">
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-muted">Responses</h4>
+                <VirtualizedResponseList
+                    responses={responseData}
+                    className="rounded-md border bg-surface-secondary/60 p-2"
+                />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -1,8 +1,8 @@
 import { useValues } from 'kea'
 
-import { IconInfo } from '@posthog/icons'
-import { LemonDivider, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
+import { LemonSkeleton } from '@posthog/lemon-ui'
 
+import { humanFriendlyNumber, pluralize } from 'lib/utils'
 import { StatelessInsightLoadingState } from 'scenes/insights/EmptyStates'
 import { SurveyNoResponsesBanner } from 'scenes/surveys/SurveyNoResponsesBanner'
 import { AnalyzeResponsesButton } from 'scenes/surveys/components/AnalyzeResponsesButton'
@@ -15,6 +15,7 @@ import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { QuestionProcessedResponses, SurveyQuestion, SurveyQuestionType } from '~/types'
 
 import { SCALE_LABELS } from '../../constants'
+import { isThumbQuestion } from '../../utils'
 import { NPSBreakdownSkeleton, RatingQuestionViz } from './RatingQuestionViz'
 
 interface Props {
@@ -27,40 +28,49 @@ function QuestionTitle({
     question,
     questionIndex,
     totalResponses = 0,
-}: Props & { totalResponses?: number }): JSX.Element {
-    // only show analzye button if there's text to analyze
+    displayedResponsesCount,
+}: Props & { totalResponses?: number; displayedResponsesCount?: number }): JSX.Element {
     const shouldShowAnalyzeButton =
         question.type === SurveyQuestionType.Open ||
         (question.type === SurveyQuestionType.SingleChoice && question.hasOpenChoice) ||
         (question.type === SurveyQuestionType.MultipleChoice && question.hasOpenChoice)
 
+    const metaParts: { text: string; className?: string }[] = []
+    const questionLabel = isThumbQuestion(question)
+        ? 'Thumbs up/down'
+        : question.type === SurveyQuestionType.Rating
+          ? `${SurveyQuestionLabel[question.type]} ${SCALE_LABELS[question.scale] || `1 - ${question.scale}`}`
+          : SurveyQuestionLabel[question.type]
+
+    metaParts.push({ text: questionLabel, className: 'font-semibold uppercase tracking-wide text-text-secondary' })
+    if (totalResponses > 0) {
+        metaParts.push({
+            text: `${humanFriendlyNumber(totalResponses)} ${pluralize(totalResponses, 'response', 'responses', false)}`,
+            className: 'text-text-secondary',
+        })
+    }
+    if (question.type === SurveyQuestionType.Open && displayedResponsesCount !== undefined && totalResponses > 0) {
+        metaParts.push({
+            text:
+                displayedResponsesCount >= totalResponses
+                    ? 'All responses'
+                    : `Showing ${humanFriendlyNumber(displayedResponsesCount)} of ${humanFriendlyNumber(totalResponses)}`,
+            className: 'text-muted',
+        })
+    }
+
     return (
-        <div className="flex flex-col">
-            <div className="inline-flex gap-1 max-w-fit font-semibold text-secondary items-center">
-                <span>
-                    {SurveyQuestionLabel[question.type]}&nbsp;
-                    {question.type === SurveyQuestionType.Rating && (
-                        <span>{SCALE_LABELS[question.scale] || `1 - ${question.scale}`}</span>
-                    )}
-                </span>
-                {totalResponses > 0 && (
-                    <>
-                        <LemonDivider vertical className="my-1 mx-1" />
-                        <span>{totalResponses} responses</span>
-                        {question.type === SurveyQuestionType.Open && (
-                            <>
-                                <LemonDivider vertical className="my-1 mx-1" />
-                                <Tooltip title="See all Open Text responses in the Events table at the bottom.">
-                                    <span>random selection</span>
-                                    <IconInfo className="text-lg text-secondary shrink-0 ml-0.5 mt-0.5" />
-                                </Tooltip>
-                            </>
-                        )}
-                    </>
-                )}
+        <div className="flex flex-col gap-1">
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+                {metaParts.map((part, index) => (
+                    <span key={`${part.text}-${index}`} className="flex items-center gap-2">
+                        {index > 0 && <span className="text-border-dark">•</span>}
+                        <span className={part.className}>{part.text}</span>
+                    </span>
+                ))}
             </div>
-            <div className="flex flex-row justify-between items-center">
-                <h3 className="text-xl font-bold mb-0">
+            <div className="flex flex-row justify-between items-center gap-3">
+                <h3 className="text-xl font-semibold mb-0 leading-tight">
                     Question {questionIndex + 1}: {question.question}
                 </h3>
 
@@ -168,7 +178,11 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
                     question={question}
                     questionIndex={questionIndex}
                     totalResponses={demoData.totalResponses}
+                    displayedResponsesCount={
+                        demoData.type === SurveyQuestionType.Open ? demoData.data.length : undefined
+                    }
                 />
+
                 <div className="flex flex-col gap-4">
                     {question.type === SurveyQuestionType.Rating && demoData.type === SurveyQuestionType.Rating && (
                         <RatingQuestionViz question={question} questionIndex={questionIndex} processedData={demoData} />
@@ -208,6 +222,7 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
         return (
             <div className="flex flex-col gap-2">
                 <QuestionTitle question={question} questionIndex={questionIndex} />
+
                 <div className="flex flex-col gap-4">
                     <QuestionLoadingSkeleton question={question} />
                 </div>
@@ -219,6 +234,7 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
         return (
             <div className="flex flex-col gap-2">
                 <QuestionTitle question={question} questionIndex={questionIndex} />
+
                 <SurveyNoResponsesBanner type="question" />
             </div>
         )
@@ -230,6 +246,9 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
                 question={question}
                 questionIndex={questionIndex}
                 totalResponses={processedData.totalResponses}
+                displayedResponsesCount={
+                    processedData.type === SurveyQuestionType.Open ? processedData.data.length : undefined
+                }
             />
             <div className="flex flex-col gap-4">
                 <ErrorBoundary className="m-0">

--- a/frontend/src/scenes/surveys/components/question-visualizations/VirtualizedResponseList.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/VirtualizedResponseList.tsx
@@ -3,6 +3,7 @@ import { Grid } from 'react-window'
 
 import { AutoSizer } from 'lib/components/AutoSizer'
 import { TZLabel } from 'lib/components/TZLabel'
+import { useWindowSize } from 'lib/hooks/useWindowSize'
 import { Popover } from 'lib/lemon-ui/Popover'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 
@@ -11,11 +12,12 @@ import { OpenQuestionResponseData } from '~/types'
 interface VirtualizedResponseListProps {
     responses: OpenQuestionResponseData[]
     maxHeight?: number
+    className?: string
 }
 
 const ROW_HEIGHT = 72
-const COLUMN_COUNT = 2
 const COLUMN_GAP = 8
+const MAX_STATIC_RESPONSES = 24
 
 function ResponseListItem({ response }: { response: OpenQuestionResponseData }): JSX.Element {
     const responseText = typeof response.response !== 'string' ? JSON.stringify(response.response) : response.response
@@ -24,7 +26,9 @@ function ResponseListItem({ response }: { response: OpenQuestionResponseData }):
 
     const cardContent = (
         <div
-            className={`border rounded bg-surface-primary p-2 h-full flex flex-col ${isLongResponse ? 'cursor-pointer hover:border-primary' : ''}`}
+            className={`p-2 h-full flex flex-col transition-colors ${
+                isLongResponse ? 'cursor-pointer hover:bg-surface-primary' : ''
+            }`}
             onClick={isLongResponse ? () => setIsExpanded(!isExpanded) : undefined}
         >
             <div className="text-sm truncate mb-auto">{responseText}</div>
@@ -75,6 +79,7 @@ function ResponseListItem({ response }: { response: OpenQuestionResponseData }):
 
 interface ResponseCellProps {
     responses: OpenQuestionResponseData[]
+    columnCount: number
 }
 
 function ResponseCell({
@@ -82,13 +87,14 @@ function ResponseCell({
     rowIndex,
     style,
     responses,
+    columnCount,
 }: {
     ariaAttributes: Record<string, unknown>
     columnIndex: number
     rowIndex: number
     style: CSSProperties
 } & ResponseCellProps): JSX.Element | null {
-    const index = rowIndex * COLUMN_COUNT + columnIndex
+    const index = rowIndex * columnCount + columnIndex
     if (index >= responses.length) {
         return null
     }
@@ -96,8 +102,9 @@ function ResponseCell({
 
     const adjustedStyle = {
         ...style,
-        left: Number(style.left) + (columnIndex === 1 ? COLUMN_GAP : 0),
+        paddingRight: columnIndex === columnCount - 1 ? 0 : COLUMN_GAP,
         paddingBottom: 8,
+        boxSizing: 'border-box' as const,
     }
 
     return (
@@ -107,8 +114,15 @@ function ResponseCell({
     )
 }
 
-export function VirtualizedResponseList({ responses, maxHeight = 400 }: VirtualizedResponseListProps): JSX.Element {
-    const rowCount = Math.ceil(responses.length / COLUMN_COUNT)
+export function VirtualizedResponseList({
+    responses,
+    maxHeight = 520,
+    className,
+}: VirtualizedResponseListProps): JSX.Element {
+    const { isWindowLessThan } = useWindowSize()
+    const isMobile = isWindowLessThan('sm')
+    const columnCount = isMobile ? 1 : 2
+    const rowCount = Math.ceil(responses.length / columnCount)
     const [isAtBottom, setIsAtBottom] = useState(false)
 
     const containerHeight = Math.min(rowCount * ROW_HEIGHT, maxHeight)
@@ -124,9 +138,9 @@ export function VirtualizedResponseList({ responses, maxHeight = 400 }: Virtuali
         [setIsAtBottom]
     )
 
-    if (responses.length <= 8) {
+    if (responses.length <= MAX_STATIC_RESPONSES) {
         return (
-            <div className="grid grid-cols-2 gap-2">
+            <div className={`grid grid-cols-1 sm:grid-cols-2 gap-3 ${className ?? ''}`}>
                 {responses.map((response, index) => (
                     <ResponseListItem key={`${response.distinctId}-${index}`} response={response} />
                 ))}
@@ -137,19 +151,24 @@ export function VirtualizedResponseList({ responses, maxHeight = 400 }: Virtuali
     const showScrollIndicator = isScrollable && !isAtBottom
 
     return (
-        <div className="relative">
+        <div className={`relative ${className ?? ''}`}>
             <div style={{ height: containerHeight }}>
                 <AutoSizer
                     renderProp={({ height, width }) =>
                         height && width ? (
                             <Grid<ResponseCellProps>
-                                style={{ width, height }}
-                                columnCount={COLUMN_COUNT}
-                                columnWidth={(width - COLUMN_GAP) / COLUMN_COUNT}
+                                style={{
+                                    width,
+                                    height,
+                                    overflowX: 'hidden',
+                                    overflowY: 'auto',
+                                }}
+                                columnCount={columnCount}
+                                columnWidth={width / columnCount}
                                 rowCount={rowCount}
                                 rowHeight={ROW_HEIGHT}
                                 cellComponent={ResponseCell}
-                                cellProps={{ responses }}
+                                cellProps={{ responses, columnCount }}
                                 overscanCount={3}
                                 onScroll={handleScroll}
                             />


### PR DESCRIPTION
## Problem

The initial redesigned survey view (PR #47036) lacked per-question filtering, had oversized stat cards, and was missing overview details and notifications integration.

## Changes

- Add per-question answer filters inline with each question visualization (`SurveyFilters.tsx`)
- Compact the stats summary — replace large `StatCard` components with a single-row `StatRow` layout with centered values and color-coded metrics
- Show relative timestamps ("Started 3 days ago") with absolute time on hover
- Add active/ended status badge with a pulsing dot for active surveys
- Show existing Hog function notifications in the sidebar
- Add overview details panel (survey type, dates, linked feature flag, targeting info)
- Fix the `LaunchSurveyButton` to enable surveys on launch when they're disabled
- Constrain results content width for readability
- Refine open-ended response cards and question headers
- Use smaller stacked bar variant (`size="sm"`)

## How did you test this code?

Manual testing across draft, active, and ended survey states. Verified per-question filters apply correctly, notifications display linked destinations, and stats render in the compact layout.

## Publish to changelog?

no