### PR TITLE
fix(sql-editor): joins for persons

### DIFF
--- a/frontend/src/scenes/data-management/database/DatabaseTable.tsx
+++ b/frontend/src/scenes/data-management/database/DatabaseTable.tsx
@@ -56,7 +56,11 @@ const JoinsMoreMenu = ({ tableName, fieldName }: { tableName: string; fieldName:
     const { loadJoins } = useActions(dataWarehouseJoinsLogic)
     const { loadDatabase } = useActions(dataWarehouseSettingsSceneLogic)
 
-    const join = joins.find((n) => n.source_table_name === tableName && n.field_name === fieldName)
+    const join =
+        joins.find((n) => n.source_table_name === tableName && n.field_name === fieldName) ||
+        (tableName === 'events'
+            ? joins.find((n) => n.source_table_name === 'persons' && n.field_name === fieldName)
+            : undefined)
 
     const overlay = useCallback(
         () =>

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -15,7 +15,7 @@ import {
 } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 
-import { LemonTree, LemonTreeRef } from 'lib/lemon-ui/LemonTree/LemonTree'
+import { LemonTree, LemonTreeRef, TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { TreeNodeDisplayIcon } from 'lib/lemon-ui/LemonTree/LemonTreeUtils'
 import { IconTextSize } from 'lib/lemon-ui/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
@@ -137,6 +137,44 @@ export const QueryDatabase = (): JSX.Element => {
         }
     }
 
+    const getTableKindLabel = (item: TreeDataItem): string | null => {
+        if (!item.record) {
+            return null
+        }
+
+        switch (item.record.type) {
+            case 'lazy-table':
+                return 'lazy join'
+            case 'virtual-table':
+                return 'virtual table'
+            case 'managed-view':
+                return 'managed view'
+            case 'endpoint':
+                return 'endpoint'
+            case 'view':
+                return item.record.view?.is_materialized ? 'materialized view' : 'view'
+            case 'table': {
+                const tableType = item.record.table?.type
+                switch (tableType) {
+                    case 'materialized_view':
+                        return 'mat view'
+                    case 'batch_export':
+                        return 'batch export'
+                    case 'data_warehouse':
+                        return ''
+                    case 'posthog':
+                        return ''
+                    case 'system':
+                        return ''
+                    default:
+                        return null
+                }
+            }
+            default:
+                return null
+        }
+    }
+
     const treeRef = useRef<LemonTreeRef>(null)
     useEffect(() => {
         setTreeRef(treeRef)
@@ -188,6 +226,7 @@ export const QueryDatabase = (): JSX.Element => {
                 const isColumn = item.record?.type === 'column'
                 const columnType = isColumn ? item.record?.field?.type : null
                 const columnKey = isColumn && item.record ? `${item.record.table}.${item.record.columnName}` : null
+                const tableKindLabel = !isColumn && item.children?.length ? getTableKindLabel(item) : null
 
                 return (
                     <span className="truncate">
@@ -222,7 +261,13 @@ export const QueryDatabase = (): JSX.Element => {
                                 )}
                                 {isColumn && columnType ? (
                                     <span className="shrink rounded px-1.5 py-0.5 text-xs text-muted-alt">
-                                        {columnType}
+                                        {columnType === 'field_traverser' && item?.record?.field.chain
+                                            ? formatTraversalChain(item.record.field.chain)
+                                            : columnType}
+                                    </span>
+                                ) : tableKindLabel ? (
+                                    <span className="shrink rounded px-1.5 py-0.5 text-xs text-muted-alt">
+                                        {tableKindLabel}
                                     </span>
                                 ) : null}
                             </div>

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -142,9 +142,9 @@ export const QueryDatabase = (): JSX.Element => {
             return null
         }
 
-        switch (item.record.type) {
+        switch (item.record.traversedFieldType ?? item.record.type) {
             case 'lazy-table':
-                return 'lazy join'
+                return 'join'
             case 'virtual-table':
                 return 'virtual table'
             case 'managed-view':

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -161,10 +161,13 @@ export const QueryDatabase = (): JSX.Element => {
                     case 'batch_export':
                         return 'batch export'
                     case 'data_warehouse':
+                        // Return "" to not clutter the interface
                         return ''
                     case 'posthog':
+                        // Return "" to not clutter the interface
                         return ''
                     case 'system':
+                        // Return "" to not clutter the interface
                         return ''
                     default:
                         return null

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -370,7 +370,7 @@ const createTraversedLazyTableNode = (
             field,
             table: tableName,
             referencedTable: traversedField.table,
-            traversedFieldType: 'lazy_table',
+            traversedFieldType: 'lazy-table',
         },
         children,
     }
@@ -404,7 +404,7 @@ const createTraversedVirtualTableNode = (
             type: 'field-traverser',
             field,
             table: tableName,
-            traversedFieldType: 'virtual_table',
+            traversedFieldType: 'virtual-table',
         },
         children,
     }

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -370,6 +370,7 @@ const createTraversedLazyTableNode = (
             field,
             table: tableName,
             referencedTable: traversedField.table,
+            traversedFieldType: 'lazy_table',
         },
         children,
     }
@@ -403,6 +404,7 @@ const createTraversedVirtualTableNode = (
             type: 'field-traverser',
             field,
             table: tableName,
+            traversedFieldType: 'virtual_table',
         },
         children,
     }

--- a/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
@@ -69,7 +69,7 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
         setSourceTablePreviewData: (data: Record<string, any>[]) => ({ data }),
         setJoiningTablePreviewData: (data: Record<string, any>[]) => ({ data }),
         setIsJoinValid: (isValid: boolean) => ({ isValid }),
-        setValidationError: (errorMessage: string) => ({ errorMessage }),
+        setValidationError: (errorMessage: string | null) => ({ errorMessage }),
         setValidationWarning: (validationWarning: string | null) => ({ validationWarning }),
         validateJoin: () => {},
         checkKeyTypeMismatch: () => {},
@@ -327,6 +327,14 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
         selectExperimentsTimestampKey: ({ experimentsTimestampKey }) => {
             if (experimentsTimestampKey) {
                 actions.setExperimentsOptimized(true)
+            }
+        },
+        setViewLinkValue: ({ name }) => {
+            const fieldName = Array.isArray(name) ? name[0] : name
+            if (fieldName === 'joining_table_key' || fieldName === 'source_table_key') {
+                actions.setIsJoinValid(false)
+                actions.setValidationError(null)
+                actions.setValidationWarning(null)
             }
         },
         selectSourceTable: async ({ selectedTableName }) => {


### PR DESCRIPTION
## Changes

Fix a few SQL editor issues:
- Add join types as comments behind fields (virtual table vs (lazy) join vs ...)
- Joins added to persons were automatically proxied to events. You couldn't edit them under events in the UI
- Fix bug with view modal where editing the linking key (if custom sql expression) wouldn't let me try validation again

<img width="536" height="743" alt="image" src="https://github.com/user-attachments/assets/2797bb56-c9dc-41f5-bf9e-9892ca4eb022" />

## How did you test this code?

Clicked around locally with a bunch of joins in the sql editor.