### PR TITLE
feat(llma): LLM analytics clustering temporal settings optimization 

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,6 +56,7 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
+                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -79,6 +80,7 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
+                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -95,7 +97,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
+                         AND (("pmat_email" ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/posthog/temporal/llm_analytics/trace_clustering/README.md
+++ b/posthog/temporal/llm_analytics/trace_clustering/README.md
@@ -140,7 +140,7 @@ The workflow uses **three separate activities** with independent timeouts and re
 
 **Activity 2 (Label)** - LangGraph agent:
 
-- Runs a multi-turn LangGraph agent powered by OpenAI GPT-5.1 (`gpt-5.1`)
+- Runs a multi-turn LangGraph agent powered by OpenAI GPT-5.1 (`gpt-5.2`)
 - Agent explores clusters using tools (overview, trace titles, trace details)
 - Iteratively generates distinctive labels for each cluster
 - Ensures labels differentiate clusters from each other
@@ -341,7 +341,7 @@ Key constants in `constants.py`:
 | `MIN_TRACES_FOR_CLUSTERING`         | 20                                | Minimum traces required for workflow          |
 | `COMPUTE_ACTIVITY_TIMEOUT`          | 120s                              | Clustering compute timeout                    |
 | `EMIT_ACTIVITY_TIMEOUT`             | 60s                               | Event emission timeout                        |
-| `LABELING_AGENT_MODEL`              | gpt-5.1                           | OpenAI model for labeling agent               |
+| `LABELING_AGENT_MODEL`              | gpt-5.2                           | OpenAI model for labeling agent               |
 | `LABELING_AGENT_MAX_ITERATIONS`     | 50                                | Max agent iterations before finalization      |
 | `LABELING_AGENT_RECURSION_LIMIT`    | 150                               | LangGraph recursion limit                     |
 | `LABELING_AGENT_TIMEOUT`            | 600.0                             | Full agent run timeout (seconds)              |

--- a/posthog/temporal/llm_analytics/trace_clustering/README.md
+++ b/posthog/temporal/llm_analytics/trace_clustering/README.md
@@ -117,11 +117,11 @@ graph TB
 
 The workflow uses **three separate activities** with independent timeouts and retry policies:
 
-| Activity                              | Purpose                              | Timeout | Retries | Data Size      |
-| ------------------------------------- | ------------------------------------ | ------- | ------- | -------------- |
-| `perform_clustering_compute_activity` | Fetch embeddings, HDBSCAN, distances | 120s    | 3       | ~150 KB output |
-| `generate_cluster_labels_activity`    | LLM-based cluster labeling           | 600s    | 2       | ~4 KB output   |
-| `emit_cluster_events_activity`        | Write results to ClickHouse          | 60s     | 3       | ~150 KB input  |
+| Activity                              | Purpose                              | Timeout | Heartbeat | Retries | Data Size      |
+| ------------------------------------- | ------------------------------------ | ------- | --------- | ------- | -------------- |
+| `perform_clustering_compute_activity` | Fetch embeddings, HDBSCAN, distances | 120s    | 60s       | 3       | ~150 KB output |
+| `generate_cluster_labels_activity`    | LLM-based cluster labeling           | 600s    | 120s      | 2       | ~4 KB output   |
+| `emit_cluster_events_activity`        | Write results to ClickHouse          | 60s     | 30s       | 3       | ~150 KB input  |
 
 **Benefits:**
 

--- a/posthog/temporal/llm_analytics/trace_clustering/labeling_agent/README.md
+++ b/posthog/temporal/llm_analytics/trace_clustering/labeling_agent/README.md
@@ -111,7 +111,7 @@ From `constants.py`:
 
 | Constant                         | Value     | Description                        |
 | -------------------------------- | --------- | ---------------------------------- |
-| `LABELING_AGENT_MODEL`           | `gpt-5.1` | OpenAI model for reasoning         |
+| `LABELING_AGENT_MODEL`           | `gpt-5.2` | OpenAI model for reasoning         |
 | `LABELING_AGENT_RECURSION_LIMIT` | 150       | Max graph steps before forced stop |
 | `LABELING_AGENT_TIMEOUT`         | 600.0     | LLM request timeout (seconds)      |
 

--- a/posthog/temporal/llm_analytics/trace_clustering/workflow.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/workflow.py
@@ -14,9 +14,16 @@ from posthog.temporal.llm_analytics.trace_clustering.activities import (
 from posthog.temporal.llm_analytics.trace_clustering.constants import (
     COMPUTE_ACTIVITY_RETRY_POLICY,
     COMPUTE_ACTIVITY_TIMEOUT,
+    COMPUTE_HEARTBEAT_TIMEOUT,
+    COMPUTE_SCHEDULE_TO_CLOSE_TIMEOUT,
     EMIT_ACTIVITY_RETRY_POLICY,
     EMIT_ACTIVITY_TIMEOUT,
+    EMIT_HEARTBEAT_TIMEOUT,
+    EMIT_SCHEDULE_TO_CLOSE_TIMEOUT,
     LLM_ACTIVITY_RETRY_POLICY,
+    LLM_ACTIVITY_TIMEOUT,
+    LLM_HEARTBEAT_TIMEOUT,
+    LLM_SCHEDULE_TO_CLOSE_TIMEOUT,
     NOISE_CLUSTER_ID,
     WORKFLOW_NAME,
 )
@@ -166,6 +173,8 @@ class DailyTraceClusteringWorkflow(PostHogWorkflow):
                 )
             ],
             start_to_close_timeout=COMPUTE_ACTIVITY_TIMEOUT,
+            schedule_to_close_timeout=COMPUTE_SCHEDULE_TO_CLOSE_TIMEOUT,
+            heartbeat_timeout=COMPUTE_HEARTBEAT_TIMEOUT,
             retry_policy=COMPUTE_ACTIVITY_RETRY_POLICY,
         )
 
@@ -188,7 +197,9 @@ class DailyTraceClusteringWorkflow(PostHogWorkflow):
                     batch_run_ids=compute_result.batch_run_ids,
                 )
             ],
-            start_to_close_timeout=timedelta(seconds=600),  # 10 minutes for agent run
+            start_to_close_timeout=LLM_ACTIVITY_TIMEOUT,
+            schedule_to_close_timeout=LLM_SCHEDULE_TO_CLOSE_TIMEOUT,
+            heartbeat_timeout=LLM_HEARTBEAT_TIMEOUT,
             retry_policy=LLM_ACTIVITY_RETRY_POLICY,
         )
 
@@ -222,6 +233,8 @@ class DailyTraceClusteringWorkflow(PostHogWorkflow):
                 )
             ],
             start_to_close_timeout=EMIT_ACTIVITY_TIMEOUT,
+            schedule_to_close_timeout=EMIT_SCHEDULE_TO_CLOSE_TIMEOUT,
+            heartbeat_timeout=EMIT_HEARTBEAT_TIMEOUT,
             retry_policy=EMIT_ACTIVITY_RETRY_POLICY,
         )
 

--- a/posthog/temporal/llm_analytics/trace_summarization/README.md
+++ b/posthog/temporal/llm_analytics/trace_summarization/README.md
@@ -5,7 +5,7 @@ Hourly Temporal workflow that generates summaries and embeddings of LLM traces f
 ## How It Works
 
 1. Coordinator workflow runs hourly, discovering teams dynamically (guaranteed teams + sampled teams with AI events)
-2. Per-team workflow queries recent traces (default: last 60 min, max 100 traces)
+2. Per-team workflow queries recent traces (default: last 60 min, max 15 items)
 3. For each trace: fetch data → generate text repr → call LLM → emit `$ai_trace_summary` event → queue embedding via Kafka
 4. Embeddings processed asynchronously by Rust worker, stored in `document_embeddings` table
 
@@ -107,19 +107,20 @@ Teams are discovered dynamically via `team_discovery.py`. Guaranteed teams (in `
 
 Key constants in `constants.py`:
 
-| Constant                             | Default        | Description                                 |
-| ------------------------------------ | -------------- | ------------------------------------------- |
-| `DEFAULT_MAX_ITEMS_PER_WINDOW`       | 15             | Max items per window                        |
-| `DEFAULT_BATCH_SIZE`                 | 3              | Concurrent trace processing                 |
-| `DEFAULT_MAX_CONCURRENT_TEAMS`       | 3              | Max teams to process in parallel            |
-| `DEFAULT_MODE`                       | "detailed"     | Summary detail level                        |
-| `DEFAULT_MODEL`                      | "gpt-4.1-nano" | LLM model for summarization                 |
-| `DEFAULT_WINDOW_MINUTES`             | 60             | Time window to query                        |
-| `WORKFLOW_EXECUTION_TIMEOUT_MINUTES` | 120            | Max workflow duration                       |
-| `SAMPLE_TIMEOUT_SECONDS`             | 900            | Sampling activity timeout (per attempt)     |
-| `GENERATE_SUMMARY_TIMEOUT_SECONDS`   | 300            | Summary activity timeout (per attempt)      |
-| `SAMPLE_HEARTBEAT_TIMEOUT`           | 120s           | Heartbeat window for sampling activity      |
-| `SUMMARIZE_HEARTBEAT_TIMEOUT`        | 60s            | Heartbeat window for summarization activity |
+| Constant                                | Default        | Description                                 |
+| --------------------------------------- | -------------- | ------------------------------------------- |
+| `DEFAULT_MAX_ITEMS_PER_WINDOW`          | 15             | Max items per window                        |
+| `DEFAULT_BATCH_SIZE`                    | 3              | Concurrent trace processing                 |
+| `DEFAULT_MAX_CONCURRENT_TEAMS`          | 3              | Max teams to process in parallel            |
+| `DEFAULT_MODE`                          | "detailed"     | Summary detail level                        |
+| `DEFAULT_MODEL`                         | "gpt-4.1-nano" | LLM model for summarization                 |
+| `DEFAULT_WINDOW_MINUTES`                | 60             | Time window to query                        |
+| `WORKFLOW_EXECUTION_TIMEOUT_MINUTES`    | 120            | Max per-team workflow duration              |
+| `COORDINATOR_EXECUTION_TIMEOUT_MINUTES` | 180            | Max coordinator workflow duration (3 hours) |
+| `SAMPLE_TIMEOUT_SECONDS`                | 900            | Sampling activity timeout (per attempt)     |
+| `GENERATE_SUMMARY_TIMEOUT_SECONDS`      | 300            | Summary activity timeout (per attempt)      |
+| `SAMPLE_HEARTBEAT_TIMEOUT`              | 120s           | Heartbeat window for sampling activity      |
+| `SUMMARIZE_HEARTBEAT_TIMEOUT`           | 60s            | Heartbeat window for summarization activity |
 
 Retry policies: `SAMPLE_RETRY_POLICY` (3 attempts), `SUMMARIZE_RETRY_POLICY` (4 attempts with backoff), `COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY` (2 attempts). All retry policies exclude `ValueError` and `TypeError` from retries.
 

--- a/posthog/temporal/llm_analytics/trace_summarization/README.md
+++ b/posthog/temporal/llm_analytics/trace_summarization/README.md
@@ -107,18 +107,21 @@ Teams are discovered dynamically via `team_discovery.py`. Guaranteed teams (in `
 
 Key constants in `constants.py`:
 
-| Constant                             | Default        | Description                 |
-| ------------------------------------ | -------------- | --------------------------- |
-| `DEFAULT_MAX_ITEMS_PER_WINDOW`       | 15             | Max items per window        |
-| `DEFAULT_BATCH_SIZE`                 | 3              | Concurrent trace processing |
-| `DEFAULT_MODE`                       | "detailed"     | Summary detail level        |
-| `DEFAULT_MODEL`                      | "gpt-4.1-nano" | LLM model for summarization |
-| `DEFAULT_WINDOW_MINUTES`             | 60             | Time window to query        |
-| `WORKFLOW_EXECUTION_TIMEOUT_MINUTES` | 120            | Max workflow duration       |
-| `SAMPLE_TIMEOUT_SECONDS`             | 300            | Sampling activity timeout   |
-| `GENERATE_SUMMARY_TIMEOUT_SECONDS`   | 300            | Summary activity timeout    |
+| Constant                             | Default        | Description                                 |
+| ------------------------------------ | -------------- | ------------------------------------------- |
+| `DEFAULT_MAX_ITEMS_PER_WINDOW`       | 15             | Max items per window                        |
+| `DEFAULT_BATCH_SIZE`                 | 3              | Concurrent trace processing                 |
+| `DEFAULT_MAX_CONCURRENT_TEAMS`       | 3              | Max teams to process in parallel            |
+| `DEFAULT_MODE`                       | "detailed"     | Summary detail level                        |
+| `DEFAULT_MODEL`                      | "gpt-4.1-nano" | LLM model for summarization                 |
+| `DEFAULT_WINDOW_MINUTES`             | 60             | Time window to query                        |
+| `WORKFLOW_EXECUTION_TIMEOUT_MINUTES` | 120            | Max workflow duration                       |
+| `SAMPLE_TIMEOUT_SECONDS`             | 900            | Sampling activity timeout (per attempt)     |
+| `GENERATE_SUMMARY_TIMEOUT_SECONDS`   | 300            | Summary activity timeout (per attempt)      |
+| `SAMPLE_HEARTBEAT_TIMEOUT`           | 120s           | Heartbeat window for sampling activity      |
+| `SUMMARIZE_HEARTBEAT_TIMEOUT`        | 60s            | Heartbeat window for summarization activity |
 
-Retry policies: `SAMPLE_RETRY_POLICY` (3 attempts), `SUMMARIZE_RETRY_POLICY` (2 attempts), `COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY` (2 attempts).
+Retry policies: `SAMPLE_RETRY_POLICY` (3 attempts), `SUMMARIZE_RETRY_POLICY` (4 attempts with backoff), `COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY` (2 attempts). All retry policies exclude `ValueError` and `TypeError` from retries.
 
 ## Error Handling
 

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -49,7 +49,7 @@ SUMMARIZE_SCHEDULE_TO_CLOSE_TIMEOUT = timedelta(
 # Workflow-level timeouts (in minutes)
 WORKFLOW_EXECUTION_TIMEOUT_MINUTES = 120  # Max time for single team workflow (increased with longer activity timeouts)
 COORDINATOR_EXECUTION_TIMEOUT_MINUTES = (
-    55  # Max time for coordinator, must be less than schedule interval to avoid blocking
+    180  # 3 hours - 209 teams with 3 concurrent, most finish instantly but a few hit 120-min child timeout
 )
 
 # Retry policies

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -24,9 +24,27 @@ MAX_TEXT_REPR_LENGTH = 2_000_000
 # Schedule configuration
 SCHEDULE_INTERVAL_HOURS = 1  # How often the coordinator runs
 
+# Coordinator concurrency settings
+DEFAULT_MAX_CONCURRENT_TEAMS = 3  # Max teams to process in parallel
+
 # Timeout configuration (in seconds)
 SAMPLE_TIMEOUT_SECONDS = 900  # 15 minutes for sampling query (buffer above QUERY_ASYNC 600s ClickHouse timeout)
 GENERATE_SUMMARY_TIMEOUT_SECONDS = 300  # 5 minutes per summary generation (increased for LLM API latency/rate limits)
+
+# Heartbeat timeouts - allows Temporal to detect dead workers faster than
+# waiting for the full start_to_close_timeout to expire. Activities must
+# send heartbeats within this interval or Temporal will consider them failed
+# and retry on another worker.
+SAMPLE_HEARTBEAT_TIMEOUT = timedelta(seconds=120)  # 2 minutes - sampling has long CH queries
+SUMMARIZE_HEARTBEAT_TIMEOUT = timedelta(seconds=60)  # 1 minute - LLM calls can be slow but should heartbeat regularly
+
+# Schedule-to-close timeouts - caps total time including all retry attempts,
+# backoff intervals, and queue time. Prevents runaway retries from blocking
+# the workflow indefinitely when something is fundamentally broken.
+SAMPLE_SCHEDULE_TO_CLOSE_TIMEOUT = timedelta(seconds=1800)  # 30 min total for sampling (3 attempts * 900s + backoff)
+SUMMARIZE_SCHEDULE_TO_CLOSE_TIMEOUT = timedelta(
+    seconds=900
+)  # 15 min total per summary (4 attempts * 300s + backoff, but cut off early)
 
 # Workflow-level timeouts (in minutes)
 WORKFLOW_EXECUTION_TIMEOUT_MINUTES = 120  # Max time for single team workflow (increased with longer activity timeouts)
@@ -35,7 +53,10 @@ COORDINATOR_EXECUTION_TIMEOUT_MINUTES = (
 )
 
 # Retry policies
-SAMPLE_RETRY_POLICY = RetryPolicy(maximum_attempts=3)
+SAMPLE_RETRY_POLICY = RetryPolicy(
+    maximum_attempts=3,
+    non_retryable_error_types=["ValueError", "TypeError"],
+)
 # Summarize retries with exponential backoff for rate limit handling (429s)
 # 15s initial with 2x backoff handles most rate limit scenarios
 SUMMARIZE_RETRY_POLICY = RetryPolicy(
@@ -43,6 +64,7 @@ SUMMARIZE_RETRY_POLICY = RetryPolicy(
     initial_interval=timedelta(seconds=15),
     backoff_coefficient=2.0,
     maximum_interval=timedelta(seconds=60),
+    non_retryable_error_types=["ValueError", "TypeError"],
 )
 COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY = RetryPolicy(maximum_attempts=2)
 

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -6,6 +6,9 @@ and spawns child workflows to process traces for each team.
 
 Per-team child workflows handle the case where a team has no traces
 gracefully (returning empty results).
+
+Teams are processed in parallel batches (default 3 at a time) using
+start_child_workflow + await pattern for controlled concurrency.
 """
 
 import dataclasses
@@ -13,6 +16,7 @@ from datetime import timedelta
 
 import structlog
 import temporalio
+from temporalio.workflow import ChildWorkflowHandle
 
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.llm_analytics.trace_summarization import constants
@@ -20,6 +24,7 @@ from posthog.temporal.llm_analytics.trace_summarization.constants import (
     CHILD_WORKFLOW_ID_PREFIX,
     COORDINATOR_WORKFLOW_NAME,
     DEFAULT_BATCH_SIZE,
+    DEFAULT_MAX_CONCURRENT_TEAMS,
     DEFAULT_MAX_ITEMS_PER_WINDOW,
     DEFAULT_MODE,
     DEFAULT_MODEL,
@@ -30,6 +35,7 @@ from posthog.temporal.llm_analytics.trace_summarization.constants import (
 from posthog.temporal.llm_analytics.trace_summarization.models import (
     AnalysisLevel,
     BatchSummarizationInputs,
+    BatchSummarizationResult,
     CoordinatorResult,
 )
 from posthog.temporal.llm_analytics.trace_summarization.workflow import BatchTraceSummarizationWorkflow
@@ -59,6 +65,7 @@ class BatchTraceSummarizationCoordinatorInputs:
     mode: SummarizationMode = DEFAULT_MODE
     window_minutes: int = DEFAULT_WINDOW_MINUTES
     model: str = DEFAULT_MODEL
+    max_concurrent_teams: int = DEFAULT_MAX_CONCURRENT_TEAMS
 
 
 @temporalio.workflow.defn(name=COORDINATOR_WORKFLOW_NAME)
@@ -67,6 +74,10 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
     Coordinator workflow that discovers teams dynamically and spawns child
     workflows for each team. Teams with no traces will complete quickly
     with empty results.
+
+    Teams are processed in parallel batches for controlled concurrency,
+    using start_child_workflow + await to start all workflows in a batch
+    before waiting for results.
     """
 
     @staticmethod
@@ -106,17 +117,28 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
 
         logger.info("Processing discovered teams", team_count=len(team_ids), team_ids=team_ids)
 
-        # Spawn child workflows for each team
+        # Spawn child workflows for each team with concurrency limit.
+        # Uses start_child_workflow + await pattern: start all workflows in a
+        # batch first, then await results. This runs teams in parallel within
+        # each batch instead of sequentially.
         total_items = 0
         total_summaries = 0
-        failed_teams = []
+        failed_teams: list[int] = []
+        successful_teams: list[int] = []
         child_id_prefix = (
             GENERATION_CHILD_WORKFLOW_ID_PREFIX if inputs.analysis_level == "generation" else CHILD_WORKFLOW_ID_PREFIX
         )
 
-        for team_id in team_ids:
-            try:
-                workflow_result = await temporalio.workflow.execute_child_workflow(
+        max_concurrent = inputs.max_concurrent_teams
+        for batch_start in range(0, len(team_ids), max_concurrent):
+            batch = team_ids[batch_start : batch_start + max_concurrent]
+
+            # Start all workflows in batch concurrently
+            workflow_handles: list[
+                tuple[int, ChildWorkflowHandle[BatchTraceSummarizationWorkflow, BatchSummarizationResult]]
+            ] = []
+            for team_id in batch:
+                handle = await temporalio.workflow.start_child_workflow(
                     BatchTraceSummarizationWorkflow.run,
                     BatchSummarizationInputs(
                         team_id=team_id,
@@ -130,15 +152,33 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
                     id=f"{child_id_prefix}-{team_id}-{temporalio.workflow.now().isoformat()}",
                     execution_timeout=timedelta(minutes=WORKFLOW_EXECUTION_TIMEOUT_MINUTES),
                     retry_policy=constants.COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY,
+                    # Allow child workflows to complete even if the coordinator
+                    # is cancelled (e.g. due to coordinator timeout). Prevents
+                    # wasting work already in progress.
+                    parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
                 )
+                workflow_handles.append((team_id, handle))
 
-                total_items += workflow_result.metrics.items_queried
-                total_summaries += workflow_result.metrics.summaries_generated
+            # Wait for all workflows in batch to complete
+            for team_id, handle in workflow_handles:
+                try:
+                    workflow_result: BatchSummarizationResult = await handle
+                    total_items += workflow_result.metrics.items_queried
+                    total_summaries += workflow_result.metrics.summaries_generated
+                    successful_teams.append(team_id)
 
-            except Exception as e:
-                logger.exception("Failed to process team", team_id=team_id, error=str(e))
-                failed_teams.append(team_id)
-                # Continue with other teams
+                except Exception:
+                    logger.exception("Failed to process team", team_id=team_id)
+                    failed_teams.append(team_id)
+
+        logger.info(
+            "Batch trace summarization coordinator completed",
+            teams_processed=len(team_ids),
+            teams_succeeded=len(successful_teams),
+            teams_failed=len(failed_teams),
+            total_items=total_items,
+            total_summaries=total_summaries,
+        )
 
         return CoordinatorResult(
             teams_processed=len(team_ids),

--- a/posthog/temporal/llm_analytics/trace_summarization/summarization.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/summarization.py
@@ -11,6 +11,7 @@ from posthog.hogql_queries.ai.trace_query_runner import TraceQueryRunner
 from posthog.models.event.util import create_event
 from posthog.models.team import Team
 from posthog.sync import database_sync_to_async
+from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.llm_analytics.trace_summarization import constants
 from posthog.temporal.llm_analytics.trace_summarization.models import SummarizationActivityResult
 
@@ -149,59 +150,60 @@ async def generate_and_save_summary_activity(
             product=LLM_TRACES_SUMMARIES_PRODUCT,
         )
 
-    # Fetch trace data and format text representation
-    result = await database_sync_to_async(_fetch_trace_and_format, thread_sensitive=False)(
-        trace_id, team_id, window_start, window_end, max_length
-    )
-
-    # Handle trace not found in window
-    if result is None:
-        logger.warning(
-            "Skipping trace - not found in time window",
-            trace_id=trace_id,
-            window_start=window_start,
-            window_end=window_end,
-        )
-        return SummarizationActivityResult(
-            trace_id=trace_id,
-            success=False,
-            skipped=True,
-            skip_reason="trace_not_found",
+    async with Heartbeater():
+        # Fetch trace data and format text representation
+        result = await database_sync_to_async(_fetch_trace_and_format, thread_sensitive=False)(
+            trace_id, team_id, window_start, window_end, max_length
         )
 
-    _trace, hierarchy, text_repr, team = result
+        # Handle trace not found in window
+        if result is None:
+            logger.warning(
+                "Skipping trace - not found in time window",
+                trace_id=trace_id,
+                window_start=window_start,
+                window_end=window_end,
+            )
+            return SummarizationActivityResult(
+                trace_id=trace_id,
+                success=False,
+                skipped=True,
+                skip_reason="trace_not_found",
+            )
 
-    # Generate summary using LLM via gateway
-    # Note: text_repr is automatically reduced to fit LLM context if needed (see format_trace_text_repr)
-    mode_enum = SummarizationMode(mode)
-    model_enum = OpenAIModel(model) if model else None
+        _trace, hierarchy, text_repr, team = result
 
-    summary_result = await database_sync_to_async(summarize, thread_sensitive=False)(
-        text_repr=text_repr,
-        team_id=team_id,
-        mode=mode_enum,
-        model=model_enum,
-        user_id=f"temporal-workflow-team-{team_id}",
-    )
+        # Generate summary using LLM via gateway
+        # Note: text_repr is automatically reduced to fit LLM context if needed (see format_trace_text_repr)
+        mode_enum = SummarizationMode(mode)
+        model_enum = OpenAIModel(model) if model else None
 
-    # Save event to ClickHouse immediately
-    await database_sync_to_async(_save_summary_event, thread_sensitive=False)(
-        summary_result, hierarchy, text_repr, team
-    )
-
-    # Request embedding by sending to Kafka
-    embedding_requested = False
-    embedding_request_error = None
-    try:
-        await database_sync_to_async(_embed_summary, thread_sensitive=False)(summary_result, team)
-        embedding_requested = True
-    except Exception as e:
-        embedding_request_error = str(e)
-        logger.exception(
-            "Failed to request embedding for trace summary",
-            trace_id=trace_id,
-            error=embedding_request_error,
+        summary_result = await database_sync_to_async(summarize, thread_sensitive=False)(
+            text_repr=text_repr,
+            team_id=team_id,
+            mode=mode_enum,
+            model=model_enum,
+            user_id=f"temporal-workflow-team-{team_id}",
         )
+
+        # Save event to ClickHouse immediately
+        await database_sync_to_async(_save_summary_event, thread_sensitive=False)(
+            summary_result, hierarchy, text_repr, team
+        )
+
+        # Request embedding by sending to Kafka
+        embedding_requested = False
+        embedding_request_error = None
+        try:
+            await database_sync_to_async(_embed_summary, thread_sensitive=False)(summary_result, team)
+            embedding_requested = True
+        except Exception as e:
+            embedding_request_error = str(e)
+            logger.exception(
+                "Failed to request embedding for trace summary",
+                trace_id=trace_id,
+                error=embedding_request_error,
+            )
 
     return SummarizationActivityResult(
         trace_id=trace_id,

--- a/posthog/temporal/llm_analytics/trace_summarization/workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/workflow.py
@@ -29,7 +29,11 @@ from posthog.temporal.llm_analytics.trace_summarization.constants import (
     DEFAULT_WINDOW_OFFSET_MINUTES,
     GENERATE_SUMMARY_TIMEOUT_SECONDS,
     MAX_TEXT_REPR_LENGTH,
+    SAMPLE_HEARTBEAT_TIMEOUT,
+    SAMPLE_SCHEDULE_TO_CLOSE_TIMEOUT,
     SAMPLE_TIMEOUT_SECONDS,
+    SUMMARIZE_HEARTBEAT_TIMEOUT,
+    SUMMARIZE_SCHEDULE_TO_CLOSE_TIMEOUT,
     WORKFLOW_NAME,
 )
 from posthog.temporal.llm_analytics.trace_summarization.generation_summarization import (
@@ -110,6 +114,8 @@ class BatchTraceSummarizationWorkflow(PostHogWorkflow):
                     ],
                     activity_id=f"summarize-gen-{item.generation_id}-{idx}",
                     start_to_close_timeout=timedelta(seconds=GENERATE_SUMMARY_TIMEOUT_SECONDS),
+                    schedule_to_close_timeout=SUMMARIZE_SCHEDULE_TO_CLOSE_TIMEOUT,
+                    heartbeat_timeout=SUMMARIZE_HEARTBEAT_TIMEOUT,
                     retry_policy=constants.SUMMARIZE_RETRY_POLICY,
                 )
             else:
@@ -129,6 +135,8 @@ class BatchTraceSummarizationWorkflow(PostHogWorkflow):
                     ],
                     activity_id=f"summarize-{item.trace_id}-{idx}",
                     start_to_close_timeout=timedelta(seconds=GENERATE_SUMMARY_TIMEOUT_SECONDS),
+                    schedule_to_close_timeout=SUMMARIZE_SCHEDULE_TO_CLOSE_TIMEOUT,
+                    heartbeat_timeout=SUMMARIZE_HEARTBEAT_TIMEOUT,
                     retry_policy=constants.SUMMARIZE_RETRY_POLICY,
                 )
 
@@ -178,6 +186,8 @@ class BatchTraceSummarizationWorkflow(PostHogWorkflow):
             sample_items_in_window_activity,
             inputs_with_window,
             start_to_close_timeout=timedelta(seconds=SAMPLE_TIMEOUT_SECONDS),
+            schedule_to_close_timeout=SAMPLE_SCHEDULE_TO_CLOSE_TIMEOUT,
+            heartbeat_timeout=SAMPLE_HEARTBEAT_TIMEOUT,
             retry_policy=constants.SAMPLE_RETRY_POLICY,
         )
         metrics.items_queried = len(items)


### PR DESCRIPTION
## Problem

The existing LLM analytics Temporal workflows for trace summarization and clustering had several issues impacting their reliability, scalability, and resource efficiency:

1.  **Sequential Processing:** The summarization coordinator processed child workflows (per team) sequentially, leading to long execution times and exceeding workflow timeouts for multiple teams.
2.  **Missing Timeouts & Heartbeats:** Activities lacked `heartbeat_timeout` and `schedule_to_close_timeout` settings, causing delays in detecting failed workers and potentially allowing runaway retries.
3.  **Orchestration Logic:** Child workflows in summarization lacked `parent_close_policy`, leading to wasted work if the coordinator timed out.
4.  **Inconsistent Constants:** A constant for LLM activity timeout in clustering was mismatched between `constants.py` and `workflow.py`.
5.  **Inefficient Retries:** Retry policies did not exclude non-retryable error types (`ValueError`, `TypeError`), wasting retry attempts on unrecoverable programming errors.
6.  **Coordinator timeout too aggressive:** The 55-minute coordinator timeout (from #47045) caused all hourly runs to `TIMED_OUT` in production — the coordinator processes ~209 teams and a few hit 120-min child workflow timeouts, making sequential runs take 8+ hours.

These issues prevented the workflows from running smoothly, scaling effectively, and adhering to Temporal best practices.

## Changes

This PR introduces several improvements to enhance the robustness and scalability of the LLM analytics Temporal workflows:

*   **Parallel Child Workflows (Summarization):** The summarization coordinator now processes teams in parallel batches (default 3 concurrent teams) using `start_child_workflow` and `await` patterns.
*   **Parent Close Policy:** Added `parent_close_policy=ABANDON` to summarization child workflows to prevent work loss if the coordinator is cancelled.
*   **Coordinator Timeout Bump:** Increased `COORDINATOR_EXECUTION_TIMEOUT_MINUTES` from 55 to 180 (3 hours) based on production data showing ~209 teams with parallel batching of 3.
*   **Activity Timeouts:** Introduced `heartbeat_timeout` and `schedule_to_close_timeout` for all activities in both summarization and clustering workflows, allowing for faster failure detection and capping total execution time.
*   **Heartbeater Utility:** Integrated the `Heartbeater` utility into all long-running activities to ensure regular heartbeats are sent to Temporal.
*   **Retry Policy Refinements:** Added `non_retryable_error_types=["ValueError", "TypeError"]` to all retry policies to prevent retrying unrecoverable errors.
*   **Constant Correction (Clustering):** Corrected the `LLM_ACTIVITY_TIMEOUT` constant in clustering from 300s to 600s and ensured its consistent use.
*   **Test Fixes:** Added `_noop_heartbeater` mocks to activity tests that call activities directly without Temporal context (required after adding `Heartbeater` to activities).
*   **README Updates:** Fixed stale values in workflow READMEs (max items, coordinator timeout, labeling agent model version).

## Context

This follows #47045 which added `BUFFER_ONE` overlap policy and initial timeouts. After deploying #47045, we observed that the 55-minute coordinator timeout was too aggressive — coordinators were timing out every run. This PR addresses that by both parallelizing team processing (reducing wall time from ~8h to ~2.5h) and bumping the timeout to 180 minutes.

## How did you test this code?

*   Ran all 152 LLMA temporal tests — all passing
*   Ran ruff check and format — all clean
*   Production observation confirmed the 55-min timeout was causing `TIMED_OUT` on every coordinator run

## Publish to changelog?

No