### PR TITLE
fix: adding insights to notebooks

### DIFF
--- a/frontend/src/scenes/saved-insights/AddSavedInsightsToDashboard.tsx
+++ b/frontend/src/scenes/saved-insights/AddSavedInsightsToDashboard.tsx
@@ -1,13 +1,17 @@
+import { useValues } from 'kea'
+
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 
 import { SavedInsightsTable } from './SavedInsightsTable'
 import { DashboardActionButton } from './components/DashboardActionButton'
 
 export function AddSavedInsightsToDashboard(): JSX.Element {
     const isExperimentEnabled = useFeatureFlag('PRODUCT_ANALYTICS_ADD_INSIGHT_TO_DASHBOARD_MODAL', 'test')
+    const { dashboard } = useValues(dashboardLogic)
 
     if (isExperimentEnabled) {
-        return <SavedInsightsTable />
+        return <SavedInsightsTable dashboard={dashboard} />
     }
 
     return <SavedInsightsTable renderActionColumn={(insight) => <DashboardActionButton insight={insight} />} />

--- a/frontend/src/scenes/saved-insights/SavedInsightsTable.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsTable.tsx
@@ -15,13 +15,12 @@ import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/column
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { pluralize } from 'lib/utils'
-import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { SavedInsightsEmptyState } from 'scenes/insights/EmptyStates'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { SavedInsightsFilters } from 'scenes/saved-insights/SavedInsightsFilters'
 import { urls } from 'scenes/urls'
 
-import { QueryBasedInsightModel } from '~/types'
+import { DashboardType, QueryBasedInsightModel } from '~/types'
 
 import { InsightIcon } from './SavedInsights'
 import { addSavedInsightsModalLogic } from './addSavedInsightsModalLogic'
@@ -29,16 +28,16 @@ import { insightDashboardModalLogic } from './insightDashboardModalLogic'
 
 interface SavedInsightsTableProps {
     renderActionColumn?: (insight: QueryBasedInsightModel) => JSX.Element
+    dashboard?: DashboardType | null
 }
 
-export function SavedInsightsTable({ renderActionColumn }: SavedInsightsTableProps): JSX.Element {
+export function SavedInsightsTable({ renderActionColumn, dashboard }: SavedInsightsTableProps): JSX.Element {
     const isExperimentEnabled = useFeatureFlag('PRODUCT_ANALYTICS_ADD_INSIGHT_TO_DASHBOARD_MODAL', 'test')
     const { modalPage, insights, count, insightsLoading, filters, sorting, insightsPerPage } =
         useValues(addSavedInsightsModalLogic)
     const { setModalPage, setModalFilters } = useActions(addSavedInsightsModalLogic)
     const { dashboardUpdatesInProgress, isInsightInDashboard } = useValues(insightDashboardModalLogic)
     const { toggleInsightOnDashboard, syncOptimisticStateWithDashboard } = useActions(insightDashboardModalLogic)
-    const { dashboard } = useValues(dashboardLogic)
     const summarizeInsight = useSummarizeInsight()
 
     const startCount = (modalPage - 1) * insightsPerPage + 1

--- a/frontend/src/scenes/saved-insights/SavedInsightsTable.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsTable.tsx
@@ -28,7 +28,7 @@ import { insightDashboardModalLogic } from './insightDashboardModalLogic'
 
 interface SavedInsightsTableProps {
     renderActionColumn?: (insight: QueryBasedInsightModel) => JSX.Element
-    dashboard?: DashboardType | null
+    dashboard?: DashboardType<QueryBasedInsightModel> | null
 }
 
 export function SavedInsightsTable({ renderActionColumn, dashboard }: SavedInsightsTableProps): JSX.Element {


### PR DESCRIPTION
We did a change where notebooks tried to access a logic which was not initialized - https://github.com/PostHog/posthog/pull/46845

It worked when trying to add insights to notebook from the dashboard but it didn't when trying to do the same but from a notebook.

Instead of accessing that from the logic which is not initialized, I made it pass required stuff through the props.

Tested this both with and without new feature flag both inside dashboard and inside notebook - everything works fine