### PR TITLE
fix(flags): Exclude encrypted remote config flags from /flags endpoint

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -76,15 +76,10 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     wrapped in a dict that HyperCache can serialize. The actual flag data is in the
     "flags" key as a list of flag dictionaries.
 
-    Remote config flags (is_remote_configuration=True) are excluded since they
-    are served via a separate API.
-
     Returns:
         dict: {"flags": [...]} where flags is a list of flag dictionaries
     """
     flags = get_feature_flags(team=team)
-    # Exclude remote config flags - they are served via a separate API
-    flags = [f for f in flags if not f.is_remote_configuration]
     flags_data = serialize_feature_flags(flags)
 
     logger.info(
@@ -105,9 +100,6 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     This avoids N+1 queries by loading all flags for all teams at once,
     then grouping them by team_id.
 
-    Remote config flags (is_remote_configuration=True) are excluded since they
-    are served via a separate API.
-
     Args:
         teams: List of Team objects to load flags for
 
@@ -120,12 +112,11 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     # Load all flags for all teams in one query with evaluation tags pre-loaded.
     # Include disabled flags (active=False) so flag dependencies can reference them
     # and evaluate them as false, rather than raising DependencyNotFound errors.
-    # Exclude remote config flags - they are served via a separate API.
     # Note: We intentionally don't select_related("team") here because we only need
     # team_id (already on the model) for grouping, and the Team objects are already
     # loaded by the caller. Avoiding the join saves memory.
     all_flags = list(
-        FeatureFlag.objects.filter(~Q(is_remote_configuration=True), team__in=teams, deleted=False).annotate(
+        FeatureFlag.objects.filter(team__in=teams, deleted=False).annotate(
             evaluation_tag_names_agg=ArrayAgg(
                 "evaluation_tags__tag__name",
                 filter=Q(evaluation_tags__isnull=False),

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -76,10 +76,17 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     wrapped in a dict that HyperCache can serialize. The actual flag data is in the
     "flags" key as a list of flag dictionaries.
 
+    Encrypted remote config flags are excluded since they can only be accessed via
+    the dedicated /remote_config endpoint which handles decryption. Including them
+    in /flags would return unusable encrypted ciphertext.
+
     Returns:
         dict: {"flags": [...]} where flags is a list of flag dictionaries
     """
     flags = get_feature_flags(team=team)
+    # Exclude encrypted remote config flags - they can only be accessed via the
+    # dedicated /remote_config endpoint which handles decryption
+    flags = [f for f in flags if not (f.is_remote_configuration and f.has_encrypted_payloads)]
     flags_data = serialize_feature_flags(flags)
 
     logger.info(
@@ -100,6 +107,10 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     This avoids N+1 queries by loading all flags for all teams at once,
     then grouping them by team_id.
 
+    Encrypted remote config flags are excluded since they can only be accessed via
+    the dedicated /remote_config endpoint which handles decryption. Including them
+    in /flags would return unusable encrypted ciphertext.
+
     Args:
         teams: List of Team objects to load flags for
 
@@ -112,11 +123,17 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     # Load all flags for all teams in one query with evaluation tags pre-loaded.
     # Include disabled flags (active=False) so flag dependencies can reference them
     # and evaluate them as false, rather than raising DependencyNotFound errors.
+    # Exclude encrypted remote config flags - they can only be accessed via the
+    # dedicated /remote_config endpoint which handles decryption.
     # Note: We intentionally don't select_related("team") here because we only need
     # team_id (already on the model) for grouping, and the Team objects are already
     # loaded by the caller. Avoiding the join saves memory.
     all_flags = list(
-        FeatureFlag.objects.filter(team__in=teams, deleted=False).annotate(
+        FeatureFlag.objects.filter(
+            ~Q(is_remote_configuration=True, has_encrypted_payloads=True),
+            team__in=teams,
+            deleted=False,
+        ).annotate(
             evaluation_tag_names_agg=ArrayAgg(
                 "evaluation_tags__tag__name",
                 filter=Q(evaluation_tags__isnull=False),

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -135,36 +135,6 @@ class TestServiceFlagsCache(BaseTest):
         inactive_flag = next(f for f in flags if f["key"] == "inactive-flag")
         assert inactive_flag["active"] is False
 
-    def test_get_feature_flags_for_service_excludes_remote_config(self):
-        """Test that remote config flags are excluded from cache.
-
-        Remote config flags (is_remote_configuration=True) are served via a
-        separate API and should not appear in /flags responses.
-        """
-        # Create regular feature flag
-        FeatureFlag.objects.create(
-            team=self.team,
-            key="regular-flag",
-            created_by=self.user,
-            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
-        )
-
-        # Create remote config flag
-        FeatureFlag.objects.create(
-            team=self.team,
-            key="remote-config-flag",
-            created_by=self.user,
-            is_remote_configuration=True,
-            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
-        )
-
-        result = _get_feature_flags_for_service(self.team)
-        flags = result["flags"]
-
-        # Only the regular flag should be included
-        assert len(flags) == 1
-        assert flags[0]["key"] == "regular-flag"
-
     def test_get_feature_flags_for_teams_batch_includes_inactive(self):
         """Test that batch function includes inactive flags for dependency resolution.
 
@@ -199,36 +169,6 @@ class TestServiceFlagsCache(BaseTest):
         # Verify the inactive flag has active=False
         inactive_flag = next(f for f in flags if f["key"] == "inactive-flag")
         assert inactive_flag["active"] is False
-
-    def test_get_feature_flags_for_teams_batch_excludes_remote_config(self):
-        """Test that batch function excludes remote config flags.
-
-        This tests the same behavior as test_get_feature_flags_for_service_excludes_remote_config
-        but for the batch function used in management commands and cache warming.
-        """
-        # Create regular feature flag
-        FeatureFlag.objects.create(
-            team=self.team,
-            key="regular-flag",
-            created_by=self.user,
-            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
-        )
-
-        # Create remote config flag
-        FeatureFlag.objects.create(
-            team=self.team,
-            key="remote-config-flag",
-            created_by=self.user,
-            is_remote_configuration=True,
-            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
-        )
-
-        result = _get_feature_flags_for_teams_batch([self.team])
-        flags = result[self.team.id]["flags"]
-
-        # Only the regular flag should be included
-        assert len(flags) == 1
-        assert flags[0]["key"] == "regular-flag"
 
     def test_get_flags_from_cache_redis_hit(self):
         """Test getting flags from Redis cache."""


### PR DESCRIPTION
## Problem

Follow-up to #47048 which reverted #46758.

PR #46758 excluded **all** remote config flags from the `/flags` endpoint, breaking customers using `useFeatureFlagPayload` with unencrypted remote config flags.

This PR takes a more targeted approach: only exclude **encrypted** remote config flags, since those can never return useful data via `/flags` anyway:
- **Rust path**: Returns raw encrypted ciphertext (unusable)
- **Python fallback**: Returns `"********* (encrypted)"` (redacted placeholder)

Unencrypted remote config flags continue to work with `useFeatureFlagPayload`.

## Changes

**Python (`flags_cache.py`):**
- `_get_feature_flags_for_service()`: Filter out flags where `is_remote_configuration=True AND has_encrypted_payloads=True`
- `_get_feature_flags_for_teams_batch()`: Add same filter to the query

**Rust (`feature_flag_list.rs`):**
- PostgreSQL fallback query: Add filter using `IS TRUE` to handle NULLs correctly

## Test matrix

| Flag Type | is_remote_configuration | has_encrypted_payloads | Included in /flags? |
|-----------|------------------------|------------------------|---------------------|
| Regular | false/null | false/null | ✅ Yes |
| Regular | false/null | true | ✅ Yes |
| Remote Config | true | false/null | ✅ Yes |
| Remote Config | true | true | ❌ No |

## How did you test this code?

- Added Python tests for both `_get_feature_flags_for_service` and `_get_feature_flags_for_teams_batch`
- Added Rust test for PostgreSQL fallback query
- Verified all existing tests pass