### PR TITLE
chore(ci): allow agentic tool bots to update snapshots

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -139,7 +139,7 @@ jobs:
                   else
                     AUTHOR="${{ github.actor }}"
                     echo "Workflow triggered by: $AUTHOR"
-                    if [[ "$AUTHOR" == *"github-actions"* ]] || [[ "$AUTHOR" == *"[bot]"* ]] || [[ "$AUTHOR" == "posthog-bot" ]]; then
+                    if [[ "$AUTHOR" == *"github-actions"* ]] || [[ "$AUTHOR" == "posthog-bot" ]]; then
                       echo "mode=check" >> $GITHUB_OUTPUT
                       echo "::notice::🔍 Running in CHECK mode - snapshots must match exactly"
                     else

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -122,7 +122,7 @@ jobs:
                   else
                     AUTHOR="${{ github.actor }}"
                     echo "Workflow triggered by: $AUTHOR"
-                    if [[ "$AUTHOR" == *"github-actions"* ]] || [[ "$AUTHOR" == *"[bot]"* ]] || [[ "$AUTHOR" == "posthog-bot" ]]; then
+                    if [[ "$AUTHOR" == *"github-actions"* ]] || [[ "$AUTHOR" == "posthog-bot" ]]; then
                       echo "mode=check" >> $GITHUB_OUTPUT
                       echo "::notice::🔍 Running in CHECK mode - snapshots must match exactly"
                     else


### PR DESCRIPTION
## Summary
- The broad `*[bot]*` pattern in snapshot mode detection was blocking all GitHub App actors from update mode
- This prevented agentic tools (Claude, Cursor, etc.) from auto-creating snapshots for new stories
- Narrow the denylist to only block `github-actions` and `posthog-bot` — the bots that commit snapshot updates and could cause infinite loops

## Test plan
- [ ] PR opened by a bot actor (e.g. Claude) should show "Running in UPDATE mode" in the `detect-snapshot-mode` step
- [ ] PRs with snapshot commits from `github-actions` should still show "Running in CHECK mode"

🤖 Generated with [Claude Code](https://claude.com/claude-code)