### PR TITLE
chore(ux): make sidepanel tab aware behind flag

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelStateLogic.test.ts
@@ -1,0 +1,125 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { initKeaTests } from '~/test/init'
+import { SidePanelTab } from '~/types'
+
+import { sidePanelStateLogic } from './sidePanelStateLogic'
+
+describe('sidePanelStateLogic - onSceneTabChanged', () => {
+    let logic: ReturnType<typeof sidePanelStateLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        featureFlagLogic.mount()
+        featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.UX_REMOVE_SIDEPANEL]: true })
+        logic = sidePanelStateLogic.build()
+        logic.mount()
+    })
+
+    it('does not run when UX_REMOVE_SIDEPANEL flag is disabled', async () => {
+        featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.UX_REMOVE_SIDEPANEL]: false })
+
+        logic.actions.openSidePanel(SidePanelTab.Max)
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
+
+        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
+    })
+
+    it('does not crash when featureFlagLogic is not mounted', async () => {
+        featureFlagLogic.unmount()
+
+        logic.actions.openSidePanel(SidePanelTab.Max)
+        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
+
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
+    })
+
+    it('saves and restores side panel state when switching between tabs', async () => {
+        // Open panel on tab-a
+        logic.actions.openSidePanel(SidePanelTab.Max)
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
+
+        // Switch to tab-b: saves tab-a state, tab-b has no saved state so panel stays as-is
+        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: true })
+
+        // Close panel on tab-b
+        logic.actions.closeSidePanel()
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: false })
+
+        // Switch back to tab-a: restores open state
+        logic.actions.onSceneTabChanged('tab-b', 'tab-a')
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
+    })
+
+    it('restores closed state for tabs that were explicitly closed', async () => {
+        // Open panel on tab-a
+        logic.actions.openSidePanel(SidePanelTab.Max)
+
+        // Switch to tab-b
+        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
+
+        // Close panel on tab-b, then switch to tab-c
+        logic.actions.closeSidePanel()
+        logic.actions.onSceneTabChanged('tab-b', 'tab-c')
+
+        // Switch back to tab-b: should restore the closed state
+        logic.actions.onSceneTabChanged('tab-c', 'tab-b')
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: false })
+    })
+
+    it('preserves current state for never-visited tabs', async () => {
+        // Open panel
+        logic.actions.openSidePanel(SidePanelTab.Max)
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: true })
+
+        // Switch to a brand-new tab: no saved state, should preserve current panel state
+        logic.actions.onSceneTabChanged('tab-a', 'tab-new')
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
+    })
+
+    it('restores selectedTabOptions along with the tab', async () => {
+        logic.actions.openSidePanel(SidePanelTab.Support, 'bug:analytics')
+        await expectLogic(logic).toMatchValues({
+            sidePanelOpen: true,
+            selectedTab: SidePanelTab.Support,
+            selectedTabOptions: 'bug:analytics',
+        })
+
+        // Switch away and back
+        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
+        logic.actions.closeSidePanel()
+        logic.actions.onSceneTabChanged('tab-b', 'tab-a')
+
+        await expectLogic(logic).toMatchValues({
+            sidePanelOpen: true,
+            selectedTab: SidePanelTab.Support,
+            selectedTabOptions: 'bug:analytics',
+        })
+    })
+
+    it('deduplicates identical transitions from activateTab and setScene', async () => {
+        logic.actions.openSidePanel(SidePanelTab.Max)
+
+        // First dispatch (from activateTab): saves tab-a state, tab-b has no saved state
+        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: true })
+
+        // Close the panel on tab-b
+        logic.actions.closeSidePanel()
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: false })
+
+        // Second dispatch (from setScene) with same transition: should be skipped
+        // If it weren't skipped, it would overwrite tab-a's saved state with {open: false}
+        logic.actions.onSceneTabChanged('tab-a', 'tab-b')
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: false })
+
+        // Switch back to tab-a: should still have the original open state
+        logic.actions.onSceneTabChanged('tab-b', 'tab-a')
+        await expectLogic(logic).toMatchValues({ sidePanelOpen: true, selectedTab: SidePanelTab.Max })
+    })
+})

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -36,6 +36,7 @@ import {
 } from 'scenes/scenes'
 import { urls } from 'scenes/urls'
 
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { FileSystemIconType, ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel } from '~/types'
 
@@ -834,7 +835,13 @@ export const sceneLogic = kea<sceneLogicType>([
             }
         },
         setTabs: () => persistTabs(values.tabs, values.homepage),
-        activateTab: () => persistTabs(values.tabs, values.homepage),
+        activateTab: ({ tab }, _, __, previousState) => {
+            const previousActiveTabId = selectors.activeTabId(previousState)
+            if (previousActiveTabId && previousActiveTabId !== tab.id) {
+                sidePanelStateLogic.findMounted()?.actions.onSceneTabChanged(previousActiveTabId, tab.id)
+            }
+            persistTabs(values.tabs, values.homepage)
+        },
         duplicateTab: () => persistTabs(values.tabs, values.homepage),
         renameTab: ({ tab }) => {
             actions.startTabEdit(tab)
@@ -1002,6 +1009,10 @@ export const sceneLogic = kea<sceneLogicType>([
             }
 
             if (tabId !== lastTabId) {
+                if (lastTabId) {
+                    sidePanelStateLogic.findMounted()?.actions.onSceneTabChanged(lastTabId, tabId)
+                }
+
                 const scrollTop = values.tabScrollDepths[tabId] ?? 0
                 window.setTimeout(() => restoreMainContentScrollTop(scrollTop, tabId), 1)
                 window.setTimeout(() => restoreMainContentScrollTop(scrollTop, tabId), 10)


### PR DESCRIPTION
## Problem
The panel is now "in the scene" so it makes sense that the panel is tab aware, meaning one tab can have it open, while another may not, switching will restore their state.

## Changes
Behind the flag `ux remove sidepanel` we implement this tab aware logic.

![2026-02-06 13 11 31](https://github.com/user-attachments/assets/904aa17e-7e94-4855-aa6d-18a85fe71f16)


## How did you test this code?
Locally

## Publish to changelog?
No