### PR TITLE
fix(llma): remove unnecessary refresh button from clusters tab

### DIFF
--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconChevronDown, IconChevronRight, IconGear, IconInfo, IconRefresh } from '@posthog/icons'
+import { IconChevronDown, IconChevronRight, IconGear, IconInfo } from '@posthog/icons'
 import { LemonButton, LemonSegmentedButton, LemonSelect, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -84,13 +84,8 @@ export function ClustersView(): JSX.Element {
         clusterMetrics,
         clusterMetricsLoading,
     } = useValues(clustersLogic)
-    const {
-        setClusteringLevel,
-        setSelectedRunId,
-        toggleClusterExpanded,
-        toggleScatterPlotExpanded,
-        loadClusteringRuns,
-    } = useActions(clustersLogic)
+    const { setClusteringLevel, setSelectedRunId, toggleClusterExpanded, toggleScatterPlotExpanded } =
+        useActions(clustersLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { openModal } = useActions(clustersAdminLogic)
 
@@ -130,14 +125,6 @@ export function ClustersView(): JSX.Element {
                             />
                         </span>
                     </Tooltip>
-                    <LemonButton
-                        type="secondary"
-                        size="small"
-                        icon={<IconRefresh />}
-                        onClick={loadClusteringRuns}
-                        tooltip="Refresh clustering runs"
-                        data-attr="clusters-refresh-runs"
-                    />
                 </div>
 
                 <div className="flex flex-col items-center justify-center p-8 text-center">
@@ -191,14 +178,6 @@ export function ClustersView(): JSX.Element {
                             />
                         </span>
                     </Tooltip>
-                    <LemonButton
-                        type="secondary"
-                        size="small"
-                        icon={<IconRefresh />}
-                        onClick={loadClusteringRuns}
-                        tooltip="Refresh clustering runs"
-                        data-attr="clusters-refresh-runs"
-                    />
                 </div>
 
                 <div className="flex items-center gap-4">


### PR DESCRIPTION
## Problem

The "Refresh clustering runs" button on the clusters tab in LLM analytics is not needed.

## Changes

Removes the refresh button from both the empty state and main view, and cleans up unused imports.

## How did you test this code?

Visual inspection of the component.

## Publish to changelog?

No.