### PR TITLE
Survey response processing

### DIFF
--- a/ee/surveys/summaries/test/test_summarize_surveys.py
+++ b/ee/surveys/summaries/test/test_summarize_surveys.py
@@ -1,0 +1,28 @@
+from parameterized import parameterized
+
+from ee.surveys.summaries.summarize_surveys import filter_low_signal_survey_responses, is_low_signal_survey_response
+
+
+class TestSurveySummaryLowSignalFilter:
+    @parameterized.expand(
+        [
+            ("empty", "", True),
+            ("whitespace", "   \n\t", True),
+            ("too_short", "ok", True),
+            ("numbers", "12345", True),
+            ("punctuation", "!!!", True),
+            ("repeated_char", "aaaaaa", True),
+            ("common_placeholder", "test", True),
+            ("keyboard_mash_like", "ddsads", True),
+            ("meaningful_single_word", "pricing", False),
+            ("meaningful_two_words", "more integrations", False),
+            ("meaningful_sentence", "Please add role-based access controls.", False),
+        ]
+    )
+    def test_is_low_signal_survey_response(self, _name: str, response: str, expected: bool) -> None:
+        assert is_low_signal_survey_response(response) is expected
+
+    def test_filter_low_signal_survey_responses_returns_kept_and_dropped(self) -> None:
+        kept, dropped = filter_low_signal_survey_responses(["ddsads", "more integrations", "test"])
+        assert kept == ["more integrations"]
+        assert dropped == ["ddsads", "test"]


### PR DESCRIPTION
## Problem

Low-signal or placeholder survey responses (e.g., "ddsads", "test", "n/a") can pollute survey summaries, reducing their usefulness and making it harder to identify actionable feedback.

## Changes

- Introduced `is_low_signal_survey_response` with heuristics to identify and filter out obvious test/placeholder/gibberish responses from survey data before summarization.
- Modified `summarize_survey_responses` to use `filter_low_signal_survey_responses`, ensuring only meaningful input is sent to the LLM.
- If all responses are filtered out, the summary now explicitly states: "No actionable feedback yet (responses look like test/placeholder input)."
- Added logging for dropped low-signal responses.

## How did you test this code?

- Added parameterized unit tests for `is_low_signal_survey_response` covering various low-signal and meaningful inputs.
- Added a unit test for `filter_low_signal_survey_responses` to verify correct separation of kept and dropped responses.
- Ran `pytest ee/surveys/summaries/test/test_summarize_surveys.py`

## Publish to changelog?

no

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c7bd0ef4-d11d-419a-b3cf-11728c937fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7bd0ef4-d11d-419a-b3cf-11728c937fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

