### PR TITLE
feat(sql-editor): Add Vim mode support to SQL editor

### DIFF
--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -176,6 +176,22 @@ export const commonConfig = {
     // no hashes in dev mode for faster reloads --> we save the old hash in index.html otherwise
     entryNames: isDev ? '[dir]/[name]' : '[dir]/[name]-[hash]',
     plugins: [
+        // monaco-vim imports monaco-editor internals without .js extensions (e.g. monaco-editor/esm/vs/editor/editor.api)
+        // which esbuild can't resolve through monaco-editor's package.json exports map
+        {
+            name: 'resolve-monaco-esm',
+            setup(build) {
+                build.onResolve({ filter: /^monaco-editor\/esm\// }, (args) => {
+                    if (args.path.endsWith('.js')) {
+                        return
+                    }
+                    return build.resolve(args.path + '.js', {
+                        kind: args.kind,
+                        resolveDir: args.resolveDir,
+                    })
+                })
+            },
+        },
         sassPlugin({
             async transform(source, resolveDir, filePath) {
                 const plugins = [autoprefixer, postcssPresetEnv({ stage: 0 })]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -205,6 +205,7 @@
         "mdast-util-find-and-replace": "^3.0.2",
         "modern-screenshot": "^4.6.7",
         "monaco-editor": "^0.55.1",
+        "monaco-vim": "^0.4.4",
         "motion": "^12.26.1",
         "natural-orderby": "^3.0.2",
         "openai": "^4.81.0",

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -369,6 +369,7 @@ export const FEATURE_FLAGS = {
     SHOW_REPLAY_FILTERS_FEEDBACK_BUTTON: 'show-replay-filters-feedback-button', // owner: @ksvat #team-replay
     SIGNUP_AA_TEST: 'signup-aa-test', // owner: @andehen #team-experiments multivariate=control,test
     SNAPCHAT_ADS_SOURCE: 'snapchat-ads-source', // owner: @jabahamondes #team-web-analytics
+    SQL_EDITOR_VIM_MODE: 'sql-editor-vim-mode', // owner: @arthurdedeus
     SSE_DASHBOARDS: 'sse-dashboards', // owner: @aspicer #team-analytics-platform
     SURVEYS_ERROR_TRACKING_CROSS_SELL: 'surveys-in-error-tracking', // owner: @adboio #team-surveys
     SURVEY_HEADLINE_SUMMARY: 'survey-headline-summary', // owner: @adboio #team-surveys

--- a/frontend/src/lib/logic/userPreferencesLogic.ts
+++ b/frontend/src/lib/logic/userPreferencesLogic.ts
@@ -15,6 +15,7 @@ export const userPreferencesLogic = kea<userPreferencesLogicType>([
         unpinPersonProperty: (prop: string) => ({ prop }),
         pinGroupProperty: (prop: string) => ({ prop }),
         unpinGroupProperty: (prop: string) => ({ prop }),
+        setEditorVimModeEnabled: (enabled: boolean) => ({ enabled }),
     }),
     connect(() => ({
         values: [teamLogic, ['currentTeam']],
@@ -46,6 +47,13 @@ export const userPreferencesLogic = kea<userPreferencesLogicType>([
             {
                 pinGroupProperty: (state, { prop }) => (state.includes(prop) ? state : [...state, prop]),
                 unpinGroupProperty: (state, { prop }) => state.filter((p) => p !== prop),
+            },
+        ],
+        editorVimModeEnabled: [
+            false,
+            { persist: true },
+            {
+                setEditorVimModeEnabled: (_, { enabled }) => enabled,
             },
         ],
     })),

--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -4,6 +4,7 @@ import MonacoEditor, { type EditorProps, Monaco, DiffEditor as MonacoDiffEditor,
 import { BuiltLogic, useMountedLogic, useValues } from 'kea'
 import * as monacoModule from 'monaco-editor'
 import { IDisposable, editor, editor as importedEditor } from 'monaco-editor'
+import { VimMode, initVimMode } from 'monaco-vim'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
@@ -41,6 +42,8 @@ export interface CodeEditorProps extends Omit<EditorProps, 'loading' | 'theme'> 
     onError?: (error: string | null) => void
     /** The original value to compare against - renders it in diff mode */
     originalValue?: string
+    /** Enable vim keybindings */
+    enableVimMode?: boolean
 }
 let codeEditorIndex = 0
 
@@ -132,6 +135,7 @@ export function CodeEditor({
     onMetadata,
     onMetadataLoading,
     originalValue,
+    enableVimMode,
     ...editorProps
 }: CodeEditorProps): JSX.Element {
     const { isDarkModeOn } = useValues(themeLogic)
@@ -143,6 +147,9 @@ export function CodeEditor({
 
     // Keep a ref to the editor for cleanup - ensures we can dispose it even if state is stale
     const editorRef = useRef<importedEditor.IStandaloneCodeEditor | null>(null)
+
+    const vimModeRef = useRef<VimMode | null>(null)
+    const vimStatusBarRef = useRef<HTMLDivElement | null>(null)
 
     const [realKey] = useState(() => codeEditorIndex++)
     const builtCodeEditorLogic = codeEditorLogic({
@@ -234,6 +241,26 @@ export function CodeEditor({
                 : [],
         })
     }, [monaco, schema])
+
+    useEffect(() => {
+        if (!editor) {
+            return
+        }
+
+        if (enableVimMode && vimStatusBarRef.current) {
+            vimModeRef.current = initVimMode(editor, vimStatusBarRef.current)
+        } else if (vimModeRef.current) {
+            vimModeRef.current.dispose()
+            vimModeRef.current = null
+        }
+
+        return () => {
+            if (vimModeRef.current) {
+                vimModeRef.current.dispose()
+                vimModeRef.current = null
+            }
+        }
+    }, [editor, enableVimMode])
 
     const editorOptions: editor.IStandaloneEditorConstructionOptions = {
         minimap: {
@@ -383,14 +410,24 @@ export function CodeEditor({
     }
 
     return (
-        <MonacoEditor // eslint-disable-line react/forbid-elements
-            key={queryKey}
-            theme={isDarkModeOn ? 'vs-dark' : 'vs-light'}
-            loading={<Spinner />}
-            value={value}
-            options={editorOptions}
-            onMount={editorOnMount}
-            {...editorProps}
-        />
+        <div className="CodeEditor flex flex-col h-full w-full">
+            <div className="flex-1 min-h-0">
+                <MonacoEditor // eslint-disable-line react/forbid-elements
+                    key={queryKey}
+                    theme={isDarkModeOn ? 'vs-dark' : 'vs-light'}
+                    loading={<Spinner />}
+                    value={value}
+                    options={editorOptions}
+                    onMount={editorOnMount}
+                    {...editorProps}
+                />
+            </div>
+            {enableVimMode && (
+                <div
+                    ref={vimStatusBarRef}
+                    className="CodeEditor__vim-status-bar font-mono text-xs px-2 py-0.5 bg-bg-light border-t"
+                />
+            )}
+        </div>
     )
 }

--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -410,22 +410,20 @@ export function CodeEditor({
     }
 
     return (
-        <div className="CodeEditor flex flex-col h-full w-full">
-            <div className="flex-1 min-h-0">
-                <MonacoEditor // eslint-disable-line react/forbid-elements
-                    key={queryKey}
-                    theme={isDarkModeOn ? 'vs-dark' : 'vs-light'}
-                    loading={<Spinner />}
-                    value={value}
-                    options={editorOptions}
-                    onMount={editorOnMount}
-                    {...editorProps}
-                />
-            </div>
+        <div className="CodeEditor relative h-full w-full">
+            <MonacoEditor // eslint-disable-line react/forbid-elements
+                key={queryKey}
+                theme={isDarkModeOn ? 'vs-dark' : 'vs-light'}
+                loading={<Spinner />}
+                value={value}
+                options={editorOptions}
+                onMount={editorOnMount}
+                {...editorProps}
+            />
             {enableVimMode && (
                 <div
                     ref={vimStatusBarRef}
-                    className="CodeEditor__vim-status-bar font-mono text-xs px-2 py-0.5 bg-bg-light border-t"
+                    className="CodeEditor__vim-status-bar absolute bottom-0 left-0 right-0 font-mono text-xs px-2 py-0.5 bg-bg-light border-t z-10"
                 />
             )}
         </div>

--- a/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
@@ -5,6 +5,8 @@ import { IconCheck, IconX } from '@posthog/icons'
 import { AutoSizer } from 'lib/components/AutoSizer'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 import { CodeEditor, CodeEditorProps } from 'lib/monaco/CodeEditor'
 import MaxTool from 'scenes/max/MaxTool'
 
@@ -32,6 +34,8 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
         reportAIQueryPromptOpen,
     } = useActions(multitabEditorLogic)
     const { acceptText, rejectText, diffShowRunButton } = useValues(multitabEditorLogic)
+    const { editorVimModeEnabled } = useValues(userPreferencesLogic)
+    const { setEditorVimModeEnabled } = useActions(userPreferencesLogic)
 
     return (
         <>
@@ -55,6 +59,7 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
                                         height={height}
                                         width={width}
                                         originalValue={props.originalValue}
+                                        enableVimMode={editorVimModeEnabled}
                                         {...props.codeEditorProps}
                                         autoFocus={true}
                                         options={{
@@ -74,6 +79,17 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
                                 ) : null
                             }
                         />
+                    </div>
+                    <div className="absolute bottom-6 left-4">
+                        <Tooltip title={editorVimModeEnabled ? 'Disable vim mode' : 'Enable vim mode'}>
+                            <LemonButton
+                                size="small"
+                                type={editorVimModeEnabled ? 'primary' : 'secondary'}
+                                onClick={() => setEditorVimModeEnabled(!editorVimModeEnabled)}
+                            >
+                                Vim
+                            </LemonButton>
+                        </Tooltip>
                     </div>
                     <div className="absolute bottom-6 right-4">
                         <MaxTool

--- a/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
@@ -77,7 +77,7 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
                             }
                         />
                     </div>
-                    <div className="absolute bottom-6 right-4">
+                    <div className={`absolute right-4 ${props.editorVimModeEnabled ? 'bottom-12' : 'bottom-6'}`}>
                         <MaxTool
                             identifier="execute_sql"
                             context={{

--- a/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
@@ -5,8 +5,6 @@ import { IconCheck, IconX } from '@posthog/icons'
 import { AutoSizer } from 'lib/components/AutoSizer'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 import { CodeEditor, CodeEditorProps } from 'lib/monaco/CodeEditor'
 import MaxTool from 'scenes/max/MaxTool'
 
@@ -23,6 +21,7 @@ interface QueryPaneProps {
     sourceQuery: HogQLQuery
     originalValue?: string
     onRun?: () => void
+    editorVimModeEnabled?: boolean
 }
 
 export function QueryPane(props: QueryPaneProps): JSX.Element {
@@ -34,8 +33,6 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
         reportAIQueryPromptOpen,
     } = useActions(multitabEditorLogic)
     const { acceptText, rejectText, diffShowRunButton } = useValues(multitabEditorLogic)
-    const { editorVimModeEnabled } = useValues(userPreferencesLogic)
-    const { setEditorVimModeEnabled } = useActions(userPreferencesLogic)
 
     return (
         <>
@@ -59,7 +56,7 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
                                         height={height}
                                         width={width}
                                         originalValue={props.originalValue}
-                                        enableVimMode={editorVimModeEnabled}
+                                        enableVimMode={props.editorVimModeEnabled}
                                         {...props.codeEditorProps}
                                         autoFocus={true}
                                         options={{
@@ -79,17 +76,6 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
                                 ) : null
                             }
                         />
-                    </div>
-                    <div className="absolute bottom-6 left-4">
-                        <Tooltip title={editorVimModeEnabled ? 'Disable vim mode' : 'Enable vim mode'}>
-                            <LemonButton
-                                size="small"
-                                type={editorVimModeEnabled ? 'primary' : 'secondary'}
-                                onClick={() => setEditorVimModeEnabled(!editorVimModeEnabled)}
-                            >
-                                Vim
-                            </LemonButton>
-                        </Tooltip>
                     </div>
                     <div className="absolute bottom-6 right-4">
                         <MaxTool

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -11,9 +11,11 @@ import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { Link } from 'lib/lemon-ui/Link'
 import { IconCancel } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -60,6 +62,9 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
     const { updatingDataWarehouseSavedQuery } = useValues(dataWarehouseViewsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const isRemovingSidePanelFlag = useFeatureFlag('UX_REMOVE_SIDEPANEL')
+    const vimModeFeatureEnabled = useFeatureFlag('SQL_EDITOR_VIM_MODE')
+    const { editorVimModeEnabled } = useValues(userPreferencesLogic)
+    const { setEditorVimModeEnabled } = useActions(userPreferencesLogic)
     const [editingViewDisabledReason, EditingViewButtonIcon] = useMemo(() => {
         if (updatingDataWarehouseSavedQuery) {
             return ['Saving...', Spinner]
@@ -242,6 +247,16 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                     </>
                 )}
                 <FixErrorButton type="tertiary" size="xsmall" source="action-bar" />
+                {vimModeFeatureEnabled && (
+                    <LemonSwitch
+                        checked={editorVimModeEnabled}
+                        onChange={setEditorVimModeEnabled}
+                        label="Vim"
+                        size="small"
+                        bordered
+                        data-attr="sql-editor-vim-toggle"
+                    />
+                )}
                 {isRemovingSidePanelFlag && (
                     <div className="ml-auto -mr-2">
                         <SceneTitlePanelButton />
@@ -254,6 +269,7 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                 sourceQuery={sourceQuery.source}
                 promptError={null}
                 onRun={runQuery}
+                editorVimModeEnabled={vimModeFeatureEnabled && editorVimModeEnabled}
                 codeEditorProps={{
                     queryKey: codeEditorKey,
                     onChange: (v) => {

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -253,7 +253,6 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                         onChange={setEditorVimModeEnabled}
                         label="Vim"
                         size="small"
-                        bordered
                         data-attr="sql-editor-vim-toggle"
                     />
                 )}

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -247,20 +247,18 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                     </>
                 )}
                 <FixErrorButton type="tertiary" size="xsmall" source="action-bar" />
-                {vimModeFeatureEnabled && (
-                    <LemonSwitch
-                        checked={editorVimModeEnabled}
-                        onChange={setEditorVimModeEnabled}
-                        label="Vim"
-                        size="small"
-                        data-attr="sql-editor-vim-toggle"
-                    />
-                )}
-                {isRemovingSidePanelFlag && (
-                    <div className="ml-auto -mr-2">
-                        <SceneTitlePanelButton />
-                    </div>
-                )}
+                <div className="ml-auto flex items-center gap-1">
+                    {vimModeFeatureEnabled && (
+                        <LemonSwitch
+                            checked={editorVimModeEnabled}
+                            onChange={setEditorVimModeEnabled}
+                            label="Vim"
+                            size="small"
+                            data-attr="sql-editor-vim-toggle"
+                        />
+                    )}
+                    {isRemovingSidePanelFlag && <SceneTitlePanelButton />}
+                </div>
             </div>
             <QueryPane
                 originalValue={originalQueryInput ?? ''}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -852,6 +852,9 @@ importers:
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
+      monaco-vim:
+        specifier: ^0.4.4
+        version: 0.4.4(monaco-editor@0.55.1)
       motion:
         specifier: ^12.26.1
         version: 12.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2217,7 +2220,7 @@ importers:
         version: 3.1.3
       jest:
         specifier: '*'
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.4.5))
       kea:
         specifier: ^3.1.7
         version: 3.1.7(react@18.3.1)
@@ -16147,6 +16150,11 @@ packages:
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
+  monaco-vim@0.4.4:
+    resolution: {integrity: sha512-LNChAb//WEm/W+eyeHG/0+pdVEHotk2hLTN+M3sQZx5E8cAlSWSgqcxpcRuQnxDybSln7pfHF9i63HmbIQvrWw==}
+    peerDependencies:
+      monaco-editor: '*'
+
   moo-color@1.0.3:
     resolution: {integrity: sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==}
 
@@ -24717,41 +24725,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.18.8
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@30.0.5(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.4.5))':
     dependencies:
       '@jest/console': 30.0.5
@@ -33248,21 +33221,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-require@1.1.1: {}
 
   crelt@1.0.5: {}
@@ -36442,25 +36400,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@30.0.5(@types/node@22.15.17)(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.4.5)):
     dependencies:
       '@jest/core': 30.0.5(esbuild-register@3.5.0(esbuild@0.27.2))(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.4.5))
@@ -36557,37 +36496,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.18.8
       ts-node: 10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5)):
-    dependencies:
-      '@babel/core': 7.28.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.0)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.18.8
-      ts-node: 10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -37218,18 +37126,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.1.0
       jest-cli: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.4.5))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -38580,6 +38476,10 @@ snapshots:
     dependencies:
       dompurify: 3.2.7
       marked: 14.0.0
+
+  monaco-vim@0.4.4(monaco-editor@0.55.1):
+    dependencies:
+      monaco-editor: 0.55.1
 
   moo-color@1.0.3:
     dependencies:


### PR DESCRIPTION
## Problem

SQL editor users who prefer Vim keybindings have no way to enable them. This feature adds optional Vim mode support to improve the editing experience for users familiar with Vim.

## Changes

- Added `monaco-vim` dependency to enable Vim keybindings in Monaco Editor
- Created new feature flag `SQL_EDITOR_VIM_MODE` to control Vim mode availability
- Added `editorVimModeEnabled` preference to `userPreferencesLogic` with persistence
- Extended `CodeEditor` component to support Vim mode with:
  - `enableVimMode` prop to toggle Vim keybindings
  - Vim status bar display at the bottom of the editor
  - Proper cleanup and disposal of Vim mode instance
- Added Vim mode toggle switch in `QueryWindow` toolbar (visible when feature flag is enabled)
- Updated `QueryPane` to pass Vim mode preference to the code editor
- Adjusted button positioning to account for Vim status bar when enabled

## How did you test this code?

https://www.loom.com/share/eb2fa30fc4364cdea00fd2c7f890a052
- Verified Vim mode initializes and disposes correctly when toggled
- Tested that Vim keybindings work when enabled (e.g., `j`/`k` for navigation, `dd` for delete line)
- Confirmed status bar appears/disappears with toggle
- Verified preference persists across page reloads
- Tested with feature flag disabled to ensure no UI changes

## Publish to changelog?

No, behind feature flag