### PR TITLE
fix(scim): make PATCH Replace for group members additive

### DIFF
--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -99,6 +99,8 @@ LOGGING = {
         "posthog.tasks.hypercache_verification": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "posthog.storage.hypercache_verifier": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "posthog.auth.mfa": {"level": "INFO", "handlers": ["console"], "propagate": False},
+        "ee.api.authentication": {"level": "INFO", "handlers": ["console"], "propagate": False},
+        "ee.api.scim": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "boto3": {"level": "WARN"},  # boto3 logs are noisy
         "botocore": {"level": "WARN"},  # botocore logs are noisy
     },


### PR DESCRIPTION
## Problem                                                                                                 
                                                                                                             
  SCIM group membership operations from IdPs like Entra ID can silently destroy existing group members. When
  Entra sends a PATCH Replace operation with a partial member list (e.g., just the newly added member),      
  `handle_replace` called `_update_members` which performed a full sync - computing the diff between current 
  members and the provided list, then deleting everyone not in the partial list. This meant adding 1 member  
  to a group of 5 could wipe the other 4.                                                                    
  
  Solves: https://posthog.slack.com/archives/C092SNQPUAG/p1770341757866729
                                                                                                             
## Changes                                                                                                 
                                                                                                             
  **`ee/api/scim/group.py`**
  - Split `_update_members` into two methods:
    - `_add_members` — additively upserts members without removing existing ones
    - `_replace_all_members` — full sync that sets membership to exactly the provided list
  - `handle_replace` and `handle_add` (PATCH) now use `_add_members` (safe, additive)
  - `put` and `from_dict` (PUT/POST) still use `_replace_all_members` (correct full-replacement semantics per
   SCIM spec)
  - `User.DoesNotExist` now logs a warning instead of being silently swallowed

## How did you test this code?

  - Added 3 new tests to `ee/api/scim/test/test_groups_api.py`:
    - `test_patch_replace_members_preserves_existing_members` — group with 2 existing members, PATCH Replace
  sends 1 new member, all 3 survive
    - `test_patch_replace_without_path_preserves_existing_members` — pathless Replace with displayName +
  members preserves existing members
    - `test_put_replaces_all_members` — confirms PUT still does full replacement (existing member removed,
  new member added)


  ## Publish to changelog?

  no