### PR TITLE
chore: document OpenAPI type generation in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@
   - Frontend: `pnpm --filter=@posthog/frontend build`
   - Start dev: `./bin/start`
 
+## API Type Generation
+
+`hogli build:openapi` syncs DRF serializers/ViewSets → TypeScript via drf-spectacular + Orval. Generated files (`api.schemas.ts`, `api.ts`) live at `frontend/src/generated/core/` and `products/{product}/frontend/generated/`. Don't edit these manually — change the serializers and rerun the command.
+
 ## Commits and Pull Requests
 
 Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for all commit messages and PR titles.


### PR DESCRIPTION
## Problem

AI agents working in this codebase have no context on how DRF types flow to the frontend. They may try to manually write TypeScript types that duplicate generated ones, or not know to rerun generation after serializer changes.

## Changes

Added a short "API Type Generation" section to AGENTS.md explaining the `hogli build:openapi` pipeline and where generated files live.

## How did you test this code?

Read-only docs change.

## Publish to changelog?

No