### PR TITLE
fix(llma): filter out oversized traces at sampling level

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -28,6 +28,11 @@ MAX_TEXT_REPR_LENGTH = 2_000_000
 # sum(len(str(properties))) per event before entering the formatter.
 MAX_RAW_TRACE_SIZE = 5_000_000
 
+# Max events per trace for sampling. Traces with more events than this are
+# excluded at the ClickHouse query level during sampling, preventing them
+# from ever reaching the CPU-intensive formatting activity.
+MAX_TRACE_EVENTS_LIMIT = 50
+
 # Schedule configuration
 SCHEDULE_INTERVAL_HOURS = 1  # How often the coordinator runs
 


### PR DESCRIPTION
## Problem

Trace summarization workers get CPU-pegged for 10+ minutes when processing mega-traces (e.g. team 2 traces with hundreds of events). The CPU-intensive Python formatting holds the GIL, blocking heartbeats, logging, and all other worker activity. The raw size guard added in #47188 catches some cases, but traces still need to be fetched before that check runs.

## Changes

- Add `MAX_TRACE_EVENTS_LIMIT = 50` constant
- Add `HAVING event_count <= 50` to the trace sampling HogQL query so oversized traces are excluded at the ClickHouse level before they ever reach the formatting activity
- Log the filter value in sampling debug output

## How did you test this code?

- Deploy to prod-us LLMA worker and verify constant is present
- Run manual trace summarization for team 2 (mega-traces) -- should return 0 sampled traces
- Run manual trace summarization for team 112495 (small traces) -- should still work normally

## Publish to changelog?

No