### PR TITLE
feat: Instrument products chosen during onboarding

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -680,6 +680,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 hasBrowsingHistory?: boolean
             }
         ) => ({ path, properties }),
+        reportOnboardingProductToggled: (productKey: string, selected: boolean, recommendationSource: string) => ({
+            productKey,
+            selected,
+            recommendationSource,
+        }),
         reportBillingCTAShown: true,
         reportBillingUsageInteraction: (properties: BillingUsageInteractionProps) => ({ properties }),
         reportBillingSpendInteraction: (properties: BillingUsageInteractionProps) => ({ properties }),
@@ -1735,6 +1740,13 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 use_case: properties?.useCase,
                 recommended_products: properties?.recommendedProducts,
                 has_browsing_history: properties?.hasBrowsingHistory,
+            })
+        },
+        reportOnboardingProductToggled: ({ productKey, selected, recommendationSource }) => {
+            posthog.capture('onboarding product toggled', {
+                product_key: productKey,
+                selected,
+                recommendation_source: recommendationSource,
             })
         },
         reportSDKSelected: ({ sdk }) => {

--- a/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
+++ b/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
@@ -35,7 +35,7 @@ export const productSelectionLogic = kea<productSelectionLogicType>([
             onboardingLogic,
             ['setOnCompleteOnboardingRedirectUrl'],
             eventUsageLogic,
-            ['reportOnboardingStarted', 'reportOnboardingProductSelectionPath'],
+            ['reportOnboardingStarted', 'reportOnboardingProductSelectionPath', 'reportOnboardingProductToggled'],
         ],
         values: [teamLogic, ['currentTeam']],
     })),
@@ -307,6 +307,8 @@ export const productSelectionLogic = kea<productSelectionLogicType>([
                 const remaining = values.selectedProducts.filter((k) => k !== productKey)
                 actions.setFirstProductOnboarding(remaining[0] || null)
             }
+
+            actions.reportOnboardingProductToggled(productKey, isNowSelected, values.recommendationSource)
         },
 
         handleStartOnboarding: () => {


### PR DESCRIPTION
## Problem

We need to track when users toggle products during the onboarding process to better understand user preferences and improve our product recommendations.

## Changes

Added a new event tracking capability to monitor when users toggle products on/off during the onboarding flow:

- Created a new `reportOnboardingProductToggled` action in `eventUsageLogic.ts` that captures when a product is toggled
- Integrated this tracking in the product selection logic to record:
  - Which product was toggled
  - Whether it was selected or deselected
  - The source of the recommendation

## How did you test this code?

Manually tested the onboarding flow and verified that the new event is properly captured in PostHog when toggling products on and off during the product selection step.

## Publish to changelog?

No