### PR TITLE
fix(signals): Run session summary priming as child workflows

### DIFF
--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -58,10 +58,10 @@ from .sync_vectors import (
 from .video_segment_clustering.activities import (
     cluster_segments_activity,
     fetch_segments_activity,
+    get_sessions_to_prime_activity,
     label_clusters_activity,
     match_clusters_activity,
     persist_reports_activity,
-    prime_session_embeddings_activity,
 )
 from .video_segment_clustering.clustering_workflow import VideoSegmentClusteringWorkflow
 from .video_segment_clustering.coordinator_workflow import (
@@ -111,7 +111,7 @@ ACTIVITIES = [
     consolidate_video_segments_activity,
     capture_timing_activity,
     # Video segment clustering activities
-    prime_session_embeddings_activity,
+    get_sessions_to_prime_activity,
     fetch_segments_activity,
     cluster_segments_activity,
     match_clusters_activity,

--- a/posthog/temporal/ai/video_segment_clustering/activities/__init__.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/__init__.py
@@ -1,4 +1,4 @@
-from .a1_prime_session_embeddings import prime_session_embeddings_activity
+from .a1_prime_session_embeddings import get_sessions_to_prime_activity
 from .a2_fetch_segments import fetch_segments_activity
 from .a3_cluster_segments import cluster_segments_activity
 from .a4_match_clusters import match_clusters_activity
@@ -6,7 +6,7 @@ from .a5_label_clusters import label_clusters_activity
 from .a6_persist_reports import persist_reports_activity
 
 __all__ = [
-    "prime_session_embeddings_activity",
+    "get_sessions_to_prime_activity",
     "fetch_segments_activity",
     "cluster_segments_activity",
     "match_clusters_activity",

--- a/posthog/temporal/ai/video_segment_clustering/activities/a1_prime_session_embeddings.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/a1_prime_session_embeddings.py
@@ -1,9 +1,7 @@
 """
 Activity 1 of the video segment clustering workflow:
-Prime session embeddings by fetching recent sessions and running summarization.
+Identify sessions that need summarization (embedding priming).
 """
-
-import asyncio
 
 import structlog
 from temporalio import activity
@@ -14,10 +12,9 @@ from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.models.team import Team
 from posthog.session_recordings.queries.session_recording_list_from_query import SessionRecordingListFromQuery
 from posthog.sync import database_sync_to_async
-from posthog.temporal.ai.session_summary.summarize_session import execute_summarize_session
 from posthog.temporal.ai.video_segment_clustering.models import (
+    GetSessionsToPrimeResult,
     PrimeSessionEmbeddingsActivityInputs,
-    PrimeSessionEmbeddingsResult,
 )
 
 from ee.hogai.session_summaries.constants import MIN_SESSION_DURATION_FOR_SUMMARY_MS
@@ -27,15 +24,14 @@ logger = structlog.get_logger(__name__)
 
 
 @activity.defn
-async def prime_session_embeddings_activity(
+async def get_sessions_to_prime_activity(
     inputs: PrimeSessionEmbeddingsActivityInputs,
-) -> PrimeSessionEmbeddingsResult:
-    """Prime the document_embeddings table by running session summarization.
+) -> GetSessionsToPrimeResult:
+    """Identify sessions that need summarization for embedding priming.
 
-    Fetches recent sessions that ended within the lookback period and runs video-based summarization
-    to populate session segment embeddings for clustering.
-
-    This is pretty crude, as it means we're summarizing EVERY session in the lookback period - but okay for small teams.
+    Fetches recent sessions (completed within within the lookback period), filters out already-summarized ones,
+    and returns the list of session IDs that need summarization along with user info
+    needed to start child summarization workflows.
     """
     team = await Team.objects.aget(id=inputs.team_id)
 
@@ -45,10 +41,10 @@ async def prime_session_embeddings_activity(
     )
 
     if not session_ids:
-        return PrimeSessionEmbeddingsResult(
-            session_ids_found=0,
-            sessions_summarized=0,
-            sessions_failed=0,
+        return GetSessionsToPrimeResult(
+            session_ids_to_summarize=[],
+            user_id=None,
+            user_distinct_id=None,
         )
 
     # Get first user with access to the team for running summarization (as summarization requires _some_ user)
@@ -57,10 +53,10 @@ async def prime_session_embeddings_activity(
 
     if not system_user:
         logger.warning("No user found to run summarization", team_id=inputs.team_id)
-        return PrimeSessionEmbeddingsResult(
-            session_ids_found=len(session_ids),
-            sessions_summarized=0,
-            sessions_failed=len(session_ids),
+        return GetSessionsToPrimeResult(
+            session_ids_to_summarize=[],
+            user_id=None,
+            user_distinct_id=None,
         )
 
     # Check which sessions already have summaries
@@ -70,38 +66,12 @@ async def prime_session_embeddings_activity(
         extra_summary_context=None,
     )
 
-    # Start summarization workflows for sessions without summaries
     sessions_to_summarize = [session_id for session_id in session_ids if not existing_summaries.get(session_id)]
-    sessions_summarized = 0
-    sessions_failed = 0
-    if sessions_to_summarize:
-        # Limit concurrent summarizations to avoid overwhelming workers
-        semaphore = asyncio.Semaphore(50)
 
-        async def summarize_with_limit(session_id: str):
-            async with semaphore:
-                return await execute_summarize_session(
-                    session_id=session_id,
-                    user=system_user,
-                    team=team,
-                    video_validation_enabled="full",
-                )
-
-        results = await asyncio.gather(
-            *[summarize_with_limit(session_id) for session_id in sessions_to_summarize],
-            return_exceptions=True,
-        )
-        for session_id, result in zip(sessions_to_summarize, results):
-            if isinstance(result, Exception):
-                sessions_failed += 1
-                logger.error("Session summarization failed", session_id=session_id, error=str(result))
-            else:
-                sessions_summarized += 1
-
-    return PrimeSessionEmbeddingsResult(
-        session_ids_found=len(session_ids),
-        sessions_summarized=sessions_summarized,
-        sessions_failed=sessions_failed,
+    return GetSessionsToPrimeResult(
+        session_ids_to_summarize=sessions_to_summarize,
+        user_id=system_user.id,
+        user_distinct_id=system_user.distinct_id,
     )
 
 

--- a/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
+++ b/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
@@ -107,7 +107,7 @@ class VideoSegmentClusteringWorkflow(PostHogWorkflow):
                             model_to_use=DEFAULT_VIDEO_UNDERSTANDING_MODEL,
                             video_validation_enabled="full",
                         ),
-                        id=f"session-summary:single:direct:{inputs.team_id}:{session_id}:{prime_info.user_id}:{session_id}:{workflow.uuid4()}",
+                        id=f"session-summary:single:direct:{inputs.team_id}:{session_id}:{prime_info.user_id}:{workflow.uuid4()}",
                         execution_timeout=timedelta(minutes=30),
                         retry_policy=RetryPolicy(
                             maximum_attempts=1,  # No retries - if video export times out, just skip

--- a/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
+++ b/posthog/temporal/ai/video_segment_clustering/clustering_workflow.py
@@ -45,7 +45,7 @@ class VideoSegmentClusteringWorkflow(PostHogWorkflow):
     2. Cluster: Clustering segments into groups, i.e. potential reports
     3. Match: Match clusters to existing SignalReports (deduplication)
     4. Label: Generate LLM-based labels for new clusters
-    5. Persist: Create/update SignalReorts and SignalReportArtefacts
+    5. Persist: Create/update SignalReports and SignalReportArtefacts
     """
 
     @staticmethod

--- a/posthog/temporal/ai/video_segment_clustering/models.py
+++ b/posthog/temporal/ai/video_segment_clustering/models.py
@@ -234,6 +234,15 @@ class PrimeSessionEmbeddingsResult:
 
 
 @dataclass
+class GetSessionsToPrimeResult:
+    """Result from the activity that identifies sessions needing summarization."""
+
+    session_ids_to_summarize: list[str]
+    user_id: int | None
+    user_distinct_id: str | None
+
+
+@dataclass
 class PersistReportsActivityInputs:
     team_id: int
     new_clusters: list[Cluster]

--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -59,7 +59,7 @@ class TestAITemporalModuleIntegrity:
             "embed_and_store_segments_activity",
             "store_video_session_summary_activity",
             "capture_timing_activity",
-            "prime_session_embeddings_activity",
+            "get_sessions_to_prime_activity",
             "fetch_segments_activity",
             "cluster_segments_activity",
             "match_clusters_activity",


### PR DESCRIPTION
## Problem

Currently sessions summary priming in the video clustering workflow runs the workflows independently, not as child workflows. This limits observability into the whole flow in Temporal. Especially if it's a child workflow timing out.

## Changes

The summarization workflows run as child workflows of clustering. Much better visibility.

<img width="1381" height="241" alt="Screenshot 2026-02-09 at 20 54 41" src="https://github.com/user-attachments/assets/3c7ec4d0-1a3c-429d-b7ae-9502b648f546" />

## How did you test this code?

Ran locally.
