### PR TITLE
fix(surveys): improve labeling for non-predefined survey responses

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -15,6 +15,7 @@ import {
     MultipleSurveyQuestion,
     RatingSurveyQuestion,
     Survey,
+    SurveyEventName,
     SurveyQuestion,
     SurveyQuestionType,
     SurveyType,
@@ -123,7 +124,8 @@ function canQuestionSkipSubmitButton(
 }
 
 export function SurveyEditQuestionGroup({ index, question }: { index: number; question: SurveyQuestion }): JSX.Element {
-    const { survey, descriptionContentType } = useValues(surveyLogic)
+    const { survey, descriptionContentType, processedSurveyStats } = useValues(surveyLogic)
+    const surveyHasResponses = (processedSurveyStats?.[SurveyEventName.SENT]?.total_count ?? 0) > 0
     const { setDefaultForQuestionType, setSurveyValue, resetBranchingForQuestion, setMultipleSurveyQuestion } =
         useActions(surveyLogic)
 
@@ -327,7 +329,15 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     <div className="flex flex-col gap-2">
                         <LemonField name="hasOpenChoice">
                             {({ value: hasOpenChoice, onChange: toggleHasOpenChoice }) => (
-                                <LemonField name="choices" label="Choices">
+                                <LemonField
+                                    name="choices"
+                                    label="Choices"
+                                    info={
+                                        surveyHasResponses
+                                            ? 'Editing choice text will cause existing responses to appear separately in results under their original text.'
+                                            : undefined
+                                    }
+                                >
                                     {({ value, onChange }) => (
                                         <div className="flex flex-col gap-2">
                                             {(value || []).map((choice: string, index: number) => {


### PR DESCRIPTION
## Problem

Confusing UX with edited responses being shown as open-ended in surveys that don't have open-ended options.

## Changes

- Rename "Other (open-ended)" to "Other" in chart bar
- Rename "Open-ended responses" section to "Other responses" with tooltip explaining it includes open-ended and edited choice responses
- Add info tooltip to choices field in editor when survey has responses warning that edits cause responses to appear separately


Opted for keeping this a simple UX change. Later, we may want to offer aggregation by response ID so purely cosmetic changes still allow users to count a response as the same one, while preserving the current behavior of treating changed answers as distinct responses.. Doing this, however, will require some schema changes.

When editing choices, a tooltip explains what happens:

<img width="1396" height="374" alt="CleanShot 2026-02-06 at 13 53 26@2x" src="https://github.com/user-attachments/assets/7cf0470a-5ff0-49e0-8bf6-7e5209147c5e" />

When looking at responses, all choices not current are shown as “Other” and listed under “Other responses” with a tooltip that explains what it shows:

<img width="1416" height="670" alt="CleanShot 2026-02-06 at 13 53 40@2x" src="https://github.com/user-attachments/assets/4342069c-3473-45da-9835-65334ac0158f" />


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
