### PR TITLE
fix(alerts): Preserve insight context when navigating to CDP creation form to preserve back button functionality

### DIFF
--- a/frontend/src/lib/components/Alerts/views/AlertDestinationSelector.tsx
+++ b/frontend/src/lib/components/Alerts/views/AlertDestinationSelector.tsx
@@ -1,18 +1,25 @@
 import { INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID } from 'lib/constants'
 import { buildAlertFilterConfig } from 'lib/utils/alertUtils'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
+import { urls } from 'scenes/urls'
+
+import { InsightShortId } from '~/types'
 
 export interface AlertDestinationSelectorProps {
     alertId: string
+    insightShortId: InsightShortId
 }
 
-export function AlertDestinationSelector({ alertId }: AlertDestinationSelectorProps): JSX.Element {
+export function AlertDestinationSelector({ alertId, insightShortId }: AlertDestinationSelectorProps): JSX.Element {
+    const returnTo = `${urls.insightAlerts(insightShortId)}?alert_id=${alertId}`
+
     return (
         <LinkedHogFunctions
             type="internal_destination"
             subTemplateIds={[INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID]}
             hideFeedback={true}
             forceFilterGroups={[buildAlertFilterConfig(alertId)]}
+            queryParams={{ returnTo }}
         />
     )
 }

--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -407,7 +407,10 @@ export function EditAlertModal({
                                 <div className="mt-2">
                                     {alertId ? (
                                         <div className="flex flex-col">
-                                            <AlertDestinationSelector alertId={alertId} />
+                                            <AlertDestinationSelector
+                                                alertId={alertId}
+                                                insightShortId={insightShortId}
+                                            />
                                         </div>
                                     ) : (
                                         <div className="text-muted-alt">

--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -109,6 +109,10 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
                 return (configuration?.filters?.events ?? []).some((e) => e.id === 'survey sent')
             },
         ],
+        returnTo: [
+            () => [router.selectors.searchParams],
+            (searchParams: Record<string, string>): string | undefined => searchParams?.returnTo,
+        ],
         breadcrumbs: [
             (s) => [
                 s.type,
@@ -117,6 +121,7 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
                 s.alertId,
                 s.surveyId,
                 s.isSurveyNotification,
+                s.returnTo,
                 (_, props) => props.id ?? null,
             ],
             (
@@ -126,6 +131,7 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
                 alertId: string | undefined,
                 surveyId: string | undefined,
                 isSurveyNotification: boolean,
+                returnTo: string | undefined,
                 id: string | null
             ): Breadcrumb[] => {
                 if (loading) {
@@ -144,18 +150,23 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
                     iconType: 'data_pipeline',
                 }
 
-                if (type === 'internal_destination' && alertId) {
+                if (type === 'internal_destination' && (alertId || returnTo)) {
+                    // returnTo contains the full path back to the alert edit view
+                    // Strip the alert_id param for the insight breadcrumb
+                    const alertPath = returnTo ?? urls.alert(alertId!)
+                    const insightPath = returnTo ? returnTo.split('?')[0] : urls.alerts()
+
                     return [
                         {
                             key: Scene.Insight,
                             name: 'Insight',
-                            path: urls.alerts(),
+                            path: insightPath,
                             iconType: 'data_pipeline',
                         },
                         {
                             key: 'alert',
                             name: 'Alert',
-                            path: urls.alert(alertId),
+                            path: alertPath,
                             iconType: 'data_pipeline',
                         },
                         finalCrumb,

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -1454,7 +1454,8 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 // Catch all for any scenario where we need to redirect away from the template to the actual hog function
 
                 cache.disabledBeforeUnload = true
-                router.actions.replace(urls.hogFunction(hogFunction.id))
+                // Preserve existing search params (integration params, returnTo, etc.) on redirect
+                router.actions.replace(urls.hogFunction(hogFunction.id), router.values.searchParams)
             }
         },
         sparklineQuery: async (sparklineQuery) => {

--- a/frontend/src/scenes/hog-functions/list/LinkedHogFunctions.tsx
+++ b/frontend/src/scenes/hog-functions/list/LinkedHogFunctions.tsx
@@ -15,6 +15,7 @@ export type LinkedHogFunctionsProps = {
     newDisabledReason?: string
     hideFeedback?: boolean
     emptyText?: string
+    queryParams?: Record<string, string>
 }
 
 const getFiltersFromSubTemplateId = (
@@ -31,6 +32,7 @@ export function LinkedHogFunctions({
     newDisabledReason,
     hideFeedback,
     emptyText,
+    queryParams,
 }: LinkedHogFunctionsProps): JSX.Element | null {
     const [showNewDestination, setShowNewDestination] = useState(false)
     const logicKey = useMemo(() => {
@@ -64,6 +66,7 @@ export function LinkedHogFunctions({
             type={templateType}
             subTemplateIds={subTemplateIds}
             getConfigurationOverrides={getConfigurationOverrides}
+            queryParams={queryParams}
             extraControls={
                 <>
                     <LemonButton type="secondary" size="small" onClick={() => setShowNewDestination(false)}>

--- a/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
@@ -47,6 +47,8 @@ export type HogFunctionTemplateListLogicProps = {
     manualTemplatesLoading?: boolean
     hideComingSoonByDefault?: boolean
     customFilterFunction?: (template: HogFunctionTemplateType) => boolean
+    /** Extra search params to include in the URL when navigating to create a new hog function */
+    queryParams?: Record<string, string>
 }
 
 export const shouldShowHogFunctionTemplate = (
@@ -220,7 +222,10 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
 
         urlForTemplate: [
             () => [(_, props) => props],
-            ({ getConfigurationOverrides }): ((template: HogFunctionTemplateWithSubTemplateType) => string | null) => {
+            ({
+                getConfigurationOverrides,
+                queryParams,
+            }): ((template: HogFunctionTemplateWithSubTemplateType) => string | null) => {
                 return (template: HogFunctionTemplateWithSubTemplateType) => {
                     if (template.status === 'coming_soon') {
                         // "Coming soon" sources don't have docs yet
@@ -262,13 +267,9 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
                         ...(filters ? { filters } : {}),
                     }
 
-                    return combineUrl(
-                        urls.hogFunctionNew(template.id),
-                        {},
-                        {
-                            configuration,
-                        }
-                    ).url
+                    return combineUrl(urls.hogFunctionNew(template.id), queryParams ?? {}, {
+                        configuration,
+                    }).url
                 }
             },
         ],


### PR DESCRIPTION
## Problem

When navigating from an alert to create a new destination (hog function), users lose context of where they came from, making it difficult to return to the alert they were configuring.

## Changes

Made it so that whenever a user navigates towards the CDP page from an alert, going back retains their context so that they can easily navigate back towards their original insight.

## How did you test this code?

**Before**:

https://github.com/user-attachments/assets/96f07afb-3a98-46a1-989e-f13ab2848f6d


**After**:

https://github.com/user-attachments/assets/19747e32-3a77-4863-847e-2ae80c9778db


## Publish to changelog?

Yes - A small bugfix which updates the CDP pathing when originating from an alter route to go bakc to the insight 