### PR TITLE
refactor: extract hog transformation into processing step

### DIFF
--- a/nodejs/src/ingestion/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/event-subpipeline.ts
@@ -14,6 +14,7 @@ import { createCreateEventStep } from '../event-processing/create-event-step'
 import { createEmitEventStep } from '../event-processing/emit-event-step'
 import { createEventPipelineRunnerV1Step } from '../event-processing/event-pipeline-runner-v1-step'
 import { createExtractHeatmapDataStep } from '../event-processing/extract-heatmap-data-step'
+import { createHogTransformEventStep } from '../event-processing/hog-transform-event-step'
 import { createNormalizeProcessPersonFlagStep } from '../event-processing/normalize-process-person-flag-step'
 import { PipelineBuilder, StartPipelineBuilder } from '../pipelines/builders/pipeline-builders'
 
@@ -46,16 +47,8 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput, TCo
 
     return builder
         .pipe(createNormalizeProcessPersonFlagStep())
-        .pipe(
-            createEventPipelineRunnerV1Step(
-                options,
-                kafkaProducer,
-                teamManager,
-                groupTypeManager,
-                hogTransformer,
-                personsStore
-            )
-        )
+        .pipe(createHogTransformEventStep(hogTransformer))
+        .pipe(createEventPipelineRunnerV1Step(options, kafkaProducer, teamManager, groupTypeManager, personsStore))
         .pipe(
             createExtractHeatmapDataStep({
                 kafkaProducer,

--- a/nodejs/src/ingestion/analytics/heatmap-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/heatmap-subpipeline.ts
@@ -1,6 +1,5 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
@@ -28,7 +27,6 @@ export interface HeatmapSubpipelineConfig {
     }
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
-    hogTransformer: HogTransformerService
     personsStore: PersonsStore
     kafkaProducer: KafkaProducerWrapper
 }
@@ -37,21 +35,12 @@ export function createHeatmapSubpipeline<TInput extends HeatmapSubpipelineInput,
     builder: StartPipelineBuilder<TInput, TContext>,
     config: HeatmapSubpipelineConfig
 ): PipelineBuilder<TInput, void, TContext> {
-    const { options, teamManager, groupTypeManager, hogTransformer, personsStore, kafkaProducer } = config
+    const { options, teamManager, groupTypeManager, personsStore, kafkaProducer } = config
 
     return builder
         .pipe(createDisablePersonProcessingStep())
         .pipe(createNormalizeEventStep(options.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE))
-        .pipe(
-            createEventPipelineRunnerHeatmapStep(
-                options,
-                kafkaProducer,
-                teamManager,
-                groupTypeManager,
-                hogTransformer,
-                personsStore
-            )
-        )
+        .pipe(createEventPipelineRunnerHeatmapStep(options, kafkaProducer, teamManager, groupTypeManager, personsStore))
         .pipe(
             createExtractHeatmapDataStep({
                 kafkaProducer,

--- a/nodejs/src/ingestion/analytics/per-event-processing-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/per-event-processing-subpipeline.ts
@@ -58,7 +58,6 @@ export function createPerEventProcessingSubpipeline<TInput extends PerEventProce
                             options,
                             teamManager,
                             groupTypeManager,
-                            hogTransformer,
                             personsStore,
                             kafkaProducer,
                         })

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
@@ -4,7 +4,6 @@ import { v4 } from 'uuid'
 import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
 import { createTestPipelineEvent } from '../../../tests/helpers/pipeline-event'
 import { createTestTeam } from '../../../tests/helpers/team'
-import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, ISOTimestamp, PipelineEvent, PreIngestionEvent, ProjectId, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
@@ -55,7 +54,6 @@ describe('event-pipeline-runner-heatmap-step', () => {
     let mockKafkaProducer: KafkaProducerWrapper
     let mockTeamManager: TeamManager
     let mockGroupTypeManager: GroupTypeManager
-    let mockHogTransformer: HogTransformerService
     let mockPersonsStore: PersonsStore
     let mockGroupStore: GroupStoreForBatch
     let mockEventPipelineRunner: jest.Mocked<EventPipelineRunner>
@@ -80,7 +78,6 @@ describe('event-pipeline-runner-heatmap-step', () => {
         mockKafkaProducer = {} as KafkaProducerWrapper
         mockTeamManager = {} as TeamManager
         mockGroupTypeManager = {} as GroupTypeManager
-        mockHogTransformer = {} as HogTransformerService
         mockPersonsStore = {} as PersonsStore
         mockGroupStore = {} as GroupStoreForBatch
 
@@ -114,7 +111,6 @@ describe('event-pipeline-runner-heatmap-step', () => {
             mockKafkaProducer,
             mockTeamManager,
             mockGroupTypeManager,
-            mockHogTransformer,
             mockPersonsStore
         )
 
@@ -134,7 +130,6 @@ describe('event-pipeline-runner-heatmap-step', () => {
             mockTeamManager,
             mockGroupTypeManager,
             mockEvent,
-            mockHogTransformer,
             mockPersonsStore,
             mockGroupStore,
             mockHeaders
@@ -157,7 +152,6 @@ describe('event-pipeline-runner-heatmap-step', () => {
             mockKafkaProducer,
             mockTeamManager,
             mockGroupTypeManager,
-            mockHogTransformer,
             mockPersonsStore
         )
 
@@ -186,7 +180,6 @@ describe('event-pipeline-runner-heatmap-step', () => {
             mockKafkaProducer,
             mockTeamManager,
             mockGroupTypeManager,
-            mockHogTransformer,
             mockPersonsStore
         )
 
@@ -216,7 +209,6 @@ describe('event-pipeline-runner-heatmap-step', () => {
             mockKafkaProducer,
             mockTeamManager,
             mockGroupTypeManager,
-            mockHogTransformer,
             mockPersonsStore
         )
 
@@ -236,7 +228,6 @@ describe('event-pipeline-runner-heatmap-step', () => {
             mockTeamManager,
             mockGroupTypeManager,
             mockEvent,
-            mockHogTransformer,
             mockPersonsStore,
             mockGroupStore,
             customHeaders
@@ -252,7 +243,6 @@ describe('event-pipeline-runner-heatmap-step', () => {
             mockKafkaProducer,
             mockTeamManager,
             mockGroupTypeManager,
-            mockHogTransformer,
             mockPersonsStore
         )
 
@@ -284,7 +274,6 @@ describe('event-pipeline-runner-heatmap-step', () => {
             mockKafkaProducer,
             mockTeamManager,
             mockGroupTypeManager,
-            mockHogTransformer,
             mockPersonsStore
         )
 

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon'
 
-import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, PipelineEvent, PreIngestionEvent, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
@@ -28,7 +27,6 @@ export function createEventPipelineRunnerHeatmapStep<TInput extends EventPipelin
     kafkaProducer: KafkaProducerWrapper,
     teamManager: TeamManager,
     groupTypeManager: GroupTypeManager,
-    hogTransformer: HogTransformerService,
     personsStore: PersonsStore
 ): ProcessingStep<TInput, EventPipelineRunnerHeatmapStepResult<TInput>> {
     return async function eventPipelineRunnerHeatmapStep(
@@ -47,7 +45,6 @@ export function createEventPipelineRunnerHeatmapStep<TInput extends EventPipelin
             teamManager,
             groupTypeManager,
             normalizedEvent,
-            hogTransformer,
             personsStore,
             groupStoreForBatch,
             headers

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-v1-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-v1-step.test.ts
@@ -5,7 +5,6 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 import { createTestMessage } from '../../../tests/helpers/kafka-message'
 import { createTestPluginEvent } from '../../../tests/helpers/plugin-event'
 import { createTestTeam } from '../../../tests/helpers/team'
-import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { ProjectId, Team, TimestampFormat } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
@@ -66,7 +65,6 @@ describe('event-pipeline-runner-v1-step', () => {
     let mockKafkaProducer: KafkaProducerWrapper
     let mockTeamManager: TeamManager
     let mockGroupTypeManager: GroupTypeManager
-    let mockHogTransformer: HogTransformerService
     let mockPersonsStore: PersonsStore
     let mockGroupStore: GroupStoreForBatch
     let mockEventPipelineRunner: jest.Mocked<EventPipelineRunner>
@@ -92,7 +90,6 @@ describe('event-pipeline-runner-v1-step', () => {
         mockKafkaProducer = {} as KafkaProducerWrapper
         mockTeamManager = {} as TeamManager
         mockGroupTypeManager = {} as GroupTypeManager
-        mockHogTransformer = {} as HogTransformerService
         mockPersonsStore = {} as PersonsStore
         mockGroupStore = {} as GroupStoreForBatch
 
@@ -140,7 +137,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {
@@ -160,7 +156,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockTeamManager,
                 mockGroupTypeManager,
                 mockEvent,
-                mockHogTransformer,
                 mockPersonsStore,
                 mockGroupStore,
                 mockHeaders
@@ -184,7 +179,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {
@@ -210,7 +204,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {
@@ -235,7 +228,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {
@@ -265,7 +257,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {
@@ -297,7 +288,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {
@@ -329,7 +319,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {
@@ -350,7 +339,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockTeamManager,
                 mockGroupTypeManager,
                 mockEvent,
-                mockHogTransformer,
                 mockPersonsStore,
                 mockGroupStore,
                 mockHeaders
@@ -367,7 +355,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {
@@ -399,7 +386,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {
@@ -422,7 +408,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {
@@ -445,7 +430,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {
@@ -468,7 +452,6 @@ describe('event-pipeline-runner-v1-step', () => {
                 mockKafkaProducer,
                 mockTeamManager,
                 mockGroupTypeManager,
-                mockHogTransformer,
                 mockPersonsStore
             )
             const input: EventPipelineRunnerInput = {

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
@@ -2,7 +2,6 @@ import { Message } from 'node-rdkafka'
 
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
@@ -37,7 +36,6 @@ export function createEventPipelineRunnerV1Step(
     kafkaProducer: KafkaProducerWrapper,
     teamManager: TeamManager,
     groupTypeManager: GroupTypeManager,
-    hogTransformer: HogTransformerService,
     personsStore: PersonsStore
 ): ProcessingStep<EventPipelineRunnerInput, EventPipelineRunnerStepResult> {
     return async function eventPipelineRunnerV1Step(
@@ -59,7 +57,6 @@ export function createEventPipelineRunnerV1Step(
             teamManager,
             groupTypeManager,
             event,
-            hogTransformer,
             personsStore,
             groupStoreForBatch,
             inputHeaders

--- a/nodejs/src/ingestion/event-processing/hog-transform-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/hog-transform-event-step.test.ts
@@ -49,12 +49,7 @@ describe('createHogTransformEventStep', () => {
         const result = await hogTransformEventStep(input)
 
         expect(result.type).toBe(PipelineResultType.OK)
-        expect(mockTransformer.transformEventAndProduceMessages).toHaveBeenCalledWith(
-            expect.objectContaining({
-                uuid: input.event.uuid,
-                team_id: input.team.id,
-            })
-        )
+        expect(mockTransformer.transformEventAndProduceMessages).toHaveBeenCalledWith(input.event)
     })
 
     it('drops event when transformation returns null', async () => {

--- a/nodejs/src/ingestion/event-processing/hog-transform-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/hog-transform-event-step.test.ts
@@ -1,0 +1,133 @@
+import { v4 } from 'uuid'
+
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { HogTransformerService, TransformationResult } from '../../cdp/hog-transformations/hog-transformer.service'
+import { PipelineResultType, isDropResult, isOkResult } from '../pipelines/results'
+import { HogTransformEventInput, createHogTransformEventStep } from './hog-transform-event-step'
+
+const createTestInput = (): HogTransformEventInput => {
+    return {
+        event: {
+            uuid: v4(),
+            event: '$pageview',
+            distinct_id: 'user-1',
+            properties: { $current_url: 'https://example.com' },
+            now: new Date().toISOString(),
+        },
+        team: {
+            id: 1,
+        },
+    } as unknown as HogTransformEventInput
+}
+
+const createMockHogTransformer = (transformFn: (event: PluginEvent) => TransformationResult): HogTransformerService => {
+    return {
+        transformEventAndProduceMessages: jest.fn(transformFn),
+    } as unknown as HogTransformerService
+}
+
+describe('createHogTransformEventStep', () => {
+    it('passes through unchanged when no transformer configured', async () => {
+        const hogTransformEventStep = createHogTransformEventStep(null)
+        const input = createTestInput()
+
+        const result = await hogTransformEventStep(input)
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        expect(isOkResult(result) && result.value).toBe(input)
+    })
+
+    it('passes through unchanged when transformer returns same event', async () => {
+        const mockTransformer = createMockHogTransformer((event) => ({
+            event,
+            invocationResults: [],
+        }))
+        const hogTransformEventStep = createHogTransformEventStep(mockTransformer)
+        const input = createTestInput()
+
+        const result = await hogTransformEventStep(input)
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        expect(mockTransformer.transformEventAndProduceMessages).toHaveBeenCalledWith(
+            expect.objectContaining({
+                uuid: input.event.uuid,
+                team_id: input.team.id,
+            })
+        )
+    })
+
+    it('drops event when transformation returns null', async () => {
+        const mockTransformer = createMockHogTransformer(() => ({
+            event: null,
+            invocationResults: [],
+        }))
+        const hogTransformEventStep = createHogTransformEventStep(mockTransformer)
+        const input = createTestInput()
+
+        const result = await hogTransformEventStep(input)
+
+        expect(result.type).toBe(PipelineResultType.DROP)
+        expect(isDropResult(result) && result.reason).toBe('dropped_by_transformation')
+    })
+
+    it('returns transformed event with modified properties', async () => {
+        const mockTransformer = createMockHogTransformer((event) => ({
+            event: {
+                ...event,
+                properties: { ...event.properties, transformed: true },
+            },
+            invocationResults: [],
+        }))
+        const hogTransformEventStep = createHogTransformEventStep(mockTransformer)
+        const input = createTestInput()
+
+        const result = await hogTransformEventStep(input)
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (isOkResult(result)) {
+            expect(result.value.event.properties).toMatchObject({
+                $current_url: 'https://example.com',
+                transformed: true,
+            })
+        }
+    })
+
+    it('returns transformed event with modified event name', async () => {
+        const mockTransformer = createMockHogTransformer((event) => ({
+            event: {
+                ...event,
+                event: 'custom_event',
+            },
+            invocationResults: [],
+        }))
+        const hogTransformEventStep = createHogTransformEventStep(mockTransformer)
+        const input = createTestInput()
+
+        const result = await hogTransformEventStep(input)
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (isOkResult(result)) {
+            expect(result.value.event.event).toBe('custom_event')
+        }
+    })
+
+    it('returns transformed event with modified distinct_id', async () => {
+        const mockTransformer = createMockHogTransformer((event) => ({
+            event: {
+                ...event,
+                distinct_id: 'new-user-id',
+            },
+            invocationResults: [],
+        }))
+        const hogTransformEventStep = createHogTransformEventStep(mockTransformer)
+        const input = createTestInput()
+
+        const result = await hogTransformEventStep(input)
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (isOkResult(result)) {
+            expect(result.value.event.distinct_id).toBe('new-user-id')
+        }
+    })
+})

--- a/nodejs/src/ingestion/event-processing/hog-transform-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/hog-transform-event-step.ts
@@ -1,0 +1,56 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
+import { PipelineEvent, Team } from '../../types'
+import { PipelineResult, drop, ok } from '../pipelines/results'
+import { ProcessingStep } from '../pipelines/steps'
+
+export interface HogTransformEventInput {
+    event: PipelineEvent
+    team: Pick<Team, 'id'>
+}
+
+/**
+ * Creates a pipeline step that runs Hog transformations on events.
+ *
+ * Hog transformations are user-defined functions that can modify event properties,
+ * change the event name, update distinct_id, or drop the event entirely.
+ *
+ * If a transformation drops the event (returns null), this step returns a `drop` result.
+ */
+export function createHogTransformEventStep<T extends HogTransformEventInput>(
+    hogTransformer: HogTransformerService | null
+): ProcessingStep<T, T> {
+    return async function hogTransformEventStep(input: T): Promise<PipelineResult<T>> {
+        const { event, team } = input
+
+        // If no transformer configured, pass through unchanged
+        if (!hogTransformer) {
+            return ok(input)
+        }
+
+        // Convert PipelineEvent to PluginEvent for transformation
+        const pluginEvent: PluginEvent = {
+            ...event,
+            team_id: team.id,
+        }
+
+        const result = await hogTransformer.transformEventAndProduceMessages(pluginEvent)
+
+        // If transformation dropped the event, return drop result
+        if (result.event === null) {
+            return drop('dropped_by_transformation')
+        }
+
+        // Convert back to PipelineEvent (preserve team_id as optional)
+        const transformedEvent: PipelineEvent = {
+            ...result.event,
+            team_id: result.event.team_id,
+        }
+
+        return ok({
+            ...input,
+            event: transformedEvent,
+        })
+    }
+}

--- a/nodejs/src/ingestion/event-processing/hog-transform-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/hog-transform-event-step.ts
@@ -19,7 +19,7 @@ export interface HogTransformEventInput {
  * If a transformation drops the event (returns null), this step returns a `drop` result.
  */
 export function createHogTransformEventStep<T extends HogTransformEventInput>(
-    hogTransformer: HogTransformerService | null
+    hogTransformer: Pick<HogTransformerService, 'transformEventAndProduceMessages'> | null
 ): ProcessingStep<T, T> {
     return async function hogTransformEventStep(input: T): Promise<PipelineResult<T>> {
         const { event } = input

--- a/nodejs/tests/main/process-event.test.ts
+++ b/nodejs/tests/main/process-event.test.ts
@@ -131,7 +131,6 @@ describe('processEvent', () => {
             hub.teamManager,
             hub.groupTypeManager,
             pluginEvent,
-            null,
             personsStoreForBatch,
             groupStoreForBatch
         )
@@ -290,7 +289,6 @@ describe('processEvent', () => {
             hub.teamManager,
             hub.groupTypeManager,
             event,
-            null,
             personsStoreForBatch,
             groupStoreForBatch
         )

--- a/nodejs/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/nodejs/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -3,12 +3,6 @@
 exports[`EventPipelineRunner runEventPipeline() runs steps 1`] = `
 [
   [
-    "transformEventStep",
-    [
-      null,
-    ],
-  ],
-  [
     "normalizeEventStep",
     [
       true,

--- a/nodejs/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/nodejs/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -218,7 +218,6 @@ describe('EventPipelineRunner', () => {
             hub.teamManager,
             hub.groupTypeManager,
             pluginEvent,
-            undefined,
             personsStoreForBatch,
             groupStoreForBatch,
             undefined // headers
@@ -238,12 +237,7 @@ describe('EventPipelineRunner', () => {
         it('runs steps', async () => {
             await runner.runEventPipeline(pluginEvent, team)
 
-            expect(runner.steps).toEqual([
-                'transformEventStep',
-                'normalizeEventStep',
-                'processPersonsStep',
-                'prepareEventStep',
-            ])
+            expect(runner.steps).toEqual(['normalizeEventStep', 'processPersonsStep', 'prepareEventStep'])
             expect(forSnapshot(runner.stepsWithArgs)).toMatchSnapshot()
         })
 
@@ -255,7 +249,7 @@ describe('EventPipelineRunner', () => {
             if (isOkResult(result)) {
                 expect(result.value.error).toBeUndefined()
             }
-            expect(pipelineStepMsSummarySpy).toHaveBeenCalledTimes(4)
+            expect(pipelineStepMsSummarySpy).toHaveBeenCalledTimes(3)
             expect(pipelineStepErrorCounterSpy).not.toHaveBeenCalled()
         })
 
@@ -353,7 +347,6 @@ describe('EventPipelineRunner', () => {
                     hub.teamManager,
                     hub.groupTypeManager,
                     heatmapEvent,
-                    undefined,
                     personsStore,
                     heatmapGroupStoreForBatch,
                     undefined // headers


### PR DESCRIPTION
## Problem

Ingestion pipeline is not composable enough, making it hard to replica an existing ingestion pipeline with small changes.

## Changes

Extract existing logic into structured pipeline processing steps

## How did you test this code?

Unit/integration tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
