### PR TITLE
fix(llma): handle evals parsing error gracefully

### DIFF
--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -415,6 +415,14 @@ Output: {output_data}"""
             f"Model '{model}' not found.",
             non_retryable=True,
         )
+    except ValueError as e:
+        increment_errors("parse_error")
+        raise ApplicationError(
+            str(e),
+            {"error_type": "parse_error"},
+            non_retryable=True,
+        ) from e
+
     except Exception:
         increment_errors("unknown_error")
         raise
@@ -600,7 +608,7 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                 error_type = details.get("error_type")
 
                 # Handle skippable errors - return success with skip info
-                if error_type in ("trial_limit_reached", "key_invalid"):
+                if error_type in ("trial_limit_reached", "key_invalid", "parse_error"):
                     if error_type == "trial_limit_reached":
                         await temporalio.workflow.execute_activity(
                             disable_evaluation_activity,

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -33,6 +33,7 @@ from products.llm_analytics.backend.llm.errors import (
     ModelPermissionError,
     QuotaExceededError,
     RateLimitError,
+    StructuredOutputParseError,
 )
 from products.llm_analytics.backend.models.evaluation_config import EvaluationConfig
 from products.llm_analytics.backend.models.evaluations import Evaluation
@@ -415,7 +416,7 @@ Output: {output_data}"""
             f"Model '{model}' not found.",
             non_retryable=True,
         )
-    except ValueError as e:
+    except StructuredOutputParseError as e:
         increment_errors("parse_error")
         raise ApplicationError(
             str(e),

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -7,6 +7,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from asgiref.sync import sync_to_async
+from temporalio.exceptions import ApplicationError
 
 from posthog.models import Organization, Team
 
@@ -386,6 +387,43 @@ class TestRunEvaluationWorkflow:
 
         await sync_to_async(evaluation.refresh_from_db)()
         assert evaluation.enabled is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_execute_llm_judge_activity_parse_error_raises_non_retryable(self, setup_data):
+        evaluation_obj = setup_data["evaluation"]
+        team = setup_data["team"]
+
+        evaluation = {
+            "id": str(evaluation_obj.id),
+            "name": "Test Evaluation",
+            "evaluation_type": "llm_judge",
+            "evaluation_config": {"prompt": "Is this response factually accurate?"},
+            "output_type": "boolean",
+            "output_config": {},
+            "team_id": team.id,
+        }
+
+        event_data = create_mock_event_data(
+            team.id,
+            properties={
+                "$ai_input": [{"role": "user", "content": "What is 2+2?"}],
+                "$ai_output_choices": [{"role": "assistant", "content": "4"}],
+            },
+        )
+
+        with patch("posthog.temporal.llm_analytics.run_evaluation.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_client.complete.side_effect = ValueError(
+                "Failed to parse structured output: I need to fetch your bundles..."
+            )
+
+            with pytest.raises(ApplicationError, match="Failed to parse structured output") as exc_info:
+                await execute_llm_judge_activity(evaluation, event_data)
+
+            assert exc_info.value.non_retryable is True
+            assert exc_info.value.details[0] == {"error_type": "parse_error"}
 
 
 class TestEvalResultModels:

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -11,6 +11,7 @@ from temporalio.exceptions import ApplicationError
 
 from posthog.models import Organization, Team
 
+from products.llm_analytics.backend.llm.errors import StructuredOutputParseError
 from products.llm_analytics.backend.models.evaluations import Evaluation
 
 from .run_evaluation import (
@@ -415,7 +416,7 @@ class TestRunEvaluationWorkflow:
         with patch("posthog.temporal.llm_analytics.run_evaluation.Client") as mock_client_class:
             mock_client = MagicMock()
             mock_client_class.return_value = mock_client
-            mock_client.complete.side_effect = ValueError(
+            mock_client.complete.side_effect = StructuredOutputParseError(
                 "Failed to parse structured output: I need to fetch your bundles..."
             )
 

--- a/products/llm_analytics/backend/llm/errors.py
+++ b/products/llm_analytics/backend/llm/errors.py
@@ -47,6 +47,10 @@ class ModelNotFoundError(LLMError):
         super().__init__(f"Model '{model}' not found")
 
 
+class StructuredOutputParseError(LLMError):
+    """Raised when the LLM response cannot be parsed into the expected structured output format"""
+
+
 class ModelPermissionError(LLMError):
     """Raised when the API key doesn't have permission to access a model"""
 

--- a/products/llm_analytics/backend/llm/providers/anthropic.py
+++ b/products/llm_analytics/backend/llm/providers/anthropic.py
@@ -14,7 +14,12 @@ from anthropic.types import MessageParam, TextBlockParam, ThinkingConfigEnabledP
 from posthoganalytics.ai.anthropic import Anthropic
 from pydantic import BaseModel
 
-from products.llm_analytics.backend.llm.errors import AuthenticationError, QuotaExceededError, RateLimitError
+from products.llm_analytics.backend.llm.errors import (
+    AuthenticationError,
+    QuotaExceededError,
+    RateLimitError,
+    StructuredOutputParseError,
+)
 from products.llm_analytics.backend.llm.types import (
     AnalyticsContext,
     CompletionRequest,
@@ -134,7 +139,7 @@ Return ONLY the JSON object, no other text or markdown formatting."""
                     parsed = request.response_format.model_validate_json(clean_content)
                 except Exception as e:
                     logger.warning(f"Failed to parse structured output from Anthropic: {e}")
-                    raise ValueError(f"Failed to parse structured output: {e}") from e
+                    raise StructuredOutputParseError(f"Failed to parse structured output: {e}") from e
 
             return CompletionResponse(
                 content=content,

--- a/products/llm_analytics/backend/llm/providers/gemini.py
+++ b/products/llm_analytics/backend/llm/providers/gemini.py
@@ -15,7 +15,12 @@ from google.genai.types import GenerateContentConfig, HttpOptions
 from posthoganalytics.ai.gemini import genai as posthog_genai
 from pydantic import BaseModel
 
-from products.llm_analytics.backend.llm.errors import AuthenticationError, QuotaExceededError, RateLimitError
+from products.llm_analytics.backend.llm.errors import (
+    AuthenticationError,
+    QuotaExceededError,
+    RateLimitError,
+    StructuredOutputParseError,
+)
 from products.llm_analytics.backend.llm.types import (
     AnalyticsContext,
     CompletionRequest,
@@ -109,7 +114,7 @@ class GeminiAdapter:
                     parsed = request.response_format.model_validate_json(content)
                 except Exception as e:
                     logger.warning(f"Failed to parse structured output from Gemini: {e}")
-                    raise ValueError(f"Failed to parse structured output: {e}") from e
+                    raise StructuredOutputParseError(f"Failed to parse structured output: {e}") from e
 
             return CompletionResponse(
                 content=content,

--- a/products/llm_analytics/backend/llm/providers/openai.py
+++ b/products/llm_analytics/backend/llm/providers/openai.py
@@ -21,6 +21,7 @@ from products.llm_analytics.backend.llm.errors import (
     ModelPermissionError,
     QuotaExceededError,
     RateLimitError,
+    StructuredOutputParseError,
 )
 from products.llm_analytics.backend.llm.types import (
     AnalyticsContext,
@@ -196,7 +197,7 @@ Return ONLY the JSON object, no other text or markdown formatting."""
             parsed = request.response_format.model_validate_json(clean_content)
         except Exception as e:
             logger.warning(f"Failed to parse structured output from OpenAI fallback: {e}")
-            raise ValueError(f"Failed to parse structured output: {e}") from e
+            raise StructuredOutputParseError(f"Failed to parse structured output: {e}") from e
 
         return CompletionResponse(
             content=content,


### PR DESCRIPTION
## Problem

Whenever the LLM doesn't return a structured output for LLMaaJ calls, this parsing error fails the activity and it makes it retry, with the same output, until it fails completely.

## Changes

This gracefully handles this, and doesn't retry it.

## Publish to changelog?

No.