### PR TITLE
fix(dwh): redshift cert error

### DIFF
--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -58,6 +58,9 @@ def get_redshift_row_count(
         password=password,
         sslmode="require",
         connect_timeout=15,
+        sslrootcert="/tmp/no.txt",
+        sslcert="/tmp/no.txt",
+        sslkey="/tmp/no.txt",
         options="-c client_encoding=UTF8",
     )
 

--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -119,6 +119,9 @@ def get_schemas(
         password=password,
         sslmode="require",
         connect_timeout=15,
+        sslrootcert="/tmp/no.txt",
+        sslcert="/tmp/no.txt",
+        sslkey="/tmp/no.txt",
         options="-c client_encoding=UTF8",
     )
 
@@ -541,6 +544,9 @@ def redshift_source(
             password=password,
             sslmode="require",
             connect_timeout=15,
+            sslrootcert="/tmp/no.txt",
+            sslcert="/tmp/no.txt",
+            sslkey="/tmp/no.txt",
             options="-c client_encoding=UTF8",
         ) as connection:
             with connection.cursor() as cursor:
@@ -619,6 +625,9 @@ def redshift_source(
                     password=password,
                     sslmode="require",
                     connect_timeout=15,
+                    sslrootcert="/tmp/no.txt",
+                    sslcert="/tmp/no.txt",
+                    sslkey="/tmp/no.txt",
                     options="-c client_encoding=UTF8",
                 )
                 connection.adapters.register_loader("json", JsonAsStringLoader)


### PR DESCRIPTION
## Problem

The redshift source is getting this error in production
> OperationalError('connection failed: connection to server at \"xx.xx.xx.xx\", port 5439 failed: could not open certificate file \"/root/.postgresql/postgresql.crt\": Permission denied')

## Changes

- provide a non-existing certificate so psycopg doesn't try to access postgresql.crt

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->