### PR TITLE
fix(surveys): prevent infinite retry loop on survey response summary

### DIFF
--- a/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
@@ -88,11 +88,11 @@ export function OpenQuestionSummaryV2({
             return
         }
 
-        // Only auto-load if we don't have a summary yet
-        if (!summary && !loading) {
+        // Only auto-load if we don't have a summary yet and haven't errored
+        if (!summary && !loading && !error) {
             loadSummary(false)
         }
-    }, [shouldShowSummary, dataProcessingAccepted, summary, loading, loadSummary])
+    }, [shouldShowSummary, dataProcessingAccepted, summary, loading, error, loadSummary])
 
     const handleRegenerateClick = (): void => {
         if (!dataProcessingAccepted) {


### PR DESCRIPTION
## Problem

when a survey response generation fails, it kicks off an infinite retry loop

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

stops retrying when we get an error :)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
manually
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no