### PR TITLE
fix(onboarding): use correct Mastra logo for light mode

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/allSDKs.tsx
+++ b/frontend/src/scenes/onboarding/sdks/allSDKs.tsx
@@ -381,7 +381,7 @@ export const ALL_SDKS: SDK[] = [
         name: 'Mastra',
         key: SDKKey.MASTRA,
         tags: [SDKTag.FRAMEWORK],
-        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/mastra_afca560af6.svg',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/mastra_7ea7df92ab.svg',
         docsLink: 'https://posthog.com/docs/llm-analytics/installation/mastra',
     },
     {


### PR DESCRIPTION
## Problem

The Mastra logo in the onboarding SDK list uses an SVG with a fill that doesn't render correctly in light mode.

## Changes

Updated the Mastra logo image URL to a version with the correct fill for light mode compatibility.

## How did you test this code?

Visual inspection of the onboarding SDK list in light mode.

## Publish to changelog?

no