### PR TITLE
fix(Filters): prevent filter rows from remounting on every change

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -5,7 +5,8 @@ import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifi
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
-import React, { useEffect } from 'react'
+import isEqual from 'lodash.isequal'
+import React, { useEffect, useRef } from 'react'
 
 import { IconPlusSmall } from '@posthog/icons'
 
@@ -158,10 +159,15 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
     const { addFilter, setLocalFilters, showModal } = useActions(logic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    // No way around this. Somehow the ordering of the logic calling each other causes stale "localFilters"
-    // to be shown on the /funnels page, even if we try to use a selector with props to hydrate it
+    // Parents like TrendsSeries recreate the filters object every render (via queryNodeToFilter).
+    // The reducer's isEqual can't catch this because toFilters includes uuid fields that the
+    // incoming filters don't have. So we guard here to avoid unnecessary setLocalFilters calls.
+    const prevFiltersRef = useRef(filters)
     useEffect(() => {
-        setLocalFilters(filters)
+        if (!isEqual(prevFiltersRef.current, filters)) {
+            prevFiltersRef.current = filters
+            setLocalFilters(filters)
+        }
     }, [filters]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     function onSortEnd({ oldIndex, newIndex }: { oldIndex: number; newIndex: number }): void {

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -5,8 +5,7 @@ import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifi
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
-import isEqual from 'lodash.isequal'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect } from 'react'
 
 import { IconPlusSmall } from '@posthog/icons'
 
@@ -159,15 +158,10 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
     const { addFilter, setLocalFilters, showModal } = useActions(logic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    // Parents like TrendsSeries recreate the filters object every render (via queryNodeToFilter).
-    // The reducer's isEqual can't catch this because toFilters includes uuid fields that the
-    // incoming filters don't have. So we guard here to avoid unnecessary setLocalFilters calls.
-    const prevFiltersRef = useRef(filters)
+    // No way around this. Somehow the ordering of the logic calling each other causes stale "localFilters"
+    // to be shown on the /funnels page, even if we try to use a selector with props to hydrate it
     useEffect(() => {
-        if (!isEqual(prevFiltersRef.current, filters)) {
-            prevFiltersRef.current = filters
-            setLocalFilters(filters)
-        }
+        setLocalFilters(filters)
     }, [filters]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     function onSortEnd({ oldIndex, newIndex }: { oldIndex: number; newIndex: number }): void {

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -5,7 +5,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { BuiltLogic, useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { IconCopy, IconEllipsis, IconFilter, IconPencil, IconStack, IconTrash, IconWarning } from '@posthog/icons'
 import {
@@ -64,6 +64,7 @@ import {
 import {
     ActionFilter,
     ActionFilter as ActionFilterType,
+    AnyPropertyFilter,
     BaseMathType,
     ChartDisplayCategory,
     ChartDisplayType,
@@ -261,6 +262,11 @@ export function ActionFilterRow({
     const onClose = (): void => {
         removeLocalFilter({ ...filter, index })
     }
+
+    const onPropertyChange = useCallback(
+        (properties: AnyPropertyFilter[]) => updateFilterProperty({ properties, index }),
+        [updateFilterProperty, index]
+    )
 
     const onMathSelect = (_: unknown, selectedMath?: string): void => {
         let mathProperties
@@ -789,7 +795,7 @@ export function ActionFilterRow({
                     <PropertyFilters
                         pageKey={`${index}-${value}-${typeKey}-filter`}
                         propertyFilters={filter.properties}
-                        onChange={(properties) => updateFilterProperty({ properties, index })}
+                        onChange={onPropertyChange}
                         showNestedArrow={showNestedArrow}
                         disablePopover={!propertyFiltersPopover}
                         metadataSource={

--- a/playwright/e2e/product-analytics/insights/trends.spec.ts
+++ b/playwright/e2e/product-analytics/insights/trends.spec.ts
@@ -103,6 +103,7 @@ test.describe('Trends insights', () => {
             await countPerUserItem.getByRole('button').click()
             await page.getByRole('menuitem', { name: 'median' }).click()
             await insight.trends.waitForChart()
+            await page.keyboard.press('Escape')
         })
 
         await test.step('change to Property value with sum', async () => {
@@ -112,11 +113,14 @@ test.describe('Trends insights', () => {
             await propertyValueItem.getByRole('button').click()
             await page.getByRole('menuitem', { name: 'sum' }).click()
             await insight.trends.waitForChart()
+            await page.keyboard.press('Escape')
         })
 
         await test.step('change to Weekly then Monthly active users', async () => {
             await insight.trends.mathSelector(0).click()
-            await page.getByRole('menuitem', { name: /Weekly active users/ }).click()
+            const weeklyOption = page.getByRole('menuitem', { name: /Weekly active users/ })
+            await weeklyOption.waitFor({ state: 'visible' })
+            await weeklyOption.click()
             await insight.trends.waitForChart()
 
             await insight.trends.mathSelector(0).click()


### PR DESCRIPTION
## Problem

Filtering feels unstable.. Lots of re-rendering causes layout shift, flashing and drop downs self closing

### Issue Examples

**Re-rendering of unrelated components:**

[Screen Recording 2026-02-09 at 13.45.35.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d2e46e32-9fa5-4366-9be8-7ab18eb90893.mov" />](https://app.graphite.com/user-attachments/video/d2e46e32-9fa5-4366-9be8-7ab18eb90893.mov)

**Multi select drop down closes on click:**

[Screen Recording 2026-02-09 at 13.44.58.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/aa79c98e-a65f-4df6-80d4-46f1e1ffd10f.mov" />](https://app.graphite.com/user-attachments/video/aa79c98e-a65f-4df6-80d4-46f1e1ffd10f.mov)

## Changes

- Stopped re-rendering of components when not needed
- Added some missing test coverage

### Result

Feels more stable, no jittering, no loading states when they're not needed.

[Screen Recording 2026-02-09 at 13.54.43.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/da7743ed-e857-4518-87fb-89782673bbc8.mov" />](https://app.graphite.com/user-attachments/video/da7743ed-e857-4518-87fb-89782673bbc8.mov)

## How did you test this code?

- Added unit tests for PropertyValue component to verify it doesn't re-fetch property values unnecessarily
- Added tests for taxonomicPropertyFilterLogic to verify proper group selection and filter conversion
- Added tests for utility functions to ensure proper type mapping and filter creation
- Added tests for entityFilterLogic to verify UUID preservation
- Manually tested property filters in the UI to ensure smooth operationclick