### PR TITLE
_

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
@@ -1,12 +1,10 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { CSSProperties, useEffect } from 'react'
+import { useEffect } from 'react'
 
 import { IconPlusSmall } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
-import { objectsEqual } from 'lib/utils'
-
-import { AnyPropertyFilter, EmptyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { SimpleOption, TaxonomicFilterGroupType } from '../TaxonomicFilter/types'
 import { PathItemSelector } from './components/PathItemSelector'
@@ -18,7 +16,6 @@ interface PropertyFiltersProps {
     propertyFilters?: AnyPropertyFilter[] | null
     onChange: (filters: AnyPropertyFilter[]) => void
     pageKey: string
-    style?: CSSProperties
     taxonomicGroupTypes: TaxonomicFilterGroupType[]
     wildcardOptions?: SimpleOption[]
 }
@@ -31,20 +28,18 @@ export function PathItemFilters({
     wildcardOptions,
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey }
-    const { filtersWithNew } = useValues(propertyFilterLogic(logicProps))
+    const { filtersWithNew, filterIdsWithNew } = useValues(propertyFilterLogic(logicProps))
     const { setFilter, remove, setFilters } = useActions(propertyFilterLogic(logicProps))
 
     useEffect(() => {
-        if (propertyFilters && !objectsEqual(propertyFilters, filtersWithNew)) {
-            setFilters([...propertyFilters, {} as EmptyPropertyFilter])
-        }
-    }, [propertyFilters]) // oxlint-disable-line react-hooks/exhaustive-deps
+        setFilters(propertyFilters ?? [])
+    }, [propertyFilters, setFilters])
 
     return (
         <BindLogic logic={propertyFilterLogic} props={logicProps}>
             {filtersWithNew?.map((filter: AnyPropertyFilter, index: number) => {
                 return (
-                    <div key={index} className="mb-2">
+                    <div key={filterIdsWithNew[index]} className="mb-2">
                         <PathItemSelector
                             pathItem={filter.value as string | undefined}
                             onChange={(pathItem) =>

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.test.tsx
@@ -1,0 +1,210 @@
+import '@testing-library/jest-dom'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { actionsModel } from '~/models/actionsModel'
+import { groupsModel } from '~/models/groupsModel'
+import { initKeaTests } from '~/test/init'
+import { mockActionDefinition, mockGetEventDefinitions, mockGetPropertyDefinitions } from '~/test/mocks'
+import { PropertyFilterType, PropertyOperator } from '~/types'
+
+import { TaxonomicFilterGroupType } from '../TaxonomicFilter/types'
+import { PropertyFilters } from './PropertyFilters'
+
+jest.mock('lib/components/AutoSizer', () => ({
+    AutoSizer: ({ renderProp }: { renderProp: (size: { height: number; width: number }) => React.ReactNode }) =>
+        renderProp({ height: 400, width: 400 }),
+}))
+
+describe('PropertyFilters', () => {
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team/event_definitions': mockGetEventDefinitions,
+                '/api/projects/:team/property_definitions': mockGetPropertyDefinitions,
+                '/api/projects/:team/actions': { results: [mockActionDefinition] },
+                '/api/environments/:team/persons/properties': [
+                    { id: 1, name: 'location', count: 1 },
+                    { id: 2, name: 'role', count: 2 },
+                ],
+                '/api/environments/:team/events/values': [{ name: 'Chrome' }, { name: 'Firefox' }, { name: 'Safari' }],
+            },
+            post: {
+                '/api/environments/:team/query': { results: [] },
+            },
+        })
+        initKeaTests()
+        actionsModel.mount()
+        groupsModel.mount()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    function renderPropertyFilters(
+        props: Partial<React.ComponentProps<typeof PropertyFilters>> = {}
+    ): ReturnType<typeof render> & { onChange: jest.Mock } {
+        const onChange = jest.fn()
+        const result = render(
+            <Provider>
+                <PropertyFilters
+                    pageKey="test-page"
+                    onChange={onChange}
+                    taxonomicGroupTypes={[
+                        TaxonomicFilterGroupType.EventProperties,
+                        TaxonomicFilterGroupType.PersonProperties,
+                    ]}
+                    {...props}
+                />
+            </Provider>
+        )
+        return { ...result, onChange }
+    }
+
+    const BROWSER_FILTER = {
+        key: '$browser',
+        type: PropertyFilterType.Event,
+        value: 'Chrome',
+        operator: PropertyOperator.Exact,
+    } as const
+
+    const OS_FILTER = {
+        key: '$os',
+        type: PropertyFilterType.Event,
+        value: 'Mac',
+        operator: PropertyOperator.Exact,
+    } as const
+
+    it('add filter: click add, search, select property, verify onChange shape', async () => {
+        const { onChange } = renderPropertyFilters({ sendAllKeyUpdates: true })
+
+        userEvent.click(screen.getByTestId('new-prop-filter-test-page'))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('taxonomic-filter-searchfield')).toBeInTheDocument()
+        })
+
+        userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), '$browser')
+
+        await waitFor(() => {
+            expect(screen.getAllByText('$browser').length).toBeGreaterThanOrEqual(1)
+        })
+
+        userEvent.click(screen.getByTestId('prop-filter-event_properties-0'))
+
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalled()
+        })
+        const filters = onChange.mock.calls[onChange.mock.calls.length - 1][0]
+        expect(filters[0].key).toBe('$browser')
+        expect(filters[0].type).toBe('event')
+    })
+
+    it('remove first of two filters: onChange has only the remaining filter', async () => {
+        const { onChange } = renderPropertyFilters({
+            propertyFilters: [BROWSER_FILTER, OS_FILTER],
+        })
+
+        expect(screen.getByText(/Chrome/)).toBeInTheDocument()
+        expect(screen.getByText(/Mac/)).toBeInTheDocument()
+
+        const firstRow = screen.getByTestId('property-filter-0')
+        const closeButton = firstRow.querySelector('.PropertyFilterButton--closeable .LemonButton')
+        userEvent.click(closeButton!)
+
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalled()
+        })
+
+        const remaining = onChange.mock.calls[onChange.mock.calls.length - 1][0]
+        expect(remaining).toHaveLength(1)
+        expect(remaining[0].key).toBe('$os')
+        expect(remaining[0].value).toBe('Mac')
+    })
+
+    it('round-trip: onChange output fed back as props renders correctly', async () => {
+        const onChange = jest.fn()
+        const { rerender } = render(
+            <Provider>
+                <PropertyFilters
+                    pageKey="round-trip"
+                    onChange={onChange}
+                    propertyFilters={[]}
+                    taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
+                    sendAllKeyUpdates={true}
+                />
+            </Provider>
+        )
+
+        userEvent.click(screen.getByTestId('new-prop-filter-round-trip'))
+        await waitFor(() => {
+            expect(screen.getByTestId('taxonomic-filter-searchfield')).toBeInTheDocument()
+        })
+
+        userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), '$browser')
+        await waitFor(() => {
+            expect(screen.getAllByText('$browser').length).toBeGreaterThanOrEqual(1)
+        })
+
+        userEvent.click(screen.getByTestId('prop-filter-event_properties-0'))
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalled()
+        })
+
+        // Feed onChange output back as props (simulates real parent component behavior)
+        const outputFilters = onChange.mock.calls[onChange.mock.calls.length - 1][0]
+        rerender(
+            <Provider>
+                <PropertyFilters
+                    pageKey="round-trip"
+                    onChange={onChange}
+                    propertyFilters={outputFilters}
+                    taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
+                    sendAllKeyUpdates={true}
+                />
+            </Provider>
+        )
+
+        const pill = screen.getByTestId('property-filter-0').querySelector('.PropertyFilterButton-content')
+        expect(pill?.textContent).toMatch(/Browser/)
+    })
+
+    it('does not change reducer state when re-rendered with same filter values', () => {
+        const filters = [BROWSER_FILTER]
+        const onChange = jest.fn()
+
+        const { rerender } = render(
+            <Provider>
+                <PropertyFilters
+                    pageKey="test-rerender"
+                    onChange={onChange}
+                    propertyFilters={[...filters]}
+                    taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
+                />
+            </Provider>
+        )
+
+        expect(screen.getByTestId('property-filter-0')).toBeInTheDocument()
+
+        const { propertyFilterLogic } = require('./propertyFilterLogic')
+        const logic = propertyFilterLogic({ pageKey: 'test-rerender', onChange, sendAllKeyUpdates: false })
+        const stateBefore = logic.values._filtersState
+
+        rerender(
+            <Provider>
+                <PropertyFilters
+                    pageKey="test-rerender"
+                    onChange={onChange}
+                    propertyFilters={[...filters]}
+                    taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
+                />
+            </Provider>
+        )
+
+        expect(logic.values._filtersState).toBe(stateBefore)
+        expect(screen.getByTestId('property-filter-0')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -91,14 +91,16 @@ export function PropertyFilters({
     operatorAllowlist,
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey, sendAllKeyUpdates }
-    const { filters, filtersWithNew } = useValues(propertyFilterLogic(logicProps))
+    const { filters, filtersWithNew, filterIds, filterIdsWithNew } = useValues(propertyFilterLogic(logicProps))
     const { remove, setFilters, setFilter } = useActions(propertyFilterLogic(logicProps))
     const [allowOpenOnInsert, setAllowOpenOnInsert] = useState<boolean>(false)
 
-    // Update the logic's internal filters when the props change
     useEffect(() => {
         setFilters(propertyFilters ?? [])
     }, [propertyFilters, setFilters])
+
+    const displayedFilters = allowNew && editable ? filtersWithNew : filters
+    const displayedFilterIds = allowNew && editable ? filterIdsWithNew : filterIds
 
     // do not open on initial render, only open if newly inserted
     useOnMountEffect(() => setAllowOpenOnInsert(true))
@@ -112,14 +114,13 @@ export function PropertyFilters({
             )}
             <div className="PropertyFilters__content max-w-full">
                 <BindLogic logic={propertyFilterLogic} props={logicProps}>
-                    {(allowNew && editable ? filtersWithNew : filters).map((item: AnyPropertyFilter, index: number) => {
+                    {displayedFilters.map((item: AnyPropertyFilter, index: number) => {
                         return (
-                            <React.Fragment key={index}>
+                            <React.Fragment key={displayedFilterIds[index]}>
                                 {logicalRowDivider && index > 0 && index !== filtersWithNew.length - 1 && (
                                     <LogicalRowDivider logicalOperator={FilterLogicalOperator.And} />
                                 )}
                                 <FilterRow
-                                    key={index}
                                     item={item}
                                     index={index}
                                     totalCount={filtersWithNew.length - 1} // empty state
@@ -134,7 +135,6 @@ export function PropertyFilters({
                                     editable={editable}
                                     filterComponent={(onComplete) => (
                                         <TaxonomicPropertyFilter
-                                            key={index}
                                             pageKey={pageKey}
                                             index={index}
                                             filters={filters}

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
@@ -1,0 +1,120 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { propertyFilterLogic } from 'lib/components/PropertyFilters/propertyFilterLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
+
+const eventFilter = (key: string, value?: string, operator?: PropertyOperator): AnyPropertyFilter =>
+    ({
+        key,
+        type: PropertyFilterType.Event,
+        ...(value !== undefined ? { value } : {}),
+        ...(operator !== undefined ? { operator } : {}),
+    }) as AnyPropertyFilter
+
+describe('propertyFilterLogic', () => {
+    let onChange: jest.Mock
+
+    beforeEach(() => {
+        useMocks({})
+        initKeaTests()
+        onChange = jest.fn()
+    })
+
+    function mountLogic(
+        overrides: { propertyFilters?: AnyPropertyFilter[]; sendAllKeyUpdates?: boolean } = {}
+    ): ReturnType<typeof propertyFilterLogic.build> {
+        const logic = propertyFilterLogic({
+            pageKey: 'test',
+            onChange,
+            ...overrides,
+        })
+        logic.mount()
+        return logic
+    }
+
+    describe('remove appends empty PropertyFilter correctly', () => {
+        it('leaves a single empty PropertyFilter when all filters are removed', () => {
+            const logic = mountLogic({
+                propertyFilters: [eventFilter('$browser', 'Chrome', PropertyOperator.Exact)],
+            })
+            logic.actions.remove(0)
+            expect(logic.values.filters).toEqual([{}])
+        })
+
+        it('appends empty PropertyFilter after removing if the last remaining filter is valid', () => {
+            const logic = mountLogic({
+                propertyFilters: [
+                    eventFilter('$browser', 'Chrome', PropertyOperator.Exact),
+                    eventFilter('$os', 'Mac', PropertyOperator.Exact),
+                ],
+            })
+            logic.actions.remove(0)
+            expect(logic.values.filters).toHaveLength(2)
+            expect(logic.values.filters[0].key).toBe('$os')
+            expect(Object.keys(logic.values.filters[1])).toHaveLength(0)
+        })
+
+        it('does not double-append if the last filter is already empty', () => {
+            const logic = mountLogic({
+                propertyFilters: [eventFilter('$browser', 'Chrome', PropertyOperator.Exact), {} as AnyPropertyFilter],
+            })
+            logic.actions.remove(0)
+            expect(logic.values.filters).toEqual([{}])
+        })
+    })
+
+    describe('setFilter conditionally calls onChange', () => {
+        async function setFilterAndCheck(filter: AnyPropertyFilter, sendAllKeyUpdates: boolean): Promise<jest.Mock> {
+            const logic = mountLogic({
+                propertyFilters: [{}] as AnyPropertyFilter[],
+                sendAllKeyUpdates,
+            })
+            logic.actions.setFilter(0, filter)
+            await expectLogic(logic).toFinishAllListeners()
+            return onChange
+        }
+
+        it('calls onChange for a filter with a value', async () => {
+            const cb = await setFilterAndCheck(eventFilter('$browser', 'Chrome', PropertyOperator.Exact), false)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not call onChange for a key-only filter', async () => {
+            const cb = await setFilterAndCheck(eventFilter('$browser'), false)
+            expect(cb).not.toHaveBeenCalled()
+        })
+
+        it('calls onChange for a key-only filter when sendAllKeyUpdates is true', async () => {
+            const cb = await setFilterAndCheck(eventFilter('$browser'), true)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        it('calls onChange for is_set operator without a value', async () => {
+            const cb = await setFilterAndCheck(eventFilter('$browser', undefined, PropertyOperator.IsSet), false)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        it('calls onChange for is_not_set operator without a value', async () => {
+            const cb = await setFilterAndCheck(eventFilter('$browser', undefined, PropertyOperator.IsNotSet), false)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        it('calls onChange for a HogQL filter with only a key', async () => {
+            const filter = {
+                key: "properties.$browser = 'Chrome'",
+                type: PropertyFilterType.HogQL,
+            } as AnyPropertyFilter
+            const cb = await setFilterAndCheck(filter, false)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not call onChange for a non-HogQL filter with only a key and no operator', async () => {
+            const filter = { key: '$browser', type: PropertyFilterType.Event } as AnyPropertyFilter
+            const cb = await setFilterAndCheck(filter, false)
+            expect(cb).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
@@ -128,7 +128,7 @@ describe('propertyFilterLogic', () => {
                         eventFilter('$device', 'Mobile', PropertyOperator.Exact),
                     ],
                 })
-                const [osId, deviceId] = logic.values.filterIds
+                const [browserId, osId, deviceId] = logic.values.filterIds
 
                 logic.actions.remove(0)
 

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.test.ts
@@ -117,4 +117,118 @@ describe('propertyFilterLogic', () => {
             expect(cb).not.toHaveBeenCalled()
         })
     })
+
+    describe('filter IDs are stable across mutations', () => {
+        describe('remove', () => {
+            it('preserves IDs of filters that were not removed', () => {
+                const logic = mountLogic({
+                    propertyFilters: [
+                        eventFilter('$browser', 'Chrome', PropertyOperator.Exact),
+                        eventFilter('$os', 'Mac', PropertyOperator.Exact),
+                        eventFilter('$device', 'Mobile', PropertyOperator.Exact),
+                    ],
+                })
+                const [osId, deviceId] = logic.values.filterIds
+
+                logic.actions.remove(0)
+
+                expect(logic.values.filterIds[0]).toBe(osId)
+                expect(logic.values.filterIds[1]).toBe(deviceId)
+            })
+        })
+
+        describe('setFilter', () => {
+            it('keeps the same ID when updating an existing position', () => {
+                const logic = mountLogic({
+                    propertyFilters: [
+                        eventFilter('$browser', 'Chrome', PropertyOperator.Exact),
+                        eventFilter('$os', 'Mac', PropertyOperator.Exact),
+                    ],
+                })
+                const idsBefore = [...logic.values.filterIds]
+
+                logic.actions.setFilter(0, eventFilter('$country', 'US', PropertyOperator.Exact))
+
+                expect(logic.values.filterIds).toEqual(idsBefore)
+            })
+
+            it('assigns a new ID when appending beyond current length', () => {
+                const logic = mountLogic({
+                    propertyFilters: [eventFilter('$browser', 'Chrome', PropertyOperator.Exact)],
+                })
+                const [browserId] = logic.values.filterIds
+
+                logic.actions.setFilter(1, eventFilter('$os', 'Mac', PropertyOperator.Exact))
+
+                expect(logic.values.filterIds[0]).toBe(browserId)
+                expect(logic.values.filterIds).toHaveLength(2)
+                expect(logic.values.filterIds[1]).not.toBe(browserId)
+            })
+        })
+
+        describe('setFilters', () => {
+            it('preserves IDs at positions that overlap with current items', () => {
+                const logic = mountLogic({
+                    propertyFilters: [
+                        eventFilter('$browser', 'Chrome', PropertyOperator.Exact),
+                        eventFilter('$os', 'Mac', PropertyOperator.Exact),
+                    ],
+                })
+                const [browserId, osId] = logic.values.filterIds
+
+                logic.actions.setFilters([
+                    eventFilter('$country', 'US', PropertyOperator.Exact),
+                    eventFilter('$city', 'SF', PropertyOperator.Exact),
+                    eventFilter('$region', 'CA', PropertyOperator.Exact),
+                ])
+
+                expect(logic.values.filterIds[0]).toBe(browserId)
+                expect(logic.values.filterIds[1]).toBe(osId)
+                expect(logic.values.filterIds[2]).not.toBe(browserId)
+                expect(logic.values.filterIds[2]).not.toBe(osId)
+            })
+
+            it('returns the same state reference when content is equal', () => {
+                const logic = mountLogic({
+                    propertyFilters: [eventFilter('$browser', 'Chrome', PropertyOperator.Exact)],
+                })
+                const stateBefore = logic.values._filtersState
+
+                logic.actions.setFilters([eventFilter('$browser', 'Chrome', PropertyOperator.Exact)])
+
+                expect(logic.values._filtersState).toBe(stateBefore)
+            })
+        })
+
+        describe('filterIdsWithNew', () => {
+            it('has the same length as filtersWithNew after each mutation', () => {
+                const logic = mountLogic({
+                    propertyFilters: [eventFilter('$browser', 'Chrome', PropertyOperator.Exact)],
+                })
+                expect(logic.values.filterIdsWithNew).toHaveLength(logic.values.filtersWithNew.length)
+
+                logic.actions.remove(0)
+                expect(logic.values.filterIdsWithNew).toHaveLength(logic.values.filtersWithNew.length)
+
+                logic.actions.setFilter(0, eventFilter('$os', 'Mac', PropertyOperator.Exact))
+                expect(logic.values.filterIdsWithNew).toHaveLength(logic.values.filtersWithNew.length)
+            })
+        })
+    })
+
+    describe('onChange receives cleaned filters', () => {
+        it('strips empty/invalid filters before calling onChange', async () => {
+            const logic = mountLogic({
+                propertyFilters: [eventFilter('$browser', 'Chrome', PropertyOperator.Exact), {} as AnyPropertyFilter],
+                sendAllKeyUpdates: true,
+            })
+
+            logic.actions.setFilter(0, eventFilter('$browser', 'Firefox', PropertyOperator.Exact))
+
+            await expectLogic(logic).toFinishAllListeners()
+            const calledWith = onChange.mock.calls[0][0]
+            expect(calledWith).toHaveLength(1)
+            expect(calledWith[0]).toMatchObject({ key: '$browser', value: 'Firefox' })
+        })
+    })
 })

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -1,4 +1,5 @@
 import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import isEqual from 'lodash.isequal'
 
 import { PropertyFilterLogicProps } from 'lib/components/PropertyFilters/types'
 import { isValidPropertyFilter, parseProperties } from 'lib/components/PropertyFilters/utils'
@@ -6,6 +7,23 @@ import { isValidPropertyFilter, parseProperties } from 'lib/components/PropertyF
 import { AnyPropertyFilter, EmptyPropertyFilter } from '~/types'
 
 import type { propertyFilterLogicType } from './propertyFilterLogicType'
+
+interface FilterItem {
+    _id: number
+    filter: AnyPropertyFilter
+}
+
+interface FiltersState {
+    nextId: number
+    items: FilterItem[]
+}
+
+function initFiltersState(filters: AnyPropertyFilter[]): FiltersState {
+    return {
+        nextId: filters.length,
+        items: filters.map((filter, i) => ({ _id: i, filter })),
+    }
+}
 
 export const propertyFilterLogic = kea<propertyFilterLogicType>([
     path((key) => ['lib', 'components', 'PropertyFilters', 'propertyFilterLogic', key]),
@@ -20,31 +38,55 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>([
     }),
 
     reducers(({ props }) => ({
-        filters: [
-            props.propertyFilters ? parseProperties(props.propertyFilters) : ([] as AnyPropertyFilter[]),
+        _filtersState: [
+            initFiltersState(props.propertyFilters ? parseProperties(props.propertyFilters) : []),
             {
-                setFilter: (state, { index, property }) => {
-                    const newFilters: AnyPropertyFilter[] = [...state]
-                    newFilters[index] = property
-                    return newFilters
+                setFilter: (
+                    state: FiltersState,
+                    { index, property }: { index: number; property: AnyPropertyFilter }
+                ) => {
+                    if (index < state.items.length) {
+                        const newItems = [...state.items]
+                        newItems[index] = { _id: state.items[index]._id, filter: property }
+                        return { ...state, items: newItems }
+                    }
+                    // Appending beyond current length (filling the virtual empty slot)
+                    const newItems = [...state.items, { _id: state.nextId, filter: property }]
+                    return { nextId: state.nextId + 1, items: newItems }
                 },
-                setFilters: (_, { filters }) => filters,
-                remove: (state, { index }) => {
-                    const newState = state.filter((_, i) => i !== index)
-                    if (newState.length === 0) {
-                        return [{} as EmptyPropertyFilter]
+                setFilters: (state: FiltersState, { filters }: { filters: AnyPropertyFilter[] }) => {
+                    const currentFilters = state.items.map((i) => i.filter)
+                    if (isEqual(currentFilters, filters)) {
+                        return state
                     }
-                    if (Object.keys(newState[newState.length - 1]).length !== 0) {
-                        return [...newState, {} as EmptyPropertyFilter]
+                    let nextId = state.nextId
+                    const items: FilterItem[] = filters.map((filter, i) => {
+                        if (i < state.items.length) {
+                            return { _id: state.items[i]._id, filter }
+                        }
+                        return { _id: nextId++, filter }
+                    })
+                    return { nextId, items }
+                },
+                remove: (state: FiltersState, { index }: { index: number }) => {
+                    const newItems = state.items.filter((_, i) => i !== index)
+                    let nextId = state.nextId
+                    if (newItems.length === 0) {
+                        return { nextId: nextId + 1, items: [{ _id: nextId, filter: {} as EmptyPropertyFilter }] }
                     }
-                    return newState
+                    if (Object.keys(newItems[newItems.length - 1].filter).length !== 0) {
+                        return {
+                            nextId: nextId + 1,
+                            items: [...newItems, { _id: nextId, filter: {} as EmptyPropertyFilter }],
+                        }
+                    }
+                    return { ...state, items: newItems }
                 },
             },
         ],
     })),
 
     listeners(({ actions, props, values }) => ({
-        // Only send update if value is set to something
         setFilter: async ({ property }) => {
             if (
                 props.sendAllKeyUpdates ||
@@ -65,6 +107,11 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>([
     })),
 
     selectors({
+        filters: [
+            (s) => [s._filtersState],
+            (state: FiltersState): AnyPropertyFilter[] => state.items.map((i) => i.filter),
+        ],
+        filterIds: [(s) => [s._filtersState], (state: FiltersState): number[] => state.items.map((i) => i._id)],
         filledFilters: [(s) => [s.filters], (filters) => filters.filter(isValidPropertyFilter)],
         filtersWithNew: [
             (s) => [s.filters],
@@ -73,6 +120,16 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>([
                     return [...filters, {} as AnyPropertyFilter]
                 }
                 return filters
+            },
+        ],
+        filterIdsWithNew: [
+            (s) => [s._filtersState, s.filtersWithNew],
+            (state: FiltersState, filtersWithNew: AnyPropertyFilter[]): number[] => {
+                const ids = state.items.map((i) => i._id)
+                if (filtersWithNew.length > ids.length) {
+                    return [...ids, state.nextId]
+                }
+                return ids
             },
         ],
     }),

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -1,0 +1,140 @@
+import '@testing-library/jest-dom'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { actionsModel } from '~/models/actionsModel'
+import { groupsModel } from '~/models/groupsModel'
+import { initKeaTests } from '~/test/init'
+import { mockActionDefinition, mockGetEventDefinitions, mockGetPropertyDefinitions } from '~/test/mocks'
+
+import { TaxonomicFilter } from './TaxonomicFilter'
+import { TaxonomicFilterGroupType } from './types'
+
+jest.mock('lib/components/AutoSizer', () => ({
+    AutoSizer: ({ renderProp }: { renderProp: (size: { height: number; width: number }) => React.ReactNode }) =>
+        renderProp({ height: 400, width: 400 }),
+}))
+
+describe('TaxonomicFilter', () => {
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team/event_definitions': mockGetEventDefinitions,
+                '/api/projects/:team/property_definitions': mockGetPropertyDefinitions,
+                '/api/projects/:team/actions': { results: [mockActionDefinition] },
+                '/api/environments/:team/persons/properties': [
+                    { id: 1, name: 'location', count: 1 },
+                    { id: 2, name: 'role', count: 2 },
+                ],
+            },
+            post: {
+                '/api/environments/:team/query': { results: [] },
+            },
+        })
+        initKeaTests()
+        actionsModel.mount()
+        groupsModel.mount()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    function renderFilter(
+        props: Partial<React.ComponentProps<typeof TaxonomicFilter>> = {}
+    ): ReturnType<typeof render> & { onChange: jest.Mock } {
+        const onChange = jest.fn()
+        const result = render(
+            <Provider>
+                <TaxonomicFilter
+                    taxonomicGroupTypes={[TaxonomicFilterGroupType.Events]}
+                    onChange={onChange}
+                    {...props}
+                />
+            </Provider>
+        )
+        return { ...result, onChange }
+    }
+
+    it('renders search input and loads results from the API', async () => {
+        renderFilter()
+
+        expect(screen.getByTestId('taxonomic-filter-searchfield')).toBeInTheDocument()
+
+        await waitFor(() => {
+            expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
+        })
+    })
+
+    it('typing in the search field filters results', async () => {
+        renderFilter()
+
+        await waitFor(() => {
+            expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
+        })
+
+        userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), 'test event')
+
+        await waitFor(() => {
+            expect(screen.getAllByText('test event').length).toBeGreaterThanOrEqual(1)
+            expect(screen.queryByText('$click')).not.toBeInTheDocument()
+        })
+    })
+
+    it('clicking a category tab switches the visible results', async () => {
+        renderFilter({
+            taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
+        })
+
+        await waitFor(() => {
+            expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
+        })
+
+        userEvent.click(screen.getByTestId('taxonomic-tab-actions'))
+
+        await waitFor(() => {
+            expect(screen.getByText('Action with a moderately long name')).toBeInTheDocument()
+        })
+    })
+
+    it('clicking a result calls onChange with the correct group, value, and item', async () => {
+        const { onChange } = renderFilter()
+
+        await waitFor(() => {
+            expect(screen.getByTestId('prop-filter-events-1')).toBeInTheDocument()
+        })
+
+        userEvent.click(screen.getByTestId('prop-filter-events-1'))
+
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledTimes(1)
+        })
+        const [group, value, item] = onChange.mock.calls[0]
+        expect(group.type).toBe(TaxonomicFilterGroupType.Events)
+        expect(value).toBe('event1')
+        expect(item.name).toBe('event1')
+    })
+
+    it('keyboard-only: type to search, enter to select', async () => {
+        const { onChange } = renderFilter()
+
+        await waitFor(() => {
+            expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
+        })
+
+        userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), '$click')
+
+        await waitFor(() => {
+            expect(screen.getAllByText('$click').length).toBeGreaterThanOrEqual(1)
+        })
+
+        userEvent.keyboard('{Enter}')
+
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledTimes(1)
+        })
+        expect(onChange.mock.calls[0][1]).toBe('$click')
+    })
+})

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.test.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.test.tsx
@@ -1,0 +1,118 @@
+import '@testing-library/jest-dom'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import { useMocks } from '~/mocks/jest'
+import { actionsModel } from '~/models/actionsModel'
+import { groupsModel } from '~/models/groupsModel'
+import { initKeaTests } from '~/test/init'
+import { mockGetEventDefinitions } from '~/test/mocks'
+
+import { TaxonomicPopover, TaxonomicStringPopover } from './TaxonomicPopover'
+
+jest.mock('lib/components/AutoSizer', () => ({
+    AutoSizer: ({ renderProp }: { renderProp: (size: { height: number; width: number }) => React.ReactNode }) =>
+        renderProp({ height: 400, width: 400 }),
+}))
+
+describe('TaxonomicPopover', () => {
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team/event_definitions': mockGetEventDefinitions,
+            },
+            post: {
+                '/api/environments/:team/query': { results: [] },
+            },
+        })
+        initKeaTests()
+        actionsModel.mount()
+        groupsModel.mount()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    function renderPopover(
+        props: Partial<React.ComponentProps<typeof TaxonomicPopover>> = {}
+    ): ReturnType<typeof render> & { onChange: jest.Mock } {
+        const onChange = jest.fn()
+        const result = render(
+            <Provider>
+                <TaxonomicPopover groupType={TaxonomicFilterGroupType.Events} onChange={onChange} {...props} />
+            </Provider>
+        )
+        return { ...result, onChange }
+    }
+
+    it('displays the current value in the button', () => {
+        renderPopover({ value: 'pageview' })
+        expect(screen.getByText('pageview')).toBeInTheDocument()
+    })
+
+    it('opens dropdown on click and calls onChange with correct args on selection', async () => {
+        const { onChange } = renderPopover({ placeholder: 'Select an event' })
+        userEvent.click(screen.getByText('Select an event'))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('prop-filter-events-1')).toBeInTheDocument()
+        })
+
+        userEvent.click(screen.getByTestId('prop-filter-events-1'))
+
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledTimes(1)
+        })
+        const [value, groupType, item] = onChange.mock.calls[0]
+        expect(value).toBe('event1')
+        expect(groupType).toBe(TaxonomicFilterGroupType.Events)
+        expect(item.name).toBe('event1')
+    })
+
+    it('clear button calls onChange with empty value', async () => {
+        const { onChange } = renderPopover({ value: 'pageview', allowClear: true })
+        userEvent.click(screen.getByLabelText('Clear selection'))
+
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledWith('', TaxonomicFilterGroupType.Events, null)
+        })
+    })
+
+    describe('TaxonomicStringPopover', () => {
+        function renderStringPopover(
+            props: Partial<React.ComponentProps<typeof TaxonomicStringPopover>> = {}
+        ): ReturnType<typeof render> & { onChange: jest.Mock } {
+            const onChange = jest.fn()
+            const result = render(
+                <Provider>
+                    <TaxonomicStringPopover
+                        groupType={TaxonomicFilterGroupType.Events}
+                        onChange={onChange}
+                        {...props}
+                    />
+                </Provider>
+            )
+            return { ...result, onChange }
+        }
+
+        it('coerces selected value to string in onChange', async () => {
+            const { onChange } = renderStringPopover({ value: '', placeholder: 'Pick event' })
+            userEvent.click(screen.getByText('Pick event'))
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-events-1')).toBeInTheDocument()
+            })
+
+            userEvent.click(screen.getByTestId('prop-filter-events-1'))
+
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalledTimes(1)
+            })
+            expect(typeof onChange.mock.calls[0][0]).toBe('string')
+        })
+    })
+})

--- a/frontend/src/test/mocks.ts
+++ b/frontend/src/test/mocks.ts
@@ -266,3 +266,17 @@ export const mockSlackChannels: SlackChannelType[] = [
         is_member: false,
     },
 ]
+
+export const mockGetEventDefinitions = (req: { url: URL }): [number, Record<string, any>] => {
+    const search = req.url.searchParams.get('search') ?? ''
+    const results = search ? mockEventDefinitions.filter((e) => e.name.includes(search)) : mockEventDefinitions
+    return [200, { results, count: results.length }]
+}
+
+export const mockGetPropertyDefinitions = (req: { url: URL }): [number, Record<string, any>] => {
+    const search = req.url.searchParams.get('search') ?? ''
+    const results = search
+        ? mockEventPropertyDefinitions.filter((p) => p.name.includes(search))
+        : mockEventPropertyDefinitions
+    return [200, { results, count: results.length }]
+}

--- a/frontend/src/toolbar/actions/ActionsToolbarMenu.tsx
+++ b/frontend/src/toolbar/actions/ActionsToolbarMenu.tsx
@@ -16,6 +16,7 @@ import { actionsLogic } from '~/toolbar/actions/actionsLogic'
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
 import { ToolbarMenu } from '~/toolbar/bar/ToolbarMenu'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
+import { joinWithUiHost } from '~/toolbar/utils'
 
 const ActionsListToolbarMenu = (): JSX.Element => {
     const { searchTerm } = useValues(actionsLogic)
@@ -53,7 +54,7 @@ const ActionsListToolbarMenu = (): JSX.Element => {
             </ToolbarMenu.Body>
             <ToolbarMenu.Footer>
                 <div className="flex items-center justify-between flex-1">
-                    <Link to={`${uiHost}${urls.actions()}`} target="_blank" className="text-primary">
+                    <Link to={joinWithUiHost(uiHost, urls.actions())} target="_blank" className="text-primary">
                         View &amp; edit all actions <IconOpenInNew />
                     </Link>
                     <LemonButton type="primary" size="small" onClick={() => newAction()} icon={<IconPlus />}>

--- a/frontend/src/toolbar/actions/actionsLogic.test.ts
+++ b/frontend/src/toolbar/actions/actionsLogic.test.ts
@@ -45,7 +45,7 @@ describe('toolbar actionsLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        toolbarConfigLogic({ apiURL: 'http://localhost' }).mount()
+        toolbarConfigLogic.build({ apiURL: 'http://localhost' }).mount()
         logic = actionsLogic()
         logic.mount()
     })

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -11,7 +11,12 @@ import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { ActionDraftType, ActionForm } from '~/toolbar/types'
-import { actionStepToActionStepFormItem, elementToActionStep, stepToDatabaseFormat } from '~/toolbar/utils'
+import {
+    actionStepToActionStepFormItem,
+    elementToActionStep,
+    joinWithUiHost,
+    stepToDatabaseFormat,
+} from '~/toolbar/utils'
 import { AccessControlLevel, ActionType, ElementType } from '~/types'
 
 import { ActionStepPropertyKey } from './ActionStep'
@@ -242,7 +247,8 @@ export const actionsTabLogic = kea<actionsTabLogicType>([
                     lemonToast.success('Action saved', {
                         button: {
                             label: 'Open in PostHog',
-                            action: () => window.open(`${values.uiHost}${urls.action(response.id)}`, '_blank'),
+                            action: () =>
+                                window.open(joinWithUiHost(values.uiHost, urls.action(response.id)), '_blank'),
                         },
                     })
                 }

--- a/frontend/src/toolbar/experiments/ExperimentsToolbarMenu.tsx
+++ b/frontend/src/toolbar/experiments/ExperimentsToolbarMenu.tsx
@@ -16,6 +16,7 @@ import { ExperimentsListView } from '~/toolbar/experiments/ExperimentsListView'
 import { experimentsLogic } from '~/toolbar/experiments/experimentsLogic'
 import { experimentsTabLogic } from '~/toolbar/experiments/experimentsTabLogic'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
+import { joinWithUiHost } from '~/toolbar/utils'
 
 const ExperimentsListToolbarMenu = (): JSX.Element => {
     const { searchTerm } = useValues(experimentsLogic)
@@ -68,7 +69,7 @@ const ExperimentsListToolbarMenu = (): JSX.Element => {
             </ToolbarMenu.Body>
             <ToolbarMenu.Footer>
                 <div className="flex items-center justify-between flex-1">
-                    <Link to={`${uiHost}${urls.experiments()}`} target="_blank">
+                    <Link to={joinWithUiHost(uiHost, urls.experiments())} target="_blank">
                         View &amp; edit all experiments <IconOpenInNew />
                     </Link>
                     <LemonButton type="primary" size="small" onClick={() => newExperiment()} icon={<IconPlus />}>

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.test.ts
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.test.ts
@@ -89,7 +89,7 @@ describe('experimentsTabLogic', () => {
         theToolbarLogic = toolbarLogic()
         theToolbarLogic.mount()
 
-        theToolbarConfigLogic = toolbarConfigLogic({ apiURL: 'http://localhost' })
+        theToolbarConfigLogic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
         theToolbarConfigLogic.mount()
     })
 

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -13,7 +13,7 @@ import { experimentsLogic } from '~/toolbar/experiments/experimentsLogic'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { WebExperiment, WebExperimentDraftType, WebExperimentForm } from '~/toolbar/types'
-import { elementToQuery } from '~/toolbar/utils'
+import { elementToQuery, joinWithUiHost } from '~/toolbar/utils'
 import { Experiment, ExperimentIdType } from '~/types'
 
 import type { experimentsTabLogicType } from './experimentsTabLogicType'
@@ -215,7 +215,7 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                     lemonToast.success('Experiment saved', {
                         button: {
                             label: 'Open in PostHog',
-                            action: () => window.open(`${uiHost}${urls.experiment(response.id)}`, '_blank'),
+                            action: () => window.open(joinWithUiHost(uiHost, urls.experiment(response.id)), '_blank'),
                         },
                     })
                     breakpoint()

--- a/frontend/src/toolbar/flags/FlagsToolbarMenu.tsx
+++ b/frontend/src/toolbar/flags/FlagsToolbarMenu.tsx
@@ -16,6 +16,7 @@ import { urls } from 'scenes/urls'
 import { ToolbarMenu } from '~/toolbar/bar/ToolbarMenu'
 import { flagsToolbarLogic } from '~/toolbar/flags/flagsToolbarLogic'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
+import { joinWithUiHost } from '~/toolbar/utils'
 
 export const FlagsToolbarMenu = (): JSX.Element => {
     const { searchTerm, filteredFlags, userFlagsLoading, draftPayloads, payloadErrors, countFlagsOverridden } =
@@ -86,11 +87,12 @@ export const FlagsToolbarMenu = (): JSX.Element => {
                                         <div className="flex-1 truncate">
                                             <Link
                                                 className="font-medium"
-                                                to={`${uiHost}${
+                                                to={joinWithUiHost(
+                                                    uiHost,
                                                     feature_flag.id
                                                         ? urls.featureFlag(feature_flag.id)
                                                         : urls.featureFlags()
-                                                }`}
+                                                )}
                                                 subtle
                                                 target="_blank"
                                             >

--- a/frontend/src/toolbar/flags/flagsToolbarLogic.test.ts
+++ b/frontend/src/toolbar/flags/flagsToolbarLogic.test.ts
@@ -36,7 +36,7 @@ describe('toolbar featureFlagsLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        toolbarConfigLogic({ apiURL: 'http://localhost' }).mount()
+        toolbarConfigLogic.build({ apiURL: 'http://localhost' }).mount()
         logic = flagsToolbarLogic()
         logic.mount()
         logic.actions.getUserFlags()

--- a/frontend/src/toolbar/product-tours/StepCard.tsx
+++ b/frontend/src/toolbar/product-tours/StepCard.tsx
@@ -7,6 +7,7 @@ import { IconDragHandle } from 'lib/lemon-ui/icons'
 import { getStepIcon, getStepTitle, hasElementTarget, hasIncompleteTargeting } from 'scenes/product-tours/stepUtils'
 
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
+import { joinWithUiHost } from '~/toolbar/utils'
 import { ProductTourProgressionTriggerType } from '~/types'
 
 import { TourStep, productToursLogic } from './productToursLogic'
@@ -58,7 +59,7 @@ export function StepCard({
         step.selector && step.selector.length > 25 ? step.selector.slice(0, 22) + '...' : step.selector
 
     const screenshotUrl = step.screenshotMediaId
-        ? `${uiHost}/uploaded_media/${step.screenshotMediaId}?token=${temporaryToken}`
+        ? joinWithUiHost(uiHost, `/uploaded_media/${step.screenshotMediaId}?token=${temporaryToken}`)
         : null
 
     return (

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -21,7 +21,7 @@ import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
 import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { ElementRect } from '~/toolbar/types'
-import { TOOLBAR_ID, elementToActionStep, getRectForElement } from '~/toolbar/utils'
+import { TOOLBAR_ID, elementToActionStep, getRectForElement, joinWithUiHost } from '~/toolbar/utils'
 import {
     ProductTour,
     ProductTourProgressionTriggerType,
@@ -392,7 +392,7 @@ export const productToursLogic = kea<productToursLogicType>([
                 const { uiHost, pendingEditInPostHog, launchedFromMainApp } = values
 
                 if (pendingEditInPostHog) {
-                    const editUrl = `${uiHost}${urls.productTour(savedTour.id, 'edit=true&tab=steps')}`
+                    const editUrl = joinWithUiHost(uiHost, urls.productTour(savedTour.id, 'edit=true&tab=steps'))
                     if (launchedFromMainApp) {
                         window.location.href = editUrl
                     } else {
@@ -402,7 +402,7 @@ export const productToursLogic = kea<productToursLogicType>([
                     lemonToast.success(isUpdate ? 'Tour updated' : 'Tour created', {
                         button: {
                             label: 'Open in PostHog',
-                            action: () => window.open(`${uiHost}${urls.productTour(savedTour.id)}`, '_blank'),
+                            action: () => window.open(joinWithUiHost(uiHost, urls.productTour(savedTour.id)), '_blank'),
                         },
                     })
                 }

--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -14,16 +14,18 @@ import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconSync } from 'lib/lemon-ui/icons'
+import { urls } from 'scenes/urls'
 
 import { ToolbarMenu } from '~/toolbar/bar/ToolbarMenu'
 import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
 import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
+import { joinWithUiHost } from '~/toolbar/utils'
 
 import { toolbarConfigLogic } from '../toolbarConfigLogic'
 
 const HeatmapsJSWarning = (): JSX.Element | null => {
-    const { posthog } = useValues(toolbarConfigLogic)
+    const { posthog, uiHost } = useValues(toolbarConfigLogic)
 
     if (!posthog || posthog?.heatmaps?.isEnabled) {
         return null
@@ -36,7 +38,10 @@ const HeatmapsJSWarning = (): JSX.Element | null => {
             ) : !posthog.heatmaps.isEnabled ? (
                 <>
                     You can enable heatmap collection in your posthog-js configuration or{' '}
-                    <Link to="https://us.posthog.com/settings/project#heatmaps">in your project config</Link>.
+                    <Link to={joinWithUiHost(uiHost, `${urls.settings()}#heatmaps`)} target="_blank">
+                        in your project config
+                    </Link>
+                    .
                 </>
             ) : null}
         </p>

--- a/frontend/src/toolbar/toolbarConfigLogic.test.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.test.ts
@@ -16,11 +16,20 @@ describe('toolbar toolbarLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        logic = toolbarConfigLogic({ apiURL: 'http://localhost' })
+        logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
         logic.mount()
     })
 
     it('is not authenticated', () => {
         expectLogic(logic).toMatchValues({ isAuthenticated: false })
+    })
+
+    it('normalizes uiHost to not end with a slash', () => {
+        const logicWithUiHost = toolbarConfigLogic.build({
+            posthog: { config: { ui_host: 'https://us.posthog.com/' } } as any,
+        } as any)
+        logicWithUiHost.mount()
+        expect(logicWithUiHost.values.uiHost.endsWith('/')).toBe(false)
+        expect(logicWithUiHost.values.uiHost).toBe('https://us.posthog.com')
     })
 })

--- a/frontend/src/toolbar/utils.test.ts
+++ b/frontend/src/toolbar/utils.test.ts
@@ -1,6 +1,52 @@
-import { slashDotDataAttrUnescape } from './utils'
+import { joinWithUiHost, slashDotDataAttrUnescape } from './utils'
 
 describe('utils', () => {
+    describe('joinWithUiHost', () => {
+        const testCases: Array<{ uiHost: string; path: string; expected: string }> = [
+            {
+                uiHost: 'https://us.posthog.com',
+                path: '/settings/project',
+                expected: 'https://us.posthog.com/settings/project',
+            },
+            {
+                uiHost: 'https://us.posthog.com/',
+                path: '/settings/project',
+                expected: 'https://us.posthog.com/settings/project',
+            },
+            {
+                uiHost: 'https://us.posthog.com///',
+                path: 'settings/project',
+                expected: 'https://us.posthog.com/settings/project',
+            },
+            {
+                uiHost: 'https://us.posthog.com',
+                path: 'settings/project',
+                expected: 'https://us.posthog.com/settings/project',
+            },
+            {
+                uiHost: 'https://us.posthog.com/',
+                path: '///settings/project',
+                expected: 'https://us.posthog.com/settings/project',
+            },
+            {
+                uiHost: 'https://us.posthog.com',
+                path: `${'/settings/project'}#heatmaps`,
+                expected: 'https://us.posthog.com/settings/project#heatmaps',
+            },
+            { uiHost: 'https://us.posthog.com', path: '?a=1', expected: 'https://us.posthog.com/?a=1' },
+            { uiHost: 'https://us.posthog.com', path: '#hash', expected: 'https://us.posthog.com/#hash' },
+            { uiHost: 'https://us.posthog.com', path: 'https://example.com/x', expected: 'https://example.com/x' },
+            { uiHost: 'https://us.posthog.com', path: '//example.com/x', expected: '//example.com/x' },
+            { uiHost: '', path: '/settings/project', expected: '/settings/project' },
+        ]
+
+        testCases.forEach(({ uiHost, path, expected }) => {
+            it(`joins "${uiHost}" + "${path}"`, () => {
+                expect(joinWithUiHost(uiHost, path)).toBe(expected)
+            })
+        })
+    })
+
     describe('slashDotDataAttrUnescape', () => {
         const testCases = [
             {

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -555,3 +555,22 @@ export function makeNavigateWrapper(onNavigate: () => void, patchKey: string): (
         }
     }
 }
+
+export function joinWithUiHost(uiHost: string, path: string): string {
+    const trimmedHost = (uiHost || '').replace(/\/+$/, '')
+    const trimmedPath = (path || '').trim()
+
+    if (!trimmedHost) {
+        return trimmedPath
+    }
+    if (!trimmedPath) {
+        return trimmedHost
+    }
+
+    // If a full URL is passed, don't try to join it.
+    if (/^https?:\/\//i.test(trimmedPath) || /^\/\/[^/]/.test(trimmedPath)) {
+        return trimmedPath
+    }
+
+    return `${trimmedHost}/${trimmedPath.replace(/^\/+/, '')}`
+}

--- a/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.test.tsx
+++ b/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.test.tsx
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { initKeaTests } from '~/test/init'
+import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
+
+import { WebVitalsToolbarMenu } from './WebVitalsToolbarMenu'
+
+describe('WebVitalsToolbarMenu', () => {
+    beforeEach(() => {
+        initKeaTests()
+        toolbarConfigLogic
+            .build({
+                posthog: {
+                    config: { ui_host: 'https://us.posthog.com/' },
+                    webVitalsAutocapture: { isEnabled: false },
+                } as any,
+            } as any)
+            .mount()
+    })
+
+    it('uses the PostHog ui host for the settings link', () => {
+        render(<WebVitalsToolbarMenu />)
+
+        const settingsLink = screen.getByRole('link', { name: 'settings page' })
+        expect(settingsLink).toHaveAttribute('href', 'https://us.posthog.com/settings/project')
+        expect(settingsLink).toHaveAttribute('target', '_blank')
+    })
+})

--- a/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.tsx
+++ b/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.tsx
@@ -13,6 +13,7 @@ import {
 } from '~/queries/nodes/WebVitals/definitions'
 import { WebVitalsMetric } from '~/queries/schema/schema-general'
 import { ToolbarMenu } from '~/toolbar/bar/ToolbarMenu'
+import { joinWithUiHost } from '~/toolbar/utils'
 
 import { toolbarConfigLogic } from '../toolbarConfigLogic'
 import { WebVitalsMetrics, webVitalsToolbarLogic } from './webVitalsToolbarLogic'
@@ -31,7 +32,10 @@ export const WebVitalsToolbarMenu = (): JSX.Element => {
                     {!posthog?.webVitalsAutocapture?.isEnabled && !inStorybookTestRunner() && !inStorybook() && (
                         <LemonBanner type="warning">
                             Web vitals are not enabled for this project so you won't see any data here. Enable it on the{' '}
-                            <Link to={urls.settings()}>settings page</Link> to start capturing web vitals.
+                            <Link to={joinWithUiHost(uiHost, urls.settings())} target="_blank">
+                                settings page
+                            </Link>{' '}
+                            to start capturing web vitals.
                         </LemonBanner>
                     )}
 
@@ -73,7 +77,7 @@ export const WebVitalsToolbarMenu = (): JSX.Element => {
 
             <ToolbarMenu.Footer>
                 <div className="flex flex-row justify-between w-full">
-                    <Link to={`${uiHost}${urls.webAnalyticsWebVitals()}`} target="_blank">
+                    <Link to={joinWithUiHost(uiHost, urls.webAnalyticsWebVitals())} target="_blank">
                         View all metrics
                     </Link>
                     <Link to="https://posthog.com/docs/web-analytics/web-vitals" target="_blank">


### PR DESCRIPTION
## Problem
We destroy and recreate all the keys storing filters state on every change because `setLocalFilters` regenerates UUIDs for every filter in that series, so React remounts all of them.

This leads to an annoying experience while trying to select options in the popover, it keeps being remounted, options jump around, the size of the popover quickly changes too.

Old:

https://github.com/user-attachments/assets/2ec85c76-9b82-494b-8d6a-2ea5328fd8bc


## Changes

- Implemented stable IDs for property filters to prevent unnecessary re-renders
- Fixed key stability in `PropertyFilters` and `PathItemFilters` components by using unique IDs instead of array indices
- Refactored the filter state management to track filter IDs alongside filter values
- Added tests to verify ID stability across various filter mutations
- Ensured proper cleanup of empty/invalid filters before calling onChange

https://github.com/user-attachments/assets/3a6318dc-da14-4a19-b951-ec9037c19db1


## How did you test this code?

- Added unit tests for the new ID stability functionality
- Tested filter mutations (add, remove, update) to verify ID preservation
- Added tests to ensure onChange receives properly cleaned filters
- Verified that components maintain their state correctly during filter operations

AI Assistant Note: This PR improves performance and stability of property filters by addressing key management issues that were causing unnecessary re-renders.