### PR TITLE
Survey response processing

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -1570,6 +1570,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
             team=self.team,
             exclude_values=question_choices,
             exclude_uuids=archived_uuids,
+            filter_for_ai_summary=True,
         )
         response_count = len(responses)
 

--- a/products/surveys/backend/summarization/test_fetch.py
+++ b/products/surveys/backend/summarization/test_fetch.py
@@ -1,0 +1,33 @@
+import pytest
+
+from products.surveys.backend.summarization.fetch import (
+    MIN_SINGLE_TOKEN_LENGTH_FOR_AI_SUMMARY,
+    MIN_TOTAL_LENGTH_FOR_AI_SUMMARY,
+    is_substantive_response_for_ai_summary,
+)
+
+
+@pytest.mark.parametrize(
+    "response,expected",
+    [
+        ("", False),
+        ("   ", False),
+        ("!", False),
+        ("!!!", False),
+        ("…", False),
+        ("ok", False),  # below MIN_TOTAL_LENGTH_FOR_AI_SUMMARY
+        ("x" * (MIN_TOTAL_LENGTH_FOR_AI_SUMMARY - 1), False),
+        ("ddsads", False),  # short single-token junk
+        ("great!", False),  # short single-token - intentionally treated as low-signal for summaries
+        ("bug", False),  # short single-token - intentionally treated as low-signal for summaries
+        ("too slow", True),  # short but multi-token
+        ("crash on launch", True),
+        ("make it faster pls", True),
+        ("needs dark mode", True),
+        ("123", False),  # short single-token - intentionally treated as low-signal for summaries
+        ("a" * MIN_SINGLE_TOKEN_LENGTH_FOR_AI_SUMMARY, True),  # boundary: allowed at threshold
+        ("a" * (MIN_SINGLE_TOKEN_LENGTH_FOR_AI_SUMMARY - 1) + " a", True),  # internal whitespace makes it multi-token
+    ],
+)
+def test_is_substantive_response_for_ai_summary(response: str, expected: bool):
+    assert is_substantive_response_for_ai_summary(response) is expected


### PR DESCRIPTION
## Problem

Low-signal or accidental survey responses (e.g., "ddsads") can degrade the quality of AI-generated summaries. While client-side validation isn't feasible in this repo, we can improve the AI summary pipeline by filtering out such noise before it reaches the LLM.

## Changes

- Introduced a heuristic filter (`is_substantive_response_for_ai_summary`) to `products/surveys/backend/summarization/fetch.py` that removes empty, punctuation-only, and very short single-token responses.
- Integrated this filter into the `fetch_responses` function, applying it when `filter_for_ai_summary` is set to `True`.
- Enabled the `filter_for_ai_summary` flag when fetching responses for AI summarization in `posthog/api/survey.py`.
- Added comprehensive unit tests for the new filtering heuristic.

## How did you test this code?

- Added dedicated unit tests for the `is_substantive_response_for_ai_summary` function, covering various edge cases and expected inputs.
- Ran `pytest` and `mypy` to ensure code correctness and type safety.

## Publish to changelog?

Yes

---
<p><a href="https://cursor.com/background-agent?bcId=bc-660b80c5-0573-4e35-85ae-8785cc8748a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-660b80c5-0573-4e35-85ae-8785cc8748a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

