### PR TITLE
fix(modeling): fix 500s because of silly queryset mistake

### DIFF
--- a/products/data_warehouse/backend/api/data_modeling_job.py
+++ b/products/data_warehouse/backend/api/data_modeling_job.py
@@ -52,21 +52,20 @@ class DataModelingJobViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewS
     ordering_fields = ["created_at"]
     ordering = "-created_at"
 
-    def safely_get_queryset(self, queryset=None):
-        queryset = super().safely_get_queryset(queryset).filter(team_id=self.team_id)
-        return queryset
+    def safely_get_queryset(self, queryset):
+        return queryset.filter(team_id=self.team_id)
 
     @action(methods=["GET"], detail=False)
     def running(self, request, *args, **kwargs):
         """Get all currently running jobs."""
-        queryset = self.safely_get_queryset().filter(status=DataModelingJob.Status.RUNNING)
+        queryset = self.get_queryset().filter(status=DataModelingJob.Status.RUNNING)
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
     @action(methods=["GET"], detail=False)
     def recent(self, request, *args, **kwargs):
         """Get recently completed/failed jobs (paginated)."""
-        queryset = self.safely_get_queryset().exclude(status__in=["Running", "Cancelled"])
+        queryset = self.get_queryset().exclude(status__in=["Running", "Cancelled"])
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)


### PR DESCRIPTION
## Problem

running/ and recent/ actions on data modeling jobs were returning 500s in the new dag scene

## Changes

learn django better; actually use the safely_get_queryset thingy right

## How did you test this code?

ran locally

## Publish to changelog?

no