### PR TITLE
fix: pass dashboard URL to insight we're editing

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -266,7 +266,7 @@ export function InsightMeta({
                                 to={
                                     isDataVisualizationNode(insight.query)
                                         ? urls.sqlEditor({ insightShortId: short_id })
-                                        : urls.insightEdit(short_id)
+                                        : urls.insightEdit(short_id, dashboardId)
                                 }
                                 fullWidth
                                 {...getOverrideWarningPropsForButton(filtersOverride, variablesOverride)}

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -687,7 +687,8 @@ export const productUrls = {
         urls.insightNew({
             query: { kind: NodeKind.DataTableNode, source: { kind: 'HogQLQuery', query, filters } } as any,
         }),
-    insightEdit: (id: InsightShortId): string => `/insights/${id}/edit`,
+    insightEdit: (id: InsightShortId, dashboardId?: number): string =>
+        `/insights/${id}/edit${dashboardId ? `?dashboard=${dashboardId}` : ''}`,
     insightView: (
         id: InsightShortId,
         dashboardId?: number,

--- a/products/product_analytics/manifest.tsx
+++ b/products/product_analytics/manifest.tsx
@@ -62,7 +62,8 @@ export const manifest: ProductManifest = {
                     source: { kind: 'HogQLQuery', query, filters },
                 } as any,
             }),
-        insightEdit: (id: InsightShortId): string => `/insights/${id}/edit`,
+        insightEdit: (id: InsightShortId, dashboardId?: number): string =>
+            `/insights/${id}/edit${dashboardId ? `?dashboard=${dashboardId}` : ''}`,
         insightView: (
             id: InsightShortId,
             dashboardId?: number,


### PR DESCRIPTION
## Problem

> Open dashboard > edit insight > save insight > click to go back > end up in /insights page rather than /dashboard???

## Changes

- Modified `InsightMeta.tsx` to pass `dashboardId` when navigating to the insight edit page
- Updated `insightEdit` URL builder in `products.tsx` to accept an optional `dashboardId` parameter and append it as a query parameter (`?dashboard={dashboardId}`)



## How did you test this code?

- ran this locally

## Publish to changelog?

no