### PR TITLE
feat(llma): add BUFFER_ONE overlap policy and execution timeouts to temporal schedules

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -18,6 +18,7 @@ DEFAULT_MAX_CONCURRENT_TEAMS = 3  # Max teams to process in parallel
 
 # Workflow timeouts
 WORKFLOW_EXECUTION_TIMEOUT = timedelta(minutes=30)
+COORDINATOR_EXECUTION_TIMEOUT = timedelta(hours=12)  # Must be less than daily schedule interval to avoid blocking
 # Temporal configuration
 WORKFLOW_NAME = "llma-trace-clustering"
 COORDINATOR_WORKFLOW_NAME = "llma-trace-clustering-coordinator"

--- a/posthog/temporal/llm_analytics/trace_clustering/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/schedule.py
@@ -4,10 +4,19 @@ from datetime import timedelta
 
 from django.conf import settings
 
-from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, ScheduleIntervalSpec, ScheduleSpec
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleSpec,
+)
 
 from posthog.temporal.common.schedule import a_create_schedule, a_delete_schedule, a_schedule_exists, a_update_schedule
 from posthog.temporal.llm_analytics.trace_clustering.constants import (
+    COORDINATOR_EXECUTION_TIMEOUT,
     COORDINATOR_SCHEDULE_ID,
     COORDINATOR_WORKFLOW_NAME,
     DEFAULT_LOOKBACK_DAYS,
@@ -38,8 +47,10 @@ async def create_trace_clustering_coordinator_schedule(client: Client):
             ),
             id=COORDINATOR_SCHEDULE_ID,
             task_queue=settings.LLMA_TASK_QUEUE,
+            execution_timeout=COORDINATOR_EXECUTION_TIMEOUT,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(days=1))]),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.BUFFER_ONE),
     )
 
     if await a_schedule_exists(client, COORDINATOR_SCHEDULE_ID):
@@ -83,8 +94,10 @@ async def create_generation_clustering_coordinator_schedule(client: Client):
             ),
             id=GENERATION_COORDINATOR_SCHEDULE_ID,
             task_queue=settings.LLMA_TASK_QUEUE,
+            execution_timeout=COORDINATOR_EXECUTION_TIMEOUT,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(days=1))]),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.BUFFER_ONE),
     )
 
     if await a_schedule_exists(client, GENERATION_COORDINATOR_SCHEDULE_ID):

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -30,6 +30,9 @@ GENERATE_SUMMARY_TIMEOUT_SECONDS = 300  # 5 minutes per summary generation (incr
 
 # Workflow-level timeouts (in minutes)
 WORKFLOW_EXECUTION_TIMEOUT_MINUTES = 120  # Max time for single team workflow (increased with longer activity timeouts)
+COORDINATOR_EXECUTION_TIMEOUT_MINUTES = (
+    55  # Max time for coordinator, must be less than schedule interval to avoid blocking
+)
 
 # Retry policies
 SAMPLE_RETRY_POLICY = RetryPolicy(maximum_attempts=3)

--- a/posthog/temporal/llm_analytics/trace_summarization/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/schedule.py
@@ -4,10 +4,19 @@ from datetime import timedelta
 
 from django.conf import settings
 
-from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, ScheduleIntervalSpec, ScheduleSpec
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleSpec,
+)
 
 from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
 from posthog.temporal.llm_analytics.trace_summarization.constants import (
+    COORDINATOR_EXECUTION_TIMEOUT_MINUTES,
     COORDINATOR_SCHEDULE_ID,
     COORDINATOR_WORKFLOW_NAME,
     DEFAULT_BATCH_SIZE,
@@ -38,8 +47,10 @@ async def create_batch_trace_summarization_schedule(client: Client):
             ),
             id=COORDINATOR_SCHEDULE_ID,
             task_queue=settings.LLMA_TASK_QUEUE,
+            execution_timeout=timedelta(minutes=COORDINATOR_EXECUTION_TIMEOUT_MINUTES),
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(hours=SCHEDULE_INTERVAL_HOURS))]),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.BUFFER_ONE),
     )
 
     if await a_schedule_exists(client, COORDINATOR_SCHEDULE_ID):
@@ -72,6 +83,7 @@ async def create_batch_generation_summarization_schedule(client: Client):
             ),
             id=GENERATION_COORDINATOR_SCHEDULE_ID,
             task_queue=settings.LLMA_TASK_QUEUE,
+            execution_timeout=timedelta(minutes=COORDINATOR_EXECUTION_TIMEOUT_MINUTES),
         ),
         spec=ScheduleSpec(
             intervals=[
@@ -81,6 +93,7 @@ async def create_batch_generation_summarization_schedule(client: Client):
                 )
             ]
         ),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.BUFFER_ONE),
     )
 
     if await a_schedule_exists(client, GENERATION_COORDINATOR_SCHEDULE_ID):


### PR DESCRIPTION
## Problem

LLMA Temporal schedules (summarization and clustering) used the default SKIP overlap policy. When a coordinator workflow got stuck (as happened today with the trace summarization coordinator running for 7+ hours), all subsequent hourly triggers were silently skipped. There was also no execution timeout on the coordinator workflows, so they could run indefinitely and block the schedule.

## Changes

- Set `ScheduleOverlapPolicy.BUFFER_ONE` on all 4 LLMA coordinator schedules (trace summarization, generation summarization, trace clustering, generation clustering) so at least one run is buffered instead of silently dropped
- Add 55-minute coordinator execution timeout for hourly summarization schedules (under the 1-hour interval)
- Add 12-hour coordinator execution timeout for daily clustering schedules (under the 24-hour interval)

## How did you test this code?

- Existing tests pass (13 summarization tests, 92 clustering tests)
- Verified schedule definitions are correct by reading the updated code

**Post-deploy step required**: Re-register schedules in both clusters:
```bash
kubectl -n posthog exec deploy/temporal-worker -- python manage.py schedule_temporal_workflows
```

## Publish to changelog?

Do not publish to changelog.