### PR TITLE
fix(sql-editor): tooltip bounds

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
@@ -36,7 +36,7 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
     return (
         <>
             <div
-                className="relative flex flex-row w-full bg-primary"
+                className="relative flex flex-row w-full bg-primary overflow-hidden"
                 // eslint-disable-next-line react/forbid-dom-props
                 style={{
                     height: `${queryPaneHeight}px`,
@@ -44,7 +44,7 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
                 ref={queryPaneResizerProps.containerRef}
             >
                 <div className="relative flex flex-col w-full min-h-0">
-                    <div className="flex-1 min-h-0" data-attr="hogql-query-editor">
+                    <div className="flex-1 min-h-0 overflow-hidden" data-attr="hogql-query-editor">
                         <AutoSizer
                             renderProp={({ height, width }) =>
                                 height && width ? (

--- a/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
@@ -36,7 +36,7 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
     return (
         <>
             <div
-                className="relative flex flex-row w-full bg-primary overflow-hidden"
+                className="relative flex flex-row w-full bg-primary"
                 // eslint-disable-next-line react/forbid-dom-props
                 style={{
                     height: `${queryPaneHeight}px`,
@@ -44,7 +44,7 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
                 ref={queryPaneResizerProps.containerRef}
             >
                 <div className="relative flex flex-col w-full min-h-0">
-                    <div className="flex-1 min-h-0 overflow-hidden" data-attr="hogql-query-editor">
+                    <div className="flex-1 min-h-0" data-attr="hogql-query-editor">
                         <AutoSizer
                             renderProp={({ height, width }) =>
                                 height && width ? (


### PR DESCRIPTION
## Problem

<img width="671" height="217" alt="Screenshot 2026-02-06 at 13 43 30" src="https://github.com/user-attachments/assets/63b995ee-af30-41dd-bf4c-1e00b0d16773" />

## Changes

<img width="669" height="205" alt="Screenshot 2026-02-06 at 13 43 22" src="https://github.com/user-attachments/assets/5dddf131-4652-4152-be71-9436e009df15" />

## How did you test this code?

I made sure the query window would not grow out of bounds by resizing it in different ways. 