### PR TITLE
chore(product tours): simplify back-to-posthog flow from toolbar

### DIFF
--- a/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
+++ b/frontend/src/toolbar/product-tours/ProductToursSidebar.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
-import { IconCheck, IconCursorClick, IconExternal, IconPlay, IconPlus, IconSidebarClose, IconX } from '@posthog/icons'
+import { IconCheck, IconCursorClick, IconPlay, IconPlus, IconSidebarClose, IconX } from '@posthog/icons'
 import { LemonButton, LemonInput, Link } from '@posthog/lemon-ui'
 
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
@@ -21,7 +21,7 @@ import { PRODUCT_TOURS_SIDEBAR_TRANSITION_MS } from './utils'
 const SIDEBAR_WIDTH = 320
 
 export function ProductToursSidebar(): JSX.Element | null {
-    const { userIntent, posthog } = useValues(toolbarConfigLogic)
+    const { posthog } = useValues(toolbarConfigLogic)
     const {
         selectedTourId,
         tourForm,
@@ -31,14 +31,12 @@ export function ProductToursSidebar(): JSX.Element | null {
         expandedStepIndex,
         isTourFormSubmitting,
         isPreviewing,
-        pendingEditInPostHog,
         sessionRecordingConsent,
         sidebarPosition,
     } = useValues(productToursLogic)
     const {
         selectTour,
         saveTour,
-        saveAndEditInPostHog,
         previewTour,
         setTourFormValue,
         addStep,
@@ -210,7 +208,7 @@ export function ProductToursSidebar(): JSX.Element | null {
                             type="primary"
                             icon={<IconCheck />}
                             onClick={saveTour}
-                            loading={isTourFormSubmitting && !pendingEditInPostHog}
+                            loading={isTourFormSubmitting}
                             disabledReason={getSaveDisabledReason()}
                             center
                             className="flex-1"
@@ -234,7 +232,10 @@ export function ProductToursSidebar(): JSX.Element | null {
                                 <IconCursorClick className="w-5 h-5" />
                             </div>
                             <p className="m-0 text-sm mb-1">No steps yet</p>
-                            <p className="m-0 text-xs text-muted-3000">Add your first step to get started</p>
+                            <p className="m-0 text-xs text-muted-3000">
+                                Add your first step to get started. When you're finished, you can edit step content back
+                                in PostHog.
+                            </p>
                         </div>
                     ) : (
                         <div className="flex flex-col gap-2">
@@ -269,21 +270,6 @@ export function ProductToursSidebar(): JSX.Element | null {
                             Add step
                         </LemonButton>
                     </div>
-                </div>
-
-                <div className="p-4 border-t border-border-bold-3000 bg-bg-light">
-                    <LemonButton
-                        type="tertiary"
-                        size="small"
-                        fullWidth
-                        icon={<IconExternal />}
-                        loading={pendingEditInPostHog}
-                        onClick={saveAndEditInPostHog}
-                    >
-                        {userIntent === 'edit-product-tour' && window.opener
-                            ? 'Save & close'
-                            : 'Save & edit in PostHog'}
-                    </LemonButton>
                 </div>
             </div>
 

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -169,7 +169,6 @@ export const productToursLogic = kea<productToursLogicType>([
         selectTour: (id: string | null) => ({ id }),
         newTour: true,
         saveTour: true,
-        saveAndEditInPostHog: true,
         deleteTour: (id: string) => ({ id }),
 
         // Preview
@@ -283,14 +282,6 @@ export const productToursLogic = kea<productToursLogicType>([
                 selectTour: () => true,
             },
         ],
-        pendingEditInPostHog: [
-            false,
-            {
-                saveAndEditInPostHog: () => true,
-                selectTour: () => false,
-                submitTourFormFailure: () => false,
-            },
-        ],
         launchedFromMainApp: [
             false,
             {
@@ -375,20 +366,18 @@ export const productToursLogic = kea<productToursLogicType>([
                 }
 
                 const savedTour = await response.json()
-                const { uiHost, pendingEditInPostHog, launchedFromMainApp } = values
+                const { uiHost, launchedFromMainApp } = values
 
-                if (pendingEditInPostHog) {
-                    const editUrl = joinWithUiHost(uiHost, urls.productTour(savedTour.id, 'edit=true&tab=steps'))
-                    if (launchedFromMainApp) {
-                        window.location.href = editUrl
-                    } else {
-                        window.open(editUrl, '_blank')
-                    }
+                const editUrl = joinWithUiHost(uiHost, urls.productTour(savedTour.id, 'edit=true'))
+
+                // always go back to posthog on save if that's where the user started
+                if (launchedFromMainApp) {
+                    window.location.href = editUrl
                 } else {
                     lemonToast.success(isUpdate ? 'Tour updated' : 'Tour created', {
                         button: {
                             label: 'Open in PostHog',
-                            action: () => window.open(joinWithUiHost(uiHost, urls.productTour(savedTour.id)), '_blank'),
+                            action: () => window.open(editUrl, '_blank'),
                         },
                     })
                 }
@@ -605,9 +594,6 @@ export const productToursLogic = kea<productToursLogicType>([
         saveTour: () => {
             actions.submitTourForm()
         },
-        saveAndEditInPostHog: () => {
-            actions.submitTourForm()
-        },
         previewTour: () => {
             const { tourForm, posthog, selectedTourId, tours } = values
             if (posthog?.version && !hasMinProductToursVersion(posthog.version)) {
@@ -726,6 +712,7 @@ export const productToursLogic = kea<productToursLogicType>([
                 actions.selectTour(productTourId)
                 toolbarConfigLogic.actions.clearUserIntent()
             } else if (userIntent === 'add-product-tour') {
+                actions.setLaunchedFromMainApp(true)
                 actions.newTour()
                 toolbarConfigLogic.actions.clearUserIntent()
             } else if (userIntent === 'preview-product-tour' && productTourId) {


### PR DESCRIPTION
## Problem

we have "save" and also "save and edit in posthog" buttons in the toolbar

it's confusing, the logic is wonky, and we basically just always want to ship the user back to posthog if that's where they came from

_UNTIL_ we get the draft system in place, so we can get rid of all this clunky saving during the back-and-forth

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

simplifies that whole flow :)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->