### PR TITLE
fix: taxonomic options icons

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -896,7 +896,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getName: (option: MaxContextTaxonomicFilterOption) => option.name,
                         getValue: (option: MaxContextTaxonomicFilterOption) => option.value,
                         getIcon: (option: MaxContextTaxonomicFilterOption) => {
-                            return <>{option.icon}</>
+                            const IconComponent = option.icon
+                            return <IconComponent />
                         },
                         getPopoverHeader: () => 'On this page',
                     },


### PR DESCRIPTION
## Problem                                                   
Icons in the TaxonomicFilter are buggy, they should be rendered as components.

## How did you test this code?
- Render <IconComponent /> rather than option.icon

## How did I test this?
- Locally

## Publish to changelog?
No