### PR TITLE
fix(cdp): request payload limitation for cdp-api

### DIFF
--- a/nodejs/src/api/router.ts
+++ b/nodejs/src/api/router.ts
@@ -27,7 +27,7 @@ export function setupExpressApp(): express.Application {
 
     app.use(
         express.json({
-            limit: '500kb',
+            limit: '20mb',
             verify: (req, res, buf) => {
                 ;(req as any).rawBody = buf.toString('utf8')
             },

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -610,8 +610,7 @@ describe('CDP API', () => {
                 .post(`/api/projects/${hogFunction.team_id}/hog_functions/${hogFunction.id}/invocations`)
                 .send({ globals, mock_async_functions: true, configuration: { large_field: largePayload } })
 
-            expect(res.status).not.toEqual(413)
-            expect(res.status).not.toEqual(500)
+            expect(res.status).toEqual(200)
         })
 
         it('accepts large payloads on hog flow invocations endpoint', async () => {
@@ -619,6 +618,7 @@ describe('CDP API', () => {
                 .post(`/api/projects/${hogFunction.team_id}/hog_flows/new/invocations`)
                 .send({ globals, mock_async_functions: true, configuration: { large_field: largePayload } })
 
+            // 400 from missing flow config, not 413/500 from body size
             expect(res.status).not.toEqual(413)
             expect(res.status).not.toEqual(500)
         })

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -602,6 +602,35 @@ describe('CDP API', () => {
         })
     })
 
+    describe('body size limits', () => {
+        const largePayload = 'x'.repeat(600 * 1024)
+
+        it('accepts large payloads on hog function invocations endpoint', async () => {
+            const res = await supertest(app)
+                .post(`/api/projects/${hogFunction.team_id}/hog_functions/${hogFunction.id}/invocations`)
+                .send({ globals, mock_async_functions: true, configuration: { large_field: largePayload } })
+
+            expect(res.status).not.toEqual(413)
+            expect(res.status).not.toEqual(500)
+        })
+
+        it('accepts large payloads on hog flow invocations endpoint', async () => {
+            const res = await supertest(app)
+                .post(`/api/projects/${hogFunction.team_id}/hog_flows/new/invocations`)
+                .send({ globals, mock_async_functions: true, configuration: { large_field: largePayload } })
+
+            expect(res.status).not.toEqual(413)
+            expect(res.status).not.toEqual(500)
+        })
+
+        it('rejects large payloads on public webhooks endpoint', async () => {
+            const res = await supertest(app).post('/public/webhooks/test-webhook').send({ large_field: largePayload })
+
+            expect(res.status).toEqual(413)
+            expect(res.body).toEqual({ error: 'Request entity too large' })
+        })
+    })
+
     describe('batch hogflow invocations', () => {
         let batchHogFlow: HogFlow
         let originalKafkaProducer: any

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -159,10 +159,19 @@ export class CdpApi {
         router.get('/api/hog_function_templates', this.getHogFunctionTemplates)
         router.post('/api/messaging/generate_preferences_token', asyncHandler(this.generatePreferencesToken()))
         router.get('/api/messaging/validate_preferences_token/:token', asyncHandler(this.validatePreferencesToken()))
-        router.post('/public/webhooks/:webhook_id', asyncHandler(this.handleWebhook()))
+        const publicBodySizeLimit = (req: express.Request, res: express.Response, next: express.NextFunction): void => {
+            const contentLength = parseInt(req.headers['content-length'] || '0', 10)
+            if (contentLength > 512_000) {
+                res.status(413).json({ error: 'Request entity too large' })
+                return
+            }
+            next()
+        }
+
+        router.post('/public/webhooks/:webhook_id', publicBodySizeLimit, asyncHandler(this.handleWebhook()))
         router.get('/public/webhooks/:webhook_id', asyncHandler(this.handleWebhook()))
         router.get('/public/m/pixel', asyncHandler(this.getEmailTrackingPixel()))
-        router.post('/public/m/ses_webhook', express.text(), asyncHandler(this.postSesWebhook()))
+        router.post('/public/m/ses_webhook', publicBodySizeLimit, express.text(), asyncHandler(this.postSesWebhook()))
         router.get('/public/m/redirect', asyncHandler(this.getEmailTrackingRedirect()))
 
         return router

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -159,9 +159,8 @@ export class CdpApi {
         router.get('/api/hog_function_templates', this.getHogFunctionTemplates)
         router.post('/api/messaging/generate_preferences_token', asyncHandler(this.generatePreferencesToken()))
         router.get('/api/messaging/validate_preferences_token/:token', asyncHandler(this.validatePreferencesToken()))
-        const publicBodySizeLimit = (req: express.Request, res: express.Response, next: express.NextFunction): void => {
-            const contentLength = parseInt(req.headers['content-length'] || '0', 10)
-            if (contentLength > 512_000) {
+        const publicBodySizeLimit = (req: ModifiedRequest, res: express.Response, next: express.NextFunction): void => {
+            if (req.rawBody && req.rawBody.length > 512_000) {
                 res.status(413).json({ error: 'Request entity too large' })
                 return
             }


### PR DESCRIPTION
## Problem

When testing large workflows via the CDP testing API, requests were failing with 500 errors. The Node.js CDP API had a global 500KB body size limit on its JSON parser, but the Django API allows up to 20MB. Since the frontend sends the entire 
workflow configuration (all actions, bytecode, inputs, filters, edges) when testing, large workflows easily exceeded 500KB and were rejected before the handler could process them.

## Changes

Increased the global JSON body limit on the CDP API from 500KB to 20MB to match Django. To avoid exposing public-facing endpoints (webhooks, SES) to the same large limit, added a per-route middleware on those public POST endpoints that rejects requests larger than 500KB with a proper 413 status code. 

## How did you test this code?

Added tests covering both behaviors: large payloads accepted on internal invocation endpoints, and rejected on public endpoints.