### PR TITLE
fix(ph-ai): correctly storing deep research traces

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -356,6 +356,8 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
         if not has_message and conversation.status == Conversation.Status.IDLE and not has_resume_payload:
             raise exceptions.ValidationError("Cannot continue streaming from an idle conversation")
 
+        is_impersonated = is_impersonated_session(request)
+
         workflow_inputs: ChatAgentWorkflowInputs | ResearchAgentWorkflowInputs
         workflow_class: type[ChatAgentWorkflow] | type[ResearchAgentWorkflow]
         if is_research:
@@ -370,13 +372,13 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
                 session_id=request.headers.get("X-POSTHOG-SESSION-ID"),  # Relies on posthog-js __add_tracing_headers
                 billing_context=serializer.validated_data.get("billing_context"),
                 is_agent_billable=False,
+                is_impersonated=is_impersonated,
                 resume_payload=serializer.validated_data.get("resume_payload"),
             )
             workflow_class = ResearchAgentWorkflow
             timeout = RESEARCH_AGENT_WORKFLOW_TIMEOUT
             max_length = RESEARCH_AGENT_STREAM_MAX_LENGTH
         else:
-            is_impersonated = is_impersonated_session(request)
             is_agent_billable = not is_impersonated
             workflow_inputs = ChatAgentWorkflowInputs(
                 team_id=self.team_id,
@@ -392,6 +394,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
                 agent_mode=serializer.validated_data.get("agent_mode"),
                 use_checkpointer=True,
                 is_agent_billable=is_agent_billable,
+                is_impersonated=is_impersonated,
                 resume_payload=serializer.validated_data.get("resume_payload"),
             )
             workflow_class = ChatAgentWorkflow

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -865,6 +865,8 @@ class TestConversation(APIBaseTest):
 
                 # Verify is_agent_billable=False for research mode
                 self.assertEqual(workflow_inputs.is_agent_billable, False)
+                # Verify is_impersonated is False (not an impersonated session)
+                self.assertEqual(workflow_inputs.is_impersonated, False)
 
                 # Verify agent_mode and contextual_tools are NOT passed in research mode
                 self.assertFalse(hasattr(workflow_inputs, "agent_mode"))

--- a/ee/hogai/chat_agent/runner.py
+++ b/ee/hogai/chat_agent/runner.py
@@ -72,6 +72,7 @@ class ChatAgentRunner(BaseAgentRunner):
         slack_thread_context: Optional["SlackThreadContext"] = None,
         use_checkpointer: bool = True,
         is_agent_billable: bool = True,
+        is_impersonated: bool = False,
         resume_payload: Optional[dict[str, Any]] = None,
     ):
         super().__init__(
@@ -91,6 +92,7 @@ class ChatAgentRunner(BaseAgentRunner):
             billing_context=billing_context,
             use_checkpointer=use_checkpointer,
             is_agent_billable=is_agent_billable,
+            is_impersonated=is_impersonated,
             stream_processor=ChatAgentStreamProcessor(
                 verbose_nodes=VERBOSE_NODES,
                 streaming_nodes=STREAMING_NODES,

--- a/ee/hogai/core/runner.py
+++ b/ee/hogai/core/runner.py
@@ -135,6 +135,7 @@ class BaseAgentRunner(ABC):
         stream_processor: AssistantStreamProcessorProtocol,
         slack_thread_context: Optional["SlackThreadContext"] = None,
         is_agent_billable: bool = True,
+        is_impersonated: bool = False,
         resume_payload: Optional[dict[str, Any]] = None,
     ):
         self._team = team
@@ -165,7 +166,7 @@ class BaseAgentRunner(ABC):
                     "$session_id": self._session_id,
                     "is_subagent": not self._use_checkpointer,
                     "$groups": event_usage.groups(team=team),
-                    "ai_support_impersonated": not is_agent_billable,
+                    "ai_support_impersonated": is_impersonated,
                     "ai_product": "mcp" if self._conversation.type == Conversation.Type.TOOL_CALL else "posthog_ai",
                     "conversation_type": self._conversation.type,
                 }

--- a/ee/hogai/research_agent/runner.py
+++ b/ee/hogai/research_agent/runner.py
@@ -53,6 +53,7 @@ class ResearchAgentRunner(BaseAgentRunner):
         billing_context: Optional[MaxBillingContext] = None,
         initial_state: Optional[AssistantState | PartialAssistantState] = None,
         is_agent_billable: bool = True,
+        is_impersonated: bool = False,
         resume_payload: Optional[dict[str, Any]] = None,
     ):
         super().__init__(
@@ -70,6 +71,7 @@ class ResearchAgentRunner(BaseAgentRunner):
             initial_state=initial_state,
             use_checkpointer=True,
             is_agent_billable=is_agent_billable,
+            is_impersonated=is_impersonated,
             stream_processor=ChatAgentStreamProcessor(
                 team=team,
                 user=user,

--- a/posthog/temporal/ai/chat_agent.py
+++ b/posthog/temporal/ai/chat_agent.py
@@ -121,6 +121,7 @@ class ChatAgentWorkflowInputs:
     billing_context: Optional[MaxBillingContext] = None
     agent_mode: AgentMode | None = None
     is_agent_billable: bool = True
+    is_impersonated: bool = False
     resume_payload: Optional[dict[str, Any]] = None
 
 
@@ -198,6 +199,7 @@ async def process_chat_agent_activity(inputs: ChatAgentWorkflowInputs) -> None:
             use_checkpointer=inputs.use_checkpointer,
             contextual_tools=inputs.contextual_tools,
             is_agent_billable=inputs.is_agent_billable,
+            is_impersonated=inputs.is_impersonated,
             resume_payload=inputs.resume_payload,
         )
 
@@ -268,6 +270,7 @@ async def process_chat_agent_activity(inputs: ChatAgentWorkflowInputs) -> None:
                 billing_context=billing_context,
                 agent_mode=agent_mode,
                 is_agent_billable=inputs.is_agent_billable,
+                is_impersonated=inputs.is_impersonated,
                 resume_payload=None,
             )
 

--- a/posthog/temporal/ai/research_agent.py
+++ b/posthog/temporal/ai/research_agent.py
@@ -44,6 +44,7 @@ class ResearchAgentWorkflowInputs:
     session_id: Optional[str] = None
     billing_context: Optional[MaxBillingContext] = None
     is_agent_billable: bool = True
+    is_impersonated: bool = False
     resume_payload: Optional[dict[str, Any]] = None
 
 
@@ -100,6 +101,7 @@ async def process_research_agent_activity(inputs: ResearchAgentWorkflowInputs) -
         session_id=inputs.session_id,
         billing_context=inputs.billing_context,
         is_agent_billable=inputs.is_agent_billable,
+        is_impersonated=inputs.is_impersonated,
         resume_payload=inputs.resume_payload,
     )
 


### PR DESCRIPTION
## Problem

`ai_support_impersonated` was derived from `not is_agent_billable`, now that we relased research mode we had `is_agent_billable=False` at the workflow level (for now)which incorrectly marked ALL research traces as `ai_support_impersonated=true`. Which is wrong. Let's fix this.

## Changes

* `is_impersonated` is now decoupled from `is_agent_billable`

## How did you test this code?

- [x] manual tests
- [x] unit tests