### PR TITLE
fix: test environment schema creation

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -1387,9 +1387,7 @@
   group4_created_at,
   person_mode,
   _timestamp,
-  _timestamp_ms,
-  _offset,
-  _partition
+  _offset
   FROM posthog_test.kafka_events_recent_json
   
   '''

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -343,9 +343,7 @@ group3_created_at,
 group4_created_at,
 person_mode,
 _timestamp,
-_timestamp_ms,
-_offset,
-_partition
+_offset
 FROM {database}.kafka_events_recent_json
 """.format(
         target_table=target_table,


### PR DESCRIPTION
## Problem

Schema setup of the test environment is failing due to mismatches between writable / MV.	

## Changes

The `_timestamp_ms` and `_partition` columns are not needed anymore for events_recent since they will use data from sharded_events isntead of Kafka.

## How did you test this code?

Unit tests.