### PR TITLE
feat(llma): drive team discovery config from feature flag payload

### DIFF
--- a/posthog/temporal/llm_analytics/team_discovery.py
+++ b/posthog/temporal/llm_analytics/team_discovery.py
@@ -12,6 +12,7 @@ import dataclasses
 from datetime import UTC, datetime, timedelta
 
 import structlog
+import posthoganalytics
 import temporalio.activity
 from temporalio.common import RetryPolicy
 
@@ -19,9 +20,8 @@ from posthog.temporal.common.heartbeat import Heartbeater
 
 logger = structlog.get_logger(__name__)
 
-# Guaranteed teams that are always included (the original hardcoded allowlist).
-# Single source of truth for both clustering and summarization workflows.
-GUARANTEED_TEAM_IDS: list[int] = [
+# Default fallbacks — used when the feature flag payload is missing or invalid.
+DEFAULT_GUARANTEED_TEAM_IDS: list[int] = [
     1,  # Local development
     2,  # Internal PostHog project
     # Dogfooding projects
@@ -34,15 +34,65 @@ GUARANTEED_TEAM_IDS: list[int] = [
     117964,
     153418,
 ]
+DEFAULT_SAMPLE_PERCENTAGE: float = 0.1
+DEFAULT_DISCOVERY_LOOKBACK_DAYS: int = 30
 
-# Default sample percentage for gradual rollout.
-# 0.0 = only guaranteed teams, 0.1 = 10% of remaining, 1.0 = all teams with AI events.
-SAMPLE_PERCENTAGE: float = 0.1
+FEATURE_FLAG_KEY = "llm-analytics-clustering-workflows"
 
-# How far back to look for teams with AI events. Intentionally wider than any
-# individual workflow's data window (e.g. 7 days for clustering, 60 min for
-# summarization) so we discover teams that have been active recently.
-DISCOVERY_LOOKBACK_DAYS: int = 30
+# Backward-compatible aliases for coordinator imports.
+# Coordinators use these only in the last-resort fallback path (when the
+# activity itself fails), so pointing at defaults is fine.
+GUARANTEED_TEAM_IDS = DEFAULT_GUARANTEED_TEAM_IDS
+SAMPLE_PERCENTAGE = DEFAULT_SAMPLE_PERCENTAGE
+DISCOVERY_LOOKBACK_DAYS = DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+
+@dataclasses.dataclass
+class LLMAConfig:
+    guaranteed_team_ids: list[int]
+    sample_percentage: float
+    discovery_lookback_days: int
+
+
+def _get_llma_config() -> LLMAConfig:
+    """Read LLMA team-discovery config from the feature flag payload, falling back to defaults."""
+    try:
+        payload: dict | None = posthoganalytics.get_feature_flag_payload(  # type: ignore[assignment]
+            FEATURE_FLAG_KEY, "internal_llma_team_discovery"
+        )
+
+        if not isinstance(payload, dict):
+            return LLMAConfig(
+                guaranteed_team_ids=DEFAULT_GUARANTEED_TEAM_IDS,
+                sample_percentage=DEFAULT_SAMPLE_PERCENTAGE,
+                discovery_lookback_days=DEFAULT_DISCOVERY_LOOKBACK_DAYS,
+            )
+
+        guaranteed = payload.get("guaranteed_team_ids", DEFAULT_GUARANTEED_TEAM_IDS)
+        if not isinstance(guaranteed, list) or not all(isinstance(t, int) for t in guaranteed):
+            guaranteed = DEFAULT_GUARANTEED_TEAM_IDS
+
+        sample_pct = payload.get("sample_percentage", DEFAULT_SAMPLE_PERCENTAGE)
+        if not isinstance(sample_pct, (int, float)):
+            sample_pct = DEFAULT_SAMPLE_PERCENTAGE
+
+        lookback = payload.get("discovery_lookback_days", DEFAULT_DISCOVERY_LOOKBACK_DAYS)
+        if not isinstance(lookback, int):
+            lookback = DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+        return LLMAConfig(
+            guaranteed_team_ids=guaranteed,
+            sample_percentage=float(sample_pct),
+            discovery_lookback_days=lookback,
+        )
+    except Exception:
+        logger.warning("Failed to read LLMA config from feature flag, using defaults", exc_info=True)
+        return LLMAConfig(
+            guaranteed_team_ids=DEFAULT_GUARANTEED_TEAM_IDS,
+            sample_percentage=DEFAULT_SAMPLE_PERCENTAGE,
+            discovery_lookback_days=DEFAULT_DISCOVERY_LOOKBACK_DAYS,
+        )
+
 
 # Activity timeout for team discovery. Must exceed the underlying ClickHouse
 # query's max_execution_time (5 min in CH_LLM_ANALYTICS_SETTINGS) plus retry
@@ -53,8 +103,8 @@ DISCOVERY_ACTIVITY_RETRY_POLICY = RetryPolicy(maximum_attempts=2)
 
 @dataclasses.dataclass
 class TeamDiscoveryInput:
-    lookback_days: int = DISCOVERY_LOOKBACK_DAYS
-    sample_percentage: float = SAMPLE_PERCENTAGE
+    lookback_days: int = DEFAULT_DISCOVERY_LOOKBACK_DAYS
+    sample_percentage: float = DEFAULT_SAMPLE_PERCENTAGE
 
 
 @temporalio.activity.defn
@@ -66,11 +116,16 @@ async def get_team_ids_for_llm_analytics(inputs: TeamDiscoveryInput) -> list[int
     On failure, falls back to guaranteed teams only.
     """
     async with Heartbeater():
-        guaranteed = set(GUARANTEED_TEAM_IDS)
+        config = _get_llma_config()
+        guaranteed = set(config.guaranteed_team_ids)
+
+        # Override input defaults with feature flag values
+        sample_percentage = config.sample_percentage
+        lookback_days = config.discovery_lookback_days
 
         try:
             end = datetime.now(UTC)
-            begin = end - timedelta(days=inputs.lookback_days)
+            begin = end - timedelta(days=lookback_days)
 
             from posthog.tasks.llm_analytics_usage_report import get_teams_with_ai_events
 
@@ -78,7 +133,7 @@ async def get_team_ids_for_llm_analytics(inputs: TeamDiscoveryInput) -> list[int
 
             remaining = [t for t in ai_event_teams if t not in guaranteed]
 
-            sample_size = math.ceil(len(remaining) * inputs.sample_percentage)
+            sample_size = math.ceil(len(remaining) * sample_percentage)
             sampled = random.sample(remaining, min(sample_size, len(remaining)))
 
             result = sorted(guaranteed | set(sampled))
@@ -90,7 +145,7 @@ async def get_team_ids_for_llm_analytics(inputs: TeamDiscoveryInput) -> list[int
                 remaining_count=len(remaining),
                 sampled_count=len(sampled),
                 total_count=len(result),
-                sample_percentage=inputs.sample_percentage,
+                sample_percentage=sample_percentage,
             )
 
             return result

--- a/posthog/temporal/llm_analytics/test_team_discovery.py
+++ b/posthog/temporal/llm_analytics/test_team_discovery.py
@@ -7,8 +7,11 @@ from unittest.mock import patch
 from parameterized import parameterized
 
 from posthog.temporal.llm_analytics.team_discovery import (
-    GUARANTEED_TEAM_IDS,
+    DEFAULT_DISCOVERY_LOOKBACK_DAYS,
+    DEFAULT_GUARANTEED_TEAM_IDS,
+    DEFAULT_SAMPLE_PERCENTAGE,
     TeamDiscoveryInput,
+    _get_llma_config,
     get_team_ids_for_llm_analytics,
 )
 
@@ -18,91 +21,192 @@ async def _noop_heartbeater(*args, **kwargs):
     yield
 
 
+FF_PAYLOAD_PATH = "posthog.temporal.llm_analytics.team_discovery.posthoganalytics.get_feature_flag_payload"
+
+
+class TestGetLlmaConfig:
+    @parameterized.expand(
+        [
+            ("none_payload", None),
+            ("string_payload", "not a dict"),
+            ("list_payload", [1, 2, 3]),
+            ("int_payload", 42),
+        ]
+    )
+    @patch(FF_PAYLOAD_PATH)
+    def test_non_dict_payload_returns_defaults(self, _name, payload, mock_ff):
+        mock_ff.return_value = payload
+
+        config = _get_llma_config()
+
+        assert config.guaranteed_team_ids == DEFAULT_GUARANTEED_TEAM_IDS
+        assert config.sample_percentage == DEFAULT_SAMPLE_PERCENTAGE
+        assert config.discovery_lookback_days == DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+    @patch(FF_PAYLOAD_PATH)
+    def test_valid_payload_returns_parsed_values(self, mock_ff):
+        mock_ff.return_value = {
+            "guaranteed_team_ids": [100, 200],
+            "sample_percentage": 0.5,
+            "discovery_lookback_days": 7,
+        }
+
+        config = _get_llma_config()
+
+        assert config.guaranteed_team_ids == [100, 200]
+        assert config.sample_percentage == 0.5
+        assert config.discovery_lookback_days == 7
+
+    @patch(FF_PAYLOAD_PATH)
+    def test_partial_payload_fills_missing_with_defaults(self, mock_ff):
+        mock_ff.return_value = {"guaranteed_team_ids": [42]}
+
+        config = _get_llma_config()
+
+        assert config.guaranteed_team_ids == [42]
+        assert config.sample_percentage == DEFAULT_SAMPLE_PERCENTAGE
+        assert config.discovery_lookback_days == DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+    @parameterized.expand(
+        [
+            ("string_ids", {"guaranteed_team_ids": "not a list"}),
+            ("mixed_ids", {"guaranteed_team_ids": [1, "two", 3]}),
+            ("string_pct", {"sample_percentage": "high"}),
+            ("float_lookback", {"discovery_lookback_days": 7.5}),
+        ]
+    )
+    @patch(FF_PAYLOAD_PATH)
+    def test_invalid_field_types_fall_back_per_field(self, _name, payload, mock_ff):
+        mock_ff.return_value = payload
+
+        config = _get_llma_config()
+
+        if not isinstance(payload.get("guaranteed_team_ids"), list) or not all(
+            isinstance(t, int) for t in payload.get("guaranteed_team_ids", [])
+        ):
+            assert config.guaranteed_team_ids == DEFAULT_GUARANTEED_TEAM_IDS
+
+        if not isinstance(payload.get("sample_percentage", DEFAULT_SAMPLE_PERCENTAGE), (int, float)):
+            assert config.sample_percentage == DEFAULT_SAMPLE_PERCENTAGE
+
+        if not isinstance(payload.get("discovery_lookback_days", DEFAULT_DISCOVERY_LOOKBACK_DAYS), int):
+            assert config.discovery_lookback_days == DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+    @patch(FF_PAYLOAD_PATH)
+    def test_exception_returns_defaults(self, mock_ff):
+        mock_ff.side_effect = Exception("network error")
+
+        config = _get_llma_config()
+
+        assert config.guaranteed_team_ids == DEFAULT_GUARANTEED_TEAM_IDS
+        assert config.sample_percentage == DEFAULT_SAMPLE_PERCENTAGE
+        assert config.discovery_lookback_days == DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+    @patch(FF_PAYLOAD_PATH)
+    def test_int_sample_percentage_cast_to_float(self, mock_ff):
+        mock_ff.return_value = {"sample_percentage": 1}
+
+        config = _get_llma_config()
+
+        assert config.sample_percentage == 1.0
+        assert isinstance(config.sample_percentage, float)
+
+
+@patch(FF_PAYLOAD_PATH, return_value=None)
 @patch("posthog.temporal.llm_analytics.team_discovery.Heartbeater", _noop_heartbeater)
 @pytest.mark.asyncio
 class TestGetTeamIdsForLlmAnalytics:
-    @parameterized.expand(
-        [
-            ("zero_percent", 0.0),
-            ("ten_percent", 0.1),
-            ("fifty_percent", 0.5),
-            ("hundred_percent", 1.0),
-        ]
-    )
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_guaranteed_teams_always_included(self, _name, sample_pct, mock_get_teams):
+    async def test_guaranteed_teams_always_included(self, mock_get_teams, _mock_ff):
         mock_get_teams.return_value = [9999, 8888]
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=sample_pct)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        for team_id in GUARANTEED_TEAM_IDS:
+        for team_id in DEFAULT_GUARANTEED_TEAM_IDS:
             assert team_id in result
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_no_duplicates_when_guaranteed_in_ai_events(self, mock_get_teams):
-        mock_get_teams.return_value = [GUARANTEED_TEAM_IDS[0], 9999]
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=1.0)
+    async def test_no_duplicates_when_guaranteed_in_ai_events(self, mock_get_teams, _mock_ff):
+        mock_get_teams.return_value = [DEFAULT_GUARANTEED_TEAM_IDS[0], 9999]
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
         assert len(result) == len(set(result))
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_result_is_sorted(self, mock_get_teams):
+    async def test_result_is_sorted(self, mock_get_teams, mock_ff):
+        mock_ff.return_value = {"sample_percentage": 1.0}
         mock_get_teams.return_value = [9999, 5555, 3333]
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=1.0)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
         assert result == sorted(result)
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_zero_sample_returns_only_guaranteed(self, mock_get_teams):
+    async def test_zero_sample_returns_only_guaranteed(self, mock_get_teams, mock_ff):
+        mock_ff.return_value = {"sample_percentage": 0.0}
         extra_teams = [9999, 8888, 7777]
         mock_get_teams.return_value = extra_teams
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.0)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        assert set(result) == set(GUARANTEED_TEAM_IDS)
+        assert set(result) == set(DEFAULT_GUARANTEED_TEAM_IDS)
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_full_sample_returns_all(self, mock_get_teams):
+    async def test_full_sample_returns_all(self, mock_get_teams, mock_ff):
+        mock_ff.return_value = {"sample_percentage": 1.0}
         extra_teams = [9999, 8888, 7777]
         mock_get_teams.return_value = extra_teams
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=1.0)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        assert set(result) == set(GUARANTEED_TEAM_IDS) | set(extra_teams)
+        assert set(result) == set(DEFAULT_GUARANTEED_TEAM_IDS) | set(extra_teams)
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_sampling_math(self, mock_get_teams):
+    async def test_sampling_math(self, mock_get_teams, _mock_ff):
         extra_teams = list(range(10000, 10100))  # 100 non-guaranteed teams
         mock_get_teams.return_value = extra_teams
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.1)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        sampled_non_guaranteed = [t for t in result if t not in GUARANTEED_TEAM_IDS]
-        expected_sample_size = math.ceil(len(extra_teams) * 0.1)
+        sampled_non_guaranteed = [t for t in result if t not in DEFAULT_GUARANTEED_TEAM_IDS]
+        expected_sample_size = math.ceil(len(extra_teams) * DEFAULT_SAMPLE_PERCENTAGE)
         assert len(sampled_non_guaranteed) == expected_sample_size
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_empty_ai_events_returns_guaranteed(self, mock_get_teams):
+    async def test_empty_ai_events_returns_guaranteed(self, mock_get_teams, _mock_ff):
         mock_get_teams.return_value = []
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.1)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        assert set(result) == set(GUARANTEED_TEAM_IDS)
+        assert set(result) == set(DEFAULT_GUARANTEED_TEAM_IDS)
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_fallback_on_exception(self, mock_get_teams):
+    async def test_fallback_on_exception(self, mock_get_teams, _mock_ff):
         mock_get_teams.side_effect = Exception("ClickHouse down")
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.1)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        assert set(result) == set(GUARANTEED_TEAM_IDS)
+        assert set(result) == set(DEFAULT_GUARANTEED_TEAM_IDS)
+
+    @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
+    async def test_feature_flag_overrides_config(self, mock_get_teams, mock_ff):
+        mock_ff.return_value = {
+            "guaranteed_team_ids": [42],
+            "sample_percentage": 0.0,
+            "discovery_lookback_days": 7,
+        }
+        mock_get_teams.return_value = [9999, 8888]
+        inputs = TeamDiscoveryInput()
+
+        result = await get_team_ids_for_llm_analytics(inputs)
+
+        assert result == [42]


### PR DESCRIPTION
## Problem

The `GUARANTEED_TEAM_IDS` list and related config (`sample_percentage`, `discovery_lookback_days`) in `team_discovery.py` are hardcoded, requiring a PR and deploy every time we want to add or remove a team or tweak discovery parameters.

## Changes

- Add `_get_llma_config()` helper that reads config from the `llm-analytics-clustering-workflows` feature flag payload via `posthoganalytics.get_feature_flag_payload`
- Parse `guaranteed_team_ids`, `sample_percentage`, `discovery_lookback_days` from the payload with per-field type validation
- Fall back to hardcoded `DEFAULT_*` constants if the payload is missing, malformed, or the call throws
- Keep backward-compatible aliases (`GUARANTEED_TEAM_IDS`, `SAMPLE_PERCENTAGE`, `DISCOVERY_LOOKBACK_DAYS`) so coordinator imports are unchanged
- Feature flag created in project 2: https://us.posthog.com/project/2/feature_flags/560786

## How did you test this code?

- 21 unit tests in `test_team_discovery.py` (12 new for `_get_llma_config`, 9 existing updated to mock the feature flag)
- Covers: valid payload, partial payload, non-dict payloads, invalid field types, exception handling, int-to-float cast, end-to-end activity with flag override
- `ruff check` and `ruff format` clean

## Publish to changelog?

No