### PR TITLE
feat(llma): clustering trace summarization limits

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -38,9 +38,10 @@ MAX_TRACE_EVENTS_LIMIT = 50
 # in a trace. Traces exceeding this are excluded during sampling, preventing
 # oversized traces from reaching the CPU-intensive formatting activity — even if
 # they have few events. Complements MAX_TRACE_EVENTS_LIMIT which only filters
-# by event count. Set to match MAX_RAW_TRACE_SIZE so traces that would be
-# rejected by the activity are filtered out before the expensive fetch.
-MAX_TRACE_PROPERTIES_SIZE = MAX_RAW_TRACE_SIZE
+# by event count. Set lower than MAX_RAW_TRACE_SIZE (5M) to be conservative —
+# formatting traces in the 2-5M range is still CPU-intensive enough to block
+# workers for minutes.
+MAX_TRACE_PROPERTIES_SIZE = 2_000_000
 
 # Schedule configuration
 SCHEDULE_INTERVAL_HOURS = 1  # How often the coordinator runs

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -33,6 +33,15 @@ MAX_RAW_TRACE_SIZE = 5_000_000
 # from ever reaching the CPU-intensive formatting activity.
 MAX_TRACE_EVENTS_LIMIT = 50
 
+# Max total estimated properties size (in characters) per trace for sampling.
+# Estimated at the ClickHouse level as sum(length(properties)) across all events
+# in a trace. Traces exceeding this are excluded during sampling, preventing
+# oversized traces from reaching the CPU-intensive formatting activity — even if
+# they have few events. Complements MAX_TRACE_EVENTS_LIMIT which only filters
+# by event count. Set to match MAX_RAW_TRACE_SIZE so traces that would be
+# rejected by the activity are filtered out before the expensive fetch.
+MAX_TRACE_PROPERTIES_SIZE = MAX_RAW_TRACE_SIZE
+
 # Schedule configuration
 SCHEDULE_INTERVAL_HOURS = 1  # How often the coordinator runs
 

--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -16,7 +16,10 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.models.team import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.heartbeat import Heartbeater
-from posthog.temporal.llm_analytics.trace_summarization.constants import MAX_TRACE_EVENTS_LIMIT
+from posthog.temporal.llm_analytics.trace_summarization.constants import (
+    MAX_TRACE_EVENTS_LIMIT,
+    MAX_TRACE_PROPERTIES_SIZE,
+)
 from posthog.temporal.llm_analytics.trace_summarization.models import BatchSummarizationInputs, SampledItem
 from posthog.temporal.llm_analytics.trace_summarization.utils import format_datetime_for_clickhouse
 
@@ -54,12 +57,16 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
             # with the trace's first_timestamp for navigation.
             # We query all AI event types to get accurate trace_first_timestamp,
             # but use argMaxIf to only pick generation UUIDs.
+            # Also filters by event count and total properties size to prevent
+            # oversized traces from reaching the CPU-intensive formatting activity.
             generations_query = parse_select(
                 """
                 SELECT
                     properties.$ai_trace_id as trace_id,
                     argMaxIf(uuid, timestamp, event = '$ai_generation') as last_generation_id,
-                    min(timestamp) as trace_first_timestamp
+                    min(timestamp) as trace_first_timestamp,
+                    count() as event_count,
+                    sum(length(properties)) as total_properties_size
                 FROM events
                 WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
                     AND timestamp >= toDateTime({start_ts}, 'UTC')
@@ -67,6 +74,8 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                     AND properties.$ai_trace_id != ''
                 GROUP BY trace_id
                 HAVING last_generation_id IS NOT NULL
+                    AND event_count <= {max_events}
+                    AND total_properties_size <= {max_properties_size}
                 ORDER BY trace_first_timestamp DESC
                 LIMIT {limit}
                 """
@@ -79,6 +88,8 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                     "start_ts": ast.Constant(value=start_dt_str),
                     "end_ts": ast.Constant(value=end_dt_str),
                     "limit": ast.Constant(value=max_items),
+                    "max_events": ast.Constant(value=MAX_TRACE_EVENTS_LIMIT),
+                    "max_properties_size": ast.Constant(value=MAX_TRACE_PROPERTIES_SIZE),
                 },
                 team=team,
                 limit_context=LimitContext.QUERY_ASYNC,
@@ -90,6 +101,8 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 start_ts=start_dt_str,
                 end_ts=end_dt_str,
                 team_id=team_id,
+                max_events_filter=MAX_TRACE_EVENTS_LIMIT,
+                max_properties_size_filter=MAX_TRACE_PROPERTIES_SIZE,
             )
 
             items: list[SampledItem] = []
@@ -110,13 +123,15 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
         else:
             # Trace-level: sample trace IDs and first timestamps.
             # Filters out traces with more than MAX_TRACE_EVENTS_LIMIT events
+            # AND traces where total properties size exceeds MAX_TRACE_PROPERTIES_SIZE
             # to prevent CPU-intensive formatting from blocking the worker.
             traces_query = parse_select(
                 """
                 SELECT
                     properties.$ai_trace_id as trace_id,
                     min(timestamp) as first_timestamp,
-                    count() as event_count
+                    count() as event_count,
+                    sum(length(properties)) as total_properties_size
                 FROM events
                 WHERE event IN ('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')
                     AND timestamp >= toDateTime({start_ts}, 'UTC')
@@ -124,6 +139,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                     AND properties.$ai_trace_id != ''
                 GROUP BY trace_id
                 HAVING event_count <= {max_events}
+                    AND total_properties_size <= {max_properties_size}
                 ORDER BY first_timestamp DESC
                 LIMIT {limit}
                 """
@@ -137,6 +153,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                     "end_ts": ast.Constant(value=end_dt_str),
                     "limit": ast.Constant(value=max_items),
                     "max_events": ast.Constant(value=MAX_TRACE_EVENTS_LIMIT),
+                    "max_properties_size": ast.Constant(value=MAX_TRACE_PROPERTIES_SIZE),
                 },
                 team=team,
                 limit_context=LimitContext.QUERY_ASYNC,
@@ -149,6 +166,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 end_ts=end_dt_str,
                 team_id=team_id,
                 max_events_filter=MAX_TRACE_EVENTS_LIMIT,
+                max_properties_size_filter=MAX_TRACE_PROPERTIES_SIZE,
             )
 
             return [


### PR DESCRIPTION
## Problem

The LLM analytics trace and generation summarization temporal workflow is pegging the CPU due to very large traces. The existing `MAX_TRACE_EVENTS_LIMIT` (50 events) was insufficient as traces with few but very large events (due to massive `properties` fields) could still cause `format_trace_text_repr` to choke. This leads to performance degradation and workflow failures.

Closes #47199

## Changes

This PR introduces a size-based filter for traces during sampling, complementing the existing event count limit.

-   **`constants.py`**: Added `MAX_TRACE_PROPERTIES_SIZE` (5MB) to define the maximum allowed total character length of `properties` across all events in a sampled trace. This value matches `MAX_RAW_TRACE_SIZE` to filter out traces that would eventually be rejected by the activity anyway.
-   **`sampling.py`**:
    -   Modified both the trace-level and generation-level HogQL sampling queries.
    -   Added `sum(length(properties)) as total_properties_size` to the `SELECT` clause.
    -   Added `AND total_properties_size <= {max_properties_size}` to the `HAVING` clause to filter out oversized traces at the ClickHouse level, before they are fetched for processing.
    -   The generation-level query also now includes `count() as event_count` and `HAVING event_count <= {max_events}` as it previously lacked event count filtering.
-   **`tests/test_workflow.py`**: Added two new tests to verify that `max_properties_size` (and `max_events` for the generation query) placeholders are correctly passed to the HogQL query.

## How did you test this code?

Automated tests were run, including the two new tests verifying the correct passing of `max_events` and `max_properties_size` placeholders to the HogQL queries. All tests passed.

## Publish to changelog?

no

---
<p><a href="https://cursor.com/background-agent?bcId=bc-d0bddc2a-3822-4f46-9e51-3ccb0eada82b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0bddc2a-3822-4f46-9e51-3ccb0eada82b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

