### PR TITLE
feat(experiments): add session reply summarization feature flag.

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -268,6 +268,7 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING_REVENUE_SORTING: 'error-tracking-revenue-sorting', // owner: @david #team-error-tracking
     ERROR_TRACKING_SPIKE_ALERTING: 'error-tracking-spike-alerting', // owner: #team-error-tracking
     EXPERIMENT_AI_SUMMARY: 'experiment-ai-summary', // owner: @jurajmajerik #team-experiments
+    EXPERIMENTS_SESSION_REPLAY_SUMMARY: 'experiments-session-replay-summary', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_FF_CROSS_SELL: 'experiments-ff-cross-sell', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     FEATURE_FLAG_COHORT_CREATION: 'feature-flag-cohort-creation', // owner: #team-feature-flags

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -550,6 +550,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             metric,
         }),
         reportExperimentAiSummaryRequested: (experiment: Experiment) => ({ experiment }),
+        reportExperimentSessionReplaySummaryRequested: (experiment: Experiment) => ({ experiment }),
         // Definition Popover
         reportDataManagementDefinitionHovered: (type: TaxonomicFilterGroupType) => ({ type }),
         reportDataManagementDefinitionClickView: (type: TaxonomicFilterGroupType) => ({ type }),
@@ -1387,6 +1388,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportExperimentAiSummaryRequested: ({ experiment }) => {
             posthog.capture('experiment ai summary requested', {
+                ...getEventPropertiesForExperiment(experiment),
+            })
+        },
+        reportExperimentSessionReplaySummaryRequested: ({ experiment }) => {
+            posthog.capture('experiment session replay summary requested', {
                 ...getEventPropertiesForExperiment(experiment),
             })
         },

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -33,6 +33,7 @@ import {
     ResultsQuery,
 } from '../components/ResultsBreakdown'
 import { SummarizeExperimentButton } from '../components/SummarizeExperimentButton'
+import { SummarizeSessionReplaysButton } from '../components/SummarizeSessionReplaysButton'
 import { experimentLogic } from '../experimentLogic'
 import type { ExperimentSceneLogicProps } from '../experimentSceneLogic'
 import { experimentSceneLogic } from '../experimentSceneLogic'
@@ -100,11 +101,14 @@ const MetricsTab = (): JSX.Element => {
         usesNewQueryRunner &&
         hasMinimumExposureForResults
 
+    const isSessionReplaySummaryEnabled = featureFlags[FEATURE_FLAGS.EXPERIMENTS_SESSION_REPLAY_SUMMARY]
+
     return (
         <>
-            {isAiSummaryEnabled && (
-                <div className="mt-1 mb-4 flex justify-start">
-                    <SummarizeExperimentButton />
+            {(isAiSummaryEnabled || isSessionReplaySummaryEnabled) && (
+                <div className="mt-1 mb-4 flex justify-start gap-2">
+                    {isAiSummaryEnabled && <SummarizeExperimentButton />}
+                    {isSessionReplaySummaryEnabled && <SummarizeSessionReplaysButton experiment={experiment} />}
                 </div>
             )}
             {usesNewQueryRunner && (

--- a/frontend/src/scenes/experiments/components/SummarizeSessionReplaysButton.tsx
+++ b/frontend/src/scenes/experiments/components/SummarizeSessionReplaysButton.tsx
@@ -30,7 +30,7 @@ export const SummarizeSessionReplaysButton = ({
             icon={<IconAI />}
             tooltip="Analyze user behavior patterns in session replays using AI"
         >
-            Summarize replays
+            Summarize session replays
         </LemonButton>
     )
 }

--- a/frontend/src/scenes/experiments/components/SummarizeSessionReplaysButton.tsx
+++ b/frontend/src/scenes/experiments/components/SummarizeSessionReplaysButton.tsx
@@ -1,6 +1,6 @@
 import { useActions } from 'kea'
 
-import { IconAI } from '@posthog/icons'
+import { IconRewindPlay } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 
@@ -27,7 +27,7 @@ export const SummarizeSessionReplaysButton = ({
                 reportExperimentSessionReplaySummaryRequested(experiment)
             }}
             type="secondary"
-            icon={<IconAI />}
+            icon={<IconRewindPlay />}
             tooltip="Analyze user behavior patterns in session replays using AI"
         >
             Summarize session replays

--- a/frontend/src/scenes/experiments/components/SummarizeSessionReplaysButton.tsx
+++ b/frontend/src/scenes/experiments/components/SummarizeSessionReplaysButton.tsx
@@ -1,0 +1,36 @@
+import { useActions } from 'kea'
+
+import { IconAI } from '@posthog/icons'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+
+import type { Experiment } from '~/types'
+
+import { experimentLogic } from '../experimentLogic'
+
+type SummarizeSessionReplaysButtonProps = {
+    experiment: Experiment
+}
+
+/**
+ * Calls the Max tool to summarize session replays for an experiment.
+ */
+export const SummarizeSessionReplaysButton = ({
+    experiment,
+}: SummarizeSessionReplaysButtonProps): JSX.Element | null => {
+    const { reportExperimentSessionReplaySummaryRequested } = useActions(experimentLogic)
+
+    return (
+        <LemonButton
+            size="small"
+            onClick={() => {
+                reportExperimentSessionReplaySummaryRequested(experiment)
+            }}
+            type="secondary"
+            icon={<IconAI />}
+            tooltip="Analyze user behavior patterns in session replays using AI"
+        >
+            Summarize replays
+        </LemonButton>
+    )
+}

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -343,6 +343,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 'reportExperimentTimeseriesViewed',
                 'reportExperimentTimeseriesRecalculated',
                 'reportExperimentAiSummaryRequested',
+                'reportExperimentSessionReplaySummaryRequested',
                 'reportExperimentMetricsRefreshed',
                 'reportExperimentAutoRefreshToggled',
                 'reportExperimentMetricBreakdownAdded',


### PR DESCRIPTION
## Problem

We want to integrate more deeply with session replay and leverage its summarization to improve experiment analysis.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are adding a new `Session Replay Summary` button behind a feature flag. This will allow us to call an agent tool to filter session replays and call the analysis tool for replays related to an experiment.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/f693a8cc-a47b-407d-a255-e73e175c4dc2)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
