### PR TITLE
fix(ux): --side-panel-width will be 0 when the panel isn't actually open

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -191,7 +191,9 @@ export function SidePanel({
         ? 0
         : sidePanelOpenAndAvailable
           ? Math.max(desiredSize ?? DEFAULT_WIDTH, SIDE_PANEL_MIN_WIDTH)
-          : SIDE_PANEL_BAR_WIDTH
+          : isRemovingSidePanelFlag
+            ? 0
+            : SIDE_PANEL_BAR_WIDTH
 
     // Update sidepanel width in panelLayoutLogic
     useEffect(() => {


### PR DESCRIPTION
 
<img width="343" height="343" alt="image" src="https://github.com/user-attachments/assets/312c363e-5ec5-4a0c-a79d-f66f025a8cf9" />

## Problem
With isRemovingSidePanelFlag true, the old tab bar strip never renders, so reporting its 40px width to the layout is incorrect. Now --side-panel-width will be 0 when the panel isn't actually open, meaning max-w-[calc(100%-0px)] effectively removes the constraint on <main>.

## Changes
Make it zero for flag!

## How did you test this code?
Locally

## Publish to changelog?
No