### PR TITLE
chore(llma): tighten temporal workflow timeouts and overlap policies

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
@@ -130,7 +130,7 @@ class TraceClusteringCoordinatorWorkflow(PostHogWorkflow):
                     id=f"{child_id_prefix}-{team_id}-{temporalio.workflow.now().isoformat()}",
                     execution_timeout=constants.WORKFLOW_EXECUTION_TIMEOUT,
                     retry_policy=constants.COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY,
-                    parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
+                    parent_close_policy=temporalio.workflow.ParentClosePolicy.TERMINATE,
                 )
                 workflow_handles.append((team_id, handle))
 

--- a/posthog/temporal/llm_analytics/trace_clustering/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/schedule.py
@@ -50,7 +50,7 @@ async def create_trace_clustering_coordinator_schedule(client: Client):
             execution_timeout=COORDINATOR_EXECUTION_TIMEOUT,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(days=1))]),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.BUFFER_ONE),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
 
     if await a_schedule_exists(client, COORDINATOR_SCHEDULE_ID):
@@ -97,7 +97,7 @@ async def create_generation_clustering_coordinator_schedule(client: Client):
             execution_timeout=COORDINATOR_EXECUTION_TIMEOUT,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(days=1))]),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.BUFFER_ONE),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
 
     if await a_schedule_exists(client, GENERATION_COORDINATOR_SCHEDULE_ID):

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -87,12 +87,8 @@ SUMMARIZE_SCHEDULE_TO_CLOSE_TIMEOUT = timedelta(
 )  # 45 min total per summary (3 full attempts * 900s + backoff)
 
 # Workflow-level timeouts (in minutes)
-WORKFLOW_EXECUTION_TIMEOUT_MINUTES = (
-    180  # Max time for single team workflow (5 batches * 45 min worst case, usually ~75 min)
-)
-COORDINATOR_EXECUTION_TIMEOUT_MINUTES = (
-    240  # 4 hours - 211 teams with 3 concurrent, most finish instantly but a few hit child timeout
-)
+WORKFLOW_EXECUTION_TIMEOUT_MINUTES = 30  # Max time for single team workflow — must be well under coordinator timeout
+COORDINATOR_EXECUTION_TIMEOUT_MINUTES = 55  # Must finish before next hourly trigger to avoid silent skips
 
 # Retry policies
 SAMPLE_RETRY_POLICY = RetryPolicy(

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -152,10 +152,7 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
                     id=f"{child_id_prefix}-{team_id}-{temporalio.workflow.now().isoformat()}",
                     execution_timeout=timedelta(minutes=WORKFLOW_EXECUTION_TIMEOUT_MINUTES),
                     retry_policy=constants.COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY,
-                    # Allow child workflows to complete even if the coordinator
-                    # is cancelled (e.g. due to coordinator timeout). Prevents
-                    # wasting work already in progress.
-                    parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
+                    parent_close_policy=temporalio.workflow.ParentClosePolicy.TERMINATE,
                 )
                 workflow_handles.append((team_id, handle))
 

--- a/posthog/temporal/llm_analytics/trace_summarization/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/schedule.py
@@ -51,7 +51,7 @@ async def create_batch_trace_summarization_schedule(client: Client):
             execution_timeout=timedelta(minutes=COORDINATOR_EXECUTION_TIMEOUT_MINUTES),
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(hours=SCHEDULE_INTERVAL_HOURS))]),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.BUFFER_ONE),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
 
     if await a_schedule_exists(client, COORDINATOR_SCHEDULE_ID):
@@ -94,7 +94,7 @@ async def create_batch_generation_summarization_schedule(client: Client):
                 )
             ]
         ),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.BUFFER_ONE),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
 
     if await a_schedule_exists(client, GENERATION_COORDINATOR_SCHEDULE_ID):


### PR DESCRIPTION
## Problem

LLMA temporal coordinators (summarization + clustering) can run for hours, creating zombie child workflows and silently skipping scheduled hourly runs. Observed today: the midnight summarization coordinator ran for ~7 hours due to abandoned child workflows with 3-hour timeouts, blocking all runs from 01:00-06:00 UTC.

Root causes:
- `ParentClosePolicy.ABANDON` lets child workflows survive after coordinator timeout
- `BUFFER_ONE` overlap queues a run that can cascade into the next interval
- Coordinator timeout (4 hours) far exceeds the 1-hour schedule interval
- Child workflow timeout (3 hours) far exceeds what any single team should need

## Changes

Config-only changes across summarization and clustering workflows:

- `ParentClosePolicy.ABANDON` -> `TERMINATE` in both coordinators -- children are killed when the coordinator times out instead of running as zombies
- `ScheduleOverlapPolicy.BUFFER_ONE` -> `SKIP` on all 4 schedules (trace/generation x summarization/clustering) -- if a coordinator is still running, the next trigger is skipped rather than queued
- Summarization coordinator timeout: 240 min -> 55 min (must finish before next hourly trigger)
- Summarization child workflow timeout: 180 min -> 30 min (bound slow teams)

Clustering timeouts left unchanged (12hr coordinator for daily schedule, 30min child are already reasonable).

## How did you test this code?

Config-only changes to constants and policy enums. No logic changes.

After merge + deploy, schedules need re-registration from the LLMA worker pod in both clusters:
```
kubectl -n posthog exec deploy/temporal-worker-llm-analytics -- python manage.py schedule_temporal_workflows
```

## Publish to changelog?

No