### PR TITLE
refactor: Simplify and help debug group properties capture during report

### DIFF
--- a/posthog/tasks/report_utils.py
+++ b/posthog/tasks/report_utils.py
@@ -45,9 +45,9 @@ def capture_event(
     organization_id: Optional[str] = None,
     team_id: Optional[int] = None,
     properties: dict[str, Any],
+    group_properties: Optional[dict[str, Any]] = None,
     timestamp: Optional[Union[datetime, str]] = None,
     distinct_id: Optional[str] = None,
-    set_on_organization: bool = False,
 ) -> None:
     """
     Captures a single event.
@@ -69,6 +69,13 @@ def capture_event(
         distinct_id = org_owner.distinct_id if org_owner and org_owner.distinct_id else f"org-{organization_id}"
 
     if is_cloud():
+        logger.info(
+            "[Usage Report] Capturing usage report event",
+            event_name=name,
+            organization_id=organization_id,
+            group_properties=group_properties,
+        )
+
         pha_client.capture(
             distinct_id=distinct_id,
             event=name,
@@ -77,12 +84,11 @@ def capture_event(
             timestamp=timestamp,
         )
 
-        # Also set properties as group properties on the organization
-        if set_on_organization:
+        if group_properties and organization_id:
             pha_client.group_identify(
-                group_type="organization",
-                group_key=str(organization_id),
-                properties=properties,
+                "organization",
+                str(organization_id),
+                properties=group_properties,
             )
     else:
         pha_client.capture(

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1698,8 +1698,8 @@ def capture_report(
             name="organization usage report",
             organization_id=organization_id,
             properties=full_report_dict,
+            group_properties={"has_non_zero_usage": full_report_dict.get("has_non_zero_usage")},
             timestamp=at_date,
-            set_on_organization=True,
         )
 
     except Exception as err:


### PR DESCRIPTION
## Problem

The current implementation of `capture_event` in `report_utils.py` uses a boolean flag `set_on_organization` to determine whether to set properties as group properties on an organization. This approach is inflexible as it forces the same properties to be used for both the event and the group.

## Changes

- Refactored `capture_event` function to accept an optional `group_properties` parameter instead of the `set_on_organization` flag
- Added logging for usage report events in cloud environments
- Updated the `capture_report` function to pass specific properties to the group identify call rather than using all event properties
- Added tests to verify the new group properties functionality works correctly

## How did you test this code?

Added two new test cases:
- `test_capture_event_calls_group_identify_with_group_properties` - Verifies that group_identify is called with the correct parameters when group_properties are provided
- `test_capture_event_skips_group_identify_without_group_properties` - Confirms that group_identify is not called when group_properties are not provided