### PR TITLE
Dashboard not working

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -86,12 +86,12 @@ function DashboardScene(): JSX.Element {
         return () => abortAnyRunningQuery()
     })
 
-    if (!dashboard && !itemsLoading && !dashboardFailedToLoad) {
-        return <NotFound object="dashboard" />
-    }
-
     if (accessDeniedToDashboard) {
         return <AccessDenied object="dashboard" />
+    }
+
+    if (!dashboard && !itemsLoading && !dashboardFailedToLoad) {
+        return <NotFound object="dashboard" />
     }
 
     return (

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -477,6 +477,48 @@ describe('dashboardLogic', () => {
         })
     })
 
+    describe('when dashboard tile streaming fails', () => {
+        it('sets access denied on 403 without marking dashboard as failed-to-load', async () => {
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.tileStreamingFailure({ status: 403, message: '403 permission_denied' })
+            }).toMatchValues({
+                accessDeniedToDashboard: true,
+                dashboardFailedToLoad: false,
+                error404: false,
+            })
+        })
+
+        it('marks dashboard as failed-to-load on non-403/404 errors', async () => {
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.tileStreamingFailure({ status: 500, message: '500 💣' })
+            }).toMatchValues({
+                dashboardFailedToLoad: true,
+            })
+        })
+
+        it('marks dashboard as not found on 404 errors', async () => {
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.tileStreamingFailure({ status: 404, message: '404' })
+            }).toMatchValues({
+                error404: true,
+                dashboardFailedToLoad: false,
+                accessDeniedToDashboard: false,
+            })
+        })
+    })
+
     describe('when props id is set to a number', () => {
         beforeEach(async () => {
             logic = dashboardLogic({ id: 5 })


### PR DESCRIPTION
## Problem

Users reported dashboards "not working". Investigation revealed that streaming dashboard load failures (SSE) were leading to incorrect UI states. Specifically, "Not Found" was displayed for "Access Denied" (403) errors and other non-404/403 streaming errors, instead of the appropriate error message or a general load failure state. This provides misleading information and a poor user experience.

## Changes

- Prioritized `AccessDenied` rendering over `NotFound` in `Dashboard.tsx` to ensure correct messaging for permission issues.
- Enhanced `tileStreamingFailure` handling in `dashboardLogic.tsx` to:
    - Correctly set `accessDeniedToDashboard` for 403 errors.
    - Correctly set `error404` for 404 errors.
    - Trigger `loadDashboardFailure` and display an error toast for all other streaming errors (e.g., 500s), ensuring these are treated as proper load failures.
- Added comprehensive regression tests in `dashboardLogic.test.ts` to cover various streaming failure scenarios.

## How did you test this code?

Automated unit tests: `pnpm --filter=@posthog/frontend jest frontend/src/scenes/dashboard/dashboardLogic.test.ts` were run and passed. These tests specifically validate the new error handling logic for 403, 404, and generic streaming failures.

## Publish to changelog?

no

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b37a128e-eef0-41ef-884e-8921b4ce2188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b37a128e-eef0-41ef-884e-8921b4ce2188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

