### PR TITLE
feat(experiments): detailed metric error messages

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -270,6 +270,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENT_AI_SUMMARY: 'experiment-ai-summary', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_FF_CROSS_SELL: 'experiments-ff-cross-sell', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
+    EXPERIMENTS_METRIC_ERROR_MESSAGE: 'experiments-metric-error-message', // owner: @rodrigoi #team-experiments
     FEATURE_FLAG_COHORT_CREATION: 'feature-flag-cohort-creation', // owner: #team-feature-flags
     FEATURE_FLAGS_V2: 'feature-flags-v2', // owner: @dmarticus #team-feature-flags
     FEATURE_FLAG_USAGE_DASHBOARD_CHECKBOX: 'feature-flag-usage-dashboard-checkbox', // owner: #team-feature-flags, globally disabled, enables opt-out of auto dashboard creation

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -270,7 +270,6 @@ export const FEATURE_FLAGS = {
     EXPERIMENT_AI_SUMMARY: 'experiment-ai-summary', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_FF_CROSS_SELL: 'experiments-ff-cross-sell', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
-    EXPERIMENTS_METRIC_ERROR_MESSAGE: 'experiments-metric-error-message', // owner: @rodrigoi #team-experiments
     FEATURE_FLAG_COHORT_CREATION: 'feature-flag-cohort-creation', // owner: #team-feature-flags
     FEATURE_FLAGS_V2: 'feature-flags-v2', // owner: @dmarticus #team-feature-flags
     FEATURE_FLAG_USAGE_DASHBOARD_CHECKBOX: 'feature-flag-usage-dashboard-checkbox', // owner: #team-feature-flags, globally disabled, enables opt-out of auto dashboard creation

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -106,10 +106,17 @@ export async function pollForResults(
                 e.code = parsed.code
             }
 
+            // Attach queryId to error for downstream error handling
+            e.queryId = queryId
+
             throw e
         }
     }
-    throw new Error(QUERY_TIMEOUT_ERROR_MESSAGE)
+
+    // if we get here, the query timed out
+    const timeoutError = new Error(QUERY_TIMEOUT_ERROR_MESSAGE)
+    ;(timeoutError as Error & { queryId?: string }).queryId = queryId
+    throw timeoutError
 }
 
 /**

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -38,7 +38,7 @@ export const QUERY_TIMEOUT_ERROR_MESSAGE = 'Query timed out'
  * This function safely extracts the message and code, falling back to the
  * original string if parsing fails.
  */
-function parseErrorMessage(errorMessage: string | undefined): { message: string; code: string | null } {
+export function parseErrorMessage(errorMessage: string | undefined): { message: string; code: string | null } {
     if (!errorMessage || typeof errorMessage !== 'string') {
         return { message: errorMessage || '', code: null }
     }

--- a/frontend/src/scenes/experiments/MetricsView/legacy/LegacyErrorChecklist.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/legacy/LegacyErrorChecklist.tsx
@@ -1,0 +1,149 @@
+import { useValues } from 'kea'
+import { combineUrl } from 'kea-router/lib/utils'
+
+import { IconCheck, IconX } from '@posthog/icons'
+import { Link, Tooltip } from '@posthog/lemon-ui'
+
+import { IconOpenInNew } from 'lib/lemon-ui/icons'
+import { urls } from 'scenes/urls'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { ActivityTab, InsightType } from '~/types'
+
+import { experimentLogic } from '../../experimentLogic'
+
+export enum ResultErrorCode {
+    NO_CONTROL_VARIANT = 'no-control-variant',
+    NO_TEST_VARIANT = 'no-test-variant',
+    NO_EXPOSURES = 'no-exposures',
+}
+
+/**
+ * @deprecated Only on Legacy Experiments. Use the ErrorChecklist component instead.
+ */
+export function LegacyErrorChecklist({ error, metric }: { error: any; metric: any }): JSX.Element {
+    const { experiment, variants, getInsightType } = useValues(experimentLogic)
+
+    if (!error) {
+        return <></>
+    }
+
+    const { statusCode, hasDiagnostics } = error
+
+    function ChecklistItem({ errorCode, value }: { errorCode: ResultErrorCode; value: boolean }): JSX.Element {
+        const failureText: Record<ResultErrorCode, string> = {
+            [ResultErrorCode.NO_CONTROL_VARIANT]: 'Events with the control variant not received',
+            [ResultErrorCode.NO_TEST_VARIANT]: 'Events with at least one test variant not received',
+            [ResultErrorCode.NO_EXPOSURES]: 'Exposure events not received',
+        }
+
+        const successText: Record<ResultErrorCode, string> = {
+            [ResultErrorCode.NO_CONTROL_VARIANT]: 'Events with the control variant received',
+            [ResultErrorCode.NO_TEST_VARIANT]: 'Events with at least one test variant received',
+            [ResultErrorCode.NO_EXPOSURES]: 'Exposure events have been received',
+        }
+
+        const insightType = getInsightType(metric)
+        const hasMissingExposure = errorCode === ResultErrorCode.NO_EXPOSURES
+
+        const requiredEvent =
+            insightType === InsightType.TRENDS
+                ? hasMissingExposure
+                    ? metric.exposure_query?.series[0]?.event || '$feature_flag_called'
+                    : metric.count_query?.series[0]?.event
+                : metric.funnels_query?.series[0]?.event
+
+        const query = {
+            kind: NodeKind.DataTableNode,
+            full: true,
+            source: {
+                kind: NodeKind.EventsQuery,
+                select: ['*', 'event', `properties."$feature/${experiment.feature_flag?.key}"`, 'timestamp'],
+                orderBy: ['timestamp DESC'],
+                after: experiment.start_date,
+                event: requiredEvent,
+                properties: [
+                    {
+                        key: `$feature/${experiment.feature_flag?.key}`,
+                        value: hasMissingExposure
+                            ? variants.map((variant) => variant.key)
+                            : errorCode === ResultErrorCode.NO_CONTROL_VARIANT
+                              ? ['control']
+                              : variants.slice(1).map((variant) => variant.key),
+                        operator: 'exact',
+                        type: 'event',
+                    },
+                    ...(hasMissingExposure
+                        ? [
+                              {
+                                  key: '$feature_flag',
+                                  value: [experiment.feature_flag?.key],
+                                  operator: 'exact',
+                                  type: 'event',
+                              },
+                          ]
+                        : []),
+                ],
+                filterTestAccounts: metric.count_query?.filter_test_accounts,
+            },
+            propertiesViaUrl: true,
+            showPersistentColumnConfigurator: true,
+        }
+
+        return (
+            <div className="flex items-center deprecated-space-x-2">
+                {value === false ? (
+                    <span className="flex items-center deprecated-space-x-2">
+                        <IconCheck className="text-success" fontSize={16} />
+                        <span className="text-secondary">{successText[errorCode]}</span>
+                    </span>
+                ) : (
+                    <span className="flex items-center deprecated-space-x-2">
+                        <IconX className="text-danger" fontSize={16} />
+                        <span>{failureText[errorCode]}</span>
+                        <Tooltip title="Verify missing events in the Activity tab">
+                            <Link
+                                target="_blank"
+                                className="font-semibold"
+                                to={combineUrl(urls.activity(ActivityTab.ExploreEvents), {}, { q: query }).url}
+                            >
+                                <IconOpenInNew fontSize="16" className="-ml-1" />
+                            </Link>
+                        </Tooltip>
+                    </span>
+                )}
+            </div>
+        )
+    }
+
+    if (hasDiagnostics) {
+        const checklistItems = []
+        for (const [errorCode, value] of Object.entries(error.detail as Record<ResultErrorCode, boolean>)) {
+            // Check if the error code is valid (cached response might still have old error codes)
+            if (!Object.values(ResultErrorCode).includes(errorCode as ResultErrorCode)) {
+                continue
+            }
+            checklistItems.push(
+                <ChecklistItem key={errorCode} errorCode={errorCode as ResultErrorCode} value={value} />
+            )
+        }
+
+        return <div>{checklistItems}</div>
+    }
+
+    if (statusCode === 504) {
+        return (
+            <>
+                <h2 className="text-xl font-semibold leading-tight">Experiment results timed out</h2>
+                <div className="text-sm text-center text-balance">
+                    This may occur when the experiment has a large amount of data or is particularly complex. We are
+                    actively working on fixing this. In the meantime, please try refreshing the experiment to retrieve
+                    the results.
+                </div>
+            </>
+        )
+    }
+
+    // Other unexpected errors
+    return <div>{error.detail}</div>
+}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricErrorState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricErrorState.tsx
@@ -30,16 +30,18 @@ function parseErrorMessage(error: MetricErrorStateProps['error']): string {
     const errorDetail = error.detail
 
     if (typeof errorDetail === 'string') {
-        // Try to match list format: [ErrorDetail(string='...', code='...')]
-        const listMatch = errorDetail.match(/\[ErrorDetail\(string='([^']*)',\s*code='([^']*)'\)\]/)
+        // Try to match list format: [ErrorDetail(string="..." or '...', code='...')]
+        // DRF's ErrorDetail.__repr__ uses double quotes if the message contains single quotes
+        // Use backreference (\1) to match the same closing quote as the opening quote
+        const listMatch = errorDetail.match(/\[ErrorDetail\(string=(["'])(.+?)\1,\s*code='([^']*)'\)\]/)
         if (listMatch) {
-            return listMatch[1]
+            return listMatch[2] // Group 2 contains the message (group 1 is the quote character)
         }
 
-        // Try to match single format: ErrorDetail(string='...', code='...')
-        const singleMatch = errorDetail.match(/ErrorDetail\(string='([^']*)',\s*code='([^']*)'\)/)
+        // Try to match single format: ErrorDetail(string="..." or '...', code='...')
+        const singleMatch = errorDetail.match(/ErrorDetail\(string=(["'])(.+?)\1,\s*code='([^']*)'\)/)
         if (singleMatch) {
-            return singleMatch[1]
+            return singleMatch[2] // Group 2 contains the message (group 1 is the quote character)
         }
 
         return errorDetail

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricErrorState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricErrorState.tsx
@@ -1,0 +1,128 @@
+import { useActions } from 'kea'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { supportLogic } from 'lib/components/Support/supportLogic'
+import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
+import { IconErrorOutline } from 'lib/lemon-ui/icons'
+import { urls } from 'scenes/urls'
+
+import { ExperimentMetric } from '~/queries/schema/schema-general'
+
+interface MetricErrorStateProps {
+    error: {
+        detail: string | object | any
+        statusCode?: number
+        queryId?: string
+    }
+    metric: ExperimentMetric
+    query?: Record<string, any>
+    onRetry?: () => void
+    height?: number
+}
+
+/**
+ * Parse error message that may be in ErrorDetail string format.
+ * Backend sometimes serializes ValidationError.detail as a string like:
+ * "[ErrorDetail(string='Message', code='code')]"
+ */
+function parseErrorMessage(error: MetricErrorStateProps['error']): string {
+    const errorDetail = error.detail
+
+    if (typeof errorDetail === 'string') {
+        // Try to match list format: [ErrorDetail(string='...', code='...')]
+        const listMatch = errorDetail.match(/\[ErrorDetail\(string='([^']*)',\s*code='([^']*)'\)\]/)
+        if (listMatch) {
+            return listMatch[1]
+        }
+
+        // Try to match single format: ErrorDetail(string='...', code='...')
+        const singleMatch = errorDetail.match(/ErrorDetail\(string='([^']*)',\s*code='([^']*)'\)/)
+        if (singleMatch) {
+            return singleMatch[1]
+        }
+
+        return errorDetail
+    }
+
+    if (typeof errorDetail === 'object' && errorDetail !== null) {
+        // If it's an object, try to extract message or detail field
+        return (errorDetail as any).message || (errorDetail as any).detail || JSON.stringify(errorDetail)
+    }
+
+    return 'An error occurred while loading metric results'
+}
+
+export function MetricErrorState({ error, query, onRetry, height = 200 }: MetricErrorStateProps): JSX.Element {
+    const { openSupportForm } = useActions(supportLogic)
+
+    const errorMessage = parseErrorMessage(error)
+    const isTimeout = error.statusCode === 504
+
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div className="flex flex-col items-center justify-center gap-1" style={{ minHeight: `${height}px` }}>
+            <div className="flex items-center justify-center">
+                <IconErrorOutline className="text-sm text-danger" />
+                <h4 className="text-sm text-danger font-semibold m-0 ml-2">
+                    {isTimeout ? 'Experiment results timed out' : 'Error loading metric results'}
+                </h4>
+            </div>
+            <p className="text-xs text-muted max-w-80 text-center m-0">
+                {isTimeout
+                    ? 'This may occur when the experiment has a large amount of data or is particularly complex. We are actively working on fixing this. In the meantime, please click try again to refresh the results.'
+                    : errorMessage}
+            </p>
+
+            <div className="flex gap-1.5 mt-1">
+                {onRetry && (
+                    <LemonButton
+                        type="primary"
+                        size="xsmall"
+                        onClick={onRetry}
+                        sideAction={
+                            query
+                                ? {
+                                      dropdown: {
+                                          overlay: (
+                                              <LemonMenuOverlay
+                                                  items={[
+                                                      {
+                                                          label: 'Open in query debugger',
+                                                          to: urls.debugQuery(query),
+                                                      },
+                                                  ]}
+                                              />
+                                          ),
+                                          placement: 'bottom-end' as const,
+                                      },
+                                  }
+                                : undefined
+                        }
+                    >
+                        Try again
+                    </LemonButton>
+                )}
+
+                <LemonButton
+                    type="secondary"
+                    size="xsmall"
+                    onClick={() =>
+                        openSupportForm({
+                            kind: 'bug',
+                            target_area: 'experiments',
+                        })
+                    }
+                >
+                    Report issue
+                </LemonButton>
+            </div>
+
+            {error.queryId && (
+                <div className="text-[10px] text-muted mt-1">
+                    Query ID: <span className="font-mono">{error.queryId}</span>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -19,6 +19,7 @@ import {
     ExperimentStatsBaseValidated,
     NewExperimentQueryResponse,
 } from '~/queries/schema/schema-general'
+import { NodeKind } from '~/queries/schema/schema-general'
 import { Experiment, InsightType } from '~/types'
 
 import { experimentLogic } from '../../experimentLogic'
@@ -97,6 +98,8 @@ interface CollapsibleBreakdownSectionProps {
     colors: ReturnType<typeof useChartColors>
     scale: ReturnType<typeof useAxisScale>
     onRemoveBreakdown: (index: number) => void
+    onRetry: () => void
+    query?: Record<string, any>
     handleTooltipMouseEnter: (e: React.MouseEvent, variantResult: ExperimentVariantResult) => void
     handleTooltipMouseLeave: () => void
     handleTooltipMouseMove: (e: React.MouseEvent, variantResult: ExperimentVariantResult) => void
@@ -113,6 +116,8 @@ function CollapsibleBreakdownSection({
     colors,
     scale,
     onRemoveBreakdown,
+    onRetry,
+    query,
     handleTooltipMouseEnter,
     handleTooltipMouseLeave,
     handleTooltipMouseMove,
@@ -215,6 +220,8 @@ function CollapsibleBreakdownSection({
                                                                         height={CELL_HEIGHT}
                                                                         experimentStarted={!!experiment.start_date}
                                                                         metric={metric}
+                                                                        query={query}
+                                                                        onRetry={onRetry}
                                                                     />
                                                                 )}
                                                             </td>
@@ -488,6 +495,7 @@ interface MetricRowGroupProps {
     result: NewExperimentQueryResponse | null
     experiment: Experiment
     metricType: InsightType
+    metricIndex: number
     displayOrder: number
     axisRange: number
     isSecondary: boolean
@@ -508,6 +516,7 @@ export function MetricRowGroup({
     result,
     experiment,
     metricType,
+    metricIndex,
     displayOrder,
     axisRange,
     isSecondary,
@@ -545,7 +554,25 @@ export function MetricRowGroup({
     const colors = useChartColors()
     const scale = useAxisScale(axisRange, VIEW_BOX_WIDTH, SVG_EDGE_MARGIN)
 
-    const { reportExperimentTimeseriesViewed } = useActions(experimentLogic)
+    const { reportExperimentTimeseriesViewed, retryPrimaryMetric, retrySecondaryMetric } = useActions(experimentLogic)
+
+    // Build retry callback for this metric
+    const handleRetry = (): void => {
+        if (isSecondary) {
+            retrySecondaryMetric(metricIndex)
+        } else {
+            retryPrimaryMetric(metricIndex)
+        }
+    }
+
+    // Build query for debugger link
+    const debugQuery = metric
+        ? {
+              kind: NodeKind.ExperimentQuery,
+              metric: metric,
+              experiment_id: experiment.id,
+          }
+        : undefined
 
     const timeseriesEnabled = experiment.scheduling_config?.timeseries
 
@@ -647,21 +674,31 @@ export function MetricRowGroup({
     const hasResultWithValidationFailures = result && hasValidationFailures(result)
 
     if (isLoading || error || !result || (!hasMinimumExposureForResults && !hasResultWithValidationFailures)) {
+        const hasError = !!error
+
         return (
             <>
                 <tr
                     className="hover:bg-bg-hover group [&:last-child>td]:border-b-0"
-                    style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                    style={
+                        hasError
+                            ? { minHeight: `${CELL_HEIGHT}px` }
+                            : { height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }
+                    }
                 >
                     {/* Metric column - always visible */}
                     <td
                         className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
                             !isLastMetric ? 'border-b' : ''
                         } ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                        style={{
-                            height: `${CELL_HEIGHT}px`,
-                            maxHeight: `${CELL_HEIGHT}px`,
-                        }}
+                        style={
+                            hasError
+                                ? { minHeight: `${CELL_HEIGHT}px` }
+                                : {
+                                      height: `${CELL_HEIGHT}px`,
+                                      maxHeight: `${CELL_HEIGHT}px`,
+                                  }
+                        }
                     >
                         <MetricHeader
                             displayOrder={displayOrder}
@@ -680,7 +717,11 @@ export function MetricRowGroup({
                         className={`p-3 text-center ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${
                             !isLastMetric ? 'border-b' : ''
                         }`}
-                        style={{ height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }}
+                        style={
+                            hasError
+                                ? { minHeight: `${CELL_HEIGHT}px` }
+                                : { height: `${CELL_HEIGHT}px`, maxHeight: `${CELL_HEIGHT}px` }
+                        }
                     >
                         {isLoading || exposuresLoading ? (
                             <ChartLoadingState height={CELL_HEIGHT} />
@@ -690,6 +731,8 @@ export function MetricRowGroup({
                                 experimentStarted={!!experiment.start_date}
                                 metric={metric}
                                 error={error}
+                                query={debugQuery}
+                                onRetry={handleRetry}
                             />
                         )}
                     </td>
@@ -990,6 +1033,8 @@ export function MetricRowGroup({
                     colors={colors}
                     scale={scale}
                     onRemoveBreakdown={onRemoveBreakdown}
+                    onRetry={handleRetry}
+                    query={debugQuery}
                     handleTooltipMouseEnter={handleTooltipMouseEnter}
                     handleTooltipMouseLeave={handleTooltipMouseLeave}
                     handleTooltipMouseMove={handleTooltipMouseMove}

--- a/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
@@ -37,6 +37,7 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
     const metrics = metricsWithResults.map(({ metric }: { metric: ExperimentMetric }) => metric)
     const results = metricsWithResults.map(({ result }: { result: CachedNewExperimentQueryResponse }) => result)
     const errors = metricsWithResults.map(({ error }: { error: any }) => error)
+    const metricIndexes = metricsWithResults.map(({ metricIndex }: { metricIndex: number }) => metricIndex)
 
     const showResultDetails = metrics.length === 1 && results[0] && hasMinimumExposureForResults && !isSecondary
     const hasSomeResults =
@@ -104,6 +105,7 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
                         metrics={metrics}
                         results={results}
                         errors={errors}
+                        metricIndexes={metricIndexes}
                         isSecondary={!!isSecondary}
                         getInsightType={getInsightType}
                         showDetailsModal={!showResultDetails}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -18,6 +18,7 @@ interface MetricsTableProps {
     metrics: ExperimentMetric[]
     results: NewExperimentQueryResponse[]
     errors: any[]
+    metricIndexes: number[]
     isSecondary: boolean
     getInsightType: (metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery) => InsightType
     showDetailsModal?: boolean
@@ -27,6 +28,7 @@ export function MetricsTable({
     metrics,
     results,
     errors,
+    metricIndexes,
     isSecondary,
     getInsightType,
     showDetailsModal = true,
@@ -95,6 +97,7 @@ export function MetricsTable({
                     {metrics.map((metric, index) => {
                         const result = results[index]
                         const error = errors[index]
+                        const metricIndex = metricIndexes[index]
 
                         const isLoading = !result && !error && !!experiment.start_date
 
@@ -105,6 +108,7 @@ export function MetricsTable({
                                 result={result}
                                 experiment={experiment}
                                 metricType={getInsightType(metric)}
+                                metricIndex={metricIndex}
                                 displayOrder={index}
                                 axisRange={axisRange}
                                 isSecondary={isSecondary}

--- a/frontend/src/scenes/experiments/MetricsView/shared/ChartEmptyState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/ChartEmptyState.tsx
@@ -1,6 +1,10 @@
 import { IconClock } from '@posthog/icons'
-import { LemonTag, Tooltip } from '@posthog/lemon-ui'
+import { LemonTag } from '@posthog/lemon-ui'
 
+import { isLegacyExperimentQuery } from 'scenes/experiments/utils'
+
+import { LegacyErrorChecklist } from '../legacy/LegacyErrorChecklist'
+import { MetricErrorState } from '../new/MetricErrorState'
 import { ErrorChecklist } from './ErrorChecklist'
 
 interface ChartEmptyStateProps {
@@ -8,39 +12,63 @@ interface ChartEmptyStateProps {
     experimentStarted: boolean
     metric: any
     error?: any
+    query?: Record<string, any>
+    onRetry?: () => void
 }
 
-export function ChartEmptyState({ height, experimentStarted, error, metric }: ChartEmptyStateProps): JSX.Element {
+export function ChartEmptyState({
+    height,
+    experimentStarted,
+    error,
+    metric,
+    query,
+    onRetry,
+}: ChartEmptyStateProps): JSX.Element | null {
+    /**
+     * early return if experiment has not started
+     */
+    if (!experimentStarted) {
+        return (
+            <div className="flex items-center justify-center text-secondary cursor-default text-[12px] font-normal">
+                <LemonTag size="small" className="mr-2">
+                    <IconClock fontSize="1em" />
+                </LemonTag>
+                <span>Waiting for experiment to start&hellip;</span>
+            </div>
+        )
+    }
+
+    /**
+     * bail if no error
+     */
+    if (!error) {
+        return null
+    }
+
+    const isLegacyMetric = isLegacyExperimentQuery(metric)
+    /**
+     * if it's a legacy metric, use the legacy error checklist
+     */
+    if (isLegacyMetric) {
+        return (
+            // eslint-disable-next-line react/forbid-dom-props
+            <div className="flex items-center justify-center w-full" style={{ height: `${height}px` }}>
+                <LegacyErrorChecklist error={error} metric={metric} />
+            </div>
+        )
+    }
+
     return (
         // eslint-disable-next-line react/forbid-dom-props
-        <div className="flex items-center justify-center w-full" style={{ height: `${height}px` }}>
-            {!experimentStarted ? (
-                <div className="flex items-center justify-center text-secondary cursor-default text-[12px] font-normal">
-                    <LemonTag size="small" className="mr-2">
-                        <IconClock fontSize="1em" />
-                    </LemonTag>
-                    <span>Waiting for experiment to start&hellip;</span>
-                </div>
+        <div
+            className="flex items-center justify-center w-full"
+            style={error ? { minHeight: `${height}px` } : { height: `${height}px` }}
+        >
+            {error.hasDiagnostics ? (
+                <ErrorChecklist error={error} metric={metric} />
             ) : (
-                <div className="flex items-center justify-center text-secondary cursor-default text-[12px] font-normal">
-                    {error?.hasDiagnostics ? (
-                        <ErrorChecklist error={error} metric={metric} />
-                    ) : (
-                        <Tooltip
-                            title={
-                                error
-                                    ? typeof error === 'string'
-                                        ? error
-                                        : error.message || error.detail || error.error || JSON.stringify(error)
-                                    : 'An error occurred'
-                            }
-                        >
-                            <LemonTag size="small" type="danger" className="mr-1 cursor-pointer">
-                                Error
-                            </LemonTag>
-                        </Tooltip>
-                    )}
-                </div>
+                // Use rich error state for all other errors
+                <MetricErrorState error={error} metric={metric} query={query} onRetry={onRetry} height={height} />
             )}
         </div>
     )

--- a/frontend/src/scenes/experiments/MetricsView/shared/ErrorChecklist.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/ErrorChecklist.tsx
@@ -8,7 +8,7 @@ import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
 
 import { NodeKind } from '~/queries/schema/schema-general'
-import { ActivityTab, InsightType } from '~/types'
+import { ActivityTab, Experiment, InsightType, MultivariateFlagVariant } from '~/types'
 
 import { experimentLogic } from '../../experimentLogic'
 
@@ -23,115 +23,136 @@ interface ErrorChecklistProps {
     metric: any
 }
 
+type ChecklistItemProps = {
+    errorCode: ResultErrorCode
+    value: boolean
+    experiment: Experiment
+    metric: any
+    variants: MultivariateFlagVariant[]
+    getInsightType: (metric: any) => InsightType
+}
+
+function ChecklistItem({
+    errorCode,
+    value,
+    experiment,
+    metric,
+    variants,
+    getInsightType,
+}: ChecklistItemProps): JSX.Element {
+    const failureText: Record<ResultErrorCode, string> = {
+        [ResultErrorCode.NO_CONTROL_VARIANT]: 'Events with the control variant not received',
+        [ResultErrorCode.NO_TEST_VARIANT]: 'Events with at least one test variant not received',
+        [ResultErrorCode.NO_EXPOSURES]: 'Exposure events not received',
+    }
+
+    const successText: Record<ResultErrorCode, string> = {
+        [ResultErrorCode.NO_CONTROL_VARIANT]: 'Events with the control variant received',
+        [ResultErrorCode.NO_TEST_VARIANT]: 'Events with at least one test variant received',
+        [ResultErrorCode.NO_EXPOSURES]: 'Exposure events have been received',
+    }
+
+    const insightType = getInsightType(metric)
+    const hasMissingExposure = errorCode === ResultErrorCode.NO_EXPOSURES
+
+    const requiredEvent =
+        insightType === InsightType.TRENDS
+            ? hasMissingExposure
+                ? metric.exposure_query?.series[0]?.event || '$feature_flag_called'
+                : metric.count_query?.series[0]?.event
+            : metric.funnels_query?.series[0]?.event
+
+    const query = {
+        kind: NodeKind.DataTableNode,
+        full: true,
+        source: {
+            kind: NodeKind.EventsQuery,
+            select: ['*', 'event', `properties."$feature/${experiment.feature_flag?.key}"`, 'timestamp'],
+            orderBy: ['timestamp DESC'],
+            after: experiment.start_date,
+            event: requiredEvent,
+            properties: [
+                {
+                    key: `$feature/${experiment.feature_flag?.key}`,
+                    value: hasMissingExposure
+                        ? variants.map((variant) => variant.key)
+                        : errorCode === ResultErrorCode.NO_CONTROL_VARIANT
+                          ? ['control']
+                          : variants.slice(1).map((variant) => variant.key),
+                    operator: 'exact',
+                    type: 'event',
+                },
+                ...(hasMissingExposure
+                    ? [
+                          {
+                              key: '$feature_flag',
+                              value: [experiment.feature_flag?.key],
+                              operator: 'exact',
+                              type: 'event',
+                          },
+                      ]
+                    : []),
+            ],
+            filterTestAccounts: metric.count_query?.filter_test_accounts,
+        },
+        propertiesViaUrl: true,
+        showPersistentColumnConfigurator: true,
+    }
+
+    return (
+        <div className="flex items-center deprecated-space-x-2">
+            {value === false ? (
+                <span className="flex items-center deprecated-space-x-2">
+                    <IconCheck className="text-success" fontSize={16} />
+                    <span className="text-secondary">{successText[errorCode]}</span>
+                </span>
+            ) : (
+                <span className="flex items-center deprecated-space-x-2">
+                    <IconX className="text-danger" fontSize={16} />
+                    <span>{failureText[errorCode]}</span>
+                    <Tooltip title="Verify missing events in the Activity tab">
+                        <Link
+                            target="_blank"
+                            className="font-semibold"
+                            to={combineUrl(urls.activity(ActivityTab.ExploreEvents), {}, { q: query }).url}
+                        >
+                            <IconOpenInNew fontSize="16" className="-ml-1" />
+                        </Link>
+                    </Tooltip>
+                </span>
+            )}
+        </div>
+    )
+}
+
 export function ErrorChecklist({ error, metric }: ErrorChecklistProps): JSX.Element | null {
     const { experiment, variants, getInsightType } = useValues(experimentLogic)
 
-    if (!error) {
+    /**
+     * bail if no error or no diagnostics
+     */
+    if (!error || !error.hasDiagnostics) {
         return <></>
     }
 
-    const { hasDiagnostics } = error
-
-    function ChecklistItem({ errorCode, value }: { errorCode: ResultErrorCode; value: boolean }): JSX.Element {
-        const failureText: Record<ResultErrorCode, string> = {
-            [ResultErrorCode.NO_CONTROL_VARIANT]: 'Events with the control variant not received',
-            [ResultErrorCode.NO_TEST_VARIANT]: 'Events with at least one test variant not received',
-            [ResultErrorCode.NO_EXPOSURES]: 'Exposure events not received',
+    const checklistItems = []
+    for (const [errorCode, value] of Object.entries(error.detail as Record<ResultErrorCode, boolean>)) {
+        // Check if the error code is valid (cached response might still have old error codes)
+        if (!Object.values(ResultErrorCode).includes(errorCode as ResultErrorCode)) {
+            continue
         }
-
-        const successText: Record<ResultErrorCode, string> = {
-            [ResultErrorCode.NO_CONTROL_VARIANT]: 'Events with the control variant received',
-            [ResultErrorCode.NO_TEST_VARIANT]: 'Events with at least one test variant received',
-            [ResultErrorCode.NO_EXPOSURES]: 'Exposure events have been received',
-        }
-
-        const insightType = getInsightType(metric)
-        const hasMissingExposure = errorCode === ResultErrorCode.NO_EXPOSURES
-
-        const requiredEvent =
-            insightType === InsightType.TRENDS
-                ? hasMissingExposure
-                    ? metric.exposure_query?.series[0]?.event || '$feature_flag_called'
-                    : metric.count_query?.series[0]?.event
-                : metric.funnels_query?.series[0]?.event
-
-        const query = {
-            kind: NodeKind.DataTableNode,
-            full: true,
-            source: {
-                kind: NodeKind.EventsQuery,
-                select: ['*', 'event', `properties."$feature/${experiment.feature_flag?.key}"`, 'timestamp'],
-                orderBy: ['timestamp DESC'],
-                after: experiment.start_date,
-                event: requiredEvent,
-                properties: [
-                    {
-                        key: `$feature/${experiment.feature_flag?.key}`,
-                        value: hasMissingExposure
-                            ? variants.map((variant) => variant.key)
-                            : errorCode === ResultErrorCode.NO_CONTROL_VARIANT
-                              ? ['control']
-                              : variants.slice(1).map((variant) => variant.key),
-                        operator: 'exact',
-                        type: 'event',
-                    },
-                    ...(hasMissingExposure
-                        ? [
-                              {
-                                  key: '$feature_flag',
-                                  value: [experiment.feature_flag?.key],
-                                  operator: 'exact',
-                                  type: 'event',
-                              },
-                          ]
-                        : []),
-                ],
-                filterTestAccounts: metric.count_query?.filter_test_accounts,
-            },
-            propertiesViaUrl: true,
-            showPersistentColumnConfigurator: true,
-        }
-
-        return (
-            <div className="flex items-center deprecated-space-x-2">
-                {value === false ? (
-                    <span className="flex items-center deprecated-space-x-2">
-                        <IconCheck className="text-success" fontSize={16} />
-                        <span className="text-secondary">{successText[errorCode]}</span>
-                    </span>
-                ) : (
-                    <span className="flex items-center deprecated-space-x-2">
-                        <IconX className="text-danger" fontSize={16} />
-                        <span>{failureText[errorCode]}</span>
-                        <Tooltip title="Verify missing events in the Activity tab">
-                            <Link
-                                target="_blank"
-                                className="font-semibold"
-                                to={combineUrl(urls.activity(ActivityTab.ExploreEvents), {}, { q: query }).url}
-                            >
-                                <IconOpenInNew fontSize="16" className="-ml-1" />
-                            </Link>
-                        </Tooltip>
-                    </span>
-                )}
-            </div>
+        checklistItems.push(
+            <ChecklistItem
+                key={errorCode}
+                errorCode={errorCode as ResultErrorCode}
+                value={value}
+                experiment={experiment}
+                metric={metric}
+                variants={variants}
+                getInsightType={getInsightType}
+            />
         )
     }
 
-    if (hasDiagnostics) {
-        const checklistItems = []
-        for (const [errorCode, value] of Object.entries(error.detail as Record<ResultErrorCode, boolean>)) {
-            // Check if the error code is valid (cached response might still have old error codes)
-            if (!Object.values(ResultErrorCode).includes(errorCode as ResultErrorCode)) {
-                continue
-            }
-            checklistItems.push(
-                <ChecklistItem key={errorCode} errorCode={errorCode as ResultErrorCode} value={value} />
-            )
-        }
-
-        return <div>{checklistItems}</div>
-    }
-
-    return null
+    return <div>{checklistItems}</div>
 }

--- a/frontend/src/scenes/experiments/MetricsView/shared/ErrorChecklist.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/ErrorChecklist.tsx
@@ -18,14 +18,19 @@ export enum ResultErrorCode {
     NO_EXPOSURES = 'no-exposures',
 }
 
-export function ErrorChecklist({ error, metric }: { error: any; metric: any }): JSX.Element {
+interface ErrorChecklistProps {
+    error: any
+    metric: any
+}
+
+export function ErrorChecklist({ error, metric }: ErrorChecklistProps): JSX.Element | null {
     const { experiment, variants, getInsightType } = useValues(experimentLogic)
 
     if (!error) {
         return <></>
     }
 
-    const { statusCode, hasDiagnostics } = error
+    const { hasDiagnostics } = error
 
     function ChecklistItem({ errorCode, value }: { errorCode: ResultErrorCode; value: boolean }): JSX.Element {
         const failureText: Record<ResultErrorCode, string> = {
@@ -128,19 +133,5 @@ export function ErrorChecklist({ error, metric }: { error: any; metric: any }): 
         return <div>{checklistItems}</div>
     }
 
-    if (statusCode === 504) {
-        return (
-            <>
-                <h2 className="text-xl font-semibold leading-tight">Experiment results timed out</h2>
-                <div className="text-sm text-center text-balance">
-                    This may occur when the experiment has a large amount of data or is particularly complex. We are
-                    actively working on fixing this. In the meantime, please try refreshing the experiment to retrieve
-                    the results.
-                </div>
-            </>
-        )
-    }
-
-    // Other unexpected errors
-    return <div>{error.detail}</div>
+    return null
 }

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -158,6 +158,8 @@ describe('experimentLogic', () => {
                             },
                             hasDiagnostics: true,
                             statusCode: 400,
+                            queryId: expect.any(String),
+                            timestamp: expect.any(Number),
                         },
                     ],
                 })
@@ -232,6 +234,8 @@ describe('experimentLogic', () => {
                             },
                             hasDiagnostics: true,
                             statusCode: 400,
+                            queryId: expect.any(String),
+                            timestamp: expect.any(Number),
                         },
                         null,
                     ],

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -187,6 +187,7 @@ const loadMetrics = async ({
 
     return await Promise.all(
         metrics.map(async (metric, index) => {
+            let response: any = null
             try {
                 let queryWithExperimentId
                 if (metric.kind === NodeKind.ExperimentMetric) {
@@ -201,7 +202,7 @@ const loadMetrics = async ({
                         experiment_id: experimentId,
                     }
                 }
-                const response = await performQuery(
+                response = await performQuery(
                     setLatestVersionsOnQuery(queryWithExperimentId),
                     undefined,
                     refresh ? 'force_async' : 'async'
@@ -242,6 +243,8 @@ const loadMetrics = async ({
                     detail: errorDetail,
                     statusCode: error.status,
                     hasDiagnostics: !!errorDetailMatch,
+                    queryId: response?.query_status?.id || error.queryId || null,
+                    timestamp: Date.now(),
                 }
                 onSetErrors(currentErrors)
 
@@ -507,9 +510,11 @@ export const experimentLogic = kea<experimentLogicType>([
         setPrimaryMetricsResultsLoading: (loading: boolean) => ({ loading }),
         loadPrimaryMetricsResults: (refresh?: boolean) => ({ refresh }),
         setPrimaryMetricsResultsErrors: (errors: any[]) => ({ errors }),
+        retryPrimaryMetric: (index: number) => ({ index }),
         setSecondaryMetricsResults: (results: CachedNewExperimentQueryResponse[]) => ({ results }),
         loadSecondaryMetricsResults: (refresh?: boolean) => ({ refresh }),
         setSecondaryMetricsResultsErrors: (errors: any[]) => ({ errors }),
+        retrySecondaryMetric: (index: number) => ({ index }),
         setSecondaryMetricsResultsLoading: (loading: boolean) => ({ loading }),
         setLegacySecondaryMetricsResults: (
             results: (
@@ -1531,6 +1536,96 @@ export const experimentLogic = kea<experimentLogicType>([
             })
 
             actions.setSecondaryMetricsResultsLoading(false)
+        },
+        retryPrimaryMetric: async ({ index }: { index: number }) => {
+            // Clear the error for this metric
+            const currentErrors = [...values.primaryMetricsResultsErrors]
+            currentErrors[index] = null
+            actions.setPrimaryMetricsResultsErrors(currentErrors)
+
+            // Get the metric to retry
+            let metrics = values.experiment?.metrics || []
+            const sharedMetrics = values.experiment?.saved_metrics
+                .filter((sharedMetric) => sharedMetric.metadata.type === 'primary')
+                .map((sharedMetric) => sharedMetric.query)
+            if (sharedMetrics) {
+                metrics = [...metrics, ...sharedMetrics]
+            }
+
+            const metricToRetry = metrics[index]
+            if (!metricToRetry) {
+                return
+            }
+
+            // Create single-item arrays for this metric
+            const singleMetricArray = [metricToRetry]
+            const currentLegacyResults = [...values.legacyPrimaryMetricsResults]
+            const currentResults = [...values.primaryMetricsResults]
+
+            // Load just this one metric
+            await loadMetrics({
+                metrics: singleMetricArray,
+                experimentId: values.experimentId,
+                refresh: true,
+                onSetLegacyResults: (results) => {
+                    currentLegacyResults[index] = results[0]
+                    actions.setLegacyPrimaryMetricsResults(currentLegacyResults)
+                },
+                onSetResults: (results) => {
+                    currentResults[index] = results[0]
+                    actions.setPrimaryMetricsResults(currentResults)
+                },
+                onSetErrors: (errors) => {
+                    currentErrors[index] = errors[0]
+                    actions.setPrimaryMetricsResultsErrors(currentErrors)
+                },
+                onTimeout: actions.reportExperimentMetricTimeout,
+            })
+        },
+        retrySecondaryMetric: async ({ index }: { index: number }) => {
+            // Clear the error for this metric
+            const currentErrors = [...values.secondaryMetricsResultsErrors]
+            currentErrors[index] = null
+            actions.setSecondaryMetricsResultsErrors(currentErrors)
+
+            // Get the metric to retry
+            let secondaryMetrics = values.experiment?.metrics_secondary || []
+            const sharedMetrics = values.experiment?.saved_metrics
+                .filter((sharedMetric) => sharedMetric.metadata.type === 'secondary')
+                .map((sharedMetric) => sharedMetric.query)
+            if (sharedMetrics) {
+                secondaryMetrics = [...secondaryMetrics, ...sharedMetrics]
+            }
+
+            const metricToRetry = secondaryMetrics[index]
+            if (!metricToRetry) {
+                return
+            }
+
+            // Create single-item arrays for this metric
+            const singleMetricArray = [metricToRetry]
+            const currentLegacyResults = [...values.legacySecondaryMetricsResults]
+            const currentResults = [...values.secondaryMetricsResults]
+
+            // Load just this one metric
+            await loadMetrics({
+                metrics: singleMetricArray,
+                experimentId: values.experimentId,
+                refresh: true,
+                onSetLegacyResults: (results) => {
+                    currentLegacyResults[index] = results[0]
+                    actions.setLegacySecondaryMetricsResults(currentLegacyResults)
+                },
+                onSetResults: (results) => {
+                    currentResults[index] = results[0]
+                    actions.setSecondaryMetricsResults(currentResults)
+                },
+                onSetErrors: (errors) => {
+                    currentErrors[index] = errors[0]
+                    actions.setSecondaryMetricsResultsErrors(currentErrors)
+                },
+                onTimeout: actions.reportExperimentMetricTimeout,
+            })
         },
         openReleaseConditionsModal: () => {
             const numericFlagId = values.experiment.feature_flag?.id

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -883,6 +883,7 @@ export function getOrderedMetricsWithResults(
     result: any
     error: any
     displayIndex: number
+    metricIndex: number
 }> {
     const metricType = isSecondary ? 'secondary' : 'primary'
     const results = isSecondary ? secondaryMetricsResults : primaryMetricsResults
@@ -908,6 +909,7 @@ export function getOrderedMetricsWithResults(
     const resultsMap = new Map()
     const errorsMap = new Map()
     const metricsMap = new Map()
+    const originalIndexMap = new Map()
 
     allMetrics.forEach((metric: any, index) => {
         const uuid = metric.uuid || metric.query?.uuid
@@ -915,6 +917,7 @@ export function getOrderedMetricsWithResults(
             resultsMap.set(uuid, results[index])
             errorsMap.set(uuid, errors[index])
             metricsMap.set(uuid, metric)
+            originalIndexMap.set(uuid, index) // Track original position for retry
         }
     })
 
@@ -931,5 +934,6 @@ export function getOrderedMetricsWithResults(
             result: resultsMap.get(metric.uuid),
             error: errorsMap.get(metric.uuid),
             displayIndex: index,
+            metricIndex: originalIndexMap.get(metric.uuid) ?? index, // Original position for retry
         }))
 }


### PR DESCRIPTION
## Problem

The error messages we present to the user when a metric fails for reasons other than no-control, variant, or exposure are inconsistent. For out-of-memory issues, we present a text that is handled by `ErrorChecklist`. But for other errors, we just show an `error` tag with a tooltip. The user has no actions to perform, and accessing context is difficult.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

The goal is to bring the `Metric` component more in line with other data visualization components, so we are borrowing extensively from the `Query` component's error handler, adapted to the actual state available at render time.

| before | after |
| - | - |
| <img width="1379" height="206" alt="image" src="https://github.com/user-attachments/assets/abb0881a-b02b-42d8-8b73-a061718c988e" /> | <img width="1383" height="238" alt="image" src="https://github.com/user-attachments/assets/d41c19d5-f5b5-4c9d-8826-dc20ca948d7b" /> |

The new `MetricErrorState` component displays the error message and action options. The main options are to _try again_, which will reload the metric the error is attached to, or _report issue_ via the support panel.
The _try again_ button has a secondary action to _open in query debugger_, which... well, opens the query in the query debugger.

We also show the query Id for easier debugging.

### Where does the error message come from

Except for the case handled by `ErrorChecklist`, all the errors come directly from the backend, where the `ValidationError` serializes the error object into a string that is de-serialized on the client by `parseErrorMessage`.

### Global changes

We had to update the `pollForResults` function, which is used by all queries, so we can attach the `queryId` to the `Error` object. We also export `parseErrorMessage` so we can parse backend messages correctly.

### Experiment Kea Logic

The experiment Kea logic is responsible for fetching the metric results. Because we want to allow the user to reload a single metric, we had to add `retryPrimaryMetric` and `retrySecondaryMetric` actions that we could pass to the `MetricErrorState` component as callbacks.

We also had to update the error handling to pass the `queryId` on the error object.

### Support for legacy experiments

| legacy metric error is preserved |
| - |
| <img width="1391" height="271" alt="image" src="https://github.com/user-attachments/assets/8572ff1a-fe52-4f06-a674-9a216d8c2fa1" /> |

To avoid breaking the _legacy_ experiments, we created a new `LegacyErrorChecklist` component that preserves the original features. Which component to load is handled by `ChartEmptyState`.

### Specializing `ErrorChecklist`

| error checklist |
| - |
| <img width="1386" height="153" alt="image" src="https://github.com/user-attachments/assets/f56038c4-40ba-46a5-abd3-541ade8e896a" /> |

The `ErrorChecklist` component also handled timeout errors. We are handling those on the `MetricErrorSource` component, so that code was removed.

We also extracted the `ChecklistItem` child component, which was declared inside the `ErrorChecklist` render.

### Chart empty state

The `ChartEmptyState` underwent a minor refactor to reduce complexity by inverting some logic to exit early when we have a draft experiment, no error, or a legacy experiment error.

This component renders either `ErrorChecklist` or `MetricErrorState`.

### Tracking metric index

To allow retrying a single metric, we need to keep track of metric indexes across the component tree. The `Metrics` and `MetricsTable` handle generating the indexes and passing them down to `MetricRowGroup`.

### Changes to `MetricRowGroup`

| timeout error handling | query out of memory |
| - | - |
| <img width="1373" height="226" alt="image" src="https://github.com/user-attachments/assets/2cf6864d-689d-47f3-ae24-adef3ce5383d" /> | <img width="1376" height="195" alt="image" src="https://github.com/user-attachments/assets/84e1b1e2-417a-46f5-b5a3-de66b6240f80" /> |

This is where we render the `ChartEmptyState` component; `MetricRowGroup` is responsible for instantiating the retry handlers and passing down all necessary props so the error renders correctly.

Also, when an error is present, we ignore the hardcoded row height to show long or complex errors effectively.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/579a8e6c-470d-4a91-a41e-08570120064a)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

yes

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
