### PR TITLE
ix(flags): Ensure unencrypted remote config flags are not hidden by postgres fallback

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -128,7 +128,11 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     # loaded by the caller. Avoiding the join saves memory.
     all_flags = list(
         FeatureFlag.objects.filter(
-            Q(is_remote_configuration=False) | Q(has_encrypted_payloads=False) | Q(has_encrypted_payloads__isnull=True),
+            Q(is_remote_configuration=False)
+            | (
+                Q(is_remote_configuration=True)
+                & (Q(has_encrypted_payloads=False) | Q(has_encrypted_payloads__isnull=True))
+            ),
             team__in=teams,
             deleted=False,
         ).annotate(

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -128,7 +128,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     # loaded by the caller. Avoiding the join saves memory.
     all_flags = list(
         FeatureFlag.objects.filter(
-            ~Q(is_remote_configuration=True, has_encrypted_payloads=True),
+            Q(is_remote_configuration=False) | Q(has_encrypted_payloads=False) | Q(has_encrypted_payloads__isnull=True),
             team__in=teams,
             deleted=False,
         ).annotate(


### PR DESCRIPTION
**Summary**
This PR fixes a regression introduced in PostHog/posthog#46758 where unencrypted remote config flags were being filtered out by the PostgreSQL fallback cache.

**The Bug**
The query `~Q(is_remote_configuration=True, has_encrypted_payloads=True)` incorrectly filtered out rows where `has_encrypted_payloads` was `NULL` (which is the default for many older flags) due to SQL ternary logic (`NOT (True AND NULL)` evaluates to `NULL`).

**The Fix**
Updated the query to explicitly include flags that are either:
1. Not remote configuration.
2. Remote configuration but unencrypted (explicitly checking for `False` or `NULL`).

**Fixes PostHog/posthog-js#3061**