### PR TITLE
fix(ux): search loading, search jumpiness

### DIFF
--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -607,8 +607,9 @@ function SearchResults({
                                     {Array.from({
                                         length: group.category === 'recents' ? RECENTS_LIMIT : 10,
                                     }).map((_, i) => (
-                                        <div key={i} className="px-2">
-                                            <WrappingLoadingSkeleton fullWidth>
+                                        // We give the height to the parent div and padding so the skeleton vibibily has some space and isn't a block
+                                        <div key={i} className="px-2 h-[30px] py-px">
+                                            <WrappingLoadingSkeleton fullWidth className="h-full">
                                                 <ButtonPrimitive fullWidth className="invisible">
                                                     &nbsp;
                                                 </ButtonPrimitive>

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -204,8 +204,6 @@ export const searchLogic = kea<searchLogicType>([
             false,
             {
                 setSearch: (_, { search }) => search.trim() !== '',
-                loadRecentsSuccess: () => false,
-                loadRecentsFailure: () => false,
                 loadUnifiedSearchResultsSuccess: () => false,
                 loadUnifiedSearchResultsFailure: () => false,
             },
@@ -987,9 +985,9 @@ export const searchLogic = kea<searchLogicType>([
         setSearch: async ({ search }, breakpoint) => {
             await breakpoint(150)
 
-            actions.loadRecents({ search })
-
-            if (search.trim() !== '') {
+            if (search.trim() === '') {
+                actions.loadRecents({ search: '' })
+            } else {
                 actions.loadUnifiedSearchResults({ searchTerm: search })
                 actions.loadPersonSearchResults({ searchTerm: search })
                 actions.loadGroupSearchResults({ searchTerm: search })

--- a/frontend/src/lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton.tsx
+++ b/frontend/src/lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton.tsx
@@ -15,7 +15,7 @@ export function WrappingLoadingSkeleton({
     return (
         <div
             className={cn(
-                'wrapping-loading-skeleton [&>*]:opacity-0 rounded flex flex-col gap-px w-fit',
+                'wrapping-loading-skeleton [&>*]:opacity-0 rounded flex flex-col gap-px w-fit overflow-hidden',
                 fullWidth && 'w-full',
                 className
             )}


### PR DESCRIPTION
## Problem
Loading skeleton for search was one big block
Searching for an item was jumpy and users miss their target as other things came in.

## Changes
* Separate the loading skeleton while matching the underlying buttons height (no layout shift)
* Prevent "recents" from re-fetching when typing, this was the crux of the jumpiness IMO. Recents now won't show more than the initial 5 and if search query matches any, we show that, nothing more. This results in a more stable search.

![2026-02-07 14 53 50](https://github.com/user-attachments/assets/587759c7-75f6-4aa4-bb2a-f9b417da2ad6)

## How did you test this code?
Locally

## Publish to changelog?
No
