### PR TITLE
feat(llma): add team 39143 to guaranteed team discovery list

### DIFF
--- a/posthog/temporal/llm_analytics/team_discovery.py
+++ b/posthog/temporal/llm_analytics/team_discovery.py
@@ -37,6 +37,7 @@ GUARANTEED_TEAM_IDS: list[int] = [
     109521,
     287645,
     306898,
+    39143,
 ]
 
 # Default sample percentage for gradual rollout.


### PR DESCRIPTION
## Summary
- Adds team 39143 to the guaranteed team IDs list for LLM analytics temporal workflows (trace summarization and clustering)

## Test plan
- [ ] Verify the team discovery activity includes team 39143 in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)