### PR TITLE
fix(llma): evals date picker missing

### DIFF
--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
@@ -15,6 +15,7 @@ import {
 } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -26,6 +27,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
+import { llmAnalyticsSharedLogic } from '../llmAnalyticsSharedLogic'
 import { LLMProviderKeysSettings } from '../settings/LLMProviderKeysSettings'
 import { TrialUsageMeter } from '../settings/TrialUsageMeter'
 import { EvaluationTemplatesEmptyState } from './EvaluationTemplates'
@@ -49,6 +51,8 @@ function LLMAnalyticsEvaluationsContent(): JSX.Element {
     const { setEvaluationsFilter, toggleEvaluationEnabled, duplicateEvaluation, loadEvaluations } =
         useActions(llmEvaluationsLogic)
     const { evaluationsWithMetrics } = useValues(evaluationMetricsLogic)
+    const { dateFilter } = useValues(llmAnalyticsSharedLogic)
+    const { setDates } = useActions(llmAnalyticsSharedLogic)
     const { currentTeamId } = useValues(teamLogic)
     const { push } = useActions(router)
 
@@ -230,6 +234,8 @@ function LLMAnalyticsEvaluationsContent(): JSX.Element {
                     </LemonButton>
                 </AccessControlAction>
             </div>
+
+            <DateFilter dateFrom={dateFilter.dateFrom} dateTo={dateFilter.dateTo} onChange={setDates} />
 
             <EvaluationMetrics />
 

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
@@ -27,7 +27,6 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
-import { llmAnalyticsSharedLogic } from '../llmAnalyticsSharedLogic'
 import { LLMProviderKeysSettings } from '../settings/LLMProviderKeysSettings'
 import { TrialUsageMeter } from '../settings/TrialUsageMeter'
 import { EvaluationTemplatesEmptyState } from './EvaluationTemplates'
@@ -47,12 +46,11 @@ export const scene: SceneExport = {
 }
 
 function LLMAnalyticsEvaluationsContent(): JSX.Element {
-    const { evaluations, filteredEvaluations, evaluationsLoading, evaluationsFilter } = useValues(llmEvaluationsLogic)
-    const { setEvaluationsFilter, toggleEvaluationEnabled, duplicateEvaluation, loadEvaluations } =
+    const { evaluations, filteredEvaluations, evaluationsLoading, evaluationsFilter, dateFilter } =
+        useValues(llmEvaluationsLogic)
+    const { setEvaluationsFilter, toggleEvaluationEnabled, duplicateEvaluation, loadEvaluations, setDates } =
         useActions(llmEvaluationsLogic)
     const { evaluationsWithMetrics } = useValues(evaluationMetricsLogic)
-    const { dateFilter } = useValues(llmAnalyticsSharedLogic)
-    const { setDates } = useActions(llmAnalyticsSharedLogic)
     const { currentTeamId } = useValues(teamLogic)
     const { push } = useActions(router)
 

--- a/products/llm_analytics/frontend/evaluations/evaluationMetricsLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/evaluationMetricsLogic.ts
@@ -7,7 +7,6 @@ import { dayjs } from 'lib/dayjs'
 import { HogQLQuery, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { ChartDisplayType, HogQLMathType } from '~/types'
 
-import { llmAnalyticsSharedLogic } from '../llmAnalyticsSharedLogic'
 import { PASS_RATE_SUCCESS_THRESHOLD } from './components/EvaluationMetrics'
 import type { evaluationMetricsLogicType } from './evaluationMetricsLogicType'
 import { llmEvaluationsLogic } from './llmEvaluationsLogic'
@@ -61,8 +60,8 @@ export const evaluationMetricsLogic = kea<evaluationMetricsLogicType>([
     path(['products', 'llm_analytics', 'frontend', 'evaluations', 'evaluationMetricsLogic']),
 
     connect(() => ({
-        values: [llmEvaluationsLogic, ['evaluations'], llmAnalyticsSharedLogic, ['dateFilter']],
-        actions: [llmAnalyticsSharedLogic, ['setDates']],
+        values: [llmEvaluationsLogic, ['evaluations', 'dateFilter']],
+        actions: [llmEvaluationsLogic, ['setDates']],
     })),
 
     actions({


### PR DESCRIPTION
## Problem

The date picker was removed accidentally in the LLMA sidebar product split.

## Changes

This adds it back, but not from the shared logic anymore, rather from the evaluations logic.

## How did you test this code?

Manually.

## Publish to changelog?

No.