### PR TITLE
feat: add intellisense helpers for surveys

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
@@ -1,4 +1,4 @@
-import { DndContext, closestCenter } from '@dnd-kit/core'
+import { DndContext, type DragEndEvent, closestCenter } from '@dnd-kit/core'
 import { SortableContext, arrayMove, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import clsx from 'clsx'
@@ -108,7 +108,7 @@ export function CyclotronJobInputs({
         <>
             <DndContext
                 collisionDetection={closestCenter}
-                onDragEnd={({ active, over }) => {
+                onDragEnd={({ active, over }: DragEndEvent) => {
                     if (over && active.id !== over.id) {
                         const oldIndex = inputSchemaIds.indexOf(active.id as string)
                         const newIndex = inputSchemaIds.indexOf(over.id as string)
@@ -153,11 +153,16 @@ function JsonConfigField(props: {
     const templatingKind = props.input.templating ?? 'hog'
     const [isExpanded, setIsExpanded] = useState(true)
 
+    const contextOptions = useMemo(
+        () => globalsToContextOptions(props.sampleGlobalsWithInputs, templatingKind),
+        [props.sampleGlobalsWithInputs, templatingKind]
+    )
+
     // Set up validation logic for this JSON field
     const logic = cyclotronJobInputLogic({
         fieldKey: key,
         initialValue: props.input.value,
-        onChange: (value) => props.onChange?.({ ...props.input, value }),
+        onChange: (value: string) => props.onChange?.({ ...props.input, value }),
     })
 
     const { error, jsonValue } = useValues(logic)
@@ -202,6 +207,7 @@ function JsonConfigField(props: {
                                     onOptionSelect={(option) => {
                                         void copyToClipboard(`{${option.example}}`, 'template code')
                                     }}
+                                    contextOptions={contextOptions}
                                 />
                             </span>
                         ) : null}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -413,6 +413,7 @@ export const FEATURE_FLAGS = {
     WORKFLOWS_INTERNAL_EVENT_FILTERS: 'workflows-internal-event-filters', // owner: @haven #team-workflows
     WORKFLOWS_PERSON_TIMEZONE: 'workflows-person-timezone', // owner: #team-workflows
     WORKFLOWS_PUSH_NOTIFICATIONS: 'workflows-push-notifications', // owner: @Odin #team-workflows
+    WORKFLOWS_SURVEY_TRIGGERS: 'workflows-survey-triggers', // owner: @fcgomes #team-growth
     AVERAGE_PAGE_VIEW_COLUMN: 'average-page-view-column', // owner: @jordanm-posthog #team-web-analytics
     EXPERIMENTS_SAMPLE_RATIO_MISMATCH: 'experiments-sample-ratio-mismatch', // owner: @jurajmajerik #team-experiments
     NEW_TAB_PROJECT_EXPLORER: 'new-tab-project-explorer', // owner: #team-platform-ux

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/sampleGlobals.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/sampleGlobals.ts
@@ -1,0 +1,80 @@
+import { CyclotronJobInputSchemaType } from '../../steps/types'
+import type { HogFlow } from '../../types'
+import { getRegisteredTriggerTypes } from './triggerTypeRegistry'
+
+// Shared sample data for hog function autocomplete
+
+export const SAMPLE_PERSON = {
+    id: 'person123',
+    properties: {
+        email: 'user@example.com',
+        name: 'John Doe',
+    },
+}
+
+export const SAMPLE_GROUPS = {}
+
+export const SAMPLE_EVENT = {
+    event: 'example_event',
+    distinct_id: 'user123',
+    properties: {
+        $current_url: 'https://example.com',
+    },
+    timestamp: '2024-01-01T12:00:00Z',
+}
+
+export const SAMPLE_WEBHOOK_REQUEST = {
+    method: 'POST',
+    headers: {},
+    body: {},
+    params: {},
+}
+
+const VARIABLE_TYPE_SAMPLES: Record<string, any> = {
+    string: 'example_value',
+    number: 123,
+    boolean: true,
+    dictionary: {},
+    json: {},
+}
+
+export function buildVariablesSample(variables: CyclotronJobInputSchemaType[] | null | undefined): Record<string, any> {
+    const result: Record<string, any> = {}
+    if (!variables) {
+        return result
+    }
+    for (const variable of variables) {
+        result[variable.key] = VARIABLE_TYPE_SAMPLES[variable.type] ?? null
+    }
+    return result
+}
+
+const DEFAULT_TRIGGER_GLOBALS: Record<string, () => Record<string, any>> = {
+    event: () => ({
+        event: SAMPLE_EVENT,
+        person: SAMPLE_PERSON,
+        groups: SAMPLE_GROUPS,
+    }),
+    webhook: () => ({
+        request: SAMPLE_WEBHOOK_REQUEST,
+    }),
+}
+
+function getDefaultTriggerGlobals(triggerType: string | undefined): Record<string, any> {
+    return DEFAULT_TRIGGER_GLOBALS[triggerType ?? '']?.() ?? {}
+}
+
+export function buildTriggerSampleGlobals(workflow: HogFlow | null | undefined): Record<string, any> {
+    const triggerConfig = workflow?.actions?.find((a) => a.type === 'trigger')?.config
+    const matchingType = triggerConfig ? getRegisteredTriggerTypes().find((t) => t.matchConfig?.(triggerConfig)) : null
+    const customGlobals = matchingType?.buildSampleGlobals?.(workflow)
+
+    return customGlobals ?? getDefaultTriggerGlobals(workflow?.trigger?.type)
+}
+
+export function buildSampleGlobals(workflow: HogFlow | null | undefined): Record<string, any> {
+    return {
+        variables: buildVariablesSample(workflow?.variables),
+        ...buildTriggerSampleGlobals(workflow),
+    }
+}

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
@@ -299,7 +299,6 @@ registerTriggerType({
     label: 'Survey response',
     icon: <IconMessage />,
     description: 'Trigger when a user submits a survey response',
-    featureFlag: FEATURE_FLAGS.WORKFLOWS_SURVEY_TRIGGERS,
     matchConfig: (config) => isSurveyTriggerConfig(config),
     buildConfig: () => ({
         type: 'event',

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
@@ -18,9 +18,13 @@ import {
 } from 'products/workflows/frontend/Workflows/hogflows/registry/triggers/triggerTypeRegistry'
 import { workflowLogic } from 'products/workflows/frontend/Workflows/workflowLogic'
 
-import { surveyTriggerLogic } from '../../steps/surveyTriggerLogic'
+import {
+    buildSurveySampleEvent,
+    getSampleValueForQuestionType,
+    surveyTriggerLogic,
+} from '../../steps/surveyTriggerLogic'
 import { HogFlowAction } from '../../types'
-import { FEATURE_FLAGS } from 'lib/constants'
+import { SAMPLE_GROUPS, SAMPLE_PERSON } from './sampleGlobals'
 
 export function isSurveyTriggerConfig(config: Extract<HogFlowAction, { type: 'trigger' }>['config']): boolean {
     if (config.type !== 'event') {
@@ -316,6 +320,19 @@ registerTriggerType({
             return { valid: false, errors: { filters: 'Please select a survey' } }
         }
         return { valid: true, errors: {} }
+    },
+    buildSampleGlobals: (workflow) => {
+        const allSurveys = surveyTriggerLogic.findMounted()?.values.allSurveys ?? []
+        const selectedSurveyId = getSelectedSurveyId(workflow?.trigger)
+        const selectedSurvey =
+            selectedSurveyId && selectedSurveyId !== 'any'
+                ? (allSurveys.find((s) => s.id === selectedSurveyId) ?? null)
+                : null
+        return {
+            event: buildSurveySampleEvent(selectedSurvey, getSampleValueForQuestionType),
+            person: SAMPLE_PERSON,
+            groups: SAMPLE_GROUPS,
+        }
     },
     ConfigComponent: StepTriggerConfigurationSurvey,
 })

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
@@ -20,6 +20,7 @@ import { workflowLogic } from 'products/workflows/frontend/Workflows/workflowLog
 
 import { surveyTriggerLogic } from '../../steps/surveyTriggerLogic'
 import { HogFlowAction } from '../../types'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export function isSurveyTriggerConfig(config: Extract<HogFlowAction, { type: 'trigger' }>['config']): boolean {
     if (config.type !== 'event') {
@@ -298,6 +299,7 @@ registerTriggerType({
     label: 'Survey response',
     icon: <IconMessage />,
     description: 'Trigger when a user submits a survey response',
+    featureFlag: FEATURE_FLAGS.WORKFLOWS_SURVEY_TRIGGERS,
     matchConfig: (config) => isSurveyTriggerConfig(config),
     buildConfig: () => ({
         type: 'event',

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/triggerTypeRegistry.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/triggerTypeRegistry.ts
@@ -24,6 +24,8 @@ export type TriggerTypeDefinition = {
     ConfigComponent?: React.ComponentType<{ node: any }>
     /** Validate the trigger config, returning errors if invalid. Triggers without this use generic validation. */
     validate?: (config: any) => { valid: boolean; errors: Record<string, string> } | null
+    /** Build sample globals for hog function autocomplete. Returns full sample globals (event, person, etc.) or null for defaults. */
+    buildSampleGlobals?: (workflow: any) => Record<string, any> | null
 }
 
 const triggerTypeDefinitions: TriggerTypeDefinition[] = []

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
@@ -178,8 +178,6 @@ export function HogFlowFunctionConfiguration({
         sampleGlobals.groups = {}
     }
 
-    // DEBUG: trace sampleGlobals contents
-
     return (
         <>
             <CyclotronJobInputs

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 import { useEffect } from 'react'
 
 import { Spinner } from '@posthog/lemon-ui'
@@ -6,28 +6,11 @@ import { Spinner } from '@posthog/lemon-ui'
 import { CyclotronJobInputs } from 'lib/components/CyclotronJob/CyclotronJobInputs'
 import { templateToConfiguration } from 'scenes/hog-functions/configuration/hogFunctionConfigurationLogic'
 
-import { CyclotronJobInputType, HogFunctionMappingType, SurveyEventName, SurveyQuestionType } from '~/types'
+import { CyclotronJobInputType, HogFunctionMappingType, SurveyQuestionType } from '~/types'
 
 import { workflowLogic } from '../../../workflowLogic'
-import { surveyTriggerLogic } from '../surveyTriggerLogic'
+import { isSurveyTrigger, surveyTriggerLogic } from '../surveyTriggerLogic'
 import { HogFlowFunctionMappings } from './HogFlowFunctionMappings'
-
-function getSampleValueForQuestionType(type: string): any {
-    switch (type) {
-        case SurveyQuestionType.Open:
-            return 'User response text'
-        case SurveyQuestionType.Rating:
-            return '8'
-        case SurveyQuestionType.SingleChoice:
-            return 'Selected option'
-        case SurveyQuestionType.MultipleChoice:
-            return ['Option A', 'Option B']
-        case SurveyQuestionType.Link:
-            return null
-        default:
-            return 'response'
-    }
-}
 
 export function HogFlowFunctionConfiguration({
     templateId,
@@ -45,30 +28,18 @@ export function HogFlowFunctionConfiguration({
     errors?: Record<string, string>
 }): JSX.Element {
     const { workflow, hogFunctionTemplatesById, hogFunctionTemplatesByIdLoading } = useValues(workflowLogic)
-    const { allSurveys, surveysLoading } = useValues(surveyTriggerLogic)
-    const { loadSurveys } = useActions(surveyTriggerLogic)
+    const { allSurveys, getSampleValueForQuestionType } = useValues(surveyTriggerLogic)
 
     const template = hogFunctionTemplatesById[templateId]
+    const surveyTrigger = isSurveyTrigger(workflow)
+    const triggerType = workflow?.trigger?.type
+
     useEffect(() => {
         // oxlint-disable-next-line exhaustive-deps
         if (template && Object.keys(inputs ?? {}).length === 0) {
             setInputs(templateToConfiguration(template).inputs ?? {})
         }
     }, [templateId])
-
-    // Detect survey trigger: exactly one event filter of 'survey sent'
-    const triggerType = workflow?.trigger?.type
-    const triggerEvents =
-        triggerType === 'event' && workflow?.trigger && 'filters' in workflow.trigger
-            ? (workflow.trigger.filters?.events ?? [])
-            : []
-    const isSurveyTrigger = triggerEvents.length === 1 && triggerEvents[0]?.id === SurveyEventName.SENT
-
-    useEffect(() => {
-        if (isSurveyTrigger && allSurveys.length === 0 && !surveysLoading) {
-            loadSurveys()
-        }
-    }, [isSurveyTrigger, allSurveys.length, surveysLoading, loadSurveys])
 
     if (hogFunctionTemplatesByIdLoading) {
         return (
@@ -84,7 +55,7 @@ export function HogFlowFunctionConfiguration({
 
     // If a specific survey is selected, find it for question-aware autocomplete
     const surveyIdProp =
-        isSurveyTrigger && workflow?.trigger && 'filters' in workflow.trigger
+        surveyTrigger && workflow?.trigger && 'filters' in workflow.trigger
             ? workflow.trigger.filters?.properties?.find((p: any) => p.key === '$survey_id' && p.operator === 'exact')
             : null
     const selectedSurvey = surveyIdProp ? allSurveys.find((s) => s.id === surveyIdProp.value) : null
@@ -120,7 +91,7 @@ export function HogFlowFunctionConfiguration({
             params: {},
         }
     } else if (triggerType === 'event') {
-        if (isSurveyTrigger) {
+        if (surveyTrigger) {
             // Properties matching the actual posthog-js SDK survey sent event schema
             const surveyProperties: Record<string, any> = {
                 $survey_id: selectedSurvey?.id ?? 'survey-uuid',

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
@@ -6,10 +6,10 @@ import { Spinner } from '@posthog/lemon-ui'
 import { CyclotronJobInputs } from 'lib/components/CyclotronJob/CyclotronJobInputs'
 import { templateToConfiguration } from 'scenes/hog-functions/configuration/hogFunctionConfigurationLogic'
 
-import { CyclotronJobInputType, HogFunctionMappingType, SurveyQuestionType } from '~/types'
+import { CyclotronJobInputType, HogFunctionMappingType } from '~/types'
 
 import { workflowLogic } from '../../../workflowLogic'
-import { isSurveyTrigger, surveyTriggerLogic } from '../surveyTriggerLogic'
+import { buildSampleGlobals } from '../../registry/triggers/sampleGlobals'
 import { HogFlowFunctionMappings } from './HogFlowFunctionMappings'
 
 export function HogFlowFunctionConfiguration({
@@ -28,11 +28,8 @@ export function HogFlowFunctionConfiguration({
     errors?: Record<string, string>
 }): JSX.Element {
     const { workflow, hogFunctionTemplatesById, hogFunctionTemplatesByIdLoading } = useValues(workflowLogic)
-    const { allSurveys, getSampleValueForQuestionType } = useValues(surveyTriggerLogic)
 
     const template = hogFunctionTemplatesById[templateId]
-    const surveyTrigger = isSurveyTrigger(workflow)
-    const triggerType = workflow?.trigger?.type
 
     useEffect(() => {
         // oxlint-disable-next-line exhaustive-deps
@@ -53,101 +50,7 @@ export function HogFlowFunctionConfiguration({
         return <div>Template not found!</div>
     }
 
-    // If a specific survey is selected, find it for question-aware autocomplete
-    const surveyIdProp =
-        surveyTrigger && workflow?.trigger && 'filters' in workflow.trigger
-            ? workflow.trigger.filters?.properties?.find((p: any) => p.key === '$survey_id' && p.operator === 'exact')
-            : null
-    const selectedSurvey = surveyIdProp ? allSurveys.find((s) => s.id === surveyIdProp.value) : null
-
-    // Build workflow variables object for autocomplete
-    const workflowVariables: Record<string, any> = {}
-    if (workflow?.variables) {
-        workflow.variables.forEach((variable) => {
-            // Use placeholder values based on variable type
-            if (variable.type === 'string') {
-                workflowVariables[variable.key] = 'example_value'
-            } else if (variable.type === 'number') {
-                workflowVariables[variable.key] = 123
-            } else if (variable.type === 'boolean') {
-                workflowVariables[variable.key] = true
-            } else if (variable.type === 'dictionary' || variable.type === 'json') {
-                workflowVariables[variable.key] = {}
-            } else {
-                workflowVariables[variable.key] = null
-            }
-        })
-    }
-
-    const sampleGlobals: Record<string, any> = {
-        variables: workflowVariables,
-    }
-
-    if (triggerType === 'webhook') {
-        sampleGlobals.request = {
-            method: 'POST',
-            headers: {},
-            body: {},
-            params: {},
-        }
-    } else if (triggerType === 'event') {
-        if (surveyTrigger) {
-            // Properties matching the actual posthog-js SDK survey sent event schema
-            const surveyProperties: Record<string, any> = {
-                $survey_id: selectedSurvey?.id ?? 'survey-uuid',
-                $survey_name: selectedSurvey?.name ?? 'Survey name',
-                $survey_completed: true,
-                $survey_submission_id: 'submission-uuid',
-                $survey_iteration: null,
-                $survey_iteration_start_date: null,
-                $survey_questions: [{ id: 'question-id', question: 'Question text', response: 'Response' }],
-            }
-
-            if (selectedSurvey?.questions) {
-                // Per-question response fields keyed by question ID
-                selectedSurvey.questions.forEach((question) => {
-                    if (question.type === SurveyQuestionType.Link) {
-                        return // Link questions don't capture responses
-                    }
-                    if (question.id) {
-                        surveyProperties[`$survey_response_${question.id}`] = getSampleValueForQuestionType(
-                            question.type
-                        )
-                    }
-                })
-                // $survey_questions contains objects with {id, question, response}
-                surveyProperties.$survey_questions = selectedSurvey.questions.map((q) => ({
-                    id: q.id ?? '',
-                    question: q.question,
-                    response: getSampleValueForQuestionType(q.type),
-                }))
-            }
-
-            sampleGlobals.event = {
-                event: 'survey sent',
-                distinct_id: 'user123',
-                properties: surveyProperties,
-                timestamp: '2024-01-01T12:00:00Z',
-            }
-        } else {
-            sampleGlobals.event = {
-                event: 'example_event',
-                distinct_id: 'user123',
-                properties: {
-                    $current_url: 'https://example.com',
-                },
-                timestamp: '2024-01-01T12:00:00Z',
-            }
-        }
-        sampleGlobals.person = {
-            id: 'person123',
-            properties: {
-                email: 'user@example.com',
-                name: 'John Doe',
-            },
-        }
-        sampleGlobals.groups = {}
-    }
+    const sampleGlobals = buildSampleGlobals(workflow)
 
     return (
         <>

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
@@ -6,10 +6,28 @@ import { Spinner } from '@posthog/lemon-ui'
 import { CyclotronJobInputs } from 'lib/components/CyclotronJob/CyclotronJobInputs'
 import { templateToConfiguration } from 'scenes/hog-functions/configuration/hogFunctionConfigurationLogic'
 
-import { CyclotronJobInputType, HogFunctionMappingType } from '~/types'
+import { CyclotronJobInputType, HogFunctionMappingType, SurveyQuestionType } from '~/types'
 
 import { workflowLogic } from '../../../workflowLogic'
+import { surveyTriggerLogic } from '../surveyTriggerLogic'
 import { HogFlowFunctionMappings } from './HogFlowFunctionMappings'
+
+function getSampleValueForQuestionType(type: string): any {
+    switch (type) {
+        case SurveyQuestionType.Open:
+            return 'User response text'
+        case SurveyQuestionType.Rating:
+            return '8'
+        case SurveyQuestionType.SingleChoice:
+            return 'Selected option'
+        case SurveyQuestionType.MultipleChoice:
+            return ['Option A', 'Option B']
+        case SurveyQuestionType.Link:
+            return null
+        default:
+            return 'response'
+    }
+}
 
 export function HogFlowFunctionConfiguration({
     templateId,
@@ -27,6 +45,7 @@ export function HogFlowFunctionConfiguration({
     errors?: Record<string, string>
 }): JSX.Element {
     const { workflow, hogFunctionTemplatesById, hogFunctionTemplatesByIdLoading } = useValues(workflowLogic)
+    const { allSurveys } = useValues(surveyTriggerLogic)
 
     const template = hogFunctionTemplatesById[templateId]
     useEffect(() => {
@@ -49,6 +68,20 @@ export function HogFlowFunctionConfiguration({
     }
 
     const triggerType = workflow?.trigger?.type
+
+    // Detect if the trigger is a survey trigger
+    const triggerEvents =
+        triggerType === 'event' && workflow?.trigger && 'filters' in workflow.trigger
+            ? (workflow.trigger.filters?.events ?? [])
+            : []
+    const isSurveyTrigger = triggerEvents.some((e: any) => e.id === 'survey sent')
+
+    // If a specific survey is selected, find it for question-aware autocomplete
+    const surveyIdProp =
+        isSurveyTrigger && workflow?.trigger && 'filters' in workflow.trigger
+            ? workflow.trigger.filters?.properties?.find((p: any) => p.key === '$survey_id' && p.operator === 'exact')
+            : null
+    const selectedSurvey = surveyIdProp ? allSurveys.find((s) => s.id === surveyIdProp.value) : null
 
     // Build workflow variables object for autocomplete
     const workflowVariables: Record<string, any> = {}
@@ -81,14 +114,53 @@ export function HogFlowFunctionConfiguration({
             params: {},
         }
     } else if (triggerType === 'event') {
-        // Event-based triggers
-        sampleGlobals.event = {
-            event: 'example_event',
-            distinct_id: 'user123',
-            properties: {
-                $current_url: 'https://example.com',
-            },
-            timestamp: '2024-01-01T12:00:00Z',
+        if (isSurveyTrigger) {
+            // Properties matching the actual posthog-js SDK survey sent event schema
+            const surveyProperties: Record<string, any> = {
+                $survey_id: selectedSurvey?.id ?? 'survey-uuid',
+                $survey_name: selectedSurvey?.name ?? 'Survey name',
+                $survey_completed: true,
+                $survey_submission_id: 'submission-uuid',
+                $survey_iteration: null,
+                $survey_iteration_start_date: null,
+                $survey_questions: [{ id: 'question-id', question: 'Question text', response: 'Response' }],
+            }
+
+            if (selectedSurvey?.questions) {
+                // Per-question response fields keyed by question ID
+                selectedSurvey.questions.forEach((question) => {
+                    if (question.type === SurveyQuestionType.Link) {
+                        return // Link questions don't capture responses
+                    }
+                    if (question.id) {
+                        surveyProperties[`$survey_response_${question.id}`] = getSampleValueForQuestionType(
+                            question.type
+                        )
+                    }
+                })
+                // $survey_questions contains objects with {id, question, response}
+                surveyProperties.$survey_questions = selectedSurvey.questions.map((q) => ({
+                    id: q.id ?? '',
+                    question: q.question,
+                    response: getSampleValueForQuestionType(q.type),
+                }))
+            }
+
+            sampleGlobals.event = {
+                event: 'survey sent',
+                distinct_id: 'user123',
+                properties: surveyProperties,
+                timestamp: '2024-01-01T12:00:00Z',
+            }
+        } else {
+            sampleGlobals.event = {
+                event: 'example_event',
+                distinct_id: 'user123',
+                properties: {
+                    $current_url: 'https://example.com',
+                },
+                timestamp: '2024-01-01T12:00:00Z',
+            }
         }
         sampleGlobals.person = {
             id: 'person123',

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '@posthog/lemon-ui'
 import { CyclotronJobInputs } from 'lib/components/CyclotronJob/CyclotronJobInputs'
 import { templateToConfiguration } from 'scenes/hog-functions/configuration/hogFunctionConfigurationLogic'
 
-import { CyclotronJobInputType, HogFunctionMappingType, SurveyQuestionType } from '~/types'
+import { CyclotronJobInputType, HogFunctionMappingType, SurveyEventName, SurveyQuestionType } from '~/types'
 
 import { workflowLogic } from '../../../workflowLogic'
 import { surveyTriggerLogic } from '../surveyTriggerLogic'
@@ -56,19 +56,19 @@ export function HogFlowFunctionConfiguration({
         }
     }, [templateId])
 
-    // Detect survey trigger early so we can ensure surveys are loaded
+    // Detect survey trigger: exactly one event filter of 'survey sent'
     const triggerType = workflow?.trigger?.type
-    const isSurveyTriggerEarly =
-        triggerType === 'event' &&
-        workflow?.trigger &&
-        'filters' in workflow.trigger &&
-        (workflow.trigger.filters?.events ?? []).some((e: any) => e.id === 'survey sent')
+    const triggerEvents =
+        triggerType === 'event' && workflow?.trigger && 'filters' in workflow.trigger
+            ? (workflow.trigger.filters?.events ?? [])
+            : []
+    const isSurveyTrigger = triggerEvents.length === 1 && triggerEvents[0]?.id === SurveyEventName.SENT
 
     useEffect(() => {
-        if (isSurveyTriggerEarly && allSurveys.length === 0 && !surveysLoading) {
+        if (isSurveyTrigger && allSurveys.length === 0 && !surveysLoading) {
             loadSurveys()
         }
-    }, [isSurveyTriggerEarly, allSurveys.length, surveysLoading, loadSurveys])
+    }, [isSurveyTrigger, allSurveys.length, surveysLoading, loadSurveys])
 
     if (hogFunctionTemplatesByIdLoading) {
         return (
@@ -81,13 +81,6 @@ export function HogFlowFunctionConfiguration({
     if (!template) {
         return <div>Template not found!</div>
     }
-
-    // Detect if the trigger is a survey trigger (reuse triggerType from above)
-    const triggerEvents =
-        triggerType === 'event' && workflow?.trigger && 'filters' in workflow.trigger
-            ? (workflow.trigger.filters?.events ?? [])
-            : []
-    const isSurveyTrigger = triggerEvents.some((e: any) => e.id === 'survey sent')
 
     // If a specific survey is selected, find it for question-aware autocomplete
     const surveyIdProp =
@@ -184,6 +177,8 @@ export function HogFlowFunctionConfiguration({
         }
         sampleGlobals.groups = {}
     }
+
+    // DEBUG: trace sampleGlobals contents
 
     return (
         <>

--- a/products/workflows/frontend/Workflows/hogflows/steps/surveyTriggerLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/surveyTriggerLogic.ts
@@ -17,7 +17,7 @@ export function isSurveyTrigger(workflow: HogFlow | null | undefined): boolean {
         return false
     }
     const trigger = workflow.actions?.find((a) => a.type === 'trigger')
-    if (!trigger || trigger.config.type !== 'event') {
+    if (!trigger || !('type' in trigger.config) || trigger.config.type !== 'event') {
         return false
     }
     const events = trigger.config.filters?.events ?? []

--- a/products/workflows/frontend/Workflows/hogflows/steps/surveyTriggerLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/surveyTriggerLogic.ts
@@ -5,11 +5,24 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 
-import { Survey } from '~/types'
+import { Survey, SurveyEventName, SurveyQuestionType } from '~/types'
 
+import type { HogFlow } from '../types'
 import type { surveyTriggerLogicType } from './surveyTriggerLogicType'
 
 const SURVEYS_PAGE_SIZE = 20
+
+export function isSurveyTrigger(workflow: HogFlow | null | undefined): boolean {
+    if (!workflow) {
+        return false
+    }
+    const trigger = workflow.actions?.find((a) => a.type === 'trigger')
+    if (!trigger || trigger.config.type !== 'event') {
+        return false
+    }
+    const events = trigger.config.filters?.events ?? []
+    return events.length === 1 && events[0]?.id === SurveyEventName.SENT
+}
 
 export const surveyTriggerLogic = kea<surveyTriggerLogicType>([
     path(['products', 'workflows', 'frontend', 'Workflows', 'hogflows', 'steps', 'surveyTriggerLogic']),
@@ -75,6 +88,26 @@ export const surveyTriggerLogic = kea<surveyTriggerLogicType>([
         ],
     }),
     selectors({
+        getSampleValueForQuestionType: [
+            () => [],
+            (): ((type: string) => any) =>
+                (type: string): any => {
+                    switch (type) {
+                        case SurveyQuestionType.Open:
+                            return 'User response text'
+                        case SurveyQuestionType.Rating:
+                            return '8'
+                        case SurveyQuestionType.SingleChoice:
+                            return 'Selected option'
+                        case SurveyQuestionType.MultipleChoice:
+                            return ['Option A', 'Option B']
+                        case SurveyQuestionType.Link:
+                            return null
+                        default:
+                            return 'response'
+                    }
+                },
+        ],
         filteredSurveys: [
             (s) => [s.allSurveys, s.searchTerm],
             (allSurveys: Survey[], searchTerm: string): Survey[] => {

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -93,6 +93,22 @@ function getTemplatingError(value: string, templating?: 'liquid' | 'hog'): strin
     }
 }
 
+function hasSurveyTrigger(workflow: HogFlow): boolean {
+    const trigger = workflow.actions.find((a) => a.type === 'trigger')
+    if (!trigger || trigger.config.type !== 'event') {
+        return false
+    }
+    const events = trigger.config.filters?.events ?? []
+    return events.some((e: any) => e.id === SurveyEventName.SENT)
+}
+
+function ensureSurveysLoaded(): void {
+    surveyTriggerLogic.mount()
+    if (surveyTriggerLogic.values.allSurveys.length === 0 && !surveyTriggerLogic.values.surveysLoading) {
+        surveyTriggerLogic.actions.loadSurveys()
+    }
+}
+
 export function sanitizeWorkflow(
     workflow: HogFlow,
     hogFunctionTemplatesById: Record<string, HogFunctionTemplateType>
@@ -431,6 +447,9 @@ export const workflowLogic = kea<workflowLogicType>([
         },
         loadWorkflowSuccess: async ({ originalWorkflow }) => {
             actions.resetWorkflow(originalWorkflow)
+            if (hasSurveyTrigger(originalWorkflow)) {
+                ensureSurveysLoaded()
+            }
         },
         saveWorkflowSuccess: async ({ originalWorkflow }) => {
             const tasksToMarkAsCompleted: SetupTaskId[] = []
@@ -513,6 +532,15 @@ export const workflowLogic = kea<workflowLogicType>([
             const changes = { actions: newActions } as Partial<HogFlow>
             if (action.type === 'trigger') {
                 changes.trigger = updatedConfig as TriggerAction['config']
+
+                // Load surveys when the trigger is changed to a survey trigger
+                if (
+                    'type' in updatedConfig &&
+                    updatedConfig.type === 'event' &&
+                    updatedConfig.filters?.events?.some((e: any) => e.id === SurveyEventName.SENT)
+                ) {
+                    ensureSurveysLoaded()
+                }
             }
 
             actions.setWorkflowValues(changes)

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -379,14 +379,14 @@ export const workflowLogic = kea<workflowLogicType>([
                                         filters: 'At least one event or action is required',
                                     }
                                 }
-                            } else if (action.config.type === 'schedule') {
+                            } else if ('type' in action.config && action.config.type === 'schedule') {
                                 if (!action.config.scheduled_at) {
                                     result.valid = false
                                     result.errors = {
                                         scheduled_at: 'A scheduled time is required',
                                     }
                                 }
-                            } else if (action.config.type === 'batch') {
+                            } else if ('type' in action.config && action.config.type === 'batch') {
                                 if (!action.config.filters.properties?.length) {
                                     result.valid = false
                                     result.errors = {

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -99,7 +99,7 @@ function hasSurveyTrigger(workflow: HogFlow): boolean {
         return false
     }
     const events = trigger.config.filters?.events ?? []
-    return events.some((e: any) => e.id === SurveyEventName.SENT)
+    return events.length === 1 && events[0]?.id === SurveyEventName.SENT
 }
 
 function ensureSurveysLoaded(): void {
@@ -537,7 +537,8 @@ export const workflowLogic = kea<workflowLogicType>([
                 if (
                     'type' in updatedConfig &&
                     updatedConfig.type === 'event' &&
-                    updatedConfig.filters?.events?.some((e: any) => e.id === SurveyEventName.SENT)
+                    updatedConfig.filters?.events?.length === 1 &&
+                    updatedConfig.filters?.events?.[0]?.id === SurveyEventName.SENT
                 ) {
                     ensureSurveysLoaded()
                 }

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -18,9 +18,10 @@ import { projectLogic } from 'scenes/projectLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { HogFunctionTemplateType } from '~/types'
+import { HogFunctionTemplateType, SurveyEventName } from '~/types'
 
 import { getRegisteredTriggerTypes } from './hogflows/registry/triggers/triggerTypeRegistry'
+import { isSurveyTrigger, surveyTriggerLogic } from './hogflows/steps/surveyTriggerLogic'
 import { HogFlowActionSchema, isFunctionAction, isTriggerFunction } from './hogflows/steps/types'
 import { type HogFlow, type HogFlowAction, HogFlowActionValidationResult, type HogFlowEdge } from './hogflows/types'
 import type { workflowLogicType } from './workflowLogicType'
@@ -91,15 +92,6 @@ function getTemplatingError(value: string, templating?: 'liquid' | 'hog'): strin
             return `Liquid template error: ${e.message}`
         }
     }
-}
-
-function hasSurveyTrigger(workflow: HogFlow): boolean {
-    const trigger = workflow.actions.find((a) => a.type === 'trigger')
-    if (!trigger || trigger.config.type !== 'event') {
-        return false
-    }
-    const events = trigger.config.filters?.events ?? []
-    return events.length === 1 && events[0]?.id === SurveyEventName.SENT
 }
 
 function ensureSurveysLoaded(): void {
@@ -447,7 +439,7 @@ export const workflowLogic = kea<workflowLogicType>([
         },
         loadWorkflowSuccess: async ({ originalWorkflow }) => {
             actions.resetWorkflow(originalWorkflow)
-            if (hasSurveyTrigger(originalWorkflow)) {
+            if (isSurveyTrigger(originalWorkflow)) {
                 ensureSurveysLoaded()
             }
         },


### PR DESCRIPTION
## Problem

When you are trying to use placeholders that use survey response data, it is too hard to find the correct property keys.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Adds survey specific suggestions (e.g. `$survey_questions`)

![Screenshot 2026-02-05 at 19.54.52.png](https://app.graphite.com/user-attachments/assets/3c8f9580-24ca-429b-8461-cc17420f1e64.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- Manually, trying all the possible options in the UI, and checking the correct side effects
- `pnpm --filter=@posthog/frontend jest products/workflows/frontend/Workflows --no-coverage`
- `pnpm --filter=@posthog/frontend jest frontend/src/lib/components/CyclotronJob --no-coverage`

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

Not necessary.
