### PR TITLE
fix: infinite list bug

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.test.tsx
@@ -1,0 +1,125 @@
+import { MOCK_TEAM_ID } from 'lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import { TaxonomicFilterGroupType, TaxonomicFilterLogicProps } from 'lib/components/TaxonomicFilter/types'
+
+import { useMocks } from '~/mocks/jest'
+import { actionsModel } from '~/models/actionsModel'
+import { groupsModel } from '~/models/groupsModel'
+import { initKeaTests } from '~/test/init'
+import { mockEventDefinitions } from '~/test/mocks'
+import { AppContext } from '~/types'
+
+import { infiniteListLogic } from './infiniteListLogic'
+import { taxonomicFilterLogic } from './taxonomicFilterLogic'
+
+window.POSTHOG_APP_CONTEXT = {
+    current_team: { id: MOCK_TEAM_ID },
+    current_project: { id: MOCK_TEAM_ID },
+} as unknown as AppContext
+
+describe('InfiniteSelectResults - CategoryPill logic mounting', () => {
+    let logic: ReturnType<typeof taxonomicFilterLogic.build>
+
+    const taxonomicFilterLogicProps: TaxonomicFilterLogicProps = {
+        taxonomicFilterLogicKey: 'test-category-pill',
+        taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
+    }
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team/event_definitions': (res) => {
+                    const search = res.url.searchParams.get('search')
+                    const results = search
+                        ? mockEventDefinitions.filter((e) => e.name.includes(search))
+                        : mockEventDefinitions
+                    return [200, { results, count: results.length }]
+                },
+            },
+        })
+        initKeaTests()
+        actionsModel.mount()
+        groupsModel.mount()
+
+        logic = taxonomicFilterLogic(taxonomicFilterLogicProps)
+        logic.mount()
+
+        // Mount infiniteListLogics for each group type (this is what BindLogic does in CategoryPill)
+        for (const listGroupType of taxonomicFilterLogicProps.taxonomicGroupTypes) {
+            infiniteListLogic({ ...taxonomicFilterLogicProps, listGroupType }).mount()
+        }
+    })
+
+    it('infiniteListLogic is properly mounted for each group type when using BindLogic pattern', async () => {
+        // The fix ensures that CategoryPill wraps its content with BindLogic, which properly mounts
+        // the infiniteListLogic for each group type. Without this, KEA throws "Can not find path" errors.
+
+        // Verify all infiniteListLogics are mounted (this simulates what BindLogic achieves)
+        await expectLogic(logic).toMount([
+            infiniteListLogic({ ...taxonomicFilterLogicProps, listGroupType: TaxonomicFilterGroupType.Events }),
+            infiniteListLogic({ ...taxonomicFilterLogicProps, listGroupType: TaxonomicFilterGroupType.Actions }),
+        ])
+
+        // Verify logic is accessible and has expected structure
+        const eventsLogic = infiniteListLogic({
+            ...taxonomicFilterLogicProps,
+            listGroupType: TaxonomicFilterGroupType.Events,
+        })
+        expect(eventsLogic.isMounted()).toBe(true)
+        expect(eventsLogic.values.listGroupType).toBe(TaxonomicFilterGroupType.Events)
+
+        const actionsLogic = infiniteListLogic({
+            ...taxonomicFilterLogicProps,
+            listGroupType: TaxonomicFilterGroupType.Actions,
+        })
+        expect(actionsLogic.isMounted()).toBe(true)
+        expect(actionsLogic.values.listGroupType).toBe(TaxonomicFilterGroupType.Actions)
+    })
+
+    it('infiniteListLogic can access values after being mounted via BindLogic pattern', async () => {
+        // This test verifies that the logic can properly access its selectors without errors
+        // The original bug caused "Can not find path" errors when trying to access these values
+
+        const eventsLogic = infiniteListLogic({
+            ...taxonomicFilterLogicProps,
+            listGroupType: TaxonomicFilterGroupType.Events,
+        })
+
+        // These are the values that CategoryPillContent accesses via useValues(infiniteListLogic)
+        // Without proper BindLogic mounting, accessing these would throw KEA errors
+        await expectLogic(eventsLogic).toMatchValues({
+            listGroupType: TaxonomicFilterGroupType.Events,
+            hasRemoteDataSource: true,
+        })
+
+        // Verify we can access result counts without errors
+        expect(typeof eventsLogic.values.totalResultCount).toBe('number')
+        expect(typeof eventsLogic.values.totalListCount).toBe('number')
+        expect(typeof eventsLogic.values.isLoading).toBe('boolean')
+    })
+
+    it('multiple infiniteListLogics with different group types can coexist', async () => {
+        // The fix ensures each CategoryPill has its own properly-bound infiniteListLogic instance
+        // This prevents conflicts between different group types
+
+        const eventsLogic = infiniteListLogic({
+            ...taxonomicFilterLogicProps,
+            listGroupType: TaxonomicFilterGroupType.Events,
+        })
+        const actionsLogic = infiniteListLogic({
+            ...taxonomicFilterLogicProps,
+            listGroupType: TaxonomicFilterGroupType.Actions,
+        })
+
+        // Both should be mounted and have distinct group types
+        expect(eventsLogic.isMounted()).toBe(true)
+        expect(actionsLogic.isMounted()).toBe(true)
+        expect(eventsLogic.values.listGroupType).not.toBe(actionsLogic.values.listGroupType)
+
+        // The logics should have different keys
+        expect(eventsLogic.pathString).toContain('events')
+        expect(actionsLogic.pathString).toContain('actions')
+    })
+})

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -24,20 +24,19 @@ export interface InfiniteSelectResultsProps {
     useVerticalLayout?: boolean
 }
 
-function CategoryPill({
+// CategoryPillContent uses useValues(infiniteListLogic) without props, relying on BindLogic context
+// This ensures proper logic mounting and prevents "Can not find path" KEA errors
+function CategoryPillContent({
     isActive,
     groupType,
-    taxonomicFilterLogicProps,
     onClick,
 }: {
     isActive: boolean
     groupType: TaxonomicFilterGroupType
-    taxonomicFilterLogicProps: TaxonomicFilterLogicProps
     onClick: () => void
 }): JSX.Element {
-    const logic = infiniteListLogic({ ...taxonomicFilterLogicProps, listGroupType: groupType })
     const { taxonomicGroups } = useValues(taxonomicFilterLogic)
-    const { totalResultCount, totalListCount, isLoading, hasRemoteDataSource, hasMore } = useValues(logic)
+    const { totalResultCount, totalListCount, isLoading, hasRemoteDataSource, hasMore } = useValues(infiniteListLogic)
 
     const group = taxonomicGroups.find((g) => g.type === groupType)
 
@@ -71,6 +70,26 @@ function CategoryPill({
                 </>
             )}
         </LemonTag>
+    )
+}
+
+// CategoryPill wraps CategoryPillContent with BindLogic to ensure infiniteListLogic is properly mounted
+// before accessing its values. Without BindLogic, KEA throws "Can not find path" errors.
+function CategoryPill({
+    isActive,
+    groupType,
+    taxonomicFilterLogicProps,
+    onClick,
+}: {
+    isActive: boolean
+    groupType: TaxonomicFilterGroupType
+    taxonomicFilterLogicProps: TaxonomicFilterLogicProps
+    onClick: () => void
+}): JSX.Element {
+    return (
+        <BindLogic logic={infiniteListLogic} props={{ ...taxonomicFilterLogicProps, listGroupType: groupType }}>
+            <CategoryPillContent isActive={isActive} groupType={groupType} onClick={onClick} />
+        </BindLogic>
     )
 }
 


### PR DESCRIPTION
## Problem
Users were seeing KEA "Can not find path" errors when opening the TaxonomicPopover menu in the PostHog AI context selector. [Session replay here](https://us.posthog.com/project/2/replay/home?filters=%7B%22filter_test_accounts%22%3Afalse%2C%22date_from%22%3A%22-3d%22%2C%22date_to%22%3Anull%2C%22filter_group%22%3A%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22key%22%3A%22email%22%2C%22value%22%3A%5B%22siddharthborderwala%40gmail.com%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22person%22%7D%5D%7D%5D%7D%2C%22duration%22%3A%5B%7B%22type%22%3A%22recording%22%2C%22key%22%3A%22active_seconds%22%2C%22value%22%3A5%2C%22operator%22%3A%22gt%22%7D%5D%2C%22order%22%3A%22start_time%22%2C%22order_direction%22%3A%22DESC%22%7D&sessionRecordingId=019c281b-10d1-7669-b759-5a83455e2afb&inspectorSideBar=true&tab=inspector)

Error: [KEA] Can not find path "lib.components.TaxonomicFilter .infiniteListLogic.taxonomic-filter-3-events" in the store.

The CategoryPill component was calling infiniteListLogic({ ...props }) and using useValues(logic) without properly mounting the logic via BindLogic, causing KEA to fail when accessing the logic's values.

## Changes
- Split CategoryPill into two components:
    - CategoryPillContent - Uses useValues(infiniteListLogic) without explicit props, relying on context from BindLogic
    - CategoryPill - Wraps CategoryPillContent with BindLogic to properly mount the infiniteListLogic

## How did you test this code?
Added tests

## Publish to changelog?
No