### PR TITLE
feat(experiments): use session replay summary tool hook.

### DIFF
--- a/frontend/src/scenes/experiments/components/SummarizeSessionReplaysButton.tsx
+++ b/frontend/src/scenes/experiments/components/SummarizeSessionReplaysButton.tsx
@@ -7,6 +7,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import type { Experiment } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
+import { useSessionReplaySummaryMaxTool } from '../hooks/useSessionReplaySummaryMaxTool'
 
 type SummarizeSessionReplaysButtonProps = {
     experiment: Experiment
@@ -18,13 +19,19 @@ type SummarizeSessionReplaysButtonProps = {
 export const SummarizeSessionReplaysButton = ({
     experiment,
 }: SummarizeSessionReplaysButtonProps): JSX.Element | null => {
+    const { openMax } = useSessionReplaySummaryMaxTool()
     const { reportExperimentSessionReplaySummaryRequested } = useActions(experimentLogic)
+
+    if (!openMax) {
+        return null
+    }
 
     return (
         <LemonButton
             size="small"
             onClick={() => {
                 reportExperimentSessionReplaySummaryRequested(experiment)
+                openMax()
             }}
             type="secondary"
             icon={<IconRewindPlay />}

--- a/frontend/src/scenes/experiments/hooks/useSessionReplaySummaryMaxTool.ts
+++ b/frontend/src/scenes/experiments/hooks/useSessionReplaySummaryMaxTool.ts
@@ -1,0 +1,66 @@
+import { useValues } from 'kea'
+import posthog from 'posthog-js'
+import { useMemo } from 'react'
+
+import { useMaxTool } from 'scenes/max/useMaxTool'
+
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+
+import { experimentLogic } from '../experimentLogic'
+
+/**
+ * Minimal context sent to the backend for session replay summarization.
+ * The backend fetches recording counts and filters for each variant.
+ */
+type MinimalSessionReplaySummaryContext = {
+    experiment_id: number | string
+    experiment_name: string
+}
+
+export const useSessionReplaySummaryMaxTool = (): ReturnType<typeof useMaxTool> => {
+    const { experiment, orderedPrimaryMetricsWithResults } = useValues(experimentLogic)
+
+    const maxToolContext = useMemo(
+        (): MinimalSessionReplaySummaryContext => ({
+            experiment_id: experiment.id,
+            experiment_name: experiment.name || 'Unnamed experiment',
+        }),
+        [experiment.id, experiment.name]
+    )
+
+    const shouldShowButton = useMemo(() => {
+        const hasResults = orderedPrimaryMetricsWithResults.length > 0
+        const hasStarted = !!experiment.start_date
+        return hasResults && hasStarted
+    }, [orderedPrimaryMetricsWithResults, experiment.start_date])
+
+    const maxToolResult = useMaxTool({
+        identifier: 'experiment_session_replays_summary',
+        context: maxToolContext,
+        contextDescription: {
+            text: `Session replays for ${maxToolContext.experiment_name}`,
+            icon: iconForType('session_replay'),
+        },
+        active: shouldShowButton,
+        initialMaxPrompt: `!Summarize session replays for experiment "${experiment.name}"`,
+        callback(toolOutput) {
+            if (toolOutput?.error) {
+                posthog.captureException(
+                    toolOutput?.error || 'Undefined error when summarizing session replays with Max',
+                    {
+                        action: 'max-ai-session-replay-summary-failed',
+                        experiment_id: experiment.id,
+                        ...toolOutput,
+                    }
+                )
+            } else {
+                posthog.capture('experiment session replays analyzed', {
+                    experiment_id: experiment.id,
+                    has_recordings: toolOutput.total_recordings > 0,
+                })
+            }
+        },
+    })
+
+    return maxToolResult
+}

--- a/frontend/src/scenes/experiments/hooks/useSessionReplaySummaryMaxTool.ts
+++ b/frontend/src/scenes/experiments/hooks/useSessionReplaySummaryMaxTool.ts
@@ -28,11 +28,12 @@ export const useSessionReplaySummaryMaxTool = (): ReturnType<typeof useMaxTool> 
         [experiment.id, experiment.name]
     )
 
+    const resultsCount = orderedPrimaryMetricsWithResults.length
     const shouldShowButton = useMemo(() => {
-        const hasResults = orderedPrimaryMetricsWithResults.length > 0
+        const hasResults = resultsCount > 0
         const hasStarted = !!experiment.start_date
         return hasResults && hasStarted
-    }, [orderedPrimaryMetricsWithResults, experiment.start_date])
+    }, [resultsCount, experiment.start_date])
 
     const maxToolResult = useMaxTool({
         identifier: 'experiment_session_replays_summary',
@@ -42,7 +43,7 @@ export const useSessionReplaySummaryMaxTool = (): ReturnType<typeof useMaxTool> 
             icon: iconForType('session_replay'),
         },
         active: shouldShowButton,
-        initialMaxPrompt: `!Summarize session replays for experiment "${experiment.name}"`,
+        initialMaxPrompt: `!Summarize session replays for experiment "${maxToolContext.experiment_name}"`,
         callback(toolOutput) {
             if (toolOutput?.error) {
                 posthog.captureException(
@@ -56,7 +57,7 @@ export const useSessionReplaySummaryMaxTool = (): ReturnType<typeof useMaxTool> 
             } else {
                 posthog.capture('experiment session replays analyzed', {
                     experiment_id: experiment.id,
-                    has_recordings: toolOutput.total_recordings > 0,
+                    has_recordings: (toolOutput?.total_recordings ?? 0) > 0,
                 })
             }
         },


### PR DESCRIPTION
## Problem

We want to integrate more deeply with session replay and leverage its summarization to improve experiment analysis.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This is the final integration step. We build the context for the tool, initial prompt, open the PostHog AI panel, and execute the initial prompt.

| experiment session replay analysis |
| - |
| <img width="3240" height="2466" alt="localhost_8010_project_1_experiments_2" src="https://github.com/user-attachments/assets/32d869e1-b162-430a-a6a8-af659585882a" /> |

| search experiments | session replay summary tool call |
| - | - |
| <img width="426" height="388" alt="image" src="https://github.com/user-attachments/assets/4398eae1-eac9-4b49-8b47-ef249300de73" /> | <img width="418" height="382" alt="image" src="https://github.com/user-attachments/assets/d20a8739-3969-4f1a-9056-523ad2c359a6" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/816e1268-1af9-4c6b-832d-cd1b893552e9)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
