### PR TITLE
chore: add automatic team scoping infrastructure for IDOR prevention

### DIFF
--- a/.semgrep/rules/celery-team-scope.yaml
+++ b/.semgrep/rules/celery-team-scope.yaml
@@ -1,0 +1,53 @@
+rules:
+    - id: celery-task-team-scope-audit
+      patterns:
+          - pattern-inside: |
+                @shared_task(...)
+                def $FUNC(...):
+                    ...
+          - pattern-either:
+                - pattern: $MODEL.objects.all()
+                - pattern: $MODEL.objects.filter(...)
+                - pattern: $MODEL.objects.get(...)
+                - pattern: $MODEL.objects.exclude(...)
+                - pattern: $MODEL.objects.first()
+                - pattern: $MODEL.objects.last()
+                - pattern: $MODEL.objects.count()
+                - pattern: $MODEL.objects.exists()
+          - pattern-not-inside: |
+                @with_team_scope(...)
+                def $FUNC(...):
+                    ...
+          - pattern-not: $MODEL.objects.unscoped()...
+      message: |
+          Celery task accesses model without explicit team scoping.
+
+          Background tasks don't have request context, so automatic team scoping
+          won't work. Either:
+          1. Add @with_team_scope() decorator if the task should be team-scoped
+          2. Use .unscoped() if intentionally querying across teams
+
+          Example with decorator:
+              @shared_task
+              @with_team_scope()
+              def my_task(team_id: int):
+                  FeatureFlag.objects.all()  # Scoped to team_id
+
+          Example with unscoped:
+              @shared_task
+              def my_task():
+                  FeatureFlag.objects.unscoped().all()  # Explicitly cross-team
+      languages: [python]
+      severity: WARNING
+      paths:
+          exclude:
+              - '**/test/**'
+              - '**/tests/**'
+              - '**/.semgrep/**'
+      metadata:
+          category: security
+          subcategory:
+              - audit
+          technology:
+              - django
+              - celery

--- a/.semgrep/rules/tests/celery-team-scope.py
+++ b/.semgrep/rules/tests/celery-team-scope.py
@@ -1,0 +1,53 @@
+# Test cases for celery-team-scope semgrep rule
+
+from celery import shared_task
+
+from posthog.models.feature_flag import FeatureFlag
+from posthog.models.scoping import with_team_scope
+
+
+# ruleid: celery-task-team-scope-audit
+@shared_task
+def bad_task_no_scoping():
+    # This should be flagged - no team scoping
+    flags = FeatureFlag.objects.all()
+    return flags
+
+
+# ruleid: celery-task-team-scope-audit
+@shared_task(ignore_result=True)
+def bad_task_with_filter():
+    # This should be flagged - no team scoping
+    flags = FeatureFlag.objects.filter(active=True)
+    return flags
+
+
+# ok: celery-task-team-scope-audit
+@shared_task
+@with_team_scope()
+def good_task_with_decorator(team_id: int):
+    # This is OK - has @with_team_scope decorator
+    flags = FeatureFlag.objects.all()
+    return flags
+
+
+# ok: celery-task-team-scope-audit
+@shared_task
+def good_task_with_unscoped():
+    # This is OK - explicitly unscoped
+    flags = FeatureFlag.objects.unscoped().all()
+    return flags
+
+
+# ok: celery-task-team-scope-audit
+@shared_task
+def good_task_with_unscoped_filter():
+    # This is OK - explicitly unscoped
+    flags = FeatureFlag.objects.unscoped().filter(active=True)
+    return flags
+
+
+# Not a celery task - should not be flagged
+def regular_function():
+    flags = FeatureFlag.objects.all()
+    return flags

--- a/posthog/models/scoping/README.md
+++ b/posthog/models/scoping/README.md
@@ -1,0 +1,157 @@
+# Team Scoping Module
+
+Automatic team scoping for Django models to prevent IDOR vulnerabilities.
+
+## Overview
+
+This module provides infrastructure for automatically filtering database queries by the current team. Instead of relying on developers to always include `team_id` filters, models can use `TeamScopedManager` to automatically apply the filter based on request context.
+
+## Quick Start
+
+### For Request Handlers (Views, API Endpoints)
+
+The middleware automatically sets the team context from `request.user.current_team_id`. Models using `TeamScopedManager` will automatically filter queries.
+
+```python
+# In a view or API endpoint - team scoping is automatic
+flags = FeatureFlag.objects.all()  # Only returns flags for current user's team
+```
+
+### For Background Jobs (Celery Tasks)
+
+Background tasks don't have request context. Use the `@with_team_scope` decorator:
+
+```python
+from celery import shared_task
+from posthog.models.scoping import with_team_scope
+
+@shared_task
+@with_team_scope()
+def process_team_data(team_id: int, data: dict):
+    # Team context is set from the team_id parameter
+    flags = FeatureFlag.objects.all()  # Filtered to team_id
+```
+
+Or use the `team_scope()` context manager directly:
+
+```python
+from posthog.models.scoping import team_scope
+
+@shared_task
+def process_team_data(team_id: int, data: dict):
+    with team_scope(team_id):
+        flags = FeatureFlag.objects.all()
+```
+
+### For Cross-Team Queries
+
+When you intentionally need to query across teams (e.g., admin dashboards, analytics), use `.unscoped()`:
+
+```python
+# Query all teams explicitly
+all_flags = FeatureFlag.objects.unscoped().filter(key="my-global-flag")
+```
+
+Or use the `unscoped()` context manager:
+
+```python
+from posthog.models.scoping import unscoped
+
+with unscoped():
+    all_flags = FeatureFlag.objects.all()  # All teams
+```
+
+## Migrating a Model
+
+### Step 1: Switch to BackwardsCompatibleTeamScopedManager
+
+This maintains compatibility with existing `filter(team_id=X)` patterns:
+
+```python
+from posthog.models.scoping.manager import BackwardsCompatibleTeamScopedManager
+
+class MyModel(models.Model):
+    team = models.ForeignKey("Team", on_delete=models.CASCADE)
+    # ... other fields ...
+
+    objects = BackwardsCompatibleTeamScopedManager()
+```
+
+### Step 2: Update Celery Tasks
+
+Add `@with_team_scope` decorator or use `.unscoped()`:
+
+```python
+# Before
+@shared_task
+def my_task(team_id: int):
+    MyModel.objects.filter(team_id=team_id).all()
+
+# After (option 1: decorator)
+@shared_task
+@with_team_scope()
+def my_task(team_id: int):
+    MyModel.objects.all()  # Automatically filtered
+
+# After (option 2: unscoped for cross-team)
+@shared_task
+def my_task():
+    MyModel.objects.unscoped().all()  # Explicitly cross-team
+```
+
+### Step 3: Update Cross-Team Queries
+
+Find places that intentionally query across teams and add `.unscoped()`:
+
+```python
+# Before
+MyModel.objects.filter(key="global-setting")  # Was relying on no team filter
+
+# After
+MyModel.objects.unscoped().filter(key="global-setting")  # Explicitly cross-team
+```
+
+### Step 4: Switch to TeamScopedManager (Optional)
+
+Once all `filter(team_id=X)` usages are removed, switch to strict scoping:
+
+```python
+from posthog.models.scoping.manager import TeamScopedManager
+
+class MyModel(models.Model):
+    objects = TeamScopedManager()
+```
+
+## API Reference
+
+### Context Functions
+
+- `get_current_team_id()` - Returns the current team_id or None
+- `set_current_team_id(team_id)` - Sets team_id, returns reset token
+- `reset_current_team_id(token)` - Resets to previous value
+
+### Context Managers
+
+- `team_scope(team_id)` - Sets team context for a block
+- `unscoped()` - Clears team context for a block
+
+### Decorators
+
+- `@with_team_scope(team_id_param="team_id")` - Wraps function in team context
+
+### Managers
+
+- `TeamScopedManager` - Strict automatic scoping
+- `BackwardsCompatibleTeamScopedManager` - Also supports `filter(team_id=X)`
+
+### Middleware
+
+- `TeamScopingMiddleware` - Sets team context from request.user
+
+## Semgrep Rules
+
+The `celery-task-team-scope-audit` rule flags Celery tasks that access models without explicit team scoping. Run with:
+
+```bash
+semgrep --config .semgrep/rules/celery-team-scope.yaml .
+```

--- a/posthog/models/scoping/__init__.py
+++ b/posthog/models/scoping/__init__.py
@@ -1,0 +1,83 @@
+# Team Scoping Context
+#
+# Provides automatic team scoping for Django models using Python's ContextVar.
+# When a request comes in, middleware sets the current team_id in a ContextVar.
+# Models using TeamScopedManager will automatically filter by this team_id.
+#
+# Usage:
+#   # In request context (automatic via middleware):
+#   FeatureFlag.objects.all()  # Auto-filtered to current team
+#
+#   # Explicit cross-team query (escape hatch):
+#   FeatureFlag.objects.unscoped().all()  # No team filtering
+#
+#   # In background jobs (no request context):
+#   with team_scope(team_id):
+#       FeatureFlag.objects.all()  # Filtered to specified team
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+
+# The current team_id, set by middleware or explicitly via team_scope()
+_current_team_id: ContextVar[int | None] = ContextVar("current_team_id", default=None)
+
+
+def get_current_team_id() -> int | None:
+    """Get the current team_id from context, or None if not set."""
+    return _current_team_id.get()
+
+
+def set_current_team_id(team_id: int | None) -> Token[int | None]:
+    """Set the current team_id in context. Returns a token to reset it later."""
+    return _current_team_id.set(team_id)
+
+
+def reset_current_team_id(token: Token[int | None]) -> None:
+    """Reset the current team_id to its previous value."""
+    _current_team_id.reset(token)
+
+
+@contextmanager
+def team_scope(team_id: int) -> Generator[None, None, None]:
+    """
+    Context manager to set the current team_id for a block of code.
+
+    Useful for background jobs or tests where there's no request context.
+
+    Example:
+        with team_scope(123):
+            flags = FeatureFlag.objects.all()  # Auto-filtered to team 123
+    """
+    token = set_current_team_id(team_id)
+    try:
+        yield
+    finally:
+        reset_current_team_id(token)
+
+
+@contextmanager
+def unscoped() -> Generator[None, None, None]:
+    """
+    Context manager to temporarily disable automatic team scoping.
+
+    Useful when you explicitly need to query across teams.
+
+    Example:
+        with unscoped():
+            all_flags = FeatureFlag.objects.all()  # All teams
+    """
+    token = set_current_team_id(None)
+    try:
+        yield
+    finally:
+        reset_current_team_id(token)
+
+
+__all__ = [
+    "get_current_team_id",
+    "set_current_team_id",
+    "reset_current_team_id",
+    "team_scope",
+    "unscoped",
+]

--- a/posthog/models/scoping/manager.py
+++ b/posthog/models/scoping/manager.py
@@ -5,18 +5,63 @@ Provides drop-in replacement for RootTeamManager that automatically filters
 queries by the current team_id from context.
 """
 
-from typing import TypeVar
+from typing import Self, TypeVar
 
 from django.db import models
 from django.db.models import Q, Subquery
 
-from posthog.models.scoping import get_current_team_id
+from posthog.models.scoping import get_current_team_context, get_current_team_id
 from posthog.person_db_router import PERSONS_DB_MODELS
 
 T = TypeVar("T", bound=models.Model)
 
 
-class TeamScopedQuerySet(models.QuerySet[T]):
+class TeamFilterMixin:
+    """
+    Mixin that provides team filtering logic.
+
+    Handles both regular models (using JOINs) and PERSONS_DB_MODELS (cross-database).
+    Uses cached parent_team_id from context when available to avoid extra queries.
+    """
+
+    model: type[models.Model]
+
+    def _apply_team_filter(self, team_id: int) -> Self:
+        """Apply team filtering with parent team logic (from RootTeamQuerySet)."""
+        from posthog.models.team import Team
+
+        # For persons DB models, we can't join with the Team table (cross-database)
+        if self.model._meta.model_name in PERSONS_DB_MODELS:
+            effective_team_id = self._get_effective_team_id_for_persons_db(team_id)
+            return self.filter(team_id=effective_team_id)
+
+        # For non-persons DB models: use JOIN logic from RootTeamQuerySet
+        parent_team_subquery = Team.objects.filter(id=team_id).values("parent_team_id")[:1]
+        team_filter = Q(team_id=Subquery(parent_team_subquery)) | Q(team_id=team_id, team__parent_team_id__isnull=True)
+        return self.filter(team_filter)
+
+    def _get_effective_team_id_for_persons_db(self, team_id: int) -> int:
+        """
+        Get the effective team ID for PERSONS_DB_MODELS.
+
+        Uses cached parent_team_id from context if available, otherwise fetches from DB.
+        """
+        from posthog.models.team import Team
+
+        # Try to use cached parent_team_id from context
+        ctx = get_current_team_context()
+        if ctx is not None and ctx.team_id == team_id:
+            return ctx.effective_team_id
+
+        # Fall back to DB query if not in context or different team_id
+        try:
+            team = Team.objects.using("default").get(id=team_id)
+            return team.parent_team_id if team.parent_team_id else team_id
+        except Team.DoesNotExist:
+            return team_id
+
+
+class TeamScopedQuerySet(TeamFilterMixin, models.QuerySet[T]):
     """
     QuerySet that supports automatic team scoping.
 
@@ -34,24 +79,6 @@ class TeamScopedQuerySet(models.QuerySet[T]):
         This creates a fresh queryset without any team filtering applied.
         """
         return TeamScopedQuerySet(self.model, using=self._db)
-
-    def _apply_team_filter(self, team_id: int) -> "TeamScopedQuerySet[T]":
-        """Apply team filtering with parent team logic (from RootTeamQuerySet)."""
-        from posthog.models.team import Team
-
-        # For persons DB models, we can't join with the Team table (cross-database)
-        if self.model._meta.model_name in PERSONS_DB_MODELS:
-            try:
-                team = Team.objects.using("default").get(id=team_id)
-                effective_team_id = team.parent_team_id if team.parent_team_id else team_id
-            except Team.DoesNotExist:
-                effective_team_id = team_id
-            return self.filter(team_id=effective_team_id)
-
-        # For non-persons DB models: use JOIN logic from RootTeamQuerySet
-        parent_team_subquery = Team.objects.filter(id=team_id).values("parent_team_id")[:1]
-        team_filter = Q(team_id=Subquery(parent_team_subquery)) | Q(team_id=team_id, team__parent_team_id__isnull=True)
-        return self.filter(team_filter)
 
 
 class TeamScopedManager(models.Manager[T]):
@@ -83,7 +110,7 @@ class TeamScopedManager(models.Manager[T]):
         return self._queryset_class(self.model, using=self._db)
 
 
-class BackwardsCompatibleTeamScopedQuerySet(TeamScopedQuerySet[T]):
+class BackwardsCompatibleTeamScopedQuerySet(TeamFilterMixin, models.QuerySet[T]):
     """
     QuerySet that supports both automatic scoping and explicit team_id filtering.
 
@@ -99,7 +126,7 @@ class BackwardsCompatibleTeamScopedQuerySet(TeamScopedQuerySet[T]):
         if "team_id" in kwargs:
             team_id = kwargs.pop("team_id")
             # Apply the team filter (handles parent team logic)
-            filtered = self._apply_team_filter(team_id)
+            filtered = self._apply_team_filter_compat(team_id)
             # Apply any remaining filters
             if args or kwargs:
                 return filtered.filter(*args, **kwargs)
@@ -110,18 +137,17 @@ class BackwardsCompatibleTeamScopedQuerySet(TeamScopedQuerySet[T]):
         """Return a queryset that bypasses automatic team scoping."""
         return BackwardsCompatibleTeamScopedQuerySet(self.model, using=self._db)
 
-    def _apply_team_filter(self, team_id: int) -> "BackwardsCompatibleTeamScopedQuerySet[T]":
-        """Apply team filtering with parent team logic."""
+    def _apply_team_filter_compat(self, team_id: int) -> "BackwardsCompatibleTeamScopedQuerySet[T]":
+        """
+        Apply team filtering for backwards compatible queryset.
+
+        Uses super().filter() to avoid recursion through our filter override.
+        """
         from posthog.models.team import Team
 
         # For persons DB models, we can't join with the Team table (cross-database)
         if self.model._meta.model_name in PERSONS_DB_MODELS:
-            try:
-                team = Team.objects.using("default").get(id=team_id)
-                effective_team_id = team.parent_team_id if team.parent_team_id else team_id
-            except Team.DoesNotExist:
-                effective_team_id = team_id
-            # Use super().filter to avoid recursion through our filter override
+            effective_team_id = self._get_effective_team_id_for_persons_db(team_id)
             return super().filter(team_id=effective_team_id)
 
         # For non-persons DB models: use JOIN logic from RootTeamQuerySet

--- a/posthog/models/scoping/manager.py
+++ b/posthog/models/scoping/manager.py
@@ -1,0 +1,89 @@
+"""
+Team-scoped manager and queryset for automatic IDOR protection.
+
+Provides drop-in replacement for RootTeamManager that automatically filters
+queries by the current team_id from context.
+"""
+
+from typing import TypeVar
+
+from django.db import models
+from django.db.models import Q, Subquery
+
+from posthog.models.scoping import get_current_team_id
+from posthog.person_db_router import PERSONS_DB_MODELS
+
+T = TypeVar("T", bound=models.Model)
+
+
+class TeamScopedQuerySet(models.QuerySet[T]):
+    """
+    QuerySet that supports automatic team scoping.
+
+    Provides an `unscoped()` method to bypass automatic filtering when you
+    need to explicitly query across teams.
+    """
+
+    def unscoped(self) -> "TeamScopedQuerySet[T]":
+        """
+        Return a queryset that bypasses automatic team scoping.
+
+        Use this when you explicitly need to query across teams:
+            FeatureFlag.objects.unscoped().filter(key="my-flag")
+
+        This creates a fresh queryset without any team filtering applied.
+        """
+        return TeamScopedQuerySet(self.model, using=self._db)
+
+    def _apply_team_filter(self, team_id: int) -> "TeamScopedQuerySet[T]":
+        """Apply team filtering with parent team logic (from RootTeamQuerySet)."""
+        from posthog.models.team import Team
+
+        # For persons DB models, we can't join with the Team table (cross-database)
+        if self.model._meta.model_name in PERSONS_DB_MODELS:
+            try:
+                team = Team.objects.using("default").get(id=team_id)
+                effective_team_id = team.parent_team_id if team.parent_team_id else team_id
+            except Team.DoesNotExist:
+                effective_team_id = team_id
+            return self.filter(team_id=effective_team_id)
+
+        # For non-persons DB models: use JOIN logic from RootTeamQuerySet
+        parent_team_subquery = Team.objects.filter(id=team_id).values("parent_team_id")[:1]
+        team_filter = Q(team_id=Subquery(parent_team_subquery)) | Q(team_id=team_id, team__parent_team_id__isnull=True)
+        return self.filter(team_filter)
+
+
+class TeamScopedManager(models.Manager[T]):
+    """
+    Manager that provides automatic team scoping.
+
+    When the current team_id is set in context (via middleware or team_scope()),
+    all queries will be automatically filtered to that team.
+
+    To bypass automatic filtering, use .unscoped():
+        MyModel.objects.unscoped().all()
+
+    Note: The team filter is applied when accessing the manager (e.g., Model.objects),
+    not at query evaluation time. This covers the vast majority of use cases where
+    you access the model within the same request/task context.
+    """
+
+    _queryset_class = TeamScopedQuerySet
+
+    def get_queryset(self) -> TeamScopedQuerySet[T]:
+        qs = self._queryset_class(self.model, using=self._db)
+        team_id = get_current_team_id()
+        if team_id is not None:
+            qs = qs._apply_team_filter(team_id)
+        return qs
+
+    def unscoped(self) -> TeamScopedQuerySet[T]:
+        """Return an unscoped queryset that bypasses automatic team filtering."""
+        return self._queryset_class(self.model, using=self._db)
+
+
+__all__ = [
+    "TeamScopedQuerySet",
+    "TeamScopedManager",
+]

--- a/posthog/models/scoping/manager.py
+++ b/posthog/models/scoping/manager.py
@@ -83,7 +83,87 @@ class TeamScopedManager(models.Manager[T]):
         return self._queryset_class(self.model, using=self._db)
 
 
+class BackwardsCompatibleTeamScopedQuerySet(TeamScopedQuerySet[T]):
+    """
+    QuerySet that supports both automatic scoping and explicit team_id filtering.
+
+    Maintains backwards compatibility with existing code that does:
+        Model.objects.filter(team_id=some_id)
+
+    When team_id is explicitly passed to filter(), it takes precedence over
+    automatic context-based scoping.
+    """
+
+    def filter(self, *args, **kwargs) -> "BackwardsCompatibleTeamScopedQuerySet[T]":
+        # If team_id is explicitly passed, handle it with parent team logic
+        if "team_id" in kwargs:
+            team_id = kwargs.pop("team_id")
+            # Apply the team filter (handles parent team logic)
+            filtered = self._apply_team_filter(team_id)
+            # Apply any remaining filters
+            if args or kwargs:
+                return filtered.filter(*args, **kwargs)
+            return filtered
+        return super().filter(*args, **kwargs)
+
+    def unscoped(self) -> "BackwardsCompatibleTeamScopedQuerySet[T]":
+        """Return a queryset that bypasses automatic team scoping."""
+        return BackwardsCompatibleTeamScopedQuerySet(self.model, using=self._db)
+
+    def _apply_team_filter(self, team_id: int) -> "BackwardsCompatibleTeamScopedQuerySet[T]":
+        """Apply team filtering with parent team logic."""
+        from posthog.models.team import Team
+
+        # For persons DB models, we can't join with the Team table (cross-database)
+        if self.model._meta.model_name in PERSONS_DB_MODELS:
+            try:
+                team = Team.objects.using("default").get(id=team_id)
+                effective_team_id = team.parent_team_id if team.parent_team_id else team_id
+            except Team.DoesNotExist:
+                effective_team_id = team_id
+            # Use super().filter to avoid recursion through our filter override
+            return super().filter(team_id=effective_team_id)
+
+        # For non-persons DB models: use JOIN logic from RootTeamQuerySet
+        parent_team_subquery = Team.objects.filter(id=team_id).values("parent_team_id")[:1]
+        team_filter = Q(team_id=Subquery(parent_team_subquery)) | Q(team_id=team_id, team__parent_team_id__isnull=True)
+        return super().filter(team_filter)
+
+
+class BackwardsCompatibleTeamScopedManager(models.Manager[T]):
+    """
+    Manager that provides automatic team scoping while maintaining backwards compatibility.
+
+    Supports:
+    - Automatic scoping from context: Model.objects.all()
+    - Explicit team_id filtering: Model.objects.filter(team_id=X)
+    - Unscoped queries: Model.objects.unscoped().all()
+
+    Use this during migration from RootTeamManager. Once all code is updated
+    to use context-based scoping, switch to TeamScopedManager.
+    """
+
+    _queryset_class = BackwardsCompatibleTeamScopedQuerySet
+
+    def get_queryset(self) -> BackwardsCompatibleTeamScopedQuerySet[T]:
+        qs = self._queryset_class(self.model, using=self._db)
+        team_id = get_current_team_id()
+        if team_id is not None:
+            qs = qs._apply_team_filter(team_id)
+        return qs
+
+    def unscoped(self) -> BackwardsCompatibleTeamScopedQuerySet[T]:
+        """Return an unscoped queryset that bypasses automatic team filtering."""
+        return self._queryset_class(self.model, using=self._db)
+
+    def filter(self, *args, **kwargs) -> BackwardsCompatibleTeamScopedQuerySet[T]:
+        """Filter with support for explicit team_id."""
+        return self.get_queryset().filter(*args, **kwargs)
+
+
 __all__ = [
     "TeamScopedQuerySet",
     "TeamScopedManager",
+    "BackwardsCompatibleTeamScopedQuerySet",
+    "BackwardsCompatibleTeamScopedManager",
 ]

--- a/posthog/models/scoping/middleware.py
+++ b/posthog/models/scoping/middleware.py
@@ -1,0 +1,42 @@
+"""
+Middleware to set the current team_id in context for automatic query scoping.
+"""
+
+from collections.abc import Callable
+
+from django.http import HttpRequest, HttpResponse
+
+from posthog.models.scoping import reset_current_team_id, set_current_team_id
+
+
+class TeamScopingMiddleware:
+    """
+    Middleware that sets the current team_id from the authenticated user.
+
+    This enables automatic team scoping for all database queries within the request.
+    Models using TeamScopedManager will automatically filter by this team_id.
+
+    Add to MIDDLEWARE in settings.py after AuthenticationMiddleware:
+        'posthog.models.scoping.middleware.TeamScopingMiddleware',
+    """
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        token = None
+
+        # Set team context if user is authenticated and has a current team
+        if hasattr(request, "user") and request.user.is_authenticated:
+            team_id = getattr(request.user, "current_team_id", None)
+            if team_id is not None:
+                token = set_current_team_id(team_id)
+
+        try:
+            response = self.get_response(request)
+        finally:
+            # Always reset the context, even if an exception occurred
+            if token is not None:
+                reset_current_team_id(token)
+
+        return response

--- a/posthog/models/scoping/test_manager.py
+++ b/posthog/models/scoping/test_manager.py
@@ -1,7 +1,7 @@
 from posthog.test.base import BaseTest
 
 from posthog.models.feature_flag import FeatureFlag
-from posthog.models.scoping import team_scope, unscoped
+from posthog.models.scoping import get_current_team_context, team_scope, unscoped
 from posthog.models.team import Team
 
 
@@ -174,3 +174,110 @@ class TestBackwardsCompatibleTeamScopedManager(BaseTest):
 
         unscoped_qs = manager.unscoped()
         assert isinstance(unscoped_qs, BackwardsCompatibleTeamScopedQuerySet)
+
+
+class TestTeamFilterMixinWithCachedContext(BaseTest):
+    """Tests for parent team caching in context to avoid extra queries."""
+
+    def test_cached_parent_team_id_is_used(self):
+        """When parent_team_id is in context, no extra DB query is needed."""
+
+        # Create a child team with a parent
+        parent_team = Team.objects.create(organization=self.organization, name="Parent Team")
+        child_team = Team.objects.create(organization=self.organization, name="Child Team", parent_team=parent_team)
+
+        FeatureFlag.objects.create(team=parent_team, key="parent-flag", created_by=self.user)
+        FeatureFlag.objects.create(team=child_team, key="child-flag", created_by=self.user)
+
+        # Set context with cached parent_team_id
+        with team_scope(child_team.id, parent_team_id=parent_team.id):
+            ctx = get_current_team_context()
+            assert ctx is not None
+            assert ctx.team_id == child_team.id
+            assert ctx.parent_team_id == parent_team.id
+            assert ctx.effective_team_id == parent_team.id
+
+    def test_effective_team_id_without_parent(self):
+        """When no parent_team_id in context, team_id is used."""
+        with team_scope(self.team.id):
+            ctx = get_current_team_context()
+            assert ctx is not None
+            assert ctx.team_id == self.team.id
+            assert ctx.parent_team_id is None
+            assert ctx.effective_team_id == self.team.id
+
+
+class TestTeamScopedManagerIntegration(BaseTest):
+    """Integration tests using real Django ORM with TeamScopedManager."""
+
+    def test_manager_get_queryset_applies_filter_in_context(self):
+        """TeamScopedManager.get_queryset() applies team filter when in context."""
+        from posthog.models.scoping.manager import TeamScopedManager
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+
+        FeatureFlag.objects.create(team=self.team, key="flag-1", created_by=self.user)
+        FeatureFlag.objects.create(team=other_team, key="flag-2", created_by=self.user)
+
+        manager = TeamScopedManager()
+        manager.model = FeatureFlag
+        manager._db = "default"
+
+        with team_scope(self.team.id):
+            qs = manager.get_queryset()
+            assert qs.count() == 1
+            assert qs.first().key == "flag-1"
+
+    def test_manager_get_queryset_no_filter_without_context(self):
+        """TeamScopedManager.get_queryset() returns all when no context."""
+        from posthog.models.scoping.manager import TeamScopedManager
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+
+        FeatureFlag.objects.create(team=self.team, key="flag-1", created_by=self.user)
+        FeatureFlag.objects.create(team=other_team, key="flag-2", created_by=self.user)
+
+        manager = TeamScopedManager()
+        manager.model = FeatureFlag
+        manager._db = "default"
+
+        # No team scope - should return all
+        qs = manager.get_queryset()
+        assert qs.count() >= 2
+
+    def test_manager_unscoped_bypasses_context(self):
+        """TeamScopedManager.unscoped() ignores team context."""
+        from posthog.models.scoping.manager import TeamScopedManager
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+
+        FeatureFlag.objects.create(team=self.team, key="flag-1", created_by=self.user)
+        FeatureFlag.objects.create(team=other_team, key="flag-2", created_by=self.user)
+
+        manager = TeamScopedManager()
+        manager.model = FeatureFlag
+        manager._db = "default"
+
+        with team_scope(self.team.id):
+            unscoped_qs = manager.unscoped()
+            assert unscoped_qs.count() >= 2
+
+    def test_queryset_chaining_preserves_team_filter(self):
+        """QuerySet chaining preserves the team filter."""
+        from posthog.models.scoping.manager import TeamScopedManager
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+
+        FeatureFlag.objects.create(team=self.team, key="active-flag", active=True, created_by=self.user)
+        FeatureFlag.objects.create(team=self.team, key="inactive-flag", active=False, created_by=self.user)
+        FeatureFlag.objects.create(team=other_team, key="other-active", active=True, created_by=self.user)
+
+        manager = TeamScopedManager()
+        manager.model = FeatureFlag
+        manager._db = "default"
+
+        with team_scope(self.team.id):
+            # Filter by active status - should only get the one from self.team
+            qs = manager.get_queryset().filter(active=True)
+            assert qs.count() == 1
+            assert qs.first().key == "active-flag"

--- a/posthog/models/scoping/test_manager.py
+++ b/posthog/models/scoping/test_manager.py
@@ -79,3 +79,98 @@ class TestTeamScopedQuerySet(BaseTest):
         # Should only return the flag from self.team
         assert filtered_qs.count() == 1
         assert filtered_qs.first().key == "flag-1"
+
+
+class TestBackwardsCompatibleTeamScopedQuerySet(BaseTest):
+    """Tests for backwards compatible queryset that supports explicit team_id filtering."""
+
+    def test_explicit_team_id_filter(self):
+        """Verify filter(team_id=X) works as before."""
+        from posthog.models.scoping.manager import BackwardsCompatibleTeamScopedQuerySet
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+
+        FeatureFlag.objects.create(team=self.team, key="flag-1", created_by=self.user)
+        FeatureFlag.objects.create(team=other_team, key="flag-2", created_by=self.user)
+
+        qs = BackwardsCompatibleTeamScopedQuerySet(FeatureFlag)
+        filtered_qs = qs.filter(team_id=other_team.id)
+
+        assert filtered_qs.count() == 1
+        assert filtered_qs.first().key == "flag-2"
+
+    def test_explicit_team_id_with_other_filters(self):
+        """Verify filter(team_id=X, other=Y) works correctly."""
+        from posthog.models.scoping.manager import BackwardsCompatibleTeamScopedQuerySet
+
+        FeatureFlag.objects.create(team=self.team, key="active-flag", active=True, created_by=self.user)
+        FeatureFlag.objects.create(team=self.team, key="inactive-flag", active=False, created_by=self.user)
+
+        qs = BackwardsCompatibleTeamScopedQuerySet(FeatureFlag)
+        filtered_qs = qs.filter(team_id=self.team.id, active=True)
+
+        assert filtered_qs.count() == 1
+        assert filtered_qs.first().key == "active-flag"
+
+    def test_explicit_team_id_overrides_context(self):
+        """Explicit team_id in filter takes precedence over context."""
+        from posthog.models.scoping.manager import BackwardsCompatibleTeamScopedQuerySet
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+
+        FeatureFlag.objects.create(team=self.team, key="flag-1", created_by=self.user)
+        FeatureFlag.objects.create(team=other_team, key="flag-2", created_by=self.user)
+
+        # Set context to self.team, but filter explicitly by other_team
+        with team_scope(self.team.id):
+            qs = BackwardsCompatibleTeamScopedQuerySet(FeatureFlag)
+            # Start fresh (no context filter applied yet)
+            qs = qs.unscoped()
+            filtered_qs = qs.filter(team_id=other_team.id)
+
+            assert filtered_qs.count() == 1
+            assert filtered_qs.first().key == "flag-2"
+
+    def test_unscoped_returns_correct_type(self):
+        """Verify unscoped() returns BackwardsCompatibleTeamScopedQuerySet."""
+        from posthog.models.scoping.manager import BackwardsCompatibleTeamScopedQuerySet
+
+        qs = BackwardsCompatibleTeamScopedQuerySet(FeatureFlag)
+        unscoped_qs = qs.unscoped()
+        assert isinstance(unscoped_qs, BackwardsCompatibleTeamScopedQuerySet)
+
+
+class TestBackwardsCompatibleTeamScopedManager(BaseTest):
+    """Tests for the backwards compatible manager."""
+
+    def test_manager_filter_method(self):
+        """Verify Manager.filter(team_id=X) works."""
+        from posthog.models.scoping.manager import BackwardsCompatibleTeamScopedManager
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+
+        FeatureFlag.objects.create(team=self.team, key="flag-1", created_by=self.user)
+        FeatureFlag.objects.create(team=other_team, key="flag-2", created_by=self.user)
+
+        # Create a manager instance (normally this would be on the model)
+        manager = BackwardsCompatibleTeamScopedManager()
+        manager.model = FeatureFlag
+        manager._db = "default"
+
+        filtered_qs = manager.filter(team_id=other_team.id)
+        assert filtered_qs.count() == 1
+        assert filtered_qs.first().key == "flag-2"
+
+    def test_manager_unscoped_method(self):
+        """Verify Manager.unscoped() returns fresh queryset."""
+        from posthog.models.scoping.manager import (
+            BackwardsCompatibleTeamScopedManager,
+            BackwardsCompatibleTeamScopedQuerySet,
+        )
+
+        manager = BackwardsCompatibleTeamScopedManager()
+        manager.model = FeatureFlag
+        manager._db = "default"
+
+        unscoped_qs = manager.unscoped()
+        assert isinstance(unscoped_qs, BackwardsCompatibleTeamScopedQuerySet)

--- a/posthog/models/scoping/test_manager.py
+++ b/posthog/models/scoping/test_manager.py
@@ -1,0 +1,81 @@
+from posthog.test.base import BaseTest
+
+from posthog.models.feature_flag import FeatureFlag
+from posthog.models.scoping import team_scope, unscoped
+from posthog.models.team import Team
+
+
+class TestTeamScopedManager(BaseTest):
+    """Tests for automatic team scoping behavior."""
+
+    def test_no_scope_returns_all_results(self):
+        """Without team scope, queries return all results (no automatic filtering)."""
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+
+        FeatureFlag.objects.create(team=self.team, key="flag-1", created_by=self.user)
+        FeatureFlag.objects.create(team=other_team, key="flag-2", created_by=self.user)
+
+        # Without scope, we get all flags (current behavior, manager applies no filter)
+        # Note: This test documents current behavior - once we migrate FeatureFlag
+        # to use TeamScopedManager, this will change
+        all_flags = FeatureFlag.objects.all()
+        assert all_flags.count() >= 2
+
+    def test_team_scope_filters_to_team(self):
+        """With team_scope context, queries are filtered to that team."""
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+
+        flag1 = FeatureFlag.objects.create(team=self.team, key="flag-1", created_by=self.user)
+        FeatureFlag.objects.create(team=other_team, key="flag-2", created_by=self.user)
+
+        # This test uses the scoping module directly to demonstrate behavior
+        # Once FeatureFlag uses TeamScopedManager, this will work automatically
+        with team_scope(self.team.id):
+            from posthog.models.scoping import get_current_team_id
+
+            assert get_current_team_id() == self.team.id
+
+            # For now, just verify the context is set correctly
+            # Full integration test will come when we migrate FeatureFlag
+            assert flag1.team_id == self.team.id
+
+    def test_unscoped_context_clears_team(self):
+        """The unscoped() context manager clears the team filter."""
+        with team_scope(self.team.id):
+            from posthog.models.scoping import get_current_team_id
+
+            assert get_current_team_id() == self.team.id
+
+            with unscoped():
+                assert get_current_team_id() is None
+
+            # Restored after exiting unscoped
+            assert get_current_team_id() == self.team.id
+
+
+class TestTeamScopedQuerySet(BaseTest):
+    """Tests for the QuerySet's unscoped() method."""
+
+    def test_queryset_unscoped_method_exists(self):
+        """Verify unscoped() method is available on queryset."""
+        from posthog.models.scoping.manager import TeamScopedQuerySet
+
+        qs = TeamScopedQuerySet(FeatureFlag)
+        unscoped_qs = qs.unscoped()
+        assert isinstance(unscoped_qs, TeamScopedQuerySet)
+
+    def test_apply_team_filter(self):
+        """Verify _apply_team_filter adds the correct filter."""
+        from posthog.models.scoping.manager import TeamScopedQuerySet
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+
+        FeatureFlag.objects.create(team=self.team, key="flag-1", created_by=self.user)
+        FeatureFlag.objects.create(team=other_team, key="flag-2", created_by=self.user)
+
+        qs = TeamScopedQuerySet(FeatureFlag)
+        filtered_qs = qs._apply_team_filter(self.team.id)
+
+        # Should only return the flag from self.team
+        assert filtered_qs.count() == 1
+        assert filtered_qs.first().key == "flag-1"

--- a/posthog/models/scoping/test_middleware.py
+++ b/posthog/models/scoping/test_middleware.py
@@ -1,0 +1,152 @@
+from unittest.mock import MagicMock
+
+from django.http import HttpRequest, HttpResponse
+from django.test import TestCase
+
+from posthog.models.scoping import get_current_team_id
+from posthog.models.scoping.middleware import TeamScopingMiddleware
+
+
+class TestTeamScopingMiddleware(TestCase):
+    def test_sets_team_id_for_authenticated_user(self):
+        """Middleware sets team_id from authenticated user."""
+        captured_team_id = None
+
+        def get_response(request: HttpRequest) -> HttpResponse:
+            nonlocal captured_team_id
+            captured_team_id = get_current_team_id()
+            return HttpResponse("OK")
+
+        middleware = TeamScopingMiddleware(get_response)
+
+        request = HttpRequest()
+        request.user = MagicMock()
+        request.user.is_authenticated = True
+        request.user.current_team_id = 42
+
+        middleware(request)
+
+        assert captured_team_id == 42
+
+    def test_resets_team_id_after_request(self):
+        """Middleware resets team_id after request completes."""
+
+        def get_response(request: HttpRequest) -> HttpResponse:
+            return HttpResponse("OK")
+
+        middleware = TeamScopingMiddleware(get_response)
+
+        request = HttpRequest()
+        request.user = MagicMock()
+        request.user.is_authenticated = True
+        request.user.current_team_id = 42
+
+        middleware(request)
+
+        # After the request, team_id should be reset to None
+        assert get_current_team_id() is None
+
+    def test_resets_team_id_on_exception(self):
+        """Middleware resets team_id even if request handler raises."""
+
+        def get_response(request: HttpRequest) -> HttpResponse:
+            raise ValueError("test error")
+
+        middleware = TeamScopingMiddleware(get_response)
+
+        request = HttpRequest()
+        request.user = MagicMock()
+        request.user.is_authenticated = True
+        request.user.current_team_id = 42
+
+        try:
+            middleware(request)
+        except ValueError:
+            pass
+
+        # Team_id should still be reset
+        assert get_current_team_id() is None
+
+    def test_no_team_id_for_unauthenticated_user(self):
+        """Middleware does not set team_id for unauthenticated users."""
+        captured_team_id = "not_set"
+
+        def get_response(request: HttpRequest) -> HttpResponse:
+            nonlocal captured_team_id
+            captured_team_id = get_current_team_id()
+            return HttpResponse("OK")
+
+        middleware = TeamScopingMiddleware(get_response)
+
+        request = HttpRequest()
+        request.user = MagicMock()
+        request.user.is_authenticated = False
+
+        middleware(request)
+
+        assert captured_team_id is None
+
+    def test_no_team_id_when_user_has_no_current_team(self):
+        """Middleware handles users without current_team_id."""
+        captured_team_id = "not_set"
+
+        def get_response(request: HttpRequest) -> HttpResponse:
+            nonlocal captured_team_id
+            captured_team_id = get_current_team_id()
+            return HttpResponse("OK")
+
+        middleware = TeamScopingMiddleware(get_response)
+
+        request = HttpRequest()
+        request.user = MagicMock()
+        request.user.is_authenticated = True
+        request.user.current_team_id = None
+
+        middleware(request)
+
+        assert captured_team_id is None
+
+    def test_handles_request_without_user(self):
+        """Middleware handles requests without user attribute."""
+        captured_team_id = "not_set"
+
+        def get_response(request: HttpRequest) -> HttpResponse:
+            nonlocal captured_team_id
+            captured_team_id = get_current_team_id()
+            return HttpResponse("OK")
+
+        middleware = TeamScopingMiddleware(get_response)
+
+        request = HttpRequest()
+        # No user attribute set
+
+        middleware(request)
+
+        assert captured_team_id is None
+
+    def test_preserves_existing_context(self):
+        """Middleware properly nests with existing team context."""
+        from posthog.models.scoping import team_scope
+
+        captured_team_ids: list[int | None] = []
+
+        def get_response(request: HttpRequest) -> HttpResponse:
+            captured_team_ids.append(get_current_team_id())
+            return HttpResponse("OK")
+
+        middleware = TeamScopingMiddleware(get_response)
+
+        # Set up an outer context (simulating nested middleware or test setup)
+        with team_scope(100):
+            request = HttpRequest()
+            request.user = MagicMock()
+            request.user.is_authenticated = True
+            request.user.current_team_id = 42
+
+            middleware(request)
+
+            # After middleware, outer context should be restored
+            assert get_current_team_id() == 100
+
+        # Request handler should have seen the inner team_id
+        assert captured_team_ids == [42]

--- a/posthog/models/scoping/test_scoping.py
+++ b/posthog/models/scoping/test_scoping.py
@@ -1,0 +1,112 @@
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from posthog.models.scoping import get_current_team_id, reset_current_team_id, set_current_team_id, team_scope, unscoped
+
+
+class TestContextVar(BaseTest):
+    def test_default_is_none(self):
+        assert get_current_team_id() is None
+
+    def test_set_and_get(self):
+        token = set_current_team_id(42)
+        try:
+            assert get_current_team_id() == 42
+        finally:
+            reset_current_team_id(token)
+
+    def test_reset_restores_previous_value(self):
+        token1 = set_current_team_id(1)
+        try:
+            token2 = set_current_team_id(2)
+            assert get_current_team_id() == 2
+            reset_current_team_id(token2)
+            assert get_current_team_id() == 1
+        finally:
+            reset_current_team_id(token1)
+
+    def test_reset_to_none(self):
+        token = set_current_team_id(99)
+        reset_current_team_id(token)
+        assert get_current_team_id() is None
+
+
+class TestTeamScopeContextManager(BaseTest):
+    @parameterized.expand(
+        [
+            (1,),
+            (42,),
+            (999,),
+        ]
+    )
+    def test_sets_team_id(self, team_id: int):
+        assert get_current_team_id() is None
+        with team_scope(team_id):
+            assert get_current_team_id() == team_id
+        assert get_current_team_id() is None
+
+    def test_nested_scopes(self):
+        with team_scope(1):
+            assert get_current_team_id() == 1
+            with team_scope(2):
+                assert get_current_team_id() == 2
+                with team_scope(3):
+                    assert get_current_team_id() == 3
+                assert get_current_team_id() == 2
+            assert get_current_team_id() == 1
+        assert get_current_team_id() is None
+
+    def test_cleans_up_on_exception(self):
+        try:
+            with team_scope(123):
+                assert get_current_team_id() == 123
+                raise ValueError("test exception")
+        except ValueError:
+            pass
+        assert get_current_team_id() is None
+
+    def test_nested_cleanup_on_exception(self):
+        with team_scope(1):
+            try:
+                with team_scope(2):
+                    raise ValueError("inner exception")
+            except ValueError:
+                pass
+            # Should restore to outer scope
+            assert get_current_team_id() == 1
+        assert get_current_team_id() is None
+
+
+class TestUnscopedContextManager(BaseTest):
+    def test_clears_team_id(self):
+        with team_scope(42):
+            assert get_current_team_id() == 42
+            with unscoped():
+                assert get_current_team_id() is None
+            assert get_current_team_id() == 42
+
+    def test_works_without_existing_scope(self):
+        assert get_current_team_id() is None
+        with unscoped():
+            assert get_current_team_id() is None
+        assert get_current_team_id() is None
+
+    def test_nested_unscoped(self):
+        with team_scope(1):
+            with unscoped():
+                assert get_current_team_id() is None
+                with team_scope(2):
+                    assert get_current_team_id() == 2
+                assert get_current_team_id() is None
+            assert get_current_team_id() == 1
+
+    def test_cleans_up_on_exception(self):
+        with team_scope(99):
+            try:
+                with unscoped():
+                    assert get_current_team_id() is None
+                    raise ValueError("test")
+            except ValueError:
+                pass
+            assert get_current_team_id() == 99

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -111,6 +111,7 @@ MIDDLEWARE = [
     "posthog.middleware.CsrfOrKeyViewMiddleware",
     "posthog.middleware.QueryTimeCountingMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "posthog.models.scoping.middleware.TeamScopingMiddleware",
     "posthog.middleware.SocialAuthExceptionMiddleware",
     "posthog.middleware.SessionAgeMiddleware",
     "posthog.middleware.ActivityLoggingMiddleware",


### PR DESCRIPTION
## Problem

PostHog is a multi-tenant application where IDOR (Insecure Direct Object Reference) vulnerabilities can occur when queries don't include proper team scoping. Currently, we rely on:

1. Developer discipline to always include `team_id` filters
2. Semgrep rules to catch missing filters (with false positives requiring `# nosemgrep` comments)

This is error-prone and doesn't prevent the vulnerability class fundamentally.

Closes #47065 (Stage 1 only)

## Changes

This PR implements **Stage 1: Foundation** - the core infrastructure for automatic team scoping without changing any model behavior yet.

### New module: `posthog/models/scoping/`

- **ContextVar infrastructure**: `team_scope()`, `unscoped()`, `get_current_team_id()`
- **TeamScopedManager**: Auto-filters queries by current team from context
- **BackwardsCompatibleTeamScopedManager**: Also supports explicit `filter(team_id=X)` for gradual migration
- **TeamScopingMiddleware**: Sets team context from `request.user.current_team_id`
- **@with_team_scope decorator**: For Celery tasks that need team context
- **Semgrep rule**: Audits Celery tasks for proper team scoping
- **Documentation**: Migration guide and API reference

### Example usage

```python
# In request context (automatic via middleware):
FeatureFlag.objects.all()  # Auto-filtered to current team

# Explicit cross-team query (escape hatch):
FeatureFlag.objects.unscoped().all()  # All teams

# In background jobs:
@shared_task
@with_team_scope()
def my_task(team_id: int):
    FeatureFlag.objects.all()  # Filtered to team_id
```

## How did you test this code?

39 unit tests covering:
- Context management (nesting, cleanup on exception)
- Middleware integration
- Manager filtering behavior
- Decorator parameter extraction
- Semgrep rule test cases

```bash
pytest posthog/models/scoping/ -v
```

## Publish to changelog?

No - this is infrastructure only, no user-facing changes yet.