### PR TITLE
chore(prop-defs-cleanup): adds batching to prop defs cleanup job

### DIFF
--- a/posthog/temporal/cleanup_property_definitions/activities.py
+++ b/posthog/temporal/cleanup_property_definitions/activities.py
@@ -14,7 +14,6 @@ from posthog.temporal.cleanup_property_definitions.types import (
     PreviewPropertyDefinitionsInput,
 )
 from posthog.temporal.common.clickhouse import get_client
-from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
 
 LOGGER = get_write_only_logger()
@@ -51,8 +50,7 @@ async def delete_property_definitions_from_postgres(
         deleted_count, _ = PropertyDefinition.objects.filter(pk__in=batch_ids).delete()
         return deleted_count
 
-    async with Heartbeater():
-        deleted_count = await delete_batch()
+    deleted_count = await delete_batch()
 
     logger.info(f"Deleted {deleted_count} property definitions from PostgreSQL")
     return deleted_count

--- a/posthog/temporal/cleanup_property_definitions/activities.py
+++ b/posthog/temporal/cleanup_property_definitions/activities.py
@@ -1,11 +1,13 @@
 from uuid import uuid4
 
 from django.conf import settings
+from django.db import transaction
 
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
 from posthog.models import PropertyDefinition, Team
+from posthog.models.event_property import EventProperty
 from posthog.sync import database_sync_to_async
 from posthog.temporal.cleanup_property_definitions.types import (
     CleanupPropertyDefinitionsError,
@@ -22,38 +24,59 @@ LOGGER = get_write_only_logger()
 @activity.defn(name="delete-property-definitions-from-postgres")
 async def delete_property_definitions_from_postgres(
     input: DeletePostgresPropertyDefinitionsInput,
-) -> int:
+) -> dict:
     """Delete up to batch_size property definitions matching the pattern from PostgreSQL.
 
-    Returns the number of rows deleted. The workflow calls this in a loop
-    until fewer than batch_size rows are deleted (meaning all rows are gone).
+    Selects a batch of matching property names, then deletes from both
+    PropertyDefinition and EventProperty (for event type) using those names
+    in a single transaction. The workflow calls this in a loop until
+    property_definitions_deleted < batch_size.
     """
     bind_contextvars(team_id=input.team_id, pattern=input.pattern, property_type=input.property_type)
     logger = LOGGER.bind()
     logger.info("Deleting property definitions from PostgreSQL", batch_size=input.batch_size)
 
     @database_sync_to_async
-    def delete_batch() -> int:
+    def delete_batch() -> dict:
         if not Team.objects.filter(id=input.team_id).exists():
             raise CleanupPropertyDefinitionsError(f"Team {input.team_id} not found")
 
-        batch_ids = list(
+        # Select a batch of matching property names to coordinate deletes across tables
+        batch_names = list(
             PropertyDefinition.objects.filter(
                 team_id=input.team_id,
                 type=input.property_type,
                 name__regex=input.pattern,
-            ).values_list("id", flat=True)[: input.batch_size]
+            ).values_list("name", flat=True)[: input.batch_size]
         )
-        if not batch_ids:
-            return 0
+        if not batch_names:
+            return {"property_definitions_deleted": 0, "event_properties_deleted": 0}
 
-        deleted_count, _ = PropertyDefinition.objects.filter(pk__in=batch_ids).delete()
-        return deleted_count
+        with transaction.atomic():
+            property_definitions_deleted, _ = PropertyDefinition.objects.filter(
+                team_id=input.team_id,
+                type=input.property_type,
+                name__in=batch_names,
+            ).delete()
 
-    deleted_count = await delete_batch()
+            event_properties_deleted = 0
+            if input.property_type == PropertyDefinition.Type.EVENT:
+                event_properties_deleted, _ = EventProperty.objects.filter(
+                    team_id=input.team_id,
+                    property__in=batch_names,
+                ).delete()
 
-    logger.info(f"Deleted {deleted_count} property definitions from PostgreSQL")
-    return deleted_count
+        return {
+            "property_definitions_deleted": property_definitions_deleted,
+            "event_properties_deleted": event_properties_deleted,
+        }
+
+    result = await delete_batch()
+    logger.info(
+        f"Deleted {result['property_definitions_deleted']} property definitions "
+        f"and {result['event_properties_deleted']} event properties from PostgreSQL"
+    )
+    return result
 
 
 @activity.defn(name="delete-property-definitions-from-clickhouse")

--- a/posthog/temporal/cleanup_property_definitions/activities.py
+++ b/posthog/temporal/cleanup_property_definitions/activities.py
@@ -28,7 +28,7 @@ async def delete_property_definitions_from_postgres(
     """Delete up to batch_size property definitions matching the pattern from PostgreSQL.
 
     Selects a batch of matching property names, then deletes from both
-    PropertyDefinition and EventProperty (for event type) using those names
+    PropertyDefinition and EventProperty using those names
     in a single transaction. The workflow calls this in a loop until
     property_definitions_deleted < batch_size.
     """
@@ -59,12 +59,10 @@ async def delete_property_definitions_from_postgres(
                 name__in=batch_names,
             ).delete()
 
-            event_properties_deleted = 0
-            if input.property_type == PropertyDefinition.Type.EVENT:
-                event_properties_deleted, _ = EventProperty.objects.filter(
-                    team_id=input.team_id,
-                    property__in=batch_names,
-                ).delete()
+            event_properties_deleted, _ = EventProperty.objects.filter(
+                team_id=input.team_id,
+                property__in=batch_names,
+            ).delete()
 
         return {
             "property_definitions_deleted": property_definitions_deleted,

--- a/posthog/temporal/cleanup_property_definitions/types.py
+++ b/posthog/temporal/cleanup_property_definitions/types.py
@@ -69,6 +69,7 @@ class DeletePostgresPropertyDefinitionsInput:
     team_id: int
     pattern: str
     property_type: int
+    batch_size: int = 5000
 
 
 @dataclass

--- a/posthog/temporal/cleanup_property_definitions/types.py
+++ b/posthog/temporal/cleanup_property_definitions/types.py
@@ -2,7 +2,7 @@ import re
 from dataclasses import dataclass
 from typing import Literal
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from posthog.models.property_definition import PropertyDefinition
 
@@ -37,6 +37,7 @@ class CleanupPropertyDefinitionsInput(BaseModel):
     pattern: str
     property_type: PropertyTypeName
     dry_run: bool = False
+    batch_size: int = Field(default=5000, gt=0, le=5000)
 
     @field_validator("pattern")
     @classmethod

--- a/posthog/temporal/cleanup_property_definitions/workflows.py
+++ b/posthog/temporal/cleanup_property_definitions/workflows.py
@@ -37,7 +37,7 @@ class CleanupPropertyDefinitionsWorkflow(PostHogWorkflow):
         """Run the cleanup workflow.
 
         Returns a dict with:
-        - postgres_deleted: Number of definitions deleted from PostgreSQL
+        - property_definitions_deleted: Number of definitions deleted from PostgreSQL
         - dry_run: Whether this was a dry run
         """
         property_type_int = input.get_property_type_int()
@@ -47,7 +47,7 @@ class CleanupPropertyDefinitionsWorkflow(PostHogWorkflow):
             "pattern": input.pattern,
             "property_type": input.property_type,
             "dry_run": input.dry_run,
-            "postgres_deleted": 0,
+            "property_definitions_deleted": 0,
             "event_properties_deleted": 0,
         }
 
@@ -101,7 +101,7 @@ class CleanupPropertyDefinitionsWorkflow(PostHogWorkflow):
                     f"({total_property_definitions_deleted:,} property definitions deleted). "
                     f"Re-run the workflow to continue deleting remaining rows."
                 )
-        result["postgres_deleted"] = total_property_definitions_deleted
+        result["property_definitions_deleted"] = total_property_definitions_deleted
         result["event_properties_deleted"] = total_event_properties_deleted
 
         # Delete from ClickHouse

--- a/posthog/temporal/cleanup_property_definitions/workflows.py
+++ b/posthog/temporal/cleanup_property_definitions/workflows.py
@@ -79,7 +79,6 @@ class CleanupPropertyDefinitionsWorkflow(PostHogWorkflow):
                     batch_size=batch_size,
                 ),
                 start_to_close_timeout=timedelta(minutes=5),
-                heartbeat_timeout=timedelta(seconds=30),
                 retry_policy=common.RetryPolicy(
                     maximum_attempts=3,
                     initial_interval=timedelta(seconds=30),

--- a/posthog/temporal/cleanup_property_definitions/workflows.py
+++ b/posthog/temporal/cleanup_property_definitions/workflows.py
@@ -95,8 +95,8 @@ class CleanupPropertyDefinitionsWorkflow(PostHogWorkflow):
                 break
             if _batch_num == max_batches:
                 raise CleanupPropertyDefinitionsError(
-                    f"Postgres delete hit the per-run limit of {max_batches * batch_size:,} rows "
-                    f"({total_postgres_deleted:,} deleted). "
+                    f"Postgres delete exceeded {max_batches} batches "
+                    f"({total_postgres_deleted:,} rows deleted). "
                     f"Re-run the workflow to continue deleting remaining rows."
                 )
         result["postgres_deleted"] = total_postgres_deleted

--- a/posthog/temporal/tests/cleanup_property_definitions/test_activities.py
+++ b/posthog/temporal/tests/cleanup_property_definitions/test_activities.py
@@ -294,7 +294,7 @@ class TestDeleteEventPropertiesFromPostgres:
         assert await verify_deleted() == 0
 
     @pytest.mark.asyncio
-    async def test_does_not_delete_event_properties_for_person_type(self):
+    async def test_deletes_event_properties_for_person_type(self):
         prop_name = f"{self.prefix}_person_prop"
 
         @sync_to_async
@@ -314,13 +314,13 @@ class TestDeleteEventPropertiesFromPostgres:
         )
 
         assert result["property_definitions_deleted"] == 1
-        assert result["event_properties_deleted"] == 0
+        assert result["event_properties_deleted"] == 1
 
         @sync_to_async
-        def verify_event_property_remains():
+        def verify_event_property_deleted():
             return EventProperty.objects.filter(team=self.team, property=prop_name).exists()
 
-        assert await verify_event_property_remains()
+        assert not await verify_event_property_deleted()
 
     @pytest.mark.asyncio
     async def test_deletes_in_batches_with_corresponding_event_properties(self):

--- a/posthog/temporal/tests/cleanup_property_definitions/test_activities.py
+++ b/posthog/temporal/tests/cleanup_property_definitions/test_activities.py
@@ -6,6 +6,7 @@ from asgiref.sync import sync_to_async
 from parameterized import parameterized_class
 
 from posthog.models import PropertyDefinition
+from posthog.models.event_property import EventProperty
 from posthog.temporal.cleanup_property_definitions.activities import (
     delete_property_definitions_from_clickhouse,
     delete_property_definitions_from_postgres,
@@ -83,7 +84,7 @@ class TestDeletePropertyDefinitionsFromPostgres:
             ),
         )
 
-        assert result == 3
+        assert result["property_definitions_deleted"] == 3
 
         @sync_to_async
         def verify_deleted():
@@ -126,7 +127,7 @@ class TestDeletePropertyDefinitionsFromPostgres:
         )
 
         # Should only delete the target property type
-        assert result == 1
+        assert result["property_definitions_deleted"] == 1
 
         @sync_to_async
         def verify_other_remains():
@@ -149,7 +150,8 @@ class TestDeletePropertyDefinitionsFromPostgres:
             ),
         )
 
-        assert result == 0
+        assert result["property_definitions_deleted"] == 0
+        assert result["event_properties_deleted"] == 0
 
     @pytest.mark.asyncio
     async def test_raises_error_for_invalid_team(self):
@@ -192,7 +194,7 @@ class TestDeletePropertyDefinitionsFromPostgres:
             ),
         )
 
-        assert result == 1
+        assert result["property_definitions_deleted"] == 1
 
         @sync_to_async
         def verify_other_team_property():
@@ -233,7 +235,7 @@ class TestDeletePropertyDefinitionsFromPostgres:
             ),
         )
 
-        assert result == 2
+        assert result["property_definitions_deleted"] == 2
 
         @sync_to_async
         def count_remaining():
@@ -245,6 +247,119 @@ class TestDeletePropertyDefinitionsFromPostgres:
 
         remaining = await count_remaining()
         assert remaining == 3
+
+
+@pytest.mark.django_db(transaction=True)
+class TestDeleteEventPropertiesFromPostgres:
+    @pytest.fixture(autouse=True)
+    def setup(self, team, test_prefix, activity_environment):
+        self.team = team
+        self.prefix = test_prefix
+        self.activity_environment = activity_environment
+
+        yield
+
+        PropertyDefinition.objects.filter(team=self.team, name__startswith=self.prefix).delete()
+        EventProperty.objects.filter(team=self.team, property__startswith=self.prefix).delete()
+
+    @pytest.mark.asyncio
+    async def test_deletes_event_properties_for_event_type(self):
+        prop_names = [f"{self.prefix}_temp_prop_{i}" for i in range(3)]
+
+        @sync_to_async
+        def create_data():
+            for name in prop_names:
+                create_property_definition(self.team, name, PropertyDefinition.Type.EVENT)
+                EventProperty.objects.create(team=self.team, event="$pageview", property=name)
+                EventProperty.objects.create(team=self.team, event="$autocapture", property=name)
+
+        await create_data()
+
+        result = await self.activity_environment.run(
+            delete_property_definitions_from_postgres,
+            DeletePostgresPropertyDefinitionsInput(
+                team_id=self.team.id,
+                pattern=f"^{self.prefix}_temp_.*",
+                property_type=PropertyDefinition.Type.EVENT,
+            ),
+        )
+
+        assert result["property_definitions_deleted"] == 3
+        assert result["event_properties_deleted"] == 6
+
+        @sync_to_async
+        def verify_deleted():
+            return EventProperty.objects.filter(team=self.team, property__startswith=self.prefix).count()
+
+        assert await verify_deleted() == 0
+
+    @pytest.mark.asyncio
+    async def test_does_not_delete_event_properties_for_person_type(self):
+        prop_name = f"{self.prefix}_person_prop"
+
+        @sync_to_async
+        def create_data():
+            create_property_definition(self.team, prop_name, PropertyDefinition.Type.PERSON)
+            EventProperty.objects.create(team=self.team, event="$pageview", property=prop_name)
+
+        await create_data()
+
+        result = await self.activity_environment.run(
+            delete_property_definitions_from_postgres,
+            DeletePostgresPropertyDefinitionsInput(
+                team_id=self.team.id,
+                pattern=f"^{self.prefix}_person_.*",
+                property_type=PropertyDefinition.Type.PERSON,
+            ),
+        )
+
+        assert result["property_definitions_deleted"] == 1
+        assert result["event_properties_deleted"] == 0
+
+        @sync_to_async
+        def verify_event_property_remains():
+            return EventProperty.objects.filter(team=self.team, property=prop_name).exists()
+
+        assert await verify_event_property_remains()
+
+    @pytest.mark.asyncio
+    async def test_deletes_in_batches_with_corresponding_event_properties(self):
+        prop_names = [f"{self.prefix}_batch_prop_{i}" for i in range(5)]
+
+        @sync_to_async
+        def create_data():
+            for name in prop_names:
+                create_property_definition(self.team, name, PropertyDefinition.Type.EVENT)
+                EventProperty.objects.create(team=self.team, event="$pageview", property=name)
+
+        await create_data()
+
+        result = await self.activity_environment.run(
+            delete_property_definitions_from_postgres,
+            DeletePostgresPropertyDefinitionsInput(
+                team_id=self.team.id,
+                pattern=f"^{self.prefix}_batch_.*",
+                property_type=PropertyDefinition.Type.EVENT,
+                batch_size=2,
+            ),
+        )
+
+        assert result["property_definitions_deleted"] == 2
+        assert result["event_properties_deleted"] == 2
+
+        @sync_to_async
+        def count_remaining():
+            prop_defs = PropertyDefinition.objects.filter(
+                team=self.team, name__startswith=f"{self.prefix}_batch_", type=PropertyDefinition.Type.EVENT
+            ).count()
+            event_props = EventProperty.objects.filter(
+                team=self.team, property__startswith=f"{self.prefix}_batch_"
+            ).count()
+            return prop_defs, event_props
+
+        remaining_defs, remaining_event_props = await count_remaining()
+        assert remaining_defs == 3
+        assert remaining_event_props == 3
 
 
 @parameterized_class(

--- a/posthog/temporal/tests/cleanup_property_definitions/test_workflows.py
+++ b/posthog/temporal/tests/cleanup_property_definitions/test_workflows.py
@@ -69,7 +69,7 @@ async def test_cleanup_property_definitions_workflow():
     assert result["pattern"] == TEST_PATTERN
     assert result["property_type"] == TEST_PROPERTY_TYPE
     assert result["dry_run"] is False
-    assert result["postgres_deleted"] == 5
+    assert result["property_definitions_deleted"] == 5
     assert result["event_properties_deleted"] == 0
     assert postgres_deleted == 5
     assert clickhouse_deleted is True
@@ -126,7 +126,7 @@ async def test_cleanup_property_definitions_workflow_dry_run():
     assert result["pattern"] == TEST_PATTERN
     assert result["property_type"] == TEST_PROPERTY_TYPE
     assert result["dry_run"] is True
-    assert result["postgres_deleted"] == 0
+    assert result["property_definitions_deleted"] == 0
     assert result["preview"]["total_count"] == 2
     assert result["preview"]["names"] == PREVIEW_NAMES
 
@@ -169,7 +169,7 @@ async def test_cleanup_property_definitions_workflow_no_matches():
                 task_queue=task_queue_name,
             )
 
-    assert result["postgres_deleted"] == 0
+    assert result["property_definitions_deleted"] == 0
     assert result["event_properties_deleted"] == 0
 
 
@@ -212,7 +212,7 @@ async def test_cleanup_property_definitions_workflow_event_type_deletes_event_pr
                 task_queue=task_queue_name,
             )
 
-    assert result["postgres_deleted"] == 10
+    assert result["property_definitions_deleted"] == 10
     assert result["event_properties_deleted"] == 25
 
 
@@ -262,7 +262,7 @@ async def test_cleanup_property_definitions_workflow_multiple_batches():
             )
 
     assert postgres_call_count == 3
-    assert result["postgres_deleted"] == BATCH_SIZE + BATCH_SIZE + 3000
+    assert result["property_definitions_deleted"] == BATCH_SIZE + BATCH_SIZE + 3000
     assert result["event_properties_deleted"] == BATCH_SIZE * 2 + BATCH_SIZE * 2 + 6000
 
 

--- a/posthog/temporal/tests/cleanup_property_definitions/test_workflows.py
+++ b/posthog/temporal/tests/cleanup_property_definitions/test_workflows.py
@@ -25,13 +25,13 @@ async def test_cleanup_property_definitions_workflow():
     clickhouse_deleted = False
 
     @activity.defn(name="delete-property-definitions-from-postgres")
-    async def delete_postgres_mocked(input: DeletePostgresPropertyDefinitionsInput) -> int:
+    async def delete_postgres_mocked(input: DeletePostgresPropertyDefinitionsInput) -> dict:
         nonlocal postgres_deleted
         assert input.team_id == TEST_TEAM_ID
         assert input.pattern == TEST_PATTERN
         assert input.property_type == 2  # PERSON
         postgres_deleted = 5
-        return 5
+        return {"property_definitions_deleted": 5, "event_properties_deleted": 0}
 
     @activity.defn(name="delete-property-definitions-from-clickhouse")
     async def delete_clickhouse_mocked(input: DeleteClickHousePropertyDefinitionsInput) -> None:
@@ -70,6 +70,7 @@ async def test_cleanup_property_definitions_workflow():
     assert result["property_type"] == TEST_PROPERTY_TYPE
     assert result["dry_run"] is False
     assert result["postgres_deleted"] == 5
+    assert result["event_properties_deleted"] == 0
     assert postgres_deleted == 5
     assert clickhouse_deleted is True
 
@@ -82,7 +83,7 @@ async def test_cleanup_property_definitions_workflow_dry_run():
     PREVIEW_NAMES = ["temp_prop_1", "temp_prop_2"]
 
     @activity.defn(name="delete-property-definitions-from-postgres")
-    async def delete_postgres_mocked(input: DeletePostgresPropertyDefinitionsInput) -> int:
+    async def delete_postgres_mocked(input: DeletePostgresPropertyDefinitionsInput) -> dict:
         raise AssertionError("Should not be called in dry run mode")
 
     @activity.defn(name="delete-property-definitions-from-clickhouse")
@@ -137,8 +138,8 @@ async def test_cleanup_property_definitions_workflow_no_matches():
     TEST_PROPERTY_TYPE = "event"
 
     @activity.defn(name="delete-property-definitions-from-postgres")
-    async def delete_postgres_mocked(input: DeletePostgresPropertyDefinitionsInput) -> int:
-        return 0
+    async def delete_postgres_mocked(input: DeletePostgresPropertyDefinitionsInput) -> dict:
+        return {"property_definitions_deleted": 0, "event_properties_deleted": 0}
 
     @activity.defn(name="delete-property-definitions-from-clickhouse")
     async def delete_clickhouse_mocked(input: DeleteClickHousePropertyDefinitionsInput) -> None:
@@ -169,25 +170,68 @@ async def test_cleanup_property_definitions_workflow_no_matches():
             )
 
     assert result["postgres_deleted"] == 0
+    assert result["event_properties_deleted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_cleanup_property_definitions_workflow_event_type_deletes_event_properties():
+    TEST_TEAM_ID = 12345
+    TEST_PATTERN = "^temp_.*"
+    TEST_PROPERTY_TYPE = "event"
+
+    @activity.defn(name="delete-property-definitions-from-postgres")
+    async def delete_postgres_mocked(input: DeletePostgresPropertyDefinitionsInput) -> dict:
+        assert input.property_type == 1  # EVENT
+        return {"property_definitions_deleted": 10, "event_properties_deleted": 25}
+
+    @activity.defn(name="delete-property-definitions-from-clickhouse")
+    async def delete_clickhouse_mocked(input: DeleteClickHousePropertyDefinitionsInput) -> None:
+        pass
+
+    task_queue_name = str(uuid.uuid4())
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue_name,
+            workflows=[CleanupPropertyDefinitionsWorkflow],
+            activities=[
+                delete_postgres_mocked,
+                delete_clickhouse_mocked,
+            ],
+            workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                CleanupPropertyDefinitionsWorkflow.run,
+                CleanupPropertyDefinitionsInput(
+                    team_id=TEST_TEAM_ID,
+                    pattern=TEST_PATTERN,
+                    property_type=TEST_PROPERTY_TYPE,
+                    dry_run=False,
+                ),
+                id=str(uuid.uuid4()),
+                task_queue=task_queue_name,
+            )
+
+    assert result["postgres_deleted"] == 10
+    assert result["event_properties_deleted"] == 25
 
 
 @pytest.mark.asyncio
 async def test_cleanup_property_definitions_workflow_multiple_batches():
     TEST_TEAM_ID = 12345
     TEST_PATTERN = "^temp_.*"
-    TEST_PROPERTY_TYPE = "person"
+    TEST_PROPERTY_TYPE = "event"
     BATCH_SIZE = 5000
     postgres_call_count = 0
 
     @activity.defn(name="delete-property-definitions-from-postgres")
-    async def delete_postgres_mocked(input: DeletePostgresPropertyDefinitionsInput) -> int:
+    async def delete_postgres_mocked(input: DeletePostgresPropertyDefinitionsInput) -> dict:
         nonlocal postgres_call_count
         postgres_call_count += 1
         assert input.batch_size == BATCH_SIZE
-        # First two calls return a full batch, third returns a partial batch
         if postgres_call_count <= 2:
-            return BATCH_SIZE
-        return 3000
+            return {"property_definitions_deleted": BATCH_SIZE, "event_properties_deleted": BATCH_SIZE * 2}
+        return {"property_definitions_deleted": 3000, "event_properties_deleted": 6000}
 
     @activity.defn(name="delete-property-definitions-from-clickhouse")
     async def delete_clickhouse_mocked(input: DeleteClickHousePropertyDefinitionsInput) -> None:
@@ -219,6 +263,7 @@ async def test_cleanup_property_definitions_workflow_multiple_batches():
 
     assert postgres_call_count == 3
     assert result["postgres_deleted"] == BATCH_SIZE + BATCH_SIZE + 3000
+    assert result["event_properties_deleted"] == BATCH_SIZE * 2 + BATCH_SIZE * 2 + 6000
 
 
 def test_cleanup_property_definitions_workflow_parse_inputs():


### PR DESCRIPTION
## Problem

The Temporal job responsible for cleaning up unwanted property definitions in PG and Clickhouse had not batching logic for the PG deletes.

Some customers might want to delete a very large number of unwanted property definitions. We should limit the number of deletes we can do in a single database transaction and use Temporal's power to run the deletes in resumable batches.

## Changes

  - Batch Postgres deletes: The Postgres delete activity now processes rows in configurable batches  
  (default 5000, max 5000) instead of a single unbounded DELETE. The workflow loops over batches     
  until all matching rows are deleted, capped at 2M rows per run to prevent runaway execution.

  - Delete EventProperty rows alongside PropertyDefinition: When deleting event-type property        
  definitions, the activity now also deletes corresponding EventProperty rows in the same            
  transaction. Each batch selects matching property names first, then deletes from both tables using
  those names, ensuring consistency.

  - User-configurable batch_size: batch_size is now an input parameter on the workflow, validated by
  pydantic to be between 1 and 5000. This allows tuning batch size per run from the Temporal UI.

  - Safety cap on Postgres deletes: The batch loop is capped at 2M total rows. If the cap is hit, the
   workflow fails with a clear error message telling the operator to re-run to continue. ClickHouse
  deletes only run after Postgres completes successfully.

## How did you test this code?

Unit tests added to test the added batch delete workflows.

Will test in dev against posthog account once it is landed

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
