### PR TITLE
fix(llma): replace TraceQueryRunner with simple query in summarization activity

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -43,6 +43,20 @@ MAX_TRACE_EVENTS_LIMIT = 50
 # workers for minutes.
 MAX_TRACE_PROPERTIES_SIZE = 2_000_000
 
+# AI event types used in trace queries (sampling and fetching)
+AI_EVENT_TYPES = (
+    "$ai_span",
+    "$ai_generation",
+    "$ai_embedding",
+    "$ai_metric",
+    "$ai_feedback",
+    "$ai_trace",
+)
+
+# Expand the time window by this amount each side when fetching traces,
+# so traces that started just before/after the window are still found.
+TRACE_CAPTURE_RANGE = timedelta(minutes=10)
+
 # Schedule configuration
 SCHEDULE_INTERVAL_HOURS = 1  # How often the coordinator runs
 

--- a/posthog/temporal/llm_analytics/trace_summarization/queries.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/queries.py
@@ -1,0 +1,106 @@
+"""ClickHouse queries for trace summarization.
+
+Simple, direct queries that avoid expensive JOINs (e.g. person table)
+which can OOM ClickHouse for teams with large AI traces.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import orjson
+
+from posthog.schema import LLMTrace, LLMTraceEvent, LLMTracePerson
+
+from posthog.hogql import ast
+from posthog.hogql.constants import LimitContext
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.models.team import Team
+from posthog.temporal.llm_analytics.trace_summarization.constants import AI_EVENT_TYPES, TRACE_CAPTURE_RANGE
+
+_TRACE_EVENTS_QUERY = """
+    SELECT uuid, event, timestamp, properties
+    FROM events
+    WHERE event IN {event_types}
+      AND timestamp >= toDateTime({start_ts}, 'UTC')
+      AND timestamp < toDateTime({end_ts}, 'UTC')
+      AND properties.$ai_trace_id = {trace_id}
+    ORDER BY timestamp
+"""
+
+
+def fetch_trace(team: Team, trace_id: str, window_start: str, window_end: str) -> LLMTrace | None:
+    """Fetch trace events with a simple query — no person JOIN, no aggregations.
+
+    Returns an LLMTrace or None if no events found. The $ai_trace meta-event
+    is used to populate trace-level fields (traceName, inputState, outputState)
+    but is excluded from the events list (matching TraceQueryRunner behavior).
+    """
+    start_dt = datetime.fromisoformat(window_start).astimezone(UTC) - TRACE_CAPTURE_RANGE
+    end_dt = datetime.fromisoformat(window_end).astimezone(UTC) + TRACE_CAPTURE_RANGE
+
+    query = parse_select(_TRACE_EVENTS_QUERY)
+    result = execute_hogql_query(
+        query_type="SummarizationTraceFetch",
+        query=query,
+        placeholders={
+            "event_types": ast.Tuple(exprs=[ast.Constant(value=e) for e in AI_EVENT_TYPES]),
+            "start_ts": ast.Constant(value=start_dt.strftime("%Y-%m-%d %H:%M:%S")),
+            "end_ts": ast.Constant(value=end_dt.strftime("%Y-%m-%d %H:%M:%S")),
+            "trace_id": ast.Constant(value=trace_id),
+        },
+        team=team,
+        limit_context=LimitContext.QUERY_ASYNC,
+    )
+
+    if not result.results:
+        return None
+
+    events: list[LLMTraceEvent] = []
+    trace_name: str | None = None
+    input_state: Any = None
+    output_state: Any = None
+    first_timestamp: str | None = None
+
+    for row in result.results:
+        event_uuid, event_name, event_timestamp, event_properties = row
+        if first_timestamp is None:
+            first_timestamp = event_timestamp.isoformat()
+
+        props = orjson.loads(event_properties) if isinstance(event_properties, str) else event_properties
+
+        if event_name == "$ai_trace":
+            # Extract trace-level metadata; exclude from events list
+            trace_name = props.get("$ai_span_name") or props.get("$ai_trace_name")
+            try:
+                input_state = orjson.loads(props["$ai_input_state"]) if props.get("$ai_input_state") else None
+            except (orjson.JSONDecodeError, TypeError):
+                input_state = None
+            try:
+                output_state = orjson.loads(props["$ai_output_state"]) if props.get("$ai_output_state") else None
+            except (orjson.JSONDecodeError, TypeError):
+                output_state = None
+            continue
+
+        events.append(
+            LLMTraceEvent(
+                id=str(event_uuid),
+                event=event_name,
+                createdAt=event_timestamp.isoformat(),
+                properties=props,
+            )
+        )
+
+    if not events:
+        return None
+
+    return LLMTrace(
+        id=trace_id,
+        createdAt=first_timestamp or events[0].createdAt,
+        traceName=trace_name,
+        inputState=input_state,
+        outputState=output_state,
+        events=events,
+        person=LLMTracePerson(uuid="", distinct_id="", created_at=first_timestamp or "", properties={}),
+    )

--- a/posthog/temporal/llm_analytics/trace_summarization/summarization.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/summarization.py
@@ -1,14 +1,21 @@
 """Activity for generating trace summaries using LLM."""
 
 import time
+from datetime import UTC, datetime, timedelta
+from typing import Any
 from uuid import uuid4
 
+import orjson
 import structlog
 import temporalio
 
-from posthog.schema import DateRange, TraceQuery
+from posthog.schema import LLMTrace, LLMTraceEvent, LLMTracePerson
 
-from posthog.hogql_queries.ai.trace_query_runner import TraceQueryRunner
+from posthog.hogql import ast
+from posthog.hogql.constants import LimitContext
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+
 from posthog.models.event.util import create_event
 from posthog.models.team import Team
 from posthog.sync import database_sync_to_async
@@ -30,6 +37,105 @@ from ee.hogai.llm_traces_summaries.constants import LLM_TRACES_SUMMARIES_DOCUMEN
 from ee.hogai.llm_traces_summaries.tools.embed_summaries import LLMTracesSummarizerEmbedder
 
 logger = structlog.get_logger(__name__)
+
+# Expand the time window by 10 minutes each side so traces that started just
+# before/after the window boundaries are still found (matches TraceQueryRunner).
+_CAPTURE_RANGE = timedelta(minutes=10)
+
+_AI_EVENT_TYPES = (
+    "$ai_span",
+    "$ai_generation",
+    "$ai_embedding",
+    "$ai_metric",
+    "$ai_feedback",
+    "$ai_trace",
+)
+
+_TRACE_EVENTS_QUERY = """
+    SELECT uuid, event, timestamp, properties
+    FROM events
+    WHERE event IN {event_types}
+      AND timestamp >= toDateTime({start_ts}, 'UTC')
+      AND timestamp < toDateTime({end_ts}, 'UTC')
+      AND properties.$ai_trace_id = {trace_id}
+    ORDER BY timestamp
+"""
+
+
+def _fetch_trace(team: Team, trace_id: str, window_start: str, window_end: str) -> LLMTrace | None:
+    """Fetch trace events with a simple query — no person JOIN, no aggregations.
+
+    Returns an LLMTrace or None if no events found. The $ai_trace meta-event
+    is used to populate trace-level fields (traceName, inputState, outputState)
+    but is excluded from the events list (matching TraceQueryRunner behavior).
+    """
+    start_dt = datetime.fromisoformat(window_start).astimezone(UTC) - _CAPTURE_RANGE
+    end_dt = datetime.fromisoformat(window_end).astimezone(UTC) + _CAPTURE_RANGE
+
+    query = parse_select(_TRACE_EVENTS_QUERY)
+    result = execute_hogql_query(
+        query_type="SummarizationTraceFetch",
+        query=query,
+        placeholders={
+            "event_types": ast.Tuple(exprs=[ast.Constant(value=e) for e in _AI_EVENT_TYPES]),
+            "start_ts": ast.Constant(value=start_dt.strftime("%Y-%m-%d %H:%M:%S")),
+            "end_ts": ast.Constant(value=end_dt.strftime("%Y-%m-%d %H:%M:%S")),
+            "trace_id": ast.Constant(value=trace_id),
+        },
+        team=team,
+        limit_context=LimitContext.QUERY_ASYNC,
+    )
+
+    if not result.results:
+        return None
+
+    events: list[LLMTraceEvent] = []
+    trace_name: str | None = None
+    input_state: Any = None
+    output_state: Any = None
+    first_timestamp: str | None = None
+
+    for row in result.results:
+        event_uuid, event_name, event_timestamp, event_properties = row
+        if first_timestamp is None:
+            first_timestamp = event_timestamp.isoformat()
+
+        props = orjson.loads(event_properties) if isinstance(event_properties, str) else event_properties
+
+        if event_name == "$ai_trace":
+            # Extract trace-level metadata; exclude from events list
+            trace_name = props.get("$ai_span_name") or props.get("$ai_trace_name")
+            try:
+                input_state = orjson.loads(props["$ai_input_state"]) if props.get("$ai_input_state") else None
+            except (orjson.JSONDecodeError, TypeError):
+                input_state = None
+            try:
+                output_state = orjson.loads(props["$ai_output_state"]) if props.get("$ai_output_state") else None
+            except (orjson.JSONDecodeError, TypeError):
+                output_state = None
+            continue
+
+        events.append(
+            LLMTraceEvent(
+                id=str(event_uuid),
+                event=event_name,
+                createdAt=event_timestamp.isoformat(),
+                properties=props,
+            )
+        )
+
+    if not events:
+        return None
+
+    return LLMTrace(
+        id=trace_id,
+        createdAt=first_timestamp or events[0].createdAt,
+        traceName=trace_name,
+        inputState=input_state,
+        outputState=output_state,
+        events=events,
+        person=LLMTracePerson(uuid="", distinct_id="", created_at=first_timestamp or "", properties={}),
+    )
 
 
 @temporalio.activity.defn
@@ -60,23 +166,17 @@ async def generate_and_save_summary_activity(
     ) -> tuple[dict, list, str, Team] | tuple[dict, list, None, Team] | None:
         """Fetch trace data and format text representation.
 
+        Uses a simple events query instead of TraceQueryRunner to avoid the
+        person table JOIN that causes ClickHouse OOM on teams with large traces.
+
         Returns tuple of (trace_dict, hierarchy, text_repr, team) or None if not found.
         text_repr is None if the trace exceeds MAX_RAW_TRACE_SIZE.
         """
         team = Team.objects.get(id=team_id)
 
-        query = TraceQuery(
-            traceId=trace_id,
-            dateRange=DateRange(date_from=window_start, date_to=window_end),
-        )
-
-        runner = TraceQueryRunner(team=team, query=query)
-        response = runner.calculate()
-
-        if not response.results:
-            return None  # Trace not found in window
-
-        llm_trace = response.results[0]
+        llm_trace = _fetch_trace(team, trace_id, window_start, window_end)
+        if llm_trace is None:
+            return None
 
         # Estimate raw size before expensive formatting
         raw_size = sum(len(str(e.properties)) for e in llm_trace.events)

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -230,9 +230,7 @@ class TestGenerateSummaryActivity:
             patch(
                 "posthog.temporal.llm_analytics.trace_summarization.summarization.format_trace_text_repr"
             ) as mock_format,
-            patch(
-                "posthog.temporal.llm_analytics.trace_summarization.summarization.TraceQueryRunner"
-            ) as mock_runner_class,
+            patch("posthog.temporal.llm_analytics.trace_summarization.summarization._fetch_trace") as mock_fetch_trace,
             patch("posthog.temporal.llm_analytics.trace_summarization.summarization.create_event") as mock_create_event,
         ):
             mock_person = LLMTracePerson(
@@ -247,8 +245,7 @@ class TestGenerateSummaryActivity:
                 events=[],
                 person=mock_person,
             )
-            mock_runner = mock_runner_class.return_value
-            mock_runner.calculate.return_value.results = [mock_trace]
+            mock_fetch_trace.return_value = mock_trace
 
             mock_to_format.return_value = ({"id": sample_trace_data["trace_id"], "properties": {}}, [])
             mock_format.return_value = ("L1: Test trace\nL2: Content", False)
@@ -292,9 +289,7 @@ class TestGenerateSummaryActivity:
             patch(
                 "posthog.temporal.llm_analytics.trace_summarization.summarization.format_trace_text_repr"
             ) as mock_format,
-            patch(
-                "posthog.temporal.llm_analytics.trace_summarization.summarization.TraceQueryRunner"
-            ) as mock_runner_class,
+            patch("posthog.temporal.llm_analytics.trace_summarization.summarization._fetch_trace") as mock_fetch_trace,
             patch("posthog.temporal.llm_analytics.trace_summarization.summarization.create_event"),
             patch(
                 "posthog.temporal.llm_analytics.trace_summarization.summarization.LLMTracesSummarizerEmbedder"
@@ -309,7 +304,7 @@ class TestGenerateSummaryActivity:
                 events=[],
                 person=mock_person,
             )
-            mock_runner_class.return_value.calculate.return_value.results = [mock_trace]
+            mock_fetch_trace.return_value = mock_trace
             mock_to_format.return_value = ({}, [])
             mock_format.return_value = ("test", False)
             mock_summarize.return_value = mock_summary
@@ -346,9 +341,7 @@ class TestGenerateSummaryActivity:
             patch(
                 "posthog.temporal.llm_analytics.trace_summarization.summarization.format_trace_text_repr"
             ) as mock_format,
-            patch(
-                "posthog.temporal.llm_analytics.trace_summarization.summarization.TraceQueryRunner"
-            ) as mock_runner_class,
+            patch("posthog.temporal.llm_analytics.trace_summarization.summarization._fetch_trace") as mock_fetch_trace,
             patch("posthog.temporal.llm_analytics.trace_summarization.summarization.create_event"),
             patch(
                 "posthog.temporal.llm_analytics.trace_summarization.summarization.LLMTracesSummarizerEmbedder"
@@ -363,7 +356,7 @@ class TestGenerateSummaryActivity:
                 events=[],
                 person=mock_person,
             )
-            mock_runner_class.return_value.calculate.return_value.results = [mock_trace]
+            mock_fetch_trace.return_value = mock_trace
             mock_to_format.return_value = ({}, [])
             mock_format.return_value = ("test", False)
             mock_summarize.return_value = mock_summary

--- a/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/tests/test_workflow.py
@@ -230,7 +230,7 @@ class TestGenerateSummaryActivity:
             patch(
                 "posthog.temporal.llm_analytics.trace_summarization.summarization.format_trace_text_repr"
             ) as mock_format,
-            patch("posthog.temporal.llm_analytics.trace_summarization.summarization._fetch_trace") as mock_fetch_trace,
+            patch("posthog.temporal.llm_analytics.trace_summarization.summarization.fetch_trace") as mock_fetch_trace,
             patch("posthog.temporal.llm_analytics.trace_summarization.summarization.create_event") as mock_create_event,
         ):
             mock_person = LLMTracePerson(
@@ -289,7 +289,7 @@ class TestGenerateSummaryActivity:
             patch(
                 "posthog.temporal.llm_analytics.trace_summarization.summarization.format_trace_text_repr"
             ) as mock_format,
-            patch("posthog.temporal.llm_analytics.trace_summarization.summarization._fetch_trace") as mock_fetch_trace,
+            patch("posthog.temporal.llm_analytics.trace_summarization.summarization.fetch_trace") as mock_fetch_trace,
             patch("posthog.temporal.llm_analytics.trace_summarization.summarization.create_event"),
             patch(
                 "posthog.temporal.llm_analytics.trace_summarization.summarization.LLMTracesSummarizerEmbedder"
@@ -341,7 +341,7 @@ class TestGenerateSummaryActivity:
             patch(
                 "posthog.temporal.llm_analytics.trace_summarization.summarization.format_trace_text_repr"
             ) as mock_format,
-            patch("posthog.temporal.llm_analytics.trace_summarization.summarization._fetch_trace") as mock_fetch_trace,
+            patch("posthog.temporal.llm_analytics.trace_summarization.summarization.fetch_trace") as mock_fetch_trace,
             patch("posthog.temporal.llm_analytics.trace_summarization.summarization.create_event"),
             patch(
                 "posthog.temporal.llm_analytics.trace_summarization.summarization.LLMTracesSummarizerEmbedder"


### PR DESCRIPTION
## Problem

Trace summarization Temporal workflows peg worker CPU at 1000m+ for 13+ minutes when processing teams with large AI traces (team 2 is the main offender). The root cause is `TraceQueryRunner.calculate()` which triggers a person table JOIN that causes ClickHouse to OOM (42 GB memory limit exceeded), even for a single trace with a narrow 10-minute window.

The summarization activity does not need person data, cost aggregations, or any of the complex logic in `TraceQueryRunner` -- it just needs events with their properties.

Closes #47199

## Changes

Replace `TraceQueryRunner` in the summarization activity with a simple `SELECT uuid, event, timestamp, properties FROM events WHERE trace_id = ...` query. No JOINs, no aggregations.

**`summarization.py`**: New `_fetch_trace()` function that:
- Runs a simple SELECT with no JOINs or aggregations
- Extracts trace-level metadata (`traceName`, `inputState`, `outputState`) from the `$ai_trace` event
- Builds `LLMTrace` directly, matching the same structure `TraceQueryRunner` produced
- Keeps the +/-10 minute capture range for consistency

**`tests/test_workflow.py`**: Updated mocks from `TraceQueryRunner` to `_fetch_trace`

### Evidence from step-by-step prod debugging

Ran each pipeline step independently on the `temporal-worker-llm-analytics` pod:

| Step | With TraceQueryRunner | With simple query |
|------|----------------------|-------------------|
| ClickHouse query | OOM (42 GB) after 40s | 1.88s |
| str() size estimation | - | 0.015s |
| llm_trace_to_formatter_format | - | <0.001s |
| format_trace_text_repr | - | 0.035s |
| **Total** | **Never completes** | **~1.9s** |

## How did you test this code?

1. **Unit tests**: All 11 existing tests pass with updated mocks
2. **Prod step-by-step**: Ran `_fetch_trace` on prod worker pod against team 2 traces -- confirmed 1.88s vs OOM
3. **Local Temporal workflow**: Ran full `llma-trace-summarization` workflow for team 1 via `temporal workflow start` against local dev. 15 traces processed successfully, all activities completed in 2.6-6.1s (dominated by LLM call time). fetch_duration_s consistently 0.06-0.19s.

## Publish to changelog?

No