### PR TITLE
fix: use same tooltip settings for total

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -441,9 +441,11 @@ export const LineGraph = ({
                                         return acc
                                     }, 0)
 
+                                    const firstSeriesSettings = tooltipTotalData[0]?.settings
+
                                     tooltipData.push({
                                         series: '',
-                                        data: totalRawData.toLocaleString(),
+                                        data: formatDataWithSettings(totalRawData, firstSeriesSettings),
                                         rawData: totalRawData,
                                         dataIndex: referenceDataPoint.dataIndex,
                                         isTotalRow: true,


### PR DESCRIPTION
## Problem

> In Line chart summaries, even though all the individual rows are $ and with 0 decimals, the Total row is not $ prefixed and has 3 decimals.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- use same setting on the total

example locally  
![image.png](https://app.graphite.com/user-attachments/assets/91fa3e87-662e-4f1d-bee5-28009bf6a9d0.png)



## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

- locally

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

no

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->