### PR TITLE
feat(logs-ingestion): add team_id labels to dropped/DLQ metrics

### DIFF
--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -253,6 +253,7 @@ describe('LogsIngestionConsumer', () => {
             await waitForBackgroundTasks(consumer.processKafkaBatch(messages))
 
             expect(getProducedKafkaMessages()).toHaveLength(0)
+            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith({ reason: 'missing_token', team_id: 'unknown' })
         })
 
         it('should drop messages with invalid token', async () => {
@@ -307,7 +308,21 @@ describe('LogsIngestionConsumer', () => {
             await waitForBackgroundTasks(consumer.processKafkaBatch(messages))
 
             expect(getProducedKafkaMessages()).toHaveLength(0)
-            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith({ reason: 'team_not_found' })
+            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith({ reason: 'team_not_found', team_id: 'unknown' })
+        })
+
+        it('should drop messages when team lookup fails and record unknown team_id', async () => {
+            jest.spyOn(hub.teamManager, 'getTeamByToken').mockRejectedValueOnce(new Error('Database error'))
+
+            const logData = createLogMessage()
+            const messages = await createKafkaMessages([logData], {
+                token: team.api_token,
+            })
+
+            await waitForBackgroundTasks(consumer.processKafkaBatch(messages))
+
+            expect(getProducedKafkaMessages()).toHaveLength(0)
+            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith({ reason: 'parse_error', team_id: 'unknown' })
         })
     })
 
@@ -452,8 +467,8 @@ describe('LogsIngestionConsumer', () => {
 
             await waitForBackgroundTasks(consumer.processKafkaBatch(messages))
 
-            // Check that DLQ counter was incremented
-            expect(logMessageDlqCounterSpy).toHaveBeenCalled()
+            // Check that DLQ counter was incremented with team_id
+            expect(logMessageDlqCounterSpy).toHaveBeenCalledWith({ reason: 'Error', team_id: team.id.toString() })
 
             // Check that a message was produced to the DLQ topic
             const dlqMessages = produceSpy.mock.calls.filter((call) => call[0].topic === 'logs_ingestion_dlq_test')
@@ -610,11 +625,14 @@ describe('LogsIngestionConsumer', () => {
             expect(logsMessages).toHaveLength(1)
             expect(bytesReceivedSpy).toHaveBeenCalledWith(3072)
             expect(bytesAllowedSpy).toHaveBeenCalledWith(1024)
-            expect(bytesDroppedSpy).toHaveBeenCalledWith(2048)
+            expect(bytesDroppedSpy).toHaveBeenCalledWith({ team_id: team.id.toString() }, 2048)
             expect(recordsReceivedSpy).toHaveBeenCalledWith(15)
             expect(recordsAllowedSpy).toHaveBeenCalledWith(5)
-            expect(recordsDroppedSpy).toHaveBeenCalledWith(10)
-            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith({ reason: 'rate_limited' }, 1)
+            expect(recordsDroppedSpy).toHaveBeenCalledWith({ team_id: team.id.toString() }, 10)
+            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith(
+                { reason: 'rate_limited', team_id: team.id.toString() },
+                1
+            )
         })
 
         it('should handle missing header values with defaults', async () => {
@@ -730,7 +748,11 @@ describe('LogsIngestionConsumer', () => {
             const parsed = await consumer['_parseKafkaBatch'](messages)
             await consumer['filterQuotaLimitedMessages'](parsed)
 
-            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith({ reason: 'quota_limited' }, 2)
+            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith(
+                { reason: 'quota_limited', team_id: team.id.toString() },
+                2
+            )
+            expect(logMessageDroppedCounterSpy).toHaveBeenCalledTimes(1)
         })
     })
 
@@ -808,7 +830,10 @@ describe('LogsIngestionConsumer', () => {
             expect(result.messages[0].token).toBe(team2.api_token)
 
             // Verify quota_limited counter was incremented for team1
-            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith({ reason: 'quota_limited' }, 1)
+            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith(
+                { reason: 'quota_limited', team_id: team.id.toString() },
+                1
+            )
         })
 
         it('should drop messages from both quota and rate limiting', async () => {
@@ -850,8 +875,14 @@ describe('LogsIngestionConsumer', () => {
             expect(result.messages[0].bytesUncompressed).toBe(500)
 
             // Verify both drop reasons were recorded
-            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith({ reason: 'quota_limited' }, 1)
-            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith({ reason: 'rate_limited' }, 1)
+            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith(
+                { reason: 'quota_limited', team_id: team.id.toString() },
+                1
+            )
+            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith(
+                { reason: 'rate_limited', team_id: team2.id.toString() },
+                1
+            )
         })
 
         it('should track usage stats correctly for mixed allowed and dropped messages', async () => {

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -62,13 +62,13 @@ export type UsageStatsByTeam = Map<number, UsageStats>
 export const logMessageDroppedCounter = new Counter({
     name: 'logs_ingestion_message_dropped_count',
     help: 'The number of logs ingestion messages dropped',
-    labelNames: ['reason'],
+    labelNames: ['reason', 'team_id'],
 })
 
 export const logMessageDlqCounter = new Counter({
     name: 'logs_ingestion_message_dlq_count',
     help: 'The number of logs ingestion messages sent to DLQ',
-    labelNames: ['reason'],
+    labelNames: ['reason', 'team_id'],
 })
 
 export const logsBytesReceivedCounter = new Counter({
@@ -84,6 +84,7 @@ export const logsBytesAllowedCounter = new Counter({
 export const logsBytesDroppedCounter = new Counter({
     name: 'logs_ingestion_bytes_dropped_total',
     help: 'Total uncompressed bytes dropped due to quota or rate limiting',
+    labelNames: ['team_id'],
 })
 
 export const logsRecordsReceivedCounter = new Counter({
@@ -99,6 +100,7 @@ export const logsRecordsAllowedCounter = new Counter({
 export const logsRecordsDroppedCounter = new Counter({
     name: 'logs_ingestion_records_dropped_total',
     help: 'Total log records dropped due to quota or rate limiting',
+    labelNames: ['team_id'],
 })
 
 export class LogsIngestionConsumer {
@@ -200,8 +202,6 @@ export class LogsIngestionConsumer {
     ): UsageStatsByTeam {
         let totalBytesAllowed = 0
         let totalRecordsAllowed = 0
-        let totalBytesDropped = 0
-        let totalRecordsDropped = 0
         const usageStats: UsageStatsByTeam = new Map()
 
         for (const message of allowedMessages) {
@@ -226,13 +226,17 @@ export class LogsIngestionConsumer {
             stats.bytesDropped += message.bytesUncompressed
             stats.recordsDropped += message.recordCount
             usageStats.set(message.teamId, stats)
-
-            totalBytesDropped += message.bytesUncompressed
-            totalRecordsDropped += message.recordCount
         }
 
-        logsBytesDroppedCounter.inc(totalBytesDropped)
-        logsRecordsDroppedCounter.inc(totalRecordsDropped)
+        for (const [teamId, stats] of usageStats) {
+            const teamIdLabel = teamId.toString()
+            if (stats.bytesDropped > 0) {
+                logsBytesDroppedCounter.inc({ team_id: teamIdLabel }, stats.bytesDropped)
+            }
+            if (stats.recordsDropped > 0) {
+                logsRecordsDroppedCounter.inc({ team_id: teamIdLabel }, stats.recordsDropped)
+            }
+        }
 
         return usageStats
     }
@@ -255,15 +259,19 @@ export class LogsIngestionConsumer {
             ).filter((token): token is string => token !== null)
         )
 
+        const droppedCountByTeam = new Map<number, number>()
         for (const message of messages) {
             if (quotaLimitedTokens.has(message.token)) {
                 quotaDroppedMessages.push(message)
+                droppedCountByTeam.set(message.teamId, (droppedCountByTeam.get(message.teamId) || 0) + 1)
             } else {
                 quotaAllowedMessages.push(message)
             }
         }
 
-        logMessageDroppedCounter.inc({ reason: 'quota_limited' }, quotaDroppedMessages.length)
+        for (const [teamId, count] of droppedCountByTeam) {
+            logMessageDroppedCounter.inc({ reason: 'quota_limited', team_id: teamId.toString() }, count)
+        }
 
         return { quotaAllowedMessages, quotaDroppedMessages }
     }
@@ -273,7 +281,15 @@ export class LogsIngestionConsumer {
         rateLimiterDroppedMessages: LogsIngestionMessage[]
     }> {
         const { allowed, dropped } = await this.rateLimiter.filterMessages(messages)
-        logMessageDroppedCounter.inc({ reason: 'rate_limited' }, dropped.length)
+
+        const droppedCountByTeam = new Map<number, number>()
+        for (const message of dropped) {
+            droppedCountByTeam.set(message.teamId, (droppedCountByTeam.get(message.teamId) || 0) + 1)
+        }
+        for (const [teamId, count] of droppedCountByTeam) {
+            logMessageDroppedCounter.inc({ reason: 'rate_limited', team_id: teamId.toString() }, count)
+        }
+
         return { rateLimiterAllowedMessages: allowed, rateLimiterDroppedMessages: dropped }
     }
 
@@ -331,7 +347,7 @@ export class LogsIngestionConsumer {
         const errorMessage = error instanceof Error ? error.message : String(error)
         const errorName = error instanceof Error ? error.name : 'UnknownError'
 
-        logMessageDlqCounter.inc({ reason: errorName })
+        logMessageDlqCounter.inc({ reason: errorName, team_id: message.teamId.toString() })
 
         try {
             await this.kafkaProducer!.produce({
@@ -420,7 +436,7 @@ export class LogsIngestionConsumer {
 
                     if (!token) {
                         logger.error('missing_token')
-                        logMessageDroppedCounter.inc({ reason: 'missing_token' })
+                        logMessageDroppedCounter.inc({ reason: 'missing_token', team_id: 'unknown' })
                         return
                     }
 
@@ -432,7 +448,7 @@ export class LogsIngestionConsumer {
 
                     if (!team) {
                         logger.error('team_not_found', { token_with_no_team: token })
-                        logMessageDroppedCounter.inc({ reason: 'team_not_found' })
+                        logMessageDroppedCounter.inc({ reason: 'team_not_found', team_id: 'unknown' })
                         return
                     }
 
@@ -450,7 +466,7 @@ export class LogsIngestionConsumer {
                     })
                 } catch (e) {
                     logger.error('Error parsing message', e)
-                    logMessageDroppedCounter.inc({ reason: 'parse_error' })
+                    logMessageDroppedCounter.inc({ reason: 'parse_error', team_id: 'unknown' })
                     return
                 }
             })


### PR DESCRIPTION
## Problem

When logs are dropped (quota/rate limited) or sent to DLQ, we can't identify which teams are affected.

## Changes

Added `team_id` label to low-cardinality "dropped" metrics only (not high-volume "allowed" metrics to avoid cardinality explosion):

- `logMessageDroppedCounter`
- `logMessageDlqCounter`
- `logsBytesDroppedCounter`
- `logsRecordsDroppedCounter`

Aggregated dropped message counts per team before incrementing counters to minimize metric operations.

Added `'unknown'` fallback for `team_id` when handling early-stage errors (missing token, team not found, parse error).

## How did you test this code?

Updated unit tests

## Publish to changelog?

No