### PR TITLE
fix(llma): reduce trace summarization batch size to 1

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -10,7 +10,8 @@ from products.llm_analytics.backend.summarization.models import OpenAIModel, Sum
 DEFAULT_MAX_ITEMS_PER_WINDOW = (
     15  # Max items to process per window (targets ~2500 summaries in 7-day clustering window)
 )
-DEFAULT_BATCH_SIZE = 5  # Number of traces to process in parallel
+DEFAULT_BATCH_SIZE = 5  # Number of generations to process in parallel
+DEFAULT_TRACE_BATCH_SIZE = 1  # Traces processed sequentially - formatting is CPU-intensive and holds the GIL
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)
 DEFAULT_WINDOW_OFFSET_MINUTES = 30  # Offset window into the past so traces have time to fully complete

--- a/posthog/temporal/llm_analytics/trace_summarization/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/schedule.py
@@ -23,6 +23,7 @@ from posthog.temporal.llm_analytics.trace_summarization.constants import (
     DEFAULT_MAX_GENERATIONS_PER_WINDOW,
     DEFAULT_MAX_ITEMS_PER_WINDOW,
     DEFAULT_MODE,
+    DEFAULT_TRACE_BATCH_SIZE,
     DEFAULT_WINDOW_MINUTES,
     GENERATION_COORDINATOR_SCHEDULE_ID,
     SCHEDULE_INTERVAL_HOURS,
@@ -41,7 +42,7 @@ async def create_batch_trace_summarization_schedule(client: Client):
             COORDINATOR_WORKFLOW_NAME,
             BatchTraceSummarizationCoordinatorInputs(
                 max_items=DEFAULT_MAX_ITEMS_PER_WINDOW,
-                batch_size=DEFAULT_BATCH_SIZE,
+                batch_size=DEFAULT_TRACE_BATCH_SIZE,
                 mode=DEFAULT_MODE,
                 window_minutes=DEFAULT_WINDOW_MINUTES,
             ),


### PR DESCRIPTION
## Problem

Trace formatting is CPU-intensive and holds the Python GIL. With batch_size=5, multiple concurrent trace formatting threads completely lock up the worker — no logs, no heartbeats, no responsiveness. This was confirmed by running manual workflows for team 2 in prod-us where the worker went silent for 10+ minutes with both pods pegged at 1000m CPU.

## Changes

- Adds `DEFAULT_TRACE_BATCH_SIZE = 1` for trace-level summarization (sequential per team)
- Keeps `DEFAULT_BATCH_SIZE = 5` for generation-level summarization (small payloads, no GIL issue)
- Updates the trace schedule to use the new constant

Parallelism still comes from the coordinator running up to 5 teams concurrently across 2 worker pods.

## How did you test this code?

- All 19 existing tests pass
- Previous manual runs confirmed the GIL contention issue with batch_size=5
- Will run manual workflow for team 2 after deploy to verify

## Publish to changelog?

No