### PR TITLE
fix: Replay unexpected filter option didn't work

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -758,8 +758,7 @@ const ReplayFiltersTab = ({
                                 kind: 'feedback',
                                 target_area: 'session_replay',
                                 isEmailFormOpen: true,
-                                message: `## Don't forget to add additional context on what you expected. including links to events/persons/etc. \n 
-                                I got unexpected results with these filters:\n\n\`\`\`\n${JSON.stringify(filters, null, 2)}\n\`\`\`\n\n`,
+                                message: `## Don't forget to add additional context on what you expected. including links to events/persons/etc. \nI got unexpected results with these filters:\n\n\`\`\`\n${JSON.stringify(filters, null, 2)}\n\`\`\`\n\n`,
                             })
                         }
                     >

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -757,6 +757,9 @@ const ReplayFiltersTab = ({
                             openSupportForm({
                                 kind: 'feedback',
                                 target_area: 'session_replay',
+                                isEmailFormOpen: true,
+                                message: `## Don't forget to add additional context on what you expected. including links to events/persons/etc. \n 
+                                I got unexpected results with these filters:\n\n\`\`\`\n${JSON.stringify(filters, null, 2)}\n\`\`\`\n\n`,
                             })
                         }
                     >

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -29,6 +29,7 @@ import {
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { PropertyFilterIcon } from 'lib/components/PropertyFilters/components/PropertyFilterIcon'
+import { supportLogic } from 'lib/components/Support/supportLogic'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
@@ -485,6 +486,8 @@ const ReplayFiltersTab = ({
 
     const [isPopoverVisible, setIsPopoverVisible] = useState(false)
 
+    const { openSupportForm } = useActions(supportLogic)
+
     useMountedLogic(cohortsModel)
     useMountedLogic(actionsModel)
     useMountedLogic(groupsModel)
@@ -750,6 +753,12 @@ const ReplayFiltersTab = ({
                         status="danger"
                         size="small"
                         data-attr="replay-filters-feedback-button"
+                        onClick={() =>
+                            openSupportForm({
+                                kind: 'feedback',
+                                target_area: 'session_replay',
+                            })
+                        }
                     >
                         Unexpected filter results?
                     </LemonButton>


### PR DESCRIPTION
## Problem

The unexpected filter option didn't do anything when clicked

## Changes

now opens the support portal and populates the topic with replay and adds a comment with their applied filters for easier debugging
<img width="953" height="831" alt="image" src="https://github.com/user-attachments/assets/6a45d41a-8424-4d76-8aed-d469c3e48ab9" />

## How did you test this code?

ran locally and changed filters

## Publish to changelog?
no 
