### PR TITLE
Survey response processing

### DIFF
--- a/products/surveys/backend/summarization/test_fetch.py
+++ b/products/surveys/backend/summarization/test_fetch.py
@@ -1,0 +1,30 @@
+import pytest
+
+from .fetch import _is_low_quality_survey_response_for_summarization
+
+
+@pytest.mark.parametrize(
+    "response,expected",
+    [
+        ("ddsads", True),
+        ("", True),
+        ("   ", True),
+        ("aaaaaa", True),
+        ("!!!!!!", True),
+        ("asdfasdf", False),  # not super repetitive; keep (might be actual text in some languages)
+        ("UI", False),
+        ("ux", False),
+        ("pricing", False),
+        ("support", False),
+        ("bug", False),
+        ("slow", False),
+        ("Speed", False),
+        ("Needs better docs", False),
+        ("too slow", False),
+        ("Crash on startup", False),
+        ("ok", True),  # single-token, short, not allowlisted
+        ("meh", True),  # same as above
+    ],
+)
+def test_low_quality_response_filtering(response: str, expected: bool) -> None:
+    assert _is_low_quality_survey_response_for_summarization(response) is expected


### PR DESCRIPTION
## Problem

Low-quality or "junk" survey responses (e.g., "ddsads", "aaaaaa") were being sent to the LLM for summarization, polluting the output and wasting LLM resources. This makes it harder to triage meaningful feedback.

## Changes

- Added a new helper function `_is_low_quality_survey_response_for_summarization` to `products/surveys/backend/summarization/fetch.py`. This function uses heuristics to identify and flag responses that are likely noise (e.g., empty, highly repetitive, or very short non-allowlisted single words).
- Integrated this filter into the `fetch_responses` function to exclude low-quality responses *before* they are passed to the summarization model. This change only affects summarization inputs, not raw data storage.
- Added a new test file `products/surveys/backend/summarization/test_fetch.py` with comprehensive unit tests for the new filtering logic.

## How did you test this code?

- Added a dedicated `pytest.mark.parametrize` test suite for `_is_low_quality_survey_response_for_summarization` covering various valid and low-quality inputs.
- Ran existing summarization test suites to ensure no regressions.

## Publish to changelog?

no

---
<p><a href="https://cursor.com/background-agent?bcId=bc-968239c8-fb1e-4cd1-b8cb-fccf0d84d676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-968239c8-fb1e-4cd1-b8cb-fccf0d84d676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

