### PR TITLE
fix(llma): disable heartbeat timeout for summarize activities

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -38,7 +38,9 @@ GENERATE_SUMMARY_TIMEOUT_SECONDS = (
 # send heartbeats within this interval or Temporal will consider them failed
 # and retry on another worker.
 SAMPLE_HEARTBEAT_TIMEOUT = timedelta(seconds=120)  # 2 minutes - sampling has long CH queries
-SUMMARIZE_HEARTBEAT_TIMEOUT = None  # Disabled - large trace formatting holds the GIL and blocks heartbeats. Relies on start_to_close (15 min) and schedule_to_close (45 min) for stuck activity detection.
+SUMMARIZE_HEARTBEAT_TIMEOUT: timedelta | None = (
+    None  # Disabled - large trace formatting holds the GIL and blocks heartbeats. Relies on start_to_close (15 min) and schedule_to_close (45 min) for stuck activity detection.
+)
 
 # Schedule-to-close timeouts - caps total time including all retry attempts,
 # backoff intervals, and queue time. Prevents runaway retries from blocking

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -38,9 +38,7 @@ GENERATE_SUMMARY_TIMEOUT_SECONDS = (
 # send heartbeats within this interval or Temporal will consider them failed
 # and retry on another worker.
 SAMPLE_HEARTBEAT_TIMEOUT = timedelta(seconds=120)  # 2 minutes - sampling has long CH queries
-SUMMARIZE_HEARTBEAT_TIMEOUT = timedelta(
-    seconds=120
-)  # 2 minutes - trace fetch + LLM calls can exceed 60s for large traces
+SUMMARIZE_HEARTBEAT_TIMEOUT = None  # Disabled - large trace formatting holds the GIL and blocks heartbeats. Relies on start_to_close (15 min) and schedule_to_close (45 min) for stuck activity detection.
 
 # Schedule-to-close timeouts - caps total time including all retry attempts,
 # backoff intervals, and queue time. Prevents runaway retries from blocking


### PR DESCRIPTION
## Problem

Trace-level summarization activities for large teams (e.g. team 2) consistently fail with heartbeat timeouts. Root cause: large trace formatting is CPU-intensive and holds the Python GIL, which blocks the asyncio event loop and prevents heartbeat pings from being sent. This happens even with idle workers and even after bumping the timeout from 60s to 120s (#47149).

The pattern is consistent: heartbeats flow for ~27s (during I/O-bound ClickHouse query), then stop completely (when CPU-bound trace formatting begins and holds the GIL).

## Changes

Sets `SUMMARIZE_HEARTBEAT_TIMEOUT = None` to disable heartbeat checking for summarize activities. Activities are still protected by:
- `start_to_close_timeout`: 15 minutes
- `schedule_to_close_timeout`: 45 minutes

The only downside is slower dead-worker detection for summarize activities (15 min vs 2 min), which is acceptable for an hourly batch job.

## How did you test this code?

- Ran 3 manual trace summarization workflows for team 2 in prod-us, all failed with heartbeat timeout
- Confirmed heartbeats stop after ~27s consistently, even on idle workers with 120s timeout
- Confirmed generation-level summarization (smaller payloads) works fine with heartbeats

## Publish to changelog?

No