### PR TITLE
feat(llma): clustering - increase summarization timeouts, concurrency, and add activity timing logs

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -10,7 +10,7 @@ from products.llm_analytics.backend.summarization.models import OpenAIModel, Sum
 DEFAULT_MAX_ITEMS_PER_WINDOW = (
     15  # Max items to process per window (targets ~2500 summaries in 7-day clustering window)
 )
-DEFAULT_BATCH_SIZE = 3  # Number of traces to process in parallel (reduced to avoid rate limits)
+DEFAULT_BATCH_SIZE = 5  # Number of traces to process in parallel
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)
 DEFAULT_WINDOW_OFFSET_MINUTES = 30  # Offset window into the past so traces have time to fully complete
@@ -25,11 +25,13 @@ MAX_TEXT_REPR_LENGTH = 2_000_000
 SCHEDULE_INTERVAL_HOURS = 1  # How often the coordinator runs
 
 # Coordinator concurrency settings
-DEFAULT_MAX_CONCURRENT_TEAMS = 3  # Max teams to process in parallel
+DEFAULT_MAX_CONCURRENT_TEAMS = 5  # Max teams to process in parallel
 
 # Timeout configuration (in seconds)
 SAMPLE_TIMEOUT_SECONDS = 900  # 15 minutes for sampling query (buffer above QUERY_ASYNC 600s ClickHouse timeout)
-GENERATE_SUMMARY_TIMEOUT_SECONDS = 300  # 5 minutes per summary generation (increased for LLM API latency/rate limits)
+GENERATE_SUMMARY_TIMEOUT_SECONDS = (
+    900  # 15 minutes per summary generation (large traces can produce ~800K token LLM calls)
+)
 
 # Heartbeat timeouts - allows Temporal to detect dead workers faster than
 # waiting for the full start_to_close_timeout to expire. Activities must
@@ -43,13 +45,15 @@ SUMMARIZE_HEARTBEAT_TIMEOUT = timedelta(seconds=60)  # 1 minute - LLM calls can 
 # the workflow indefinitely when something is fundamentally broken.
 SAMPLE_SCHEDULE_TO_CLOSE_TIMEOUT = timedelta(seconds=1800)  # 30 min total for sampling (3 attempts * 900s + backoff)
 SUMMARIZE_SCHEDULE_TO_CLOSE_TIMEOUT = timedelta(
-    seconds=900
-)  # 15 min total per summary (4 attempts * 300s + backoff, but cut off early)
+    seconds=2700
+)  # 45 min total per summary (3 full attempts * 900s + backoff)
 
 # Workflow-level timeouts (in minutes)
-WORKFLOW_EXECUTION_TIMEOUT_MINUTES = 120  # Max time for single team workflow (increased with longer activity timeouts)
+WORKFLOW_EXECUTION_TIMEOUT_MINUTES = (
+    180  # Max time for single team workflow (5 batches * 45 min worst case, usually ~75 min)
+)
 COORDINATOR_EXECUTION_TIMEOUT_MINUTES = (
-    180  # 3 hours - 209 teams with 3 concurrent, most finish instantly but a few hit 120-min child timeout
+    240  # 4 hours - 211 teams with 3 concurrent, most finish instantly but a few hit child timeout
 )
 
 # Retry policies

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -344,7 +344,7 @@ class TestBatchTraceSummarizationWorkflow:
         assert inputs.team_id == 123
         assert inputs.analysis_level == "trace"
         assert inputs.max_items == 15
-        assert inputs.batch_size == 3
+        assert inputs.batch_size == 5
         assert inputs.mode == "detailed"
         assert inputs.window_minutes == 60
 


### PR DESCRIPTION
## Problem

Team 2 (PostHog internal) has a 0% summarization success rate -- every `generate_and_save_summary_activity` times out. The 5-min `start_to_close_timeout` is too short for large traces that involve a CH query + up to 2M char text repr formatting + ~800K token LLM calls. The batch size (3) and concurrent teams (3) are also too conservative.

Additionally, the activities had no timing instrumentation, making it impossible to identify which phase (fetch, LLM, save, embed) is the bottleneck.

## Changes

- Increase per-attempt activity timeout from 5min to 15min (`GENERATE_SUMMARY_TIMEOUT_SECONDS`)
- Increase schedule-to-close from 15min to 45min (`SUMMARIZE_SCHEDULE_TO_CLOSE_TIMEOUT`)
- Increase workflow timeout from 120min to 180min, coordinator from 180min to 240min
- Bump batch size from 3 to 5 (traces processed in parallel per team)
- Bump concurrent teams from 3 to 5 (teams processed in parallel by coordinator)
- Add per-phase timing instrumentation to both `summarization.py` and `generation_summarization.py` with structured logging (fetch, LLM, save, embed durations)

## How did you test this code?

- Existing unit tests updated and passing (19/19)
- Timeout/concurrency changes are config-only, picked up by existing workflow/schedule definitions
- Logging changes are additive structured log statements with no behavioral impact

## Publish to changelog?

No