### PR TITLE
fix: password modal z-index

### DIFF
--- a/frontend/src/lib/components/Sharing/SharePasswordsTable.tsx
+++ b/frontend/src/lib/components/Sharing/SharePasswordsTable.tsx
@@ -136,7 +136,7 @@ export function SharePasswordsTable({ dashboardId, insightId, recordingId }: Sha
                 onClose={handleCloseModal}
                 title="Create new share password"
                 width={480}
-                zIndex={1163}
+                className="z-[1163]"
                 footer={
                     createdPasswordResult ? (
                         <LemonButton type="primary" onClick={handleCloseModal}>

--- a/frontend/src/lib/components/Sharing/SharePasswordsTable.tsx
+++ b/frontend/src/lib/components/Sharing/SharePasswordsTable.tsx
@@ -136,6 +136,7 @@ export function SharePasswordsTable({ dashboardId, insightId, recordingId }: Sha
                 onClose={handleCloseModal}
                 title="Create new share password"
                 width={480}
+                zIndex={1163}
                 footer={
                     createdPasswordResult ? (
                         <LemonButton type="primary" onClick={handleCloseModal}>


### PR DESCRIPTION
## Problem

When sharing a replay publicly and attempting to add a password, the "Create new share password" modal appears behind the main share modal, making it unusable. This occurs because the password modal's z-index is lower than the share modal's.

## Changes

Increased the `zIndex` of the `LemonModal` component used for creating new share passwords in `SharePasswordsTable.tsx` to `1163`. This ensures it renders above the share modal, which has a z-index of `1162`.

## How did you test this code?

I have not tested locally.

no

---
[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1770669977301379?thread_ts=1770669977.301379&cid=D0ACMC57HDE)

<p><a href="https://cursor.com/background-agent?bcId=bc-709d61a7-6cee-502d-9638-5ebc1d0477da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-709d61a7-6cee-502d-9638-5ebc1d0477da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

