### PR TITLE
feat(flags): implement custom canary workflow

### DIFF
--- a/.github/workflows/canary-flags.yml
+++ b/.github/workflows/canary-flags.yml
@@ -1,0 +1,136 @@
+name: Feature Flags PR Canary
+
+on:
+    pull_request:
+        types: [labeled, synchronize, closed, unlabeled]
+
+concurrency:
+    group: canary-flags-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    build:
+        name: Build feature-flags canary image
+        if: >-
+            github.event.pull_request.head.repo.full_name == github.repository
+            && contains(github.event.pull_request.labels.*.name, 'canary-flags')
+            && (
+              (github.event.action == 'labeled' && github.event.label.name == 'canary-flags')
+              || github.event.action == 'synchronize'
+            )
+        runs-on: depot-ubuntu-22.04
+        permissions:
+            id-token: write
+            contents: read
+            packages: write
+        defaults:
+            run:
+                working-directory: rust
+        outputs:
+            short_sha: ${{ steps.short_sha.outputs.short_sha }}
+
+        steps:
+            - name: Check Out Repo
+              uses: actions/checkout@v6
+              with:
+                  sparse-checkout: 'rust/'
+                  sparse-checkout-cone-mode: false
+
+            - name: Set up Depot CLI
+              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+              with:
+                  image: tonistiigi/binfmt:latest
+                  platforms: all
+
+            - name: Login to ghcr.io
+              uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+                  logout: false
+
+            - name: Compute short SHA
+              id: short_sha
+              run: echo "short_sha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+            - name: Retrieve sccache configuration
+              id: sccache
+              run: |
+                  echo "endpoint=$SCCACHE_WEBDAV_ENDPOINT" >> "$GITHUB_OUTPUT"
+                  echo "::add-mask::$SCCACHE_WEBDAV_TOKEN"
+                  echo "token=$SCCACHE_WEBDAV_TOKEN" >> "$GITHUB_OUTPUT"
+
+            - name: Build and push image
+              id: docker_build
+              uses: depot/build-push-action@9785b135c3c76c33db102e45be96a25ab55cd507 # v1.16.2
+              with:
+                  project: vglf58qgzw
+                  context: ./rust/
+                  file: ./rust/Dockerfile
+                  push: true
+                  tags: ghcr.io/posthog/posthog/feature-flags:${{ steps.short_sha.outputs.short_sha }}
+                  platforms: linux/arm64,linux/amd64
+                  build-args: |
+                      SCCACHE_LOG=debug
+                      SCCACHE_NO_DAEMON=1
+                      BIN=feature-flags
+                  secrets: |
+                      SCCACHE_WEBDAV_ENDPOINT=${{ steps.sccache.outputs.endpoint }}
+                      SCCACHE_WEBDAV_TOKEN=${{ steps.sccache.outputs.token }}
+
+    enable:
+        name: Enable canary flags
+        needs: build
+        runs-on: ubuntu-24.04
+
+        steps:
+            - name: Get deployer token
+              id: deployer
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
+              with:
+                  app_id: ${{ secrets.GH_APP_CHARTS_DEPLOYER_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_CHARTS_DEPLOYER_PRIVATE_KEY }}
+
+            - name: Dispatch enable-canary-flags
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repository: PostHog/charts
+                  event-type: enable-canary-flags
+                  client-payload: |
+                      {
+                        "pr_number": "${{ github.event.pull_request.number }}",
+                        "canary_weight": "1"
+                      }
+
+    disable:
+        name: Disable canary flags
+        if: >-
+            github.event.pull_request.head.repo.full_name == github.repository
+            && (
+              (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'canary-flags'))
+              || (github.event.action == 'unlabeled' && github.event.label.name == 'canary-flags')
+            )
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Get deployer token
+              id: deployer
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
+              with:
+                  app_id: ${{ secrets.GH_APP_CHARTS_DEPLOYER_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_CHARTS_DEPLOYER_PRIVATE_KEY }}
+
+            - name: Dispatch disable-canary-flags
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repository: PostHog/charts
+                  event-type: disable-canary-flags
+                  client-payload: |
+                      {
+                        "pr_number": "${{ github.event.pull_request.number }}"
+                      }

--- a/.github/workflows/canary-flags.yml
+++ b/.github/workflows/canary-flags.yml
@@ -86,7 +86,8 @@ jobs:
         name: Enable canary flags
         needs: build
         runs-on: ubuntu-24.04
-
+        permissions:
+            contents: read
         steps:
             - name: Get deployer token
               id: deployer
@@ -116,6 +117,8 @@ jobs:
               || (github.event.action == 'unlabeled' && github.event.label.name == 'canary-flags')
             )
         runs-on: ubuntu-24.04
+        permissions:
+            contents: read
         steps:
             - name: Get deployer token
               id: deployer


### PR DESCRIPTION
## Problem

This is the second step for having the custom feature flags canary rollout system, started at https://github.com/PostHog/charts/pull/8220.

## Changes

It introduces a new workflow with three steps:
1. Build and push to the registry a new feature flag image from the branch. Runs on labeled (specifically the canary-flags label) or synchronize events when the label is present.
2. `enable` — Runs after build succeeds. Dispatches enable-canary-flags to PostHog/charts with the PR number and canary weight.
3. `disable` — Dispatches `disable-canary-flags` to PostHog/charts when the PR is closed (with label present) or the canary flags label is removed. Independent of the build job.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
