### PR TITLE
chore(devex): claude code hooks for file formatting

### DIFF
--- a/.claude/hooks/format-on-save.sh
+++ b/.claude/hooks/format-on-save.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euo pipefail
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
@@ -14,23 +13,23 @@ REL_PATH="${FILE_PATH#"$CLAUDE_PROJECT_DIR"/}"
 
 case "$REL_PATH" in
     *.py)
-        ./bin/ruff.sh check --fix --quiet "$FILE_PATH" 2>/dev/null || true
+        ./bin/ruff.sh check --fix --quiet "$FILE_PATH" 2>/dev/null
         ./bin/ruff.sh format --quiet "$FILE_PATH" 2>/dev/null
         ;;
     nodejs/*.js)
-        pnpm --dir nodejs exec eslint --fix "$FILE_PATH" 2>/dev/null || true
+        pnpm --dir nodejs exec eslint --fix "$FILE_PATH" 2>/dev/null
         pnpm --dir nodejs exec prettier --write "$FILE_PATH" 2>/dev/null
         ;;
     *.ts|*.tsx|*.js|*.jsx)
-        pnpm oxlint --fix --fix-suggestions --quiet "$FILE_PATH" 2>/dev/null || true
+        pnpm oxlint --fix --fix-suggestions --quiet "$FILE_PATH" 2>/dev/null
         pnpm prettier --write "$FILE_PATH" 2>/dev/null
         ;;
     *.css|*.scss)
-        pnpm stylelint --fix --allow-empty-input "$FILE_PATH" 2>/dev/null || true
+        pnpm stylelint --fix --allow-empty-input "$FILE_PATH" 2>/dev/null
         pnpm prettier --write "$FILE_PATH" 2>/dev/null
         ;;
     *.md)
-        pnpm exec markdownlint-cli2 --config .config/.markdownlint-cli2.jsonc --fix "$FILE_PATH" 2>/dev/null || true
+        pnpm exec markdownlint-cli2 --config .config/.markdownlint-cli2.jsonc --fix "$FILE_PATH" 2>/dev/null
         pnpm exec prettier --write "$FILE_PATH" 2>/dev/null
         ;;
     *.json|*.yaml|*.yml)
@@ -40,3 +39,5 @@ case "$REL_PATH" in
         rustfmt "$FILE_PATH" 2>/dev/null
         ;;
 esac
+
+exit 0

--- a/.claude/hooks/format-on-save.sh
+++ b/.claude/hooks/format-on-save.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+    exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+REL_PATH="${FILE_PATH#"$CLAUDE_PROJECT_DIR"/}"
+
+case "$REL_PATH" in
+    *.py)
+        ./bin/ruff.sh check --fix --quiet "$FILE_PATH" 2>/dev/null || true
+        ./bin/ruff.sh format --quiet "$FILE_PATH" 2>/dev/null
+        ;;
+    nodejs/*.js)
+        pnpm --dir nodejs exec eslint --fix "$FILE_PATH" 2>/dev/null || true
+        pnpm --dir nodejs exec prettier --write "$FILE_PATH" 2>/dev/null
+        ;;
+    *.ts|*.tsx|*.js|*.jsx)
+        pnpm oxlint --fix --fix-suggestions --quiet "$FILE_PATH" 2>/dev/null || true
+        pnpm prettier --write "$FILE_PATH" 2>/dev/null
+        ;;
+    *.css|*.scss)
+        pnpm stylelint --fix --allow-empty-input "$FILE_PATH" 2>/dev/null || true
+        pnpm prettier --write "$FILE_PATH" 2>/dev/null
+        ;;
+    *.md)
+        pnpm exec markdownlint-cli2 --config .config/.markdownlint-cli2.jsonc --fix "$FILE_PATH" 2>/dev/null || true
+        pnpm exec prettier --write "$FILE_PATH" 2>/dev/null
+        ;;
+    *.json|*.yaml|*.yml)
+        pnpm prettier --write "$FILE_PATH" 2>/dev/null
+        ;;
+    *.rs)
+        rustfmt "$FILE_PATH" 2>/dev/null
+        ;;
+esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,18 @@
     "enabledPlugins": {
         "pyright-lsp@claude-plugins-official": true,
         "typescript-lsp@claude-plugins-official": true
+    },
+    "hooks": {
+        "PostToolUse": [
+            {
+                "matcher": "Edit|Write",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format-on-save.sh"
+                    }
+                ]
+            }
+        ]
     }
 }


### PR DESCRIPTION
 ## Problem

Claude Code doesn't automatically format files, so it has to call more tools, which it doesn't always do. This PR implements hooks for different file types that we use in the project. Should also work in the cloud.

## Changes

Added a format-on-save hook for Claude AI that automatically formats files after edits:
- Created a new bash script `.claude/hooks/format-on-save.sh` that formats different file types using appropriate tools
- Updated `.claude/settings.json` to trigger the formatting hook after Edit/Write operations
- Supports formatting for multiple languages and file types:
  - Python files with ruff
  - JavaScript/TypeScript with eslint, oxlint, and prettier
  - CSS/SCSS with stylelint and prettier
  - Markdown with markdownlint and prettier
  - JSON/YAML with prettier
  - Rust with rustfmt

## How did you test this code?

N/A

## Publish to changelog?

No