### PR TITLE
fix(ux): add this week + respect team start of week

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -19,6 +19,7 @@ import { LemonCalendarRange } from 'lib/lemon-ui/LemonCalendarRange/LemonCalenda
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { dateFilterToText, dateMapping, uuid } from 'lib/utils'
 import { formatResolvedDateRange } from 'lib/utils/dateTimeUtils'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { ResolvedDateRangeResponse } from '~/queries/schema/schema-general'
 import { DateMappingOption, PropertyOperator } from '~/types'
@@ -138,6 +139,7 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
         fixedRangeGranularity,
     } = useValues(dateFilterLogic(logicProps))
 
+    const { weekStartDay } = useValues(teamLogic)
     const optionsRef = useRef<HTMLDivElement | null>(null)
     const rollingDateRangeRef = useRef<HTMLDivElement | null>(null)
     const [granularity, setGranularity] = useState<LemonCalendarSelectProps['granularity']>(
@@ -225,7 +227,10 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
                         values[1],
                         CUSTOM_OPTION_DESCRIPTION,
                         dateOptions,
-                        isDateFormatted
+                        isDateFormatted,
+                        undefined,
+                        undefined,
+                        weekStartDay
                     )
                     const startOfRangeDateValue = dateFilterToText(
                         values[0],

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -332,6 +332,40 @@ describe('lib/utils', () => {
                 )
             })
         })
+
+        describe('week formatting respects weekStartDay', () => {
+            // 2012-03-02 is a Friday
+            beforeEach(() => {
+                tk.freeze(new Date(1330688329321))
+            })
+            afterEach(() => {
+                tk.reset()
+            })
+
+            it('This week with Sunday start (default)', () => {
+                expect(
+                    dateFilterToText('wStart', undefined, 'default', dateMapping, true, undefined, undefined, 0)
+                ).toEqual('February 26 - March 2, 2012')
+            })
+
+            it('This week with Monday start', () => {
+                expect(
+                    dateFilterToText('wStart', undefined, 'default', dateMapping, true, undefined, undefined, 1)
+                ).toEqual('February 27 - March 2, 2012')
+            })
+
+            it('Last week with Sunday start (default)', () => {
+                expect(
+                    dateFilterToText('-1wStart', '-1wEnd', 'default', dateMapping, true, undefined, undefined, 0)
+                ).toEqual('February 19 - February 25, 2012')
+            })
+
+            it('Last week with Monday start', () => {
+                expect(
+                    dateFilterToText('-1wStart', '-1wEnd', 'default', dateMapping, true, undefined, undefined, 1)
+                ).toEqual('February 20 - February 26, 2012')
+            })
+        })
     })
 
     describe('dateStringToDayJs', () => {
@@ -424,6 +458,10 @@ describe('lib/utils', () => {
 
         it('should return days for month to date', () => {
             expect(getDefaultInterval('mStart', null)).toEqual('day')
+        })
+
+        it('should return days for week to date', () => {
+            expect(getDefaultInterval('wStart', null)).toEqual('day')
         })
 
         it('should return month for year to date', () => {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1159,8 +1159,9 @@ export const formatDateTimeRange = (dateFrom: dayjs.Dayjs, dateTo: dayjs.Dayjs):
 }
 
 /** Returns the start of the current week, respecting the team's week start day (0=Sunday, 1=Monday). */
-function startOfWeek(date: dayjs.Dayjs, weekStartDay: number = 0): dayjs.Dayjs {
-    return date.subtract((date.day() - weekStartDay + 7) % 7, 'day').startOf('day')
+function startOfWeek(date: dayjs.Dayjs, weekStartDay?: number | null): dayjs.Dayjs {
+    const start = weekStartDay === 1 ? 1 : 0
+    return date.subtract((date.day() - start + 7) % 7, 'day').startOf('day')
 }
 
 export const dateMapping: DateMappingOption[] = [

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1158,6 +1158,11 @@ export const formatDateTimeRange = (dateFrom: dayjs.Dayjs, dateTo: dayjs.Dayjs):
     return `${dateFrom.format(fromComponents.join(''))} - ${dateTo.format(toComponents.join(''))}`
 }
 
+/** Returns the start of the current week, respecting the team's week start day (0=Sunday, 1=Monday). */
+function startOfWeek(date: dayjs.Dayjs, weekStartDay: number = 0): dayjs.Dayjs {
+    return date.subtract((date.day() - weekStartDay + 7) % 7, 'day').startOf('day')
+}
+
 export const dateMapping: DateMappingOption[] = [
     { key: CUSTOM_OPTION_KEY, values: [] },
     {
@@ -1221,9 +1226,14 @@ export const dateMapping: DateMappingOption[] = [
         getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(180, 'd'), date.endOf('d')),
         defaultInterval: 'month',
     },
+
     {
         key: 'Last week',
         values: ['-1wStart', '-1wEnd'],
+        getFormattedDate: (date: dayjs.Dayjs, _format?: string, weekStartDay?: number): string => {
+            const lastWeekStart = startOfWeek(date, weekStartDay).subtract(7, 'day')
+            return formatDateRange(lastWeekStart, lastWeekStart.add(6, 'day').endOf('d'))
+        },
         defaultInterval: 'day',
     },
     {
@@ -1231,6 +1241,13 @@ export const dateMapping: DateMappingOption[] = [
         values: ['-1mStart', '-1mEnd'],
         getFormattedDate: (date: dayjs.Dayjs): string =>
             formatDateRange(date.subtract(1, 'month').startOf('month'), date.subtract(1, 'month').endOf('month')),
+        defaultInterval: 'day',
+    },
+    {
+        key: 'This week',
+        values: ['wStart'],
+        getFormattedDate: (date: dayjs.Dayjs, _format?: string, weekStartDay?: number): string =>
+            formatDateRange(startOfWeek(date, weekStartDay), date.endOf('d')),
         defaultInterval: 'day',
     },
     {
@@ -1276,7 +1293,8 @@ export function dateFilterToText(
     dateOptions: DateMappingOption[] = dateMapping,
     isDateFormatted: boolean = false,
     dateFormat: string = DATE_FORMAT,
-    startOfRange: boolean = false
+    startOfRange: boolean = false,
+    weekStartDay?: number
 ): string | null {
     if (dayjs.isDayjs(dateFrom) && dayjs.isDayjs(dateTo)) {
         return formatDateRange(dateFrom, dateTo, dateFormat)
@@ -1309,7 +1327,7 @@ export function dateFilterToText(
 
     for (const { key, values, getFormattedDate } of dateOptions) {
         if (values[0] === dateFrom && values[1] === dateTo && key !== CUSTOM_OPTION_KEY) {
-            return isDateFormatted && getFormattedDate ? getFormattedDate(dayjs(), dateFormat) : key
+            return isDateFormatted && getFormattedDate ? getFormattedDate(dayjs(), dateFormat, weekStartDay) : key
         }
     }
 
@@ -1475,7 +1493,12 @@ export const getDefaultInterval = (dateFrom: string | null, dateTo: string | nul
         return 'hour'
     }
 
-    if (parsedDateFrom?.unit === 'day' || parsedDateTo?.unit === 'day' || dateFrom === 'mStart') {
+    if (
+        parsedDateFrom?.unit === 'day' ||
+        parsedDateTo?.unit === 'day' ||
+        dateFrom === 'mStart' ||
+        dateFrom === 'wStart'
+    ) {
         return 'day'
     }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4406,7 +4406,7 @@ export interface DateMappingOption {
     key: string
     inactive?: boolean // Options removed due to low usage (see relevant PR); will not show up for new insights but will be kept for existing
     values: string[]
-    getFormattedDate?: (date: dayjs.Dayjs, format?: string) => string
+    getFormattedDate?: (date: dayjs.Dayjs, format?: string, weekStartDay?: number) => string
     defaultInterval?: IntervalType
 }
 

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -279,6 +279,22 @@ class TestRelativeDateParse(TestCase):
             "2019-01-01",
         )
 
+    @parameterized.expand(
+        [
+            # 2020-01-31 is a Friday
+            # Sunday week start (default): week started on Sunday Jan 26
+            ("sunday_start", 0, "2020-01-26"),
+            # Monday week start: week started on Monday Jan 27
+            ("monday_start", 1, "2020-01-27"),
+        ]
+    )
+    @freeze_time("2020-01-31")
+    def test_week_start(self, _name, week_start_day, expected_date):
+        self.assertEqual(
+            relative_date_parse("wStart", ZoneInfo("UTC"), team_week_start_day=week_start_day).strftime("%Y-%m-%d"),
+            expected_date,
+        )
+
     @freeze_time("2020-01-31")
     def test_normal_date(self):
         self.assertEqual(


### PR DESCRIPTION
## Problem

- #46885 
- Last week didn't respect teams' selected start of week selection.

## Changes

- Add quick range for 'this week' in date filter
- Have it respect teams selected start of week.
- Existing "Last week" now respects teams selected start of week selection.

![2026-02-09 05 02 29](https://github.com/user-attachments/assets/0427627a-a6cc-4fdb-880c-17af23c0845a)



## How did you test this code?
locally

## Publish to changelog?
yes