### PR TITLE
feat: Add last_seen_at column to persons

### DIFF
--- a/rust/persons_migrations/20260206000001_add_last_seen_at_to_person.sql
+++ b/rust/persons_migrations/20260206000001_add_last_seen_at_to_person.sql
@@ -1,0 +1,9 @@
+-- Add last_seen_at column to person table
+-- This tracks when a person was last seen (last event timestamp)
+--
+-- SAFE: Adding nullable column without default is instant (metadata-only)
+-- No table rewrite required regardless of table size
+-- For partitioned tables, ALTER TABLE propagates to all partitions automatically
+
+ALTER TABLE posthog_person
+    ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMP WITH TIME ZONE;


### PR DESCRIPTION
## Problem

We want to add a feature to allow users to know when was the last time a person was seen.

This PR is the first step towards that goal

## Changes

- Adds last_seen_at column to person table
  - Migration should only alter metadata as the column is nullable

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
