### PR TITLE
fix(deduplicator): avoid blocking on checkpoint imports in each revoke-assign cycle

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -92,6 +92,10 @@ pub struct Config {
     // 15 minutes default - minimum staleness (no recent WAL activity) before orphan directories can be deleted
     pub orphan_cleanup_min_staleness_secs: u64,
 
+    #[envconfig(default = "16")]
+    // Max parallel directory deletions during rebalance cleanup (bounded scatter-gather)
+    pub rebalance_cleanup_parallelism: usize,
+
     // Consumer processing configuration
     #[envconfig(default = "100")]
     pub max_in_flight_messages: usize,

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -165,7 +165,7 @@ pub const REBALANCE_ASYNC_SETUP_CANCELLED: &str = "rebalance_async_setup_cancell
 pub const PARTITION_STORE_SETUP_SKIPPED: &str = "partition_store_setup_skipped_total";
 
 /// Counter for partitions where checkpoint import failed and we fell back to empty store
-/// Labels: checkpoint_failure_reason (import, restore)
+/// Labels: reason (no_importer | import_failed | import_cancelled | unknown)
 /// This is an important metric for alerting - indicates degraded deduplication quality
 pub const PARTITION_STORE_FALLBACK_EMPTY: &str = "partition_store_fallback_empty_total";
 

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -190,6 +190,12 @@ pub const REBALANCE_RESUME_SKIPPED_NO_OWNED: &str = "rebalance_resume_skipped_no
 /// how many of these empty rebalances we short-circuit.
 pub const REBALANCE_EMPTY_SKIPPED: &str = "rebalance_empty_skipped_total";
 
+/// Histogram for partition directory cleanup duration at end of rebalance cycle.
+/// Measures total time for parallel scatter-gather deletion of unowned partition directories.
+/// Use to monitor cleanup performance and detect I/O bottlenecks blocking consumption resume.
+pub const REBALANCE_DIRECTORY_CLEANUP_DURATION_HISTOGRAM: &str =
+    "rebalance_directory_cleanup_duration_seconds";
+
 // ==== Partition Batch Processing Diagnostics ====
 /// Histogram for partition batch processing duration (in milliseconds)
 pub const PARTITION_BATCH_PROCESSING_DURATION_MS: &str = "partition_batch_processing_duration_ms";

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -2,7 +2,11 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+use futures::future::Shared;
 use rdkafka::TopicPartitionList;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -21,11 +25,30 @@ use crate::metrics_const::{
 use crate::rebalance_tracker::RebalanceTracker;
 use crate::store_manager::StoreManager;
 
+/// Type alias for the shared task handle. The closure maps JoinHandle's Result to ()
+/// so it can be Clone (required by Shared).
+type SharedTaskHandle =
+    Shared<futures::future::Map<JoinHandle<()>, fn(Result<(), tokio::task::JoinError>) -> ()>>;
+
+/// Tracks a partition setup task with its cancellation token.
+///
+/// The `Shared` future allows multiple async_setup calls to await the same task.
+/// The `CancellationToken` allows cancelling ONLY this partition's download on revoke.
+struct PartitionSetupTask {
+    /// None = claimed but task not yet spawned, Some = task spawned and awaitable
+    handle: Option<SharedTaskHandle>,
+    cancel_token: CancellationToken,
+}
+
 /// Rebalance handler that coordinates store cleanup and partition workers.
 ///
 /// Partition ownership is tracked in RebalanceTracker (the single source of truth).
 /// This handler updates ownership and uses it to determine which partitions to
 /// resume and which to cleanup.
+///
+/// Setup task tracking is managed here (not in RebalanceTracker) because:
+/// - Only this handler spawns and awaits setup tasks
+/// - We need access to StoreManager to detect stale entries
 pub struct ProcessorRebalanceHandler<T, P>
 where
     T: Send + 'static,
@@ -36,6 +59,14 @@ where
     router: Option<Arc<PartitionRouter<T, P>>>,
     offset_tracker: Arc<OffsetTracker>,
     checkpoint_importer: Option<Arc<CheckpointImporter>>,
+    /// Max parallel directory deletions during rebalance cleanup
+    rebalance_cleanup_parallelism: usize,
+    /// Per-partition setup task handles with cancellation tokens.
+    /// Tracks in-flight checkpoint imports so we can:
+    /// - Cancel them on revoke (save S3 bandwidth)
+    /// - Await them before resuming (ensure stores ready)
+    /// - Detect stale entries and allow re-claim
+    partition_setup_tasks: DashMap<Partition, PartitionSetupTask>,
 }
 
 impl<T, P> ProcessorRebalanceHandler<T, P>
@@ -48,6 +79,7 @@ where
         rebalance_tracker: Arc<RebalanceTracker>,
         offset_tracker: Arc<OffsetTracker>,
         checkpoint_importer: Option<Arc<CheckpointImporter>>,
+        rebalance_cleanup_parallelism: usize,
     ) -> Self {
         Self {
             store_manager,
@@ -55,6 +87,8 @@ where
             router: None,
             offset_tracker,
             checkpoint_importer,
+            rebalance_cleanup_parallelism,
+            partition_setup_tasks: DashMap::new(),
         }
     }
 
@@ -64,6 +98,7 @@ where
         router: Arc<PartitionRouter<T, P>>,
         offset_tracker: Arc<OffsetTracker>,
         checkpoint_importer: Option<Arc<CheckpointImporter>>,
+        rebalance_cleanup_parallelism: usize,
     ) -> Self {
         Self {
             store_manager,
@@ -71,8 +106,133 @@ where
             router: Some(router),
             offset_tracker,
             checkpoint_importer,
+            rebalance_cleanup_parallelism,
+            partition_setup_tasks: DashMap::new(),
         }
     }
+
+    // ============================================
+    // PARTITION SETUP TASK TRACKING
+    // ============================================
+
+    /// Atomically claim a partition for setup, with stale entry detection.
+    ///
+    /// Returns true if claimed successfully (either fresh claim or stale entry replaced).
+    /// Returns false if:
+    /// - A store already exists (task succeeded, keep entry)
+    /// - A task is still running (let it finish, don't cancel legitimate work)
+    ///
+    /// Stale entry detection: An entry is "stale" if the task completed but no store
+    /// was created (task bailed due to revoke, failed, or was cancelled). We replace
+    /// stale entries to allow a fresh checkpoint import attempt.
+    fn try_claim_partition_setup(
+        &self,
+        partition: &Partition,
+        cancel_token: CancellationToken,
+    ) -> bool {
+        match self.partition_setup_tasks.entry(partition.clone()) {
+            Entry::Vacant(e) => {
+                // Fresh claim - no existing entry
+                e.insert(PartitionSetupTask {
+                    handle: None,
+                    cancel_token,
+                });
+                true
+            }
+            Entry::Occupied(mut e) => {
+                let task = e.get();
+                let store_exists = self
+                    .store_manager
+                    .get(partition.topic(), partition.partition_number())
+                    .is_some();
+
+                // peek() returns Some if resolved, None if still pending
+                let task_completed = task
+                    .handle
+                    .as_ref()
+                    .map(|h| h.peek().is_some())
+                    .unwrap_or(false); // None = not spawned yet, treat as running
+
+                if store_exists {
+                    // Task succeeded, keep entry
+                    false
+                } else if task_completed {
+                    // Task completed but no store → stale entry (task bailed), safe to replace
+                    e.get().cancel_token.cancel();
+                    e.insert(PartitionSetupTask {
+                        handle: None,
+                        cancel_token,
+                    });
+                    debug!(
+                        topic = partition.topic(),
+                        partition = partition.partition_number(),
+                        "Replaced stale setup task entry (task completed, no store)"
+                    );
+                    true
+                } else {
+                    // Task still running, let it finish
+                    debug!(
+                        topic = partition.topic(),
+                        partition = partition.partition_number(),
+                        "Setup task already in progress, skipping"
+                    );
+                    false
+                }
+            }
+        }
+    }
+
+    /// Attach the task handle after spawning.
+    ///
+    /// Must be called after `try_claim_partition_setup()` returns true.
+    /// Converts the JoinHandle to a Shared future so multiple callers can await it.
+    fn finalize_partition_setup(&self, partition: &Partition, handle: JoinHandle<()>) {
+        use futures::future::FutureExt;
+
+        // Helper function to discard JoinHandle result (must be fn, not closure, for type matching)
+        fn discard_result(_: Result<(), tokio::task::JoinError>) {}
+
+        if let Some(mut task) = self.partition_setup_tasks.get_mut(partition) {
+            // Map the JoinHandle result to () so it's Clone (required for Shared)
+            let shared_handle = handle.map(discard_result as fn(_) -> ()).shared();
+            task.handle = Some(shared_handle);
+        }
+    }
+
+    /// Get the setup task handle for a partition (if finalized).
+    ///
+    /// Returns a clone of the Shared handle that can be awaited by multiple callers.
+    /// Returns None if no task exists OR if task is claimed but not yet finalized.
+    fn get_setup_task(&self, partition: &Partition) -> Option<SharedTaskHandle> {
+        self.partition_setup_tasks
+            .get(partition)
+            .and_then(|t| t.handle.clone())
+    }
+
+    /// Cancel and remove setup tasks for revoked partitions.
+    ///
+    /// This immediately cancels any in-flight S3 downloads to save cost/time.
+    /// The tasks will detect cancellation and clean up.
+    fn cancel_setup_tasks(&self, partitions: &[Partition]) {
+        for partition in partitions {
+            if let Some((_, task)) = self.partition_setup_tasks.remove(partition) {
+                // Cancel the token - S3 download will stop at next chunk
+                task.cancel_token.cancel();
+                // Handle is dropped, task continues but we won't wait for it
+            }
+        }
+    }
+
+    /// Remove a completed setup task for a partition.
+    ///
+    /// Called after awaiting the task to clean up the tracking entry.
+    fn complete_setup_task(&self, partition: &Partition) {
+        self.partition_setup_tasks.remove(partition);
+    }
+
+    // ============================================
+    // PARTITION SETUP TASK SPAWNING
+    // ============================================
 
     /// Spawn a task to attempt checkpoint import for a single partition.
     ///
@@ -253,6 +413,113 @@ where
             }
         })
     }
+
+    /// Finalize the rebalance cycle when all rebalances are complete (counter == 0).
+    ///
+    /// This method:
+    /// 1. Awaits all pending import tasks (always - cleans up JoinHandles)
+    /// 2. Checks if new rebalance started → early return if true
+    /// 3. Creates fallback stores for owned partitions without stores
+    /// 4. Cleans up unowned partition directories
+    /// 5. Resumes consumption
+    ///
+    /// The early return check (step 2) happens before creating fallback stores to avoid
+    /// wasted work when a new rebalance has already started.
+    async fn finalize_rebalance_cycle(
+        &self,
+        consumer_command_tx: &ConsumerCommandSender,
+    ) -> Result<()> {
+        info!("Finalizing rebalance cycle - awaiting import tasks");
+
+        // Step 1: Await all pending import tasks
+        // Get current owned partitions and wait for their setup tasks
+        let owned_partitions = self.rebalance_tracker.get_owned_partitions();
+        for partition in &owned_partitions {
+            if let Some(handle) = self.get_setup_task(partition) {
+                let _ = handle.await; // Ignore panic result - task handles its own errors
+                self.complete_setup_task(partition);
+            }
+        }
+
+        // Step 2: Check if a new rebalance started while we were awaiting
+        // If so, skip fallback stores, cleanup and resume - the new cycle will handle them
+        if self.rebalance_tracker.is_rebalancing() {
+            info!("New rebalance started during finalize - skipping fallback stores, cleanup and resume");
+            return Ok(());
+        }
+
+        // Step 3: Create fallback stores for any owned partitions that don't have a registered store
+        // This handles cases where checkpoint import failed, was cancelled, or was disabled
+        let current_owned = self.rebalance_tracker.get_owned_partitions();
+        for partition in &current_owned {
+            if self
+                .store_manager
+                .get(partition.topic(), partition.partition_number())
+                .is_none()
+            {
+                match self
+                    .store_manager
+                    .get_or_create_for_rebalance(partition.topic(), partition.partition_number())
+                    .await
+                {
+                    Ok(_) => {
+                        metrics::counter!(PARTITION_STORE_FALLBACK_EMPTY, "reason" => "missing_at_resume")
+                            .increment(1);
+                        warn!(
+                            topic = partition.topic(),
+                            partition = partition.partition_number(),
+                            "Created fallback empty store - deduplication quality may be degraded"
+                        );
+                    }
+                    Err(e) => {
+                        error!(
+                            topic = partition.topic(),
+                            partition = partition.partition_number(),
+                            error = %e,
+                            "Failed to create fallback store - processor will retry on first message"
+                        );
+                    }
+                }
+            }
+        }
+
+        // Step 4: Delete unowned partition directories using parallel scatter-gather
+        // This is simpler than tracking revoked partitions - just scan disk and delete
+        // anything not in owned_partitions. Also catches orphans from previous runs.
+        let owned = self.rebalance_tracker.get_owned_partitions();
+        if let Err(e) = self
+            .store_manager
+            .cleanup_unowned_partition_directories(&owned, self.rebalance_cleanup_parallelism)
+            .await
+        {
+            warn!(
+                error = %e,
+                "Partition directory cleanup failed - orphan cleaner will handle it"
+            );
+        }
+
+        // Step 5: Resume consumption
+        let owned = self.rebalance_tracker.get_owned_partitions();
+        if owned.is_empty() {
+            info!("No owned partitions to resume");
+            metrics::counter!(REBALANCE_RESUME_SKIPPED_NO_OWNED).increment(1);
+        } else {
+            let mut resume_tpl = TopicPartitionList::new();
+            for p in &owned {
+                resume_tpl.add_partition(p.topic(), p.partition_number());
+            }
+            info!(
+                owned_count = owned.len(),
+                "Resuming all owned partitions (rebalance cycle complete)"
+            );
+            if let Err(e) = consumer_command_tx.send(ConsumerCommand::Resume(resume_tpl)) {
+                error!("Failed to send resume command after store setup: {}", e);
+                return Err(anyhow::anyhow!("Failed to send resume command: {}", e));
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -346,7 +613,7 @@ where
         // CANCEL and remove setup tasks for revoked partitions
         // This immediately cancels any in-flight S3 downloads to save cost/time
         // Tasks will also check is_partition_owned() as a backup
-        self.rebalance_tracker.cancel_setup_tasks(&partition_infos);
+        self.cancel_setup_tasks(&partition_infos);
 
         // Unregister stores from DashMap BEFORE revocation completes
         // This prevents new store creation during shutdown (Step 1 of two-step cleanup)
@@ -370,7 +637,6 @@ where
 
     async fn async_setup_assigned_partitions(
         &self,
-        _partitions: &TopicPartitionList, // Ignored - we use owned_partitions from coordinator
         consumer_command_tx: &ConsumerCommandSender,
     ) -> Result<()> {
         // Get ALL owned partitions (not just incremental from this rebalance)
@@ -385,94 +651,29 @@ where
         // Spawn setup tasks for partitions that don't have one yet.
         // Uses atomic two-phase registration to prevent race conditions where overlapping
         // rebalances could both spawn tasks for the same partition.
+        // NOTE: We do NOT await these tasks here - that's deferred to finalize_rebalance_cycle
         for partition in &owned_partitions {
             let cancel_token = CancellationToken::new();
-            // Atomically claim the partition - if another rebalance already claimed it, skip
-            if self
-                .rebalance_tracker
-                .try_claim_partition_setup(partition, cancel_token.clone())
-            {
+            // Atomically claim the partition - if stale entry exists, it will be replaced
+            if self.try_claim_partition_setup(partition, cancel_token.clone()) {
                 // We claimed it - now spawn the task and finalize registration
                 let handle =
                     self.spawn_partition_setup_task(partition.clone(), cancel_token.clone());
-                self.rebalance_tracker
-                    .finalize_partition_setup(partition, handle);
+                self.finalize_partition_setup(partition, handle);
             }
-            // If claim failed, another rebalance already owns this partition's setup
-        }
-
-        // Wait for ALL owned partition tasks to complete
-        // This ensures stores are ready before we resume
-        for partition in &owned_partitions {
-            if let Some(handle) = self.rebalance_tracker.get_setup_task(partition) {
-                let _ = handle.await; // Ignore panic result - task handles its own errors
-                self.rebalance_tracker.complete_setup_task(partition);
-            }
-        }
-
-        // Create fallback stores for any owned partitions that don't have a registered store.
-        // This handles cases where checkpoint import failed, was cancelled, or was disabled.
-        // Centralizing this here ensures consistent logging/metrics and catches edge cases.
-        let current_owned = self.rebalance_tracker.get_owned_partitions();
-        for partition in &current_owned {
-            if self
-                .store_manager
-                .get(partition.topic(), partition.partition_number())
-                .is_none()
-            {
-                match self
-                    .store_manager
-                    .get_or_create_for_rebalance(partition.topic(), partition.partition_number())
-                    .await
-                {
-                    Ok(_) => {
-                        metrics::counter!(PARTITION_STORE_FALLBACK_EMPTY, "reason" => "missing_at_resume")
-                            .increment(1);
-                        warn!(
-                            topic = partition.topic(),
-                            partition = partition.partition_number(),
-                            "Created fallback empty store - deduplication quality may be degraded"
-                        );
-                    }
-                    Err(e) => {
-                        error!(
-                            topic = partition.topic(),
-                            partition = partition.partition_number(),
-                            error = %e,
-                            "Failed to create fallback store - processor will retry on first message"
-                        );
-                    }
-                }
-            }
+            // If claim failed, either a store exists or a task is still running
         }
 
         // Decrement rebalancing counter
         self.rebalance_tracker.finish_rebalancing();
 
-        // Only send Resume if this is the LAST rebalance (counter == 0)
-        // This ensures all overlapping rebalances complete before resuming
+        // Only finalize (await tasks, cleanup, resume) if this is the LAST rebalance
+        // This ensures all events in the cycle are processed before blocking on I/O
         if !self.rebalance_tracker.is_rebalancing() {
-            let owned = self.rebalance_tracker.get_owned_partitions();
-            if owned.is_empty() {
-                info!("No owned partitions to resume");
-                metrics::counter!(REBALANCE_RESUME_SKIPPED_NO_OWNED).increment(1);
-            } else {
-                let mut resume_tpl = TopicPartitionList::new();
-                for p in &owned {
-                    resume_tpl.add_partition(p.topic(), p.partition_number());
-                }
-                info!(
-                    owned_count = owned.len(),
-                    "Resuming all owned partitions (all rebalances complete)"
-                );
-                if let Err(e) = consumer_command_tx.send(ConsumerCommand::Resume(resume_tpl)) {
-                    error!("Failed to send resume command after store setup: {}", e);
-                    return Err(anyhow::anyhow!("Failed to send resume command: {}", e));
-                }
-            }
+            self.finalize_rebalance_cycle(consumer_command_tx).await?;
         } else {
             debug!(
-                "Rebalance async setup complete, but other rebalances still in progress - skipping Resume"
+                "Rebalance async setup complete, but other rebalances still in progress - deferring finalize"
             );
         }
 
@@ -527,12 +728,12 @@ where
             self.offset_tracker.clear_partition(partition);
         }
 
-        // File cleanup is handled by the orphan directory cleaner, not here.
-        // This simplifies the cleanup flow and avoids race conditions with rapid revoke→assign.
+        // File cleanup is handled by finalize_rebalance_cycle at end of the rebalance cycle.
+        // This uses disk scan + owned_partitions to delete unowned directories.
 
         info!(
             cleaned_count = partitions_to_cleanup.len(),
-            "Revoked partition cleanup completed (files will be cleaned by orphan cleaner)"
+            "Revoked partition cleanup completed (files will be cleaned at end of cycle)"
         );
 
         Ok(())
@@ -547,8 +748,8 @@ where
 
     async fn on_post_rebalance(&self) -> Result<()> {
         info!("Post-rebalance: Sync callbacks complete, async cleanup may continue");
-        // Note: rebalance_tracker counter is decremented via RebalancingGuard
-        // at the end of async_setup_assigned_partitions (ensures panic safety).
+        // Note: rebalance_tracker counter is decremented via finish_rebalancing()
+        // at the end of async_setup_assigned_partitions.
         // The rebalance_tracker's rebalancing counter is the single source of truth.
 
         // Log current stats
@@ -601,6 +802,7 @@ mod tests {
                 coordinator.clone(),
                 offset_tracker.clone(),
                 None,
+                16, // rebalance_cleanup_parallelism
             );
         assert!(handler.router.is_none());
 
@@ -617,6 +819,7 @@ mod tests {
             router.clone(),
             offset_tracker,
             None,
+            16, // rebalance_cleanup_parallelism
         );
         assert!(handler_with_router.router.is_some());
     }
@@ -644,6 +847,7 @@ mod tests {
             router.clone(),
             offset_tracker,
             None,
+            16, // rebalance_cleanup_parallelism
         );
 
         // Initially no workers
@@ -681,8 +885,8 @@ mod tests {
         // This test verifies that stores are removed from the map (in setup_revoked_partitions)
         // BEFORE workers are shut down (in cleanup_revoked_partitions).
         //
-        // Note: File cleanup is now handled by the orphan directory cleaner, NOT during revoke.
-        // This prevents race conditions and simplifies the cleanup flow.
+        // Note: File cleanup is handled by finalize_rebalance_cycle at end of cycle,
+        // NOT during cleanup_revoked_partitions. This avoids race conditions with rapid revoke→assign.
 
         let temp_dir = TempDir::new().unwrap();
         let store_config = DeduplicationStoreConfig {
@@ -705,6 +909,7 @@ mod tests {
             router.clone(),
             offset_tracker,
             None,
+            16, // rebalance_cleanup_parallelism
         );
 
         // Assign partition and create a store
@@ -726,7 +931,7 @@ mod tests {
         // Worker still exists at this point
         assert_eq!(router.worker_count(), 1);
 
-        // Async cleanup shuts down workers (but does NOT delete files - orphan cleaner handles that)
+        // Async cleanup shuts down workers (files are deleted in finalize_rebalance_cycle)
         handler
             .cleanup_revoked_partitions(&partitions)
             .await
@@ -735,10 +940,10 @@ mod tests {
         // After cleanup:
         // - Worker should be shut down
         // - Store should be unregistered from map
-        // - Files still exist (will be cleaned by orphan cleaner)
+        // - Files still exist (will be cleaned in finalize_rebalance_cycle)
         assert_eq!(router.worker_count(), 0);
 
-        // Files are NOT immediately deleted - orphan cleaner handles this
+        // Files are NOT immediately deleted - finalize_rebalance_cycle handles this
         let partition_dir = temp_dir.path().join("test-topic_0");
         assert!(
             partition_dir.exists(),
@@ -809,6 +1014,7 @@ mod tests {
             router.clone(),
             offset_tracker,
             None,
+            16, // rebalance_cleanup_parallelism
         );
 
         // Step 1: Initial assignment
@@ -904,6 +1110,7 @@ mod tests {
                 coordinator.clone(),
                 offset_tracker,
                 None,
+                16, // rebalance_cleanup_parallelism
             );
 
         // First assignment
@@ -949,6 +1156,7 @@ mod tests {
                 coordinator,
                 offset_tracker,
                 None,
+                16, // rebalance_cleanup_parallelism
             );
 
         // Create command channel
@@ -966,10 +1174,7 @@ mod tests {
         handler.setup_assigned_partitions(&partitions);
 
         // Now do async setup - should send Resume command
-        handler
-            .async_setup_assigned_partitions(&partitions, &tx)
-            .await
-            .unwrap();
+        handler.async_setup_assigned_partitions(&tx).await.unwrap();
 
         // Check that Resume command was sent
         let command = rx.try_recv().expect("Should have received a command");
@@ -1010,6 +1215,7 @@ mod tests {
                 coordinator.clone(),
                 offset_tracker,
                 None,
+                16, // rebalance_cleanup_parallelism
             );
 
         // Create command channel
@@ -1036,10 +1242,7 @@ mod tests {
         );
 
         // First async setup completes - should NOT send Resume (counter still > 0)
-        handler
-            .async_setup_assigned_partitions(&partitions_a, &tx)
-            .await
-            .unwrap();
+        handler.async_setup_assigned_partitions(&tx).await.unwrap();
 
         // No Resume yet (counter is still 1)
         // Give a moment for any potential Resume to be sent
@@ -1052,10 +1255,7 @@ mod tests {
         );
 
         // Second async setup completes - should send Resume (counter == 0)
-        handler
-            .async_setup_assigned_partitions(&partitions_b, &tx)
-            .await
-            .unwrap();
+        handler.async_setup_assigned_partitions(&tx).await.unwrap();
 
         // Should have received exactly one Resume command (from the last rebalance)
         let cmd = rx.try_recv().expect("Should have received Resume command");
@@ -1091,6 +1291,7 @@ mod tests {
                 coordinator.clone(),
                 offset_tracker,
                 None,
+                16, // rebalance_cleanup_parallelism
             );
 
         // Create command channel
@@ -1126,10 +1327,7 @@ mod tests {
         assert!(!coordinator.is_partition_owned(&Partition::new("test-topic".to_string(), 1)));
 
         // Now do async setup - should resume only owned partitions (0 and 2)
-        handler
-            .async_setup_assigned_partitions(&partitions, &tx)
-            .await
-            .unwrap();
+        handler.async_setup_assigned_partitions(&tx).await.unwrap();
 
         // Check that Resume command contains only owned partitions
         let command = rx.try_recv().expect("Should have received a command");
@@ -1190,6 +1388,7 @@ mod tests {
                 coordinator.clone(),
                 offset_tracker,
                 None,
+                16, // rebalance_cleanup_parallelism
             );
 
         // Create command channel
@@ -1209,10 +1408,7 @@ mod tests {
         assert!(!coordinator.is_partition_owned(&Partition::new("test-topic".to_string(), 0)));
 
         // Now do async setup - should skip Resume entirely (no owned partitions)
-        handler
-            .async_setup_assigned_partitions(&partitions, &tx)
-            .await
-            .unwrap();
+        handler.async_setup_assigned_partitions(&tx).await.unwrap();
 
         // Should NOT have received a Resume command (no owned partitions)
         assert!(
@@ -1240,6 +1436,7 @@ mod tests {
                 coordinator.clone(),
                 offset_tracker,
                 None,
+                16, // rebalance_cleanup_parallelism
             );
 
         // Create command channel
@@ -1272,10 +1469,7 @@ mod tests {
         assert!(!coordinator.is_partition_owned(&Partition::new("test-topic".to_string(), 1)));
 
         // Now run async setup - should skip store creation for partition 1
-        handler
-            .async_setup_assigned_partitions(&partitions, &tx)
-            .await
-            .unwrap();
+        handler.async_setup_assigned_partitions(&tx).await.unwrap();
 
         // Verify: store for partition 0 should exist (still owned)
         assert!(
@@ -1319,6 +1513,7 @@ mod tests {
                 coordinator.clone(),
                 offset_tracker,
                 None,
+                16, // rebalance_cleanup_parallelism
             );
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1339,10 +1534,7 @@ mod tests {
         assert!(coordinator.is_partition_owned(&Partition::new("test-topic".to_string(), 1)));
 
         // Rebalance A: Complete async setup - creates stores and sends Resume
-        handler
-            .async_setup_assigned_partitions(&partitions_a, &tx)
-            .await
-            .unwrap();
+        handler.async_setup_assigned_partitions(&tx).await.unwrap();
 
         // Verify A's stores were created
         assert!(
@@ -1384,10 +1576,7 @@ mod tests {
         assert!(!coordinator.is_partition_owned(&Partition::new("test-topic".to_string(), 1)));
 
         // Rebalance B's async setup with empty list - should still resume partition 0!
-        handler
-            .async_setup_assigned_partitions(&partitions_b, &tx)
-            .await
-            .unwrap();
+        handler.async_setup_assigned_partitions(&tx).await.unwrap();
 
         // Should resume partition 0 (still owned) but not partition 1 (revoked)
         let command = rx
@@ -1426,6 +1615,7 @@ mod tests {
                 coordinator.clone(),
                 offset_tracker,
                 None,
+                16, // rebalance_cleanup_parallelism
             );
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1464,10 +1654,7 @@ mod tests {
         assert_eq!(coordinator.owned_partition_count(), 2);
 
         // Complete async setup - should resume only owned partitions
-        handler
-            .async_setup_assigned_partitions(&partitions, &tx)
-            .await
-            .unwrap();
+        handler.async_setup_assigned_partitions(&tx).await.unwrap();
 
         let command = rx.try_recv().expect("Should have received Resume");
         match command {

--- a/rust/kafka-deduplicator/src/rebalance_tracker.rs
+++ b/rust/kafka-deduplicator/src/rebalance_tracker.rs
@@ -293,8 +293,11 @@ impl RebalanceTracker {
         self.owned_partitions.len()
     }
 
-    /// Get the current rebalancing count (for testing/debugging).
-    #[cfg(test)]
+    /// Get the current rebalancing count.
+    ///
+    /// Used by ProcessorRebalanceHandler to decide whether to run finalize before or after
+    /// decrementing (so is_rebalancing() stays true during finalize and orphan cleanup skips).
+    /// Also useful for observability.
     pub fn rebalancing_count(&self) -> usize {
         self.rebalancing_count.load(Ordering::SeqCst)
     }

--- a/rust/kafka-deduplicator/src/rebalance_tracker.rs
+++ b/rust/kafka-deduplicator/src/rebalance_tracker.rs
@@ -35,10 +35,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
-use dashmap::mapref::entry::Entry;
-use dashmap::{DashMap, DashSet};
-use futures::future::Shared;
-use tokio::task::JoinHandle;
+use dashmap::DashSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -48,25 +45,6 @@ use crate::metrics_const::{
     REBALANCING_COUNT,
 };
 
-/// Type alias for the shared task handle. The closure maps JoinHandle's Result to ()
-/// so it can be Clone (required by Shared).
-type SharedTaskHandle =
-    Shared<futures::future::Map<JoinHandle<()>, fn(Result<(), tokio::task::JoinError>) -> ()>>;
-
-/// Tracks a partition setup task with its cancellation token.
-///
-/// The `Shared` future allows multiple async_setup calls to await the same task.
-/// The `CancellationToken` allows cancelling ONLY this partition's download on revoke.
-///
-/// Two-phase registration: `handle` is None when claimed but task not yet spawned,
-/// then set via `finalize_partition_setup()` after the task is spawned.
-/// This prevents race conditions where overlapping rebalances could spawn duplicate tasks.
-struct PartitionSetupTask {
-    /// None = claimed but task not yet spawned, Some = task spawned and awaitable
-    handle: Option<SharedTaskHandle>,
-    cancel_token: CancellationToken,
-}
-
 /// Tracks rebalance state across multiple components.
 ///
 /// This is a lightweight struct that can be cheaply cloned via `Arc`.
@@ -74,6 +52,9 @@ struct PartitionSetupTask {
 /// - Whether a rebalance is in progress (counter-based for overlapping rebalances)
 /// - Which partitions are currently owned by this consumer
 /// - Export suppression during rebalancing (to prioritize imports)
+///
+/// Note: Partition setup task tracking is handled by ProcessorRebalanceHandler
+/// (not here) because it needs access to StoreManager to detect stale entries.
 pub struct RebalanceTracker {
     /// Counter tracking the number of in-progress rebalances.
     /// Using a counter (not bool) correctly handles overlapping rebalances.
@@ -83,11 +64,6 @@ pub struct RebalanceTracker {
     /// Updated synchronously in ASSIGN (add) and REVOKE (remove) callbacks.
     /// Used to determine which partitions to resume and which to cleanup.
     owned_partitions: DashSet<Partition>,
-
-    /// Per-partition setup task handles with cancellation tokens.
-    /// - Shared<JoinHandle> allows multiple async_setup calls to await the same task
-    /// - CancellationToken allows cancelling ONLY this partition's S3 download on revoke
-    partition_setup_tasks: DashMap<Partition, PartitionSetupTask>,
 
     /// Token for suppressing checkpoint exports during rebalancing.
     /// Cancelled when rebalancing starts (count 0->1), recreated when complete (count 1->0).
@@ -103,7 +79,6 @@ impl RebalanceTracker {
         Self {
             rebalancing_count: AtomicUsize::new(0),
             owned_partitions: DashSet::new(),
-            partition_setup_tasks: DashMap::new(),
             export_suppression_token: RwLock::new(CancellationToken::new()),
         }
     }
@@ -310,95 +285,6 @@ impl RebalanceTracker {
             .filter(|p| !self.owned_partitions.contains(*p))
             .cloned()
             .collect()
-    }
-
-    // ============================================
-    // PER-PARTITION SETUP TASK MANAGEMENT
-    //
-    // Two-phase registration prevents race conditions in overlapping rebalances:
-    // 1. try_claim_partition_setup() - atomically claims a partition for setup
-    // 2. finalize_partition_setup() - attaches the task handle after spawning
-    // ============================================
-
-    /// Atomically claim a partition for setup.
-    ///
-    /// Returns true if claimed successfully, false if a task already exists (claimed or finalized).
-    /// After claiming, caller MUST call `finalize_partition_setup()` with the spawned task handle.
-    ///
-    /// This two-phase approach prevents race conditions where overlapping rebalances could
-    /// both pass a "no task exists" check and spawn duplicate tasks.
-    pub fn try_claim_partition_setup(
-        &self,
-        partition: &Partition,
-        cancel_token: CancellationToken,
-    ) -> bool {
-        match self.partition_setup_tasks.entry(partition.clone()) {
-            Entry::Vacant(e) => {
-                // Claim the slot with handle=None (task not yet spawned)
-                e.insert(PartitionSetupTask {
-                    handle: None,
-                    cancel_token,
-                });
-                true
-            }
-            Entry::Occupied(_) => false, // Already claimed or finalized
-        }
-    }
-
-    /// Attach the task handle after spawning.
-    ///
-    /// Must be called after `try_claim_partition_setup()` returns true.
-    /// Converts the JoinHandle to a Shared future so multiple callers can await it.
-    pub fn finalize_partition_setup(&self, partition: &Partition, handle: JoinHandle<()>) {
-        use futures::future::FutureExt;
-
-        // Helper function to discard JoinHandle result (must be fn, not closure, for type matching)
-        fn discard_result(_: Result<(), tokio::task::JoinError>) {}
-
-        if let Some(mut task) = self.partition_setup_tasks.get_mut(partition) {
-            // Map the JoinHandle result to () so it's Clone (required for Shared)
-            let shared_handle = handle.map(discard_result as fn(_) -> ()).shared();
-            task.handle = Some(shared_handle);
-        }
-    }
-
-    /// Get the setup task handle for a partition (if finalized).
-    ///
-    /// Returns a clone of the Shared handle that can be awaited by multiple callers.
-    /// Returns None if no task exists OR if task is claimed but not yet finalized.
-    pub fn get_setup_task(&self, partition: &Partition) -> Option<SharedTaskHandle> {
-        self.partition_setup_tasks
-            .get(partition)
-            .and_then(|t| t.handle.clone())
-    }
-
-    /// Check if a partition has a claimed or finalized setup task.
-    ///
-    /// Returns true if the partition has been claimed (even if not yet finalized).
-    /// Use this to check if setup is in progress before spawning a new task.
-    pub fn has_setup_task(&self, partition: &Partition) -> bool {
-        self.partition_setup_tasks.contains_key(partition)
-    }
-
-    /// Cancel and remove setup tasks for revoked partitions.
-    ///
-    /// This immediately cancels any in-flight S3 downloads to save cost/time.
-    /// The tasks will detect cancellation and clean up.
-    pub fn cancel_setup_tasks(&self, partitions: &[Partition]) {
-        for partition in partitions {
-            if let Some((_, task)) = self.partition_setup_tasks.remove(partition) {
-                // Cancel the token - S3 download will stop at next chunk
-                task.cancel_token.cancel();
-                // Handle is dropped, task continues but we won't wait for it
-            }
-        }
-    }
-
-    /// Remove a completed setup task for a partition.
-    ///
-    /// Called after awaiting the task to clean up the tracking entry.
-    pub fn complete_setup_task(&self, partition: &Partition) {
-        self.partition_setup_tasks.remove(partition);
     }
 
     /// Get the count of owned partitions (for testing/debugging).
@@ -632,129 +518,6 @@ mod tests {
         // Empty unowned query
         let unowned = tracker.get_unowned_partitions(&[]);
         assert!(unowned.is_empty());
-    }
-
-    // ============================================
-    // TWO-PHASE TASK REGISTRATION TESTS
-    // ============================================
-
-    #[test]
-    fn test_try_claim_partition_setup_success() {
-        let tracker = RebalanceTracker::new();
-        let p0 = Partition::new("topic".to_string(), 0);
-        let token = CancellationToken::new();
-
-        // First claim should succeed
-        assert!(tracker.try_claim_partition_setup(&p0, token));
-
-        // has_setup_task should return true (claimed)
-        assert!(tracker.has_setup_task(&p0));
-
-        // get_setup_task should return None (not yet finalized)
-        assert!(tracker.get_setup_task(&p0).is_none());
-    }
-
-    #[test]
-    fn test_try_claim_partition_setup_already_claimed() {
-        let tracker = RebalanceTracker::new();
-        let p0 = Partition::new("topic".to_string(), 0);
-        let token1 = CancellationToken::new();
-        let token2 = CancellationToken::new();
-
-        // First claim succeeds
-        assert!(tracker.try_claim_partition_setup(&p0, token1));
-
-        // Second claim fails (already claimed)
-        assert!(!tracker.try_claim_partition_setup(&p0, token2));
-    }
-
-    #[tokio::test]
-    async fn test_finalize_partition_setup() {
-        let tracker = RebalanceTracker::new();
-        let p0 = Partition::new("topic".to_string(), 0);
-        let token = CancellationToken::new();
-
-        // Claim the partition
-        assert!(tracker.try_claim_partition_setup(&p0, token));
-        assert!(tracker.get_setup_task(&p0).is_none()); // Not yet finalized
-
-        // Spawn a simple task
-        let handle = tokio::spawn(async { /* do nothing */ });
-
-        // Finalize with the handle
-        tracker.finalize_partition_setup(&p0, handle);
-
-        // Now get_setup_task should return Some
-        assert!(tracker.get_setup_task(&p0).is_some());
-
-        // Can await the task
-        let task = tracker.get_setup_task(&p0).unwrap();
-        task.await;
-    }
-
-    #[test]
-    fn test_cancel_claimed_but_not_finalized_task() {
-        let tracker = RebalanceTracker::new();
-        let p0 = Partition::new("topic".to_string(), 0);
-        let token = CancellationToken::new();
-
-        // Claim but don't finalize
-        assert!(tracker.try_claim_partition_setup(&p0, token.clone()));
-        assert!(!token.is_cancelled());
-
-        // Cancel should work even on claimed-but-not-finalized tasks
-        tracker.cancel_setup_tasks(std::slice::from_ref(&p0));
-
-        // Token should be cancelled
-        assert!(token.is_cancelled());
-
-        // Task should be removed
-        assert!(!tracker.has_setup_task(&p0));
-    }
-
-    #[test]
-    fn test_overlapping_rebalances_cannot_claim_same_partition() {
-        // Simulates the race condition we're preventing:
-        // Two overlapping rebalances both try to claim the same partition
-        let tracker = RebalanceTracker::new();
-        let p0 = Partition::new("topic".to_string(), 0);
-
-        // Rebalance A claims p0
-        let token_a = CancellationToken::new();
-        assert!(
-            tracker.try_claim_partition_setup(&p0, token_a),
-            "Rebalance A should claim p0"
-        );
-
-        // Rebalance B tries to claim p0 - should fail
-        let token_b = CancellationToken::new();
-        assert!(
-            !tracker.try_claim_partition_setup(&p0, token_b),
-            "Rebalance B should NOT be able to claim p0 (already claimed by A)"
-        );
-
-        // Only A's claim exists
-        assert!(tracker.has_setup_task(&p0));
-    }
-
-    #[tokio::test]
-    async fn test_complete_setup_task_removes_entry() {
-        let tracker = RebalanceTracker::new();
-        let p0 = Partition::new("topic".to_string(), 0);
-        let token = CancellationToken::new();
-
-        // Claim and finalize
-        assert!(tracker.try_claim_partition_setup(&p0, token));
-        let handle = tokio::spawn(async { /* do nothing */ });
-        tracker.finalize_partition_setup(&p0, handle);
-
-        assert!(tracker.has_setup_task(&p0));
-
-        // Complete removes the entry
-        tracker.complete_setup_task(&p0);
-
-        assert!(!tracker.has_setup_task(&p0));
-        assert!(tracker.get_setup_task(&p0).is_none());
     }
 
     // ============================================

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -370,6 +370,7 @@ impl KafkaDeduplicatorService {
             router,
             offset_tracker.clone(),
             self.checkpoint_importer.clone(),
+            self.config.rebalance_cleanup_parallelism,
         ));
 
         // Create consumer config using the kafka module's builder

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -1,5 +1,7 @@
 use anyhow::{Context, Result};
 use dashmap::DashMap;
+use futures::stream::{self, StreamExt};
+use std::collections::HashSet;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -25,7 +27,8 @@ use crate::kafka::types::Partition;
 use crate::metrics::MetricsHelper;
 use crate::metrics_const::{
     ACTIVE_STORE_COUNT, CLEANUP_BYTES_FREED_HISTOGRAM, CLEANUP_DURATION_HISTOGRAM,
-    CLEANUP_OPERATIONS_COUNTER, STORE_CREATION_DURATION_MS, STORE_CREATION_EVENTS,
+    CLEANUP_OPERATIONS_COUNTER, REBALANCE_DIRECTORY_CLEANUP_DURATION_HISTOGRAM,
+    STORE_CREATION_DURATION_MS, STORE_CREATION_EVENTS,
 };
 use crate::rebalance_tracker::RebalanceTracker;
 use crate::rocksdb::metrics_consts::ROCKSDB_OLDEST_DATA_AGE_SECONDS_GAUGE;
@@ -465,6 +468,111 @@ impl StoreManager {
                 partition = partition,
                 path = partition_dir_str,
                 "Partition directory doesn't exist"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Delete partition directories not in the owned set using bounded parallelism.
+    ///
+    /// Called at end of rebalance cycle to clean up directories for revoked partitions.
+    /// Uses scatter-gather pattern with configurable parallelism for fast cleanup
+    /// before resuming consumption.
+    ///
+    /// This is simpler and more aggressive than the periodic orphan cleaner:
+    /// - No staleness check (we know ownership is final at end of cycle)
+    /// - Also catches orphans from previous runs
+    pub async fn cleanup_unowned_partition_directories(
+        &self,
+        owned: &[Partition],
+        parallelism: usize,
+    ) -> Result<()> {
+        let start = Instant::now();
+
+        // Build HashSet of owned partition dir names for O(1) lookup
+        let owned_dirs: HashSet<String> = owned
+            .iter()
+            .map(|p| format_partition_dir(p.topic(), p.partition_number()))
+            .collect();
+
+        // Scan disk for all partition directories
+        let base_path = &self.store_config.path;
+        let entries: Vec<PathBuf> = match std::fs::read_dir(base_path) {
+            Ok(read_dir) => read_dir
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+                .map(|e| e.path())
+                .filter(|path| {
+                    // Keep only directories NOT in owned set
+                    path.file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|name| !owned_dirs.contains(name))
+                        .unwrap_or(false)
+                })
+                .collect(),
+            Err(e) => {
+                warn!(
+                    path = %base_path.display(),
+                    error = %e,
+                    "Failed to read store base directory for cleanup"
+                );
+                return Ok(());
+            }
+        };
+
+        if entries.is_empty() {
+            debug!("No unowned partition directories to clean up");
+            return Ok(());
+        }
+
+        let count = entries.len();
+        info!(
+            count = count,
+            parallelism = parallelism,
+            "Cleaning up unowned partition directories"
+        );
+
+        // Delete in parallel with bounded concurrency
+        let results: Vec<std::io::Result<()>> = stream::iter(entries)
+            .map(|path| async move {
+                let path_str = path.display().to_string();
+                match tokio::fs::remove_dir_all(&path).await {
+                    Ok(_) => {
+                        debug!(path = %path_str, "Deleted unowned partition directory");
+                        Ok(())
+                    }
+                    Err(e) => {
+                        warn!(path = %path_str, error = %e, "Failed to delete partition directory");
+                        Err(e)
+                    }
+                }
+            })
+            .buffer_unordered(parallelism)
+            .collect()
+            .await;
+
+        // Record timing
+        let duration = start.elapsed();
+        self.metrics
+            .histogram(REBALANCE_DIRECTORY_CLEANUP_DURATION_HISTOGRAM)
+            .record(duration.as_secs_f64());
+
+        let failed = results.iter().filter(|r| r.is_err()).count();
+        let succeeded = count - failed;
+
+        if failed > 0 {
+            warn!(
+                succeeded = succeeded,
+                failed = failed,
+                duration_ms = duration.as_millis(),
+                "Partition directory cleanup completed with failures (orphan cleaner will retry)"
+            );
+        } else {
+            info!(
+                deleted = succeeded,
+                duration_ms = duration.as_millis(),
+                "Partition directory cleanup completed"
             );
         }
 

--- a/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
@@ -342,11 +342,10 @@ impl RebalanceHandler for RoutingRebalanceHandler {
 
     async fn async_setup_assigned_partitions(
         &self,
-        partitions: &TopicPartitionList,
         consumer_command_tx: &ConsumerCommandSender,
     ) -> Result<()> {
         self.inner
-            .async_setup_assigned_partitions(partitions, consumer_command_tx)
+            .async_setup_assigned_partitions(consumer_command_tx)
             .await
     }
 

--- a/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
@@ -331,6 +331,7 @@ async fn test_rebalance_with_checkpoint_import() -> Result<()> {
             router.clone(),
             offset_tracker.clone(),
             Some(importer),
+            16, // rebalance_cleanup_parallelism
         ));
 
     // Create routing processor
@@ -456,6 +457,7 @@ async fn test_messages_dropped_for_revoked_partition() -> Result<()> {
             coordinator,
             offset_tracker.clone(),
             None,
+            16, // rebalance_cleanup_parallelism
         );
 
     // Assign partition 0
@@ -469,9 +471,7 @@ async fn test_messages_dropped_for_revoked_partition() -> Result<()> {
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
 
     // Async setup (creates stores, sends resume)
-    handler
-        .async_setup_assigned_partitions(&partitions, &tx)
-        .await?;
+    handler.async_setup_assigned_partitions(&tx).await?;
 
     // Verify store exists
     assert!(
@@ -544,6 +544,7 @@ async fn test_rapid_revoke_assign_preserves_new_store() -> Result<()> {
             coordinator,
             offset_tracker.clone(),
             None,
+            16, // rebalance_cleanup_parallelism
         );
 
     let mut partitions = TopicPartitionList::new();
@@ -554,9 +555,7 @@ async fn test_rapid_revoke_assign_preserves_new_store() -> Result<()> {
     handler.setup_assigned_partitions(&partitions);
 
     let (tx1, _rx1) = tokio::sync::mpsc::unbounded_channel();
-    handler
-        .async_setup_assigned_partitions(&partitions, &tx1)
-        .await?;
+    handler.async_setup_assigned_partitions(&tx1).await?;
 
     assert!(
         store_manager.get(&test_topic, 0).is_some(),
@@ -577,9 +576,7 @@ async fn test_rapid_revoke_assign_preserves_new_store() -> Result<()> {
     handler.setup_assigned_partitions(&partitions);
 
     let (tx2, mut rx2) = tokio::sync::mpsc::unbounded_channel();
-    handler
-        .async_setup_assigned_partitions(&partitions, &tx2)
-        .await?;
+    handler.async_setup_assigned_partitions(&tx2).await?;
 
     // Step 4: Now run the stale cleanup from Step 2
     info!("Step 4: Run stale cleanup (should be no-op for re-assigned partition)");


### PR DESCRIPTION
## Problem
We are still seeing unexpected partition churn and delay during rebalancing cycles. This is partially due to blocking in Assign cycles in the rebalance worker while we await checkpoint import tasks to complete.

By deferring this to the end of the whole pause/resume interval (rebalance_count = 0, consumption about to resume) we can speed this up considerably, and hopefully get the rebalance completed faster and without expiring pod sessions and causing more partition churn.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Refactor rebalance modules (store manager, processor rebalance handler, rebalance tracker, etc.) to enable nonblocking Revoke-Assign cycles in worker
* Consolidate cleanup of local store dirs associated with (now) unassigned partitions at the end of the pause/resume cycle to avoid storage pileup during rebalance storms
* Related changes to tests and comments

This change is larger than I'd like for two reasons:
* We must now handle more potential race conditions than before
* To keep the components as decoupled as possible, some functionality had to move into the rebalance handler

If this change has the desired effect, I'm going to make one more pass in a follow-on PR to reduce the AI slop and _add a README documenting the rebalance process and it's components_ 🎗️ 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
