### PR TITLE
feat(hogql): recognize UUIDv7ToDateTime as constant for predicate pushdown

### DIFF
--- a/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v3_where_clause_extractor.ambr
+++ b/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v3_where_clause_extractor.ambr
@@ -152,6 +152,49 @@
   LIMIT 50000
   '''
 # ---
+# name: TestSessionsV3QueriesHogQLToClickhouse.test_single_session_lookup_with_uuidv7_timestamp
+  '''
+  SELECT
+      sessions.session_id AS session_id,
+      sessions.`$start_timestamp` AS `$start_timestamp`,
+      sessions.`$end_timestamp` AS `$end_timestamp`
+  FROM
+      (SELECT
+          toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions_v3.session_id_v7, 64), bitShiftRight(raw_sessions_v3.session_id_v7, 64)))) AS session_id,
+          min(toTimeZone(raw_sessions_v3.min_timestamp, %(hogql_val_0)s)) AS `$start_timestamp`,
+          max(toTimeZone(raw_sessions_v3.max_timestamp, %(hogql_val_1)s)) AS `$end_timestamp`,
+          raw_sessions_v3.session_id_v7 AS session_id_v7
+      FROM
+          raw_sessions_v3
+      WHERE
+          and(equals(raw_sessions_v3.team_id, <TEAM_ID>), greaterOrEquals(raw_sessions_v3.session_timestamp, minus(UUIDv7ToDateTime(accurateCastOrNull(%(hogql_val_2)s, %(hogql_val_3)s)), toIntervalDay(3))), lessOrEquals(raw_sessions_v3.session_timestamp, plus(plus(UUIDv7ToDateTime(accurateCastOrNull(%(hogql_val_4)s, %(hogql_val_5)s)), toIntervalHour(1)), toIntervalDay(3))), equals(raw_sessions_v3.session_timestamp, fromUnixTimestamp64Milli(toUInt64(bitShiftRight(toUInt128(accurateCastOrNull(%(hogql_val_6)s, %(hogql_val_7)s)), 80)))))
+      GROUP BY
+          raw_sessions_v3.session_id_v7) AS sessions
+  WHERE
+      and(ifNull(greaterOrEquals(sessions.`$start_timestamp`, UUIDv7ToDateTime(accurateCastOrNull(%(hogql_val_8)s, %(hogql_val_9)s))), 0), ifNull(lessOrEquals(sessions.`$start_timestamp`, plus(UUIDv7ToDateTime(accurateCastOrNull(%(hogql_val_10)s, %(hogql_val_11)s)), toIntervalHour(1))), 0), ifNull(equals(sessions.session_id, %(hogql_val_12)s), 0))
+  LIMIT 1
+  '''
+# ---
+# name: TestSessionsV3QueriesHogQLToClickhouse.test_single_session_lookup_with_uuidv7_timestamp_simple
+  '''
+  SELECT
+      sessions.session_id AS session_id
+  FROM
+      (SELECT
+          toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions_v3.session_id_v7, 64), bitShiftRight(raw_sessions_v3.session_id_v7, 64)))) AS session_id,
+          min(toTimeZone(raw_sessions_v3.min_timestamp, %(hogql_val_0)s)) AS `$start_timestamp`,
+          raw_sessions_v3.session_id_v7 AS session_id_v7
+      FROM
+          raw_sessions_v3
+      WHERE
+          and(equals(raw_sessions_v3.team_id, <TEAM_ID>), greaterOrEquals(raw_sessions_v3.session_timestamp, minus(UUIDv7ToDateTime(accurateCastOrNull(%(hogql_val_1)s, %(hogql_val_2)s)), toIntervalDay(3))), lessOrEquals(raw_sessions_v3.session_timestamp, plus(plus(UUIDv7ToDateTime(accurateCastOrNull(%(hogql_val_3)s, %(hogql_val_4)s)), toIntervalDay(2)), toIntervalDay(3))), equals(raw_sessions_v3.session_timestamp, fromUnixTimestamp64Milli(toUInt64(bitShiftRight(toUInt128(accurateCastOrNull(%(hogql_val_5)s, %(hogql_val_6)s)), 80)))))
+      GROUP BY
+          raw_sessions_v3.session_id_v7) AS sessions
+  WHERE
+      and(ifNull(greaterOrEquals(sessions.`$start_timestamp`, UUIDv7ToDateTime(accurateCastOrNull(%(hogql_val_7)s, %(hogql_val_8)s))), 0), ifNull(lessOrEquals(sessions.`$start_timestamp`, plus(UUIDv7ToDateTime(accurateCastOrNull(%(hogql_val_9)s, %(hogql_val_10)s)), toIntervalDay(2))), 0), ifNull(equals(sessions.session_id, %(hogql_val_11)s), 0))
+  LIMIT 50000
+  '''
+# ---
 # name: TestSessionsV3QueriesHogQLToClickhouse.test_union
   '''
   SELECT

--- a/posthog/hogql/helpers/timestamp_visitor.py
+++ b/posthog/hogql/helpers/timestamp_visitor.py
@@ -196,6 +196,8 @@ class IsTimeOrIntervalConstantVisitor(Visitor[bool]):
             "toDateTime64",
             "toTimeZone",
             "assumeNotNull",
+            "UUIDv7ToDateTime",
+            "toUUID",
         ] or any(node.name.startswith(prefix) for prefix in ["toInterval", "toStartOf"]):
             return self.visit(node.args[0])
 


### PR DESCRIPTION
## Problem

When the WHERE clause extractor evaluates filters like `$start_timestamp >= UUIDv7ToDateTime(toUUID('session-id'))`, it checks if the right side is a "constant" expression. `UUIDv7ToDateTime` and `toUUID` weren't in the whitelist, so `is_time_or_interval_constant()` returned `False`, preventing predicate pushdown into inner subqueries and causing full table scans.

The reason this was being done was to be able to do a faster point query using just the session ID on the sessions v2 table. 

This was actually fixed by changing how we send the queries on the frontend/backend to use `toDateTime` instead of the UUIDv7 hack that was first attempted on the hackathon that built this scene, but I think this could still be useful.

Related to #46891

## Changes

- Add `UUIDv7ToDateTime` and `toUUID` to the constant function whitelist in `IsTimeOrIntervalConstantVisitor`
- Add unit tests verifying `UUIDv7ToDateTime(toUUID(...))` filters are pushed down correctly
- Add snapshot tests showing the full generated ClickHouse SQL with predicates pushed into the inner subquery

## How did you test this code?

- Added two new unit test cases for the WHERE clause extractor
- Added two new snapshot tests showing full query generation with predicate pushdown
- All 41 V3 where clause extractor tests pass

## Publish to changelog?

no