### PR TITLE
fix: highlight api key scope when hovering the actions

### DIFF
--- a/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
@@ -162,14 +162,16 @@ export function EditKeyModal({ zIndex }: EditKeyModalProps): JSX.Element {
                                                             editingKey.access_type === 'teams'
                                                         return (
                                                             <Fragment key={key}>
-                                                                <div className="flex items-center justify-between gap-2 min-h-8">
+                                                                <div className="flex items-center justify-between gap-2 min-h-8 group">
                                                                     <div
                                                                         className={clsx(
                                                                             'flex items-center gap-1',
                                                                             disabledDueToProjectScope && 'text-muted'
                                                                         )}
                                                                     >
-                                                                        <b>{objectName}</b>
+                                                                        <b className="transition-colors group-hover:text-highlight">
+                                                                            {objectName}
+                                                                        </b>
 
                                                                         {info ? (
                                                                             <Tooltip title={info}>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
hard to know what you're doing - probably a bigger issue to solve, but for now it's worth highlighting the scope

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/13528a12-2771-4268-b6fd-d8f5f1b3cedf.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- locally eyed it
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
