### PR TITLE
fix(flags): Exclude encrypted remote config flags from /flags endpoint

### DIFF
--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -559,7 +559,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''
@@ -821,7 +823,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''
@@ -917,7 +921,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''
@@ -1255,7 +1261,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''
@@ -1335,7 +1343,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''
@@ -1431,7 +1441,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''
@@ -1936,7 +1948,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''
@@ -2385,7 +2399,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''
@@ -2599,7 +2615,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''
@@ -2847,7 +2865,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''
@@ -2984,7 +3004,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''
@@ -3350,7 +3372,9 @@
              LIMIT 1)
           OR ("posthog_team"."parent_team_id" IS NULL
               AND "posthog_featureflag"."team_id" = 99999))
-         AND NOT ("posthog_featureflag"."is_remote_configuration"
+         AND NOT ("posthog_featureflag"."has_encrypted_payloads"
+                  AND "posthog_featureflag"."has_encrypted_payloads" IS NOT NULL
+                  AND "posthog_featureflag"."is_remote_configuration"
                   AND "posthog_featureflag"."is_remote_configuration" IS NOT NULL)
          AND NOT "posthog_featureflag"."deleted")
   '''

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -556,6 +556,7 @@ class FeatureFlagOverride(models.Model):
 def get_feature_flags(
     team: Optional["Team"] = None,
     project_id: Optional[int] = None,
+    exclude_encrypted_remote_config: bool = False,
 ) -> list[FeatureFlag]:
     """
     Fetch FeatureFlag objects for a team or project.
@@ -566,6 +567,9 @@ def get_feature_flags(
     Args:
         team: Team to get flags for (mutually exclusive with project_id)
         project_id: Project ID to get flags for (mutually exclusive with team)
+        exclude_encrypted_remote_config: If True, exclude flags where both
+            is_remote_configuration=True AND has_encrypted_payloads=True.
+            These flags can only be accessed via the /remote_config endpoint.
 
     Returns:
         List of FeatureFlag model instances with evaluation tags pre-loaded
@@ -590,6 +594,11 @@ def get_feature_flags(
     # many flags. The evaluation tags are stored as a many-to-many relationship
     # through FeatureFlagEvaluationTag, but we aggregate them here for efficiency.
     qs = FeatureFlag.objects.filter(**filter_kwargs)
+
+    # Exclude encrypted remote config flags at the database level if requested
+    if exclude_encrypted_remote_config:
+        qs = qs.filter(~Q(is_remote_configuration=True, has_encrypted_payloads=True))
+
     qs = qs.annotate(
         evaluation_tag_names_agg=ArrayAgg(
             "evaluation_tags__tag__name",

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -83,10 +83,8 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     Returns:
         dict: {"flags": [...]} where flags is a list of flag dictionaries
     """
-    flags = get_feature_flags(team=team)
-    # Exclude encrypted remote config flags - they can only be accessed via the
-    # dedicated /remote_config endpoint which handles decryption
-    flags = [f for f in flags if not (f.is_remote_configuration and f.has_encrypted_payloads)]
+    # Exclude encrypted remote config flags at DB level for efficiency
+    flags = get_feature_flags(team=team, exclude_encrypted_remote_config=True)
     flags_data = serialize_feature_flags(flags)
 
     logger.info(

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -76,10 +76,17 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     wrapped in a dict that HyperCache can serialize. The actual flag data is in the
     "flags" key as a list of flag dictionaries.
 
+    Encrypted remote config flags are excluded since they can only be accessed via
+    the dedicated /remote_config endpoint which handles decryption. Including them
+    in /flags would return unusable encrypted ciphertext.
+
     Returns:
         dict: {"flags": [...]} where flags is a list of flag dictionaries
     """
     flags = get_feature_flags(team=team)
+    # Exclude encrypted remote config flags - they can only be accessed via the
+    # dedicated /remote_config endpoint which handles decryption
+    flags = [f for f in flags if not (f.is_remote_configuration and f.has_encrypted_payloads)]
     flags_data = serialize_feature_flags(flags)
 
     logger.info(
@@ -100,6 +107,10 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     This avoids N+1 queries by loading all flags for all teams at once,
     then grouping them by team_id.
 
+    Encrypted remote config flags are excluded since they can only be accessed via
+    the dedicated /remote_config endpoint which handles decryption. Including them
+    in /flags would return unusable encrypted ciphertext.
+
     Args:
         teams: List of Team objects to load flags for
 
@@ -112,11 +123,17 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     # Load all flags for all teams in one query with evaluation tags pre-loaded.
     # Include disabled flags (active=False) so flag dependencies can reference them
     # and evaluate them as false, rather than raising DependencyNotFound errors.
+    # Exclude encrypted remote config flags - they can only be accessed via the
+    # dedicated /remote_config endpoint which handles decryption.
     # Note: We intentionally don't select_related("team") here because we only need
     # team_id (already on the model) for grouping, and the Team objects are already
     # loaded by the caller. Avoiding the join saves memory.
     all_flags = list(
-        FeatureFlag.objects.filter(team__in=teams, deleted=False).annotate(
+        FeatureFlag.objects.filter(
+            ~Q(is_remote_configuration=True, has_encrypted_payloads=True),
+            team__in=teams,
+            deleted=False,
+        ).annotate(
             evaluation_tag_names_agg=ArrayAgg(
                 "evaluation_tags__tag__name",
                 filter=Q(evaluation_tags__isnull=False),

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -389,10 +389,14 @@ def _get_flags_for_local_evaluation(team: Team, include_cohorts: bool = True) ->
         using=DATABASE_FOR_LOCAL_EVALUATION,
     )
 
+    # Exclude encrypted remote config flags since they can only be accessed via the
+    # dedicated /remote_config endpoint which handles decryption. Including them in
+    # local evaluation would return unusable encrypted ciphertext. Unencrypted remote
+    # config flags are included since they work with useFeatureFlagPayload.
     feature_flags = (
         FeatureFlag.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
         .filter(
-            ~Q(is_remote_configuration=True),
+            ~Q(is_remote_configuration=True, has_encrypted_payloads=True),
             team_id=team.id,
             deleted=False,
         )

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -104,7 +104,7 @@ impl FeatureFlagList {
               AND f.deleted = false
               -- Exclude encrypted remote config flags - they can only be accessed via
               -- the dedicated /remote_config endpoint which handles decryption.
-              -- Use IS TRUE to handle NULL values (NULL IS TRUE = false, not NULL)
+              -- Use IS TRUE to handle NULL values (NULL IS TRUE evaluates to FALSE, not NULL)
               AND NOT (f.is_remote_configuration IS TRUE AND f.has_encrypted_payloads IS TRUE)
             GROUP BY f.id, f.team_id, f.name, f.key, f.filters, f.deleted, f.active,
                      f.ensure_experience_continuity, f.version, f.evaluation_runtime
@@ -472,6 +472,119 @@ mod tests {
         assert!(flag_keys.contains(&"regular_flag"));
         assert!(flag_keys.contains(&"unencrypted_remote_config_flag"));
         assert!(!flag_keys.contains(&"encrypted_remote_config_flag"));
+    }
+
+    #[tokio::test]
+    async fn test_null_values_included_in_pg_query() {
+        // Verify that flags with NULL values for is_remote_configuration and/or
+        // has_encrypted_payloads are correctly included (not excluded by the filter).
+        // This tests the IS TRUE logic: NULL IS TRUE evaluates to FALSE, so
+        // NOT (NULL IS TRUE AND ...) evaluates to TRUE, including the row.
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team");
+
+        let mut conn = context
+            .non_persons_writer
+            .get_connection()
+            .await
+            .expect("Failed to get connection");
+
+        // Insert flag with is_remote_configuration = NULL, has_encrypted_payloads = false
+        let null_remote_config_id = rand::thread_rng().gen_range(1_000_000..100_000_000);
+        sqlx::query(
+            r#"INSERT INTO posthog_featureflag
+            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+             is_remote_configuration, has_encrypted_payloads, created_at)
+            VALUES ($1, $2, $3, $4, $5, false, true, false, NULL, false, '2024-06-17')"#,
+        )
+        .bind(null_remote_config_id)
+        .bind(team.id)
+        .bind("Null Remote Config Flag")
+        .bind("null_remote_config")
+        .bind(serde_json::json!({"groups": [{"properties": [], "rollout_percentage": 100}]}))
+        .execute(&mut *conn)
+        .await
+        .expect("Failed to insert null remote config flag");
+
+        // Insert flag with is_remote_configuration = true, has_encrypted_payloads = NULL
+        let null_encrypted_id = rand::thread_rng().gen_range(1_000_000..100_000_000);
+        sqlx::query(
+            r#"INSERT INTO posthog_featureflag
+            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+             is_remote_configuration, has_encrypted_payloads, created_at)
+            VALUES ($1, $2, $3, $4, $5, false, true, false, true, NULL, '2024-06-17')"#,
+        )
+        .bind(null_encrypted_id)
+        .bind(team.id)
+        .bind("Null Encrypted Flag")
+        .bind("null_encrypted")
+        .bind(serde_json::json!({"groups": [{"properties": [], "rollout_percentage": 100}]}))
+        .execute(&mut *conn)
+        .await
+        .expect("Failed to insert null encrypted flag");
+
+        // Insert legacy flag with both fields NULL
+        let legacy_flag_id = rand::thread_rng().gen_range(1_000_000..100_000_000);
+        sqlx::query(
+            r#"INSERT INTO posthog_featureflag
+            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+             is_remote_configuration, has_encrypted_payloads, created_at)
+            VALUES ($1, $2, $3, $4, $5, false, true, false, NULL, NULL, '2024-06-17')"#,
+        )
+        .bind(legacy_flag_id)
+        .bind(team.id)
+        .bind("Legacy Flag")
+        .bind("legacy_flag")
+        .bind(serde_json::json!({"groups": [{"properties": [], "rollout_percentage": 100}]}))
+        .execute(&mut *conn)
+        .await
+        .expect("Failed to insert legacy flag");
+
+        // Insert flag with is_remote_configuration = NULL, has_encrypted_payloads = true
+        // This should still be included because is_remote_configuration is not TRUE
+        let null_remote_encrypted_true_id = rand::thread_rng().gen_range(1_000_000..100_000_000);
+        sqlx::query(
+            r#"INSERT INTO posthog_featureflag
+            (id, team_id, name, key, filters, deleted, active, ensure_experience_continuity,
+             is_remote_configuration, has_encrypted_payloads, created_at)
+            VALUES ($1, $2, $3, $4, $5, false, true, false, NULL, true, '2024-06-17')"#,
+        )
+        .bind(null_remote_encrypted_true_id)
+        .bind(team.id)
+        .bind("Null Remote Encrypted True Flag")
+        .bind("null_remote_encrypted_true")
+        .bind(serde_json::json!({"groups": [{"properties": [], "rollout_percentage": 100}]}))
+        .execute(&mut *conn)
+        .await
+        .expect("Failed to insert null remote encrypted true flag");
+
+        let flags_from_pg = FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.id)
+            .await
+            .expect("Failed to fetch flags from pg");
+
+        // All flags with NULL values should be included
+        assert_eq!(flags_from_pg.len(), 4);
+
+        let flag_keys: Vec<&str> = flags_from_pg.iter().map(|f| f.key.as_str()).collect();
+        assert!(
+            flag_keys.contains(&"null_remote_config"),
+            "Flag with NULL is_remote_configuration should be included"
+        );
+        assert!(
+            flag_keys.contains(&"null_encrypted"),
+            "Flag with NULL has_encrypted_payloads should be included"
+        );
+        assert!(
+            flag_keys.contains(&"legacy_flag"),
+            "Legacy flag with both NULL should be included"
+        );
+        assert!(
+            flag_keys.contains(&"null_remote_encrypted_true"),
+            "Flag with NULL is_remote_configuration and TRUE has_encrypted_payloads should be included"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Follow-up to #47048 which reverted #46758.

PR #46758 excluded **all** remote config flags (`is_remote_configuration=True`) from the `/flags` endpoint. This was too aggressive and broke customers using `useFeatureFlagPayload` with unencrypted remote config flags.

This PR takes a more targeted approach: only exclude **encrypted** remote config flags, since those can never return useful data via `/flags` anyway:
- **Rust path**: Returns raw encrypted ciphertext (unusable gibberish)
- **Python fallback**: Returns `"********* (encrypted)"` (redacted placeholder)

Encrypted remote config flags can only be accessed via the dedicated `/api/projects/@current/feature_flags/{flagKey}/remote_config` endpoint which handles decryption.

## Changes

**Python (`flags_cache.py`):**
- `_get_feature_flags_for_service()`: Filter out flags where `is_remote_configuration=True AND has_encrypted_payloads=True`
- `_get_feature_flags_for_teams_batch()`: Add same filter to the Django query

**Rust (`feature_flag_list.rs`):**
- PostgreSQL fallback query: Add filter using `IS TRUE` to handle NULL values correctly

## Why this is safe

1. **Encrypted remote config flags never worked via `/flags`** - They would return either encrypted ciphertext (Rust) or a redacted placeholder (Python), neither of which is useful. No customer could have been relying on this broken behavior.

2. **Unencrypted remote config flags continue to work** - Unlike #46758, this change only excludes flags where BOTH `is_remote_configuration=True` AND `has_encrypted_payloads=True`. Unencrypted remote config flags are still returned.

3. **The dedicated endpoint still works** - Customers using the `/remote_config` endpoint for encrypted payloads are unaffected.

4. **Test coverage confirms the filtering logic**:
   | Flag Type | is_remote_configuration | has_encrypted_payloads | Included in /flags? |
   |-----------|------------------------|------------------------|---------------------|
   | Regular | false/null | false/null | ✅ Yes |
   | Regular | false/null | true | ✅ Yes |
   | Remote Config | true | false/null | ✅ Yes |
   | Remote Config | true | true | ❌ No |

## How did you test this code?

- Added Python tests for both `_get_feature_flags_for_service` and `_get_feature_flags_for_teams_batch`
- Added Rust test `test_encrypted_remote_config_flags_excluded_from_pg`
- Verified all existing tests pass (including NULL handling for legacy flags)

## Publish to changelog?

No