### PR TITLE
fix(sql-editor): views expand in schema tree

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -147,11 +147,14 @@ export const QueryDatabase = (): JSX.Element => {
                 return 'join'
             case 'virtual-table':
                 return 'virtual table'
+            case 'materialized_view':
+                return 'materialized view'
             case 'managed-view':
                 return 'managed view'
             case 'endpoint':
                 return 'endpoint'
             case 'view':
+            case 'view-table':
                 return item.record.view?.is_materialized ? 'materialized view' : 'view'
             case 'table': {
                 const tableType = item.record.table?.type

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -644,7 +644,7 @@ const createTableLookup = ({
                     : [view.name, createSavedQueryLookupEntry(view)]
             }),
             ...managedViews.map((view) => [view.name, { name: view.name, fields: view.fields }]),
-        ].map(([name, entry]) => [normalizeTableLookupKey(name) ?? name, entry])
+        ].map(([name, entry]) => [normalizeTableLookupKey(name ? String(name) : null) ?? name, entry])
     )
 }
 

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -86,7 +86,8 @@ const getSavedQuerySchemaTable = (
     view: DataWarehouseSavedQuery,
     allTablesMap: Record<string, DatabaseSchemaTable>
 ): DatabaseSchemaTable | undefined => {
-    const schemaTable = allTablesMap[view.name]
+    const lookupKey = normalizeTableLookupKey(view.name)
+    const schemaTable = lookupKey ? allTablesMap[lookupKey] : undefined
 
     if (schemaTable?.type === 'view' || schemaTable?.type === 'materialized_view') {
         return schemaTable


### PR DESCRIPTION
## Problem

In the SQL editor's schema tree, we can expand joins added to posthog, system and warehouse tables, but not joins added to views.

Plus some views don't show as folders when expanding under tables.

Also, we're showing "team_id" in some expanded joins. You can't do much with it, but it's just noise (e.g. in events -> pdi, we show team_id, distint_id and person_id)

## Changes

Fix the bug and add joins in the tree under views as well.

![2026-02-06 17 53 57](https://github.com/user-attachments/assets/d9282548-6583-4fa8-8aea-876602ba88eb)

## How did you test this code?

👀 

## Publish to changelog?

no