### PR TITLE
fix(surveys): enable person properties on hosted survey responses

### DIFF
--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -995,6 +995,7 @@
         if (distinctID) {
             config.bootstrap = {
                 distinctID: distinctID,
+                isIdentifiedID: true,
             }
         }
 


### PR DESCRIPTION
## Problem

When a distinct_id is passed to a hosted survey via URL parameter, set isIdentifiedID: true in the PostHog bootstrap config. This ensures $process_person_profile is true on the event, which causes the ingestion pipeline to include person properties on the event.

Without this, destinations like Slack show blank person properties because the event's person_properties field is empty, even though the person is correctly linked via distinct_id.

## How did you test this code?

locally:

1. Created a hosted survey and tested with http://localhost:8010/external_surveys/019c3352-c855-0000-6dcd-485ce42e6e77?distinct_id=test@posthog.com
2. Response came in with person processing

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
