### PR TITLE
fix(workflows): ses-v2 not using env creds

### DIFF
--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -40,10 +40,6 @@ export class EmailService {
             endpoint: this.hub.SES_ENDPOINT || undefined,
         })
         this.sesV2Client = new SESv2Client({
-            credentials: {
-                accessKeyId: this.hub.SES_ACCESS_KEY_ID,
-                secretAccessKey: this.hub.SES_SECRET_ACCESS_KEY,
-            },
             region: this.hub.SES_REGION,
             endpoint: this.hub.SES_ENDPOINT || undefined,
         })


### PR DESCRIPTION
## Problem

The new SDK handles credentials a bit different from the old one, not falling back to the env credentials when code-provided ones aren't present:

<img width="1193" height="223" alt="image" src="https://github.com/user-attachments/assets/f970d326-f219-4cbc-9e87-2b32b10cf99b" />


## Changes

Just remove code-provided credentials

## How did you test this code?

Tested locally against dev:

<img width="1179" height="101" alt="image" src="https://github.com/user-attachments/assets/271c6d41-d566-4cce-bfd2-083ec82377d6" />


## Publish to changelog?

No