### PR TITLE
fix: apply correct threshold for hog functons in daily digest

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1480,7 +1480,7 @@ class TestUserAPI(APIBaseTest):
                 "project_weekly_digest_disabled": {},  # Default value
                 "all_weekly_digest_disabled": True,
                 "error_tracking_issue_assigned": True,  # Default value
-                "data_pipeline_error_threshold": 0.0,  # Default value
+                "data_pipeline_error_threshold": 0.01,  # Default value
                 "project_api_key_exposed": True,  # Default value
                 "materialized_view_sync_failed": False,  # Default value
             },

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -42,7 +42,7 @@ NOTIFICATION_DEFAULTS: Notifications = {
     "discussions_mentioned": True,  # Mentions in comments enabled by default
     "project_weekly_digest_disabled": {},  # Empty dict by default - no projects disabled
     "all_weekly_digest_disabled": False,  # Weekly digests enabled by default
-    "data_pipeline_error_threshold": 0.0,  # Default: notify on any failure (0% threshold)
+    "data_pipeline_error_threshold": 0.01,  # Default: notify when failure rate exceeds 1%
     "project_api_key_exposed": True,  # Project API key exposure alerts enabled by default
     "materialized_view_sync_failed": False,  # Materialized view failure disabled by default
 }


### PR DESCRIPTION
## Problem

There is a separate check for the hog function digest that ensures all hog functions in the digest must have a failure rate > 1%. This is problem because it could conflict with the user's configured notification threshold. 

For example, if a hog function fails at a failure rate of 0.5%, the user has a threshold of 0%, then they will not receive a notification for the failed hog function.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Update default notification threshold to 1%
- Remove the hardcoded 1% check for hog functions

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
