### PR TITLE
fix(alerts): optimistic state update on alert create/edit/delete

### DIFF
--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -132,11 +132,21 @@ export const alertFormLogic = kea<alertFormLogicType>([
                     payload.threshold.configuration.type = InsightThresholdType.ABSOLUTE
                 }
 
+                const upsertToParent = (updatedAlert: AlertType): void => {
+                    if (props.insightVizDataLogicProps) {
+                        insightAlertsLogic({
+                            insightId: props.insightId,
+                            insightLogicProps: props.insightVizDataLogicProps,
+                        }).actions.upsertAlert(updatedAlert)
+                    }
+                }
+
                 try {
                     if (alert.id === undefined) {
                         const updatedAlert: AlertType = await api.alerts.create(payload)
 
                         lemonToast.success(`Alert created.`)
+                        upsertToParent(updatedAlert)
                         props.onEditSuccess(updatedAlert.id)
 
                         return updatedAlert
@@ -145,6 +155,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                     const updatedAlert: AlertType = await api.alerts.update(alert.id, payload)
 
                     lemonToast.success(`Alert saved.`)
+                    upsertToParent(updatedAlert)
                     props.onEditSuccess(updatedAlert.id)
 
                     return updatedAlert
@@ -158,47 +169,61 @@ export const alertFormLogic = kea<alertFormLogicType>([
     })),
 
     listeners(({ props, values }) => {
-        // Helper to refresh alerts in the parent logic if available
-        const refreshParentAlerts = (): void => {
+        const getParentLogic = (): ReturnType<typeof insightAlertsLogic.build> | undefined => {
             if (props.insightVizDataLogicProps) {
-                insightAlertsLogic({
+                return insightAlertsLogic({
                     insightId: props.insightId,
                     insightLogicProps: props.insightVizDataLogicProps,
-                }).actions.loadAlerts()
+                })
             }
+            return undefined
         }
 
         return {
             deleteAlert: async () => {
-                // deletion only allowed on created alert (which will have alertId)
                 if (!values.alertForm.id) {
                     throw new Error("Cannot delete alert that doesn't exist")
                 }
                 await api.alerts.delete(values.alertForm.id)
                 lemonToast.success('Alert deleted.')
-                refreshParentAlerts()
+                const parent = getParentLogic()
+                if (parent) {
+                    parent.actions.removeAlert(values.alertForm.id)
+                    parent.actions.loadAlerts()
+                }
                 props.onEditSuccess(undefined)
             },
             snoozeAlert: async ({ snoozeUntil }) => {
-                // snoozing only allowed on created alert (which will have alertId)
                 if (!values.alertForm.id) {
                     throw new Error("Cannot snooze alert that doesn't exist")
                 }
-                await api.alerts.update(values.alertForm.id, { snoozed_until: snoozeUntil })
-                refreshParentAlerts()
+                const updatedAlert: AlertType = await api.alerts.update(values.alertForm.id, {
+                    snoozed_until: snoozeUntil,
+                })
+                const parent = getParentLogic()
+                if (parent) {
+                    parent.actions.upsertAlert(updatedAlert)
+                    parent.actions.loadAlerts()
+                }
                 props.onEditSuccess(values.alertForm.id)
             },
             clearSnooze: async () => {
-                // resolution only allowed on created alert (which will have alertId)
                 if (!values.alertForm.id) {
                     throw new Error("Cannot resolve alert that doesn't exist")
                 }
-                await api.alerts.update(values.alertForm.id, { snoozed_until: null })
-                refreshParentAlerts()
+                const updatedAlert: AlertType = await api.alerts.update(values.alertForm.id, {
+                    snoozed_until: null,
+                })
+                const parent = getParentLogic()
+                if (parent) {
+                    parent.actions.upsertAlert(updatedAlert)
+                    parent.actions.loadAlerts()
+                }
                 props.onEditSuccess(values.alertForm.id)
             },
             submitAlertFormSuccess: async () => {
-                refreshParentAlerts()
+                // Background sync to pick up any server-side changes
+                getParentLogic()?.actions.loadAlerts()
             },
         }
     }),

--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -181,6 +181,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
 
         return {
             deleteAlert: async () => {
+                // deletion only allowed on created alert (which will have alertId)
                 if (!values.alertForm.id) {
                     throw new Error("Cannot delete alert that doesn't exist")
                 }
@@ -194,6 +195,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                 props.onEditSuccess(undefined)
             },
             snoozeAlert: async ({ snoozeUntil }) => {
+                // snoozing only allowed on created alert (which will have alertId)
                 if (!values.alertForm.id) {
                     throw new Error("Cannot snooze alert that doesn't exist")
                 }
@@ -208,6 +210,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                 props.onEditSuccess(values.alertForm.id)
             },
             clearSnooze: async () => {
+                // resolution only allowed on created alert (which will have alertId)
                 if (!values.alertForm.id) {
                     throw new Error("Cannot resolve alert that doesn't exist")
                 }

--- a/frontend/src/lib/components/Alerts/insightAlertsLogic.ts
+++ b/frontend/src/lib/components/Alerts/insightAlertsLogic.ts
@@ -27,6 +27,8 @@ export const insightAlertsLogic = kea<insightAlertsLogicType>([
     key(({ insightId }) => `insight-${insightId}`),
     actions({
         setShouldShowAlertDeletionWarning: (show: boolean) => ({ show }),
+        upsertAlert: (alert: AlertType) => ({ alert }),
+        removeAlert: (alertId: AlertType['id']) => ({ alertId }),
     }),
 
     connect((props: InsightAlertsLogicProps) => ({
@@ -50,6 +52,19 @@ export const insightAlertsLogic = kea<insightAlertsLogicType>([
     })),
 
     reducers({
+        alerts: [
+            [] as AlertType[],
+            {
+                upsertAlert: (state, { alert }) => {
+                    const index = state.findIndex((a) => a.id === alert.id)
+                    if (index >= 0) {
+                        return [...state.slice(0, index), alert, ...state.slice(index + 1)]
+                    }
+                    return [...state, alert]
+                },
+                removeAlert: (state, { alertId }) => state.filter((a) => a.id !== alertId),
+            },
+        ],
         shouldShowAlertDeletionWarning: [
             false,
             {

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -6,7 +6,7 @@ import { IconCode2, IconInfo, IconPencil, IconPeople, IconShare, IconTrash } fro
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { AddToDashboardModal } from 'lib/components/AddToDashboard/AddToDashboardModal'
-import { areAlertsSupportedForInsight, insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
+import { areAlertsSupportedForInsight } from 'lib/components/Alerts/insightAlertsLogic'
 import { EditAlertModal } from 'lib/components/Alerts/views/EditAlertModal'
 import { ManageAlertsModal } from 'lib/components/Alerts/views/ManageAlertsModal'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
@@ -105,14 +105,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     } = useValues(insightLogic(insightLogicProps))
     const { setInsightMetadata, saveAs, saveInsight, duplicateInsight, reloadSavedInsights } = useActions(
         insightLogic(insightLogicProps)
-    )
-
-    // insightAlertsLogic
-    const { loadAlerts } = useActions(
-        insightAlertsLogic({
-            insightLogicProps,
-            insightId: insight.id as number,
-        })
     )
 
     // insightDataLogic
@@ -219,7 +211,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             insightShortId={insight.short_id as InsightShortId}
                             insightId={insight.id}
                             onEditSuccess={() => {
-                                loadAlerts()
                                 push(urls.insightAlerts(insight.short_id as InsightShortId))
                             }}
                             insightLogicProps={insightLogicProps}


### PR DESCRIPTION
## Problem

The current alert system in the frontend doesn't update the UI immediately after creating, updating, or deleting alerts. This creates a poor user experience as users have to wait for a full (async) reload to see their changes reflected. Depending on the speed of the API / load on the system, this can feel "slow" (e.g >1s), but even if the responses are fast, this still feels clunky, especially as users need to edit their alert in order to add destinations. 

## Changes

Implemented optimistic updates for alerts in the insight UI

## How did you test this code?

**Before**:

[Alerts without hte optimistic addition.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/97942b66-b709-461f-b1ce-1e3825ac4e4c.mov" />](https://app.graphite.com/user-attachments/video/97942b66-b709-461f-b1ce-1e3825ac4e4c.mov)

**After**:

[Optimistic alerts - After.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0c92f2cc-5273-4c22-bb03-fdfbe44083a9.mov" />](https://app.graphite.com/user-attachments/video/0c92f2cc-5273-4c22-bb03-fdfbe44083a9.mov)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

Yes