### PR TITLE
fix(flags): Revert remote config flag filtering from PostgreSQL fallback

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -76,15 +76,10 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     wrapped in a dict that HyperCache can serialize. The actual flag data is in the
     "flags" key as a list of flag dictionaries.
 
-    Remote config flags (is_remote_configuration=True) are excluded since they
-    are served via a separate API.
-
     Returns:
         dict: {"flags": [...]} where flags is a list of flag dictionaries
     """
     flags = get_feature_flags(team=team)
-    # Exclude remote config flags - they are served via a separate API
-    flags = [f for f in flags if not f.is_remote_configuration]
     flags_data = serialize_feature_flags(flags)
 
     logger.info(
@@ -105,9 +100,6 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     This avoids N+1 queries by loading all flags for all teams at once,
     then grouping them by team_id.
 
-    Remote config flags (is_remote_configuration=True) are excluded since they
-    are served via a separate API.
-
     Args:
         teams: List of Team objects to load flags for
 
@@ -120,12 +112,11 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     # Load all flags for all teams in one query with evaluation tags pre-loaded.
     # Include disabled flags (active=False) so flag dependencies can reference them
     # and evaluate them as false, rather than raising DependencyNotFound errors.
-    # Exclude remote config flags - they are served via a separate API.
     # Note: We intentionally don't select_related("team") here because we only need
     # team_id (already on the model) for grouping, and the Team objects are already
     # loaded by the caller. Avoiding the join saves memory.
     all_flags = list(
-        FeatureFlag.objects.filter(~Q(is_remote_configuration=True), team__in=teams, deleted=False).annotate(
+        FeatureFlag.objects.filter(team__in=teams, deleted=False).annotate(
             evaluation_tag_names_agg=ArrayAgg(
                 "evaluation_tags__tag__name",
                 filter=Q(evaluation_tags__isnull=False),

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -135,36 +135,6 @@ class TestServiceFlagsCache(BaseTest):
         inactive_flag = next(f for f in flags if f["key"] == "inactive-flag")
         assert inactive_flag["active"] is False
 
-    def test_get_feature_flags_for_service_excludes_remote_config(self):
-        """Test that remote config flags are excluded from cache.
-
-        Remote config flags (is_remote_configuration=True) are served via a
-        separate API and should not appear in /flags responses.
-        """
-        # Create regular feature flag
-        FeatureFlag.objects.create(
-            team=self.team,
-            key="regular-flag",
-            created_by=self.user,
-            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
-        )
-
-        # Create remote config flag
-        FeatureFlag.objects.create(
-            team=self.team,
-            key="remote-config-flag",
-            created_by=self.user,
-            is_remote_configuration=True,
-            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
-        )
-
-        result = _get_feature_flags_for_service(self.team)
-        flags = result["flags"]
-
-        # Only the regular flag should be included
-        assert len(flags) == 1
-        assert flags[0]["key"] == "regular-flag"
-
     def test_get_feature_flags_for_teams_batch_includes_inactive(self):
         """Test that batch function includes inactive flags for dependency resolution.
 
@@ -199,36 +169,6 @@ class TestServiceFlagsCache(BaseTest):
         # Verify the inactive flag has active=False
         inactive_flag = next(f for f in flags if f["key"] == "inactive-flag")
         assert inactive_flag["active"] is False
-
-    def test_get_feature_flags_for_teams_batch_excludes_remote_config(self):
-        """Test that batch function excludes remote config flags.
-
-        This tests the same behavior as test_get_feature_flags_for_service_excludes_remote_config
-        but for the batch function used in management commands and cache warming.
-        """
-        # Create regular feature flag
-        FeatureFlag.objects.create(
-            team=self.team,
-            key="regular-flag",
-            created_by=self.user,
-            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
-        )
-
-        # Create remote config flag
-        FeatureFlag.objects.create(
-            team=self.team,
-            key="remote-config-flag",
-            created_by=self.user,
-            is_remote_configuration=True,
-            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
-        )
-
-        result = _get_feature_flags_for_teams_batch([self.team])
-        flags = result[self.team.id]["flags"]
-
-        # Only the regular flag should be included
-        assert len(flags) == 1
-        assert flags[0]["key"] == "regular-flag"
 
     def test_get_flags_from_cache_redis_hit(self):
         """Test getting flags from Redis cache."""


### PR DESCRIPTION
## Problem

PR #46758 introduced filtering that excluded remote config flags (`is_remote_configuration=true`) from the PostgreSQL fallback path in the Rust feature-flags service. This was too aggressive and caused issues.

Hyrum's law strikes again!

## Changes

This PR reverts commit 3cc41402ae0d (PR #46758), which:
- Removed `is_remote_configuration` filtering from the PostgreSQL query in Rust
- Removed filtering from `_get_feature_flags_for_service()` in Python
- Removed filtering from `_get_feature_flags_for_teams_batch()` in Python
- Removed associated tests

## How did you test this code?

This is a clean revert of a previous PR.