### PR TITLE
feat(workflows): support text based emails

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputsValidation.test.ts
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputsValidation.test.ts
@@ -167,7 +167,7 @@ describe('CyclotronJobInputsValidation', () => {
 
                 expect(result.valid).toBe(false)
                 expect(result.errors.email).toBe(
-                    'HTML is required, Subject is required, From is required, To is required'
+                    'HTML or plain text is required, Subject is required, From is required, To is required'
                 )
             })
 
@@ -303,7 +303,7 @@ describe('CyclotronJobInputsValidation', () => {
                 expect(Object.keys(result.errors)).toHaveLength(3)
                 expect(result.errors.name).toBe('This field is required')
                 expect(result.errors.age).toBe('Value must be a number')
-                expect(result.errors.email).toContain('HTML is required')
+                expect(result.errors.email).toContain('HTML or plain text is required')
             })
 
             it('should handle mixed valid and invalid inputs', () => {

--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputsValidation.ts
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputsValidation.ts
@@ -56,9 +56,14 @@ const validateInput = (input: CyclotronJobInputType, inputSchema: CyclotronJobIn
 
     if (['email', 'native_email'].includes(inputSchema.type) && value) {
         const emailTemplateErrors: Partial<EmailTemplate> = {
-            html: !value.html ? 'HTML is required' : getTemplatingError(value.html),
+            html:
+                !value.html && !value.text
+                    ? 'HTML or plain text is required'
+                    : value.html
+                      ? getTemplatingError(value.html)
+                      : undefined,
+            text: value.text ? getTemplatingError(value.text) : undefined,
             subject: !value.subject ? 'Subject is required' : getTemplatingError(value.subject),
-            // text: !value.text ? 'Text is required' : getTemplatingError(value.text),
             from: !value.from ? 'From is required' : getTemplatingError(value.from),
             to: !value.to ? 'To is required' : getTemplatingError(value.to),
         }

--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -117,7 +117,7 @@ function DestinationEmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX
     return (
         <>
             <Form
-                className="flex overflow-hidden flex-col flex-1 rounded border"
+                {...{ className: 'flex overflow-hidden flex-col flex-1 rounded border' }}
                 logic={emailTemplaterLogic}
                 props={logicProps}
                 formKey="emailTemplate"
@@ -437,7 +437,7 @@ function NativeEmailTemplaterForm({
     return (
         <>
             <Form
-                className="flex overflow-hidden flex-col flex-1 rounded border"
+                {...{ className: 'flex overflow-hidden flex-col flex-1 rounded border' }}
                 logic={emailTemplaterLogic}
                 props={logicProps}
                 formKey="emailTemplate"

--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -2,9 +2,9 @@ import 'products/workflows/frontend/TemplateLibrary/MessageTemplatesGrid.scss'
 
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
-import { Form } from 'kea-forms'
+import { ChildFunctionProps, Form } from 'kea-forms'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import EmailEditor from 'react-email-editor'
+import EmailEditor, { EditorRef } from 'react-email-editor'
 
 import { IconChevronDown, IconChevronLeft, IconChevronRight, IconExternal } from '@posthog/icons'
 import { LemonButton, LemonLabel, LemonModal, LemonSelect, LemonTabs } from '@posthog/lemon-ui'
@@ -76,7 +76,7 @@ function PlainTextEditor(): JSX.Element {
 
     return (
         <LemonField name="text" className="flex flex-col flex-1">
-            {({ value, onChange }) => (
+            {({ value, onChange }: ChildFunctionProps) => (
                 <div className="flex flex-col flex-1 relative group">
                     <span className="absolute top-1 right-2 z-20 p-px opacity-0 transition-opacity group-hover:opacity-100">
                         <CyclotronJobTemplateSuggestionsButton
@@ -130,7 +130,7 @@ function DestinationEmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX
                         // We will handle the error display ourselves
                         renderError={() => null}
                     >
-                        {({ value, onChange, error }) => (
+                        {({ value, onChange, error }: ChildFunctionProps) => (
                             <div className="flex gap-2 items-center">
                                 <LemonLabel
                                     className={error ? 'text-danger' : ''}
@@ -171,7 +171,7 @@ function DestinationEmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX
                                 )}
                             >
                                 <EmailEditor
-                                    ref={(r) => setEmailEditorRef(r)}
+                                    ref={(r: EditorRef | null) => setEmailEditorRef(r)}
                                     onReady={() => onEmailEditorReady()}
                                     minHeight={20}
                                     options={{
@@ -190,7 +190,7 @@ function DestinationEmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX
                     </>
                 ) : (
                     <LemonField name="html" className="flex relative flex-col">
-                        {({ value }) => (
+                        {({ value }: ChildFunctionProps) => (
                             <>
                                 <div className="flex absolute inset-0 justify-center items-end p-2 opacity-0 transition-opacity hover:opacity-100">
                                     <div className="absolute inset-0 opacity-50 bg-surface-primary" />
@@ -451,7 +451,7 @@ function NativeEmailTemplaterForm({
                         renderError={() => null}
                         showOptional={field.optional}
                     >
-                        {({ value, onChange, error }) => (
+                        {({ value, onChange, error }: ChildFunctionProps) => (
                             <div className="flex gap-2 items-center">
                                 <LemonLabel
                                     className={error ? 'text-danger' : ''}
@@ -511,7 +511,7 @@ function NativeEmailTemplaterForm({
                                 )}
                             >
                                 <EmailEditor
-                                    ref={(r) => setEmailEditorRef(r)}
+                                    ref={(r: EditorRef | null) => setEmailEditorRef(r)}
                                     onReady={() => onEmailEditorReady()}
                                     minHeight={20}
                                     options={{
@@ -564,7 +564,7 @@ function NativeEmailTemplaterForm({
                     </>
                 ) : (
                     <LemonField name="html" className="flex relative flex-col">
-                        {({ value }) => (
+                        {({ value }: ChildFunctionProps) => (
                             <>
                                 <div
                                     className={clsx(

--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import EmailEditor from 'react-email-editor'
 
 import { IconChevronDown, IconChevronLeft, IconChevronRight, IconExternal } from '@posthog/icons'
-import { LemonButton, LemonLabel, LemonModal, LemonSelect } from '@posthog/lemon-ui'
+import { LemonButton, LemonLabel, LemonModal, LemonSelect, LemonTabs } from '@posthog/lemon-ui'
 
 import { CyclotronJobTemplateSuggestionsButton } from 'lib/components/CyclotronJob/CyclotronJobTemplateSuggestions'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
@@ -15,6 +15,7 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
 import { CodeEditorInline } from 'lib/monaco/CodeEditorInline'
+import { CodeEditorResizeable } from 'lib/monaco/CodeEditorResizable'
 import { urls } from 'scenes/urls'
 
 import { MessageTemplateCard } from 'products/workflows/frontend/TemplateLibrary/MessageTemplateCard'
@@ -69,9 +70,49 @@ const EMAIL_TYPE_SUPPORTED_FIELDS: Record<EmailTemplaterType, EmailMetaField[]> 
     native_email_template: [EMAIL_META_FIELDS.SUBJECT, EMAIL_META_FIELDS.PREHEADER],
 }
 
+function PlainTextEditor(): JSX.Element {
+    const { logicProps, templatingEngine } = useValues(emailTemplaterLogic)
+    const { setTemplatingEngine } = useActions(emailTemplaterLogic)
+
+    return (
+        <LemonField name="text" className="flex flex-col flex-1">
+            {({ value, onChange }) => (
+                <div className="flex flex-col flex-1 relative group">
+                    <span className="absolute top-1 right-2 z-20 p-px opacity-0 transition-opacity group-hover:opacity-100">
+                        <CyclotronJobTemplateSuggestionsButton
+                            templating={templatingEngine}
+                            setTemplatingEngine={setTemplatingEngine}
+                            value={value}
+                            onOptionSelect={(option) => {
+                                onChange(`${value || ''}${option.example}`)
+                            }}
+                        />
+                    </span>
+                    <CodeEditorResizeable
+                        className="flex-1"
+                        language={templatingEngine === 'hog' ? 'hogTemplate' : 'liquid'}
+                        value={value}
+                        onChange={onChange}
+                        globals={logicProps.variables}
+                        options={{
+                            wordWrap: 'on',
+                            lineNumbers: 'off',
+                            minimap: { enabled: false },
+                        }}
+                        minHeight="100%"
+                        maxHeight="100%"
+                        allowManualResize={false}
+                    />
+                </div>
+            )}
+        </LemonField>
+    )
+}
+
 function DestinationEmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX.Element {
-    const { logicProps, mergeTags } = useValues(emailTemplaterLogic)
-    const { setEmailEditorRef, onEmailEditorReady, setIsModalOpen } = useActions(emailTemplaterLogic)
+    const { logicProps, mergeTags, activeContentTab } = useValues(emailTemplaterLogic)
+    const { setEmailEditorRef, onEmailEditorReady, setIsModalOpen, setActiveContentTab } =
+        useActions(emailTemplaterLogic)
 
     return (
         <>
@@ -111,20 +152,42 @@ function DestinationEmailTemplaterForm({ mode }: { mode: EmailEditorMode }): JSX
                 ))}
 
                 {mode === 'full' ? (
-                    <EmailEditor
-                        ref={(r) => setEmailEditorRef(r)}
-                        onReady={() => onEmailEditorReady()}
-                        minHeight={20}
-                        options={{
-                            mergeTags,
-                            displayMode: 'email',
-                            features: {
-                                preview: true,
-                                imageEditor: true,
-                                stockImages: false,
-                            },
-                        }}
-                    />
+                    <>
+                        <LemonTabs
+                            activeKey={activeContentTab}
+                            onChange={(key) => setActiveContentTab(key as 'visual' | 'plaintext')}
+                            tabs={[
+                                { key: 'visual', label: 'Visual' },
+                                { key: 'plaintext', label: 'Plain text' },
+                            ]}
+                            className="px-2 shrink-0 border-b"
+                        />
+                        <div className="relative flex flex-col flex-1">
+                            <div
+                                className={clsx(
+                                    activeContentTab === 'visual'
+                                        ? 'flex flex-col flex-1'
+                                        : 'absolute inset-0 -z-10 opacity-0 pointer-events-none'
+                                )}
+                            >
+                                <EmailEditor
+                                    ref={(r) => setEmailEditorRef(r)}
+                                    onReady={() => onEmailEditorReady()}
+                                    minHeight={20}
+                                    options={{
+                                        mergeTags,
+                                        displayMode: 'email',
+                                        features: {
+                                            preview: true,
+                                            imageEditor: true,
+                                            stockImages: false,
+                                        },
+                                    }}
+                                />
+                            </div>
+                            {activeContentTab === 'plaintext' && <PlainTextEditor />}
+                        </div>
+                    </>
                 ) : (
                     <LemonField name="html" className="flex relative flex-col">
                         {({ value }) => (
@@ -364,8 +427,12 @@ function NativeEmailTemplaterForm({
     mode: EmailEditorMode
     onSaveAsTemplate?: () => void
 }): JSX.Element {
-    const { unlayerEditorProjectId, logicProps, templates, mergeTags } = useValues(emailTemplaterLogic)
-    const { setEmailEditorRef, onEmailEditorReady, setIsModalOpen, applyTemplate } = useActions(emailTemplaterLogic)
+    const { unlayerEditorProjectId, logicProps, templates, mergeTags, activeContentTab } =
+        useValues(emailTemplaterLogic)
+    const { setEmailEditorRef, onEmailEditorReady, setIsModalOpen, applyTemplate, setActiveContentTab } =
+        useActions(emailTemplaterLogic)
+
+    const [previewTemplate, setPreviewTemplate] = useState<(typeof templates)[0] | null>(null)
 
     return (
         <>
@@ -426,41 +493,74 @@ function NativeEmailTemplaterForm({
                                 onSaveAsTemplate={onSaveAsTemplate}
                             />
                         )}
-
-                        <EmailEditor
-                            ref={(r) => setEmailEditorRef(r)}
-                            onReady={() => onEmailEditorReady()}
-                            minHeight={20}
-                            options={{
-                                mergeTags,
-                                displayMode: 'email',
-                                features: {
-                                    preview: true,
-                                    imageEditor: true,
-                                    stockImages: false,
-                                },
-                                projectId: unlayerEditorProjectId,
-                                customJS: [unsubscribeLinkToolCustomJs],
-                                fonts: unlayerEditorProjectId
-                                    ? {
-                                          showDefaultFonts: true,
-                                          customFonts: [
-                                              {
-                                                  label: 'Ubuntu',
-                                                  value: "'Ubuntu',sans-serif",
-                                                  url: 'https://fonts.googleapis.com/css2?family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap',
-                                                  weights: [
-                                                      { label: 'Light', value: 300 },
-                                                      { label: 'Regular', value: 400 },
-                                                      { label: 'Medium', value: 500 },
-                                                      { label: 'Bold', value: 700 },
-                                                  ],
-                                              },
-                                          ],
-                                      }
-                                    : undefined,
-                            }}
+                        <LemonTabs
+                            activeKey={activeContentTab}
+                            onChange={(key) => setActiveContentTab(key as 'visual' | 'plaintext')}
+                            tabs={[
+                                { key: 'visual', label: 'Visual' },
+                                { key: 'plaintext', label: 'Plain text' },
+                            ]}
+                            className="px-2 shrink-0 border-b"
                         />
+                        <div className="relative flex flex-col flex-1">
+                            <div
+                                className={clsx(
+                                    activeContentTab === 'visual'
+                                        ? 'flex flex-col flex-1'
+                                        : 'absolute inset-0 -z-10 opacity-0 pointer-events-none'
+                                )}
+                            >
+                                <EmailEditor
+                                    ref={(r) => setEmailEditorRef(r)}
+                                    onReady={() => onEmailEditorReady()}
+                                    minHeight={20}
+                                    options={{
+                                        mergeTags,
+                                        displayMode: 'email',
+                                        features: {
+                                            preview: true,
+                                            imageEditor: true,
+                                            stockImages: false,
+                                        },
+                                        projectId: unlayerEditorProjectId,
+                                        customJS: [unsubscribeLinkToolCustomJs],
+                                        fonts: unlayerEditorProjectId
+                                            ? {
+                                                  showDefaultFonts: true,
+                                                  customFonts: [
+                                                      {
+                                                          label: 'Ubuntu',
+                                                          value: "'Ubuntu',sans-serif",
+                                                          url: 'https://fonts.googleapis.com/css2?family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap',
+                                                          weights: [
+                                                              { label: 'Light', value: 300 },
+                                                              { label: 'Regular', value: 400 },
+                                                              { label: 'Medium', value: 500 },
+                                                              { label: 'Bold', value: 700 },
+                                                          ],
+                                                      },
+                                                  ],
+                                              }
+                                            : undefined,
+                                    }}
+                                />
+                            </div>
+                            {activeContentTab === 'plaintext' && <PlainTextEditor />}
+                        </div>
+                        <LemonModal
+                            isOpen={!!previewTemplate}
+                            onClose={() => setPreviewTemplate(null)}
+                            title={`Preview: ${previewTemplate?.name}`}
+                            width="90vw"
+                        >
+                            <div className="h-[80vh] overflow-auto">
+                                <iframe
+                                    srcDoc={previewTemplate?.content.email.html}
+                                    sandbox=""
+                                    className="w-full h-full border-0"
+                                />
+                            </div>
+                        </LemonModal>
                     </>
                 ) : (
                     <LemonField name="html" className="flex relative flex-col">

--- a/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
@@ -185,7 +185,6 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
                     const finalValues: EmailTemplate = {
                         ...formValues,
                         html: '',
-                        design: null,
                     }
                     props.onChange(finalValues)
                     actions.setIsModalOpen(false)
@@ -298,7 +297,6 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
                     emailContent = {
                         ...currentValues,
                         html: '',
-                        design: null,
                     }
                 } else {
                     const editor = values.emailEditorRef?.editor

--- a/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
@@ -104,7 +104,10 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
             'visual' as 'visual' | 'plaintext',
             {
                 setActiveContentTab: (_, { tab }) => tab,
-                applyTemplate: () => 'visual' as const,
+                applyTemplate: (_, { template }) => {
+                    const hasHtml = !!template.content.email.html
+                    return hasHtml ? 'visual' : 'plaintext'
+                },
             },
         ],
     }),

--- a/products/workflows/frontend/TemplateLibrary/MessageTemplatesGrid.scss
+++ b/products/workflows/frontend/TemplateLibrary/MessageTemplatesGrid.scss
@@ -36,9 +36,8 @@
 
 .MessageTemplatesGrid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fill, 340px);
     gap: 0.75em;
-    max-width: 1100px;
 
     .MessageTemplateItem {
         width: 340px;

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -298,9 +298,15 @@ export const workflowLogic = kea<workflowLogicType>([
                             const emailTemplating = action.config.inputs?.email?.templating
 
                             const emailTemplateErrors: Partial<EmailTemplate> = {
-                                html: !emailValue?.html
-                                    ? 'HTML is required'
-                                    : getTemplatingError(emailValue?.html, emailTemplating),
+                                html:
+                                    !emailValue?.html && !emailValue?.text
+                                        ? 'HTML or plain text is required'
+                                        : emailValue?.html
+                                          ? getTemplatingError(emailValue?.html, emailTemplating)
+                                          : undefined,
+                                text: emailValue?.text
+                                    ? getTemplatingError(emailValue?.text, emailTemplating)
+                                    : undefined,
                                 subject: !emailValue?.subject
                                     ? 'Subject is required'
                                     : getTemplatingError(emailValue?.subject, emailTemplating),


### PR DESCRIPTION
### Problem

Previously, the email editor in workflows only supported the visual (Unlayer) HTML editor. The plain text field existed on the EmailTemplate model and was sent with emails, but it was always auto-generated from the HTML content — users had no way to customize it or send text-only emails.
                                                                                                                                                                                                                                                    
This was a problem for users who wanted to:                                                                                                                                                                                                     
  - Send plain text emails without HTML markup or styling
  - Avoid the forced white background that the Unlayer editor applies to all HTML emails
  - Have full control over the exact text content of their emails

### Changes

![2026-02-09 14 09 31](https://github.com/user-attachments/assets/6a691f0d-0ddb-48c0-a5a3-918f310c10ab)


Added a Visual / Plain text tab switcher to the email editor modal. The active tab determines the content type of the email:

- Visual tab (default): Uses the Unlayer drag-and-drop editor to produce HTML emails with an auto-generated plain text fallback. This is the existing behavior.
- Plain text tab: A code editor where users write plain text (with merge tag support). When saved, only the text field is populated — html and design are cleared, so the email is sent as text-only.

- When re-opening the editor, the tab is automatically set based on the saved content: if html is present it opens on Visual, otherwise on Plain text.

- Frontend validation was updated to require either html or text (previously html was always required).
