### PR TITLE
fix(alerts): clean up CDP destinations when alert is   deleted

### DIFF
--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -181,7 +181,6 @@ export const alertFormLogic = kea<alertFormLogicType>([
 
         return {
             deleteAlert: async () => {
-                // deletion only allowed on created alert (which will have alertId)
                 if (!values.alertForm.id) {
                     throw new Error("Cannot delete alert that doesn't exist")
                 }
@@ -195,7 +194,6 @@ export const alertFormLogic = kea<alertFormLogicType>([
                 props.onEditSuccess(undefined)
             },
             snoozeAlert: async ({ snoozeUntil }) => {
-                // snoozing only allowed on created alert (which will have alertId)
                 if (!values.alertForm.id) {
                     throw new Error("Cannot snooze alert that doesn't exist")
                 }
@@ -210,7 +208,6 @@ export const alertFormLogic = kea<alertFormLogicType>([
                 props.onEditSuccess(values.alertForm.id)
             },
             clearSnooze: async () => {
-                // resolution only allowed on created alert (which will have alertId)
                 if (!values.alertForm.id) {
                     throw new Error("Cannot resolve alert that doesn't exist")
                 }

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -454,11 +454,11 @@ def handle_alert_subscription_change(before_update, after_update, activity, user
 
 @receiver(pre_delete, sender=AlertConfiguration)
 def cleanup_alert_hog_functions(sender, instance: AlertConfiguration, **kwargs):
-    from posthog.models.hog_functions.hog_function import HogFunction
+    from posthog.models.hog_functions.hog_function import HogFunction, HogFunctionType
 
     for hog_function in HogFunction.objects.filter(
         team_id=instance.team_id,
-        type="internal_destination",
+        type=HogFunctionType.INTERNAL_DESTINATION,
         deleted=False,
         filters__contains={"properties": [{"key": "alert_id", "value": str(instance.id)}]},
     ):

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -452,6 +452,18 @@ def handle_alert_subscription_change(before_update, after_update, activity, user
         )
 
 
+@receiver(pre_delete, sender=AlertConfiguration)
+def cleanup_alert_hog_functions(sender, instance: AlertConfiguration, **kwargs):
+    from posthog.models.hog_functions.hog_function import HogFunction
+
+    HogFunction.objects.filter(
+        team_id=instance.team_id,
+        type="internal_destination",
+        deleted=False,
+        filters__contains={"properties": [{"key": "alert_id", "value": str(instance.id)}]},
+    ).update(enabled=False, deleted=True)
+
+
 @receiver(pre_delete, sender=AlertSubscription)
 def handle_alert_subscription_delete(sender, instance, **kwargs):
     from posthog.models.activity_logging.model_activity import get_current_user, get_was_impersonated

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -456,12 +456,15 @@ def handle_alert_subscription_change(before_update, after_update, activity, user
 def cleanup_alert_hog_functions(sender, instance: AlertConfiguration, **kwargs):
     from posthog.models.hog_functions.hog_function import HogFunction
 
-    HogFunction.objects.filter(
+    for hog_function in HogFunction.objects.filter(
         team_id=instance.team_id,
         type="internal_destination",
         deleted=False,
         filters__contains={"properties": [{"key": "alert_id", "value": str(instance.id)}]},
-    ).update(enabled=False, deleted=True)
+    ):
+        hog_function.enabled = False
+        hog_function.deleted = True
+        hog_function.save()
 
 
 @receiver(pre_delete, sender=AlertSubscription)


### PR DESCRIPTION
## Problem

When an alert is deleted, any associated HogFunctions remain active, which can lead to orphaned functions and potentially unwanted behaviour / database clutter. Currently users are unable to view their CDP's as they are filtered out on the http://localhost:8010/project/1/data-management/destinations page (e.g. that page does not show `internal_destination` targets). Thus it's difficult (but not impossible with browser history) to find the CDP's for deleted alerts, which can cause weird things / behaviour if they are modified for an already deleted alert.

## Changes

- Added a signal handler (`cleanup_alert_hog_functions`) that automatically cleans up HogFunctions when an AlertConfiguration is deleted
- Added a test case to verify this cleanup behavior works correctly

## How did you test this code?

✅ The new test is passing in the CI

✅ Manual test in the UI:

**Create the CDP destination:**
<img width="1828" height="564" alt="CleanShot 2026-02-09 at 15 43 29" src="https://github.com/user-attachments/assets/0bdfc917-efe4-478e-b335-b352019eae48" />

**Delete the alert:**
<img width="592" height="205" alt="CleanShot 2026-02-09 at 15 44 09" src="https://github.com/user-attachments/assets/aaf9823d-f2fc-4bdd-a0eb-95240a9e4040" />

**Confirm soft-deletion:**
<img width="2081" height="282" alt="CleanShot 2026-02-09 at 15 44 47" src="https://github.com/user-attachments/assets/3dc0af39-5814-46c9-9f8c-d1439f4253dd" />
<img width="1012" height="432" alt="CleanShot 2026-02-09 at 15 45 00" src="https://github.com/user-attachments/assets/b65e81cd-1a40-4b82-b12e-a817c3915754" />


## Publish to changelog?

No, this is mostly for internal benefits