### PR TITLE
feat(capture-logs): allow configuration of max capture body size

### DIFF
--- a/rust/capture-logs/src/config.rs
+++ b/rust/capture-logs/src/config.rs
@@ -25,6 +25,9 @@ pub struct Config {
     pub kafka: KafkaConfig,
 
     pub drop_events_by_token: Option<String>, // "<token>,<token>..."
+
+    #[envconfig(from = "MAX_REQUEST_BODY_SIZE_BYTES", default = "2097152")] // 2MB (Axum default)
+    pub max_request_body_size_bytes: usize,
 }
 
 impl Config {

--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::{http::Method, routing::get, routing::post, Router};
+use axum::{extract::DefaultBodyLimit, http::Method, routing::get, routing::post, Router};
 use capture::metrics_middleware::track_metrics;
 use capture_logs::config::Config;
 use capture_logs::endpoints::datadog;
@@ -149,6 +149,7 @@ async fn main() {
             post(datadog::export_datadog_logs_http).options(options_handler),
         )
         .with_state(logs_service)
+        .layer(DefaultBodyLimit::max(config.max_request_body_size_bytes))
         .layer(axum::middleware::from_fn(track_metrics))
         .layer(RequestDecompressionLayer::new())
         .layer(cors);


### PR DESCRIPTION
## Problem

Cloudflare's OTEL exporter was hitting 413 errors when sending batched logs to `/v1/logs`. The endpoint was using Axum's default 2MB body limit, which was too small for some Cloudflare batches.

## Changes

- Added configurable `MAX_REQUEST_BODY_SIZE_BYTES` env var (default: 2MB to match previous behavior)
- Applied `DefaultBodyLimit` middleware to the logs ingestion routes
- Helm chart sets this to 10MB

## How did you test this code?

- Verified 3MB payload returns 413 with 2MB limit
- Verified 3MB payload is accepted with 10MB limit
- Build and existing tests pass

## Publish to changelog?

No