### PR TITLE
fix(tabs): instrument

### DIFF
--- a/frontend/src/layout/scenes/SceneTabContextMenu.tsx
+++ b/frontend/src/layout/scenes/SceneTabContextMenu.tsx
@@ -114,7 +114,7 @@ export function SceneTabContextMenu({ tab, children, onConfigurePinnedTabs }: Sc
                     )}
                     <ContextMenuSeparator />
                     <ContextMenuItem asChild>
-                        <ButtonPrimitive menuItem onClick={() => removeTab(tab)}>
+                        <ButtonPrimitive menuItem onClick={() => removeTab(tab, { source: 'context_menu' })}>
                             <IconX /> Close tab <KeyboardShortcut command option w />
                         </ButtonPrimitive>
                     </ContextMenuItem>

--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -125,7 +125,8 @@ export function SceneTabs(): JSX.Element {
                                     const currentPath = router.values.location.pathname
                                     // If on /sql route, open a new /sql tab, otherwise default to /search
                                     const isSqlRoute = currentPath.endsWith('/sql')
-                                    newTab(isSqlRoute ? '/sql' : null)
+                                    const source = e.detail === 0 ? 'keyboard_shortcut' : 'new_tab_button'
+                                    newTab(isSqlRoute ? '/sql' : null, { source })
                                 }}
                                 tooltip="New tab"
                                 tooltipCloseDelayMs={0}
@@ -250,7 +251,8 @@ function SceneTabComponent({ tab, className, isDragging, containerClassName, ind
                             onClick={(e) => {
                                 e.stopPropagation()
                                 e.preventDefault()
-                                removeTab(tab)
+                                const source = e.detail === 0 ? 'keyboard_shortcut' : 'close_button'
+                                removeTab(tab, { source })
                             }}
                             tooltip={!tab.active ? 'Close tab' : 'Close active tab'}
                             tooltipCloseDelayMs={0}
@@ -276,7 +278,7 @@ function SceneTabComponent({ tab, className, isDragging, containerClassName, ind
                         e.stopPropagation()
                         e.preventDefault()
                         if (e.button === 1 && !isDragging && canRemoveTab) {
-                            removeTab(tab)
+                            removeTab(tab, { source: 'middle_click' })
                         }
                     }}
                     onDoubleClick={(e) => {

--- a/frontend/src/lib/utils/newInternalTab.tsx
+++ b/frontend/src/lib/utils/newInternalTab.tsx
@@ -2,9 +2,9 @@ import { getContext } from 'kea'
 
 export const NEW_INTERNAL_TAB = 'NEW_INTERNAL_TAB'
 
-export function newInternalTab(path?: string): void {
+export function newInternalTab(path?: string, source: 'internal_link' | 'unknown' = 'internal_link'): void {
     getContext().store.dispatch({
         type: NEW_INTERNAL_TAB,
-        payload: { path },
+        payload: { path, source },
     })
 }

--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -313,7 +313,7 @@ export const MaxInstance = React.memo(function MaxInstance({
                                 sideIcon={<IconOpenSidebar />}
                                 onClick={() => {
                                     openSidePanelMax(conversationId ?? undefined)
-                                    closeTabId(tabId)
+                                    closeTabId(tabId, { source: 'open_in_side_panel' })
                                 }}
                             >
                                 Open in side panel

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -52,8 +52,8 @@ import { userLogic } from './userLogic'
 const TAB_STATE_KEY = 'scene-tabs-state'
 const PINNED_TAB_STATE_KEY = 'scene-tabs-pinned-state'
 
-type TabOpenSource = 'internal_link' | 'keyboard_shortcut' | 'new_tab_button' | 'unknown'
-type TabCloseSource =
+export type TabOpenSource = 'internal_link' | 'keyboard_shortcut' | 'new_tab_button' | 'unknown'
+export type TabCloseSource =
     | 'close_button'
     | 'context_menu'
     | 'keyboard_shortcut'


### PR DESCRIPTION
## Problem

We don't know how many people use tabs.

## Changes

- Adds a `tab opened` event if a tab is opened (no matter if "+", keyboard shortcut or "open in new tab" button)
- Adds a `tab closed` event if a tab is closed (no matter if "x" or keyboard shortcur)
- Adds a `tab_count` super property to events
- No events on back/forward button presses

## How did you test this code?

Made sure the events fired when written above, and that the `tab_count` property was present on other events.