### PR TITLE
fix(toolbar): Fix using wrong icon for experiments in the toolbar

### DIFF
--- a/frontend/src/scenes/toolbar-launch/ToolbarLaunch.tsx
+++ b/frontend/src/scenes/toolbar-launch/ToolbarLaunch.tsx
@@ -1,6 +1,6 @@
 import './ToolbarLaunch.scss'
 
-import { IconFlag, IconPieChart, IconSearch, IconTestTube } from '@posthog/icons'
+import { IconFlag, IconFlask, IconPieChart, IconSearch } from '@posthog/icons'
 import { LemonBanner } from '@posthog/lemon-ui'
 
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
@@ -55,7 +55,7 @@ export function ToolbarLaunch(): JSX.Element {
                   {
                       title: 'Experiments',
                       caption: 'Run experiments and A/B test your website.',
-                      icon: <IconTestTube />,
+                      icon: <IconFlask />,
                   },
               ]
             : []),

--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -11,6 +11,7 @@ import {
     IconCursorClick,
     IconDay,
     IconEye,
+    IconFlask,
     IconHide,
     IconLive,
     IconNight,
@@ -19,7 +20,6 @@ import {
     IconSearch,
     IconSpotlight,
     IconStethoscope,
-    IconTestTube,
     IconToggle,
     IconWarning,
     IconX,
@@ -447,7 +447,7 @@ export function Toolbar(): JSX.Element | null {
                         </ToolbarButton>
                         {showExperiments && (
                             <ToolbarButton menuId="experiments" title="Experiments">
-                                <IconTestTube />
+                                <IconFlask />
                             </ToolbarButton>
                         )}
                         {showProductTours && (


### PR DESCRIPTION
## Problem

The toolbar used a wrong icon for experiments. 

## Changes

Use the same icon as used in the sidebar:

<img width="230" height="132" alt="sidebar" src="https://github.com/user-attachments/assets/be4ddb60-715e-49b1-b211-03dc6c964993" />

| location | before | after |
| -  | - | - |
| toolbar page | <img width="1276" height="318" alt="toolbar-launch-before" src="https://github.com/user-attachments/assets/cd2f2ec6-d72a-4c99-b3c2-dd9f0faa5695" /> | <img width="1245" height="350" alt="toolbar-launch-after" src="https://github.com/user-attachments/assets/27507aba-3cae-46b5-b89a-e692a2a07ced" /> |
| toolbar itself | <img width="458" height="60" alt="toolbar-before" src="https://github.com/user-attachments/assets/26cc2302-fb06-45bf-8b8d-cc3a737013e7" /> | <img width="530" height="125" alt="toolbar-after" src="https://github.com/user-attachments/assets/7c9db697-1dd5-42d7-bedf-a055db2c0860" /> |

## How did you test this code?

Manually

## Publish to changelog?

No