### PR TITLE
fix: external link icon showing when LemonButton has custom icon

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -273,7 +273,7 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                         {children ? <span className="LemonButton__content">{children}</span> : null}
                         {sideIcon ? (
                             <span className="LemonButton__icon">{sideIcon}</span>
-                        ) : targetBlank && !hideExternalLinkIcon ? (
+                        ) : targetBlank && !hideExternalLinkIcon && !icon ? (
                             <IconExternal />
                         ) : null}
                     </span>

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -273,7 +273,7 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                         {children ? <span className="LemonButton__content">{children}</span> : null}
                         {sideIcon ? (
                             <span className="LemonButton__icon">{sideIcon}</span>
-                        ) : targetBlank && !hideExternalLinkIcon && icon === undefined ? (
+                        ) : targetBlank && !hideExternalLinkIcon && !icon ? (
                             <IconExternal />
                         ) : null}
                     </span>

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -273,7 +273,7 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                         {children ? <span className="LemonButton__content">{children}</span> : null}
                         {sideIcon ? (
                             <span className="LemonButton__icon">{sideIcon}</span>
-                        ) : targetBlank && !hideExternalLinkIcon && !icon ? (
+                        ) : targetBlank && !hideExternalLinkIcon && icon === undefined ? (
                             <IconExternal />
                         ) : null}
                     </span>


### PR DESCRIPTION
## Problem

When a LemonButton has both a custom `icon` prop and `targetBlank` enabled, the external link icon was being displayed alongside the custom icon, creating a visual conflict and confusing UI.

For example in replay

<img width="886" height="612" alt="CleanShot 2026-02-09 at 08 28 19@2x" src="https://github.com/user-attachments/assets/c61458d5-c671-4c8d-8b0e-51011b2933a3" />

## Changes

Updated the condition in LemonButton to prevent the external link icon from rendering when a custom icon is already present.

## Publish to changelog?

no

https://claude.ai/code/session_014SKhgoyqx9w3QrDkRawpkH