### PR TITLE
feat(llma): 5/5 route sentiment workflows to dedicated task queue

### DIFF
--- a/nodejs/src/llm-analytics/services/temporal.service.ts
+++ b/nodejs/src/llm-analytics/services/temporal.service.ts
@@ -19,7 +19,7 @@ export type TemporalServiceHub = Pick<
 >
 
 const EVALUATION_TASK_QUEUE = isDevEnv() ? 'development-task-queue' : 'llm-analytics-evals-task-queue'
-const SENTIMENT_TASK_QUEUE = isDevEnv() ? 'development-task-queue' : 'llm-analytics-task-queue'
+const SENTIMENT_TASK_QUEUE = isDevEnv() ? 'development-task-queue' : 'llm-analytics-sentiment-task-queue'
 
 const temporalWorkflowsStarted = new Counter({
     name: 'evaluation_run_workflows_started',


### PR DESCRIPTION
## Problem

Part of #47244 (PR 4/4 in stack, depends on #47247).

Final step in the migration: switch the Kafka sentiment scheduler to target the new dedicated `llm-analytics-sentiment-task-queue` instead of the shared `llm-analytics-task-queue`.

### Deploy prereqs

- PR 3 (#47247) must be deployed
- Charts repo PR (`feat/llma-sentiment-worker`) must be deployed so the worker is running

## Changes

- `nodejs/src/llm-analytics/services/temporal.service.ts` — changes `SENTIMENT_TASK_QUEUE` from `llm-analytics-task-queue` to `llm-analytics-sentiment-task-queue`

One-line change. All new sentiment workflows will route to the dedicated worker after this lands.

## How did you test this code?

- Verified the constant change compiles
- In dev mode, both queues resolve to `development-task-queue` so local behavior is unchanged
- Production verification: check Temporal UI for workflows landing on the new queue after deploy

## Publish to changelog?

No — infrastructure routing change only.