### PR TITLE
fix(llma): enable content truncation and skip oversized traces

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -22,6 +22,12 @@ DEFAULT_MODEL = OpenAIModel.GPT_4_1_NANO
 # 2M chars = ~800K tokens, leaving room for system prompt and output.
 MAX_TEXT_REPR_LENGTH = 2_000_000
 
+# Max estimated raw trace size (in characters) before formatting.
+# Traces exceeding this are skipped — formatting huge traces is CPU-intensive
+# and can block the worker for 10+ minutes. Estimated cheaply from
+# sum(len(str(properties))) per event before entering the formatter.
+MAX_RAW_TRACE_SIZE = 5_000_000
+
 # Schedule configuration
 SCHEDULE_INTERVAL_HOURS = 1  # How often the coordinator runs
 

--- a/posthog/temporal/llm_analytics/trace_summarization/summarization.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/summarization.py
@@ -14,6 +14,7 @@ from posthog.models.team import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.llm_analytics.trace_summarization import constants
+from posthog.temporal.llm_analytics.trace_summarization.constants import MAX_RAW_TRACE_SIZE
 from posthog.temporal.llm_analytics.trace_summarization.models import SummarizationActivityResult
 
 from products.llm_analytics.backend.summarization.llm import summarize
@@ -56,10 +57,11 @@ async def generate_and_save_summary_activity(
 
     def _fetch_trace_and_format(
         trace_id: str, team_id: int, window_start: str, window_end: str, max_length: int | None = None
-    ) -> tuple[dict, list, str, Team] | None:
+    ) -> tuple[dict, list, str, Team] | tuple[dict, list, None, Team] | None:
         """Fetch trace data and format text representation.
 
         Returns tuple of (trace_dict, hierarchy, text_repr, team) or None if not found.
+        text_repr is None if the trace exceeds MAX_RAW_TRACE_SIZE.
         """
         team = Team.objects.get(id=team_id)
 
@@ -75,11 +77,26 @@ async def generate_and_save_summary_activity(
             return None  # Trace not found in window
 
         llm_trace = response.results[0]
+
+        # Estimate raw size before expensive formatting
+        raw_size = sum(len(str(e.properties)) for e in llm_trace.events)
+        if raw_size > MAX_RAW_TRACE_SIZE:
+            logger.warning(
+                "Skipping oversized trace",
+                trace_id=trace_id,
+                team_id=team_id,
+                event_count=len(llm_trace.events),
+                raw_size=raw_size,
+                max_raw_size=MAX_RAW_TRACE_SIZE,
+            )
+            trace_dict, hierarchy = llm_trace_to_formatter_format(llm_trace)
+            return trace_dict, hierarchy, None, team
+
         trace_dict, hierarchy = llm_trace_to_formatter_format(llm_trace)
 
         options: FormatterOptions = {
             "include_line_numbers": True,
-            "truncated": False,
+            "truncated": True,
             "include_markers": False,
             "collapsed": False,
             "max_length": max_length,
@@ -178,6 +195,21 @@ async def generate_and_save_summary_activity(
             )
 
         _trace, hierarchy, text_repr, team = result
+
+        # Handle oversized trace (raw data exceeded MAX_RAW_TRACE_SIZE)
+        if text_repr is None:
+            log.warning(
+                "Skipping trace - exceeds max raw size",
+                fetch_duration_s=round(fetch_duration_s, 2),
+                event_count=len(hierarchy),
+            )
+            return SummarizationActivityResult(
+                trace_id=trace_id,
+                success=False,
+                skipped=True,
+                skip_reason="trace_too_large",
+            )
+
         log.info(
             "Trace fetched and formatted",
             fetch_duration_s=round(fetch_duration_s, 2),


### PR DESCRIPTION
## Problem

Trace summarization activities peg the worker CPU at 1000m+ for 10+ minutes with zero log output when processing large traces (e.g. team 2). This blocks the entire Temporal worker, preventing heartbeats, logging, and all other work.

Two root causes:
1. `truncated=False` in the formatter options meant each event's full content (potentially megabytes of LLM messages) was formatted before the output-level `max_length` limit could kick in.
2. No size guard before entering the expensive formatting pipeline.

## Changes

- Fix `truncated: False` -> `True` in the trace summarization activity so individual content blocks are truncated to 1000 chars before formatting, dramatically reducing CPU work for large traces.
- Add `MAX_RAW_TRACE_SIZE` constant (5M chars) and a raw size estimate check after the ClickHouse fetch but before formatting. Traces exceeding this are skipped with a `trace_too_large` skip reason and warning log.

## How did you test this code?

- Manual trace summarization workflows on prod for team 112495 (small traces) confirmed working end-to-end.
- Team 2 traces confirmed to cause the CPU saturation issue. This fix will skip the pathological ones and process normal-sized ones with truncation enabled.
- Will verify after deploy with manual runs for both teams.

## Publish to changelog?

No