### PR TITLE
fix(sessions): restore sessionProperties selector and improve session links

### DIFF
--- a/frontend/src/scenes/activity/explore/sessionsColumns.tsx
+++ b/frontend/src/scenes/activity/explore/sessionsColumns.tsx
@@ -36,7 +36,7 @@ const renderSessionId: QueryContextColumnComponent = ({ value, record, query }) 
         isLive = isSessionLive(endTimestamp)
     }
 
-    return <SessionDisplay sessionId={sessionId} isLive={isLive} />
+    return <SessionDisplay sessionId={sessionId} isLive={isLive} noPopover />
 }
 
 export function getSessionsColumns(): QueryContext['columns'] {

--- a/frontend/src/scenes/sessions/sessionProfileLogic.ts
+++ b/frontend/src/scenes/sessions/sessionProfileLogic.ts
@@ -651,6 +651,44 @@ export const sessionProfileLogic = kea<sessionProfileLogicType>([
             (sessionEventsLoading: boolean, sessionEvents: SessionEventType[] | null): boolean =>
                 sessionEventsLoading && sessionEvents !== null,
         ],
+        sessionProperties: [
+            (s) => [s.sessionData],
+            (sessionData: SessionData | null): Record<string, any> | null => {
+                if (!sessionData) {
+                    return null
+                }
+
+                const props: Record<string, any> = {}
+                const mappings: [string, any][] = [
+                    ['$session_duration', sessionData.session_duration],
+                    ['$start_timestamp', sessionData.start_timestamp],
+                    ['$end_timestamp', sessionData.end_timestamp],
+                    ['$entry_current_url', sessionData.entry_current_url],
+                    ['$end_current_url', sessionData.end_current_url],
+                    ['$urls', sessionData.urls?.length ? sessionData.urls : null],
+                    ['$pageview_count', sessionData.pageview_count],
+                    ['$autocapture_count', sessionData.autocapture_count],
+                    ['$screen_count', sessionData.screen_count],
+                    ['$channel_type', sessionData.channel_type],
+                    ['$is_bounce', sessionData.is_bounce],
+                    ['$entry_hostname', sessionData.entry_hostname],
+                    ['$entry_pathname', sessionData.entry_pathname],
+                    ['$entry_utm_source', sessionData.entry_utm_source],
+                    ['$entry_utm_campaign', sessionData.entry_utm_campaign],
+                    ['$entry_utm_medium', sessionData.entry_utm_medium],
+                    ['$entry_referring_domain', sessionData.entry_referring_domain],
+                    ['$last_external_click_url', sessionData.last_external_click_url],
+                ]
+
+                for (const [key, value] of mappings) {
+                    if (value != null) {
+                        props[key] = value
+                    }
+                }
+
+                return props
+            },
+        ],
     }),
     listeners(({ actions, values }) => ({
         loadSessionData: () => {


### PR DESCRIPTION
## Problem

1. The `sessionProperties` selector was accidentally removed in #47201 during a rebase conflict resolution
2. On the sessions activity page, clicking a session ID shows a popover instead of navigating directly to the session details page

## Changes

1. Restores the `sessionProperties` selector to `sessionProfileLogic.ts`
2. Adds `noPopover` to SessionDisplay on the sessions activity page so clicking navigates directly to the session details page (the popover is still used on the events page where it makes more sense)

## How did you test this code?

- Verified the selector is present in the file
- Code review

🤖 Generated with [Claude Code](https://claude.ai/code)