### PR TITLE
docs(react): use @posthog/react in product-analytics onboarding

### DIFF
--- a/docs/onboarding/product-analytics/react.tsx
+++ b/docs/onboarding/product-analytics/react.tsx
@@ -13,28 +13,28 @@ export const getReactSteps = (ctx: OnboardingComponentsContext): StepDefinition[
             badge: 'required',
             content: (
                 <>
-                    <Markdown>Install the PostHog JavaScript library using your package manager:</Markdown>
+                    <Markdown>Install [`posthog-js`](https://github.com/posthog/posthog-js) and `@posthog/react` using your package manager:</Markdown>
                     <CodeBlock
                         blocks={[
                             {
                                 language: 'bash',
                                 file: 'npm',
                                 code: dedent`
-                                    npm install posthog-js
+                                    npm install posthog-js @posthog/react
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'yarn',
                                 code: dedent`
-                                    yarn add posthog-js
+                                    yarn add posthog-js @posthog/react
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'pnpm',
                                 code: dedent`
-                                    pnpm add posthog-js
+                                    pnpm add posthog-js @posthog/react
                                 `,
                             },
                         ]}
@@ -85,7 +85,7 @@ export const getReactSteps = (ctx: OnboardingComponentsContext): StepDefinition[
                                     import { createRoot } from 'react-dom/client'
                                     import './index.css'
                                     import App from './App.jsx'
-                                    import { PostHogProvider } from 'posthog-js/react'
+                                    import { PostHogProvider } from '@posthog/react'
 
                                     const options = {
                                       api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
@@ -128,7 +128,7 @@ export const getReactSteps = (ctx: OnboardingComponentsContext): StepDefinition[
                                 language: 'tsx',
                                 file: 'MyComponent.tsx',
                                 code: dedent`
-                                    import { usePostHog } from 'posthog-js/react'
+                                    import { usePostHog } from '@posthog/react'
 
                                     function MyComponent() {
                                         const posthog = usePostHog()


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
There is a mismatch between onboarding step and docs linked from this document. 
<img width="969" height="235" alt="image" src="https://github.com/user-attachments/assets/cfe96ee9-e5b6-4e84-b0d5-635da94f156f" />
<img width="1064" height="274" alt="image" src="https://github.com/user-attachments/assets/3155de00-ea3c-4faf-b3be-546c717209c6" />


I would assume readme for @posthog/react has the latest changes on how to use the package that is a part of posthog-js.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
Applied relevant installation and import changes for `docs/onboarding/product-analytics/react.tsx` similarly to [@posthog/react README.md](https://github.com/PostHog/posthog-js/blob/main/packages/react/README.md)

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- docs change
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog
