### PR TITLE
chore: make team_id arg non-optional

### DIFF
--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -917,17 +917,13 @@ class HogQLPropertyChecker(TraversingVisitor):
             self.person_properties.append(node.chain[3])
 
 
-def extract_tables_and_properties(props: list[Property], team_id: Optional[int] = None) -> TCounter[PropertyIdentifier]:
+def extract_tables_and_properties(props: list[Property], team_id: int) -> TCounter[PropertyIdentifier]:
     counters: list[tuple] = []
     for prop in props:
         if prop.type == "hogql":
             counters.extend(count_hogql_properties(prop.key))
         elif prop.type == "behavioral" and prop.event_type == "actions":
-            if team_id is not None:
-                action = Action.objects.get(pk=prop.key, team_id=team_id)
-            else:
-                # nosemgrep: idor-lookup-without-team -- legacy fallback, all callers now pass team_id
-                action = Action.objects.get(pk=prop.key)
+            action = Action.objects.get(pk=prop.key, team_id=team_id)
             action_counter = get_action_tables_and_properties(action)
             counters.extend(action_counter)
         else:


### PR DESCRIPTION
This is always passed.
