### PR TITLE
feat(llma): bump trace summarization batch size to 2

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -11,7 +11,7 @@ DEFAULT_MAX_ITEMS_PER_WINDOW = (
     15  # Max items to process per window (targets ~2500 summaries in 7-day clustering window)
 )
 DEFAULT_BATCH_SIZE = 5  # Number of generations to process in parallel
-DEFAULT_TRACE_BATCH_SIZE = 1  # Traces processed sequentially - formatting is CPU-intensive and holds the GIL
+DEFAULT_TRACE_BATCH_SIZE = 2  # Traces processed in small parallel batches
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)
 DEFAULT_WINDOW_OFFSET_MINUTES = 30  # Offset window into the past so traces have time to fully complete


### PR DESCRIPTION
## Problem

Trace summarization batch size was set to 1 (sequential) because formatting was believed to be CPU-intensive and hold the GIL. After #47220 replaced `TraceQueryRunner` with a simple direct query, profiling confirmed formatting takes ~0.3s per trace -- not a bottleneck.

## Changes

- Bump `DEFAULT_TRACE_BATCH_SIZE` from 1 to 2
- Update comment to reflect current understanding

## How did you test this code?

Manual team 2 workflow on prod-us completed 5 traces in 28s with the new query path. Batch size increase is safe given the low per-trace CPU cost.

## Publish to changelog?

No