### PR TITLE
fix(Filters): stop re-fetching values when selecting from dropdown

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { initKeaTests } from '~/test/init'
+import { PropertyFilterType, PropertyOperator } from '~/types'
+
+import { PropertyValue } from './PropertyValue'
+
+jest.mock('lib/components/AutoSizer', () => ({
+    AutoSizer: ({ renderProp }: { renderProp: (size: { height: number; width: number }) => React.ReactNode }) =>
+        renderProp({ height: 400, width: 400 }),
+}))
+
+describe('PropertyValue', () => {
+    let loadPropertyValuesSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/event/values': [{ name: 'Chrome' }, { name: 'Firefox' }, { name: 'Safari' }],
+                '/api/environments/:team/events/values': [{ name: 'Chrome' }, { name: 'Firefox' }, { name: 'Safari' }],
+            },
+        })
+        initKeaTests()
+        propertyDefinitionsModel.mount()
+        loadPropertyValuesSpy = jest.spyOn(propertyDefinitionsModel.actions, 'loadPropertyValues')
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('does not re-fetch property values when selecting a value from the dropdown', async () => {
+        const onSet = jest.fn()
+        render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="$browser"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Exact}
+                    onSet={onSet}
+                    value={[]}
+                />
+            </Provider>
+        )
+
+        // Focus the input to open the dropdown
+        const input = screen.getByRole('textbox')
+        userEvent.click(input)
+
+        // Wait for options to load and appear
+        await waitFor(() => {
+            expect(screen.getByText('Chrome')).toBeInTheDocument()
+        })
+
+        const callCountAfterLoad = loadPropertyValuesSpy.mock.calls.length
+
+        // Select a value from the dropdown
+        userEvent.click(screen.getByText('Chrome'))
+
+        // loadPropertyValues should not have been called again
+        expect(loadPropertyValuesSpy.mock.calls.length).toBe(callCountAfterLoad)
+    })
+})

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
@@ -61,6 +61,8 @@ describe('PropertyValue', () => {
 
         // Select a value from the dropdown
         userEvent.click(screen.getByText('Chrome'))
+        // Flush pending microtasks so any async loadPropertyValues calls settle before we assert
+        await new Promise((r) => setTimeout(r, 0))
 
         // loadPropertyValues should not have been called again
         expect(loadPropertyValuesSpy.mock.calls.length).toBe(callCountAfterLoad)

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -179,8 +179,9 @@ export function PropertyValue({
     }, [propertyOptions?.values, initialSuggestedValues])
 
     const onSearchTextChange = (newInput: string): void => {
-        if (!Object.keys(options).includes(newInput) && !(operator && isOperatorFlag(operator))) {
-            load(newInput.trim())
+        const trimmedInput = newInput.trim()
+        if (trimmedInput !== currentSearchInput.current && !(operator && isOperatorFlag(operator))) {
+            load(trimmedInput)
         }
     }
 

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -5,7 +5,8 @@ import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifi
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
-import React, { useEffect } from 'react'
+import isEqual from 'lodash.isequal'
+import React, { useEffect, useRef } from 'react'
 
 import { IconPlusSmall } from '@posthog/icons'
 
@@ -158,10 +159,15 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
     const { addFilter, setLocalFilters, showModal } = useActions(logic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    // No way around this. Somehow the ordering of the logic calling each other causes stale "localFilters"
-    // to be shown on the /funnels page, even if we try to use a selector with props to hydrate it
+    // Parents like TrendsSeries recreate the filters object every render (via queryNodeToFilter).
+    // The reducer's isEqual can't catch this because toFilters includes uuid fields that the
+    // incoming filters don't have. So we guard here to avoid unnecessary setLocalFilters calls.
+    const prevFiltersRef = useRef(filters)
     useEffect(() => {
-        setLocalFilters(filters)
+        if (!isEqual(prevFiltersRef.current, filters)) {
+            prevFiltersRef.current = filters
+            setLocalFilters(filters)
+        }
     }, [filters]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     function onSortEnd({ oldIndex, newIndex }: { oldIndex: number; newIndex: number }): void {

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -5,8 +5,7 @@ import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifi
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
-import isEqual from 'lodash.isequal'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect } from 'react'
 
 import { IconPlusSmall } from '@posthog/icons'
 
@@ -159,15 +158,10 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
     const { addFilter, setLocalFilters, showModal } = useActions(logic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    // Parents like TrendsSeries recreate the filters object every render (via queryNodeToFilter).
-    // The reducer's isEqual can't catch this because toFilters includes uuid fields that the
-    // incoming filters don't have. So we guard here to avoid unnecessary setLocalFilters calls.
-    const prevFiltersRef = useRef(filters)
+    // No way around this. Somehow the ordering of the logic calling each other causes stale "localFilters"
+    // to be shown on the /funnels page, even if we try to use a selector with props to hydrate it
     useEffect(() => {
-        if (!isEqual(prevFiltersRef.current, filters)) {
-            prevFiltersRef.current = filters
-            setLocalFilters(filters)
-        }
+        setLocalFilters(filters)
     }, [filters]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     function onSortEnd({ oldIndex, newIndex }: { oldIndex: number; newIndex: number }): void {


### PR DESCRIPTION
## Problem

Unnecessary API calls to fetch filter values resulting in loading states and re-ordering of lists while trying to use it.

## [Screen Recording 2026-02-09 at 13.46.06.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/279ed7cb-b319-458d-a0ca-810545a703e8.mov" />](https://app.graphite.com/user-attachments/video/279ed7cb-b319-458d-a0ca-810545a703e8.mov)

## Changes

- Added a test case to verify that property values aren't re-fetched when selecting a value from the dropdown
- Modified the `onSearchTextChange` function in `PropertyValue.tsx` to:
    - Trim the input before checking if it needs to be loaded
    - Compare with the current search input to avoid redundant loads
    - Only load new values when the search input has actually changed

[Screen Recording 2026-02-09 at 19.48.42.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/ee50d6b0-c8ba-4ac3-8d35-798541e90862.mov" />](https://app.graphite.com/user-attachments/video/ee50d6b0-c8ba-4ac3-8d35-798541e90862.mov)





## How did you test this code?

Added a test, ran it! 🏃‍♂️

The test ensures the fix works as expected by spying on the `loadPropertyValues` action and checking its call count before and after selecting a value.