### PR TITLE
fix(modeling): default to false for matview failure emails

### DIFF
--- a/frontend/src/scenes/settings/user/UpdateEmailPreferences.tsx
+++ b/frontend/src/scenes/settings/user/UpdateEmailPreferences.tsx
@@ -17,7 +17,7 @@ const NOTIFICATION_DEFAULTS: BooleanNotificationSettings = {
     discussions_mentioned: true,
     all_weekly_digest_disabled: false,
     project_api_key_exposed: true,
-    materialized_view_sync_failed: true,
+    materialized_view_sync_failed: false,
 }
 
 export function UpdateEmailPreferences(): JSX.Element {

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1482,7 +1482,7 @@ class TestUserAPI(APIBaseTest):
                 "error_tracking_issue_assigned": True,  # Default value
                 "data_pipeline_error_threshold": 0.0,  # Default value
                 "project_api_key_exposed": True,  # Default value
-                "materialized_view_sync_failed": True,  # Default value
+                "materialized_view_sync_failed": False,  # Default value
             },
         )
 

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -44,7 +44,7 @@ NOTIFICATION_DEFAULTS: Notifications = {
     "all_weekly_digest_disabled": False,  # Weekly digests enabled by default
     "data_pipeline_error_threshold": 0.0,  # Default: notify on any failure (0% threshold)
     "project_api_key_exposed": True,  # Project API key exposure alerts enabled by default
-    "materialized_view_sync_failed": True,  # Materialized view failure enabled by default
+    "materialized_view_sync_failed": False,  # Materialized view failure disabled by default
 }
 
 # We don't need the following attributes in most cases, so we defer them by default

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -155,7 +155,7 @@ def should_send_notification(
         return settings.get(notification_type, True)
 
     elif notification_type == NotificationSetting.MATERIALIZED_VIEW_SYNC_FAILED.value:
-        return settings.get(notification_type, True)
+        return settings.get(notification_type, False)
 
     # The below typeerror is ignored because we're currently handling the notification
     # types above, so technically it's unreachable. However if another is added but


### PR DESCRIPTION
## Problem

too many emails

## Changes

default to false for matview failure emails (for now)

## How did you test this code?

i didn't

## Publish to changelog?

no