### PR TITLE
chore(batch-exports): Put earliest backfills behind a FF

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -188,6 +188,7 @@ export const FEATURE_FLAGS = {
     GAME_CENTER: 'game-center', // owner: everybody, this is just internal for now
     HEDGEHOG_SKIN_SPIDERHOG: 'hedgehog-skin-spiderhog', // owner: #team-web-analytics, used to reward beta users for web analytics
     HIGH_FREQUENCY_BATCH_EXPORTS: 'high-frequency-batch-exports', // owner: #team-batch-exports, allow batch exports to be run every 5min
+    BATCH_EXPORT_EARLIEST_BACKFILL: 'batch-export-earliest-backfill', // owner: #team-batch-exports, allow backfilling from beginning of time
     METALYTICS: 'metalytics', // owner: #team-platform-features, used to allow companies to see (meta) analytics on access to a specific page
     REPLAY_EXCLUDE_FROM_HIDE_RECORDINGS_MENU: 'replay-exclude-from-hide-recordings-menu', // owner: #team-replay, used to exclude what other people are seeing in Replay
     SELF_SERVE_CREDIT_OVERRIDE: 'self-serve-credit-override', // owner: #team-platform-features, used to allow users to self-serve credits even when they don't qualify

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportBackfillModal.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportBackfillModal.tsx
@@ -5,6 +5,7 @@ import { IconInfo } from '@posthog/icons'
 import { Tooltip } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
 import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
@@ -23,6 +24,7 @@ import { formatHourString } from './utils'
 
 export function BatchExportBackfillModal({ id }: BatchExportBackfillModalLogicProps): JSX.Element {
     const logic = batchExportBackfillModalLogic({ id })
+    const earliestBackfillEnabled = useFeatureFlag('BATCH_EXPORT_EARLIEST_BACKFILL')
 
     const {
         batchExportConfig,
@@ -119,7 +121,8 @@ export function BatchExportBackfillModal({ id }: BatchExportBackfillModalLogicPr
                     }
                 </LemonField>
 
-                {batchExportConfig?.model == 'persons' ? (
+                {/* Note: This is behind a feature flag while we improve backfilling behavior. */}
+                {earliestBackfillEnabled && batchExportConfig?.model == 'persons' ? (
                     <LemonField name="earliest_backfill">
                         {({ onChange }) => (
                             <LemonCheckbox

--- a/posthog/api/test/batch_exports/operations.py
+++ b/posthog/api/test/batch_exports/operations.py
@@ -154,7 +154,7 @@ def list_batch_exports_ok(client: TestClient, team_id: int):
     return response.json()
 
 
-def backfill_batch_export(client: TestClient, team_id: int, batch_export_id: str, start_at: str, end_at: str):
+def backfill_batch_export(client: TestClient, team_id: int, batch_export_id: str, start_at: str | None, end_at: str):
     """Create a backfill for a BatchExport."""
     url = f"/api/projects/{team_id}/batch_exports/{batch_export_id}/backfills"
 

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -1135,6 +1135,21 @@ def create_backfill(
     Returns:
         The backfill workflow ID
     """
+    if start_at_input is None:
+        if not posthoganalytics.feature_enabled(
+            "batch-export-earliest-backfill",
+            str(team.uuid),
+            groups={"organization": str(team.organization.id)},
+            group_properties={
+                "organization": {
+                    "id": str(team.organization.id),
+                    "created_at": team.organization.created_at,
+                }
+            },
+            send_feature_flag_events=False,
+        ):
+            raise ValidationError("Backfilling from the beginning of time is not enabled for this team.")
+
     temporal = sync_connect()
 
     if start_at_input is not None:

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -1135,6 +1135,8 @@ def create_backfill(
     Returns:
         The backfill workflow ID
     """
+    # Currently, backfills from the beginning of time usually fail due to us hitting ClickHouse memory limits.
+    # Therefore, this feature is behind a feature flag while we improve backfilling behavior.
     if start_at_input is None:
         if not posthoganalytics.feature_enabled(
             "batch-export-earliest-backfill",


### PR DESCRIPTION
## Problem

Currently we support backfills without a start date for the persons model, which will create a single backfill that queries all persons data without a start date. The problem with this is that this usually queries too much data and we run into ClickHouse memory limits.

## Changes

- Put earliest backfills behind a FF since they are not working as expected
- We want to improve the backfilling process, so we can re-evaluate this functionality later

## How did you test this code?

- Added unit tests for the API
- Tested stack locally (with and without FF enabled)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
