### PR TITLE
fix(surveys): add closeButtonColor to survey appearance

### DIFF
--- a/frontend/src/queries/schema/schema-surveys.ts
+++ b/frontend/src/queries/schema/schema-surveys.ts
@@ -89,6 +89,7 @@ export interface SurveyDisplayConditionsSchema {
 export interface SurveyAppearanceSchema {
     backgroundColor?: string
     borderColor?: string
+    closeButtonColor?: string
     position?: SurveyPosition
     tabPosition?: SurveyTabPosition
     whiteLabel?: boolean

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
@@ -245,6 +245,13 @@ export function SurveyColorsAppearance({
                     placeholder="Leave empty for auto-contrast"
                 />
                 <SurveyAppearanceInput
+                    value={appearance.closeButtonColor}
+                    onChange={(closeButtonColor) => onAppearanceChange({ closeButtonColor })}
+                    error={validationErrors?.closeButtonColor}
+                    label="Close button color"
+                    placeholder="Leave empty for auto-contrast"
+                />
+                <SurveyAppearanceInput
                     value={appearance.borderColor}
                     onChange={(borderColor) => onAppearanceChange({ borderColor })}
                     error={validationErrors?.borderColor}

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -145,6 +145,7 @@ describe('survey utils', () => {
             const input: SurveyAppearance = {
                 backgroundColor: 'ff0000',
                 borderColor: '00ff00',
+                closeButtonColor: 'aabbcc',
                 ratingButtonActiveColor: '0000ff',
                 ratingButtonColor: 'ffffff',
                 submitButtonColor: '000000',
@@ -156,6 +157,7 @@ describe('survey utils', () => {
 
             expect(result?.backgroundColor).toBe('#ff0000')
             expect(result?.borderColor).toBe('#00ff00')
+            expect(result?.closeButtonColor).toBe('#aabbcc')
             expect(result?.ratingButtonActiveColor).toBe('#0000ff')
             expect(result?.ratingButtonColor).toBe('#ffffff')
             expect(result?.submitButtonColor).toBe('#000000')

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -174,6 +174,7 @@ export function sanitizeSurveyAppearance(
         shuffleQuestions: isPartialResponsesEnabled ? false : appearance.shuffleQuestions,
         backgroundColor: sanitizeColor(appearance.backgroundColor),
         borderColor: sanitizeColor(appearance.borderColor),
+        closeButtonColor: sanitizeColor(appearance.closeButtonColor),
         ratingButtonActiveColor: sanitizeColor(appearance.ratingButtonActiveColor),
         ratingButtonColor: sanitizeColor(appearance.ratingButtonColor),
         submitButtonColor: sanitizeColor(appearance.submitButtonColor),

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -68,6 +68,7 @@ export function validateSurveyAppearance(
         }),
         submitButtonColor: validateCSSProperty('background-color', appearance.submitButtonColor),
         submitButtonTextColor: validateCSSProperty('color', appearance.submitButtonTextColor),
+        closeButtonColor: validateCSSProperty('color', appearance.closeButtonColor),
         maxWidth: validateCSSProperty('width', appearance.maxWidth),
         boxPadding: validateCSSProperty('padding', appearance.boxPadding),
         boxShadow: validateCSSProperty('box-shadow', appearance.boxShadow),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3602,6 +3602,8 @@ export interface SurveyAppearance {
     backgroundColor?: string
     // Optional override for main survey text color. If not set, auto-calculated from backgroundColor.
     textColor?: string
+    // Optional override for close button (X) color. If not set, auto-calculated from backgroundColor.
+    closeButtonColor?: string
     submitButtonColor?: string
     // TODO: remove submitButtonText in favor of buttonText once it's more deprecated
     submitButtonText?: string

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -6404,6 +6404,7 @@ class SurveyAppearanceSchema(BaseModel):
     borderColor: str | None = None
     buttonColor: str | None = None
     buttonTextColor: str | None = None
+    closeButtonColor: str | None = None
     inputBackground: str | None = None
     inputTextColor: str | None = None
     maxWidth: str | None = None

--- a/services/mcp/src/schema/surveys.ts
+++ b/services/mcp/src/schema/surveys.ts
@@ -338,6 +338,7 @@ const SurveyAppearance = z.object({
     backgroundColor: z.string().optional(),
     submitButtonColor: z.string().optional(),
     textColor: z.string().optional(), // deprecated, use auto contrast text color instead
+    closeButtonColor: z.string().optional(), // Optional override for close button (X) color
     submitButtonText: z.string().optional(),
     submitButtonTextColor: z.string().optional(),
     descriptionTextColor: z.string().optional(),


### PR DESCRIPTION
## Problem

Fixes #46074

The survey close button (X) color is currently tied to the text color. When users configure a dark background with white text, the close button becomes invisible because it's also white on a white/light-contrasting area.

## Solution

Added a new `closeButtonColor` property to the survey appearance settings, allowing users to customize the close button color independently from the text color.

### Changes
- Added `closeButtonColor` to `SurveyAppearance` type in frontend types
- Added to survey appearance schemas (frontend + Python + MCP)
- Added UI input field for 'Close button color' in survey appearance settings
- Added sanitization for the new color property
- Added test coverage for the new property

### Note
This PR adds the backend/frontend configuration. For the color to actually be applied when rendering surveys, `posthog-js` will need a companion update to read and apply this new CSS variable. I can submit that PR as a follow-up once this is reviewed.

## Screenshots
The new 'Close button color' field appears in the survey appearance settings with a placeholder 'Leave empty for auto-contrast'.