### PR TITLE
feat(revenue-analytics): adds a dropoff event property for subscriptions

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -28561,6 +28561,10 @@
                     "description": "The number of days we still consider a subscription to be active after the last event. This is useful to avoid the current month's data to look as if most of the subscriptions have churned since we might not have an event for the current month.",
                     "type": "number"
                 },
+                "subscriptionDropoffDaysProperty": {
+                    "description": "Property used to override the subscription dropoff days for the event. If set, this value takes precedence over subscriptionDropoffDays.",
+                    "type": "string"
+                },
                 "subscriptionDropoffMode": {
                     "$ref": "#/definitions/SubscriptionDropoffMode",
                     "default": "last_event",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -4275,6 +4275,12 @@ export interface RevenueAnalyticsEventItem {
     subscriptionDropoffDays: number
 
     /**
+     * Property used to override the subscription dropoff days for the event.
+     * If set, this value takes precedence over subscriptionDropoffDays.
+     */
+    subscriptionDropoffDaysProperty?: string
+
+    /**
      * After a subscription has dropped off, when should we consider it to have ended?
      * It should either be at the date of the last event (will alter past periods, the default),
      * or at the date of the last event plus the dropoff period.

--- a/posthog/management/commands/generate_revenue_analytics_subscription_data.py
+++ b/posthog/management/commands/generate_revenue_analytics_subscription_data.py
@@ -1,0 +1,156 @@
+"""
+Generate realistic subscription revenue events for revenue analytics.
+
+Usage:
+    ./manage.py generate_revenue_analytics_subscription_data --team-id=1
+"""
+
+from __future__ import annotations
+
+import uuid
+import random
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+import structlog
+from dateutil.relativedelta import relativedelta
+
+from posthog.api.capture import capture_internal
+from posthog.models import Team
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class Plan:
+    name: str
+    product_id: str
+    monthly_price: int
+    annual_price: int
+    currency: str
+    dropoff_days: int
+
+
+def add_months(timestamp: datetime, months: int) -> datetime:
+    return timestamp + relativedelta(months=months)
+
+
+def add_years(timestamp: datetime, years: int) -> datetime:
+    return timestamp + relativedelta(years=years)
+
+
+class Command(BaseCommand):
+    help = "Generate realistic subscription charge events via capture_internal"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", type=int, required=True, help="Team ID to create events for")
+        parser.add_argument("--num-customers", type=int, default=50, help="Number of customers to generate")
+        parser.add_argument("--start-date", type=str, default="2024-01-01", help="Start date (YYYY-MM-DD)")
+        parser.add_argument("--months", type=int, default=12, help="Months of activity to generate")
+        parser.add_argument("--event-name", type=str, default="subscription_charge", help="Event name to emit")
+        parser.add_argument("--revenue-property", type=str, default="price", help="Property for revenue amount")
+        parser.add_argument(
+            "--subscription-property",
+            type=str,
+            default="subscription_id",
+            help="Property for subscription identifier",
+        )
+        parser.add_argument("--product-property", type=str, default="product_id", help="Property for product id")
+        parser.add_argument("--coupon-property", type=str, default="coupon", help="Property for coupon id")
+        parser.add_argument(
+            "--dropoff-days-property",
+            type=str,
+            default="dropoff_days",
+            help="Property for subscription dropoff days",
+        )
+        parser.add_argument("--seed", type=int, help="Random seed for reproducibility")
+
+    def handle(self, *args, **options):
+        team_id = options["team_id"]
+        num_customers = options["num_customers"]
+        start_date = datetime.fromisoformat(options["start_date"]).replace(tzinfo=UTC)
+        months = options["months"]
+        event_name = options["event_name"]
+        revenue_property = options["revenue_property"]
+        subscription_property = options["subscription_property"]
+        product_property = options["product_property"]
+        coupon_property = options["coupon_property"]
+        dropoff_days_property = options["dropoff_days_property"]
+        seed = options.get("seed")
+
+        if seed is not None:
+            random.seed(seed)
+
+        try:
+            team = Team.objects.get(pk=team_id)
+        except Team.DoesNotExist:
+            self.stderr.write(self.style.ERROR(f"Team with ID {team_id} does not exist!"))
+            return
+
+        plans = [
+            Plan("Starter", "starter", monthly_price=29, annual_price=290, currency="USD", dropoff_days=30),
+            Plan("Pro", "pro", monthly_price=79, annual_price=790, currency="USD", dropoff_days=45),
+            Plan("Business", "business", monthly_price=199, annual_price=1990, currency="USD", dropoff_days=60),
+        ]
+
+        token = team.api_token
+        self.stdout.write(self.style.SUCCESS(f"Seeding revenue events for team '{team.name}' (ID: {team_id})"))
+        self.stdout.write(f"  Customers: {num_customers}")
+        self.stdout.write(f"  Months: {months}")
+        self.stdout.write(f"  Event: {event_name}")
+
+        failures = 0
+        events_sent = 0
+
+        for customer_index in range(num_customers):
+            distinct_id = f"customer_{customer_index}_{uuid.uuid4()}"
+            subscription_id = f"sub_{uuid.uuid4()}"
+            plan = random.choice(plans)
+            is_annual = random.random() < 0.2
+            churn_after = random.randint(3, months) if random.random() < 0.35 else months
+            coupon = f"PROMO{random.randint(10, 40)}" if random.random() < 0.15 else None
+
+            for period_index in range(churn_after if not is_annual else max(1, churn_after // 12)):
+                timestamp = add_years(start_date, period_index) if is_annual else add_months(start_date, period_index)
+
+                price = plan.annual_price if is_annual else plan.monthly_price
+                if period_index > 0 and random.random() < 0.1:
+                    price = int(price * 1.25)
+
+                properties: dict[str, Any] = {
+                    subscription_property: subscription_id,
+                    product_property: plan.product_id,
+                    revenue_property: price,
+                    "currency": plan.currency,
+                    "plan": plan.name,
+                    "billing_period": "annual" if is_annual else "monthly",
+                    dropoff_days_property: plan.dropoff_days,
+                }
+                if coupon and period_index < 2:
+                    properties[coupon_property] = coupon
+
+                try:
+                    resp = capture_internal(
+                        token=token,
+                        event_name=event_name,
+                        event_source="generate_revenue_analytics_subscription_data",
+                        distinct_id=distinct_id,
+                        timestamp=timestamp,
+                        properties=properties,
+                        process_person_profile=True,
+                    )
+                    resp.raise_for_status()
+                    events_sent += 1
+                except Exception as e:
+                    failures += 1
+                    logger.warning(
+                        "subscription_event_failed",
+                        distinct_id=distinct_id,
+                        error=str(e),
+                        subscription_id=subscription_id,
+                    )
+
+        self.stdout.write(self.style.SUCCESS(f"Finished. Sent {events_sent} events, failures: {failures}."))

--- a/posthog/models/team/team_revenue_analytics_config.py
+++ b/posthog/models/team/team_revenue_analytics_config.py
@@ -43,7 +43,12 @@ class TeamRevenueAnalyticsConfig(models.Model):
             dumped_value = [RevenueAnalyticsEventItem.model_validate(event).model_dump() for event in value]
             # Sanitize empty strings to None for optional property fields
             for event in dumped_value:
-                for key in ("subscriptionProperty", "productProperty", "couponProperty"):
+                for key in (
+                    "subscriptionProperty",
+                    "subscriptionDropoffDaysProperty",
+                    "productProperty",
+                    "couponProperty",
+                ):
                     if event.get(key) == "":
                         event[key] = None
             self._events = dumped_value

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5794,8 +5794,8 @@ class RevenueAnalyticsEventItem(BaseModel):
     subscriptionDropoffDaysProperty: str | None = Field(
         default=None,
         description=(
-            "Property used to override the subscription dropoff days for the event."
-            " If set, this value takes precedence over subscriptionDropoffDays."
+            "Property used to override the subscription dropoff days for the event. If"
+            " set, this value takes precedence over subscriptionDropoffDays."
         ),
     )
     subscriptionDropoffMode: SubscriptionDropoffMode | None = Field(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5791,6 +5791,13 @@ class RevenueAnalyticsEventItem(BaseModel):
             " event for the current month."
         ),
     )
+    subscriptionDropoffDaysProperty: str | None = Field(
+        default=None,
+        description=(
+            "Property used to override the subscription dropoff days for the event."
+            " If set, this value takes precedence over subscriptionDropoffDays."
+        ),
+    )
     subscriptionDropoffMode: SubscriptionDropoffMode | None = Field(
         default=SubscriptionDropoffMode.LAST_EVENT,
         description=(

--- a/products/revenue_analytics/frontend/settings/EventConfiguration.tsx
+++ b/products/revenue_analytics/frontend/settings/EventConfiguration.tsx
@@ -164,7 +164,18 @@ export function EventConfiguration({ buttonRef }: { buttonRef?: React.RefObject<
                                             {item.subscriptionProperty}
                                         </code>
                                         <div className="text-xs text-muted-alt">
-                                            Drop subscription after {item.subscriptionDropoffDays} days
+                                            Dropoff days:{' '}
+                                            {item.subscriptionDropoffDaysProperty ? (
+                                                <>
+                                                    from{' '}
+                                                    <code className="bg-bg-lighter px-1 rounded text-xs">
+                                                        {item.subscriptionDropoffDaysProperty}
+                                                    </code>{' '}
+                                                    (fallback {item.subscriptionDropoffDays})
+                                                </>
+                                            ) : (
+                                                item.subscriptionDropoffDays
+                                            )}
                                         </div>
                                         <div className="text-xs text-muted-alt">
                                             Subscription ends on the day{' '}

--- a/products/revenue_analytics/frontend/settings/EventConfigurationModal.tsx
+++ b/products/revenue_analytics/frontend/settings/EventConfigurationModal.tsx
@@ -41,6 +41,7 @@ export function EventConfigurationModal({ event, onClose }: EventConfigurationMo
         updateEventCouponProperty,
         updateEventSubscriptionProperty,
         updateEventSubscriptionDropoffDays,
+        updateEventSubscriptionDropoffDaysProperty,
         updateEventSubscriptionDropoffMode,
         save,
     } = useActions(revenueAnalyticsSettingsLogic)
@@ -90,6 +91,10 @@ export function EventConfigurationModal({ event, onClose }: EventConfigurationMo
             updateEventCouponProperty(originalEvent.eventName, originalEvent.couponProperty || '')
             updateEventSubscriptionProperty(originalEvent.eventName, originalEvent.subscriptionProperty || '')
             updateEventSubscriptionDropoffDays(originalEvent.eventName, originalEvent.subscriptionDropoffDays)
+            updateEventSubscriptionDropoffDaysProperty(
+                originalEvent.eventName,
+                originalEvent.subscriptionDropoffDaysProperty || ''
+            )
             updateEventSubscriptionDropoffMode(originalEvent.eventName, originalEvent.subscriptionDropoffMode)
         } else if (eventName) {
             deleteEvent(eventName)
@@ -307,10 +312,13 @@ export function EventConfigurationModal({ event, onClose }: EventConfigurationMo
                 {/* Subscription Configuration */}
                 <div className="space-y-3">
                     <h4 className="text-md font-semibold">Subscription Tracking</h4>
+                    <p className="text-xs text-muted-alt">
+                        Define how to identify a subscription and when it should be considered ended.
+                    </p>
 
                     <div className="space-y-3">
                         <div className="space-y-1">
-                            <label className="text-sm font-medium">Subscription Property</label>
+                            <label className="text-sm font-medium">Subscription identifier property</label>
                             <TaxonomicPopover
                                 groupType={TaxonomicFilterGroupType.EventProperties}
                                 onChange={(propertyName) => {
@@ -323,14 +331,13 @@ export function EventConfigurationModal({ event, onClose }: EventConfigurationMo
                                 disabledReason={!currentEvent?.eventName ? 'Select an event name first' : undefined}
                             />
                             <p className="text-xs text-muted-alt">
-                                Track subscription information for ARPU and LTV calculations. Recommended for better
-                                revenue insights.
+                                Used to group recurring revenue events into subscriptions.
                             </p>
                         </div>
 
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <div className="space-y-1">
-                                <label className="text-sm font-medium">Dropoff Days</label>
+                                <label className="text-sm font-medium">Default dropoff days</label>
                                 <LemonInput
                                     type="number"
                                     min={1}
@@ -346,13 +353,32 @@ export function EventConfigurationModal({ event, onClose }: EventConfigurationMo
                                     }}
                                     disabledReason={!currentEvent?.eventName ? 'Select an event name first' : undefined}
                                 />
+                                <p className="text-xs text-muted-alt">Used when no override property is set.</p>
+                            </div>
+
+                            <div className="space-y-1">
+                                <label className="text-sm font-medium">Dropoff days override property</label>
+                                <TaxonomicPopover
+                                    groupType={TaxonomicFilterGroupType.EventProperties}
+                                    onChange={(propertyName) => {
+                                        if (currentEvent?.eventName) {
+                                            updateEventSubscriptionDropoffDaysProperty(
+                                                currentEvent.eventName,
+                                                propertyName || ''
+                                            )
+                                        }
+                                    }}
+                                    value={currentEvent?.subscriptionDropoffDaysProperty || undefined}
+                                    placeholder="Select dropoff days property (optional)"
+                                    disabledReason={!currentEvent?.eventName ? 'Select an event name first' : undefined}
+                                />
                                 <p className="text-xs text-muted-alt">
-                                    Days to consider subscription active after last event
+                                    If set, this value is used instead of the default.
                                 </p>
                             </div>
 
                             <div className="space-y-1">
-                                <label className="text-sm font-medium">Dropoff Mode</label>
+                                <label className="text-sm font-medium">Subscription end date</label>
                                 <LemonSelect<SubscriptionDropoffMode>
                                     value={currentEvent?.subscriptionDropoffMode || 'last_event'}
                                     onChange={(value) => {

--- a/products/revenue_analytics/frontend/settings/revenueAnalyticsSettingsLogic.ts
+++ b/products/revenue_analytics/frontend/settings/revenueAnalyticsSettingsLogic.ts
@@ -101,6 +101,10 @@ export const revenueAnalyticsSettingsLogic = kea<revenueAnalyticsSettingsLogicTy
         updateEventRevenueProperty: (eventName: string, property: string) => ({ eventName, property }),
         updateEventSubscriptionProperty: (eventName: string, property: string) => ({ eventName, property }),
         updateEventSubscriptionDropoffDays: (eventName: string, property: number) => ({ eventName, property }),
+        updateEventSubscriptionDropoffDaysProperty: (eventName: string, property: string) => ({
+            eventName,
+            property,
+        }),
         updateEventSubscriptionDropoffMode: (eventName: string, property: SubscriptionDropoffMode) => ({
             eventName,
             property,
@@ -160,6 +164,9 @@ export const revenueAnalyticsSettingsLogic = kea<revenueAnalyticsSettingsLogicTy
                 updateEventRevenueProperty: updatePropertyReducerBuilder('revenueProperty'),
                 updateEventSubscriptionProperty: updatePropertyReducerBuilder('subscriptionProperty'),
                 updateEventSubscriptionDropoffDays: updatePropertyReducerBuilder('subscriptionDropoffDays'),
+                updateEventSubscriptionDropoffDaysProperty: updatePropertyReducerBuilder(
+                    'subscriptionDropoffDaysProperty'
+                ),
                 updateEventSubscriptionDropoffMode: updatePropertyReducerBuilder('subscriptionDropoffMode'),
 
                 addGoal: (state: RevenueAnalyticsConfig | null, { goal }) => {


### PR DESCRIPTION
## Problem

Enable revenue analytics subscriptions to use per-event dropoff days from a property (with safe fallback), so teams can model churn windows dynamically instead of a fixed static value.  
Closes #37981

## Changes

- Add `subscriptionDropoffDaysProperty` to revenue analytics event config (backend + TS).
- Use latest event’s property value for dropoff days in subscription view with safe fallback.
- Update settings UI labels for clarity.
- Add query-structure tests for the override path.

![Screenshot 2026-02-07 at 22.13.43.png](https://app.graphite.com/user-attachments/assets/f01261d7-3c18-4d5a-b4ca-e2810bacf74d.png)

## How did you test this code?

- `pytest products/revenue_analytics/backend/views/sources/test/events/test_events_subscription.py -v`

## Publish to changelog?

no