### PR TITLE
feat(logs-ingestion): handle team lookup errors and update dropped message reason

### DIFF
--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -322,7 +322,10 @@ describe('LogsIngestionConsumer', () => {
             await waitForBackgroundTasks(consumer.processKafkaBatch(messages))
 
             expect(getProducedKafkaMessages()).toHaveLength(0)
-            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith({ reason: 'parse_error', team_id: 'unknown' })
+            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith({
+                reason: 'team_lookup_error',
+                team_id: 'unknown',
+            })
         })
     })
 

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -440,10 +440,17 @@ export class LogsIngestionConsumer {
                         return
                     }
 
-                    let team = await this.hub.teamManager.getTeamByToken(token)
-                    if (isDevEnv() && token === 'phc_local') {
-                        // phc_local is a special token used in dev to refer to team 1
-                        team = await this.hub.teamManager.getTeam(1)
+                    let team
+                    try {
+                        team = await this.hub.teamManager.getTeamByToken(token)
+                        if (isDevEnv() && token === 'phc_local') {
+                            // phc_local is a special token used in dev to refer to team 1
+                            team = await this.hub.teamManager.getTeam(1)
+                        }
+                    } catch (e) {
+                        logger.error('team_lookup_error', { error: e })
+                        logMessageDroppedCounter.inc({ reason: 'team_lookup_error', team_id: 'unknown' })
+                        return
                     }
 
                     if (!team) {


### PR DESCRIPTION
## Problem

When team lookups fail (DB/network issues), the error is labeled as `parse_error` in metrics, making it hard to distinguish actual parsing failures from infrastructure issues.

## Changes

- Separated team lookup errors from parsing errors with distinct try/catch blocks
- Added new `team_lookup_error` reason label for when `getTeamByToken` throws
- `parse_error` now only fires for actual message parsing failures

## How did you test this code?

Updated unit tests to verify the correct error reason is recorded when team lookup fails.

## Publish to changelog?

No
