### PR TITLE
fix(insights): add missing optional chaining on empty series array ac…

### DIFF
--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -840,7 +840,7 @@ const handleQuerySourceUpdateSideEffects = (
         display !== maybeChangedDisplay &&
         maybeChangedDisplay === ChartDisplayType.WorldMap
     ) {
-        const math = (maybeChangedSeries || (currentState as TrendsQuery).series)?.[0].math
+        const math = (maybeChangedSeries || (currentState as TrendsQuery).series)?.[0]?.math
 
         mergedUpdate['breakdownFilter'] = {
             breakdown: '$geoip_country_code',

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -71,7 +71,7 @@ function useBoldNumberTooltip({
                 renderSeries={(value: React.ReactNode) => <span className="font-semibold">{value}</span>}
                 hideColorCol
                 hideInspectActorsSection={!showPersonsModal}
-                groupTypeLabel={groupTypeLabel || aggregationLabel(series?.[0].math_group_type_index).plural}
+                groupTypeLabel={groupTypeLabel || aggregationLabel(series?.[0]?.math_group_type_index).plural}
             />
         )
     }, [isTooltipShown]) // oxlint-disable-line react-hooks/exhaustive-deps

--- a/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
@@ -72,7 +72,7 @@ function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGEl
                             showHeader={false}
                             hideColorCol
                             hideInspectActorsSection={!showPersonsModal || !currentTooltip[1]}
-                            groupTypeLabel={aggregationLabel(series?.[0].math_group_type_index).plural}
+                            groupTypeLabel={aggregationLabel(series?.[0]?.math_group_type_index).plural}
                         />
                     )}
                 </>


### PR DESCRIPTION
## Problem

Users hitting a `TypeError: Cannot read properties of undefined (reading 'math_group_type_index')` crash when hovering over BoldNumber or WorldMap insights that have an empty series array (e.g. during loading, after removing all series, or with formula-only insights).

Tracked in [error tracking](https://us.posthog.com/error_tracking/019a077b-a7be-7252-8410-57e612569ffd).

## Changes

Three locations used `series?.[0].someProperty` — the optional chaining guards against `series` being nullish, but not against `series[0]` being `undefined` when the array is empty. Added the missing `?.` after `[0]` in:

- `BoldNumber.tsx` — tooltip `groupTypeLabel` prop
- `WorldMap.tsx` — tooltip `groupTypeLabel` prop
- `insightVizDataLogic.ts` — math type detection when switching to WorldMap display

All three downstream consumers already handle `undefined` input gracefully (`aggregationLabel` falls back to "persons", and the `math` variable is compared with `includes()` which handles `undefined`), so no further changes are needed.

## How did you test this code?

1. Create a new Trends insight
2. Add an event group to group multiple events
3. Set the display type to **Number**
4. Delete the event group
5. Verify the insight shows an empty state instead of crashing with `TypeError: Cannot read properties of undefined (reading 'math_group_type_index')`
6. Repeat steps 2-5 with **World map** display type

## Publish to changelog?

No