### PR TITLE
feat(frontend): test only what's changed

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -16,6 +16,7 @@
         "common/plugin_transpiler/dist",
         "common/hogvm/__tests__/__snapshots__",
         "common/hogvm/__tests__/__snapshots__/**",
+        "frontend/scripts/**",
         "frontend/src/queries/validators.js",
         "frontend/src/generated/**",
         "services/mcp/**/generated.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
         "typegen:write:no-cache": "cd .. && NODE_OPTIONS=\"--max-old-space-size=16384\" kea-typegen write --delete --show-ts-errors",
         "schema:build:json": "ts-node ./bin/build-schema-json.mjs && prettier --write ./src/queries/schema.json && ts-node ./bin/build-validators.mjs && prettier --write ./src/queries/validators.js",
         "test": "SHARD_IDX=${SHARD_INDEX:-1}; SHARD_TOTAL=${SHARD_COUNT:-1}; echo $SHARD_IDX/$SHARD_TOTAL; pnpm build:products && jest --testPathPattern='(frontend/|products/|common/)' --forceExit --shard=$SHARD_IDX/$SHARD_TOTAL",
+        "test:changed": "pnpm build:products && node scripts/jest-changed-tests.js",
         "jest": "pnpm build:products && jest",
         "prettier": "prettier --write \"../{products,frontend/src}/**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\" --ignore-path \"../.prettierignore\"",
         "prettier:check": "prettier --check \"../{products,frontend/src}/**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\" --ignore-path \"../.prettierignore\"",

--- a/frontend/scripts/jest-changed-tests.js
+++ b/frontend/scripts/jest-changed-tests.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+/**
+ * Runs Jest tests only for files that have changed relative to a base branch.
+ * Uses Jest's --findRelatedTests to run tests affected by the changed files.
+ *
+ * Usage:
+ *   node scripts/jest-changed-tests.js [--base <branch>] [--dry-run] [-- <jest-args>]
+ *
+ * Options:
+ *   --base <branch>  Base branch to compare against (default: origin/master)
+ *   --dry-run        Show detected files without running tests
+ *
+ * Examples:
+ *   node scripts/jest-changed-tests.js
+ *   node scripts/jest-changed-tests.js --dry-run
+ *   node scripts/jest-changed-tests.js --base origin/main
+ *   node scripts/jest-changed-tests.js -- --coverage
+ */
+
+const { execSync, spawn } = require('child_process')
+const path = require('path')
+
+const REPO_ROOT = path.resolve(__dirname, '../..')
+const FRONTEND_ROOT = path.resolve(__dirname, '..')
+
+const RELEVANT_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx']
+const RELEVANT_DIRS = ['frontend/', 'products/', 'common/']
+
+function parseArgs() {
+    const args = process.argv.slice(2)
+    let baseBranch = 'origin/master'
+    let jestArgs = []
+    let dryRun = false
+
+    const separatorIndex = args.indexOf('--')
+    const ourArgs = separatorIndex >= 0 ? args.slice(0, separatorIndex) : args
+    jestArgs = separatorIndex >= 0 ? args.slice(separatorIndex + 1) : []
+
+    for (let i = 0; i < ourArgs.length; i++) {
+        if (ourArgs[i] === '--base' && ourArgs[i + 1]) {
+            baseBranch = ourArgs[i + 1]
+            i++
+        } else if (ourArgs[i] === '--dry-run') {
+            dryRun = true
+        }
+    }
+
+    return { baseBranch, jestArgs, dryRun }
+}
+
+function getChangedFiles(baseBranch) {
+    try {
+        // Get files changed since the base branch (staged + unstaged + committed)
+        const diffOutput = execSync(`git diff --name-only ${baseBranch}...HEAD`, {
+            cwd: REPO_ROOT,
+            encoding: 'utf-8',
+        }).trim()
+
+        // Also get uncommitted changes (staged and unstaged)
+        const uncommittedOutput = execSync('git diff --name-only HEAD', {
+            cwd: REPO_ROOT,
+            encoding: 'utf-8',
+        }).trim()
+
+        const stagedOutput = execSync('git diff --name-only --cached', {
+            cwd: REPO_ROOT,
+            encoding: 'utf-8',
+        }).trim()
+
+        const allFiles = new Set([
+            ...diffOutput.split('\n').filter(Boolean),
+            ...uncommittedOutput.split('\n').filter(Boolean),
+            ...stagedOutput.split('\n').filter(Boolean),
+        ])
+
+        return [...allFiles]
+    } catch (error) {
+        console.error('Error getting changed files from git:', error.message)
+        process.exit(1)
+    }
+}
+
+function filterRelevantFiles(files) {
+    return files.filter((file) => {
+        const ext = path.extname(file)
+        const isRelevantExtension = RELEVANT_EXTENSIONS.includes(ext)
+        const isInRelevantDir = RELEVANT_DIRS.some((dir) => file.startsWith(dir))
+        const isNotTest = !file.includes('.test.') && !file.includes('.spec.') && !file.includes('__tests__')
+
+        return isRelevantExtension && isInRelevantDir && isNotTest
+    })
+}
+
+function runJestWithRelatedTests(files, jestArgs) {
+    const absolutePaths = files.map((file) => path.resolve(REPO_ROOT, file))
+
+    const args = ['--findRelatedTests', '--passWithNoTests', ...absolutePaths, ...jestArgs]
+
+    const jest = spawn('npx', ['jest', ...args], {
+        cwd: FRONTEND_ROOT,
+        stdio: 'inherit',
+        shell: true,
+    })
+
+    jest.on('close', (code) => {
+        process.exit(code)
+    })
+
+    jest.on('error', (error) => {
+        console.error('Failed to run Jest:', error.message)
+        process.exit(1)
+    })
+}
+
+function main() {
+    const { baseBranch, jestArgs, dryRun } = parseArgs()
+
+    const changedFiles = getChangedFiles(baseBranch)
+    const relevantFiles = filterRelevantFiles(changedFiles)
+
+    if (dryRun) {
+        changedFiles.forEach((file) => {
+            console.log(`Changed: ${file}`)
+        })
+
+        relevantFiles.forEach((file) => {
+            console.log(`Relevant: ${file}`)
+        })
+        process.exit(0)
+    }
+
+    if (relevantFiles.length === 0) {
+        process.exit(0)
+    }
+
+    runJestWithRelatedTests(relevantFiles, jestArgs)
+}
+
+main()


### PR DESCRIPTION
## Problem

Developers currently run `pnpm test` which executes the entire test suite, even when only a few files have changed. This slows down the local development feedback loop.

This PR adds infrastructure to run only tests affected by changed files, using jest's `--findRelatedTests` feature. [This uses an inverse dependency graph to determine what tests need to run based on given file paths.](https://thesametech.com/under-the-hood-jest-related-tests/) However, during implementation we discovered a deeper issue: the codebase has extremely high dependency coupling, causing Jest's `--findRelatedTests` to select 90%+ of tests for almost any file change.

**Root causes**: `src/types.ts` is imported by 1,514 files and imports from barrel exports. UI components like `Tooltip` and `Link` import application-level logic (`featureFlagLogic`, `sidePanelStateLogic`), creating a tightly connected dependency graph where any change propagates to nearly all tests. [Barelling index files also play a role in this problem.](https://uglow.medium.com/burn-the-barrel-c282578f21b6)

| Changed File         | Tests Selected | % of Suite |
| -------------------- | -------------- | ---------- |
| PasswordStrength.tsx | 284            | 91%        |
| LemonDivider.tsx     | 284            | 91%        |
| css-classes.ts       | 284            | 91%        |
| semver.ts            | 295            | 95%        |

## Changes

- Added `test:changed` npm script to `frontend/package.json`
- Created `frontend/scripts/jest-changed-tests.js` script that:
  - Detects changed files by comparing current branch to `origin/master` (configurable)
  - Includes uncommitted changes (staged and unstaged)
  - Filters to relevant frontend files (`.ts`, `.tsx`, `.js`, `.jsx` in `frontend/`, `products/`, `common/`)
  - Runs Jest with `--findRelatedTests` to execute only affected tests

Usage:

```bash
pnpm test:changed              # Run tests for changed filesvvv
pnpm test:changed --dry-run    # Preview without running
pnpm test:changed --base main  # Compare to different branch
pnpm test:changed -- --coverage  # Pass Jest args
```

## How did you test this code?

1. Created a feature branch with a single file change
2. Ran `pnpm test:changed --dry-run` to verify file detection
3. Ran `pnpm test:changed` to confirm Jest executes with `--findRelatedTests`
4. Tested various flags (`--base`, `--dry-run`, passing Jest args)
5. Verified behavior with uncommitted, staged, and committed changes

Note: Due to the coupling issue described above, I discovered most tests still run even if you touch a single small component file only imported in one or two places. The infrastructure works correctly, but realizing its full benefit requires longer-term architectural improvements (colocating tests, extracting pure UI primitives, creating module boundaries).

## Publish to changelog?

No - this is developer tooling infrastructure, and the coupling issue limits its current effectiveness.
