### PR TITLE
chore: make sessions profile use toDateTime

### DIFF
--- a/frontend/src/scenes/sessions/sessionProfileLogic.ts
+++ b/frontend/src/scenes/sessions/sessionProfileLogic.ts
@@ -174,8 +174,8 @@ export const sessionProfileLogic = kea<sessionProfileLogicType>([
                             $entry_referring_domain,
                             $last_external_click_url
                         FROM sessions
-                        WHERE $start_timestamp >= parseDateTimeBestEffort(${startDate.toISOString()})
-                            AND $start_timestamp <= parseDateTimeBestEffort(${endDate.toISOString()})
+                        WHERE $start_timestamp >= toDateTime(${startDate.toISOString()})
+                            AND $start_timestamp <= toDateTime(${endDate.toISOString()})
                             AND session_id = ${props.sessionId}
                         LIMIT 1
                     `
@@ -269,8 +269,8 @@ export const sessionProfileLogic = kea<sessionProfileLogicType>([
                             properties.$exception_list,
                             distinct_id
                         FROM events
-                        WHERE timestamp >= parseDateTimeBestEffort(${startDate.toISOString()})
-                            AND timestamp <= parseDateTimeBestEffort(${endDate.toISOString()})
+                        WHERE timestamp >= toDateTime(${startDate.toISOString()})
+                            AND timestamp <= toDateTime(${endDate.toISOString()})
                             AND \`$session_id\` = ${props.sessionId}
                         ORDER BY timestamp ASC
                         LIMIT 50
@@ -292,8 +292,8 @@ export const sessionProfileLogic = kea<sessionProfileLogicType>([
                             properties.$exception_list,
                             distinct_id
                         FROM events
-                        WHERE timestamp >= parseDateTimeBestEffort(${startDate.toISOString()})
-                            AND timestamp <= parseDateTimeBestEffort(${endDate.toISOString()})
+                        WHERE timestamp >= toDateTime(${startDate.toISOString()})
+                            AND timestamp <= toDateTime(${endDate.toISOString()})
                             AND \`$session_id\` = ${props.sessionId}
                         ORDER BY timestamp DESC
                         LIMIT 50
@@ -384,8 +384,8 @@ export const sessionProfileLogic = kea<sessionProfileLogicType>([
                             properties.$exception_list,
                             distinct_id
                         FROM events
-                        WHERE timestamp >= parseDateTimeBestEffort(${startDate.toISOString()})
-                            AND timestamp <= parseDateTimeBestEffort(${endDate.toISOString()})
+                        WHERE timestamp >= toDateTime(${startDate.toISOString()})
+                            AND timestamp <= toDateTime(${endDate.toISOString()})
                             AND \`$session_id\` = ${props.sessionId}
                         ORDER BY timestamp ASC
                         LIMIT 50
@@ -408,8 +408,8 @@ export const sessionProfileLogic = kea<sessionProfileLogicType>([
                             properties.$exception_list,
                             distinct_id
                         FROM events
-                        WHERE timestamp >= parseDateTimeBestEffort(${startDate.toISOString()})
-                            AND timestamp <= parseDateTimeBestEffort(${endDate.toISOString()})
+                        WHERE timestamp >= toDateTime(${startDate.toISOString()})
+                            AND timestamp <= toDateTime(${endDate.toISOString()})
                             AND \`$session_id\` = ${props.sessionId}
                         ORDER BY timestamp DESC
                         LIMIT 50
@@ -488,8 +488,8 @@ export const sessionProfileLogic = kea<sessionProfileLogicType>([
                         SELECT properties, uuid
                         FROM events
                         WHERE event = ${eventName}
-                        AND timestamp >= parseDateTimeBestEffort(${startDate.toISOString()})
-                        AND timestamp <= parseDateTimeBestEffort(${endDate.toISOString()})
+                        AND timestamp >= toDateTime(${startDate.toISOString()})
+                        AND timestamp <= toDateTime(${endDate.toISOString()})
                         AND uuid = ${eventId}
                         LIMIT 1
                     `
@@ -518,8 +518,8 @@ export const sessionProfileLogic = kea<sessionProfileLogicType>([
                     const countQuery = hogql`
                         SELECT count(*) as total
                         FROM events
-                        WHERE timestamp >= parseDateTimeBestEffort(${startDate.toISOString()})
-                            AND timestamp <= parseDateTimeBestEffort(${endDate.toISOString()})
+                        WHERE timestamp >= toDateTime(${startDate.toISOString()})
+                            AND timestamp <= toDateTime(${endDate.toISOString()})
                             AND \`$session_id\` = ${props.sessionId}
                     `
 
@@ -563,8 +563,8 @@ export const sessionProfileLogic = kea<sessionProfileLogicType>([
                             properties.zendesk_ticket_id,
                             distinct_id
                         FROM events
-                        WHERE timestamp >= parseDateTimeBestEffort(${startDate.toISOString()})
-                            AND timestamp <= parseDateTimeBestEffort(${endDate.toISOString()})
+                        WHERE timestamp >= toDateTime(${startDate.toISOString()})
+                            AND timestamp <= toDateTime(${endDate.toISOString()})
                             AND \`$session_id\` = ${props.sessionId}
                             AND event = 'support_ticket'
                         ORDER BY timestamp DESC

--- a/posthog/hogql_queries/test/__snapshots__/test_session_profile_query.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_session_profile_query.ambr
@@ -32,3 +32,31 @@
   LIMIT 1
   '''
 # ---
+# name: TestSessionProfileQuery.test_session_profile_with_timestamp_filter_v2
+  '''
+  SELECT
+      sessions.session_id AS session_id,
+      sessions.distinct_id AS distinct_id,
+      sessions.`$start_timestamp` AS `$start_timestamp`,
+      sessions.`$end_timestamp` AS `$end_timestamp`,
+      sessions.`$session_duration` AS `$session_duration`
+  FROM
+      (SELECT
+          toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+          nullIf(argMaxMerge(raw_sessions.distinct_id), %(hogql_val_0)s) AS distinct_id,
+          min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_1)s)) AS `$start_timestamp`,
+          max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_2)s)) AS `$end_timestamp`,
+          dateDiff(%(hogql_val_3)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_4)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_5)s))) AS `$session_duration`,
+          raw_sessions.session_id_v7 AS session_id_v7
+      FROM
+          raw_sessions
+      WHERE
+          and(equals(raw_sessions.team_id, <TEAM_ID>), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(parseDateTime64BestEffort(%(hogql_val_6)s, 6, %(hogql_val_7)s), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(parseDateTime64BestEffort(%(hogql_val_8)s, 6, %(hogql_val_9)s), toIntervalDay(3))))
+      GROUP BY
+          raw_sessions.session_id_v7,
+          raw_sessions.session_id_v7) AS sessions
+  WHERE
+      and(ifNull(greaterOrEquals(sessions.`$start_timestamp`, parseDateTime64BestEffort(%(hogql_val_10)s, 6, %(hogql_val_11)s)), 0), ifNull(lessOrEquals(sessions.`$start_timestamp`, parseDateTime64BestEffort(%(hogql_val_12)s, 6, %(hogql_val_13)s)), 0), ifNull(equals(sessions.session_id, %(hogql_val_14)s), 0))
+  LIMIT 1
+  '''
+# ---

--- a/posthog/hogql_queries/test/test_session_profile_query.py
+++ b/posthog/hogql_queries/test/test_session_profile_query.py
@@ -9,9 +9,9 @@ from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 
 
 class TestSessionProfileQuery(ClickhouseTestMixin, APIBaseTest):
-    def _print_session_v3_query(self, query: str) -> str:
+    def _print_session_query(self, query: str, version: SessionTableVersion) -> str:
         modifiers = create_default_modifiers_for_team(self.team)
-        modifiers.sessionTableVersion = SessionTableVersion.V3
+        modifiers.sessionTableVersion = version
         context = HogQLContext(
             team_id=self.team.pk,
             team=self.team,
@@ -22,6 +22,12 @@ class TestSessionProfileQuery(ClickhouseTestMixin, APIBaseTest):
         if prepared_ast is None:
             return ""
         return print_prepared_ast(prepared_ast, context=context, dialect="clickhouse", pretty=True)
+
+    def _print_session_v3_query(self, query: str) -> str:
+        return self._print_session_query(query, SessionTableVersion.V3)
+
+    def _print_session_v2_query(self, query: str) -> str:
+        return self._print_session_query(query, SessionTableVersion.V2)
 
     def test_session_profile_point_query_v3(self):
         actual = self._print_session_v3_query(
@@ -37,6 +43,28 @@ SELECT
     $is_bounce
 FROM sessions
 WHERE session_id = '019c2a52-6519-772d-b99a-60ba7cc4e266'
+LIMIT 1
+"""
+        )
+        assert self.generalize_sql(actual) == self.snapshot
+
+    def test_session_profile_with_timestamp_filter_v2(self):
+        """
+        Test that toDateTime is properly recognized for partition pruning on v2 sessions.
+        The frontend extracts the timestamp from UUIDv7 and uses toDateTime for filtering.
+        """
+        actual = self._print_session_v2_query(
+            """
+SELECT
+    session_id,
+    distinct_id,
+    $start_timestamp,
+    $end_timestamp,
+    $session_duration
+FROM sessions
+WHERE $start_timestamp >= toDateTime('2025-01-15T10:00:00.000Z')
+    AND $start_timestamp <= toDateTime('2025-01-15T11:00:00.000Z')
+    AND session_id = '019c2a52-6519-772d-b99a-60ba7cc4e266'
 LIMIT 1
 """
         )


### PR DESCRIPTION
## Problem

Follow-up to #47201. The timestamp_visitor.py checks for ClickHouse function names (like parseDateTime64BestEffortOrNull) but the HogQL AST uses HogQL function names (parseDateTimeBestEffort). This means the visitor doesn't recognize timestamp comparisons as constants, preventing predicate pushdown for partition pruning.

## Changes

- Replace parseDateTimeBestEffort with toDateTime in session profile queries                                                                                                                                                                                                          
- toDateTime is in the visitor's recognized function list, so timestamp comparisons are correctly identified as constants
- Add test showing the v2 query with timestamp filtering and the generated ClickHouse SQL

## How did you test this code?

Manually

## Publish to changelog?

No