### PR TITLE
fix(ux): tooltips in product tree menus

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/menus/DashboardsMenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/DashboardsMenuItems.tsx
@@ -48,6 +48,8 @@ export function DashboardsMenuItems({
                                             menuItem: true,
                                         }}
                                         to={urls.dashboard(dashboard.id)}
+                                        tooltip={dashboard.name}
+                                        tooltipPlacement="right"
                                         onClick={(e) => {
                                             e.stopPropagation()
                                             onLinkClick?.(false)

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/SessionReplayMenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/SessionReplayMenuItems.tsx
@@ -69,6 +69,8 @@ export function SessionReplayMenuItems({
                                                 savedFilterId: savedFilter.short_id,
                                             }).url
                                         )}
+                                        tooltip={savedFilter.name || savedFilter.derived_name || 'Unnamed'}
+                                        tooltipPlacement="right"
                                         onKeyDown={handleKeyDown}
                                         onClick={() => onLinkClick?.(false)}
                                     >
@@ -122,6 +124,8 @@ export function SessionReplayMenuItems({
                                             menuItem: true,
                                         }}
                                         to={urls.replayPlaylist(playlist.short_id)}
+                                        tooltip={playlist.name || playlist.derived_name || 'Unnamed'}
+                                        tooltipPlacement="right"
                                         onKeyDown={handleKeyDown}
                                         onClick={() => onLinkClick?.(false)}
                                     >


### PR DESCRIPTION
## Problem
https://github.com/PostHog/posthog/issues/46007

## Changes
- Added tooltips to pinned dashboard items in the DashboardsMenuItems component
- Added tooltips to saved filters and collections in the SessionReplayMenuItems component
- Tooltips display the full name on the right side, useful when names are truncated

## Test plan
- [ ] Open the project tree and hover over pinned dashboards - tooltip should appear on the right
- [ ] Open session replay menu and hover over saved filters - tooltip should appear on the right
- [ ] Open session replay menu and hover over collections - tooltip should appear on the right
