### PR TITLE
chore(flags): pause flags cache verification task

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -17,10 +17,7 @@ from posthog.tasks.alerts.checks import (
 )
 from posthog.tasks.email import send_hog_functions_daily_digest
 from posthog.tasks.feature_flags import cleanup_stale_flags_expiry_tracking_task, refresh_expiring_flags_cache_entries
-from posthog.tasks.hypercache_verification import (
-    verify_and_fix_flags_cache_task,
-    verify_and_fix_team_metadata_cache_task,
-)
+from posthog.tasks.hypercache_verification import verify_and_fix_team_metadata_cache_task
 from posthog.tasks.integrations import refresh_integrations
 from posthog.tasks.llm_analytics_usage_report import send_llm_analytics_usage_reports
 from posthog.tasks.remote_config import sync_all_remote_configs
@@ -209,15 +206,16 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         expires_seconds=60 * 60,
     )
 
-    # Flags cache verification - every 30 minutes
+    # Flags cache verification - PAUSED (investigating OOMs)
+    # See: https://posthog.slack.com/archives/C0ADNEL58N8/p1770411297997849
     # Task takes ~8-10 minutes with 250-team batch size
-    add_periodic_task_with_expiry(
-        sender,
-        crontab(minute="*/30"),
-        verify_and_fix_flags_cache_task.s(),
-        name="verify and fix flags cache",
-        expires_seconds=30 * 60,
-    )
+    # add_periodic_task_with_expiry(
+    #     sender,
+    #     crontab(minute="*/30"),
+    #     verify_and_fix_flags_cache_task.s(),
+    #     name="verify and fix flags cache",
+    #     expires_seconds=30 * 60,
+    # )
 
     # Update events table partitions twice a week
     sender.add_periodic_task(


### PR DESCRIPTION
## Problem

We're investigating OOM errors in production and believe the `verify_and_fix_flags_cache_task` may be the cause. Pausing the task to see if OOMs stop occurring.

See: https://posthog.slack.com/archives/C0ADNEL58N8/p1770411297997849

## Changes

- Commented out the periodic scheduling of `verify_and_fix_flags_cache_task` in `scheduled.py`
- Removed the unused import
- Added comment with link to Slack thread for context

The task definition itself remains intact, so it can be manually triggered if needed.

## How did you test this code?

Code review only - this is a simple scheduling change. The task will no longer run on the 30-minute schedule.

## Publish to changelog?

No