### PR TITLE
fix: Increase bottom padding in CodeEditor when Vim mode is enabled

### DIFF
--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -279,7 +279,7 @@ export function CodeEditor({
         overviewRulerLanes: 3,
         overflowWidgetsDomNode: monacoRoot,
         ...options,
-        padding: { bottom: 8, top: 8 },
+        padding: { bottom: enableVimMode ? 28 : 8, top: 8 },
         scrollbar: {
             vertical: scrollbarRendering,
             horizontal: scrollbarRendering,


### PR DESCRIPTION
## Problem

When Vim mode is enabled in the CodeEditor, the bottom padding needs to be increased to accommodate the Vim command palette that appears at the bottom of the editor. Without this adjustment, the palette may overlap with the editor content or be cut off.

## Changes
<img width="1291" height="425" alt="image" src="https://github.com/user-attachments/assets/9705b9f1-fd80-49e6-b214-861229227cd1" />

- Modified the bottom padding in CodeEditor's Monaco editor options to conditionally use 28px when `enableVimMode` is true, and 8px otherwise
- This ensures adequate space is reserved for the Vim mode UI elements without affecting the normal editor layout

## How did you test this code?

- Toggled Vim mode on and off in the CodeEditor to verify the padding adjusts correctly
- Confirmed that the Vim command palette displays properly without overlapping editor content when enabled
- Verified that normal editor padding remains unchanged when Vim mode is disabled

Do not publish to changelog

https://claude.ai/code/session_011YonspZQ4AgcSFnfW9KSQd