### PR TITLE
fix(dwh): doit handle invalid report names

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,6 +56,7 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
+                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -79,6 +80,7 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
+                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -95,7 +97,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
+                         AND (("pmat_email" ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/posthog/temporal/data_imports/sources/doit/doit.py
+++ b/posthog/temporal/data_imports/sources/doit/doit.py
@@ -57,7 +57,18 @@ def doit_list_reports(config: DoItSourceConfig) -> list[tuple[str, str]]:
 
     reports = res.json()["reports"]
 
-    return [(NamingConvention().normalize_identifier(report["reportName"]), report["id"]) for report in reports]
+    result = []
+    for report in reports:
+        report_name = report.get("reportName") or ""
+        if not report_name.strip():
+            continue
+        try:
+            normalized = NamingConvention().normalize_identifier(report_name)
+            result.append((normalized, report["id"]))
+        except ValueError:
+            continue
+
+    return result
 
 
 def append_primary_key(row: dict[str, Any]) -> dict[str, Any]:

--- a/posthog/temporal/data_imports/sources/doit/doit.py
+++ b/posthog/temporal/data_imports/sources/doit/doit.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 
 import pyarrow as pa
 import requests
+import structlog
 from dateutil import parser
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 from structlog.types import FilteringBoundLogger
@@ -50,7 +51,10 @@ def build_pyarrow_schema(schema: dict[str, str]) -> pa.Schema:
     return pa.schema(fields)
 
 
-def doit_list_reports(config: DoItSourceConfig) -> list[tuple[str, str]]:
+def doit_list_reports(config: DoItSourceConfig, logger: Optional[FilteringBoundLogger] = None) -> list[tuple[str, str]]:
+    if logger is None:
+        logger = structlog.get_logger(__name__)
+
     res = requests.get(
         "https://api.doit.com/analytics/v1/reports", headers={"Authorization": f"Bearer {config.api_key}"}
     )
@@ -60,12 +64,15 @@ def doit_list_reports(config: DoItSourceConfig) -> list[tuple[str, str]]:
     result = []
     for report in reports:
         report_name = report.get("reportName") or ""
+        report_id = report.get("id", "unknown")
         if not report_name.strip():
+            logger.warning("Skipping DoIt report with empty name", report_id=report_id)
             continue
         try:
             normalized = NamingConvention().normalize_identifier(report_name)
             result.append((normalized, report["id"]))
         except ValueError:
+            logger.warning("Skipping DoIt report with invalid name", report_id=report_id, report_name=report_name)
             continue
 
     return result
@@ -92,7 +99,7 @@ def doit_source(
     db_incremental_field_last_value: Optional[Any],
     should_use_incremental_field: bool = False,
 ) -> SourceResponse:
-    all_reports = doit_list_reports(config)
+    all_reports = doit_list_reports(config, logger=logger)
     selected_reports = [id for name, id in all_reports if name == report_name]
     if len(selected_reports) == 0:
         raise Exception("Report no longer exists")


### PR DESCRIPTION
## Changes

- We have an invalid report with an empty string as the name. Our current implementation will fail if that happens. Handle this correctly.

https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/01983179-80c9-0000-4bbd-da8a1488fdb2-2026-02-06T07%3A14%3A56Z/019c31cd-cdb6-7a84-b670-1a0de373c551/history

## Publish to changelog?

no
