### PR TITLE
feat(experiments): Remove description from variants form and polish

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanel.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanel.test.tsx
@@ -127,7 +127,7 @@ describe('VariantsPanel', () => {
         it('shows variant keys section when feature flag key is set', () => {
             render(<VariantsPanel experiment={defaultExperiment} updateFeatureFlag={mockUpdateFeatureFlag} />)
 
-            expect(screen.getByText('Variant keys')).toBeInTheDocument()
+            expect(screen.getByText('Variant key')).toBeInTheDocument()
         })
     })
 
@@ -538,15 +538,15 @@ describe('VariantsPanel', () => {
                 <VariantsPanel experiment={experimentWithEmptyKey} updateFeatureFlag={mockUpdateFeatureFlag} />
             )
 
-            // Find variant rows
-            const variantRows = container.querySelectorAll('.grid.grid-cols-24')
+            // Find variant rows in the table
+            const variantRows = container.querySelectorAll('tbody tr')
 
             // First variant (control) should not have error highlighting
-            expect(variantRows[1]).not.toHaveClass('bg-danger-highlight')
+            expect(variantRows[0]).not.toHaveClass('bg-danger-highlight')
 
             // Second variant (empty key) should have error highlighting
-            expect(variantRows[2]).toHaveClass('bg-danger-highlight')
-            expect(variantRows[2]).toHaveClass('border-danger')
+            expect(variantRows[1]).toHaveClass('bg-danger-highlight')
+            expect(variantRows[1]).toHaveClass('border-danger')
         })
     })
 

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.test.tsx
@@ -78,7 +78,7 @@ describe('VariantsPanelCreateFeatureFlag', () => {
         it('renders variant keys section', () => {
             renderComponent(defaultExperiment)
 
-            expect(screen.getByText('Variant keys')).toBeInTheDocument()
+            expect(screen.getByText('Variant key')).toBeInTheDocument()
         })
 
         it('renders default variants (control and test)', () => {
@@ -263,8 +263,8 @@ describe('VariantsPanelCreateFeatureFlag', () => {
                 <VariantsPanelCreateFeatureFlag experiment={experimentWithThreeVariants} onChange={mockOnChange} />
             )
 
-            const rows = container.querySelectorAll('.grid.grid-cols-18')
-            const controlRow = rows[1] // First row after header
+            const rows = container.querySelectorAll('tbody tr')
+            const controlRow = rows[0] // First row (control variant)
 
             // Control variant should not have a delete button
             const deleteButton = controlRow.querySelector('[data-attr^="delete-prop-filter"]')

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.test.tsx
@@ -175,18 +175,6 @@ describe('VariantsPanelCreateFeatureFlag', () => {
             expect(hasVariantUpdate).toBe(true)
         })
 
-        it('updates variant description', async () => {
-            renderComponent(defaultExperiment)
-
-            const descriptionInputs = screen.getAllByPlaceholderText('Description')
-            await userEvent.type(descriptionInputs[0], 'Control group')
-
-            // Verify onChange was called with variant updates
-            expect(mockOnChange).toHaveBeenCalled()
-            const hasVariantUpdate = mockOnChange.mock.calls.some((call) => call[0].parameters?.feature_flag_variants)
-            expect(hasVariantUpdate).toBe(true)
-        })
-
         it('updates rollout percentage after enabling custom split', async () => {
             const { container } = renderComponent(defaultExperiment)
 
@@ -275,7 +263,7 @@ describe('VariantsPanelCreateFeatureFlag', () => {
                 <VariantsPanelCreateFeatureFlag experiment={experimentWithThreeVariants} onChange={mockOnChange} />
             )
 
-            const rows = container.querySelectorAll('.grid.grid-cols-24')
+            const rows = container.querySelectorAll('.grid.grid-cols-18')
             const controlRow = rows[1] // First row after header
 
             // Control variant should not have a delete button

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
@@ -115,11 +115,11 @@ export const VariantsPanelCreateFeatureFlag = ({
     return (
         <div className="flex flex-col gap-4">
             <LemonField.Pure label="Variants">
-                <div className="text-sm border border-primary rounded p-4">
-                    <div className="grid grid-cols-18 gap-2 font-bold mb-2 items-center">
+                <div className="text-sm border border-primary rounded pt-2 ps-4 pb-4">
+                    <div className="grid grid-cols-18 gap-2 font-bold mb-0 items-center px-2">
                         <div />
                         <div className="col-span-4">Variant key</div>
-                        <div className="col-span-3 flex items-center gap-1">
+                        <div className="col-span-2 flex items-center gap-1 min-w-24">
                             <span>Split</span>
                             {!disabled && (
                                 <div className="flex items-center gap-1 min-w-[72px]">
@@ -144,7 +144,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                     {variants.map((variant, index) => (
                         <div
                             key={index}
-                            className={`grid grid-cols-18 gap-2 mb-2 p-2 rounded ${
+                            className={`grid grid-cols-18 gap-2 mb-1 p-1 rounded ${
                                 hasVariantError(index)
                                     ? 'bg-danger-highlight border border-danger'
                                     : 'bg-transparent border border-transparent'
@@ -153,7 +153,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                             <div className="flex items-center justify-center">
                                 <Lettermark name={alphabet[index]} color={LettermarkColor.Gray} />
                             </div>
-                            <div className="col-span-4">
+                            <div className="col-span-4 flex items-center">
                                 <LemonInput
                                     value={variant.key}
                                     disabledReason={
@@ -174,7 +174,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                                     spellCheck={false}
                                 />
                             </div>
-                            <div className="col-span-3">
+                            <div className="col-span-2 min-w-24 flex items-center">
                                 {isCustomSplit && !disabled ? (
                                     <LemonInput
                                         type="number"

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
@@ -116,10 +116,9 @@ export const VariantsPanelCreateFeatureFlag = ({
         <div className="flex flex-col gap-4">
             <LemonField.Pure label="Variant keys">
                 <div className="text-sm border border-primary rounded p-4">
-                    <div className="grid grid-cols-24 gap-2 font-bold mb-2 items-center">
+                    <div className="grid grid-cols-18 gap-2 font-bold mb-2 items-center">
                         <div />
                         <div className="col-span-4">Variant key</div>
-                        <div className="col-span-6">Description</div>
                         <div className="col-span-3 flex items-center gap-1">
                             <span>Split</span>
                             {!disabled && (
@@ -145,7 +144,7 @@ export const VariantsPanelCreateFeatureFlag = ({
                     {variants.map((variant, index) => (
                         <div
                             key={index}
-                            className={`grid grid-cols-24 gap-2 mb-2 p-2 rounded ${
+                            className={`grid grid-cols-18 gap-2 mb-2 p-2 rounded ${
                                 hasVariantError(index)
                                     ? 'bg-danger-highlight border border-danger'
                                     : 'bg-transparent border border-transparent'
@@ -173,20 +172,6 @@ export const VariantsPanelCreateFeatureFlag = ({
                                     autoCapitalize="off"
                                     autoCorrect="off"
                                     spellCheck={false}
-                                />
-                            </div>
-                            <div className="col-span-6">
-                                <LemonInput
-                                    value={variant.name || ''}
-                                    onChange={(value) => updateVariant(index, { name: value })}
-                                    disabledReason={
-                                        disabled
-                                            ? 'You cannot change the variant name when editing an experiment.'
-                                            : undefined
-                                    }
-                                    data-attr="experiment-variant-name"
-                                    className="ph-ignore-input"
-                                    placeholder="Description"
                                 />
                             </div>
                             <div className="col-span-3">

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
@@ -115,112 +115,125 @@ export const VariantsPanelCreateFeatureFlag = ({
     return (
         <div className="flex flex-col gap-4">
             <LemonField.Pure label="Variants">
-                <div className="text-sm border border-primary rounded pt-2 ps-4 pb-4">
-                    <div className="grid grid-cols-18 gap-2 font-bold mb-0 items-center px-2">
-                        <div />
-                        <div className="col-span-4">Variant key</div>
-                        <div className="col-span-2 flex items-center gap-1 min-w-24">
-                            <span>Split</span>
-                            {!disabled && (
-                                <div className="flex items-center gap-1 min-w-[72px]">
-                                    <LemonButton
-                                        onClick={() => setIsCustomSplit(!isCustomSplit)}
-                                        tooltip="Customize split"
-                                    >
-                                        <IconPencil />
-                                    </LemonButton>
-                                    {!isEvenlyDistributed(variants) && (
-                                        <LemonButton
-                                            onClick={() => distributeVariantsEqually()}
-                                            tooltip="Distribute split evenly"
-                                        >
-                                            <IconBalance />
-                                        </LemonButton>
-                                    )}
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                    {variants.map((variant, index) => (
-                        <div
-                            key={index}
-                            className={`grid grid-cols-18 gap-2 mb-1 p-1 rounded ${
-                                hasVariantError(index)
-                                    ? 'bg-danger-highlight border border-danger'
-                                    : 'bg-transparent border border-transparent'
-                            }`}
-                        >
-                            <div className="flex items-center justify-center">
-                                <Lettermark name={alphabet[index]} color={LettermarkColor.Gray} />
-                            </div>
-                            <div className="col-span-4 flex items-center">
-                                <LemonInput
-                                    value={variant.key}
-                                    disabledReason={
-                                        disabled
-                                            ? 'Cannot edit feature flag in edit mode'
-                                            : variant.key === 'control'
-                                              ? 'Control variant cannot be changed'
-                                              : null
-                                    }
-                                    onChange={(value) => updateVariant(index, { key: value.replace(/\s+/g, '-') })}
-                                    data-attr="experiment-variant-key"
-                                    data-key-index={index.toString()}
-                                    className="ph-ignore-input"
-                                    placeholder={`example-variant-${index + 1}`}
-                                    autoComplete="off"
-                                    autoCapitalize="off"
-                                    autoCorrect="off"
-                                    spellCheck={false}
-                                />
-                            </div>
-                            <div className="col-span-2 min-w-24 flex items-center">
-                                {isCustomSplit && !disabled ? (
-                                    <LemonInput
-                                        type="number"
-                                        min={0}
-                                        max={100}
-                                        value={variant.rollout_percentage}
-                                        onChange={(changedValue) => {
-                                            const valueInt =
-                                                changedValue !== undefined && !Number.isNaN(changedValue)
-                                                    ? parseInt(changedValue.toString(), 10)
-                                                    : 0
-                                            updateVariant(index, { rollout_percentage: valueInt })
-                                        }}
-                                        suffix={<span>%</span>}
-                                        data-attr="experiment-variant-rollout-percentage-input"
-                                    />
-                                ) : (
-                                    <div className="flex items-center h-10 px-2 text-sm">
-                                        {variant.rollout_percentage}%
+                <div className="border border-primary rounded p-4">
+                    <table className="w-full">
+                        <thead>
+                            <tr className="text-sm font-bold">
+                                <td className="w-5" />
+                                <td className="w-20">Variant key</td>
+                                <td className="w-10">
+                                    <div className="flex items-center gap-1">
+                                        <span>Split</span>
+                                        {!disabled && (
+                                            <>
+                                                <LemonButton
+                                                    onClick={() => setIsCustomSplit(!isCustomSplit)}
+                                                    tooltip="Customize split"
+                                                >
+                                                    <IconPencil />
+                                                </LemonButton>
+                                                <LemonButton
+                                                    onClick={() => distributeVariantsEqually()}
+                                                    tooltip="Distribute split evenly"
+                                                    className={isEvenlyDistributed(variants) ? 'invisible' : ''}
+                                                >
+                                                    <IconBalance />
+                                                </LemonButton>
+                                            </>
+                                        )}
                                     </div>
-                                )}
-                            </div>
-                            <div className="flex items-center justify-center">
-                                {!disabled && variants.length > 2 && index > 0 && (
-                                    <LemonButton
-                                        icon={<IconTrash />}
-                                        data-attr={`delete-prop-filter-${index}`}
-                                        noPadding
-                                        onClick={() => removeVariant(index)}
-                                        tooltipPlacement="top-end"
-                                    />
-                                )}
-                            </div>
-                        </div>
-                    ))}
+                                </td>
+                                <td className="w-65" />
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {variants.map((variant, index) => (
+                                <tr
+                                    key={index}
+                                    className={hasVariantError(index) ? 'bg-danger-highlight border border-danger' : ''}
+                                >
+                                    <td className="py-2">
+                                        <div className="flex items-center justify-center">
+                                            <Lettermark name={alphabet[index]} color={LettermarkColor.Gray} />
+                                        </div>
+                                    </td>
+                                    <td className="py-2 pr-2">
+                                        <LemonInput
+                                            value={variant.key}
+                                            disabledReason={
+                                                disabled
+                                                    ? 'Cannot edit feature flag in edit mode'
+                                                    : variant.key === 'control'
+                                                      ? 'Control variant cannot be changed'
+                                                      : null
+                                            }
+                                            onChange={(value) =>
+                                                updateVariant(index, { key: value.replace(/\s+/g, '-') })
+                                            }
+                                            data-attr="experiment-variant-key"
+                                            data-key-index={index.toString()}
+                                            className="ph-ignore-input"
+                                            placeholder={`example-variant-${index + 1}`}
+                                            autoComplete="off"
+                                            autoCapitalize="off"
+                                            autoCorrect="off"
+                                            spellCheck={false}
+                                        />
+                                    </td>
+                                    <td className="py-2">
+                                        {isCustomSplit && !disabled ? (
+                                            <LemonInput
+                                                type="number"
+                                                min={0}
+                                                max={100}
+                                                value={variant.rollout_percentage}
+                                                onChange={(changedValue) => {
+                                                    const valueInt =
+                                                        changedValue !== undefined && !Number.isNaN(changedValue)
+                                                            ? parseInt(changedValue.toString(), 10)
+                                                            : 0
+                                                    updateVariant(index, { rollout_percentage: valueInt })
+                                                }}
+                                                suffix={<span>%</span>}
+                                                data-attr="experiment-variant-rollout-percentage-input"
+                                                className="w-30"
+                                            />
+                                        ) : (
+                                            <div className="flex items-center h-10 px-2">
+                                                {variant.rollout_percentage}%
+                                            </div>
+                                        )}
+                                    </td>
+                                    <td className="py-2">
+                                        <div className="flex items-center justify-center">
+                                            {!disabled && variants.length > 2 && index > 0 && (
+                                                <LemonButton
+                                                    icon={<IconTrash />}
+                                                    data-attr={`delete-prop-filter-${index}`}
+                                                    noPadding
+                                                    onClick={() => removeVariant(index)}
+                                                    tooltipPlacement="top-end"
+                                                />
+                                            )}
+                                        </div>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                     {variants.length > 0 && !areVariantRolloutsValid && (
-                        <p className="text-danger">Variant splits must sum to 100 (currently {variantRolloutSum}).</p>
+                        <p className="text-danger mt-2">
+                            Variant splits must sum to 100 (currently {variantRolloutSum}).
+                        </p>
                     )}
                     {variants.length > 0 && !areVariantKeysValid && (
-                        <p className="text-danger">All variants must have a key.</p>
+                        <p className="text-danger mt-2">All variants must have a key.</p>
                     )}
                     {variants.length > 0 && hasDuplicateKeys && (
-                        <p className="text-danger">Variant keys must be unique.</p>
+                        <p className="text-danger mt-2">Variant keys must be unique.</p>
                     )}
                     {!disabled && variants.length < MAX_EXPERIMENT_VARIANTS && (
-                        <LemonButton type="secondary" onClick={addVariant} icon={<IconPlus />} center>
+                        <LemonButton type="secondary" onClick={addVariant} icon={<IconPlus />} className="mt-2">
                             Add variant
                         </LemonButton>
                     )}

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
@@ -114,7 +114,7 @@ export const VariantsPanelCreateFeatureFlag = ({
 
     return (
         <div className="flex flex-col gap-4">
-            <LemonField.Pure label="Variant keys">
+            <LemonField.Pure label="Variants">
                 <div className="text-sm border border-primary rounded p-4">
                     <div className="grid grid-cols-18 gap-2 font-bold mb-2 items-center">
                         <div />


### PR DESCRIPTION
## Problem

Variants have a description field that nobody used, so we can remove it from the form. Additionally the variants section had some small layout issues.

## Changes

- Remove the description field from the variants section of the experiments creation form
- Change section label from "variant keys" to "variants" (as the whole section is about variants and the keys are just one part of it)
- Give it a more polished look
  - Reduce spacing to make form more compact
  - Fix alignment issues between table caption and fields

| before | after |
| - | - |
| <img width="802" height="639" alt="variants-before" src="https://github.com/user-attachments/assets/d98c73d1-04cb-40b4-b8f2-8eb67e40d510" /> | <img width="803" height="611" alt="variants-after" src="https://github.com/user-attachments/assets/9dbe9255-7be6-4415-af42-8edc24a8315e" /> |

## How did you test this code?

Manually

## Publish to changelog?

No