### PR TITLE
feat(experiments): add the MaxTool for session replay summarizarion.

### DIFF
--- a/ee/hogai/core/agent_modes/presets/flags.py
+++ b/ee/hogai/core/agent_modes/presets/flags.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from posthog.schema import AgentMode
 
-from products.experiments.backend.max_tools import CreateExperimentTool, ExperimentSummaryTool
+from products.experiments.backend.max_tools import CreateExperimentTool, ExperimentSummaryTool, SessionReplaySummaryTool
 from products.feature_flags.backend.max_tools import CreateFeatureFlagTool
 
 from ee.hogai.chat_agent.executables import ChatAgentPlanExecutable, ChatAgentPlanToolsExecutable
@@ -77,7 +77,7 @@ class FlagsAgentToolkit(AgentToolkit):
 
     @property
     def tools(self) -> list[type["MaxTool"]]:
-        tools: list[type[MaxTool]] = [CreateFeatureFlagTool, CreateExperimentTool]
+        tools: list[type[MaxTool]] = [CreateFeatureFlagTool, CreateExperimentTool, SessionReplaySummaryTool]
         if has_experiment_summary_tool_feature_flag(self._team, self._user):
             tools.append(ExperimentSummaryTool)
         return tools

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1966,6 +1966,7 @@
                 "search_error_tracking_issues",
                 "find_error_tracking_impactful_issue_event_list",
                 "experiment_results_summary",
+                "experiment_session_replays_summary",
                 "create_survey",
                 "edit_survey",
                 "analyze_survey_responses",

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -405,6 +405,7 @@ export type AssistantTool =
     | 'search_error_tracking_issues'
     | 'find_error_tracking_impactful_issue_event_list'
     | 'experiment_results_summary'
+    | 'experiment_session_replays_summary'
     | 'create_survey'
     | 'edit_survey'
     | 'analyze_survey_responses'

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -605,6 +605,19 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
             return 'Summarizing experiment results...'
         },
     },
+    experiment_session_replays_summary: {
+        name: 'Summarize experiment session replays',
+        description: 'Analyze user behavior patterns across experiment variants using session recordings',
+        product: Scene.Experiment,
+        icon: iconForType('session_replay'),
+        modes: [AgentMode.Flags],
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Analyzed session replay patterns'
+            }
+            return 'Analyzing session replays...'
+        },
+    },
     create_survey: {
         name: 'Create surveys',
         description: 'Create surveys in seconds',

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -607,7 +607,8 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
     },
     experiment_session_replays_summary: {
         name: 'Summarize experiment session replays',
-        description: 'Analyze user behavior patterns across experiment variants using session recordings',
+        description:
+            'Summarize experiment session replays to analyze user behavior patterns across experiment variants using session recordings',
         product: Scene.Experiment,
         icon: iconForType('session_replay'),
         modes: [AgentMode.Flags],

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -338,6 +338,7 @@ class AssistantTool(StrEnum):
     SEARCH_ERROR_TRACKING_ISSUES = "search_error_tracking_issues"
     FIND_ERROR_TRACKING_IMPACTFUL_ISSUE_EVENT_LIST = "find_error_tracking_impactful_issue_event_list"
     EXPERIMENT_RESULTS_SUMMARY = "experiment_results_summary"
+    EXPERIMENT_SESSION_REPLAYS_SUMMARY = "experiment_session_replays_summary"
     CREATE_SURVEY = "create_survey"
     EDIT_SURVEY = "edit_survey"
     ANALYZE_SURVEY_RESPONSES = "analyze_survey_responses"

--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel, Field
 from posthog.schema import MaxExperimentSummaryContext
 
 from posthog.models import Experiment, FeatureFlag
+from posthog.session_recordings.queries.session_recording_list_from_query import filter_from_params_to_query
+from posthog.session_recordings.session_recording_api import list_recordings_from_query
 from posthog.sync import database_sync_to_async
 
 from ee.hogai.llm import MaxChatOpenAI
@@ -423,3 +425,255 @@ class ExperimentSummaryTool(MaxTool):
                 },
             )
             return f"❌ Failed to summarize experiment: {str(e)}", {"error": "summary_failed", "details": str(e)}
+
+
+# Session Replay Summary Tool
+
+
+class SessionReplaySummaryArgs(BaseModel):
+    """
+    Analyze session replay patterns for an experiment to understand user behavior across variants.
+    """
+
+    experiment_id: int = Field(description="The ID of the experiment to analyze session replays for")
+
+
+class SessionReplaySummaryOutput(BaseModel):
+    """Structured output for session replay summary"""
+
+    behavioral_patterns: list[str] = Field(
+        description="Key behavioral patterns observed across experiment variants", max_length=20
+    )
+    recording_counts: dict[str, int] = Field(description="Number of recordings available per variant")
+    variant_insights: dict[str, list[str]] = Field(default_factory=dict, description="Specific insights per variant")
+    warning: str | None = Field(default=None, description="Warning about data quality or availability")
+
+
+SESSION_REPLAY_SUMMARY_TOOL_DESCRIPTION = """
+Use this tool to analyze session replay patterns across experiment variants to understand user behavior differences.
+The tool provides recording counts per variant and context for Max to analyze actual session recordings.
+
+This tool is useful when:
+- Understanding how users interact with different experiment variants
+- Identifying usability issues or confusion in specific variants
+- Comparing user behavior patterns between control and test variants
+- Getting qualitative insights to complement quantitative experiment results
+
+**Important:** This tool provides the context and recording counts. Use the filter_session_recordings tool to actually fetch and analyze the recordings for each variant.
+
+# Examples
+
+<example>
+User: How are users behaving in my experiment?
+Assistant: I'll analyze session replay patterns across your experiment variants.
+*Uses experiment_session_replays_summary tool*
+Assistant: I found 299 total recordings across your variants. Let me analyze them...
+
+<reasoning>
+The assistant used experiment_session_replays_summary to get recording counts and filters for the experiment variants.
+</reasoning>
+</example>
+""".strip()
+
+
+class SessionReplaySummaryTool(MaxTool):
+    name: str = "experiment_session_replays_summary"
+    description: str = SESSION_REPLAY_SUMMARY_TOOL_DESCRIPTION
+    context_prompt_template: str = "Analyzes session replay patterns in experiment variants."
+
+    args_schema: type[BaseModel] = SessionReplaySummaryArgs
+
+    def get_required_resource_access(self):
+        return [("experiment", "viewer")]
+
+    async def _arun_impl(
+        self,
+        experiment_id: int,
+    ) -> tuple[str, dict[str, Any]]:
+        try:
+            # Fetch experiment
+            @database_sync_to_async
+            def get_experiment():
+                try:
+                    return Experiment.objects.select_related("team", "feature_flag").get(
+                        id=experiment_id, team=self._team
+                    )
+                except Experiment.DoesNotExist:
+                    raise ValueError(f"Experiment {experiment_id} not found")
+
+            experiment = await get_experiment()
+
+            if not experiment.start_date:
+                return "❌ Experiment has not started yet. No session replays available.", {
+                    "error": "not_started",
+                    "experiment_id": experiment_id,
+                }
+
+            # Get variants from feature flag
+            feature_flag = experiment.feature_flag
+            multivariate = feature_flag.filters.get("multivariate", {})
+            variants = multivariate.get("variants", [])
+            variant_keys = [v["key"] for v in variants]
+
+            if not variant_keys:
+                return "❌ No variants configured for this experiment.", {
+                    "error": "no_variants",
+                    "experiment_id": experiment_id,
+                }
+
+            # Count recordings per variant
+            recording_counts = {}
+            for variant_key in variant_keys:
+                # Build recording filters for this variant
+                filters = self._build_experiment_recording_filters(experiment, variant_key)
+
+                # Convert to RecordingsQuery and count
+                try:
+                    query = filter_from_params_to_query(filters)
+
+                    @database_sync_to_async
+                    def count_recordings(query=query):
+                        recordings, has_more, _, _ = list_recordings_from_query(
+                            query=query, user=None, team=self._team, limit=100
+                        )
+                        # If has_more, there are 100+ recordings
+                        return len(recordings) if not has_more else 100
+
+                    count = await count_recordings()
+                    recording_counts[variant_key] = count
+                except Exception as e:
+                    capture_exception(
+                        e,
+                        properties={
+                            "team_id": self._team.id,
+                            "experiment_id": experiment_id,
+                            "variant_key": variant_key,
+                        },
+                    )
+                    recording_counts[variant_key] = 0
+
+            total_recordings = sum(recording_counts.values())
+
+            if total_recordings == 0:
+                return (
+                    f"❌ No session recordings found for experiment '{experiment.name}'. "
+                    "Make sure session replay is enabled and users have been exposed to the experiment.",
+                    {
+                        "error": "no_recordings",
+                        "experiment_id": experiment_id,
+                        "experiment_name": experiment.name,
+                        "recording_counts": recording_counts,
+                    },
+                )
+
+            # Build response
+            behavioral_patterns = [
+                f"Experiment '{experiment.name}' has {total_recordings} total session recordings across {len(variant_keys)} variants",
+                "To analyze user behavior, use the filter_session_recordings tool with the filters for each variant",
+                "Compare behavior patterns between variants to understand the impact of your changes",
+            ]
+
+            # Add variant-specific guidance
+            for variant_key, count in recording_counts.items():
+                if count > 0:
+                    behavioral_patterns.append(f"Variant '{variant_key}': {count} recordings available for analysis")
+
+            user_message = self._format_summary_for_user(
+                experiment_name=experiment.name,
+                recording_counts=recording_counts,
+                total_recordings=total_recordings,
+            )
+
+            return user_message, {
+                "experiment_id": experiment_id,
+                "experiment_name": experiment.name,
+                "recording_counts": recording_counts,
+                "total_recordings": total_recordings,
+                "variants": variant_keys,
+                "date_range": {
+                    "start": experiment.start_date.isoformat() if experiment.start_date else None,
+                    "end": experiment.end_date.isoformat() if experiment.end_date else None,
+                },
+            }
+
+        except ValueError as e:
+            return f"❌ {str(e)}", {"error": "validation_error", "details": str(e)}
+        except Exception as e:
+            capture_exception(
+                e,
+                properties={
+                    "team_id": self._team.id,
+                    "user_id": self._user.id,
+                    "experiment_id": experiment_id,
+                },
+            )
+            return f"❌ Failed to analyze session replays: {str(e)}", {
+                "error": "analysis_failed",
+                "details": str(e),
+            }
+
+    def _build_experiment_recording_filters(self, experiment: Experiment, variant_key: str) -> dict[str, Any]:
+        """
+        Build recording filters for experiment variant.
+
+        Replicates frontend getViewRecordingFilters() logic from experiments/utils.ts
+        """
+        from datetime import datetime
+
+        feature_flag_key = experiment.feature_flag.key
+
+        # Build filter structure matching RecordingUniversalFilters
+        return {
+            "date_from": experiment.start_date.isoformat() if experiment.start_date else None,
+            "date_to": experiment.end_date.isoformat() if experiment.end_date else datetime.now().isoformat(),
+            "events": [
+                {
+                    "id": "$feature_flag_called",
+                    "type": "events",
+                    "properties": [
+                        {
+                            "key": "$feature_flag",
+                            "value": [feature_flag_key],
+                            "operator": "exact",
+                            "type": "event",
+                        },
+                        {
+                            "key": f"$feature/{feature_flag_key}",
+                            "value": [variant_key],
+                            "operator": "exact",
+                            "type": "event",
+                        },
+                    ],
+                }
+            ],
+        }
+
+    def _format_summary_for_user(
+        self, experiment_name: str, recording_counts: dict[str, int], total_recordings: int
+    ) -> str:
+        """Format the session replay summary for user display"""
+        lines = [
+            f"📹 Session Replay Summary for '{experiment_name}'",
+            "",
+            f"Total recordings: {total_recordings}",
+            "",
+            "Recordings by variant:",
+        ]
+
+        for variant_key, count in recording_counts.items():
+            percentage = (count / total_recordings * 100) if total_recordings > 0 else 0
+            lines.append(f"  • {variant_key}: {count} ({percentage:.1f}%)")
+
+        lines.extend(
+            [
+                "",
+                "💡 To analyze user behavior patterns:",
+                "  1. I can help you filter and view specific recordings",
+                "  2. Compare behavior differences between variants",
+                "  3. Identify usability issues or unexpected user journeys",
+                "",
+                "What would you like to explore?",
+            ]
+        )
+
+        return "\n".join(lines)

--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel, Field
 from posthog.schema import MaxExperimentSummaryContext
 
 from posthog.models import Experiment, FeatureFlag
-from posthog.session_recordings.queries.session_recording_list_from_query import filter_from_params_to_query
 from posthog.session_recordings.session_recording_api import list_recordings_from_query
+from posthog.session_recordings.utils import filter_from_params_to_query
 from posthog.sync import database_sync_to_async
 
 from ee.hogai.llm import MaxChatOpenAI

--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from typing import Any, Literal
 
 from posthoganalytics import capture_exception
@@ -617,14 +618,12 @@ class SessionReplaySummaryTool(MaxTool):
 
         Replicates frontend getViewRecordingFilters() logic from experiments/utils.ts
         """
-        from datetime import datetime
-
         feature_flag_key = experiment.feature_flag.key
 
         # Build filter structure matching RecordingUniversalFilters
         return {
             "date_from": experiment.start_date.isoformat() if experiment.start_date else None,
-            "date_to": experiment.end_date.isoformat() if experiment.end_date else datetime.now().isoformat(),
+            "date_to": experiment.end_date.isoformat() if experiment.end_date else datetime.now(UTC).isoformat(),
             "events": [
                 {
                     "id": "$feature_flag_called",

--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -530,12 +530,11 @@ class SessionReplaySummaryTool(MaxTool):
                 # Convert to RecordingsQuery and count
                 try:
                     query = filter_from_params_to_query(filters)
+                    query.limit = 100
 
                     @database_sync_to_async
                     def count_recordings(query=query):
-                        recordings, has_more, _, _ = list_recordings_from_query(
-                            query=query, user=None, team=self._team, limit=100
-                        )
+                        recordings, has_more, _, _ = list_recordings_from_query(query=query, user=None, team=self._team)
                         # If has_more, there are 100+ recordings
                         return len(recordings) if not has_more else 100
 

--- a/products/experiments/backend/test/test_session_replay_summary_tool.py
+++ b/products/experiments/backend/test/test_session_replay_summary_tool.py
@@ -1,0 +1,366 @@
+from datetime import datetime, timedelta
+
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from posthog.models import Experiment, FeatureFlag
+from posthog.session_recordings.models.session_recording import SessionRecording
+
+from products.experiments.backend.max_tools import SessionReplaySummaryTool
+
+from ee.hogai.utils.types import AssistantState
+
+
+@freeze_time("2025-01-15T12:00:00Z")
+class TestSessionReplaySummaryTool(APIBaseTest):
+    """Comprehensive tests for SessionReplaySummaryTool"""
+
+    async def acreate_feature_flag(self, key="test-experiment", variant_keys=None):
+        """
+        Create a feature flag with multivariate variants for experiments.
+
+        Args:
+            key: Feature flag key
+            variant_keys: List of variant keys, defaults to ["control", "test"]
+        """
+        if variant_keys is None:
+            variant_keys = ["control", "test"]
+
+        variants = [
+            {"key": variant_key, "name": variant_key.title(), "rollout_percentage": 100 // len(variant_keys)}
+            for variant_key in variant_keys
+        ]
+
+        return await FeatureFlag.objects.acreate(
+            name=f"Test experiment flag: {key}",
+            key=key,
+            team=self.team,
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": None}],
+                "multivariate": {"variants": variants},
+            },
+            created_by=self.user,
+        )
+
+    async def acreate_experiment(
+        self, name="test-experiment", feature_flag=None, started=True, start_days_ago=7, end_days_ahead=7
+    ):
+        """
+        Create an experiment with optional started state.
+
+        Args:
+            name: Experiment name
+            feature_flag: FeatureFlag instance, creates one if None
+            started: Whether experiment has started (start_date is set)
+            start_days_ago: Days before now for start_date
+            end_days_ahead: Days after now for end_date
+        """
+        if feature_flag is None:
+            feature_flag = await self.acreate_feature_flag(name)
+
+        return await Experiment.objects.acreate(
+            name=name,
+            team=self.team,
+            feature_flag=feature_flag,
+            start_date=(datetime(2025, 1, 15, 12, 0, 0) - timedelta(days=start_days_ago) if started else None),
+            end_date=(datetime(2025, 1, 15, 12, 0, 0) + timedelta(days=end_days_ahead) if started else None),
+        )
+
+    def create_mock_session_recording(self, session_id, distinct_id="user_1"):
+        """Create a mock SessionRecording object for testing."""
+        recording = SessionRecording(
+            session_id=session_id,
+            team=self.team,
+            distinct_id=distinct_id,
+            start_time=datetime(2025, 1, 10, 10, 0, 0),
+            duration=300,
+        )
+        return recording
+
+    async def create_tool(self):
+        """Create SessionReplaySummaryTool instance for testing."""
+        return await SessionReplaySummaryTool.create_tool_class(
+            team=self.team,
+            user=self.user,
+            state=AssistantState(messages=[]),
+        )
+
+    @patch("products.experiments.backend.max_tools.list_recordings_from_query")
+    async def test_experiment_with_recordings_returns_counts(self, mock_list_recordings):
+        """Test successful analysis of experiment with recordings for each variant."""
+        experiment = await self.acreate_experiment(name="test-experiment")
+
+        # Mock recordings for each variant
+        mock_recordings_control = [self.create_mock_session_recording(f"session_control_{i}") for i in range(50)]
+        mock_recordings_test = [self.create_mock_session_recording(f"session_test_{i}") for i in range(75)]
+
+        mock_list_recordings.side_effect = [
+            (mock_recordings_control, False, "", None),
+            (mock_recordings_test, False, "", None),
+        ]
+
+        tool = await self.create_tool()
+        result, artifact = await tool._arun_impl(experiment_id=experiment.id)
+
+        # Assert result message
+        self.assertIn("Session Replay Summary", result)
+        self.assertIn("test-experiment", result)
+        self.assertIn("Total recordings: 125", result)
+        self.assertIn("control: 50", result)
+        self.assertIn("test: 75", result)
+        self.assertIn("40.0%", result)
+        self.assertIn("60.0%", result)
+        self.assertIn("What would you like to explore?", result)
+
+        # Assert artifact structure
+        assert isinstance(artifact, dict)
+        self.assertEqual(artifact["experiment_id"], experiment.id)
+        self.assertEqual(artifact["experiment_name"], "test-experiment")
+        self.assertEqual(artifact["recording_counts"], {"control": 50, "test": 75})
+        self.assertEqual(artifact["total_recordings"], 125)
+        self.assertEqual(artifact["variants"], ["control", "test"])
+        self.assertIn("date_range", artifact)
+        self.assertIsNotNone(artifact["date_range"]["start"])
+        self.assertIsNotNone(artifact["date_range"]["end"])
+
+        self.assertEqual(mock_list_recordings.call_count, 2)
+
+    @patch("products.experiments.backend.max_tools.list_recordings_from_query")
+    async def test_experiment_with_100_plus_recordings(self, mock_list_recordings):
+        """Test that tool correctly handles has_more=True (100+ recordings)."""
+        experiment = await self.acreate_experiment()
+
+        mock_recordings = [self.create_mock_session_recording(f"session_{i}") for i in range(100)]
+
+        mock_list_recordings.side_effect = [
+            (mock_recordings, True, "", None),
+            (mock_recordings, True, "", None),
+        ]
+
+        tool = await self.create_tool()
+        result, artifact = await tool._arun_impl(experiment_id=experiment.id)
+
+        self.assertEqual(artifact["recording_counts"], {"control": 100, "test": 100})
+        self.assertEqual(artifact["total_recordings"], 200)
+        self.assertIn("200", result)
+
+    @patch("products.experiments.backend.max_tools.list_recordings_from_query")
+    async def test_experiment_with_no_recordings(self, mock_list_recordings):
+        """Test error message when no recordings found for any variant."""
+        experiment = await self.acreate_experiment()
+
+        mock_list_recordings.side_effect = [
+            ([], False, "", None),
+            ([], False, "", None),
+        ]
+
+        tool = await self.create_tool()
+        result, artifact = await tool._arun_impl(experiment_id=experiment.id)
+
+        self.assertIn("No session recordings found", result)
+        self.assertIn("test-experiment", result)
+        self.assertIn("session replay is enabled", result)
+
+        self.assertEqual(artifact["error"], "no_recordings")
+        self.assertEqual(artifact["experiment_id"], experiment.id)
+        self.assertEqual(artifact["recording_counts"], {"control": 0, "test": 0})
+
+    async def test_experiment_not_found(self):
+        """Test error when experiment ID doesn't exist."""
+        tool = await self.create_tool()
+        result, artifact = await tool._arun_impl(experiment_id=99999)
+
+        self.assertIn("Experiment 99999 not found", result)
+        self.assertEqual(artifact["error"], "validation_error")
+        self.assertIn("not found", artifact["details"])
+
+    async def test_experiment_not_started(self):
+        """Test error when experiment hasn't been started yet."""
+        experiment = await self.acreate_experiment(started=False)
+
+        tool = await self.create_tool()
+        result, artifact = await tool._arun_impl(experiment_id=experiment.id)
+
+        self.assertIn("Experiment has not started yet", result)
+        self.assertIn("No session replays available", result)
+        self.assertEqual(artifact["error"], "not_started")
+        self.assertEqual(artifact["experiment_id"], experiment.id)
+
+    async def test_experiment_with_no_variants(self):
+        """Test error when feature flag has no multivariate variants configured."""
+        feature_flag = await FeatureFlag.objects.acreate(
+            name="No variants flag",
+            key="no-variants",
+            team=self.team,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+            created_by=self.user,
+        )
+
+        experiment = await self.acreate_experiment(name="no-variants-exp", feature_flag=feature_flag, started=True)
+
+        tool = await self.create_tool()
+        result, artifact = await tool._arun_impl(experiment_id=experiment.id)
+
+        self.assertIn("No variants configured", result)
+        self.assertEqual(artifact["error"], "no_variants")
+        self.assertEqual(artifact["experiment_id"], experiment.id)
+
+    @patch("products.experiments.backend.max_tools.capture_exception")
+    @patch("products.experiments.backend.max_tools.list_recordings_from_query")
+    async def test_recording_query_exception_graceful_handling(self, mock_list_recordings, mock_capture_exception):
+        """Test that query exceptions for individual variants are caught and logged."""
+        experiment = await self.acreate_experiment()
+
+        mock_recordings = [self.create_mock_session_recording(f"session_{i}") for i in range(25)]
+        mock_list_recordings.side_effect = [
+            (mock_recordings, False, "", None),
+            Exception("ClickHouse connection failed"),
+        ]
+
+        tool = await self.create_tool()
+        result, artifact = await tool._arun_impl(experiment_id=experiment.id)
+
+        self.assertEqual(artifact["recording_counts"], {"control": 25, "test": 0})
+        self.assertEqual(artifact["total_recordings"], 25)
+
+        self.assertEqual(mock_capture_exception.call_count, 1)
+        captured_exception = mock_capture_exception.call_args[0][0]
+        self.assertIn("ClickHouse connection failed", str(captured_exception))
+
+    @patch("products.experiments.backend.max_tools.list_recordings_from_query")
+    async def test_experiment_with_multiple_variants(self, mock_list_recordings):
+        """Test experiment with 3+ variants."""
+        feature_flag = await self.acreate_feature_flag(
+            key="multi-variant", variant_keys=["control", "variant_a", "variant_b"]
+        )
+        experiment = await self.acreate_experiment(name="multi-variant-exp", feature_flag=feature_flag)
+
+        mock_list_recordings.side_effect = [
+            ([self.create_mock_session_recording(f"c_{i}") for i in range(20)], False, "", None),
+            ([self.create_mock_session_recording(f"a_{i}") for i in range(30)], False, "", None),
+            ([self.create_mock_session_recording(f"b_{i}") for i in range(50)], False, "", None),
+        ]
+
+        tool = await self.create_tool()
+        result, artifact = await tool._arun_impl(experiment_id=experiment.id)
+
+        self.assertEqual(artifact["variants"], ["control", "variant_a", "variant_b"])
+        self.assertEqual(artifact["recording_counts"]["control"], 20)
+        self.assertEqual(artifact["recording_counts"]["variant_a"], 30)
+        self.assertEqual(artifact["recording_counts"]["variant_b"], 50)
+        self.assertEqual(artifact["total_recordings"], 100)
+
+        self.assertIn("control: 20 (20.0%)", result)
+        self.assertIn("variant_a: 30 (30.0%)", result)
+        self.assertIn("variant_b: 50 (50.0%)", result)
+
+    async def test_build_experiment_recording_filters(self):
+        """Test that recording filters are built correctly for experiment variants."""
+        feature_flag = await self.acreate_feature_flag(key="test-flag")
+        experiment = await self.acreate_experiment(name="filter-test", feature_flag=feature_flag)
+
+        tool = await self.create_tool()
+        filters = tool._build_experiment_recording_filters(experiment, "control")
+
+        # Verify filter structure
+        self.assertIn("date_from", filters)
+        self.assertIn("date_to", filters)
+        self.assertIn("events", filters)
+        self.assertEqual(len(filters["events"]), 1)
+
+        # Verify event filter
+        event_filter = filters["events"][0]
+        self.assertEqual(event_filter["id"], "$feature_flag_called")
+        self.assertEqual(event_filter["type"], "events")
+
+        # Verify properties
+        properties = event_filter["properties"]
+        self.assertEqual(len(properties), 2)
+
+        self.assertEqual(properties[0]["key"], "$feature_flag")
+        self.assertEqual(properties[0]["value"], ["test-flag"])
+        self.assertEqual(properties[0]["operator"], "exact")
+
+        self.assertEqual(properties[1]["key"], "$feature/test-flag")
+        self.assertEqual(properties[1]["value"], ["control"])
+        self.assertEqual(properties[1]["operator"], "exact")
+
+    @patch("products.experiments.backend.max_tools.list_recordings_from_query")
+    async def test_date_range_in_artifact(self, mock_list_recordings):
+        """Test that date range is correctly included in artifact."""
+        experiment = await self.acreate_experiment(start_days_ago=10, end_days_ahead=5)
+
+        mock_list_recordings.side_effect = [
+            ([self.create_mock_session_recording("s1")], False, "", None),
+            ([self.create_mock_session_recording("s2")], False, "", None),
+        ]
+
+        tool = await self.create_tool()
+        result, artifact = await tool._arun_impl(experiment_id=experiment.id)
+
+        self.assertIn("date_range", artifact)
+        # Django adds timezone info, so check if it starts with the expected date
+        self.assertTrue(artifact["date_range"]["start"].startswith("2025-01-05T12:00:00"))
+        self.assertTrue(artifact["date_range"]["end"].startswith("2025-01-20T12:00:00"))
+
+    @patch("products.experiments.backend.max_tools.database_sync_to_async")
+    @patch("products.experiments.backend.max_tools.capture_exception")
+    async def test_general_exception_handling(self, mock_capture_exception, mock_db_sync):
+        """Test that unexpected exceptions in get_experiment are caught and logged."""
+        # Make database_sync_to_async raise an exception when fetching experiment
+        mock_db_sync.side_effect = RuntimeError("Database connection lost")
+
+        tool = await self.create_tool()
+        result, artifact = await tool._arun_impl(experiment_id=123)
+
+        self.assertIn("Failed to analyze session replays", result)
+        self.assertEqual(artifact["error"], "analysis_failed")
+        self.assertIn("Database connection lost", artifact["details"])
+
+        self.assertEqual(mock_capture_exception.call_count, 1)
+        call_kwargs = mock_capture_exception.call_args[1]
+        self.assertEqual(call_kwargs["properties"]["team_id"], self.team.id)
+        self.assertEqual(call_kwargs["properties"]["user_id"], self.user.id)
+        self.assertEqual(call_kwargs["properties"]["experiment_id"], 123)
+
+    async def test_format_summary_for_user_structure(self):
+        """Test the structure and content of formatted user message."""
+        tool = await self.create_tool()
+
+        recording_counts = {"control": 100, "test": 150, "variant_c": 50}
+        message = tool._format_summary_for_user(
+            experiment_name="My Test Experiment", recording_counts=recording_counts, total_recordings=300
+        )
+
+        self.assertIn("📹 Session Replay Summary for 'My Test Experiment'", message)
+        self.assertIn("Total recordings: 300", message)
+        self.assertIn("Recordings by variant:", message)
+        self.assertIn("control: 100 (33.3%)", message)
+        self.assertIn("test: 150 (50.0%)", message)
+        self.assertIn("variant_c: 50 (16.7%)", message)
+        self.assertIn("To analyze user behavior patterns:", message)
+        self.assertIn("filter and view specific recordings", message)
+        self.assertIn("Compare behavior differences", message)
+        self.assertIn("What would you like to explore?", message)
+
+    async def test_experiment_with_empty_multivariate_variants_list(self):
+        """Test handling when multivariate.variants is an empty list."""
+        feature_flag = await FeatureFlag.objects.acreate(
+            name="Empty variants flag",
+            key="empty-variants",
+            team=self.team,
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+                "multivariate": {"variants": []},
+            },
+            created_by=self.user,
+        )
+
+        experiment = await self.acreate_experiment(name="empty-variants-exp", feature_flag=feature_flag, started=True)
+
+        tool = await self.create_tool()
+        result, artifact = await tool._arun_impl(experiment_id=experiment.id)
+
+        self.assertIn("No variants configured", result)
+        self.assertEqual(artifact["error"], "no_variants")


### PR DESCRIPTION
## Problem

We want to integrate more deeply with session replay and leverage its summarization to improve experiment analysis.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Here we are setting up the backend tool that will fetch the experiment information, filter existing sessions, and call the `filter_session_recordings` to analyze each variant's recordings.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
hogli test:python products/experiments/backend/test/test_session_replay_summary_tool.py
```

![cat-type](https://github.com/user-attachments/assets/d9fb6b93-5cd6-4dd2-96dc-64c9011efbb4)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
