### PR TITLE
feat(llma): 2/5 add Kafka scheduler for sentiment classification

### DIFF
--- a/common/hogli/tests/test_devenv.py
+++ b/common/hogli/tests/test_devenv.py
@@ -365,6 +365,13 @@ class TestIntentMapLoading:
         for intent in key_intents:
             assert intent in intent_map.intents, f"Missing intent: {intent}"
 
+    def test_llm_analytics_intent_enables_nodejs_llm_analytics_group(self) -> None:
+        """llm_analytics should include the nodejs_llm_analytics capability group."""
+        intent_map = load_intent_map()
+        llm_analytics = intent_map.intents["llm_analytics"]
+
+        assert "nodejs_llm_analytics" in llm_analytics.capabilities
+
     def test_real_intent_map_resolves_without_errors(self) -> None:
         """All intents in real map resolve successfully."""
         intent_map = load_intent_map()

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -119,6 +119,11 @@ capabilities:
         requires: [flag_evaluation]
         docker_profiles: []
 
+    nodejs_llm_analytics:
+        description: 'Node.js LLM Analytics - sentiment scheduler'
+        requires: [event_ingestion]
+        docker_profiles: []
+
     batch_imports:
         description: 'Batch data import worker'
         requires: [event_ingestion]
@@ -171,7 +176,8 @@ intents:
 
     llm_analytics:
         description: 'LLM/AI observability and analytics'
-        capabilities: [event_ingestion, ai_capture, llm_gateway, property_definitions, temporal_workflows]
+        capabilities:
+            [event_ingestion, ai_capture, llm_gateway, property_definitions, temporal_workflows, nodejs_llm_analytics]
 
     web_analytics:
         description: 'Web analytics, traffic analysis, and heatmaps'

--- a/nodejs/src/capabilities.ts
+++ b/nodejs/src/capabilities.ts
@@ -56,6 +56,11 @@ export const CAPABILITIES_FEATURE_FLAGS: PluginServerCapabilities = {
     evaluationScheduler: true,
 }
 
+/** LLM Analytics - sentiment classification scheduler */
+export const CAPABILITIES_LLM_ANALYTICS: PluginServerCapabilities = {
+    sentimentScheduler: true,
+}
+
 /** Ingestion Only - basic event ingestion without CDP processing */
 export const CAPABILITIES_INGESTION_ONLY: PluginServerCapabilities = {
     ingestionV2Combined: true,
@@ -82,6 +87,7 @@ const CAPABILITY_GROUP_MAP: Record<string, PluginServerCapabilities> = {
     recording_api: CAPABILITIES_RECORDING_API,
     logs: CAPABILITIES_LOGS,
     feature_flags: CAPABILITIES_FEATURE_FLAGS,
+    llm_analytics: CAPABILITIES_LLM_ANALYTICS,
 }
 
 export function getPluginServerCapabilities(config: PluginsServerConfig): PluginServerCapabilities {
@@ -126,7 +132,8 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 { sessionRecordingBlobIngestionV2Overflow: config.SESSION_RECORDING_OVERFLOW_ENABLED },
                 CAPABILITIES_RECORDING_API,
                 CAPABILITIES_LOGS,
-                CAPABILITIES_FEATURE_FLAGS
+                CAPABILITIES_FEATURE_FLAGS,
+                CAPABILITIES_LLM_ANALYTICS
             )
 
         case PluginServerMode.local_cdp:
@@ -193,6 +200,10 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
         case PluginServerMode.evaluation_scheduler:
             return {
                 evaluationScheduler: true,
+            }
+        case PluginServerMode.sentiment_scheduler:
+            return {
+                sentimentScheduler: true,
             }
         case PluginServerMode.ingestion_logs:
             return {

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -126,6 +126,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         TEMPORAL_CLIENT_ROOT_CA: undefined,
         TEMPORAL_CLIENT_CERT: undefined,
         TEMPORAL_CLIENT_KEY: undefined,
+        LLMA_SENTIMENT_SAMPLE_RATE: isDevEnv() ? 1.0 : 0.01, // 100% in dev, 1% in prod
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: KAFKA_EVENTS_JSON,
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: KAFKA_CLICKHOUSE_HEATMAP_EVENTS,
         PERSON_INFO_CACHE_TTL: 5 * 60, // 5 min

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -128,7 +128,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         TEMPORAL_CLIENT_KEY: undefined,
         LLMA_SENTIMENT_SAMPLE_RATE: isDevEnv() ? 1.0 : 0.01, // 100% in dev, 1% in prod
         LLMA_SENTIMENT_TEAM_IDS: isDevEnv() ? '' : '2', // empty = all teams; restrict to team 2 in prod for dogfooding
-        LLMA_SENTIMENT_BATCH_SIZE: isDevEnv() ? 10 : 100, // max events per sentiment workflow
+        LLMA_SENTIMENT_BATCH_SIZE: isDevEnv() ? 2 : 100, // max events per sentiment workflow
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: KAFKA_EVENTS_JSON,
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: KAFKA_CLICKHOUSE_HEATMAP_EVENTS,
         PERSON_INFO_CACHE_TTL: 5 * 60, // 5 min

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -129,6 +129,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         LLMA_SENTIMENT_SAMPLE_RATE: isDevEnv() ? 1.0 : 0.01, // 100% in dev, 1% in prod
         LLMA_SENTIMENT_TEAM_IDS: isDevEnv() ? '' : '2', // empty = all teams; restrict to team 2 in prod for dogfooding
         LLMA_SENTIMENT_BATCH_SIZE: isDevEnv() ? 5 : 100, // max events per sentiment workflow
+        LLMA_SENTIMENT_FLUSH_INTERVAL_MS: isDevEnv() ? 10_000 : 30_000, // flush buffer every 10s in dev, 30s in prod
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: KAFKA_EVENTS_JSON,
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: KAFKA_CLICKHOUSE_HEATMAP_EVENTS,
         PERSON_INFO_CACHE_TTL: 5 * 60, // 5 min

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -127,6 +127,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         TEMPORAL_CLIENT_CERT: undefined,
         TEMPORAL_CLIENT_KEY: undefined,
         LLMA_SENTIMENT_SAMPLE_RATE: isDevEnv() ? 1.0 : 0.01, // 100% in dev, 1% in prod
+        LLMA_SENTIMENT_TEAM_IDS: isDevEnv() ? '' : '2', // empty = all teams; restrict to team 2 in prod for dogfooding
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: KAFKA_EVENTS_JSON,
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: KAFKA_CLICKHOUSE_HEATMAP_EVENTS,
         PERSON_INFO_CACHE_TTL: 5 * 60, // 5 min

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -128,6 +128,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         TEMPORAL_CLIENT_KEY: undefined,
         LLMA_SENTIMENT_SAMPLE_RATE: isDevEnv() ? 1.0 : 0.01, // 100% in dev, 1% in prod
         LLMA_SENTIMENT_TEAM_IDS: isDevEnv() ? '' : '2', // empty = all teams; restrict to team 2 in prod for dogfooding
+        LLMA_SENTIMENT_BATCH_SIZE: isDevEnv() ? 10 : 100, // max events per sentiment workflow
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: KAFKA_EVENTS_JSON,
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: KAFKA_CLICKHOUSE_HEATMAP_EVENTS,
         PERSON_INFO_CACHE_TTL: 5 * 60, // 5 min

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -128,7 +128,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         TEMPORAL_CLIENT_KEY: undefined,
         LLMA_SENTIMENT_SAMPLE_RATE: isDevEnv() ? 1.0 : 0.01, // 100% in dev, 1% in prod
         LLMA_SENTIMENT_TEAM_IDS: isDevEnv() ? '' : '2', // empty = all teams; restrict to team 2 in prod for dogfooding
-        LLMA_SENTIMENT_BATCH_SIZE: isDevEnv() ? 2 : 100, // max events per sentiment workflow
+        LLMA_SENTIMENT_BATCH_SIZE: isDevEnv() ? 5 : 100, // max events per sentiment workflow
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: KAFKA_EVENTS_JSON,
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: KAFKA_CLICKHOUSE_HEATMAP_EVENTS,
         PERSON_INFO_CACHE_TTL: 5 * 60, // 5 min

--- a/nodejs/src/sentiment-scheduler/sentiment-scheduler.test.ts
+++ b/nodejs/src/sentiment-scheduler/sentiment-scheduler.test.ts
@@ -1,0 +1,168 @@
+import { Message } from 'node-rdkafka'
+
+import { createAiGenerationEvent } from '~/llm-analytics/_tests/fixtures'
+
+import {
+    SampleRateProvider,
+    checkSampleRate,
+    filterAndParseMessages,
+    parseSampleRatePayload,
+} from './sentiment-scheduler'
+
+jest.mock('~/llm-analytics/services/temporal.service')
+
+describe('Sentiment Scheduler', () => {
+    const teamId = 1
+
+    describe('filterAndParseMessages', () => {
+        it('filters messages by productTrack header and parses JSON', () => {
+            const messages: Message[] = [
+                {
+                    headers: [{ productTrack: Buffer.from('llma') }],
+                    value: Buffer.from(JSON.stringify(createAiGenerationEvent(teamId))),
+                } as any,
+                {
+                    headers: [{ productTrack: Buffer.from('general') }],
+                    value: Buffer.from(JSON.stringify({ event: '$pageview', team_id: teamId })),
+                } as any,
+                {
+                    headers: [{ productTrack: Buffer.from('llma') }],
+                    value: Buffer.from(JSON.stringify(createAiGenerationEvent(teamId))),
+                } as any,
+            ]
+
+            const result = filterAndParseMessages(messages)
+
+            expect(result).toHaveLength(2)
+            result.forEach((event) => expect(event.event).toBe('$ai_generation'))
+        })
+
+        it('handles malformed JSON gracefully', () => {
+            const messages: Message[] = [
+                {
+                    headers: [{ productTrack: Buffer.from('llma') }],
+                    value: Buffer.from('invalid json{'),
+                } as any,
+                {
+                    headers: [{ productTrack: Buffer.from('llma') }],
+                    value: Buffer.from(JSON.stringify(createAiGenerationEvent(teamId))),
+                } as any,
+            ]
+
+            const result = filterAndParseMessages(messages)
+
+            expect(result).toHaveLength(1)
+        })
+
+        it('filters out non-llma messages', () => {
+            const messages: Message[] = [
+                {
+                    headers: [{ productTrack: Buffer.from('general') }],
+                    value: Buffer.from(JSON.stringify({ event: '$pageview' })),
+                } as any,
+                {
+                    value: Buffer.from(JSON.stringify({ event: '$pageview' })),
+                } as any,
+            ]
+
+            const result = filterAndParseMessages(messages)
+
+            expect(result).toHaveLength(0)
+        })
+
+        it('filters out non-$ai_generation events', () => {
+            const messages: Message[] = [
+                {
+                    headers: [{ productTrack: Buffer.from('llma') }],
+                    value: Buffer.from(JSON.stringify({ ...createAiGenerationEvent(teamId), event: '$ai_trace' })),
+                } as any,
+            ]
+
+            const result = filterAndParseMessages(messages)
+
+            expect(result).toHaveLength(0)
+        })
+    })
+
+    describe('checkSampleRate', () => {
+        it('always includes when sample rate is 1.0 (100%)', () => {
+            expect(checkSampleRate('event-1', 1.0)).toBe(true)
+            expect(checkSampleRate('event-2', 1.0)).toBe(true)
+            expect(checkSampleRate('any-event', 1.0)).toBe(true)
+        })
+
+        it('always includes when sample rate is above 1.0', () => {
+            expect(checkSampleRate('event-1', 1.5)).toBe(true)
+        })
+
+        it('always excludes when sample rate is 0', () => {
+            expect(checkSampleRate('event-1', 0)).toBe(false)
+            expect(checkSampleRate('event-2', 0)).toBe(false)
+        })
+
+        it('always excludes when sample rate is negative', () => {
+            expect(checkSampleRate('event-1', -0.5)).toBe(false)
+        })
+
+        it('is deterministic for same event id', () => {
+            const result1 = checkSampleRate('event-123', 0.5)
+            const result2 = checkSampleRate('event-123', 0.5)
+            expect(result1).toBe(result2)
+        })
+
+        it('includes roughly correct percentage of events at 10%', () => {
+            const testEventIds = Array.from({ length: 10000 }, (_, i) => `event-${i}`)
+            const included = testEventIds.filter((eventId) => checkSampleRate(eventId, 0.1))
+
+            // Should be roughly 10%, allow 2% variance
+            expect(included.length).toBeGreaterThan(800)
+            expect(included.length).toBeLessThan(1200)
+        })
+
+        it('includes roughly correct percentage of events at 1%', () => {
+            const testEventIds = Array.from({ length: 100000 }, (_, i) => `event-${i}`)
+            const included = testEventIds.filter((eventId) => checkSampleRate(eventId, 0.01))
+
+            // Should be roughly 1%, allow 0.5% variance
+            expect(included.length).toBeGreaterThan(500)
+            expect(included.length).toBeLessThan(1500)
+        })
+    })
+
+    describe('parseSampleRatePayload', () => {
+        const fallback = 0.01
+
+        it.each([
+            ['JSON string with valid rate', '{"sample_rate": 0.5}', 0.5],
+            ['JSON string with zero rate', '{"sample_rate": 0}', 0],
+            ['JSON string with 1.0 rate', '{"sample_rate": 1.0}', 1.0],
+            ['object with valid rate', { sample_rate: 0.25 }, 0.25],
+        ])('parses %s', (_label, payload, expected) => {
+            expect(parseSampleRatePayload(payload, fallback)).toBe(expected)
+        })
+
+        it.each([
+            ['null', null],
+            ['undefined', undefined],
+            ['invalid JSON string', 'not-json'],
+            ['missing sample_rate key', '{"other": 0.5}'],
+            ['NaN sample_rate', '{"sample_rate": "abc"}'],
+            ['negative sample_rate', '{"sample_rate": -0.5}'],
+            ['sample_rate > 1', '{"sample_rate": 1.5}'],
+            ['non-object type', 42],
+        ])('returns fallback for %s', (_label, payload) => {
+            expect(parseSampleRatePayload(payload, fallback)).toBe(fallback)
+        })
+    })
+
+    describe('SampleRateProvider', () => {
+        it('uses fallback rate when no API key is provided', async () => {
+            const provider = new SampleRateProvider(0.05)
+            await provider.start()
+
+            expect(provider.getSampleRate()).toBe(0.05)
+
+            await provider.stop()
+        })
+    })
+})

--- a/nodejs/src/sentiment-scheduler/sentiment-scheduler.ts
+++ b/nodejs/src/sentiment-scheduler/sentiment-scheduler.ts
@@ -1,0 +1,269 @@
+/**
+ * Sentiment Scheduler
+ *
+ * Consumes $ai_generation events from the main events stream and triggers
+ * sentiment classification workflows via Temporal. Uses deterministic sampling
+ * controlled by a PostHog feature flag payload (`llm-analytics-sentiment-rollout`)
+ * so the sample rate can be changed from the PostHog UI without a deploy.
+ *
+ * Separate from the evaluation scheduler — sentiment runs a local HuggingFace
+ * model (free, fast) rather than an external LLM API.
+ */
+import * as crypto from 'crypto'
+import { Message } from 'node-rdkafka'
+import { PostHog } from 'posthog-node'
+import { Counter, Gauge } from 'prom-client'
+
+import { KAFKA_EVENTS_JSON, prefix as KAFKA_PREFIX } from '../config/kafka-topics'
+import { KafkaConsumer } from '../kafka/consumer'
+import { TemporalService, TemporalServiceHub } from '../llm-analytics/services/temporal.service'
+import { Hub, PluginServerService, RawKafkaEvent } from '../types'
+import { parseJSON } from '../utils/json-parse'
+import { logger } from '../utils/logger'
+
+/** Narrowed Hub type for sentiment scheduler */
+export type SentimentSchedulerHub = TemporalServiceHub &
+    Pick<Hub, 'LLMA_SENTIMENT_SAMPLE_RATE' | 'POSTHOG_API_KEY' | 'POSTHOG_HOST_URL'>
+
+const FEATURE_FLAG_KEY = 'llm-analytics-sentiment-rollout'
+const FLAG_POLL_INTERVAL_MS = 30_000
+const FLAG_DISTINCT_ID = 'llma-sentiment-scheduler'
+
+/** Default sample rate (1%) — used when feature flag is unavailable */
+const DEFAULT_SAMPLE_RATE = 0.01
+
+const sentimentSchedulerMessagesReceived = new Counter({
+    name: 'llma_sentiment_scheduler_messages_received',
+    help: 'Number of Kafka messages received before filtering',
+})
+
+const sentimentSchedulerEventsFiltered = new Counter({
+    name: 'llma_sentiment_scheduler_events_filtered',
+    help: 'Number of events after productTrack header filter',
+    labelNames: ['passed'],
+})
+
+const sentimentSchedulerEventsProcessed = new Counter({
+    name: 'llma_sentiment_scheduler_events_processed',
+    help: 'Number of events processed by sentiment scheduler',
+    labelNames: ['status'], // sampled_in, sampled_out, success, error
+})
+
+const sentimentSchedulerSampleRate = new Gauge({
+    name: 'llma_sentiment_scheduler_sample_rate',
+    help: 'Current sample rate used by the sentiment scheduler',
+})
+
+// Pure functions for testability
+
+export function filterAndParseMessages(messages: Message[]): RawKafkaEvent[] {
+    return messages
+        .filter((message) => {
+            const headers = message.headers as { productTrack?: Buffer }[] | undefined
+            const productTrack = headers?.find((h) => h.productTrack)?.productTrack?.toString('utf8')
+            return productTrack === 'llma'
+        })
+        .map((message) => {
+            try {
+                return parseJSON(message.value!.toString()) as RawKafkaEvent
+            } catch (e) {
+                logger.error('Error parsing event', { error: e })
+                return null
+            }
+        })
+        .filter((event): event is RawKafkaEvent => event !== null)
+        .filter((event) => event.event === '$ai_generation')
+}
+
+export function checkSampleRate(eventId: string, sampleRate: number): boolean {
+    if (sampleRate >= 1.0) {
+        return true
+    }
+    if (sampleRate <= 0) {
+        return false
+    }
+
+    // Deterministic sampling via MD5 hash
+    const hash = crypto.createHash('md5').update(eventId).digest('hex')
+    const hashValue = parseInt(hash.substring(0, 8), 16)
+    const percentage = hashValue / 0xffffffff
+
+    return percentage < sampleRate
+}
+
+export function parseSampleRatePayload(payload: unknown, fallback: number): number {
+    if (payload === null || payload === undefined) {
+        return fallback
+    }
+
+    let parsed: Record<string, unknown>
+    if (typeof payload === 'string') {
+        try {
+            parsed = parseJSON(payload)
+        } catch {
+            return fallback
+        }
+    } else if (typeof payload === 'object') {
+        parsed = payload as Record<string, unknown>
+    } else {
+        return fallback
+    }
+
+    const rate = Number(parsed.sample_rate)
+    if (isNaN(rate) || rate < 0 || rate > 1) {
+        return fallback
+    }
+    return rate
+}
+
+/**
+ * Provides the current sample rate, polling a PostHog feature flag payload
+ * periodically. Falls back to the env var / default if the flag is unavailable.
+ */
+export class SampleRateProvider {
+    private currentRate: number
+    private pollTimer: ReturnType<typeof setInterval> | null = null
+    private posthogClient: PostHog | null = null
+
+    constructor(
+        private fallbackRate: number,
+        private apiKey?: string,
+        private hostUrl?: string
+    ) {
+        this.currentRate = fallbackRate
+    }
+
+    async start(): Promise<void> {
+        if (this.apiKey) {
+            this.posthogClient = new PostHog(this.apiKey, {
+                host: this.hostUrl,
+                enableExceptionAutocapture: false,
+            })
+            await this.refresh()
+            this.pollTimer = setInterval(() => void this.refresh(), FLAG_POLL_INTERVAL_MS)
+        } else {
+            logger.info('No POSTHOG_API_KEY — using static sample rate', { sampleRate: this.fallbackRate })
+        }
+        sentimentSchedulerSampleRate.set(this.currentRate)
+    }
+
+    async refresh(): Promise<void> {
+        if (!this.posthogClient) {
+            return
+        }
+        try {
+            const flagValue = await this.posthogClient.getFeatureFlag(FEATURE_FLAG_KEY, FLAG_DISTINCT_ID)
+            if (!flagValue) {
+                // Flag is off — use 0 to disable sampling entirely
+                this.currentRate = 0
+            } else {
+                const payload = await this.posthogClient.getFeatureFlagPayload(
+                    FEATURE_FLAG_KEY,
+                    FLAG_DISTINCT_ID,
+                    flagValue
+                )
+                this.currentRate = parseSampleRatePayload(payload, this.fallbackRate)
+            }
+        } catch (error) {
+            logger.warn('Failed to fetch sentiment sample rate flag, keeping current rate', {
+                error: error instanceof Error ? error.message : String(error),
+                currentRate: this.currentRate,
+            })
+        }
+        sentimentSchedulerSampleRate.set(this.currentRate)
+    }
+
+    getSampleRate(): number {
+        return this.currentRate
+    }
+
+    async stop(): Promise<void> {
+        if (this.pollTimer) {
+            clearInterval(this.pollTimer)
+            this.pollTimer = null
+        }
+        if (this.posthogClient) {
+            await this.posthogClient.shutdown()
+            this.posthogClient = null
+        }
+    }
+}
+
+export const startSentimentScheduler = async (hub: SentimentSchedulerHub): Promise<PluginServerService> => {
+    logger.info('Starting sentiment scheduler')
+
+    const temporalService = new TemporalService(hub)
+    const fallbackRate = hub.LLMA_SENTIMENT_SAMPLE_RATE ?? DEFAULT_SAMPLE_RATE
+
+    const sampleRateProvider = new SampleRateProvider(fallbackRate, hub.POSTHOG_API_KEY, hub.POSTHOG_HOST_URL)
+    await sampleRateProvider.start()
+
+    logger.info('Sentiment scheduler started', { sampleRate: sampleRateProvider.getSampleRate() })
+
+    const kafkaConsumer = new KafkaConsumer({
+        groupId: `${KAFKA_PREFIX}llma-sentiment-scheduler`,
+        topic: KAFKA_EVENTS_JSON,
+    })
+
+    await kafkaConsumer.connect((messages) =>
+        eachBatchSentimentScheduler(messages, temporalService, sampleRateProvider)
+    )
+
+    const onShutdown = async () => {
+        await sampleRateProvider.stop()
+        await temporalService.disconnect()
+        await kafkaConsumer.disconnect()
+    }
+
+    return {
+        id: 'llma-sentiment-scheduler',
+        healthcheck: () => kafkaConsumer.isHealthy(),
+        onShutdown,
+    }
+}
+
+async function eachBatchSentimentScheduler(
+    messages: Message[],
+    temporalService: TemporalService,
+    sampleRateProvider: SampleRateProvider
+): Promise<void> {
+    sentimentSchedulerMessagesReceived.inc(messages.length)
+
+    const aiGenerationEvents = filterAndParseMessages(messages)
+
+    sentimentSchedulerEventsFiltered.labels({ passed: 'false' }).inc(messages.length - aiGenerationEvents.length)
+    sentimentSchedulerEventsFiltered.labels({ passed: 'true' }).inc(aiGenerationEvents.length)
+
+    if (aiGenerationEvents.length === 0) {
+        return
+    }
+
+    const sampleRate = sampleRateProvider.getSampleRate()
+    const tasks: Promise<void>[] = []
+
+    for (const event of aiGenerationEvents) {
+        if (!checkSampleRate(event.uuid, sampleRate)) {
+            sentimentSchedulerEventsProcessed.labels({ status: 'sampled_out' }).inc()
+            continue
+        }
+
+        sentimentSchedulerEventsProcessed.labels({ status: 'sampled_in' }).inc()
+
+        const task = temporalService
+            .startSentimentClassificationWorkflow(event)
+            .then(() => {
+                sentimentSchedulerEventsProcessed.labels({ status: 'success' }).inc()
+            })
+            .catch((error: unknown) => {
+                logger.error('Error starting sentiment workflow', {
+                    eventUuid: event.uuid,
+                    error: error instanceof Error ? error.message : String(error),
+                })
+                sentimentSchedulerEventsProcessed.labels({ status: 'error' }).inc()
+            })
+
+        tasks.push(task)
+    }
+
+    await Promise.allSettled(tasks)
+}

--- a/nodejs/src/sentiment-scheduler/sentiment-scheduler.ts
+++ b/nodejs/src/sentiment-scheduler/sentiment-scheduler.ts
@@ -208,9 +208,12 @@ export class SampleRateProvider {
         }
         try {
             const flagValue = await this.posthogClient.getFeatureFlag(FEATURE_FLAG_KEY, FLAG_DISTINCT_ID)
-            if (!flagValue) {
-                // Flag is off — use 0 to disable sampling entirely
+            if (flagValue === false) {
+                // Flag is explicitly off — disable sampling
                 this.currentRate = 0
+            } else if (flagValue === undefined) {
+                // Flag doesn't exist or SDK can't evaluate — use fallback
+                this.currentRate = this.fallbackRate
             } else {
                 const payload = await this.posthogClient.getFeatureFlagPayload(
                     FEATURE_FLAG_KEY,

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -30,6 +30,7 @@ import { KafkaProducerWrapper } from './kafka/producer'
 import { onShutdown } from './lifecycle'
 import { LogsIngestionConsumer } from './logs-ingestion/logs-ingestion-consumer'
 import { RecordingApi } from './recording-api/recording-api'
+import { startSentimentScheduler } from './sentiment-scheduler/sentiment-scheduler'
 import { SessionRecordingIngester } from './session-recording/consumer'
 import { Hub, PluginServerService, PluginsServerConfig } from './types'
 import { ServerCommands } from './utils/commands'
@@ -138,6 +139,10 @@ export class PluginServer {
 
             if (capabilities.evaluationScheduler) {
                 serviceLoaders.push(() => startEvaluationScheduler(hub))
+            }
+
+            if (capabilities.sentimentScheduler) {
+                serviceLoaders.push(() => startSentimentScheduler(hub))
             }
 
             if (capabilities.sessionRecordingBlobIngestionV2) {

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -472,6 +472,7 @@ export interface PluginsServerConfig
     LLMA_SENTIMENT_SAMPLE_RATE: number
     LLMA_SENTIMENT_TEAM_IDS: string
     LLMA_SENTIMENT_BATCH_SIZE: number
+    LLMA_SENTIMENT_FLUSH_INTERVAL_MS: number
     PERSON_INFO_CACHE_TTL: number
     KAFKA_HEALTHCHECK_SECONDS: number
     PLUGIN_SERVER_MODE: PluginServerMode | null

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -471,6 +471,7 @@ export interface PluginsServerConfig
     TEMPORAL_CLIENT_KEY: string | undefined
     LLMA_SENTIMENT_SAMPLE_RATE: number
     LLMA_SENTIMENT_TEAM_IDS: string
+    LLMA_SENTIMENT_BATCH_SIZE: number
     PERSON_INFO_CACHE_TTL: number
     KAFKA_HEALTHCHECK_SECONDS: number
     PLUGIN_SERVER_MODE: PluginServerMode | null

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -57,6 +57,7 @@ export enum PluginServerMode {
     cdp_api = 'cdp-api',
     cdp_legacy_on_event = 'cdp-legacy-on-event',
     evaluation_scheduler = 'evaluation-scheduler',
+    sentiment_scheduler = 'sentiment-scheduler',
     ingestion_logs = 'ingestion-logs',
     cdp_batch_hogflow_requests = 'cdp-batch-hogflow-requests',
     cdp_cyclotron_shadow_worker = 'cdp-cyclotron-shadow-worker',
@@ -468,6 +469,7 @@ export interface PluginsServerConfig
     TEMPORAL_CLIENT_ROOT_CA: string | undefined
     TEMPORAL_CLIENT_CERT: string | undefined
     TEMPORAL_CLIENT_KEY: string | undefined
+    LLMA_SENTIMENT_SAMPLE_RATE: number
     PERSON_INFO_CACHE_TTL: number
     KAFKA_HEALTHCHECK_SECONDS: number
     PLUGIN_SERVER_MODE: PluginServerMode | null
@@ -575,6 +577,7 @@ export interface PluginServerCapabilities {
     cdpApi?: boolean
     appManagementSingleton?: boolean
     evaluationScheduler?: boolean
+    sentimentScheduler?: boolean
     cdpCyclotronShadowWorker?: boolean
     recordingApi?: boolean
 }

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -470,6 +470,7 @@ export interface PluginsServerConfig
     TEMPORAL_CLIENT_CERT: string | undefined
     TEMPORAL_CLIENT_KEY: string | undefined
     LLMA_SENTIMENT_SAMPLE_RATE: number
+    LLMA_SENTIMENT_TEAM_IDS: string
     PERSON_INFO_CACHE_TTL: number
     KAFKA_HEALTHCHECK_SECONDS: number
     PLUGIN_SERVER_MODE: PluginServerMode | null

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -475,7 +475,7 @@ export interface PluginsServerConfig
     PERSON_INFO_CACHE_TTL: number
     KAFKA_HEALTHCHECK_SECONDS: number
     PLUGIN_SERVER_MODE: PluginServerMode | null
-    /** Comma-separated list of capability groups for local dev: cdp_workflows, realtime_cohorts, session_replay, logs, feature_flags */
+    /** Comma-separated list of capability groups for local dev: cdp, cdp_workflows, realtime_cohorts, session_replay, logs, feature_flags, llm_analytics */
     NODEJS_CAPABILITY_GROUPS: string | null
     PLUGIN_SERVER_EVENTS_INGESTION_PIPELINE: string | null // TODO: shouldn't be a string probably
     PLUGIN_LOAD_SEQUENTIALLY: boolean // could help with reducing memory usage spikes on startup


### PR DESCRIPTION
## Problem

Part of #47244 (PR 3/6 in stack).

Need a way to trigger sentiment classification on incoming `$ai_generation` events with controlled sampling.

## Changes

- New `nodejs/src/sentiment-scheduler/` Kafka consumer
  - Filters `$ai_generation` events with deterministic MD5-based sampling
  - `SampleRateProvider` polls feature flag `llm-analytics-sentiment-rollout` every 30s
  - Team allowlist (`LLMA_SENTIMENT_TEAM_IDS`) restricts to specific teams for dogfooding
  - Configurable batch size (`LLMA_SENTIMENT_BATCH_SIZE`): 5 in dev, 100 in prod
- **Buffered batch dispatch** via `SentimentBatchBuffer`
  - Accumulates sampled events in memory across Kafka polls
  - Flushes to Temporal when buffer reaches `batchSize` or a periodic timer fires (10s dev, 30s prod)
  - Reduces the number of small Temporal workflows in production
  - Flushes remaining events on shutdown
  - New metrics: `llma_sentiment_scheduler_buffer_size` gauge, `llma_sentiment_scheduler_flushes` counter
- Routes sentiment workflows via `temporal.service.ts` task queue config
- Wires scheduler into server capabilities and config
- Adds `nodejs_llm_analytics` capability group to devenv intent map so hogli can start the scheduler as part of `llm_analytics` intent

## How did you test this code?

- 48 unit tests covering filtering, sampling determinism, batch buffering (size flush, timer flush, shutdown flush, overflow), team allowlist
- Local end-to-end: generated demo traces, verified batch workflows in Temporal UI

## Publish to changelog?

No