### PR TITLE
fix: Clarify card authorization hold message

### DIFF
--- a/frontend/src/scenes/billing/PaymentEntryModal.tsx
+++ b/frontend/src/scenes/billing/PaymentEntryModal.tsx
@@ -45,8 +45,8 @@ export const PaymentForm = (): JSX.Element => {
         <div>
             <PaymentElement />
             <p className="text-xs text-secondary mt-0.5">
-                Your card will not be charged but we place a $0.50 hold on it to verify your card that will be released
-                in 7 days.
+                A temporary $0.50 authorization hold will be placed on your card to verify it. This hold will be
+                automatically released within 7 days and you will not be charged.
             </p>
             {stripeError && <LemonBanner type="error">{stripeError}</LemonBanner>}
             <div className="flex justify-end deprecated-space-x-2 mt-2">


### PR DESCRIPTION
## Problem

The current wording about the card verification hold is unclear and could potentially cause confusion for users about what happens during the payment verification process.

## Changes

Updated the text in the payment form to more clearly explain the temporary authorization hold process. The new wording clarifies that:
- The $0.50 hold is temporary and for verification purposes only
- The hold will be automatically released within 7 days
- Users will not be charged for this verification process

## How did you test this code?

Verified the text change renders correctly in the payment form and that the message accurately reflects our payment verification process.

## Publish to changelog?

No