### PR TITLE
feat(deduplicator): implement head of output topic fetcher

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -140,6 +140,12 @@ pub struct Config {
     // 5 minutes - max time between poll() calls before consumer leaves group
     pub kafka_max_poll_interval_ms: u32,
 
+    // Timeout for head-of-log fetch operations (used after checkpoint import to
+    // fetch latest message from output topic for validation). Applies to each
+    // Kafka operation: watermark fetch, seek, and poll.
+    #[envconfig(default = "10000")] // 10 seconds
+    pub head_fetch_timeout_ms: u64,
+
     // Partition worker channel buffer size for pipeline parallelism
     #[envconfig(default = "10")]
     pub partition_worker_channel_buffer_size: usize,

--- a/rust/kafka-deduplicator/src/kafka/batch_context.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_context.rs
@@ -23,6 +23,10 @@ pub enum RebalanceEvent {
 pub enum ConsumerCommand {
     /// Resume consumption for the specified partitions (after checkpoint import completes)
     Resume(TopicPartitionList),
+    /// Batch seek partitions to their specified offsets (fire-and-forget).
+    /// Used after checkpoint import to align consumer position with restored store state.
+    /// Offsets are set in the TPL elements via add_partition_offset().
+    SeekPartitions(TopicPartitionList),
 }
 
 /// Sender for consumer commands - passed to rebalance handler

--- a/rust/kafka-deduplicator/src/kafka/head_fetcher.rs
+++ b/rust/kafka-deduplicator/src/kafka/head_fetcher.rs
@@ -1,0 +1,408 @@
+//! One-shot head-of-log fetcher for Kafka partitions.
+//!
+//! Provides a simple API to fetch the latest message from specified partitions
+//! without joining a consumer group. Used after checkpoint imports to fetch
+//! head-of-log from the output topic for validation/synchronization.
+
+use std::time::{Duration, Instant};
+
+use metrics::{counter, histogram};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::error::KafkaError;
+use rdkafka::{Offset, TopicPartitionList};
+use serde::Deserialize;
+use thiserror::Error;
+use tracing::warn;
+
+use crate::kafka::batch_message::KafkaMessage;
+
+/// Metric name for head fetch duration histogram
+pub const HEAD_FETCH_DURATION_HISTOGRAM: &str = "kafka_dedup_head_fetch_duration_ms";
+/// Metric name for head fetch errors counter
+pub const HEAD_FETCH_ERROR_COUNTER: &str = "kafka_dedup_head_fetch_errors";
+
+/// Errors that can occur during head-of-log fetching.
+///
+/// These error types allow callers to distinguish between different failure modes
+/// and take appropriate action (e.g., retry on timeout, alert on persistent errors).
+#[derive(Error, Debug)]
+pub enum HeadFetchError {
+    /// Failed to create the Kafka consumer
+    #[error("failed to create consumer: {0}")]
+    ConsumerCreation(#[source] KafkaError),
+
+    /// Failed to assign partitions to the consumer
+    #[error("failed to assign partitions: {0}")]
+    PartitionAssignment(#[source] KafkaError),
+
+    /// Timeout occurred during a Kafka operation
+    #[error("timeout during {operation} for partition {partition}")]
+    Timeout {
+        operation: &'static str,
+        partition: i32,
+    },
+
+    /// Kafka broker returned an error
+    #[error("kafka error during {operation} for partition {partition}: {source}")]
+    Kafka {
+        operation: &'static str,
+        partition: i32,
+        #[source]
+        source: KafkaError,
+    },
+}
+
+impl HeadFetchError {
+    /// Returns the error type tag for metrics
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            HeadFetchError::ConsumerCreation(_) => "consumer_creation",
+            HeadFetchError::PartitionAssignment(_) => "partition_assignment",
+            HeadFetchError::Timeout { .. } => "timeout",
+            HeadFetchError::Kafka { .. } => "kafka_error",
+        }
+    }
+
+    /// Returns true if this error is a timeout
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, HeadFetchError::Timeout { .. })
+    }
+}
+
+/// Result of fetching head message for a single partition.
+#[derive(Debug)]
+pub enum PartitionFetchResult<T> {
+    /// Successfully fetched and deserialized the head message
+    Success(KafkaMessage<T>),
+    /// Partition is empty (high watermark == low watermark)
+    Empty,
+    /// Failed to deserialize the message payload
+    DeserializationError(String),
+    /// Kafka operation failed for this partition
+    Error(HeadFetchError),
+}
+
+impl<T> PartitionFetchResult<T> {
+    /// Returns the message if successful, None otherwise
+    pub fn into_message(self) -> Option<KafkaMessage<T>> {
+        match self {
+            PartitionFetchResult::Success(msg) => Some(msg),
+            _ => None,
+        }
+    }
+
+    /// Returns true if the fetch was successful
+    pub fn is_success(&self) -> bool {
+        matches!(self, PartitionFetchResult::Success(_))
+    }
+
+    /// Returns true if this was a timeout error
+    pub fn is_timeout(&self) -> bool {
+        matches!(
+            self,
+            PartitionFetchResult::Error(HeadFetchError::Timeout { .. })
+        )
+    }
+
+    /// Returns the result type tag for metrics/logging
+    pub fn result_type(&self) -> &'static str {
+        match self {
+            PartitionFetchResult::Success(_) => "success",
+            PartitionFetchResult::Empty => "empty",
+            PartitionFetchResult::DeserializationError(_) => "deserialization_error",
+            PartitionFetchResult::Error(e) => e.error_type(),
+        }
+    }
+}
+
+/// One-shot fetcher for the latest message from specified partitions.
+///
+/// Uses `BaseConsumer` with manual assignment (no consumer group coordination).
+/// Generic over T (the message payload type) - uses same deserialization
+/// as `BatchConsumer` via `KafkaMessage<T>::from_borrowed_message()`.
+///
+/// Each call creates a fresh, temporary `BaseConsumer` that is dropped after use,
+/// ensuring clean resource cleanup and fresh metadata for accurate high watermarks.
+#[derive(Clone)]
+pub struct HeadFetcher {
+    config: ClientConfig,
+    timeout: Duration,
+}
+
+impl HeadFetcher {
+    /// Create a new HeadFetcher with the given Kafka client configuration and timeout.
+    ///
+    /// The config should NOT include `group.id` - manual assignment is used.
+    /// The timeout applies to each Kafka operation (watermark fetch, seek, poll).
+    pub fn new(config: ClientConfig, timeout: Duration) -> Self {
+        Self { config, timeout }
+    }
+
+    /// Fetch the latest available message from each specified partition.
+    ///
+    /// Creates a temporary `BaseConsumer` for this call only (dropped on return),
+    /// ensuring fresh metadata and clean resource cleanup. Queries watermarks
+    /// fresh for each partition to get the true latest high watermark.
+    ///
+    /// # Arguments
+    /// * `topic` - The topic to fetch from
+    /// * `partitions` - List of partition numbers to fetch head messages from
+    ///
+    /// # Returns
+    /// On success, returns `Vec` of `(partition_number, PartitionFetchResult<T>)`.
+    /// On fatal error (consumer creation/assignment failure), returns `Err(HeadFetchError)`.
+    pub fn fetch_head_messages<T>(
+        &self,
+        topic: &str,
+        partitions: &[i32],
+    ) -> Result<Vec<(i32, PartitionFetchResult<T>)>, HeadFetchError>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let start = Instant::now();
+
+        // Create temporary BaseConsumer - dropped at end of function for clean cleanup.
+        // Fresh consumer ensures we get latest metadata (no stale cached watermarks).
+        let consumer: BaseConsumer = self
+            .config
+            .create()
+            .map_err(HeadFetchError::ConsumerCreation)?;
+
+        // Fetch metadata for the topic to ensure we have fresh partition info
+        // This is important for newly created topics where metadata may not be cached
+        let _ = consumer.fetch_metadata(Some(topic), self.timeout);
+
+        // Build TopicPartitionList for assignment
+        let mut tpl = TopicPartitionList::new();
+        for &partition in partitions {
+            tpl.add_partition(topic, partition);
+        }
+        consumer
+            .assign(&tpl)
+            .map_err(HeadFetchError::PartitionAssignment)?;
+
+        // Poll a few times to trigger consumer internal state initialization.
+        // rdkafka needs this to properly set up partition state before seeks.
+        // Without this, we get "Erroneous state" errors on subsequent seeks.
+        for _ in 0..3 {
+            let _ = consumer.poll(Duration::from_millis(100));
+        }
+
+        // For each partition, query watermarks fresh and fetch if non-empty
+        let mut results = Vec::with_capacity(partitions.len());
+        for &partition in partitions {
+            let result = self.fetch_single_partition(&consumer, topic, partition);
+
+            // Record per-partition error metrics
+            if !result.is_success() && !matches!(result, PartitionFetchResult::Empty) {
+                counter!(
+                    HEAD_FETCH_ERROR_COUNTER,
+                    "topic" => topic.to_string(),
+                    "partition" => partition.to_string(),
+                    "error_type" => result.result_type()
+                )
+                .increment(1);
+            }
+
+            results.push((partition, result));
+        }
+
+        // Record timing metric
+        let elapsed_ms = start.elapsed().as_millis() as f64;
+        histogram!(HEAD_FETCH_DURATION_HISTOGRAM, "topic" => topic.to_string()).record(elapsed_ms);
+
+        // Consumer is dropped here - connection closed, resources freed
+        Ok(results)
+    }
+
+    /// Fetch head message from a single partition.
+    fn fetch_single_partition<T>(
+        &self,
+        consumer: &BaseConsumer,
+        topic: &str,
+        partition: i32,
+    ) -> PartitionFetchResult<T>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        // fetch_watermarks queries broker directly - gets true current high watermark
+        let (low, high) = match consumer.fetch_watermarks(topic, partition, self.timeout) {
+            Ok(watermarks) => watermarks,
+            Err(e) => {
+                let error = if is_timeout_error(&e) {
+                    HeadFetchError::Timeout {
+                        operation: "fetch_watermarks",
+                        partition,
+                    }
+                } else {
+                    HeadFetchError::Kafka {
+                        operation: "fetch_watermarks",
+                        partition,
+                        source: e,
+                    }
+                };
+                warn!(
+                    topic,
+                    partition,
+                    error_type = error.error_type(),
+                    error = %error,
+                    "Failed to fetch watermarks for partition"
+                );
+                return PartitionFetchResult::Error(error);
+            }
+        };
+
+        if high <= low {
+            // Partition is empty
+            return PartitionFetchResult::Empty;
+        }
+
+        // Seek to high_watermark - 1 (the last message)
+        if let Err(e) = consumer.seek(topic, partition, Offset::Offset(high - 1), self.timeout) {
+            let error = if is_timeout_error(&e) {
+                HeadFetchError::Timeout {
+                    operation: "seek",
+                    partition,
+                }
+            } else {
+                HeadFetchError::Kafka {
+                    operation: "seek",
+                    partition,
+                    source: e,
+                }
+            };
+            warn!(
+                topic,
+                partition,
+                offset = high - 1,
+                error_type = error.error_type(),
+                error = %error,
+                "Failed to seek to head offset"
+            );
+            return PartitionFetchResult::Error(error);
+        }
+
+        // Poll once with timeout, deserialize using KafkaMessage<T>
+        match consumer.poll(self.timeout) {
+            Some(Ok(borrowed_msg)) => {
+                match KafkaMessage::<T>::from_borrowed_message(&borrowed_msg) {
+                    Ok(kafka_msg) => PartitionFetchResult::Success(kafka_msg),
+                    Err(e) => {
+                        let error_msg = e.to_string();
+                        warn!(
+                            topic,
+                            partition,
+                            error_type = "deserialization_error",
+                            error = %e,
+                            "Failed to deserialize head message"
+                        );
+                        PartitionFetchResult::DeserializationError(error_msg)
+                    }
+                }
+            }
+            Some(Err(e)) => {
+                let error = if is_timeout_error(&e) {
+                    HeadFetchError::Timeout {
+                        operation: "poll",
+                        partition,
+                    }
+                } else {
+                    HeadFetchError::Kafka {
+                        operation: "poll",
+                        partition,
+                        source: e,
+                    }
+                };
+                warn!(
+                    topic,
+                    partition,
+                    error_type = error.error_type(),
+                    error = %error,
+                    "Error polling partition for head message"
+                );
+                PartitionFetchResult::Error(error)
+            }
+            None => {
+                // No message returned within timeout (unexpected after seek to valid offset)
+                let error = HeadFetchError::Timeout {
+                    operation: "poll",
+                    partition,
+                };
+                warn!(
+                    topic,
+                    partition,
+                    error_type = "timeout",
+                    "Poll returned no message after seek to head offset"
+                );
+                PartitionFetchResult::Error(error)
+            }
+        }
+    }
+}
+
+/// Check if a KafkaError represents a timeout condition
+fn is_timeout_error(e: &KafkaError) -> bool {
+    match e {
+        KafkaError::Global(code) | KafkaError::MessageConsumption(code) => {
+            matches!(
+                code,
+                rdkafka::types::RDKafkaErrorCode::RequestTimedOut
+                    | rdkafka::types::RDKafkaErrorCode::OperationTimedOut
+            )
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_head_fetcher_creation() {
+        let config = ClientConfig::new();
+        let fetcher = HeadFetcher::new(config, Duration::from_secs(10));
+        // Just verify it can be created and cloned
+        let _cloned = fetcher.clone();
+    }
+
+    #[test]
+    fn test_head_fetch_error_types() {
+        let timeout_err = HeadFetchError::Timeout {
+            operation: "poll",
+            partition: 0,
+        };
+        assert!(timeout_err.is_timeout());
+        assert_eq!(timeout_err.error_type(), "timeout");
+
+        let kafka_err = HeadFetchError::Kafka {
+            operation: "fetch_watermarks",
+            partition: 1,
+            source: KafkaError::Subscription("test".to_string()),
+        };
+        assert!(!kafka_err.is_timeout());
+        assert_eq!(kafka_err.error_type(), "kafka_error");
+    }
+
+    #[test]
+    fn test_partition_fetch_result_methods() {
+        let success: PartitionFetchResult<String> =
+            PartitionFetchResult::DeserializationError("test".to_string());
+        assert!(!success.is_success());
+        assert!(!success.is_timeout());
+        assert_eq!(success.result_type(), "deserialization_error");
+
+        let empty: PartitionFetchResult<String> = PartitionFetchResult::Empty;
+        assert!(!empty.is_success());
+        assert_eq!(empty.result_type(), "empty");
+
+        let timeout: PartitionFetchResult<String> =
+            PartitionFetchResult::Error(HeadFetchError::Timeout {
+                operation: "poll",
+                partition: 0,
+            });
+        assert!(timeout.is_timeout());
+        assert_eq!(timeout.result_type(), "timeout");
+    }
+}

--- a/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
+++ b/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
@@ -65,6 +65,9 @@ pub const BATCH_CONSUMER_BATCH_FILL_RATIO: &str = "kafka_batch_consumer_batch_fi
 pub const BATCH_CONSUMER_BATCH_COLLECTION_DURATION_MS: &str =
     "kafka_batch_consumer_batch_collection_duration_ms";
 
+/// Counter for seek_partitions errors after checkpoint import
+pub const BATCH_CONSUMER_SEEK_ERROR: &str = "kafka_batch_consumer_seek_error_total";
+
 // ==== Partition Worker metrics ====
 /// Counter for partition worker channel backpressure events
 /// Incremented when route_batch has to wait because the worker channel is full

--- a/rust/kafka-deduplicator/src/kafka/mod.rs
+++ b/rust/kafka-deduplicator/src/kafka/mod.rs
@@ -3,6 +3,7 @@ pub mod batch_consumer;
 pub mod batch_context;
 pub mod batch_message;
 pub mod config;
+pub mod head_fetcher;
 pub mod metrics_consts;
 pub mod offset_tracker;
 pub mod partition_router;
@@ -16,6 +17,7 @@ pub mod test_utils;
 
 // Public API
 pub use config::ConsumerConfigBuilder;
+pub use head_fetcher::HeadFetcher;
 pub use offset_tracker::{OffsetTracker, OffsetTrackerError};
 pub use partition_router::{PartitionRouter, PartitionRouterConfig};
 pub use partition_worker::{PartitionBatch, PartitionWorker, PartitionWorkerConfig};

--- a/rust/kafka-deduplicator/tests/head_fetcher_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/head_fetcher_integration_tests.rs
@@ -1,0 +1,417 @@
+//! Integration tests for HeadFetcher - one-shot head-of-log fetching.
+//!
+//! These tests require a running Kafka instance (typically via docker-compose).
+
+use std::time::Duration;
+
+use common_types::CapturedEvent;
+use kafka_deduplicator::kafka::head_fetcher::PartitionFetchResult;
+use kafka_deduplicator::kafka::{ConsumerConfigBuilder, HeadFetcher};
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::client::DefaultClientContext;
+use rdkafka::config::ClientConfig;
+use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
+use rdkafka::util::Timeout;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+const KAFKA_BROKERS: &str = "localhost:9092";
+const TEST_TOPIC_BASE: &str = "kdedup-head-fetcher-integration-test";
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Helper to create a topic with specific number of partitions
+async fn create_topic_with_partitions(topic: &str, num_partitions: i32) -> anyhow::Result<()> {
+    let admin_client: AdminClient<DefaultClientContext> = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .create()?;
+
+    let new_topic = NewTopic::new(topic, num_partitions, TopicReplication::Fixed(1));
+    let opts = AdminOptions::new();
+
+    let results = admin_client.create_topics(&[new_topic], &opts).await?;
+    for result in results {
+        match result {
+            Ok(_) => {}
+            Err((_, rdkafka::types::RDKafkaErrorCode::TopicAlreadyExists)) => {}
+            Err((topic, e)) => {
+                return Err(anyhow::anyhow!("Failed to create topic {}: {:?}", topic, e))
+            }
+        }
+    }
+
+    // Give Kafka time to create partitions and propagate metadata
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    Ok(())
+}
+
+/// Create a test CapturedEvent with unique identifiers
+fn create_captured_event() -> CapturedEvent {
+    let now = std::time::SystemTime::now();
+    let now_offset_datetime = OffsetDateTime::from(now);
+    let now_rfc3339 = chrono::DateTime::<chrono::Utc>::from(now).to_rfc3339();
+    let distinct_id = Uuid::now_v7().to_string();
+    let token = Uuid::now_v7().to_string();
+    let event_name = "$pageview";
+    let event_uuid = Uuid::now_v7();
+    let data = format!(
+        r#"{{"uuid": "{event_uuid}", "event": "{event_name}", "distinct_id": "{distinct_id}", "token": "{token}", "properties": {{}}}}"#,
+    );
+
+    CapturedEvent {
+        uuid: event_uuid,
+        distinct_id: distinct_id.to_string(),
+        session_id: None,
+        ip: "127.0.0.1".to_string(),
+        now: now_rfc3339,
+        token: token.to_string(),
+        data,
+        sent_at: Some(now_offset_datetime),
+        event: event_name.to_string(),
+        timestamp: chrono::Utc::now(),
+        is_cookieless_mode: false,
+        historical_migration: false,
+    }
+}
+
+/// Send a test message to a specific partition
+async fn send_message_to_partition(
+    topic: &str,
+    partition: i32,
+    event: &CapturedEvent,
+) -> anyhow::Result<()> {
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .set("message.timeout.ms", "5000")
+        .create()?;
+
+    let serialized = serde_json::to_string(event)?;
+    let key = event.uuid.to_string();
+    let record = FutureRecord::to(topic)
+        .partition(partition)
+        .key(&key)
+        .payload(&serialized);
+
+    producer
+        .send(record, Timeout::After(Duration::from_secs(5)))
+        .await
+        .map_err(|(e, _)| anyhow::anyhow!("Failed to send message: {e}"))?;
+
+    // Flush to ensure message is fully sent
+    producer.flush(Timeout::After(Duration::from_secs(5)))?;
+
+    // Small delay for message propagation
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    Ok(())
+}
+
+/// Create a HeadFetcher with default test config
+fn create_head_fetcher() -> HeadFetcher {
+    create_head_fetcher_with_timeout(DEFAULT_TIMEOUT)
+}
+
+/// Create a HeadFetcher with custom timeout
+fn create_head_fetcher_with_timeout(timeout: Duration) -> HeadFetcher {
+    let config = ConsumerConfigBuilder::new_for_fetch(KAFKA_BROKERS).build_for_fetch();
+    HeadFetcher::new(config, timeout)
+}
+
+#[tokio::test]
+async fn test_fetch_head_from_empty_partition() -> anyhow::Result<()> {
+    // Create unique topic to ensure it's empty
+    let topic = format!("{}-empty-{}", TEST_TOPIC_BASE, Uuid::now_v7());
+    create_topic_with_partitions(&topic, 1).await?;
+
+    let fetcher = create_head_fetcher();
+
+    // Fetch from empty partition - should return Empty result
+    let results = fetcher.fetch_head_messages::<CapturedEvent>(&topic, &[0])?;
+
+    assert_eq!(results.len(), 1);
+    let (partition, result) = &results[0];
+    assert_eq!(*partition, 0);
+    assert!(
+        matches!(result, PartitionFetchResult::Empty),
+        "Empty partition should return Empty result"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fetch_head_from_single_partition() -> anyhow::Result<()> {
+    let topic = format!("{}-single-{}", TEST_TOPIC_BASE, Uuid::now_v7());
+    create_topic_with_partitions(&topic, 1).await?;
+
+    // Send multiple messages to partition 0
+    let event1 = create_captured_event();
+    let event2 = create_captured_event();
+    let event3 = create_captured_event();
+
+    send_message_to_partition(&topic, 0, &event1).await?;
+    send_message_to_partition(&topic, 0, &event2).await?;
+    send_message_to_partition(&topic, 0, &event3).await?;
+
+    let fetcher = create_head_fetcher();
+
+    // Fetch head - should get the last message (event3)
+    let results = fetcher.fetch_head_messages::<CapturedEvent>(&topic, &[0])?;
+
+    assert_eq!(results.len(), 1);
+    let (partition, result) = &results[0];
+    assert_eq!(*partition, 0);
+    assert!(
+        result.is_success(),
+        "Should get the head message, got: {:?}",
+        result
+    );
+
+    let kafka_msg = match result {
+        PartitionFetchResult::Success(msg) => msg,
+        _ => panic!("Expected Success result"),
+    };
+    let event = kafka_msg
+        .get_message()
+        .expect("Should have deserialized event");
+    assert_eq!(event.uuid, event3.uuid, "Should get the latest message");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fetch_head_from_multiple_partitions() -> anyhow::Result<()> {
+    let topic = format!("{}-multi-{}", TEST_TOPIC_BASE, Uuid::now_v7());
+    create_topic_with_partitions(&topic, 3).await?;
+
+    // Send different messages to each partition
+    let events: Vec<CapturedEvent> = (0..3).map(|_| create_captured_event()).collect();
+
+    send_message_to_partition(&topic, 0, &events[0]).await?;
+    send_message_to_partition(&topic, 1, &events[1]).await?;
+    send_message_to_partition(&topic, 2, &events[2]).await?;
+
+    let fetcher = create_head_fetcher();
+
+    // Fetch head from all 3 partitions
+    let results = fetcher.fetch_head_messages::<CapturedEvent>(&topic, &[0, 1, 2])?;
+
+    assert_eq!(results.len(), 3);
+
+    // Verify each partition got the correct head message
+    for (partition, result) in results {
+        assert!(
+            result.is_success(),
+            "Partition {} should have a message, got: {:?}",
+            partition,
+            result
+        );
+        let kafka_msg = match result {
+            PartitionFetchResult::Success(msg) => msg,
+            _ => panic!("Expected Success result for partition {}", partition),
+        };
+        let event = kafka_msg
+            .get_message()
+            .expect("Should have deserialized event");
+        assert_eq!(
+            event.uuid, events[partition as usize].uuid,
+            "Partition {} should have its head message",
+            partition
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fetch_head_partial_partitions() -> anyhow::Result<()> {
+    // Test fetching only some partitions from a topic with more partitions
+    let topic = format!("{}-partial-{}", TEST_TOPIC_BASE, Uuid::now_v7());
+    create_topic_with_partitions(&topic, 4).await?;
+
+    // Only send messages to partitions 1 and 3
+    let event1 = create_captured_event();
+    let event3 = create_captured_event();
+
+    send_message_to_partition(&topic, 1, &event1).await?;
+    send_message_to_partition(&topic, 3, &event3).await?;
+
+    let fetcher = create_head_fetcher();
+
+    // Fetch head only from partitions 0 and 1 (0 empty, 1 has message)
+    let results = fetcher.fetch_head_messages::<CapturedEvent>(&topic, &[0, 1])?;
+
+    assert_eq!(results.len(), 2);
+
+    // Partition 0 should be empty
+    let (p0, result0) = &results[0];
+    assert_eq!(*p0, 0);
+    assert!(
+        matches!(result0, PartitionFetchResult::Empty),
+        "Partition 0 should be empty"
+    );
+
+    // Partition 1 should have the message
+    let (p1, result1) = &results[1];
+    assert_eq!(*p1, 1);
+    assert!(result1.is_success(), "Partition 1 should have message");
+    let kafka_msg = match result1 {
+        PartitionFetchResult::Success(msg) => msg,
+        _ => panic!("Expected Success result"),
+    };
+    let event = kafka_msg
+        .get_message()
+        .expect("Should have deserialized event");
+    assert_eq!(event.uuid, event1.uuid);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fetch_head_deserialization_failure() -> anyhow::Result<()> {
+    let topic = format!("{}-bad-json-{}", TEST_TOPIC_BASE, Uuid::now_v7());
+    create_topic_with_partitions(&topic, 1).await?;
+
+    // Send invalid JSON to the partition
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .set("message.timeout.ms", "5000")
+        .create()?;
+
+    let invalid_json = "this is not valid json";
+    let record = FutureRecord::to(&topic)
+        .partition(0)
+        .key("bad-key")
+        .payload(invalid_json);
+
+    producer
+        .send(record, Timeout::After(Duration::from_secs(5)))
+        .await
+        .map_err(|(e, _)| anyhow::anyhow!("Failed to send message: {e}"))?;
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let fetcher = create_head_fetcher();
+
+    // Fetch should return DeserializationError
+    let results = fetcher.fetch_head_messages::<CapturedEvent>(&topic, &[0])?;
+
+    assert_eq!(results.len(), 1);
+    let (partition, result) = &results[0];
+    assert_eq!(*partition, 0);
+    assert!(
+        matches!(result, PartitionFetchResult::DeserializationError(_)),
+        "Should return DeserializationError, got: {:?}",
+        result.result_type()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fetch_head_fresh_consumer_per_call() -> anyhow::Result<()> {
+    // Verify that each fetch call gets fresh metadata by sending messages between calls
+    let topic = format!("{}-fresh-{}", TEST_TOPIC_BASE, Uuid::now_v7());
+    create_topic_with_partitions(&topic, 1).await?;
+
+    let fetcher = create_head_fetcher();
+
+    // First fetch - should be empty
+    let results1 = fetcher.fetch_head_messages::<CapturedEvent>(&topic, &[0])?;
+    assert!(
+        matches!(results1[0].1, PartitionFetchResult::Empty),
+        "First fetch should be empty"
+    );
+
+    // Send a message
+    let event = create_captured_event();
+    send_message_to_partition(&topic, 0, &event).await?;
+
+    // Second fetch - should get the new message (proves fresh consumer was created)
+    let results2 = fetcher.fetch_head_messages::<CapturedEvent>(&topic, &[0])?;
+    assert!(
+        results2[0].1.is_success(),
+        "Second fetch should get the new message"
+    );
+    let kafka_msg = match &results2[0].1 {
+        PartitionFetchResult::Success(msg) => msg,
+        _ => panic!("Expected Success result"),
+    };
+    let fetched_event = kafka_msg
+        .get_message()
+        .expect("Should have deserialized event");
+    assert_eq!(fetched_event.uuid, event.uuid);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_head_fetcher_clone() -> anyhow::Result<()> {
+    // Verify that cloned HeadFetcher works correctly
+    let topic = format!("{}-clone-{}", TEST_TOPIC_BASE, Uuid::now_v7());
+    create_topic_with_partitions(&topic, 1).await?;
+
+    let event = create_captured_event();
+    send_message_to_partition(&topic, 0, &event).await?;
+
+    let fetcher = create_head_fetcher();
+    let cloned_fetcher = fetcher.clone();
+
+    // Both should work independently
+    let results1 = fetcher.fetch_head_messages::<CapturedEvent>(&topic, &[0])?;
+    let results2 = cloned_fetcher.fetch_head_messages::<CapturedEvent>(&topic, &[0])?;
+
+    assert!(
+        results1[0].1.is_success(),
+        "First fetch failed: type={:?}, details={:?}",
+        results1[0].1.result_type(),
+        results1[0].1
+    );
+    assert!(
+        results2[0].1.is_success(),
+        "Second fetch failed: type={:?}, details={:?}",
+        results2[0].1.result_type(),
+        results2[0].1
+    );
+
+    let uuid1 = match &results1[0].1 {
+        PartitionFetchResult::Success(msg) => msg.get_message().unwrap().uuid,
+        _ => panic!("Expected Success"),
+    };
+    let uuid2 = match &results2[0].1 {
+        PartitionFetchResult::Success(msg) => msg.get_message().unwrap().uuid,
+        _ => panic!("Expected Success"),
+    };
+
+    assert_eq!(uuid1, uuid2, "Both should get the same head message");
+    assert_eq!(uuid1, event.uuid);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_partition_fetch_result_methods() -> anyhow::Result<()> {
+    // Test the PartitionFetchResult helper methods
+    let topic = format!("{}-result-methods-{}", TEST_TOPIC_BASE, Uuid::now_v7());
+    create_topic_with_partitions(&topic, 1).await?;
+
+    let event = create_captured_event();
+    send_message_to_partition(&topic, 0, &event).await?;
+
+    let fetcher = create_head_fetcher();
+    let results = fetcher.fetch_head_messages::<CapturedEvent>(&topic, &[0])?;
+
+    let (partition, result) = results.into_iter().next().unwrap();
+    assert!(
+        result.is_success(),
+        "Expected success for partition {}, got: {:?}",
+        partition,
+        result.result_type()
+    );
+    assert!(!result.is_timeout());
+    assert_eq!(result.result_type(), "success");
+
+    // Test into_message consumes and returns the message
+    let msg = result.into_message();
+    assert!(msg.is_some());
+
+    Ok(())
+}

--- a/rust/kafka-deduplicator/tests/head_fetcher_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/head_fetcher_integration_tests.rs
@@ -111,7 +111,7 @@ fn create_head_fetcher() -> HeadFetcher {
 
 /// Create a HeadFetcher with custom timeout
 fn create_head_fetcher_with_timeout(timeout: Duration) -> HeadFetcher {
-    let config = ConsumerConfigBuilder::new_for_fetch(KAFKA_BROKERS).build_for_fetch();
+    let config = ConsumerConfigBuilder::for_manual_assignment(KAFKA_BROKERS).build();
     HeadFetcher::new(config, timeout)
 }
 

--- a/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
@@ -331,6 +331,8 @@ async fn test_rebalance_with_checkpoint_import() -> Result<()> {
             router.clone(),
             offset_tracker.clone(),
             Some(importer),
+            None,
+            None,
         ));
 
     // Create routing processor
@@ -456,6 +458,8 @@ async fn test_messages_dropped_for_revoked_partition() -> Result<()> {
             coordinator,
             offset_tracker.clone(),
             None,
+            None,
+            None,
         );
 
     // Assign partition 0
@@ -543,6 +547,8 @@ async fn test_rapid_revoke_assign_preserves_new_store() -> Result<()> {
             store_manager.clone(),
             coordinator,
             offset_tracker.clone(),
+            None,
+            None,
             None,
         );
 


### PR DESCRIPTION
## Problem
**Part two of our plan to fast-forward input topic to match output topic on rebalance:** implement a fetcher module to pull only the _head event of each output partition_ corresponding to the checkpoints imported from the input topic on each pod.

This sets us up to pass those sentinel output events on to the processor, which will (in part three) push the resulting events into a set on the store manager so each processor pipeline can decide whether to publish or drop unseen events in the deduplicator until we have encountered each event in the input topic and know we've fast forwarded successfully so input and output are in sync.

**Open question:** are we partitioning the output topic such that these partitions will match the input topic in every case? We should be at the moment, just something to consider as we implement this - we'll need to enforce this invariant where the deduplicator is applied in the future 🎗️ 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement head of topic fetcher module
* Related metrics and unit tests
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; smoke test in PoC env on the way 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
