### PR TITLE
fix: storybook snapshots

### DIFF
--- a/frontend/src/scenes/settings/stories/SettingsOrganization.stories.tsx
+++ b/frontend/src/scenes/settings/stories/SettingsOrganization.stories.tsx
@@ -35,6 +35,7 @@ const meta: Meta<(props: StoryProps) => JSX.Element> = {
                     realm: 'cloud',
                 },
                 '/api/projects/:id/integrations': { results: [] },
+                '/api/organizations/:id/integrations': { results: [] },
             },
             patch: {
                 '/api/projects/:id': async (req, res, ctx) => {


### PR DESCRIPTION
## Problem

The org settings page fails the smoke test, so snapshots can't regenerate.

## Changes

- Mock the integrations endpoint.

## How did you test this code?

N/A
