### PR TITLE
fix(ma): Refreshing oauth token before fetching snapchat data

### DIFF
--- a/posthog/temporal/data_imports/sources/snapchat_ads/source.py
+++ b/posthog/temporal/data_imports/sources/snapchat_ads/source.py
@@ -92,7 +92,9 @@ class SnapchatAdsSource(SimpleSource[SnapchatAdsSourceConfig], OAuthMixin):
             oauth_integration.refresh_access_token()
 
         if oauth_integration.integration.errors == ERROR_TOKEN_REFRESH_FAILED:
-            raise ValueError("Failed to refresh token for Snapchat Ads integration. Please re-authorize the integration.")
+            raise ValueError(
+                "Failed to refresh token for Snapchat Ads integration. Please re-authorize the integration."
+            )
 
         integration = oauth_integration.integration
 


### PR DESCRIPTION
## Problem

I had 401 for new snapshots request after sometime, when trying to sync.

## Changes

I was missing refreshing the token before doing the calls as other sources do.

## How did you test this code?
Manually and worked (: