### PR TITLE
feat(marketing-analytics): integrate external data sources and refres…

### DIFF
--- a/frontend/src/scenes/marketing-analytics/MarketingAnalyticsScene.tsx
+++ b/frontend/src/scenes/marketing-analytics/MarketingAnalyticsScene.tsx
@@ -6,6 +6,7 @@ import { LemonBanner, LemonSkeleton, Link } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { externalDataSourcesLogic } from 'scenes/data-warehouse/externalDataSourcesLogic'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
 import { QueryTile } from 'scenes/web-analytics/common'
@@ -69,10 +70,17 @@ const QueryTileItem = ({ tile }: { tile: QueryTile }): JSX.Element => {
 const MarketingAnalyticsDashboard = (): JSX.Element => {
     const { featureFlags } = useValues(featureFlagLogic)
     const { hasSources, hasNoConfiguredSources, loading } = useValues(marketingAnalyticsLogic)
+    const { loadSources } = useActions(externalDataSourcesLogic)
     const { conversion_goals } = useValues(marketingAnalyticsSettingsLogic)
     const { tiles: marketingTiles } = useValues(marketingAnalyticsTilesLogic)
     const { showOnboarding } = useValues(marketingOnboardingLogic)
     const { completeOnboarding, resetOnboarding } = useActions(marketingOnboardingLogic)
+
+    // Reload sources on every navigation to this scene so newly configured
+    // data warehouse sources are picked up without a full page refresh
+    useEffect(() => {
+        loadSources(null)
+    }, [])
 
     // Auto-complete onboarding if user already has sources and conversion goals configured
     useEffect(() => {

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
@@ -177,7 +177,7 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
         ],
         actions: [
             dataWarehouseSettingsLogic,
-            ['loadSources', 'loadSourcesSuccess'],
+            ['loadSources', 'loadSourcesSuccess', 'loadDatabase'],
             dataNodeCollectionLogic({ key: MARKETING_ANALYTICS_DATA_COLLECTION_NODE_ID }),
             ['reloadAll'],
             marketingAnalyticsSettingsLogic,
@@ -374,7 +374,7 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
                     return null
                 }
 
-                const validSourcesMap = sources_map
+                const validSourcesMap = { ...sources_map }
                 const requiredColumns = Object.values(MarketingAnalyticsColumnsSchemaNames).filter(
                     (column_name: MarketingAnalyticsColumnsSchemaNames) =>
                         MARKETING_ANALYTICS_SCHEMA[column_name].required
@@ -816,6 +816,9 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
                     }
                 }
 
+                // Refresh warehouse tables so newly added source tables are picked up
+                actions.loadDatabase()
+
                 // Reload all queries to reflect the updated sources
                 actions.reloadAll()
 
@@ -870,5 +873,6 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
         }
 
         actions.loadSources(null)
+        actions.loadDatabase()
     }),
 ])


### PR DESCRIPTION
## Problem

People had to refresh the window in order to see a new source in the marketing trend chart

## Changes

- Added loadSources from externalDataSourcesLogic to reload sources on scene navigation, ensuring newly configured data warehouse sources are picked up without a full page refresh.
- Updated marketingAnalyticsLogic to include loadDatabase action for refreshing warehouse tables when new sources are added.

## How did you test this code?
Manually