### PR TITLE
fix: alter writable session replay events in ingestion layer

### DIFF
--- a/posthog/clickhouse/migrations/0210_add_is_deleted_to_session_replay_events.py
+++ b/posthog/clickhouse/migrations/0210_add_is_deleted_to_session_replay_events.py
@@ -26,6 +26,7 @@ operations = [
         ADD_IS_DELETED_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL(),
         sharded=False,
         is_alter_on_replicated_table=False,
+        node_roles=[NodeRole.INGESTION_SMALL],
     ),
     # Distributed table for reads - Distributed engine
     run_sql_with_exceptions(


### PR DESCRIPTION
## Problem

The alter is run in data nodes instead of ingestion layer