### PR TITLE
chore(flags): move update_team_flags_cache to feature_flags queue

### DIFF
--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -20,7 +20,7 @@ from posthog.tasks.utils import CeleryQueue, PushGatewayTask
 logger = structlog.get_logger(__name__)
 
 
-@shared_task(ignore_result=True, queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value)
+@shared_task(ignore_result=True, queue=CeleryQueue.FEATURE_FLAGS.value)
 def update_team_flags_cache(team_id: int) -> None:
     try:
         team = Team.objects.get(id=team_id)


### PR DESCRIPTION
## Problem

The `update_team_flags_cache` task was running on the `feature_flags_long_running` queue alongside periodic verification/maintenance tasks. When the long-running queue backs up with these periodic tasks, flag cache updates get delayed, impacting the responsiveness of flag changes.

## Changes

Move `update_team_flags_cache` from the `feature_flags_long_running` queue to the standard `feature_flags` queue. This ensures that flag cache updates triggered by flag changes are processed promptly, independent of periodic maintenance tasks.

## How did you test this code?

Queue assignment change only - verified the task decorator change is correct.

## Publish to changelog?

No