### PR TITLE
fix: Update elixir integration guide

### DIFF
--- a/docs/onboarding/product-analytics/elixir.tsx
+++ b/docs/onboarding/product-analytics/elixir.tsx
@@ -21,7 +21,7 @@ export const getElixirSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 code: dedent`
                                 def deps do
                                     [
-                                        {:posthog, "~> 1.1.0"}
+                                        {:posthog, "~> 2.2.0"}
                                     ]
                                 end
                             `,
@@ -65,8 +65,10 @@ export const getElixirSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'elixir',
                                 file: 'Elixir',
                                 code: dedent`
-                                Posthog.capture("user_123", "button_clicked", %{
-                                    button_name: "signup"
+                                PostHog.capture("user_signed_up", %{
+                                    distinct_id: "distinct_id_of_the_user",
+                                    login_type: "email",
+                                    is_free_trial: true
                                 })
                             `,
                             },


### PR DESCRIPTION
## Problem

Our Elixir onboarding guide was for an old version of the SDK: https://posthoghelp.zendesk.com/agent/tickets/50025. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/51430)

## Changes

Update it to be consistent with https://github.com/PostHog/posthog-elixir.