### PR TITLE
chore(flags): re-enable flags cache verification task

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -17,7 +17,10 @@ from posthog.tasks.alerts.checks import (
 )
 from posthog.tasks.email import send_hog_functions_daily_digest
 from posthog.tasks.feature_flags import cleanup_stale_flags_expiry_tracking_task, refresh_expiring_flags_cache_entries
-from posthog.tasks.hypercache_verification import verify_and_fix_team_metadata_cache_task
+from posthog.tasks.hypercache_verification import (
+    verify_and_fix_flags_cache_task,
+    verify_and_fix_team_metadata_cache_task,
+)
 from posthog.tasks.integrations import refresh_integrations
 from posthog.tasks.llm_analytics_usage_report import send_llm_analytics_usage_reports
 from posthog.tasks.remote_config import sync_all_remote_configs
@@ -206,16 +209,15 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         expires_seconds=60 * 60,
     )
 
-    # Flags cache verification - PAUSED (investigating OOMs)
-    # See: https://posthog.slack.com/archives/C0ADNEL58N8/p1770411297997849
+    # Flags cache verification - every 30 minutes
     # Task takes ~8-10 minutes with 250-team batch size
-    # add_periodic_task_with_expiry(
-    #     sender,
-    #     crontab(minute="*/30"),
-    #     verify_and_fix_flags_cache_task.s(),
-    #     name="verify and fix flags cache",
-    #     expires_seconds=30 * 60,
-    # )
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(minute="*/30"),
+        verify_and_fix_flags_cache_task.s(),
+        name="verify and fix flags cache",
+        expires_seconds=30 * 60,
+    )
 
     # Update events table partitions twice a week
     sender.add_periodic_task(


### PR DESCRIPTION
## Problem

The flags cache verification task was paused in #47189 to investigate OOM errors. The investigation is complete and we're ready to re-enable it.

This reverts commit f0aa25d5729ddfb1d5c3776ea0dac32d82ab5f0b.

## Changes

- Re-enabled the `verify_and_fix_flags_cache_task` periodic scheduling (every 30 minutes)
- Restored the import that was removed

## How did you test this code?

Code review only - this is a simple scheduling change that restores the previous behavior.