### PR TITLE
fix(toolbar): add larger container ref so tooltips work

### DIFF
--- a/frontend/src/toolbar/ToolbarContainer.tsx
+++ b/frontend/src/toolbar/ToolbarContainer.tsx
@@ -28,10 +28,11 @@ export function ToolbarContainer(): JSX.Element {
             <FloatingContainerContext.Provider value={ref}>
                 <Elements />
                 <ToolbarFixedZones />
-                <div id="button-toolbar" ref={ref} {...themeProps}>
+                <div id="button-toolbar" {...themeProps}>
                     <Toolbar />
                 </div>
                 <HedgehogButton />
+                <div ref={ref} className="fixed inset-0 pointer-events-none z-[2147483647] [&>*]:pointer-events-auto" />
             </FloatingContainerContext.Provider>
         </Fade>
     )


### PR DESCRIPTION
## Problem

all the tooltips and popup menus in the toolbar are constrained to a very tiny width because the container ref is on the subjectively-"wrong" element

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

the robot added a new div ref for the toolbar so the tooltips/menus/etc can display properly

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
