### PR TITLE
fix: ensure org license key is write-only

### DIFF
--- a/ee/api/license.py
+++ b/ee/api/license.py
@@ -26,7 +26,7 @@ class LicenseSerializer(serializers.ModelSerializer):
             "created_at",
         ]
         read_only_fields = ["plan", "valid_until"]
-        write_only_fields = ["key"]
+        extra_kwargs = {"key": {"write_only": True}}
 
     def validate(self, data):
         validation = requests.post("https://license.posthog.com/licenses/activate", data={"key": data["key"]})


### PR DESCRIPTION
This doesn't need to be exposed via our API.
