### PR TITLE
fix(llma): increase summarize heartbeat timeout from 60s to 120s

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -38,7 +38,9 @@ GENERATE_SUMMARY_TIMEOUT_SECONDS = (
 # send heartbeats within this interval or Temporal will consider them failed
 # and retry on another worker.
 SAMPLE_HEARTBEAT_TIMEOUT = timedelta(seconds=120)  # 2 minutes - sampling has long CH queries
-SUMMARIZE_HEARTBEAT_TIMEOUT = timedelta(seconds=60)  # 1 minute - LLM calls can be slow but should heartbeat regularly
+SUMMARIZE_HEARTBEAT_TIMEOUT = timedelta(
+    seconds=120
+)  # 2 minutes - trace fetch + LLM calls can exceed 60s for large traces
 
 # Schedule-to-close timeouts - caps total time including all retry attempts,
 # backoff intervals, and queue time. Prevents runaway retries from blocking


### PR DESCRIPTION
## Problem

Trace-level summarization activities for large teams (e.g. team 2) are hitting heartbeat timeouts. Observed in prod-us: heartbeats stop flowing after ~28s and the 60s timeout kills the activity before it produces any output. Activities retry but keep failing with `TIMEOUT_TYPE_HEARTBEAT`.

## Changes

Bumps `SUMMARIZE_HEARTBEAT_TIMEOUT` from 60s to 120s, matching `SAMPLE_HEARTBEAT_TIMEOUT` which already works reliably for long ClickHouse queries.

## How did you test this code?

- Confirmed the failure by running a manual trace summarization workflow for team 2 in prod-us (`llma-trace-summarization-team-2-manual-6b4ef927`)
- Verified activities fail with `TIMEOUT_TYPE_HEARTBEAT` in Temporal UI
- Will run another manual workflow after deploy to confirm fix

## Publish to changelog?

No