### PR TITLE
chore(signals): Prefix summarization workflow ID with team ID

### DIFF
--- a/posthog/temporal/ai/session_summary/summarize_session.py
+++ b/posthog/temporal/ai/session_summary/summarize_session.py
@@ -780,7 +780,7 @@ def _prepare_execution(
         video_validation_enabled=video_validation_enabled,
     )
     workflow_id = (
-        f"session-summary:single:{'stream' if stream else 'direct'}:{session_id}:{user.id}:{shared_id}:{uuid.uuid4()}"
+        f"session-summary:single:{'stream' if stream else 'direct'}:{team.id}:{session_id}:{shared_id}:{uuid.uuid4()}"
     )
     return redis_client, redis_input_key, redis_output_key, session_input, workflow_id
 


### PR DESCRIPTION
## Problem

Searching in the Temporal UI for all single session summarization workflow runs for a particular team is impossible - but it's crucial to debug the progress of emitting signals from session analysis, for proactive tasks.

## Changes

Adding `team.id` to `"session-summary:single:etcetera"`.
Keeping `session-summary:group` unchanged, as that one is always user-initiated.
