### PR TITLE
fix(llma): reduce trace clustering sample limit to 1500

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -6,7 +6,7 @@ from temporalio.common import RetryPolicy
 
 # Clustering parameters
 DEFAULT_LOOKBACK_DAYS = 7
-DEFAULT_MAX_SAMPLES = 2500
+DEFAULT_MAX_SAMPLES = 1500
 DEFAULT_MIN_K = 2
 DEFAULT_MAX_K = 10
 


### PR DESCRIPTION
## Summary
- Reduces `DEFAULT_MAX_SAMPLES` from 2500 to 1500 for trace clustering runs
- The frontend scatter plot was struggling to render 2500 data points

## Test plan
- [ ] Verify the scatter plot renders smoothly with the reduced sample limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)