### PR TITLE
feat(ai): expose activity logs in Posthog AI read_data tool

### DIFF
--- a/ee/hogai/chat_agent/prompts/base.py
+++ b/ee/hogai/chat_agent/prompts/base.py
@@ -61,6 +61,7 @@ Created data is used by the user on the PostHog's website to perform business ac
 - Feature flags – feature flags that the user creates to control the feature rollout in their product.
 - Notebooks – notebooks that the user creates to perform business analysis.
 - Error tracking issues – issues that the user creates to track errors in their product.
+- Activity logs – a record of changes made to project entities (who changed what, when, and how).
 
 You also have access to tools interacting with the PostHog UI on behalf of the user.
 

--- a/ee/hogai/context/activity_log/__init__.py
+++ b/ee/hogai/context/activity_log/__init__.py
@@ -1,0 +1,3 @@
+from .context import ActivityLogContext
+
+__all__ = ["ActivityLogContext"]

--- a/ee/hogai/context/activity_log/context.py
+++ b/ee/hogai/context/activity_log/context.py
@@ -65,6 +65,12 @@ class ActivityLogContext:
         limit: int = 20,
         offset: int = 0,
     ) -> str:
+        warnings: list[str] = []
+        if after and self._parse_datetime(after) is None:
+            warnings.append(f"Warning: 'after' filter '{after}' is not a valid ISO 8601 datetime and was ignored.")
+        if before and self._parse_datetime(before) is None:
+            warnings.append(f"Warning: 'before' filter '{before}' is not a valid ISO 8601 datetime and was ignored.")
+
         entries, total_count = await self._fetch_entries(
             scope=scope,
             activity=activity,
@@ -75,7 +81,7 @@ class ActivityLogContext:
             limit=limit,
             offset=offset,
         )
-        return self._format_entries(
+        result = self._format_entries(
             entries,
             scope=scope,
             user_email=user_email,
@@ -83,6 +89,9 @@ class ActivityLogContext:
             offset=offset,
             limit=limit,
         )
+        if warnings:
+            return "\n".join(warnings) + "\n\n" + result
+        return result
 
     @staticmethod
     def _parse_datetime(value: str) -> datetime | None:

--- a/ee/hogai/context/activity_log/context.py
+++ b/ee/hogai/context/activity_log/context.py
@@ -1,0 +1,184 @@
+import json
+from typing import Any
+
+from django.db.models import QuerySet
+
+from posthog.api.advanced_activity_logs.utils import get_activity_log_lookback_restriction
+from posthog.api.advanced_activity_logs.viewset import apply_organization_scoped_filter
+from posthog.models import Team, User
+from posthog.models.activity_logging.activity_log import ActivityLog, apply_activity_visibility_restrictions
+from posthog.sync import database_sync_to_async
+
+from .prompts import ACTIVITY_LOG_CONTEXT_TEMPLATE, ACTIVITY_LOG_ENTRY_TEMPLATE, ACTIVITY_LOG_NO_RESULTS
+
+MAX_VALUE_LENGTH = 200
+
+
+class ActivityLogContext:
+    def __init__(
+        self,
+        team: Team,
+        user: User,
+    ):
+        self._team = team
+        self._user = user
+
+    async def fetch_and_format(
+        self,
+        *,
+        scope: str | None = None,
+        item_id: str | None = None,
+        user_email: str | None = None,
+        limit: int = 20,
+    ) -> str:
+        entries = await self._fetch_entries(
+            scope=scope,
+            item_id=item_id,
+            user_email=user_email,
+            limit=limit,
+        )
+        return self._format_entries(
+            entries,
+            scope=scope,
+            user_email=user_email,
+        )
+
+    @database_sync_to_async
+    def _fetch_entries(
+        self,
+        *,
+        scope: str | None = None,
+        item_id: str | None = None,
+        user_email: str | None = None,
+        limit: int = 20,
+    ) -> list[ActivityLog]:
+        queryset: QuerySet[ActivityLog] = ActivityLog.objects.select_related("user").order_by("-created_at")
+
+        queryset = apply_organization_scoped_filter(
+            queryset,
+            bool(self._team.receive_org_level_activity_logs),
+            self._team.id,
+            self._team.organization_id,
+        )
+
+        lookback_date = get_activity_log_lookback_restriction(self._team.organization)
+        if lookback_date:
+            queryset = queryset.filter(created_at__gte=lookback_date)
+
+        queryset = apply_activity_visibility_restrictions(queryset, self._user)
+
+        if scope:
+            queryset = queryset.filter(scope=scope)
+        if item_id:
+            queryset = queryset.filter(item_id=item_id)
+        if user_email:
+            queryset = queryset.filter(user__email=user_email)
+
+        limit = min(max(limit, 1), 50)
+        return list(queryset[:limit])
+
+    def _format_entries(
+        self,
+        entries: list[ActivityLog],
+        *,
+        scope: str | None = None,
+        user_email: str | None = None,
+    ) -> str:
+        if not entries:
+            return ACTIVITY_LOG_NO_RESULTS
+
+        formatted_entries: list[str] = []
+        for entry in entries:
+            formatted_entries.append(self._format_single_entry(entry))
+
+        scope_filter = f" for scope={scope}" if scope else ""
+        user_filter = f" by {user_email}" if user_email else ""
+
+        return ACTIVITY_LOG_CONTEXT_TEMPLATE.format(
+            count=len(formatted_entries),
+            scope_filter=scope_filter,
+            user_filter=user_filter,
+            entries="\n".join(formatted_entries),
+        )
+
+    def _format_single_entry(self, entry: ActivityLog) -> str:
+        timestamp = entry.created_at.strftime("%Y-%m-%d %H:%M UTC")
+
+        user_attribution = self._format_user_attribution(entry)
+        item_name = self._extract_item_name(entry)
+        changes = self._format_changes(entry)
+
+        return ACTIVITY_LOG_ENTRY_TEMPLATE.format(
+            timestamp=timestamp,
+            scope=entry.scope,
+            activity=entry.activity,
+            item_name=item_name,
+            user_attribution=user_attribution,
+            changes=changes,
+        )
+
+    def _format_user_attribution(self, entry: ActivityLog) -> str:
+        if entry.is_system:
+            return " | by System"
+        if entry.user:
+            name = entry.user.first_name or entry.user.email
+            suffix = " (impersonated)" if entry.was_impersonated else ""
+            return f" | by {name}{suffix}"
+        return ""
+
+    def _extract_item_name(self, entry: ActivityLog) -> str:
+        detail = entry.detail
+        if not detail or not isinstance(detail, dict):
+            return entry.item_id or "(unknown)"
+
+        name = detail.get("name")
+        if name:
+            return str(name)
+
+        short_id = detail.get("short_id")
+        if short_id:
+            return str(short_id)
+
+        return entry.item_id or "(unknown)"
+
+    def _format_changes(self, entry: ActivityLog) -> str:
+        detail = entry.detail
+        if not detail or not isinstance(detail, dict):
+            return ""
+
+        changes_data = detail.get("changes")
+        if not changes_data or not isinstance(changes_data, list):
+            return ""
+
+        change_lines: list[str] = []
+        for change in changes_data:
+            if not isinstance(change, dict):
+                continue
+
+            field = change.get("field", "unknown")
+            action = change.get("action", "changed")
+            before = self._truncate_value(change.get("before"))
+            after = self._truncate_value(change.get("after"))
+
+            if action == "created":
+                change_lines.append(f"  - {field}: set to {after}")
+            elif action == "deleted":
+                change_lines.append(f"  - {field}: removed (was {before})")
+            else:
+                change_lines.append(f"  - {field}: {before} -> {after}")
+
+        if not change_lines:
+            return ""
+        return "\n" + "\n".join(change_lines)
+
+    def _truncate_value(self, value: Any) -> str:
+        if value is None:
+            return "(none)"
+        if isinstance(value, dict | list):
+            text = json.dumps(value, default=str)
+        else:
+            text = str(value)
+
+        if len(text) > MAX_VALUE_LENGTH:
+            return text[:MAX_VALUE_LENGTH] + "..."
+        return text

--- a/ee/hogai/context/activity_log/context.py
+++ b/ee/hogai/context/activity_log/context.py
@@ -16,7 +16,7 @@ from posthog.models.activity_logging.activity_log import (
 )
 from posthog.sync import database_sync_to_async
 
-from .prompts import (
+from ee.hogai.context.activity_log.prompts import (
     ACTIVITY_LOG_CONTEXT_TEMPLATE,
     ACTIVITY_LOG_ENTRY_TEMPLATE,
     ACTIVITY_LOG_NO_RESULTS,
@@ -131,11 +131,11 @@ class ActivityLogContext:
         if scope:
             queryset = queryset.filter(scope=scope)
         if activity:
-            queryset = queryset.filter(activity=activity)
+            queryset = queryset.filter(activity__iexact=activity)
         if item_id:
             queryset = queryset.filter(item_id=item_id)
         if user_email:
-            queryset = queryset.filter(user__email=user_email)
+            queryset = queryset.filter(user__email__iexact=user_email)
         if after:
             parsed = self._parse_datetime(after)
             if parsed:
@@ -189,7 +189,7 @@ class ActivityLogContext:
         )
 
     def _format_single_entry(self, entry: ActivityLog) -> str:
-        timestamp = entry.created_at.strftime("%Y-%m-%d %H:%M UTC")
+        timestamp = entry.created_at.isoformat()
 
         user_attribution = self._format_user_attribution(entry)
         item_name = self._extract_item_name(entry)

--- a/ee/hogai/context/activity_log/context.py
+++ b/ee/hogai/context/activity_log/context.py
@@ -27,12 +27,14 @@ class ActivityLogContext:
         self,
         *,
         scope: str | None = None,
+        activity: str | None = None,
         item_id: str | None = None,
         user_email: str | None = None,
         limit: int = 20,
     ) -> str:
         entries = await self._fetch_entries(
             scope=scope,
+            activity=activity,
             item_id=item_id,
             user_email=user_email,
             limit=limit,
@@ -48,6 +50,7 @@ class ActivityLogContext:
         self,
         *,
         scope: str | None = None,
+        activity: str | None = None,
         item_id: str | None = None,
         user_email: str | None = None,
         limit: int = 20,
@@ -69,6 +72,8 @@ class ActivityLogContext:
 
         if scope:
             queryset = queryset.filter(scope=scope)
+        if activity:
+            queryset = queryset.filter(activity=activity)
         if item_id:
             queryset = queryset.filter(item_id=item_id)
         if user_email:

--- a/ee/hogai/context/activity_log/prompts.py
+++ b/ee/hogai/context/activity_log/prompts.py
@@ -1,0 +1,13 @@
+ACTIVITY_LOG_CONTEXT_TEMPLATE = """
+## Activity log
+
+Showing {count} entries{scope_filter}{user_filter}.
+
+{entries}
+""".strip()
+
+ACTIVITY_LOG_ENTRY_TEMPLATE = """
+- **{timestamp}** | {scope} | {activity} | {item_name}{user_attribution}{changes}
+""".strip()
+
+ACTIVITY_LOG_NO_RESULTS = "No activity log entries found matching the given filters."

--- a/ee/hogai/context/activity_log/prompts.py
+++ b/ee/hogai/context/activity_log/prompts.py
@@ -1,9 +1,12 @@
 ACTIVITY_LOG_CONTEXT_TEMPLATE = """
 ## Activity log
 
-Showing {count} entries{scope_filter}{user_filter}.
+Showing entries {offset_start}-{offset_end} of {total_count}{scope_filter}{user_filter}.
 
 {entries}
+
+---
+{pagination_hint}
 """.strip()
 
 ACTIVITY_LOG_ENTRY_TEMPLATE = """
@@ -11,3 +14,7 @@ ACTIVITY_LOG_ENTRY_TEMPLATE = """
 """.strip()
 
 ACTIVITY_LOG_NO_RESULTS = "No activity log entries found matching the given filters."
+
+ACTIVITY_LOG_PAGINATION_MORE = "<system_reminder>To see more results, use offset={next_offset}</system_reminder>"
+
+ACTIVITY_LOG_PAGINATION_END = "<system_reminder>You reached the end of results.</system_reminder>"

--- a/ee/hogai/context/activity_log/test/test_context.py
+++ b/ee/hogai/context/activity_log/test/test_context.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import Any
 
 from freezegun import freeze_time
 from posthog.test.base import BaseTest
@@ -15,12 +16,12 @@ from ee.hogai.context.activity_log.context import MAX_VALUE_LENGTH, ActivityLogC
 from ee.hogai.context.activity_log.prompts import ACTIVITY_LOG_NO_RESULTS
 
 
-class ActivityLogTestMixin:
-    def setUp(self):
+class ActivityLogTestBase(BaseTest):
+    def setUp(self) -> None:
         super().setUp()
         post_save.disconnect(activity_log_created, sender=ActivityLog)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         post_save.connect(activity_log_created, sender=ActivityLog)
         super().tearDown()
 
@@ -31,7 +32,7 @@ class ActivityLogTestMixin:
         activity: str = "updated",
         item_id: str = "1",
         detail: dict | None = None,
-        user=None,
+        user: Any = None,
         is_system: bool = False,
         was_impersonated: bool = False,
         created_at: datetime | None = None,
@@ -50,7 +51,7 @@ class ActivityLogTestMixin:
 
 
 @freeze_time("2025-06-15T12:00:00Z")
-class TestActivityLogContext(ActivityLogTestMixin, BaseTest):
+class TestActivityLogContext(ActivityLogTestBase):
     def _create_context(self) -> ActivityLogContext:
         return ActivityLogContext(team=self.team, user=self.user)
 
@@ -355,7 +356,7 @@ class TestActivityLogContext(ActivityLogTestMixin, BaseTest):
 
 
 @freeze_time("2025-06-15T12:00:00Z")
-class TestActivityLogContextTruncation(ActivityLogTestMixin, BaseTest):
+class TestActivityLogContextTruncation(ActivityLogTestBase):
     def _create_context(self) -> ActivityLogContext:
         return ActivityLogContext(team=self.team, user=self.user)
 
@@ -413,7 +414,7 @@ class TestActivityLogContextTruncation(ActivityLogTestMixin, BaseTest):
 
 
 @freeze_time("2025-06-15T12:00:00Z")
-class TestActivityLogContextVisibility(ActivityLogTestMixin, BaseTest):
+class TestActivityLogContextVisibility(ActivityLogTestBase):
     def _create_context(self, user=None) -> ActivityLogContext:
         return ActivityLogContext(team=self.team, user=user or self.user)
 
@@ -577,7 +578,7 @@ class TestActivityLogContextVisibility(ActivityLogTestMixin, BaseTest):
 
 
 @freeze_time("2025-06-15T12:00:00Z")
-class TestActivityLogContextFormatting(ActivityLogTestMixin, BaseTest):
+class TestActivityLogContextFormatting(ActivityLogTestBase):
     async def test_timestamp_format(self):
         await self._create_log(
             scope="FeatureFlag",

--- a/ee/hogai/context/activity_log/test/test_context.py
+++ b/ee/hogai/context/activity_log/test/test_context.py
@@ -796,7 +796,7 @@ class TestActivityLogContextFormatting(ActivityLogTestBase):
         context = ActivityLogContext(team=self.team, user=self.user)
         result = await context.fetch_and_format()
 
-        assert "2025-06-15 12:00 UTC" in result
+        assert "2025-06-15T12:00:00+00:00" in result
 
     async def test_entry_format_structure(self):
         await self._create_log(
@@ -809,7 +809,7 @@ class TestActivityLogContextFormatting(ActivityLogTestBase):
         context = ActivityLogContext(team=self.team, user=self.user)
         result = await context.fetch_and_format()
 
-        assert "- **2025-06-15 12:00 UTC** | Dashboard | deleted | My Dashboard" in result
+        assert "- **2025-06-15T12:00:00+00:00** | Dashboard | deleted | My Dashboard" in result
 
     async def test_detail_with_non_dict_type_uses_item_id(self):
         await ActivityLog.objects.acreate(

--- a/ee/hogai/context/activity_log/test/test_context.py
+++ b/ee/hogai/context/activity_log/test/test_context.py
@@ -86,6 +86,16 @@ class TestActivityLogContext(ActivityLogTestMixin, BaseTest):
         assert "Insight" not in result
         assert "for scope=FeatureFlag" in result
 
+    async def test_fetch_and_format_filters_by_activity(self):
+        await self._create_log(scope="FeatureFlag", activity="created", item_id="1")
+        await self._create_log(scope="FeatureFlag", activity="deleted", item_id="2")
+
+        context = self._create_context()
+        result = await context.fetch_and_format(activity="created")
+
+        assert "1 entries" in result
+        assert "created" in result
+
     async def test_fetch_and_format_filters_by_item_id(self):
         await self._create_log(scope="FeatureFlag", item_id="10")
         await self._create_log(scope="FeatureFlag", item_id="20")

--- a/ee/hogai/context/activity_log/test/test_context.py
+++ b/ee/hogai/context/activity_log/test/test_context.py
@@ -1,0 +1,613 @@
+from datetime import datetime, timedelta
+
+from freezegun import freeze_time
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.db.models.signals import post_save
+from django.utils import timezone
+
+from parameterized import parameterized
+
+from posthog.models.activity_logging.activity_log import ActivityLog, activity_log_created
+
+from ee.hogai.context.activity_log.context import MAX_VALUE_LENGTH, ActivityLogContext
+from ee.hogai.context.activity_log.prompts import ACTIVITY_LOG_NO_RESULTS
+
+
+class ActivityLogTestMixin:
+    def setUp(self):
+        super().setUp()
+        post_save.disconnect(activity_log_created, sender=ActivityLog)
+
+    def tearDown(self):
+        post_save.connect(activity_log_created, sender=ActivityLog)
+        super().tearDown()
+
+    async def _create_log(
+        self,
+        *,
+        scope: str = "FeatureFlag",
+        activity: str = "updated",
+        item_id: str = "1",
+        detail: dict | None = None,
+        user=None,
+        is_system: bool = False,
+        was_impersonated: bool = False,
+        created_at: datetime | None = None,
+    ) -> ActivityLog:
+        return await ActivityLog.objects.acreate(
+            team_id=self.team.id,
+            user=user if user is not None and not is_system else (None if is_system else self.user),
+            is_system=is_system,
+            was_impersonated=was_impersonated,
+            scope=scope,
+            activity=activity,
+            item_id=item_id,
+            detail=detail or {},
+            created_at=created_at or timezone.now(),
+        )
+
+
+@freeze_time("2025-06-15T12:00:00Z")
+class TestActivityLogContext(ActivityLogTestMixin, BaseTest):
+    def _create_context(self) -> ActivityLogContext:
+        return ActivityLogContext(team=self.team, user=self.user)
+
+    async def test_fetch_and_format_returns_no_results_message_when_empty(self):
+        context = self._create_context()
+        result = await context.fetch_and_format()
+        assert result == ACTIVITY_LOG_NO_RESULTS
+
+    async def test_fetch_and_format_returns_formatted_activity_logs(self):
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="created",
+            item_id="42",
+            detail={"name": "my-flag"},
+        )
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "Activity log" in result
+        assert "1 entries" in result
+        assert "FeatureFlag" in result
+        assert "created" in result
+        assert "my-flag" in result
+
+    async def test_fetch_and_format_filters_by_scope(self):
+        await self._create_log(scope="FeatureFlag", activity="created", item_id="1")
+        await self._create_log(scope="Insight", activity="updated", item_id="2")
+
+        context = self._create_context()
+        result = await context.fetch_and_format(scope="FeatureFlag")
+
+        assert "FeatureFlag" in result
+        assert "Insight" not in result
+        assert "for scope=FeatureFlag" in result
+
+    async def test_fetch_and_format_filters_by_item_id(self):
+        await self._create_log(scope="FeatureFlag", item_id="10")
+        await self._create_log(scope="FeatureFlag", item_id="20")
+
+        context = self._create_context()
+        result = await context.fetch_and_format(item_id="10")
+
+        assert "1 entries" in result
+
+    async def test_fetch_and_format_filters_by_user_email(self):
+        await self._create_log(scope="Insight", activity="created", item_id="1")
+
+        context = self._create_context()
+        result = await context.fetch_and_format(user_email=self.user.email)
+
+        assert "1 entries" in result
+        assert f"by {self.user.email}" in result
+
+    async def test_fetch_and_format_filters_by_user_email_no_match(self):
+        await self._create_log(scope="Insight", activity="created", item_id="1")
+
+        context = self._create_context()
+        result = await context.fetch_and_format(user_email="nonexistent@example.com")
+
+        assert result == ACTIVITY_LOG_NO_RESULTS
+
+    async def test_fetch_and_format_respects_limit(self):
+        for i in range(5):
+            await self._create_log(item_id=str(i), created_at=timezone.now() - timedelta(minutes=i))
+
+        context = self._create_context()
+        result = await context.fetch_and_format(limit=2)
+
+        assert "2 entries" in result
+
+    async def test_fetch_and_format_clamps_limit_to_valid_range(self):
+        for i in range(3):
+            await self._create_log(item_id=str(i))
+
+        context = self._create_context()
+
+        result_low = await context.fetch_and_format(limit=0)
+        assert "1 entries" in result_low
+
+        result_high = await context.fetch_and_format(limit=100)
+        assert "3 entries" in result_high
+
+    async def test_fetch_and_format_orders_by_created_at_desc(self):
+        await self._create_log(
+            scope="Insight",
+            activity="created",
+            item_id="old",
+            detail={"name": "OldInsight"},
+            created_at=timezone.now() - timedelta(hours=2),
+        )
+        await self._create_log(
+            scope="Insight",
+            activity="updated",
+            item_id="new",
+            detail={"name": "NewInsight"},
+            created_at=timezone.now(),
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        new_pos = result.index("NewInsight")
+        old_pos = result.index("OldInsight")
+        assert new_pos < old_pos
+
+    async def test_system_action_shows_system_attribution(self):
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="updated",
+            item_id="1",
+            detail={"name": "sys-flag"},
+            is_system=True,
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "by System" in result
+
+    async def test_impersonated_action_shows_impersonated_suffix(self):
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="updated",
+            item_id="1",
+            detail={"name": "imp-flag"},
+            was_impersonated=True,
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "(impersonated)" in result
+
+    async def test_user_attribution_uses_first_name_when_available(self):
+        self.user.first_name = "Alice"
+        await self.user.asave()
+
+        await self._create_log(scope="Insight", activity="created", item_id="1")
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "by Alice" in result
+
+    async def test_user_attribution_falls_back_to_email(self):
+        self.user.first_name = ""
+        await self.user.asave()
+
+        await self._create_log(scope="Insight", activity="created", item_id="1")
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert f"by {self.user.email}" in result
+
+    async def test_item_name_from_detail_name(self):
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="created",
+            item_id="42",
+            detail={"name": "my-feature-flag"},
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "my-feature-flag" in result
+
+    async def test_item_name_from_detail_short_id(self):
+        await self._create_log(
+            scope="Insight",
+            activity="created",
+            item_id="99",
+            detail={"short_id": "abc123"},
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "abc123" in result
+
+    async def test_item_name_falls_back_to_item_id(self):
+        await self._create_log(
+            scope="Dashboard",
+            activity="created",
+            item_id="77",
+            detail={},
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "77" in result
+
+    async def test_item_name_falls_back_to_unknown_when_no_detail_or_item_id(self):
+        await ActivityLog.objects.acreate(
+            team_id=self.team.id,
+            user=self.user,
+            is_system=False,
+            was_impersonated=False,
+            scope="Insight",
+            activity="created",
+            item_id=None,
+            detail=None,
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "(unknown)" in result
+
+    @parameterized.expand(
+        [
+            (
+                "created_change",
+                [{"field": "enabled", "action": "created", "after": True}],
+                "enabled: set to True",
+            ),
+            (
+                "deleted_change",
+                [{"field": "description", "action": "deleted", "before": "old desc"}],
+                "description: removed (was old desc)",
+            ),
+            (
+                "changed_value",
+                [{"field": "name", "action": "changed", "before": "old", "after": "new"}],
+                "name: old -> new",
+            ),
+        ]
+    )
+    async def test_format_changes(self, _name, changes, expected_text):
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="updated",
+            item_id="1",
+            detail={"name": "test", "changes": changes},
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert expected_text in result
+
+    async def test_format_changes_with_none_values(self):
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="updated",
+            item_id="1",
+            detail={
+                "name": "test",
+                "changes": [{"field": "rollout", "action": "changed", "before": None, "after": 50}],
+            },
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "rollout: (none) -> 50" in result
+
+    async def test_format_changes_empty_changes_list(self):
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="created",
+            item_id="1",
+            detail={"name": "no-changes", "changes": []},
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "no-changes" in result
+        assert "  - " not in result
+
+    async def test_format_changes_non_dict_change_is_skipped(self):
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="updated",
+            item_id="1",
+            detail={
+                "name": "test",
+                "changes": [
+                    "not-a-dict",
+                    {"field": "name", "action": "changed", "before": "a", "after": "b"},
+                ],
+            },
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "name: a -> b" in result
+
+
+@freeze_time("2025-06-15T12:00:00Z")
+class TestActivityLogContextTruncation(ActivityLogTestMixin, BaseTest):
+    def _create_context(self) -> ActivityLogContext:
+        return ActivityLogContext(team=self.team, user=self.user)
+
+    async def test_truncate_large_string_value(self):
+        long_value = "x" * (MAX_VALUE_LENGTH + 50)
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="updated",
+            item_id="1",
+            detail={
+                "name": "test",
+                "changes": [{"field": "description", "action": "changed", "before": "short", "after": long_value}],
+            },
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "..." in result
+        assert long_value not in result
+
+    async def test_truncate_large_dict_value(self):
+        large_dict = {"key_" + str(i): "value_" + str(i) for i in range(100)}
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="updated",
+            item_id="1",
+            detail={
+                "name": "test",
+                "changes": [{"field": "filters", "action": "changed", "before": {}, "after": large_dict}],
+            },
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "..." in result
+
+    async def test_truncate_large_list_value(self):
+        large_list = list(range(200))
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="updated",
+            item_id="1",
+            detail={
+                "name": "test",
+                "changes": [{"field": "groups", "action": "changed", "before": [], "after": large_list}],
+            },
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "..." in result
+
+
+@freeze_time("2025-06-15T12:00:00Z")
+class TestActivityLogContextVisibility(ActivityLogTestMixin, BaseTest):
+    def _create_context(self, user=None) -> ActivityLogContext:
+        return ActivityLogContext(team=self.team, user=user or self.user)
+
+    async def test_non_staff_user_cannot_see_restricted_scopes(self):
+        self.user.is_staff = False
+        await self.user.asave()
+
+        await self._create_log(
+            scope="User",
+            activity="logged_in",
+            item_id="1",
+            detail={},
+            was_impersonated=True,
+        )
+        await self._create_log(
+            scope="User",
+            activity="created",
+            item_id="2",
+            detail={"name": "user-created"},
+        )
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="created",
+            item_id="3",
+            detail={"name": "visible-flag"},
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "visible-flag" in result
+        assert "logged_in" not in result
+        assert "user-created" not in result
+
+    async def test_staff_user_can_see_restricted_scopes(self):
+        self.user.is_staff = True
+        await self.user.asave()
+
+        await self._create_log(
+            scope="User",
+            activity="logged_in",
+            item_id="1",
+            detail={"name": "staff-login"},
+            was_impersonated=True,
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "logged_in" in result
+
+    @patch("ee.hogai.context.activity_log.context.get_activity_log_lookback_restriction")
+    async def test_lookback_restriction_applied(self, mock_lookback):
+        mock_lookback.return_value = timezone.now() - timedelta(days=7)
+
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="created",
+            item_id="recent",
+            detail={"name": "recent-flag"},
+            created_at=timezone.now() - timedelta(days=1),
+        )
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="created",
+            item_id="old",
+            detail={"name": "old-flag"},
+            created_at=timezone.now() - timedelta(days=30),
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "recent-flag" in result
+        assert "old-flag" not in result
+
+    @patch("ee.hogai.context.activity_log.context.get_activity_log_lookback_restriction")
+    async def test_no_lookback_restriction_when_none(self, mock_lookback):
+        mock_lookback.return_value = None
+
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="created",
+            item_id="old",
+            detail={"name": "old-flag"},
+            created_at=timezone.now() - timedelta(days=365),
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "old-flag" in result
+
+    async def test_only_returns_entries_for_current_team(self):
+        other_team_id = self.team.id + 9999
+
+        await ActivityLog.objects.acreate(
+            team_id=other_team_id,
+            user=self.user,
+            is_system=False,
+            was_impersonated=False,
+            scope="FeatureFlag",
+            activity="created",
+            item_id="1",
+            detail={"name": "other-team-flag"},
+        )
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="created",
+            item_id="2",
+            detail={"name": "my-team-flag"},
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "my-team-flag" in result
+        assert "other-team-flag" not in result
+
+    async def test_includes_org_scoped_logs_when_enabled(self):
+        self.team.receive_org_level_activity_logs = True
+        await self.team.asave()
+
+        await ActivityLog.objects.acreate(
+            team_id=None,
+            organization_id=self.team.organization_id,
+            user=self.user,
+            is_system=False,
+            was_impersonated=False,
+            scope="Organization",
+            activity="updated",
+            item_id=str(self.team.organization_id),
+            detail={"name": "org-change"},
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert "org-change" in result
+
+    async def test_excludes_org_scoped_logs_when_disabled(self):
+        self.team.receive_org_level_activity_logs = False
+        await self.team.asave()
+
+        await ActivityLog.objects.acreate(
+            team_id=None,
+            organization_id=self.team.organization_id,
+            user=self.user,
+            is_system=False,
+            was_impersonated=False,
+            scope="Organization",
+            activity="updated",
+            item_id=str(self.team.organization_id),
+            detail={"name": "org-change"},
+        )
+
+        context = self._create_context()
+        result = await context.fetch_and_format()
+
+        assert result == ACTIVITY_LOG_NO_RESULTS
+
+
+@freeze_time("2025-06-15T12:00:00Z")
+class TestActivityLogContextFormatting(ActivityLogTestMixin, BaseTest):
+    async def test_timestamp_format(self):
+        await self._create_log(
+            scope="FeatureFlag",
+            activity="created",
+            item_id="1",
+            detail={"name": "test"},
+            created_at=timezone.now(),
+        )
+
+        context = ActivityLogContext(team=self.team, user=self.user)
+        result = await context.fetch_and_format()
+
+        assert "2025-06-15 12:00 UTC" in result
+
+    async def test_entry_format_structure(self):
+        await self._create_log(
+            scope="Dashboard",
+            activity="deleted",
+            item_id="5",
+            detail={"name": "My Dashboard"},
+        )
+
+        context = ActivityLogContext(team=self.team, user=self.user)
+        result = await context.fetch_and_format()
+
+        assert "- **2025-06-15 12:00 UTC** | Dashboard | deleted | My Dashboard" in result
+
+    async def test_detail_with_non_dict_type_uses_item_id(self):
+        await ActivityLog.objects.acreate(
+            team_id=self.team.id,
+            user=self.user,
+            is_system=False,
+            was_impersonated=False,
+            scope="Insight",
+            activity="created",
+            item_id="42",
+            detail="not-a-dict",
+        )
+
+        context = ActivityLogContext(team=self.team, user=self.user)
+        result = await context.fetch_and_format()
+
+        assert "42" in result

--- a/ee/hogai/context/activity_log/test/test_context.py
+++ b/ee/hogai/context/activity_log/test/test_context.py
@@ -480,13 +480,15 @@ class TestActivityLogContextDatetimeFilter(ActivityLogTestBase):
         assert "too-old" not in result
         assert "too-new" not in result
 
-    async def test_invalid_datetime_string_is_ignored(self):
+    async def test_invalid_datetime_string_is_ignored_with_warning(self):
         await self._create_log(item_id="1", detail={"name": "entry"})
 
         context = self._create_context()
         result = await context.fetch_and_format(after="not-a-date", before="also-invalid")
 
         assert "entry" in result
+        assert "'after' filter 'not-a-date' is not a valid ISO 8601 datetime and was ignored" in result
+        assert "'before' filter 'also-invalid' is not a valid ISO 8601 datetime and was ignored" in result
 
 
 @freeze_time("2025-06-15T12:00:00Z")

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -20,6 +20,7 @@ from posthog.schema import (
     ModeContext,
 )
 
+from posthog.constants import AvailableFeature
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
@@ -128,6 +129,12 @@ class AssistantContextManager(AssistantContextMixin):
             OrganizationMembership.Level.ADMIN,
             OrganizationMembership.Level.OWNER,
         )
+
+    def check_has_audit_logs_access(self) -> bool:
+        """
+        Check if the user has access to the audit logs tool.
+        """
+        return self._team.organization.is_feature_available(AvailableFeature.AUDIT_LOGS)
 
     def get_groups(self):
         """

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -130,6 +130,7 @@ class AssistantContextManager(AssistantContextMixin):
             OrganizationMembership.Level.OWNER,
         )
 
+    @database_sync_to_async
     def check_has_audit_logs_access(self) -> bool:
         """
         Check if the user has access to the audit logs tool.

--- a/ee/hogai/tools/read_data/prompts.py
+++ b/ee/hogai/tools/read_data/prompts.py
@@ -7,6 +7,23 @@ If the user wants to reduce their spending, always call this tool to get suggest
 If an insight shows zero data, it could mean either the query is looking at the wrong data or there was a temporary data collection issue. You can investigate potential dips in usage/captured data using the billing tool.
 """.strip()
 
+READ_DATA_ACTIVITY_LOG_PROMPT = """
+# Activity log
+
+Retrieves recent activity log entries showing who changed what and when.
+
+## Use this when:
+- The user wants to know what changed recently in their project.
+- The user asks who made a specific change or when something was modified.
+- The user wants to audit changes to a specific entity (e.g. a feature flag or insight).
+
+## Parameters:
+- scope: Filter by entity type (e.g. 'FeatureFlag', 'Insight', 'Experiment', 'Dashboard'). Optional.
+- item_id: Filter by specific item ID. Optional.
+- user_email: Filter by the email of the user who made the change. Optional.
+- limit: Number of entries to return (1-50, default 20).
+""".strip()
+
 READ_DATA_PROMPT = """
 Use this tool to read user data created in PostHog. This tool returns data that the user manually creates in PostHog.
 
@@ -63,12 +80,19 @@ Retrieves an experiment by its numeric ID or by its feature flag's key.
 - id: The numeric ID of the experiment (optional if feature_flag_key is provided)
 - feature_flag_key: The key of the experiment's feature flag (optional if id is provided)
 
+{{{activity_log_prompt}}}
+
 {{{billing_prompt}}}
 """.strip()
 
 BILLING_INSUFFICIENT_ACCESS_PROMPT = """
 The user does not have admin access to view detailed billing information. They would need to contact an organization admin for billing details.
 Suggest the user to contact the admins.
+""".strip()
+
+ACTIVITY_LOG_INSUFFICIENT_ACCESS_PROMPT = """
+Activity logs are not available on your current plan. Activity logs require the Scale or Enterprise add-on.
+Suggest the user upgrade their plan to access audit logs.
 """.strip()
 
 INSIGHT_NOT_FOUND_PROMPT = """

--- a/ee/hogai/tools/read_data/prompts.py
+++ b/ee/hogai/tools/read_data/prompts.py
@@ -23,6 +23,10 @@ Retrieves recent activity log entries showing who changed what and when.
 - item_id: Filter by specific item ID. Optional.
 - user_email: Filter by the email of the user who made the change. Optional.
 - limit: Number of entries to return (1-50, default 20).
+
+## Important note on organization-level logs:
+Some activity logs are organization-level — they are not tied to a specific project but to the organization as a whole. Examples include Organization, OrganizationDomain, OrganizationMembership, Role, User, and similar scopes that represent org-wide settings, members, or permissions rather than project-specific entities like feature flags or insights.
+These logs are always captured, but they are only included in query results when the project has the "Include organization-level activity" setting enabled. If the user asks about such changes and no results are found, let them know this setting may need to be turned on in Project settings > Activity log.
 """.strip()
 
 READ_DATA_PROMPT = """

--- a/ee/hogai/tools/read_data/prompts.py
+++ b/ee/hogai/tools/read_data/prompts.py
@@ -19,6 +19,7 @@ Retrieves recent activity log entries showing who changed what and when.
 
 ## Parameters:
 - scope: Filter by entity type (e.g. 'FeatureFlag', 'Insight', 'Experiment', 'Dashboard'). Optional.
+- activity: Filter by activity type (e.g. 'created', 'updated', 'deleted'). Optional.
 - item_id: Filter by specific item ID. Optional.
 - user_email: Filter by the email of the user who made the change. Optional.
 - limit: Number of entries to return (1-50, default 20).

--- a/ee/hogai/tools/read_data/test/test_tool.py
+++ b/ee/hogai/tools/read_data/test/test_tool.py
@@ -1119,7 +1119,9 @@ class TestReadDataTool(BaseTest):
             result, artifact = await tool._arun_impl({"kind": "activity_log"})
 
             MockActivityLogContext.assert_called_once_with(team=self.team, user=self.user)
-            mock_instance.fetch_and_format.assert_called_once_with(scope=None, item_id=None, user_email=None, limit=20)
+            mock_instance.fetch_and_format.assert_called_once_with(
+                scope=None, activity=None, item_id=None, user_email=None, limit=20
+            )
             assert "Activity log" in result
             assert artifact is None
 
@@ -1142,6 +1144,7 @@ class TestReadDataTool(BaseTest):
                 {
                     "kind": "activity_log",
                     "scope": "FeatureFlag",
+                    "activity": "updated",
                     "item_id": "42",
                     "user_email": "test@example.com",
                     "limit": 10,
@@ -1149,7 +1152,7 @@ class TestReadDataTool(BaseTest):
             )
 
             mock_instance.fetch_and_format.assert_called_once_with(
-                scope="FeatureFlag", item_id="42", user_email="test@example.com", limit=10
+                scope="FeatureFlag", activity="updated", item_id="42", user_email="test@example.com", limit=10
             )
 
     async def test_create_tool_class_includes_activity_log_when_feature_available(self):

--- a/ee/hogai/tools/read_data/test/test_tool.py
+++ b/ee/hogai/tools/read_data/test/test_tool.py
@@ -1100,3 +1100,78 @@ class TestReadDataTool(BaseTest):
 
             assert "Allowed Experiment" in result
             mock_uac.check_access_level_for_object.assert_called_once()
+
+    async def test_read_activity_log_delegates_to_activity_log_context(self):
+        state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
+        context_manager = MagicMock()
+        context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = MagicMock(return_value=True)
+
+        tool = await ReadDataTool.create_tool_class(
+            team=self.team, user=self.user, state=state, context_manager=context_manager
+        )
+
+        with patch("ee.hogai.tools.read_data.tool.ActivityLogContext") as MockActivityLogContext:
+            mock_instance = MagicMock()
+            mock_instance.fetch_and_format = AsyncMock(return_value="## Activity log\n\nShowing 5 entries.\n\n...")
+            MockActivityLogContext.return_value = mock_instance
+
+            result, artifact = await tool._arun_impl({"kind": "activity_log"})
+
+            MockActivityLogContext.assert_called_once_with(team=self.team, user=self.user)
+            mock_instance.fetch_and_format.assert_called_once_with(scope=None, item_id=None, user_email=None, limit=20)
+            assert "Activity log" in result
+            assert artifact is None
+
+    async def test_read_activity_log_passes_filters(self):
+        state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
+        context_manager = MagicMock()
+        context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = MagicMock(return_value=True)
+
+        tool = await ReadDataTool.create_tool_class(
+            team=self.team, user=self.user, state=state, context_manager=context_manager
+        )
+
+        with patch("ee.hogai.tools.read_data.tool.ActivityLogContext") as MockActivityLogContext:
+            mock_instance = MagicMock()
+            mock_instance.fetch_and_format = AsyncMock(return_value="## Activity log\n\n...")
+            MockActivityLogContext.return_value = mock_instance
+
+            await tool._arun_impl(
+                {
+                    "kind": "activity_log",
+                    "scope": "FeatureFlag",
+                    "item_id": "42",
+                    "user_email": "test@example.com",
+                    "limit": 10,
+                }
+            )
+
+            mock_instance.fetch_and_format.assert_called_once_with(
+                scope="FeatureFlag", item_id="42", user_email="test@example.com", limit=10
+            )
+
+    async def test_create_tool_class_includes_activity_log_when_feature_available(self):
+        state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
+        context_manager = MagicMock()
+        context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = MagicMock(return_value=True)
+
+        tool = await ReadDataTool.create_tool_class(
+            team=self.team, user=self.user, state=state, context_manager=context_manager
+        )
+
+        assert "Activity log" in tool.description
+
+    async def test_create_tool_class_excludes_activity_log_when_feature_unavailable(self):
+        state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
+        context_manager = MagicMock()
+        context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = MagicMock(return_value=False)
+
+        tool = await ReadDataTool.create_tool_class(
+            team=self.team, user=self.user, state=state, context_manager=context_manager
+        )
+
+        assert "Activity log" not in tool.description

--- a/ee/hogai/tools/read_data/test/test_tool.py
+++ b/ee/hogai/tools/read_data/test/test_tool.py
@@ -32,6 +32,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=True)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=team,
@@ -50,6 +51,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=team,
@@ -72,6 +74,7 @@ class TestReadDataTool(BaseTest):
         with patch("ee.hogai.tools.read_data.tool.AssistantContextManager") as mock_context_class:
             mock_context = MagicMock()
             mock_context.check_user_has_billing_access = AsyncMock(return_value=False)
+            mock_context.check_has_audit_logs_access = AsyncMock(return_value=False)
             mock_context_class.return_value = mock_context
 
             tool = await ReadDataTool.create_tool_class(
@@ -90,6 +93,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         mock_query = AssistantTrendsQuery(series=[AssistantTrendsEventsNode(name="$pageview")])
         mock_content = VisualizationArtifactContent(
@@ -126,6 +130,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=tool_call_id)
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         mock_query = AssistantTrendsQuery(series=[AssistantTrendsEventsNode(name="$pageview")])
         mock_content = VisualizationArtifactContent(
@@ -178,6 +183,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
         context_manager.artifacts = MagicMock()
         context_manager.artifacts.aget_visualization = AsyncMock(return_value=None)
 
@@ -200,6 +206,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
         context_manager.artifacts = MagicMock()
         context_manager.artifacts.aget_insight = AsyncMock(return_value=None)
 
@@ -236,6 +243,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         mock_query = AssistantTrendsQuery(series=[AssistantTrendsEventsNode(name="$pageview")])
         mock_content = VisualizationArtifactContent(
@@ -273,6 +281,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -320,6 +329,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         with patch("ee.hogai.tools.read_data.tool.DashboardContext") as MockDashboardContext:
             mock_instance = MagicMock()
@@ -361,6 +371,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -417,6 +428,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -451,6 +463,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -470,6 +483,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -516,6 +530,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -558,6 +573,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -577,6 +593,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -596,6 +613,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -622,6 +640,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -657,6 +676,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -679,6 +699,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -697,6 +718,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -743,6 +765,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -780,6 +803,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -800,6 +824,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -818,6 +843,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team,
@@ -838,6 +864,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         mock_query = AssistantTrendsQuery(series=[AssistantTrendsEventsNode(name="$pageview")])
         mock_content = VisualizationArtifactContent(name="Secret Insight", query=mock_query)
@@ -866,6 +893,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         mock_query = AssistantTrendsQuery(series=[AssistantTrendsEventsNode(name="$pageview")])
         mock_content = VisualizationArtifactContent(name="Allowed Insight", query=mock_query)
@@ -894,6 +922,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         mock_query = AssistantTrendsQuery(series=[AssistantTrendsEventsNode(name="$pageview")])
         mock_content = VisualizationArtifactContent(name="State Insight", query=mock_query)
@@ -918,6 +947,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=user, state=state, context_manager=context_manager
@@ -936,6 +966,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=user, state=state, context_manager=context_manager
@@ -955,6 +986,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=user, state=state, context_manager=context_manager
@@ -974,6 +1006,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=user, state=state, context_manager=context_manager
@@ -996,6 +1029,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=user, state=state, context_manager=context_manager
@@ -1018,6 +1052,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=user, state=state, context_manager=context_manager
@@ -1040,6 +1075,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=user, state=state, context_manager=context_manager
@@ -1063,6 +1099,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=user, state=state, context_manager=context_manager
@@ -1088,6 +1125,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=user, state=state, context_manager=context_manager
@@ -1105,7 +1143,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
-        context_manager.check_has_audit_logs_access = MagicMock(return_value=True)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=True)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=self.user, state=state, context_manager=context_manager
@@ -1129,7 +1167,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
-        context_manager.check_has_audit_logs_access = MagicMock(return_value=True)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=True)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=self.user, state=state, context_manager=context_manager
@@ -1166,7 +1204,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
-        context_manager.check_has_audit_logs_access = MagicMock(return_value=True)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=True)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=self.user, state=state, context_manager=context_manager
@@ -1201,7 +1239,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
-        context_manager.check_has_audit_logs_access = MagicMock(return_value=True)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=True)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=self.user, state=state, context_manager=context_manager
@@ -1213,7 +1251,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
-        context_manager.check_has_audit_logs_access = MagicMock(return_value=False)
+        context_manager.check_has_audit_logs_access = AsyncMock(return_value=False)
 
         tool = await ReadDataTool.create_tool_class(
             team=self.team, user=self.user, state=state, context_manager=context_manager

--- a/ee/hogai/tools/read_data/test/test_tool.py
+++ b/ee/hogai/tools/read_data/test/test_tool.py
@@ -1120,7 +1120,7 @@ class TestReadDataTool(BaseTest):
 
             MockActivityLogContext.assert_called_once_with(team=self.team, user=self.user)
             mock_instance.fetch_and_format.assert_called_once_with(
-                scope=None, activity=None, item_id=None, user_email=None, limit=20, offset=0
+                scope=None, activity=None, item_id=None, user_email=None, after=None, before=None, limit=20, offset=0
             )
             assert "Activity log" in result
             assert artifact is None
@@ -1152,7 +1152,14 @@ class TestReadDataTool(BaseTest):
             )
 
             mock_instance.fetch_and_format.assert_called_once_with(
-                scope="FeatureFlag", activity="updated", item_id="42", user_email="test@example.com", limit=10, offset=0
+                scope="FeatureFlag",
+                activity="updated",
+                item_id="42",
+                user_email="test@example.com",
+                after=None,
+                before=None,
+                limit=10,
+                offset=0,
             )
 
     async def test_read_activity_log_passes_offset(self):
@@ -1180,7 +1187,14 @@ class TestReadDataTool(BaseTest):
             )
 
             mock_instance.fetch_and_format.assert_called_once_with(
-                scope="FeatureFlag", activity=None, item_id=None, user_email=None, limit=10, offset=20
+                scope="FeatureFlag",
+                activity=None,
+                item_id=None,
+                user_email=None,
+                after=None,
+                before=None,
+                limit=10,
+                offset=20,
             )
 
     async def test_create_tool_class_includes_activity_log_when_feature_available(self):

--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -205,7 +205,7 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
             prompt_vars["billing_prompt"] = READ_DATA_BILLING_PROMPT
             kinds.append(ReadBillingInfo)
 
-        has_audit_logs_access = context_manager.check_has_audit_logs_access()
+        has_audit_logs_access = await context_manager.check_has_audit_logs_access()
 
         if has_audit_logs_access:
             prompt_vars["activity_log_prompt"] = READ_DATA_ACTIVITY_LOG_PROMPT
@@ -281,7 +281,7 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
             case ReadExperiment() as schema:
                 return await self._read_experiment(schema.id, schema.feature_flag_key), None
             case ReadActivityLog() as schema:
-                if not self._context_manager.check_has_audit_logs_access():
+                if not await self._context_manager.check_has_audit_logs_access():
                     raise MaxToolFatalError(ACTIVITY_LOG_INSUFFICIENT_ACCESS_PROMPT)
                 return await self._read_activity_log(
                     schema.scope,

--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -132,7 +132,7 @@ class ReadActivityLog(BaseModel):
     kind: Literal["activity_log"] = "activity_log"
     scope: str | None = Field(
         default=None,
-        description="Filter by scope (e.g. 'FeatureFlag', 'Insight', 'Experiment', 'Dashboard').",
+        description="Filter by scope (e.g. 'FeatureFlag', 'Insight', 'Experiment', 'Dashboard', 'HogFunction', 'BatchExport', 'Survey').",
     )
     activity: str | None = Field(
         default=None,

--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -140,6 +140,12 @@ class ReadActivityLog(BaseModel):
     )
     item_id: str | None = Field(default=None, description="Filter by item ID.")
     user_email: str | None = Field(default=None, description="Filter by user email.")
+    after: str | None = Field(
+        default=None, description="Only entries created after this ISO 8601 datetime (e.g. '2025-01-15T00:00:00Z')."
+    )
+    before: str | None = Field(
+        default=None, description="Only entries created before this ISO 8601 datetime (e.g. '2025-02-01T00:00:00Z')."
+    )
     limit: int = Field(default=20, ge=1, le=50, description="Number of entries to return.")
     offset: int = Field(default=0, ge=0, description="Number of entries to skip for pagination.")
 
@@ -278,7 +284,14 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
                 if not self._context_manager.check_has_audit_logs_access():
                     raise MaxToolFatalError(ACTIVITY_LOG_INSUFFICIENT_ACCESS_PROMPT)
                 return await self._read_activity_log(
-                    schema.scope, schema.activity, schema.item_id, schema.user_email, schema.limit, schema.offset
+                    schema.scope,
+                    schema.activity,
+                    schema.item_id,
+                    schema.user_email,
+                    schema.after,
+                    schema.before,
+                    schema.limit,
+                    schema.offset,
                 ), None
 
     async def _read_insight(
@@ -560,6 +573,8 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
         activity: str | None,
         item_id: str | None,
         user_email: str | None,
+        after: str | None,
+        before: str | None,
         limit: int,
         offset: int,
     ) -> str:
@@ -569,6 +584,8 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
             activity=activity,
             item_id=item_id,
             user_email=user_email,
+            after=after,
+            before=before,
             limit=limit,
             offset=offset,
         )

--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -141,6 +141,7 @@ class ReadActivityLog(BaseModel):
     item_id: str | None = Field(default=None, description="Filter by item ID.")
     user_email: str | None = Field(default=None, description="Filter by user email.")
     limit: int = Field(default=20, ge=1, le=50, description="Number of entries to return.")
+    offset: int = Field(default=0, ge=0, description="Number of entries to skip for pagination.")
 
 
 ReadDataQuery = (
@@ -277,7 +278,7 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
                 if not self._context_manager.check_has_audit_logs_access():
                     raise MaxToolFatalError(ACTIVITY_LOG_INSUFFICIENT_ACCESS_PROMPT)
                 return await self._read_activity_log(
-                    schema.scope, schema.activity, schema.item_id, schema.user_email, schema.limit
+                    schema.scope, schema.activity, schema.item_id, schema.user_email, schema.limit, schema.offset
                 ), None
 
     async def _read_insight(
@@ -560,6 +561,7 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
         item_id: str | None,
         user_email: str | None,
         limit: int,
+        offset: int,
     ) -> str:
         context = ActivityLogContext(team=self._team, user=self._user)
         return await context.fetch_and_format(
@@ -568,4 +570,5 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
             item_id=item_id,
             user_email=user_email,
             limit=limit,
+            offset=offset,
         )

--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -132,7 +132,16 @@ class ReadActivityLog(BaseModel):
     kind: Literal["activity_log"] = "activity_log"
     scope: str | None = Field(
         default=None,
-        description="Filter by scope (e.g. 'FeatureFlag', 'Insight', 'Experiment', 'Dashboard', 'HogFunction', 'BatchExport', 'Survey').",
+        description=(
+            "Filter by resource scope. Available scopes: "
+            "Action, AlertConfiguration, Annotation, BatchExport, BatchImport, Cohort, Comment, "
+            "Dashboard, DataManagement, EarlyAccessFeature, EventDefinition, Experiment, "
+            "ExternalDataSchema, ExternalDataSource, FeatureFlag, HogFlow, HogFunction, "
+            "Insight, Notebook, Organization, OrganizationDomain, OrganizationMembership, "
+            "Person, PersonalAPIKey, Plugin, PluginConfig, Project, PropertyDefinition, "
+            "Replay, SessionRecordingPlaylist, Survey, Tag, TaggedItem, Team, User, "
+            "WebAnalyticsFilterPreset."
+        ),
     )
     activity: str | None = Field(
         default=None,

--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -134,6 +134,10 @@ class ReadActivityLog(BaseModel):
         default=None,
         description="Filter by scope (e.g. 'FeatureFlag', 'Insight', 'Experiment', 'Dashboard').",
     )
+    activity: str | None = Field(
+        default=None,
+        description="Filter by activity type (e.g. 'created', 'updated', 'deleted').",
+    )
     item_id: str | None = Field(default=None, description="Filter by item ID.")
     user_email: str | None = Field(default=None, description="Filter by user email.")
     limit: int = Field(default=20, ge=1, le=50, description="Number of entries to return.")
@@ -273,7 +277,7 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
                 if not self._context_manager.check_has_audit_logs_access():
                     raise MaxToolFatalError(ACTIVITY_LOG_INSUFFICIENT_ACCESS_PROMPT)
                 return await self._read_activity_log(
-                    schema.scope, schema.item_id, schema.user_email, schema.limit
+                    schema.scope, schema.activity, schema.item_id, schema.user_email, schema.limit
                 ), None
 
     async def _read_insight(
@@ -552,6 +556,7 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
     async def _read_activity_log(
         self,
         scope: str | None,
+        activity: str | None,
         item_id: str | None,
         user_email: str | None,
         limit: int,
@@ -559,6 +564,7 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
         context = ActivityLogContext(team=self._team, user=self._user)
         return await context.fetch_and_format(
             scope=scope,
+            activity=activity,
             item_id=item_id,
             user_email=user_email,
             limit=limit,

--- a/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
+++ b/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
@@ -138,6 +138,7 @@ export function userNameForLogItem(logItem: ActivityLogItem): string {
 
 const NO_PLURAL_SCOPES: ActivityScope[] = [ActivityScope.DATA_MANAGEMENT]
 
+// Keep in sync with SCOPE_DISPLAY_NAMES in ee/hogai/context/activity_log/context.py
 const SCOPE_DISPLAY_NAMES: Partial<Record<ActivityScope, { singular: string; plural: string }>> = {
     [ActivityScope.ALERT_CONFIGURATION]: { singular: 'Alert', plural: 'Alerts' },
     [ActivityScope.BATCH_EXPORT]: { singular: 'Destination', plural: 'Destinations' },


### PR DESCRIPTION
## Problem
                                                                                                                                    
  PostHog AI has no way to answer questions about recent changes in a project — "who changed this flag?" or "what was modified last week?" require users to manually dig through the activity log UI.                                                                             
               
## Changes                                                                                                                             
                                                           
[LOOM](https://www.loom.com/share/cf4db4ea56d449f38dafd19a877b6892)

  - Add `activity_log` kind to the `read_data` tool with `scope`, `activity`, `item_id`, `user_email`, `created` and pagination filters
  - New `ActivityLogContext` class (`ee/hogai/context/activity_log/`) that fetches and formats log entries
  - Feature-gated behind `AvailableFeature.AUDIT_LOGS` using schema exclusion (same pattern as billing)
  - `context_manager.check_has_audit_logs_access()` for consistent access checking
  - Respects `apply_activity_visibility_restrictions()` and `apply_organization_scoped_filter()`
  - Includes org-scoped logs when `team.receive_org_level_activity_logs` is true
  - Applies lookback restriction based on org plan
  - Adds display names for activity logs on the BE (unfortunately no way to autosync with FE display names).

## How did you test this code?

- Unit tests

## Publish to changelog?

  yes