### PR TITLE
feat(batch-imports): support gzipped JSONL in S3 managed migrations

### DIFF
--- a/posthog/models/batch_imports.py
+++ b/posthog/models/batch_imports.py
@@ -112,6 +112,28 @@ class BatchImportConfigBuilder:
         self.batch_import.secrets[secret_access_key_key] = secret_access_key
         return self
 
+    def from_s3_gzip(
+        self,
+        bucket: str,
+        prefix: str,
+        region: str,
+        access_key_id: str,
+        secret_access_key: str,
+        access_key_id_key: str = "aws_access_key_id",
+        secret_access_key_key: str = "aws_secret_access_key",
+    ) -> Self:
+        self.batch_import.import_config["source"] = {
+            "type": "s3_gzip",
+            "bucket": bucket,
+            "prefix": prefix,
+            "region": region,
+            "access_key_id_key": access_key_id_key,
+            "secret_access_key_key": secret_access_key_key,
+        }
+        self.batch_import.secrets[access_key_id_key] = access_key_id
+        self.batch_import.secrets[secret_access_key_key] = secret_access_key
+        return self
+
     def from_date_range(
         self,
         start_date: str,

--- a/products/managed_migrations/frontend/ManagedMigration.tsx
+++ b/products/managed_migrations/frontend/ManagedMigration.tsx
@@ -82,6 +82,16 @@ export function ManagedMigration(): JSX.Element {
                                 ),
                             },
                             {
+                                value: 's3_gzip',
+                                label: 'S3 (gzipped JSONL)',
+                                icon: (
+                                    <img
+                                        src="https://a0.awsstatic.com/libra-css/images/site/fav/favicon.ico"
+                                        className="w-4 h-4"
+                                    />
+                                ),
+                            },
+                            {
                                 value: 'mixpanel',
                                 label: 'Mixpanel',
                                 icon: <img src="https://mixpanel.com/favicon.ico" className="w-4 h-4" />,
@@ -95,7 +105,7 @@ export function ManagedMigration(): JSX.Element {
                     />
                 </LemonField>
 
-                {managedMigration.source_type === 's3' && (
+                {(managedMigration.source_type === 's3' || managedMigration.source_type === 's3_gzip') && (
                     <>
                         <LemonField name="content_type" label="Content Type">
                             <LemonSelect
@@ -111,7 +121,7 @@ export function ManagedMigration(): JSX.Element {
                     </>
                 )}
 
-                {managedMigration.source_type === 's3' && (
+                {(managedMigration.source_type === 's3' || managedMigration.source_type === 's3_gzip') && (
                     <>
                         <div className="flex gap-4">
                             <LemonField name="s3_region" label="S3 Region" className="flex-1">
@@ -278,6 +288,11 @@ export function ManagedMigrations(): JSX.Element {
                                             icon: 'https://a0.awsstatic.com/libra-css/images/site/fav/favicon.ico',
                                             label: 'AWS S3',
                                             alt: 'S3',
+                                        },
+                                        s3_gzip: {
+                                            icon: 'https://a0.awsstatic.com/libra-css/images/site/fav/favicon.ico',
+                                            label: 'S3 (gzipped JSONL)',
+                                            alt: 'S3 Gzip',
                                         },
                                         mixpanel: {
                                             icon: 'https://mixpanel.com/favicon.ico',

--- a/products/managed_migrations/frontend/managedMigrationLogic.ts
+++ b/products/managed_migrations/frontend/managedMigrationLogic.ts
@@ -15,7 +15,7 @@ import type { managedMigrationLogicType } from './managedMigrationLogicType'
 import { ManagedMigration } from './types'
 
 export interface ManagedMigrationForm {
-    source_type: 's3' | 'mixpanel' | 'amplitude'
+    source_type: 's3' | 's3_gzip' | 'mixpanel' | 'amplitude'
     access_key: string
     secret_key: string
     content_type: 'captured' | 'mixpanel' | 'amplitude'
@@ -98,7 +98,7 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
                     secret_key: !secret_key ? 'Secret key is required' : null,
                 }
 
-                if (source_type === 's3') {
+                if (source_type === 's3' || source_type === 's3_gzip') {
                     errors.s3_region = !s3_region ? 'S3 region is required' : null
                     errors.s3_bucket = !s3_bucket ? 'S3 bucket is required' : null
                 } else if (source_type === 'mixpanel' || source_type === 'amplitude') {
@@ -135,7 +135,7 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
                     secret_key: values.secret_key,
                     content_type: values.content_type,
                 }
-                if (values.source_type === 's3') {
+                if (values.source_type === 's3' || values.source_type === 's3_gzip') {
                     payload = {
                         ...payload,
                         s3_region: values.s3_region,

--- a/products/managed_migrations/frontend/types.ts
+++ b/products/managed_migrations/frontend/types.ts
@@ -32,10 +32,17 @@ export interface S3ManagedMigration extends BaseManagedMigration {
     s3_prefix: string
 }
 
+export interface S3GzipManagedMigration extends BaseManagedMigration {
+    source_type: 's3_gzip'
+    s3_region: string
+    s3_bucket: string
+    s3_prefix: string
+}
+
 export interface DateRangeManagedMigration extends BaseManagedMigration {
     source_type: 'mixpanel' | 'amplitude' | 'date_range_export'
     start_date: string
     end_date: string
 }
 
-export type ManagedMigration = S3ManagedMigration | DateRangeManagedMigration
+export type ManagedMigration = S3ManagedMigration | S3GzipManagedMigration | DateRangeManagedMigration

--- a/rust/batch-import-worker/Cargo.toml
+++ b/rust/batch-import-worker/Cargo.toml
@@ -49,3 +49,4 @@ moka = { workspace = true }
 
 [dev-dependencies]
 httpmock = { workspace = true }
+flate2 = { workspace = true }

--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -74,6 +74,8 @@ pub struct S3SourceConfig {
     bucket: String,
     prefix: String,
     region: String,
+    #[serde(default)]
+    endpoint_url: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -308,7 +310,7 @@ impl S3SourceConfig {
             "job_config",
         );
 
-        let aws_conf = aws_sdk_s3::config::Builder::new()
+        let mut builder = aws_sdk_s3::config::Builder::new()
             .region(Region::new(self.region.clone()))
             .credentials_provider(aws_credentials)
             .behavior_version(BehaviorVersion::latest())
@@ -317,9 +319,11 @@ impl S3SourceConfig {
                     .operation_timeout(Duration::from_secs(30))
                     .build(),
             )
-            .retry_config(RetryConfig::standard())
-            .build();
-        let client = aws_sdk_s3::Client::from_conf(aws_conf);
+            .retry_config(RetryConfig::standard());
+        if let Some(ref url) = self.endpoint_url {
+            builder = builder.endpoint_url(url).force_path_style(true);
+        }
+        let client = aws_sdk_s3::Client::from_conf(builder.build());
 
         Ok(S3Source::new(
             client,
@@ -363,7 +367,7 @@ impl S3SourceConfig {
             "job_config",
         );
 
-        let aws_conf = aws_sdk_s3::config::Builder::new()
+        let mut builder = aws_sdk_s3::config::Builder::new()
             .region(Region::new(self.region.clone()))
             .credentials_provider(aws_credentials)
             .behavior_version(BehaviorVersion::latest())
@@ -372,9 +376,11 @@ impl S3SourceConfig {
                     .operation_timeout(Duration::from_secs(30))
                     .build(),
             )
-            .retry_config(RetryConfig::standard())
-            .build();
-        let client = aws_sdk_s3::Client::from_conf(aws_conf);
+            .retry_config(RetryConfig::standard());
+        if let Some(ref url) = self.endpoint_url {
+            builder = builder.endpoint_url(url).force_path_style(true);
+        }
+        let client = aws_sdk_s3::Client::from_conf(builder.build());
 
         Ok(GzipS3Source::new(
             client,

--- a/rust/batch-import-worker/src/source/mod.rs
+++ b/rust/batch-import-worker/src/source/mod.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 pub mod date_range_export;
 pub mod folder;
 pub mod s3;
+pub mod s3_gzip;
 pub mod url_list;
 
 #[async_trait]

--- a/rust/batch-import-worker/src/source/s3.rs
+++ b/rust/batch-import-worker/src/source/s3.rs
@@ -23,7 +23,7 @@ impl S3Source {
 }
 
 // String matching hack to get around the fact that there didn't seem to be an easy way to import and handle the different error types with the aws sdk
-fn extract_user_friendly_error(
+pub(crate) fn extract_user_friendly_error(
     error: &dyn std::error::Error,
     bucket: &str,
     operation: &str,

--- a/rust/batch-import-worker/src/source/s3_gzip.rs
+++ b/rust/batch-import-worker/src/source/s3_gzip.rs
@@ -1,0 +1,307 @@
+use crate::error::ToUserError;
+use crate::extractor::{ExtractedPartData, PartExtractor};
+use anyhow::{Context, Error};
+use aws_sdk_s3::Client as S3Client;
+use axum::async_trait;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+use tokio::{fs::File, io::AsyncReadExt, io::AsyncSeekExt, io::AsyncWriteExt};
+use tracing::{debug, info, warn};
+
+use super::s3::extract_user_friendly_error;
+use super::DataSource;
+
+fn sanitize_key_for_path(key: &str) -> String {
+    key.replace(['/', ':'], "_")
+}
+
+pub struct GzipS3Source {
+    client: S3Client,
+    bucket: String,
+    prefix: String,
+    extractor: Arc<dyn PartExtractor>,
+    temp_dir: Arc<Mutex<Option<TempDir>>>,
+    prepared_keys: Arc<Mutex<HashMap<String, ExtractedPartData>>>,
+}
+
+impl GzipS3Source {
+    pub fn new(
+        client: S3Client,
+        bucket: String,
+        prefix: String,
+        extractor: Arc<dyn PartExtractor>,
+    ) -> Self {
+        Self {
+            client,
+            bucket,
+            prefix,
+            extractor,
+            temp_dir: Arc::new(Mutex::new(None)),
+            prepared_keys: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    async fn get_temp_dir_path(&self) -> Result<PathBuf, Error> {
+        let guard = self.temp_dir.lock().await;
+        Ok(guard
+            .as_ref()
+            .ok_or_else(|| Error::msg("Temp directory not initialized"))?
+            .path()
+            .to_path_buf())
+    }
+
+    async fn get_chunk_from_prepared_key(
+        &self,
+        key: &str,
+        offset: u64,
+        size: u64,
+    ) -> Result<Vec<u8>, Error> {
+        let extracted_part = {
+            let prepared_keys = self.prepared_keys.lock().await;
+            prepared_keys
+                .get(key)
+                .ok_or_else(|| Error::msg(format!("Key not prepared: {key}")))?
+                .clone()
+        };
+
+        if extracted_part.data_file_size == 0 {
+            return Ok(Vec::new());
+        }
+
+        let total_size = extracted_part.data_file_size as u64;
+        if offset >= total_size {
+            return Ok(Vec::new());
+        }
+
+        let end_offset = std::cmp::min(offset + size, total_size);
+        let read_size = (end_offset - offset) as usize;
+
+        let mut file = File::open(&extracted_part.data_file_path)
+            .await
+            .with_context(|| format!("Failed to open extracted data file for key: {key}"))?;
+        file.seek(std::io::SeekFrom::Start(offset))
+            .await
+            .with_context(|| {
+                format!("Failed to seek to offset {offset} in extracted data file for key: {key}")
+            })?;
+        let mut buffer = vec![0u8; read_size];
+        file.read_exact(&mut buffer).await.with_context(|| {
+            format!(
+                "Failed to read exact {read_size} bytes from extracted data file for key: {key}"
+            )
+        })?;
+
+        if end_offset == total_size {
+            if let Err(e) = self.cleanup_key(key).await {
+                warn!("Failed to cleanup key {key}: {e:?}");
+            }
+        }
+
+        Ok(buffer)
+    }
+}
+
+#[async_trait]
+impl DataSource for GzipS3Source {
+    async fn keys(&self) -> Result<Vec<String>, Error> {
+        debug!(
+            "Listing keys in bucket {} with prefix {}",
+            self.bucket, self.prefix
+        );
+        let mut keys = Vec::new();
+        let mut continuation_token = None;
+        loop {
+            let mut cmd = self
+                .client
+                .list_objects_v2()
+                .bucket(&self.bucket)
+                .prefix(self.prefix.clone());
+            if let Some(token) = continuation_token {
+                cmd = cmd.continuation_token(token);
+            }
+            let output = cmd.send().await.or_else(|sdk_error| {
+                let friendly_msg =
+                    extract_user_friendly_error(&sdk_error, &self.bucket, "list objects");
+                Err(sdk_error).user_error(friendly_msg)
+            })?;
+
+            debug!("Got response: {:?}", output);
+            if let Some(contents) = output.contents {
+                keys.extend(contents.iter().filter_map(|o| o.key.clone()));
+            }
+            match output.next_continuation_token {
+                Some(token) => continuation_token = Some(token),
+                None => break,
+            }
+        }
+        Ok(keys)
+    }
+
+    async fn size(&self, key: &str) -> Result<Option<u64>, Error> {
+        let prepared_keys = self.prepared_keys.lock().await;
+        if let Some(extracted_part) = prepared_keys.get(key) {
+            Ok(Some(extracted_part.data_file_size as u64))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn get_chunk(&self, key: &str, offset: u64, size: u64) -> Result<Vec<u8>, Error> {
+        self.get_chunk_from_prepared_key(key, offset, size).await
+    }
+
+    async fn prepare_for_job(&self) -> Result<(), Error> {
+        let temp_dir =
+            tempfile::tempdir().with_context(|| "Failed to create temp directory for job")?;
+        debug!("Created temp directory for job: {:?}", temp_dir.path());
+
+        {
+            let mut temp_dir_guard = self.temp_dir.lock().await;
+            *temp_dir_guard = Some(temp_dir);
+        }
+
+        Ok(())
+    }
+
+    async fn cleanup_after_job(&self) -> Result<(), Error> {
+        {
+            let mut prepared_keys = self.prepared_keys.lock().await;
+            prepared_keys.clear();
+        }
+        {
+            let mut temp_dir_guard = self.temp_dir.lock().await;
+            if let Some(temp_dir) = temp_dir_guard.take() {
+                drop(temp_dir);
+                debug!("Cleaned up temp directory");
+            }
+        }
+        debug!("Job cleanup complete");
+        Ok(())
+    }
+
+    async fn prepare_key(&self, key: &str) -> Result<(), Error> {
+        {
+            let prepared_keys = self.prepared_keys.lock().await;
+            if prepared_keys.contains_key(key) {
+                debug!("Key already prepared: {}", key);
+                return Ok(());
+            }
+        }
+
+        let get = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+            .or_else(|sdk_error| {
+                let friendly_msg =
+                    extract_user_friendly_error(&sdk_error, &self.bucket, "get object");
+                Err(sdk_error).user_error(friendly_msg)
+            })?;
+
+        let data = get.body.collect().await.with_context(|| {
+            format!(
+                "Failed to read body data from S3 object s3://{0}/{key}",
+                self.bucket,
+            )
+        })?;
+
+        let bytes = data.to_vec();
+        let temp_dir = self.get_temp_dir_path().await?;
+        let safe_key = sanitize_key_for_path(key);
+
+        if bytes.is_empty() {
+            let empty_data_file_path = temp_dir.join(format!("{}.data", safe_key));
+            let empty_file = File::create(&empty_data_file_path)
+                .await
+                .with_context(|| format!("Failed to create empty data file for key: {key}"))?;
+            empty_file.sync_all().await?;
+
+            let extracted_part = ExtractedPartData {
+                data_file_path: empty_data_file_path,
+                data_file_size: 0,
+            };
+            let mut prepared_keys = self.prepared_keys.lock().await;
+            prepared_keys.insert(key.to_string(), extracted_part);
+            info!("Prepared key {} (empty object)", key);
+            return Ok(());
+        }
+
+        let raw_file_path = temp_dir.join(format!("{}.raw", safe_key));
+        let mut raw_file = File::create(&raw_file_path)
+            .await
+            .with_context(|| format!("Failed to create raw file: {}", raw_file_path.display()))?;
+        raw_file
+            .write_all(&bytes)
+            .await
+            .with_context(|| format!("Failed to write raw file: {}", raw_file_path.display()))?;
+        raw_file
+            .sync_all()
+            .await
+            .with_context(|| format!("Failed to sync raw file: {}", raw_file_path.display()))?;
+        drop(raw_file);
+
+        let extracted_part = self
+            .extractor
+            .extract_compressed_to_seekable_file(&safe_key, &raw_file_path, &temp_dir)
+            .await
+            .with_context(|| {
+                format!("Failed to extract compressed to seekable file for key: {key}")
+            })?;
+
+        if let Err(e) = tokio::fs::remove_file(&raw_file_path).await {
+            warn!(
+                "Failed to remove raw file {}: {e:?}",
+                raw_file_path.display()
+            );
+        }
+
+        {
+            let mut prepared_keys = self.prepared_keys.lock().await;
+            prepared_keys.insert(key.to_string(), extracted_part.clone());
+        }
+
+        info!(
+            "Prepared key {} ({} bytes decompressed)",
+            key, extracted_part.data_file_size
+        );
+
+        Ok(())
+    }
+
+    async fn cleanup_key(&self, key: &str) -> Result<(), Error> {
+        let extracted_part = {
+            let mut prepared_keys = self.prepared_keys.lock().await;
+            prepared_keys.remove(key)
+        };
+
+        if let Some(extracted_part) = extracted_part {
+            if let Err(e) = tokio::fs::remove_file(&extracted_part.data_file_path).await {
+                warn!("Failed to remove temp file for key {}: {}", key, e);
+            } else {
+                debug!("Cleaned up key: {}", key);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_key_for_path() {
+        assert_eq!(sanitize_key_for_path("a/b/c.jsonl.gz"), "a_b_c.jsonl.gz");
+        assert_eq!(sanitize_key_for_path("key:with:colons"), "key_with_colons");
+        assert_eq!(
+            sanitize_key_for_path("path/to/file.jsonl.gz"),
+            "path_to_file.jsonl.gz"
+        );
+    }
+}

--- a/rust/batch-import-worker/tests/common/mod.rs
+++ b/rust/batch-import-worker/tests/common/mod.rs
@@ -1,0 +1,51 @@
+//! Shared test utilities for MinIO/S3 integration tests.
+
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::config::Region;
+use aws_sdk_s3::Client as AwsS3Client;
+
+pub const MINIO_ENDPOINT: &str = "http://localhost:19000";
+pub const MINIO_ACCESS_KEY: &str = "object_storage_root_user";
+pub const MINIO_SECRET_KEY: &str = "object_storage_root_password";
+
+pub async fn create_minio_client() -> AwsS3Client {
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .endpoint_url(MINIO_ENDPOINT)
+        .region(Region::new("us-east-1"))
+        .credentials_provider(aws_sdk_s3::config::Credentials::new(
+            MINIO_ACCESS_KEY,
+            MINIO_SECRET_KEY,
+            None,
+            None,
+            "test",
+        ))
+        .load()
+        .await;
+
+    let s3_config = aws_sdk_s3::config::Builder::from(&config)
+        .force_path_style(true)
+        .build();
+
+    AwsS3Client::from_conf(s3_config)
+}
+
+pub async fn ensure_bucket_exists(client: &AwsS3Client, bucket: &str) {
+    drop(client.create_bucket().bucket(bucket).send().await);
+}
+
+pub async fn cleanup_bucket(client: &AwsS3Client, bucket: &str, prefix: &str) {
+    let list_result = client
+        .list_objects_v2()
+        .bucket(bucket)
+        .prefix(prefix)
+        .send()
+        .await;
+
+    if let Ok(response) = list_result {
+        for object in response.contents() {
+            if let Some(key) = object.key() {
+                drop(client.delete_object().bucket(bucket).key(key).send().await);
+            }
+        }
+    }
+}

--- a/rust/batch-import-worker/tests/s3_gzip_minio_integration_test.rs
+++ b/rust/batch-import-worker/tests/s3_gzip_minio_integration_test.rs
@@ -1,0 +1,189 @@
+//! MinIO integration test for S3 gzip source: upload 3 × 10-event .jsonl.gz files,
+//! run the pipeline (source + captured parser + file sink), assert 30 well-formed output events.
+//!
+//! Requires MinIO running at localhost:19000 (e.g. docker-compose.dev.yml). Skips if unreachable.
+
+use anyhow::Result;
+use batch_import_worker::{
+    cache::{MemoryGroupCache, MemoryIdentifyCache},
+    job::config::{JobSecrets, SourceConfig},
+    parse::content::{captured::captured_parse_fn, TransformContext},
+    parse::format::{json_nd, skip_geoip},
+    parse::Parsed,
+    source::DataSource,
+};
+use common_types::{InternallyCapturedEvent, RawEvent};
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use std::collections::HashSet;
+use std::io::Write;
+use std::sync::Arc;
+use tempfile::NamedTempFile;
+use uuid::Uuid;
+
+mod common;
+use common::{
+    cleanup_bucket, create_minio_client, ensure_bucket_exists, MINIO_ACCESS_KEY, MINIO_ENDPOINT,
+    MINIO_SECRET_KEY,
+};
+
+const TEST_BUCKET: &str = "batch-import-test";
+const TEST_PREFIX: &str = "s3_gzip_integration";
+const CHUNK_SIZE: u64 = 64 * 1024;
+
+fn make_captured_event(i: u32) -> String {
+    let uuid = Uuid::now_v7();
+    let distinct_id = format!("user-{}", i);
+    let timestamp = format!("2024-01-{:02}T12:00:00Z", (i % 28) + 1);
+    serde_json::json!({
+        "event": "$pageview",
+        "distinct_id": distinct_id,
+        "timestamp": timestamp,
+        "uuid": uuid.to_string(),
+        "properties": { "idx": i }
+    })
+    .to_string()
+}
+
+fn gzip_bytes(data: &[u8]) -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(data).unwrap();
+    encoder.finish().unwrap()
+}
+
+#[tokio::test]
+async fn test_s3_gzip_minio_integration() {
+    let client = match create_minio_client().await.list_buckets().send().await {
+        Ok(_) => create_minio_client().await,
+        Err(_) => {
+            eprintln!("MinIO unreachable at {}, skipping test", MINIO_ENDPOINT);
+            return;
+        }
+    };
+
+    ensure_bucket_exists(&client, TEST_BUCKET).await;
+    cleanup_bucket(&client, TEST_BUCKET, TEST_PREFIX).await;
+
+    let prefix = format!("{}/", TEST_PREFIX);
+    for file_idx in 1..=3 {
+        let mut lines = Vec::new();
+        for i in 0..10 {
+            let global_idx = (file_idx - 1) * 10 + i;
+            lines.push(make_captured_event(global_idx));
+        }
+        let jsonl = lines.join("\n") + "\n";
+        let gz = gzip_bytes(jsonl.as_bytes());
+        let key = format!("{}file{}.jsonl.gz", prefix, file_idx);
+        client
+            .put_object()
+            .bucket(TEST_BUCKET)
+            .key(&key)
+            .body(aws_sdk_s3::primitives::ByteStream::from(gz))
+            .send()
+            .await
+            .expect("upload test file");
+    }
+
+    let source_config: SourceConfig = serde_json::from_value(serde_json::json!({
+        "type": "s3_gzip",
+        "access_key_id_key": "aws_access_key_id",
+        "secret_access_key_key": "aws_secret_access_key",
+        "bucket": TEST_BUCKET,
+        "prefix": prefix,
+        "region": "us-east-1",
+        "endpoint_url": MINIO_ENDPOINT
+    }))
+    .expect("source config from json");
+    let s3_config = match &source_config {
+        SourceConfig::S3Gzip(c) => c.clone(),
+        _ => panic!("expected s3_gzip"),
+    };
+
+    let secrets = JobSecrets {
+        secrets: [
+            (
+                "aws_access_key_id".to_string(),
+                serde_json::Value::String(MINIO_ACCESS_KEY.to_string()),
+            ),
+            (
+                "aws_secret_access_key".to_string(),
+                serde_json::Value::String(MINIO_SECRET_KEY.to_string()),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    };
+
+    let source = s3_config
+        .create_gzip_source(&secrets)
+        .await
+        .expect("create gzip source");
+    source.prepare_for_job().await.expect("prepare for job");
+
+    let keys = source.keys().await.expect("keys");
+    assert_eq!(keys.len(), 3, "expected 3 keys");
+
+    let transform_context = TransformContext {
+        team_id: 1,
+        token: "test-token".to_string(),
+        job_id: Uuid::now_v7(),
+        identify_cache: Arc::new(MemoryIdentifyCache::with_defaults()),
+        group_cache: Arc::new(MemoryGroupCache::with_defaults()),
+        import_events: true,
+        generate_identify_events: false,
+        generate_group_identify_events: false,
+    };
+
+    let format_parse = json_nd::<RawEvent>(true);
+    let event_transform = captured_parse_fn(transform_context, skip_geoip());
+
+    let parser = move |data: Vec<u8>| -> Result<Parsed<Vec<InternallyCapturedEvent>>> {
+        let parsed_raw = format_parse(data)?;
+        let mut events = Vec::new();
+        for raw in parsed_raw.data {
+            if let Some(ev) = event_transform(raw)? {
+                events.push(ev);
+            }
+        }
+        Ok(Parsed {
+            data: events,
+            consumed: parsed_raw.consumed,
+        })
+    };
+
+    let out_file = NamedTempFile::new().expect("temp file");
+    let out_path = out_file.path().to_path_buf();
+
+    let mut all_events: Vec<InternallyCapturedEvent> = Vec::new();
+    for key in &keys {
+        source.prepare_key(key).await.expect("prepare_key");
+        let size = source.size(key).await.expect("size").expect("size some");
+        let mut offset = 0u64;
+        while offset < size {
+            let chunk = source
+                .get_chunk(key, offset, CHUNK_SIZE)
+                .await
+                .expect("get_chunk");
+            let parsed = parser(chunk).expect("parse chunk");
+            all_events.extend(parsed.data);
+            offset += parsed.consumed as u64;
+        }
+    }
+
+    let out_json = all_events
+        .iter()
+        .map(|e| serde_json::to_string(&e.inner).expect("serialize"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&out_path, out_json + "\n").expect("write output");
+
+    assert_eq!(all_events.len(), 30, "expected 30 events");
+
+    let mut uuids = HashSet::new();
+    for ev in &all_events {
+        uuids.insert(ev.inner.uuid.to_string());
+    }
+    assert_eq!(uuids.len(), 30, "30 unique uuids (no duplicate events)");
+
+    cleanup_bucket(&client, TEST_BUCKET, TEST_PREFIX).await;
+}


### PR DESCRIPTION
## Problem
We have use cases where an end user exports their data to S3 in `.jsonl.gz` format. Because our current S3 managed migration job type uses byte ranges to fetch and process data in chunks, it doesn't natively support compressed JSONL inputs.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement `GzipS3Source` and related plumbing in `batch-imports`
* Implement related Django and UI changes to support this job mode
* Related test suite updates

**Risk:** since this requires downloading full objects locally prior to processing, as we do with API results in `DateRangeExportSource`-backed job types, this will be less stable at scale, and subject to GZIP bombs and more coarse fail modes/event dup risks
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
