### PR TITLE
test(experiments): adding unit tests for the new parse message function.

### DIFF
--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -3,7 +3,7 @@ import posthog from 'posthog-js'
 import api, { ApiError } from 'lib/api'
 
 import { useMocks } from '~/mocks/jest'
-import { performQuery, pollForResults, queryExportContext } from '~/queries/query'
+import { parseErrorMessage, performQuery, pollForResults, queryExportContext } from '~/queries/query'
 import { EventsQuery, HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { PropertyFilterType, PropertyOperator } from '~/types'
@@ -196,6 +196,189 @@ describe('query', () => {
 
             await expect(pollForResults('test-query-id')).rejects.toMatchObject({
                 detail: { nested: 'object' },
+            })
+        })
+    })
+
+    describe('parseErrorMessage', () => {
+        it('parses ErrorDetail list format', () => {
+            const result = parseErrorMessage(
+                "[ErrorDetail(string='Query exceeded memory limit', code='memory_limit_exceeded')]"
+            )
+            expect(result).toEqual({ message: 'Query exceeded memory limit', code: 'memory_limit_exceeded' })
+        })
+
+        it('parses ErrorDetail single format', () => {
+            const result = parseErrorMessage("ErrorDetail(string='Database connection failed', code='db_error')")
+            expect(result).toEqual({ message: 'Database connection failed', code: 'db_error' })
+        })
+
+        it('handles plain string messages', () => {
+            const result = parseErrorMessage('Simple error message')
+            expect(result).toEqual({ message: 'Simple error message', code: null })
+        })
+
+        it('handles empty string', () => {
+            const result = parseErrorMessage('')
+            expect(result).toEqual({ message: '', code: null })
+        })
+
+        it('handles undefined', () => {
+            const result = parseErrorMessage(undefined)
+            expect(result).toEqual({ message: '', code: null })
+        })
+
+        it('handles messages with special characters', () => {
+            const result = parseErrorMessage(
+                "[ErrorDetail(string='Error: Invalid query \"SELECT *\"', code='syntax_error')]"
+            )
+            expect(result).toEqual({ message: 'Error: Invalid query "SELECT *"', code: 'syntax_error' })
+        })
+
+        it('handles messages with single quotes using double quote delimiters', () => {
+            // Backend uses double quotes for the string value when the message contains single quotes
+            const result = parseErrorMessage("ErrorDetail(string=\"User's query failed\", code='user_error')")
+            expect(result).toEqual({
+                message: "User's query failed",
+                code: 'user_error',
+            })
+        })
+
+        it('preserves malformed ErrorDetail strings', () => {
+            const result = parseErrorMessage("ErrorDetail(string='Incomplete")
+            expect(result).toEqual({ message: "ErrorDetail(string='Incomplete", code: null })
+        })
+
+        it('handles ErrorDetail with missing code', () => {
+            const result = parseErrorMessage("ErrorDetail(string='Error message')")
+            expect(result).toEqual({ message: "ErrorDetail(string='Error message')", code: null })
+        })
+
+        it('handles ErrorDetail with extra whitespace', () => {
+            const result = parseErrorMessage("[ErrorDetail(string='Test error',   code='test_code')]")
+            expect(result).toEqual({ message: 'Test error', code: 'test_code' })
+        })
+
+        it('parses ErrorDetail with double quotes in list format', () => {
+            const result = parseErrorMessage(
+                "[ErrorDetail(string=\"Invalid metric configuration: breakdown property 'user_id' does not exist.\", code='invalid')]"
+            )
+            expect(result).toEqual({
+                message: "Invalid metric configuration: breakdown property 'user_id' does not exist.",
+                code: 'invalid',
+            })
+        })
+
+        it('parses ErrorDetail with double quotes in single format', () => {
+            const result = parseErrorMessage('ErrorDetail(string="Database error occurred", code=\'db_error\')')
+            expect(result).toEqual({ message: 'Database error occurred', code: 'db_error' })
+        })
+
+        describe('experiment error messages', () => {
+            it('parses memory limit exceeded error', () => {
+                const result = parseErrorMessage(
+                    "[ErrorDetail(string='This experiment query is using too much memory. Try viewing a shorter time period or contact support for help.', code='memory_limit_exceeded')]"
+                )
+                expect(result).toEqual({
+                    message:
+                        'This experiment query is using too much memory. Try viewing a shorter time period or contact support for help.',
+                    code: 'memory_limit_exceeded',
+                })
+            })
+
+            it('parses too many variants error', () => {
+                const result = parseErrorMessage(
+                    "[ErrorDetail(string='Can\\'t calculate experiment results for more than 10 variants', code='too_much_data')]"
+                )
+                expect(result).toEqual({
+                    message: "Can't calculate experiment results for more than 10 variants",
+                    code: 'too_much_data',
+                })
+            })
+
+            it('parses too few variants error', () => {
+                const result = parseErrorMessage(
+                    "[ErrorDetail(string='Can\\'t calculate experiment results for less than 2 variants', code='no_data')]"
+                )
+                expect(result).toEqual({
+                    message: "Can't calculate experiment results for less than 2 variants",
+                    code: 'no_data',
+                })
+            })
+
+            it('parses no results validation error', () => {
+                const result = parseErrorMessage(
+                    '[ErrorDetail(string=\'{"no-control-variant": true, "no-test-variant": false}\', code=\'no-results\')]'
+                )
+                expect(result).toEqual({
+                    message: '{"no-control-variant": true, "no-test-variant": false}',
+                    code: 'no-results',
+                })
+            })
+
+            it('parses validation error without code', () => {
+                const result = parseErrorMessage('experiment_id is required')
+                expect(result).toEqual({
+                    message: 'experiment_id is required',
+                    code: null,
+                })
+            })
+
+            it('parses statistic calculation error', () => {
+                const result = parseErrorMessage(
+                    'Unable to calculate experiment statistics. Please ensure your experiment has sufficient data and try again.'
+                )
+                expect(result).toEqual({
+                    message:
+                        'Unable to calculate experiment statistics. Please ensure your experiment has sufficient data and try again.',
+                    code: null,
+                })
+            })
+
+            it('parses HogQL error message', () => {
+                const result = parseErrorMessage(
+                    'Unable to process your experiment query. Please check your metric configuration and try again.'
+                )
+                expect(result).toEqual({
+                    message:
+                        'Unable to process your experiment query. Please check your metric configuration and try again.',
+                    code: null,
+                })
+            })
+
+            it('parses ClickHouse error message', () => {
+                const result = parseErrorMessage('Unable to retrieve experiment data. Please try refreshing the page.')
+                expect(result).toEqual({
+                    message: 'Unable to retrieve experiment data. Please try refreshing the page.',
+                    code: null,
+                })
+            })
+
+            it('parses zero division error message', () => {
+                const result = parseErrorMessage(
+                    'Unable to calculate results due to insufficient data. Please wait for more experiment data.'
+                )
+                expect(result).toEqual({
+                    message:
+                        'Unable to calculate results due to insufficient data. Please wait for more experiment data.',
+                    code: null,
+                })
+            })
+
+            it('parses maximum breakdowns error', () => {
+                const result = parseErrorMessage('Maximum of 3 breakdowns are supported for experiment metrics')
+                expect(result).toEqual({
+                    message: 'Maximum of 3 breakdowns are supported for experiment metrics',
+                    code: null,
+                })
+            })
+
+            it('parses experiment not found error', () => {
+                const result = parseErrorMessage('Experiment with id 123 not found')
+                expect(result).toEqual({
+                    message: 'Experiment with id 123 not found',
+                    code: null,
+                })
             })
         })
     })


### PR DESCRIPTION
## Problem

Some error details returned by the backend are not parsed correctly, so we default to including labels when the `MetricErrorState` returns the error to the user.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We just added unit tests to cover the existing checks and the new case we've found while testing the new metric error state.

| before | after |
| - | - |
| <img width="314" height="150" alt="image" src="https://github.com/user-attachments/assets/2710f62b-dd66-49e3-8d96-3ee19389603b" /> | <img width="300" height="136" alt="image" src="https://github.com/user-attachments/assets/a489d97a-648b-4300-87a8-e227245e99dc" /> | 


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/4a5814c5-b353-49fa-bec8-850df8c06b8a)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
