### PR TITLE
feat(ai): implement MCP tool discovery and execution endpoints

### DIFF
--- a/products/posthog_ai/backend/api/mcp_tools.py
+++ b/products/posthog_ai/backend/api/mcp_tools.py
@@ -1,5 +1,7 @@
 from typing import cast
+
 from django.views.generic import View
+
 import pydantic
 from asgiref.sync import async_to_sync
 from posthoganalytics import capture_exception
@@ -9,43 +11,87 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from structlog import get_logger
+
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models.user import User
 from posthog.renderers import SafeJSONRenderer
+
 from ee.hogai.mcp_tool import mcp_tool_registry
 from ee.hogai.tool_errors import MaxToolError
 
 logger = get_logger(__name__)
 
+
 class MCPToolsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
+    scope_object = "project"
     renderer_classes = [SafeJSONRenderer]
 
+    def dangerously_get_required_scopes(self, request: Request, view: View) -> list[str] | None:
+        if self.action == "run":
+            tool_name = request.data.get("tool_name")
+            if tool_name:
+                return mcp_tool_registry.get_scopes(tool_name)
+        return None
+
     def list(self, request: Request, *args, **kwargs) -> Response:
-        tools = mcp_tool_registry.get_all_tools()
-        return Response({"tools": [tool.model_dump() for tool in tools]})
+        """
+        List all available MCP tools.
+        """
+        user = cast(User, request.user)
+        tools = []
+        for name in mcp_tool_registry.get_names():
+            tool = mcp_tool_registry.get(name, team=self.team, user=user)
+            if tool:
+                tools.append(tool.model_dump())
+        return Response({"tools": tools})
 
     @action(methods=["POST"], detail=False)
     def run(self, request: Request, *args, **kwargs) -> Response:
+        """
+        Execute a specific MCP tool.
+        Expects tool_name and args in the request body.
+        """
         tool_name = request.data.get("tool_name")
         args_data = request.data.get("args", {})
 
         if not tool_name:
-            return Response({"success": False, "content": "Tool name is required."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"success": False, "content": "Tool name is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         user = cast(User, request.user)
-        try:
-            tool = mcp_tool_registry.get_tool(tool_name)
-            if not tool:
-                 return Response({"success": False, "content": f"Tool {tool_name} not found."}, status=status.HTTP_404_NOT_FOUND)
+        tool = mcp_tool_registry.get(tool_name, team=self.team, user=user)
 
-            content = async_to_sync(tool.run)(args=args_data, context={"team_id": self.team_id, "user": user})
+        if not tool:
+            return Response(
+                {"success": False, "content": f"Tool {tool_name} not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            validated_args = tool.args_schema.model_validate(args_data)
+            content = async_to_sync(tool.execute)(validated_args)
+
         except pydantic.ValidationError as e:
-            return Response({"success": False, "content": f"Invalid arguments: {e}"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"success": False, "content": f"Invalid arguments: {e}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except MaxToolError as e:
-            return Response({"success": False, "content": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"success": False, "content": str(e)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except Exception as e:
             logger.exception("Error calling tool", extra={"tool_name": tool_name, "error": str(e)})
             capture_exception(e, properties={"tag": "mcp", "args": args_data})
-            return Response({"success": False, "content": "Internal error. Do not retry."})
+            return Response(
+                {
+                    "success": False,
+                    "content": "The tool raised an internal error. Do not immediately retry the tool call.",
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
         return Response({"success": True, "content": content})

--- a/products/posthog_ai/backend/api/mcp_tools.py
+++ b/products/posthog_ai/backend/api/mcp_tools.py
@@ -1,7 +1,5 @@
 from typing import cast
-
 from django.views.generic import View
-
 import pydantic
 from asgiref.sync import async_to_sync
 from posthoganalytics import capture_exception
@@ -11,75 +9,43 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from structlog import get_logger
-
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models.user import User
 from posthog.renderers import SafeJSONRenderer
-
 from ee.hogai.mcp_tool import mcp_tool_registry
 from ee.hogai.tool_errors import MaxToolError
 
 logger = get_logger(__name__)
 
-
 class MCPToolsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
-    scope_object = "project"
-
     renderer_classes = [SafeJSONRenderer]
 
-    def dangerously_get_required_scopes(self, request: Request, view: View) -> list[str] | None:
-        if self.action == "invoke_tool":
-            tool_name = self.kwargs.get("tool_name", "")
-            scopes = mcp_tool_registry.get_scopes(tool_name)
-            return scopes or None
-        return None
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        tools = mcp_tool_registry.get_all_tools()
+        return Response({"tools": [tool.model_dump() for tool in tools]})
 
-    @action(
-        detail=False,
-        methods=["POST"],
-        url_path="(?P<tool_name>[^/.]+)",
-    )
-    def invoke_tool(self, request: Request, tool_name: str, *args, **kwargs):
-        """
-        Invoke an MCP tool by name.
-
-        This endpoint allows MCP callers to invoke Max AI tools directly
-        without going through the full LangChain conversation flow.
-
-        Scopes are resolved dynamically per tool via dangerously_get_required_scopes.
-        """
-        tool = mcp_tool_registry.get(tool_name, team=self.team, user=cast(User, request.user))
-        if tool is None:
-            return Response(
-                {"success": False, "content": f"Tool '{tool_name}' not found"},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-
+    @action(methods=["POST"], detail=False)
+    def run(self, request: Request, *args, **kwargs) -> Response:
+        tool_name = request.data.get("tool_name")
         args_data = request.data.get("args", {})
 
-        try:
-            validated_args = tool.args_schema.model_validate(args_data)
-        except pydantic.ValidationError as e:
-            return Response(
-                {
-                    "success": False,
-                    "content": f"There was a validation error calling the tool:\n{e.errors(include_url=False)}",
-                },
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        if not tool_name:
+            return Response({"success": False, "content": "Tool name is required."}, status=status.HTTP_400_BAD_REQUEST)
 
+        user = cast(User, request.user)
         try:
-            content = async_to_sync(tool.execute)(validated_args)
+            tool = mcp_tool_registry.get_tool(tool_name)
+            if not tool:
+                 return Response({"success": False, "content": f"Tool {tool_name} not found."}, status=status.HTTP_404_NOT_FOUND)
+
+            content = async_to_sync(tool.run)(args=args_data, context={"team_id": self.team_id, "user": user})
+        except pydantic.ValidationError as e:
+            return Response({"success": False, "content": f"Invalid arguments: {e}"}, status=status.HTTP_400_BAD_REQUEST)
         except MaxToolError as e:
-            return Response({"success": False, "content": f"Tool failed: {e.to_summary()}.{e.retry_hint}"})
+            return Response({"success": False, "content": str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except Exception as e:
             logger.exception("Error calling tool", extra={"tool_name": tool_name, "error": str(e)})
             capture_exception(e, properties={"tag": "mcp", "args": args_data})
-            return Response(
-                {
-                    "success": False,
-                    "content": "The tool raised an internal error. Do not immediately retry the tool call.",
-                }
-            )
+            return Response({"success": False, "content": "Internal error. Do not retry."})
 
         return Response({"success": True, "content": content})


### PR DESCRIPTION
Problem The previous implementation lacked a way to list available tools dynamically and used a URL-based invocation pattern (invoke_tool) that was harder to generalize for the AI agent.

Changes

Added list endpoint: Allows the AI agent to discover all available MCP tools and their schemas.

Refactored Execution: Replaced invoke_tool with a generic run action that accepts tool_name and args in the request body.

Simplified Logic: Streamlined the tool retrieval and execution flow using mcp_tool_registry.

Error Handling: Added standardized error responses for ValidationError, MaxToolError, and generic exceptions.