### PR TITLE
feat(billing): update JobSwitchers DAG for contacts array schema

### DIFF
--- a/ee/billing/dags/job_switchers.py
+++ b/ee/billing/dags/job_switchers.py
@@ -72,7 +72,10 @@ def dataframe_to_clay_payload(df: pl.DataFrame) -> list[dict[str, Any]]:
     for row in df.to_dicts():
         contacts_raw = row.get("contacts") or []
         if isinstance(contacts_raw, str):
-            contacts_raw = json.loads(contacts_raw) if contacts_raw else []
+            try:
+                contacts_raw = json.loads(contacts_raw) if contacts_raw else []
+            except json.JSONDecodeError:
+                contacts_raw = []
 
         payload.append(
             {

--- a/ee/billing/dags/job_switchers.py
+++ b/ee/billing/dags/job_switchers.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import polars as pl
@@ -23,25 +24,25 @@ TRUNCATABLE_FIELDS = [
     "removal_timestamps",
     "removal_types",
     "source_type",
-    "organization_names",
-    "organization_ids",
     "emails",
+    "contacts",
 ]
 
 # Column definitions matching JobSwitchers_v3 schema
 COLUMNS = [
+    "bounce_count",
+    "bounce_reasons",
+    "contacts",
     "email_domain",
     "emails",
-    "bounce_count",
     "first_bounce_at",
     "last_bounce_at",
-    "subjects",
-    "bounce_reasons",
-    "organization_ids",
-    "organization_names",
+    "organization_id",
+    "organization_name",
     "removal_timestamps",
     "removal_types",
     "source_type",
+    "subjects",
 ]
 
 
@@ -69,17 +70,22 @@ def dataframe_to_clay_payload(df: pl.DataFrame) -> list[dict[str, Any]]:
     """Convert DataFrame to Clay webhook payload format."""
     payload = []
     for row in df.to_dicts():
+        contacts_raw = row.get("contacts") or []
+        if isinstance(contacts_raw, str):
+            contacts_raw = json.loads(contacts_raw) if contacts_raw else []
+
         payload.append(
             {
                 "domain": row["email_domain"],
                 "emails": row.get("emails", []) or [],
+                "contacts": contacts_raw,
                 "bounce_count": row.get("bounce_count", 0),
-                "first_bounce_at": (row["first_bounce_at"].isoformat() if row["first_bounce_at"] else None),
-                "last_bounce_at": (row["last_bounce_at"].isoformat() if row["last_bounce_at"] else None),
+                "first_bounce_at": (row["first_bounce_at"].isoformat() if row.get("first_bounce_at") else None),
+                "last_bounce_at": (row["last_bounce_at"].isoformat() if row.get("last_bounce_at") else None),
                 "subjects": row.get("subjects", []) or [],
                 "bounce_reasons": row.get("bounce_reasons", []) or [],
-                "organization_ids": row.get("organization_ids", []) or [],
-                "organization_names": row.get("organization_names", []) or [],
+                "organization_id": row.get("organization_id", "") or "",
+                "organization_name": row.get("organization_name", "") or "",
                 "removal_timestamps": row.get("removal_timestamps", []) or [],
                 "removal_types": row.get("removal_types", []) or [],
                 "source_type": row.get("source_type", []) or [],

--- a/ee/billing/dags/test_job_switchers.py
+++ b/ee/billing/dags/test_job_switchers.py
@@ -26,18 +26,19 @@ class TestClickhouseToDataframe:
                 "single_row",
                 [
                     (
-                        "example.com",
-                        ["user1@example.com", "user2@example.com"],
-                        5,
-                        datetime(2024, 1, 15, 10, 30),
-                        datetime(2024, 6, 20, 14, 22),
-                        ["Subject 1"],
-                        ["mailbox full"],
-                        ["org-123"],
-                        ["Example Corp"],
-                        [1704067200],
-                        ["voluntary"],
-                        ["customer_io_delivery"],
+                        5,  # bounce_count
+                        ["mailbox full"],  # bounce_reasons
+                        [{"email": "user1@example.com", "first_name": "Alice"}],  # contacts
+                        "example.com",  # email_domain
+                        ["user1@example.com", "user2@example.com"],  # emails
+                        datetime(2024, 1, 15, 10, 30),  # first_bounce_at
+                        datetime(2024, 6, 20, 14, 22),  # last_bounce_at
+                        "org-123",  # organization_id
+                        "Example Corp",  # organization_name
+                        [1704067200],  # removal_timestamps
+                        ["voluntary"],  # removal_types
+                        ["customer_io_delivery"],  # source_type
+                        ["Subject 1"],  # subjects
                     ),
                 ],
                 1,
@@ -47,34 +48,8 @@ class TestClickhouseToDataframe:
             (
                 "multiple_rows",
                 [
-                    (
-                        "a.com",
-                        ["a@a.com"],
-                        1,
-                        None,
-                        None,
-                        [],
-                        [],
-                        [],
-                        [],
-                        [],
-                        [],
-                        [],
-                    ),
-                    (
-                        "b.com",
-                        ["b@b.com"],
-                        2,
-                        None,
-                        None,
-                        [],
-                        [],
-                        [],
-                        [],
-                        [],
-                        [],
-                        [],
-                    ),
+                    (1, [], [], "a.com", ["a@a.com"], None, None, "", "", [], [], [], []),
+                    (2, [], [], "b.com", ["b@b.com"], None, None, "", "", [], [], [], []),
                 ],
                 2,
                 "a.com",
@@ -206,13 +181,24 @@ class TestDataframeToClayPayload:
             {
                 "email_domain": ["example.com"],
                 "emails": [["user@example.com"]],
+                "contacts": [
+                    [
+                        {
+                            "email": "user@example.com",
+                            "first_name": "Alice",
+                            "last_name": "Smith",
+                            "is_active": "true",
+                            "date_joined": "2024-01-01 00:00:00",
+                        }
+                    ]
+                ],
                 "bounce_count": [5],
                 "first_bounce_at": [datetime(2024, 1, 15)],
                 "last_bounce_at": [None],
                 "subjects": [["Test subject"]],
                 "bounce_reasons": [["mailbox full"]],
-                "organization_ids": [["org-1"]],
-                "organization_names": [["Example Corp"]],
+                "organization_id": ["org-1"],
+                "organization_name": ["Example Corp"],
                 "removal_timestamps": [[1704067200]],
                 "removal_types": [["voluntary"]],
                 "source_type": [["customer_io"]],
@@ -225,23 +211,58 @@ class TestDataframeToClayPayload:
         assert len(payload) == 1
         assert payload[0]["domain"] == "example.com"
         assert payload[0]["emails"] == ["user@example.com"]
+        assert payload[0]["contacts"] == [
+            {
+                "email": "user@example.com",
+                "first_name": "Alice",
+                "last_name": "Smith",
+                "is_active": "true",
+                "date_joined": "2024-01-01 00:00:00",
+            }
+        ]
         assert payload[0]["first_bounce_at"] == "2024-01-15T00:00:00"
         assert payload[0]["last_bounce_at"] is None
         assert payload[0]["bounce_count"] == 5
-        assert payload[0]["organization_names"] == ["Example Corp"]
+        assert payload[0]["organization_id"] == "org-1"
+        assert payload[0]["organization_name"] == "Example Corp"
 
-    def test_handles_null_arrays(self):
+    def test_handles_contacts_as_json_string(self):
+        contacts_json = '[{"email": "a@test.com", "first_name": "A"}]'
+        df = pl.DataFrame(
+            {
+                "email_domain": ["test.com"],
+                "emails": [["a@test.com"]],
+                "contacts": [contacts_json],
+                "bounce_count": [0],
+                "first_bounce_at": [None],
+                "last_bounce_at": [None],
+                "subjects": [[]],
+                "bounce_reasons": [[]],
+                "organization_id": [""],
+                "organization_name": [""],
+                "removal_timestamps": [[]],
+                "removal_types": [[]],
+                "source_type": [[]],
+            }
+        )
+
+        payload = dataframe_to_clay_payload(df)
+
+        assert payload[0]["contacts"] == [{"email": "a@test.com", "first_name": "A"}]
+
+    def test_handles_null_values(self):
         df = pl.DataFrame(
             {
                 "email_domain": ["test.com"],
                 "emails": [None],
+                "contacts": [None],
                 "bounce_count": [0],
                 "first_bounce_at": [None],
                 "last_bounce_at": [None],
                 "subjects": [None],
                 "bounce_reasons": [None],
-                "organization_ids": [None],
-                "organization_names": [None],
+                "organization_id": [None],
+                "organization_name": [None],
                 "removal_timestamps": [None],
                 "removal_types": [None],
                 "source_type": [None],
@@ -251,7 +272,10 @@ class TestDataframeToClayPayload:
         payload = dataframe_to_clay_payload(df)
 
         assert payload[0]["emails"] == []
+        assert payload[0]["contacts"] == []
         assert payload[0]["bounce_reasons"] == []
+        assert payload[0]["organization_id"] == ""
+        assert payload[0]["organization_name"] == ""
 
 
 class TestGetPriorHashesFromMetadata:


### PR DESCRIPTION
## Summary

Updated: https://us.posthog.com/project/2/insights/AJnFRfBD to enrich with better contact level data so the Person enrichment in Clay yields more matches

- Update the JobSwitchers DAG to match the new `JobSwitchers_v3` saved query schema
- Aggregates all users per domain into a structured `contacts` JSON array (with email, first_name, last_name, is_active, date_joined) instead of picking a single email
- Organization fields (`organization_id`, `organization_name`) are now singular strings instead of arrays
- `contacts` and `emails` are added as truncatable fields for Clay batch size management

## Test plan

- [x] All 30 tests pass (`pytest ee/billing/dags/test_job_switchers.py -v`)
- [x] Ruff check and format pass
- [ ] Verify first DAG run syncs all domains (expected: hash change due to new fields)
- [ ] Verify Clay receives structured contacts array per domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)