### PR TITLE
fix(surveys): validate targeting_flag_id belongs to current team

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -412,6 +412,13 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
             except FeatureFlag.DoesNotExist:
                 raise serializers.ValidationError("Feature Flag with this ID does not exist")
 
+        targeting_flag_id = data.get("targeting_flag_id")
+        if targeting_flag_id:
+            try:
+                FeatureFlag.objects.get(pk=targeting_flag_id, team_id=self.context["team_id"])
+            except FeatureFlag.DoesNotExist:
+                raise serializers.ValidationError("Targeting Feature Flag with this ID does not exist")
+
         # Validate linkedFlagVariant if provided
         conditions = data.get("conditions") or {}
         linked_flag_variant = conditions.get("linkedFlagVariant")

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -1061,6 +1061,49 @@ class TestSurvey(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "Feature Flag with this ID does not exist" in str(response.json())
 
+    def test_creating_survey_with_targeting_flag_from_different_team_returns_400(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        other_flag = FeatureFlag.objects.create(team=other_team, key="other-team-flag", created_by=self.user)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "Test Survey",
+                "type": "popover",
+                "questions": [{"type": "open", "question": "Test?"}],
+                "targeting_flag_id": other_flag.id,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Targeting Feature Flag with this ID does not exist" in str(response.json())
+        assert FeatureFlag.objects.filter(id=other_flag.id).exists()
+
+    def test_updating_survey_with_targeting_flag_from_different_team_returns_400(self):
+        survey = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "Test Survey",
+                "type": "popover",
+                "questions": [{"type": "open", "question": "Test?"}],
+            },
+            format="json",
+        ).json()
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        other_flag = FeatureFlag.objects.create(team=other_team, key="other-team-flag", created_by=self.user)
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey['id']}/",
+            data={"targeting_flag_id": other_flag.id},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Targeting Feature Flag with this ID does not exist" in str(response.json())
+        assert FeatureFlag.objects.filter(id=other_flag.id).exists()
+
     def test_creating_survey_with_nonexistent_linked_flag_returns_400(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/surveys/",


### PR DESCRIPTION
## Problem

The survey serializer accepted `targeting_flag_id` without checking team ownership, unlike `linked_flag_id` which was properly validated. This allowed cross-tenant feature flag hijacking — a user could associate their survey with another team's feature flag, then delete the survey to cascade-delete the victim's flag.

## Changes

- Add team ownership validation for `targeting_flag_id` in `SurveySerializerCreateUpdateOnly.validate()`, matching the existing check for `linked_flag_id`

[Context](We received a security report about a cross-tenant feature flag modification via surveys. Full report in :thread:)

## How did you test this code?

- Added tests for cross-team `targeting_flag_id` rejection on both create (POST) and update (PATCH)