### PR TITLE
fix(product-analytics): View funnel button in paths insights

### DIFF
--- a/frontend/src/scenes/paths-v2/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths-v2/pathsDataLogic.ts
@@ -6,6 +6,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
+import { buildFunnelEventsFromPathNode } from 'scenes/paths/pathsDataLogic'
 import { OpenPersonsModalProps, openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 import { pathsTitle } from 'scenes/trends/persons-modal/persons-modal-utils'
 import { urls } from 'scenes/urls'
@@ -13,7 +14,7 @@ import { urls } from 'scenes/urls'
 import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import { InsightActorsQuery, InsightVizNode, NodeKind, PathsLink, PathsQuery } from '~/queries/schema/schema-general'
 import { isPathsQuery } from '~/queries/utils'
-import { ActionFilter, InsightLogicProps, PathType, PropertyFilterType, PropertyOperator } from '~/types'
+import { InsightLogicProps, PathType } from '~/types'
 
 import { PathNodeData } from './pathUtils'
 import type { pathsDataLogicType } from './pathsDataLogicType'
@@ -130,47 +131,23 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
             openPersonsModal(modalProps)
         },
         viewPathToFunnel: ({ pathItemCard }) => {
-            const events: ActionFilter[] = []
-            let currentItemCard = pathItemCard
-            while (currentItemCard) {
-                const name = currentItemCard.name.includes('http')
-                    ? '$pageview'
-                    : currentItemCard.name.replace(/(^[0-9]+_)/, '')
-                const url = new URL(currentItemCard.name.replace(/(^[0-9]+_)/, ''))
-                events.push({
-                    id: name,
-                    name: name,
-                    type: 'events',
-                    order: currentItemCard.depth,
-                    ...(currentItemCard.name.includes('http') && {
-                        properties: [
-                            {
-                                key: '$current_url',
-                                operator: PropertyOperator.Exact,
-                                type: PropertyFilterType.Event,
-                                value: url.href,
-                            },
-                        ],
-                    }),
-                })
-                currentItemCard = currentItemCard.targetLinks[0]?.source
+            const events = buildFunnelEventsFromPathNode(pathItemCard)
+            if (events.length === 0) {
+                return
             }
-            events.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
 
             const query: InsightVizNode = {
                 kind: NodeKind.InsightVizNode,
                 source: {
                     kind: NodeKind.FunnelsQuery,
-                    series: actionsAndEventsToSeries({ events: events.reverse() }, true, MathAvailability.None),
+                    series: actionsAndEventsToSeries({ events }, true, MathAvailability.None),
                     dateRange: {
                         date_from: values.dateRange?.date_from,
                     },
                 },
             }
 
-            if (events.length > 0) {
-                router.actions.push(urls.insightNew({ query }))
-            }
+            router.actions.push(urls.insightNew({ query }))
         },
     })),
 ])

--- a/frontend/src/scenes/paths/pathsDataLogic.test.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.test.ts
@@ -1,13 +1,15 @@
 import { expectLogic } from 'kea-test-utils'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { pathsDataLogic } from 'scenes/paths/pathsDataLogic'
+import { buildFunnelEventsFromPathNode, pathsDataLogic } from 'scenes/paths/pathsDataLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { examples } from '~/queries/examples'
 import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { InsightLogicProps, PathType } from '~/types'
+import { InsightLogicProps, PathType, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { PathNodeData, PathTargetLink } from './pathUtils'
 
 let logic: ReturnType<typeof pathsDataLogic.build>
 
@@ -46,5 +48,78 @@ describe('pathsDataLogic', () => {
                     TaxonomicFilterGroupType.Wildcards,
                 ],
             })
+    })
+})
+
+const makeNode = (name: string, depth: number, parent?: PathNodeData): PathNodeData =>
+    ({
+        name,
+        depth,
+        targetLinks: parent ? [{ source: parent } as PathTargetLink] : [],
+    }) as PathNodeData
+
+describe('buildFunnelEventsFromPathNode', () => {
+    it.each([
+        {
+            scenario: 'custom event',
+            node: makeNode('1_signed_up', 0),
+            expected: [{ id: 'signed_up', name: 'signed_up', type: 'events', order: 0 }],
+        },
+        {
+            scenario: 'URL node adds $pageview with $current_url property',
+            node: makeNode('1_https://example.com/page', 0),
+            expected: [
+                {
+                    id: '$pageview',
+                    name: '$pageview',
+                    type: 'events',
+                    order: 0,
+                    properties: [
+                        {
+                            key: '$current_url',
+                            operator: PropertyOperator.Exact,
+                            type: PropertyFilterType.Event,
+                            value: 'https://example.com/page',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            scenario: 'relative path',
+            node: makeNode('1_/dashboard', 0),
+            expected: [{ id: '/dashboard', name: '/dashboard', type: 'events', order: 0 }],
+        },
+        {
+            scenario: 'screen name',
+            node: makeNode('1_$screen', 0),
+            expected: [{ id: '$screen', name: '$screen', type: 'events', order: 0 }],
+        },
+        {
+            scenario: 'chain of mixed nodes walks backward via targetLinks',
+            node: (() => {
+                const start = makeNode('1_https://example.com/', 0)
+                return makeNode('2_signed_up', 1, start)
+            })(),
+            expected: [
+                { id: 'signed_up', name: 'signed_up', type: 'events', order: 1 },
+                {
+                    id: '$pageview',
+                    name: '$pageview',
+                    type: 'events',
+                    order: 0,
+                    properties: [
+                        {
+                            key: '$current_url',
+                            operator: PropertyOperator.Exact,
+                            type: PropertyFilterType.Event,
+                            value: 'https://example.com/',
+                        },
+                    ],
+                },
+            ],
+        },
+    ])('$scenario', ({ node, expected }) => {
+        expect(buildFunnelEventsFromPathNode(node)).toEqual(expected)
     })
 })

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -24,7 +24,7 @@ export function buildFunnelEventsFromPathNode(pathItemCard: PathNodeData): Actio
     let currentItemCard: PathNodeData | undefined = pathItemCard
     while (currentItemCard) {
         const rawName = currentItemCard.name.replace(/(^[0-9]+_)/, '')
-        const isPageview = currentItemCard.name.includes('http')
+        const isPageview = /^https?:\/\//.test(rawName)
         events.push({
             id: isPageview ? '$pageview' : rawName,
             name: isPageview ? '$pageview' : rawName,

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -19,6 +19,33 @@ import { PathNodeData } from './pathUtils'
 import type { pathsDataLogicType } from './pathsDataLogicType'
 import { Paths, PathsNode } from './types'
 
+export function buildFunnelEventsFromPathNode(pathItemCard: PathNodeData): ActionFilter[] {
+    const events: ActionFilter[] = []
+    let currentItemCard: PathNodeData | undefined = pathItemCard
+    while (currentItemCard) {
+        const rawName = currentItemCard.name.replace(/(^[0-9]+_)/, '')
+        const isPageview = currentItemCard.name.includes('http')
+        events.push({
+            id: isPageview ? '$pageview' : rawName,
+            name: isPageview ? '$pageview' : rawName,
+            type: 'events',
+            order: currentItemCard.depth,
+            ...(isPageview && {
+                properties: [
+                    {
+                        key: '$current_url',
+                        operator: PropertyOperator.Exact,
+                        type: PropertyFilterType.Event,
+                        value: rawName,
+                    },
+                ],
+            }),
+        })
+        currentItemCard = currentItemCard.targetLinks[0]?.source
+    }
+    return events
+}
+
 export const DEFAULT_STEP_LIMIT = 5
 
 const DEFAULT_PATH_LOGIC_KEY = 'default_path_key'
@@ -130,47 +157,23 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
             openPersonsModal(modalProps)
         },
         viewPathToFunnel: ({ pathItemCard }) => {
-            const events: ActionFilter[] = []
-            let currentItemCard = pathItemCard
-            while (currentItemCard) {
-                const name = currentItemCard.name.includes('http')
-                    ? '$pageview'
-                    : currentItemCard.name.replace(/(^[0-9]+_)/, '')
-                const url = new URL(currentItemCard.name.replace(/(^[0-9]+_)/, ''))
-                events.push({
-                    id: name,
-                    name: name,
-                    type: 'events',
-                    order: currentItemCard.depth,
-                    ...(currentItemCard.name.includes('http') && {
-                        properties: [
-                            {
-                                key: '$current_url',
-                                operator: PropertyOperator.Exact,
-                                type: PropertyFilterType.Event,
-                                value: url.href,
-                            },
-                        ],
-                    }),
-                })
-                currentItemCard = currentItemCard.targetLinks[0]?.source
+            const events = buildFunnelEventsFromPathNode(pathItemCard)
+            if (events.length === 0) {
+                return
             }
-            events.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
 
             const query: InsightVizNode = {
                 kind: NodeKind.InsightVizNode,
                 source: {
                     kind: NodeKind.FunnelsQuery,
-                    series: actionsAndEventsToSeries({ events: events.reverse() }, true, MathAvailability.None),
+                    series: actionsAndEventsToSeries({ events }, true, MathAvailability.None),
                     dateRange: {
                         date_from: values.dateRange?.date_from,
                     },
                 },
             }
 
-            if (events.length > 0) {
-                actions.newTab(urls.insightNew({ query }))
-            }
+            actions.newTab(urls.insightNew({ query }))
         },
     })),
 ])


### PR DESCRIPTION
## Problem

The "View funnel" menu option on path node cards silently fails for non-URL path nodes (custom events, screen names, relative paths). The `viewPathToFunnel` listener calls `new URL()` unconditionally on every node name, which throws `TypeError: Invalid URL` for non-URL strings. Kea's listener error handling swallows the error, so the button just does nothing.

## Changes

- Remove the unconditional `new URL()` call — the raw name string (after stripping the numeric prefix) is used directly as the `$current_url` property value, which is equivalent to `url.href` for valid URLs
- Extract event-building logic into a pure `buildFunnelEventsFromPathNode()` function for testability
- Remove redundant `.sort()` and `.reverse()` calls (`actionsAndEventsToSeries` already re-sorts by `.order` internally)
- Apply the same fix to `paths-v2/pathsDataLogic.ts` by importing the shared function
- Add parameterized tests covering custom events, URL nodes, relative paths, screen names, and mixed chains

## How did you test this code?
https://www.loom.com/share/2750f7a638bb4bfab84023f58eb98430

- Added parameterized unit tests for `buildFunnelEventsFromPathNode` covering all node types and chain traversal
- `pnpm --filter=@posthog/frontend jest pathsDataLogic` — 7 tests pass across both paths and paths-v2

## Publish to changelog?

No