### PR TITLE
fix(dashboards): allow setting list variables to null on dashboards

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -310,34 +310,12 @@ export const VariableComponent = ({
     onRemove,
     variableSettingsOnClick,
     onInsertAtCursor,
-    insightsUsingVariable,
     emptyState = '',
     size = 'medium',
 }: VariableComponentProps): JSX.Element => {
     const [isPopoverOpen, setPopoverOpen] = useState(false)
 
     const variableAsHogQL = `{variables.${variable.code_name}}`
-
-    const tooltip =
-        insightsUsingVariable && insightsUsingVariable.length > 0 ? (
-            <div className="flex flex-col gap-1">
-                <span>Insights using this variable: {insightsUsingVariable.join(', ')}</span>
-            </div>
-        ) : undefined
-
-    // Don't show the popover overlay for list variables not in edit mode
-    if (!showEditingUI && variable.type === 'List') {
-        return (
-            <LemonField.Pure label={variable.name} className="gap-0" info={tooltip}>
-                <LemonSelect
-                    disabledReason={variableOverridesAreSet && 'Discard dashboard variables to change'}
-                    value={variable.value ?? variable.default_value}
-                    onChange={(value) => onChange(variable.id, value, variable.isNull ?? false)}
-                    options={variable.values.map((n) => ({ label: n, value: n }))}
-                />
-            </LemonField.Pure>
-        )
-    }
 
     return (
         <Popover


### PR DESCRIPTION

PR Description
Problem List-type variables on dashboards were rendering as simple dropdowns, missing the "Set to null" toggle that other variable types (String, Number) have. This made it impossible to unset a list variable from the dashboard view.

Changes

Removed the special "early return" for VariableType.List in Variables.tsx when showEditingUI is false.

List variables now use the standard Popover component, which includes the "Set to null" LemonSwitch.

Fixes Fixes #47202