### PR TITLE
fix(cli): add skip-release-on-fail option

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.5.27
+
+- fix: only warns on release id mismatch errors
+
 # 0.5.26
 
 - feat: use env variables provided by github actions when available

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1566,7 +1566,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.26"
+version = "0.5.27"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.26"
+version = "0.5.27"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/api/symbol_sets.rs
+++ b/cli/src/api/symbol_sets.rs
@@ -154,11 +154,15 @@ fn start_upload(symbol_sets: &[&SymbolSetUpload]) -> Result<BulkUploadStartRespo
     });
 
     match res {
-        Ok(response) => Ok(response.json().context("Failed to parse start upload response")?),
+        Ok(response) => Ok(response
+            .json()
+            .context("Failed to parse start upload response")?),
         Err(ClientError::ApiError(_, _, body)) if body.contains("release_id_mismatch") => {
             Err(UploadError::ReleaseIdMismatch)
         }
-        Err(e) => Err(UploadError::Other(anyhow::anyhow!(e).context("Failed to start upload"))),
+        Err(e) => Err(UploadError::Other(
+            anyhow::anyhow!(e).context("Failed to start upload"),
+        )),
     }
 }
 

--- a/cli/src/api/symbol_sets.rs
+++ b/cli/src/api/symbol_sets.rs
@@ -3,14 +3,24 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use reqwest::blocking::multipart::{Form, Part};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Debug, iter, thread::sleep, time::Duration};
+use thiserror::Error;
 use tracing::{debug, info, warn};
 
 use crate::{
+    api::client::ClientError,
     invocation_context::context,
     utils::{files::content_hash, raise_for_err},
 };
 
 const MAX_FILE_SIZE: usize = 100 * 1024 * 1024; // 100 MB
+
+#[derive(Error, Debug)]
+pub enum UploadError {
+    #[error("Release ID mismatch: symbol sets already exist with different release IDs")]
+    ReleaseIdMismatch,
+    #[error("{0}")]
+    Other(#[from] anyhow::Error),
+}
 
 #[derive(Debug, Clone)]
 pub struct SymbolSetUpload {
@@ -47,7 +57,37 @@ struct BulkUploadFinishRequest {
     content_hashes: HashMap<String, String>,
 }
 
+/// Upload symbol sets with optional retry on release_id_mismatch error.
+/// If `skip_release_on_fail` is true and the server returns a release_id_mismatch error,
+/// the upload will be retried without release IDs.
+pub fn upload_with_retry(
+    input_sets: &[SymbolSetUpload],
+    batch_size: usize,
+    skip_release_on_fail: bool,
+) -> Result<()> {
+    match upload_inner(input_sets, batch_size) {
+        Ok(()) => Ok(()),
+        Err(UploadError::ReleaseIdMismatch) if skip_release_on_fail => {
+            warn!("Release ID mismatch detected. Retrying upload without release IDs...");
+            let sets_without_release: Vec<_> = input_sets
+                .iter()
+                .map(|s| SymbolSetUpload {
+                    chunk_id: s.chunk_id.clone(),
+                    release_id: None,
+                    data: s.data.clone(),
+                })
+                .collect();
+            upload_inner(&sets_without_release, batch_size).map_err(|e| e.into())
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
 pub fn upload(input_sets: &[SymbolSetUpload], batch_size: usize) -> Result<()> {
+    upload_inner(input_sets, batch_size).map_err(|e| e.into())
+}
+
+fn upload_inner(input_sets: &[SymbolSetUpload], batch_size: usize) -> Result<(), UploadError> {
     let upload_requests: Vec<_> = input_sets
         .iter()
         .filter(|s| {
@@ -96,7 +136,7 @@ pub fn upload(input_sets: &[SymbolSetUpload], batch_size: usize) -> Result<()> {
     Ok(())
 }
 
-fn start_upload(symbol_sets: &[&SymbolSetUpload]) -> Result<BulkUploadStartResponse> {
+fn start_upload(symbol_sets: &[&SymbolSetUpload]) -> Result<BulkUploadStartResponse, UploadError> {
     let client = &context().client;
 
     let request = BulkUploadStartRequest {
@@ -111,10 +151,15 @@ fn start_upload(symbol_sets: &[&SymbolSetUpload]) -> Result<BulkUploadStartRespo
             client.project_url("error_tracking/symbol_sets/bulk_start_upload")?,
             |req| req.json(&request),
         )
-    })
-    .context("Failed to start upload")?;
+    });
 
-    Ok(res.json()?)
+    match res {
+        Ok(response) => Ok(response.json().context("Failed to parse start upload response")?),
+        Err(ClientError::ApiError(_, _, body)) if body.contains("release_id_mismatch") => {
+            Err(UploadError::ReleaseIdMismatch)
+        }
+        Err(e) => Err(UploadError::Other(anyhow::anyhow!(e).context("Failed to start upload"))),
+    }
 }
 
 fn upload_to_s3(presigned_url: PresignedUrl, data: &[u8]) -> Result<()> {
@@ -137,7 +182,7 @@ fn upload_to_s3(presigned_url: PresignedUrl, data: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn finish_upload(content_hashes: HashMap<String, String>) -> Result<()> {
+fn finish_upload(content_hashes: HashMap<String, String>) -> Result<(), UploadError> {
     let client = &context().client;
     let request = BulkUploadFinishRequest { content_hashes };
 
@@ -147,7 +192,7 @@ fn finish_upload(content_hashes: HashMap<String, String>) -> Result<()> {
             |req| req.json(&request),
         )
     })
-    .context("Failed to finish upload")?;
+    .map_err(|e| UploadError::Other(anyhow::anyhow!(e).context("Failed to finish upload")))?;
 
     Ok(())
 }

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -71,7 +71,7 @@ pub fn upload(args: &Args) -> Result<()> {
 
     let to_upload: SymbolSetUpload = file.try_into()?;
 
-    api::symbol_sets::upload_with_retry(&[to_upload], *batch_size, *skip_release_on_fail)?;
+    api::symbol_sets::upload_with_retry(vec![to_upload], *batch_size, *skip_release_on_fail)?;
 
     Ok(())
 }

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -30,6 +30,11 @@ pub struct Args {
     /// if not provided.
     #[arg(long)]
     pub version: Option<String>,
+
+    /// If the server returns a release_id_mismatch error (symbol set already exists with a different release),
+    /// retry the upload without associating a release instead of failing.
+    #[arg(long, default_value = "false")]
+    pub skip_release_on_fail: bool,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -38,6 +43,7 @@ pub fn upload(args: &Args) -> Result<()> {
         map_id,
         project,
         version,
+        skip_release_on_fail,
     } = args;
 
     let path = path
@@ -69,7 +75,7 @@ pub fn upload(args: &Args) -> Result<()> {
 
     let to_upload: SymbolSetUpload = file.try_into()?;
 
-    api::symbol_sets::upload(&[to_upload], 50)?;
+    api::symbol_sets::upload_with_retry(&[to_upload], 50, *skip_release_on_fail)?;
 
     Ok(())
 }

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Result};
 use crate::{
     api::{self, releases::ReleaseBuilder, symbol_sets::SymbolSetUpload},
     proguard::ProguardFile,
+    sourcemaps::args::ReleaseArgs,
     utils::git::get_git_info,
 };
 
@@ -19,32 +20,27 @@ pub struct Args {
     #[arg(short, long)]
     pub map_id: String,
 
-    /// The project name associated with this build. Required to have the exceptions associated with
-    /// a specific release. We will try to auto-derive this from git information if not provided. Strongly recommended
-    /// to be set explicitly during release CD workflows
-    #[arg(long)]
-    pub project: Option<String>,
+    /// The maximum number of chunks to upload in a single batch
+    #[arg(long, default_value = "50")]
+    pub batch_size: usize,
 
-    /// The version of the project - this can be a version number, semantic version, or a git commit hash. Required
-    /// to have the uploaded chunks associated with a specific release. We will try to auto-derive this from git information
-    /// if not provided.
-    #[arg(long)]
-    pub version: Option<String>,
-
-    /// If the server returns a release_id_mismatch error (symbol set already exists with a different release),
-    /// retry the upload without associating a release instead of failing.
-    #[arg(long, default_value = "false")]
-    pub skip_release_on_fail: bool,
+    #[clap(flatten)]
+    pub release: ReleaseArgs,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
     let Args {
         path,
         map_id,
+        batch_size,
+        release,
+    } = args;
+
+    let ReleaseArgs {
         project,
         version,
         skip_release_on_fail,
-    } = args;
+    } = release;
 
     let path = path
         .canonicalize()
@@ -75,7 +71,7 @@ pub fn upload(args: &Args) -> Result<()> {
 
     let to_upload: SymbolSetUpload = file.try_into()?;
 
-    api::symbol_sets::upload_with_retry(&[to_upload], 50, *skip_release_on_fail)?;
+    api::symbol_sets::upload_with_retry(&[to_upload], *batch_size, *skip_release_on_fail)?;
 
     Ok(())
 }

--- a/cli/src/sourcemaps/args.rs
+++ b/cli/src/sourcemaps/args.rs
@@ -61,6 +61,11 @@ pub struct ReleaseArgs {
     /// if not provided.
     #[arg(long)]
     pub version: Option<String>,
+
+    /// If the server returns a release_id_mismatch error (symbol set already exists with a different release),
+    /// retry the upload without associating a release instead of failing.
+    #[arg(long, default_value = "false")]
+    pub skip_release_on_fail: bool,
 }
 
 impl From<ReleaseArgs> for ReleaseBuilder {

--- a/cli/src/sourcemaps/args.rs
+++ b/cli/src/sourcemaps/args.rs
@@ -64,7 +64,7 @@ pub struct ReleaseArgs {
 
     /// If the server returns a release_id_mismatch error (symbol set already exists with a different release),
     /// retry the upload without associating a release instead of failing.
-    #[arg(long, default_value = "false")]
+    #[arg(long, default_value = "true")]
     pub skip_release_on_fail: bool,
 }
 

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -64,7 +64,7 @@ pub fn upload(args: &Args) -> Result<()> {
 
     info!("Found {} maps to upload", uploads.len());
 
-    symbol_sets::upload_with_retry(&uploads, *batch_size, release.skip_release_on_fail)?;
+    symbol_sets::upload_with_retry(uploads, *batch_size, release.skip_release_on_fail)?;
 
     Ok(())
 }

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -16,13 +16,21 @@ pub struct Args {
     #[arg(short, long)]
     pub directory: PathBuf,
 
+    /// The maximum number of chunks to upload in a single batch
+    #[arg(long, default_value = "50")]
+    pub batch_size: usize,
+
     #[clap(flatten)]
     pub release: ReleaseArgs,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
     context().capture_command_invoked("hermes_upload");
-    let Args { directory, release } = args;
+    let Args {
+        directory,
+        release,
+        batch_size,
+    } = args;
 
     let directory = directory.canonicalize().map_err(|e| {
         anyhow!(
@@ -56,7 +64,7 @@ pub fn upload(args: &Args) -> Result<()> {
 
     info!("Found {} maps to upload", uploads.len());
 
-    symbol_sets::upload_with_retry(&uploads, 100, release.skip_release_on_fail)?;
+    symbol_sets::upload_with_retry(&uploads, *batch_size, release.skip_release_on_fail)?;
 
     Ok(())
 }

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -56,7 +56,7 @@ pub fn upload(args: &Args) -> Result<()> {
 
     info!("Found {} maps to upload", uploads.len());
 
-    symbol_sets::upload(&uploads, 100)?;
+    symbol_sets::upload_with_retry(&uploads, 100, release.skip_release_on_fail)?;
 
     Ok(())
 }

--- a/cli/src/sourcemaps/mod.rs
+++ b/cli/src/sourcemaps/mod.rs
@@ -1,4 +1,4 @@
-mod args;
+pub mod args;
 pub mod constant;
 pub mod content;
 pub mod hermes;

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -13,6 +13,11 @@ use crate::{
     utils::files::{delete_files, FileSelection},
 };
 
+pub struct UploadOptions {
+    pub batch_size: usize,
+    pub skip_release_on_fail: bool,
+}
+
 #[derive(clap::Args, Clone)]
 pub struct Args {
     #[clap(flatten)]
@@ -82,7 +87,7 @@ pub fn upload(args: &Args) -> Result<()> {
         .collect::<Result<Vec<SymbolSetUpload>>>()
         .context("While preparing files for upload")?;
 
-    symbol_sets::upload(&uploads, args.batch_size)?;
+    symbol_sets::upload_with_retry(&uploads, args.batch_size, args.release.skip_release_on_fail)?;
 
     if args.delete_after {
         delete_files(sourcemap_paths).context("While deleting sourcemaps")?;

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -13,11 +13,6 @@ use crate::{
     utils::files::{delete_files, FileSelection},
 };
 
-pub struct UploadOptions {
-    pub batch_size: usize,
-    pub skip_release_on_fail: bool,
-}
-
 #[derive(clap::Args, Clone)]
 pub struct Args {
     #[clap(flatten)]

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -82,7 +82,7 @@ pub fn upload(args: &Args) -> Result<()> {
         .collect::<Result<Vec<SymbolSetUpload>>>()
         .context("While preparing files for upload")?;
 
-    symbol_sets::upload_with_retry(&uploads, args.batch_size, args.release.skip_release_on_fail)?;
+    symbol_sets::upload_with_retry(uploads, args.batch_size, args.release.skip_release_on_fail)?;
 
     if args.delete_after {
         delete_files(sourcemap_paths).context("While deleting sourcemaps")?;


### PR DESCRIPTION
## Changes

- add skip-release-on-fail when uploading sourcemaps
