### PR TITLE
fix(insights): view sql insight table formatting

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -1,5 +1,6 @@
 import {
     actions,
+    afterMount,
     connect,
     kea,
     key,
@@ -291,6 +292,12 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             ['loadData'],
         ],
     })),
+    afterMount(({ actions, props }) => {
+        if (props.query) {
+            // populate fields like tabularColumnSettings, etc
+            actions._setQuery(props.query)
+        }
+    }),
     propsChanged(({ actions, values, props }) => {
         if (props.query && !objectsEqual(props.query, values.query)) {
             actions._setQuery(props.query)


### PR DESCRIPTION
## Problem

The table formatting wouldn't apply up in the SQL insight's view mode

<img width="1143" height="421" alt="image" src="https://github.com/user-attachments/assets/377086fd-6363-43a3-bcc3-a5907d57313b" />

even if it was defined in the sql editor:

<img width="1284" height="1148" alt="image" src="https://github.com/user-attachments/assets/f1be4dce-9c41-4d64-82bf-2836dd396c93" />


## Changes

Apply the formatting correctly:

<img width="1142" height="465" alt="Screenshot 2026-02-06 at 02 31 16" src="https://github.com/user-attachments/assets/c40f88af-4e34-42e1-a5d4-41744b955d66" />


## How did you test this code?

See png above for before/after.