### PR TITLE
feat(deduplicator): expose detailed task status for rebalance reassign flow poller

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -106,7 +106,7 @@ impl Default for CheckpointConfig {
             s3_attempt_timeout: Duration::from_secs(20),
             s3_max_retries: 3,
             checkpoint_import_attempt_depth: 10,
-            max_concurrent_checkpoint_file_downloads: 50,
+            max_concurrent_checkpoint_file_downloads: 25,
             max_concurrent_checkpoint_file_uploads: 25,
             checkpoint_partition_import_timeout: Duration::from_secs(240),
         }

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -245,7 +245,7 @@ pub struct Config {
     // Limits memory usage by bounding the number of in-flight HTTP connections
     // Critical during rebalance when many partitions are assigned simultaneously
     // Higher values speed up rebalance; streaming bounds memory per download to ~8KB
-    #[envconfig(default = "50")]
+    #[envconfig(default = "25")]
     pub max_concurrent_checkpoint_file_downloads: usize,
 
     // Maximum concurrent S3 file uploads during checkpoint export

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -544,7 +544,9 @@ where
                 let (result, reason): (&str, &str) = match peeked {
                     None => ("cancelled", "revoked_incomplete"),
                     Some(Ok(PartitionImportOutcome::Completed(_))) => ("success", "not_owned"),
-                    Some(Ok(PartitionImportOutcome::Cancelled)) => ("cancelled", "import_cancelled"),
+                    Some(Ok(PartitionImportOutcome::Cancelled)) => {
+                        ("cancelled", "import_cancelled")
+                    }
                     Some(Ok(PartitionImportOutcome::Failed(_))) => ("failed", "import"),
                     Some(Ok(PartitionImportOutcome::TimedOut)) => ("failed", "timeout"),
                     Some(Err(_)) => ("failed", "panic"),

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -10,6 +11,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
+use crate::checkpoint::error::{DownloadCancelledError, ImportTimeoutError};
 use crate::checkpoint::import::CheckpointImporter;
 use crate::kafka::batch_consumer::BatchConsumerProcessor;
 use crate::kafka::batch_context::{ConsumerCommand, ConsumerCommandSender};
@@ -25,10 +27,36 @@ use crate::metrics_const::{
 use crate::rebalance_tracker::RebalanceTracker;
 use crate::store_manager::StoreManager;
 
-/// Type alias for the shared task handle. The closure maps JoinHandle's Result to ()
-/// so it can be Clone (required by Shared).
-type SharedTaskHandle =
-    Shared<futures::future::Map<JoinHandle<()>, fn(Result<(), tokio::task::JoinError>) -> ()>>;
+/// Outcome of a partition checkpoint import task; used when peeking/polling the task handle.
+#[derive(Clone, Debug)]
+pub enum PartitionImportOutcome {
+    /// Import completed successfully; path is the imported store dir.
+    Completed(PathBuf),
+    /// Import was cancelled (revoke, not_owned, or download cancelled); attempt dir already cleaned.
+    Cancelled,
+    /// Import failed (S3, IO, etc.); attempt dir already cleaned by ImportCleanupGuard.
+    Failed(String),
+    /// Import timed out; attempt dir already cleaned by ImportCleanupGuard.
+    TimedOut,
+}
+
+/// Shared requires Output: Clone; JoinError is not Clone, so we map to String.
+fn map_join_result(
+    r: Result<PartitionImportOutcome, tokio::task::JoinError>,
+) -> Result<PartitionImportOutcome, String> {
+    r.map_err(|e| e.to_string())
+}
+
+/// Type alias for the shared task handle. We keep the outcome so we can peek before re-attach
+/// and apply Option A (register/delete) in finalize. Mapped to Result<O, String> so Output is Clone.
+type SharedTaskHandle = Shared<
+    futures::future::Map<
+        JoinHandle<PartitionImportOutcome>,
+        fn(
+            Result<PartitionImportOutcome, tokio::task::JoinError>,
+        ) -> Result<PartitionImportOutcome, String>,
+    >,
+>;
 
 /// Tracks a partition setup task with its cancellation token.
 ///
@@ -67,6 +95,9 @@ where
     /// - Await them before resuming (ensure stores ready)
     /// - Detect stale entries and allow re-claim
     partition_setup_tasks: DashMap<Partition, PartitionSetupTask>,
+    /// Revoked partition setup tasks; we keep handles here so we can re-attach on re-assign
+    /// and peek to see if cancellation took (spawn fresh) or task completed (re-attach).
+    revoked_setup_tasks: DashMap<Partition, PartitionSetupTask>,
     /// Reason per partition when setup task exited without registering a store.
     /// Used to tag PARTITION_STORE_FALLBACK_EMPTY with no_importer | import_failed | import_cancelled.
     partition_fallback_reasons: Arc<DashMap<Partition, &'static str>>,
@@ -92,6 +123,7 @@ where
             checkpoint_importer,
             rebalance_cleanup_parallelism,
             partition_setup_tasks: DashMap::new(),
+            revoked_setup_tasks: DashMap::new(),
             partition_fallback_reasons: Arc::new(DashMap::new()),
         }
     }
@@ -112,6 +144,7 @@ where
             checkpoint_importer,
             rebalance_cleanup_parallelism,
             partition_setup_tasks: DashMap::new(),
+            revoked_setup_tasks: DashMap::new(),
             partition_fallback_reasons: Arc::new(DashMap::new()),
         }
     }
@@ -151,31 +184,39 @@ where
                     .get(partition.topic(), partition.partition_number())
                     .is_some();
 
-                // peek() returns Some if resolved, None if still pending
-                let task_completed = task
-                    .handle
-                    .as_ref()
-                    .map(|h| h.peek().is_some())
-                    .unwrap_or(false); // None = not spawned yet, treat as running
+                // peek() returns Some(&result) if resolved, None if still pending
+                let peeked = task.handle.as_ref().and_then(|h| h.peek());
 
                 if store_exists {
-                    // Task succeeded, keep entry
+                    // Task succeeded (or we already registered in finalize), keep entry
                     false
-                } else if task_completed {
-                    // Task completed but no store → stale entry (task bailed), safe to replace
-                    e.get().cancel_token.cancel();
-                    e.insert(PartitionSetupTask {
-                        handle: None,
-                        cancel_token,
-                    });
-                    debug!(
-                        topic = partition.topic(),
-                        partition = partition.partition_number(),
-                        "Replaced stale setup task entry (task completed, no store)"
-                    );
-                    true
+                } else if let Some(result) = peeked {
+                    // Task completed; check outcome to decide replace vs keep
+                    match result {
+                        Ok(PartitionImportOutcome::Completed(_)) => {
+                            // Will be registered in finalize; don't replace
+                            false
+                        }
+                        Ok(PartitionImportOutcome::Cancelled)
+                        | Ok(PartitionImportOutcome::Failed(_))
+                        | Ok(PartitionImportOutcome::TimedOut)
+                        | Err(_) => {
+                            // Stale entry (task bailed or panicked), safe to replace
+                            e.get().cancel_token.cancel();
+                            e.insert(PartitionSetupTask {
+                                handle: None,
+                                cancel_token,
+                            });
+                            debug!(
+                                topic = partition.topic(),
+                                partition = partition.partition_number(),
+                                "Replaced stale setup task entry (task completed, no store)"
+                            );
+                            true
+                        }
+                    }
                 } else {
-                    // Task still running, let it finish
+                    // Task still running (handle None = not spawned yet, or peek None = pending)
                     debug!(
                         topic = partition.topic(),
                         partition = partition.partition_number(),
@@ -191,15 +232,22 @@ where
     ///
     /// Must be called after `try_claim_partition_setup()` returns true.
     /// Converts the JoinHandle to a Shared future so multiple callers can await it.
-    fn finalize_partition_setup(&self, partition: &Partition, handle: JoinHandle<()>) {
+    fn finalize_partition_setup(
+        &self,
+        partition: &Partition,
+        handle: JoinHandle<PartitionImportOutcome>,
+    ) {
         use futures::future::FutureExt;
 
-        // Helper function to discard JoinHandle result (must be fn, not closure, for type matching)
-        fn discard_result(_: Result<(), tokio::task::JoinError>) {}
-
         if let Some(mut task) = self.partition_setup_tasks.get_mut(partition) {
-            // Map the JoinHandle result to () so it's Clone (required for Shared)
-            let shared_handle = handle.map(discard_result as fn(_) -> ()).shared();
+            let shared_handle = handle
+                .map(
+                    map_join_result
+                        as fn(
+                            Result<PartitionImportOutcome, tokio::task::JoinError>,
+                        ) -> Result<PartitionImportOutcome, String>,
+                )
+                .shared();
             task.handle = Some(shared_handle);
         }
     }
@@ -216,14 +264,13 @@ where
 
     /// Cancel and remove setup tasks for revoked partitions.
     ///
-    /// This immediately cancels any in-flight S3 downloads to save cost/time.
-    /// The tasks will detect cancellation and clean up.
+    /// Moves handles to revoked_setup_tasks so we can re-attach on re-assign and peek
+    /// to see if cancellation took (spawn fresh) or task completed (re-attach).
     fn cancel_setup_tasks(&self, partitions: &[Partition]) {
         for partition in partitions {
             if let Some((_, task)) = self.partition_setup_tasks.remove(partition) {
-                // Cancel the token - S3 download will stop at next chunk
                 task.cancel_token.cancel();
-                // Handle is dropped, task continues but we won't wait for it
+                self.revoked_setup_tasks.insert(partition.clone(), task);
             }
             self.partition_fallback_reasons.remove(partition);
         }
@@ -255,7 +302,7 @@ where
         &self,
         partition: Partition,
         cancel_token: CancellationToken,
-    ) -> tokio::task::JoinHandle<()> {
+    ) -> tokio::task::JoinHandle<PartitionImportOutcome> {
         let store_manager = self.store_manager.clone();
         let coordinator = self.rebalance_tracker.clone();
         let importer = self.checkpoint_importer.clone();
@@ -270,7 +317,7 @@ where
                 )
                 .increment(1);
                 fallback_reasons.insert(partition.clone(), "import_cancelled");
-                return;
+                return PartitionImportOutcome::Cancelled;
             }
 
             // Skip if store already exists (handles rapid revoke→assign race)
@@ -284,117 +331,37 @@ where
                     "reason" => "store_exists",
                 )
                 .increment(1);
-                return;
+                return PartitionImportOutcome::Cancelled;
             }
 
-            // Try checkpoint import WITH per-partition cancellation token
-            // RAII cleanup guard handles partial downloads on failure/timeout/cancel
-            // Fallback empty store creation is handled centrally at resume time.
+            // Try checkpoint import WITH per-partition cancellation token.
+            // We return the outcome; finalize applies Option A (register if owned, delete if not).
             if let Some(ref importer) = importer {
                 match importer
                     .import_checkpoint_for_topic_partition_cancellable(
                         partition.topic(),
                         partition.partition_number(),
-                        Some(&cancel_token), // Per-partition token - stops S3 download on revoke
+                        Some(&cancel_token),
                     )
                     .await
                 {
-                    Ok(path) => {
-                        // === CHECKPOINT 2: After download completes ===
-                        // Check if we should skip registration (token cancelled or ownership lost)
-                        let is_cancelled = cancel_token.is_cancelled();
-                        let is_owned = coordinator.is_partition_owned(&partition);
-
-                        if is_cancelled || !is_owned {
-                            let reason = if is_cancelled {
-                                "cancelled"
-                            } else {
-                                "not_owned"
-                            };
+                    Ok(path) => PartitionImportOutcome::Completed(path),
+                    Err(e) => {
+                        if e.downcast_ref::<ImportTimeoutError>().is_some() {
                             metrics::counter!(
-                                PARTITION_STORE_SETUP_SKIPPED,
-                                "reason" => reason,
+                                REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                                "result" => "failed",
+                                "reason" => "timeout",
                             )
                             .increment(1);
+                            fallback_reasons.insert(partition.clone(), "import_timeout");
+                            PartitionImportOutcome::TimedOut
+                        } else if cancel_token.is_cancelled()
+                            || e.downcast_ref::<DownloadCancelledError>().is_some()
+                        {
                             fallback_reasons.insert(partition.clone(), "import_cancelled");
-
-                            // Clean up the successfully imported directory since we can't use it.
-                            // With unique Utc::now() timestamps, each import attempt creates a new path,
-                            // so there's no collision risk with a new task - it will create its own directory.
-                            if path.exists() {
-                                match std::fs::remove_dir_all(&path) {
-                                    Ok(_) => {
-                                        metrics::counter!(
-                                            CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER,
-                                            "result" => "success",
-                                        )
-                                        .increment(1);
-                                        info!(
-                                            topic = partition.topic(),
-                                            partition = partition.partition_number(),
-                                            path = %path.display(),
-                                            reason = reason,
-                                            "Cleaned up unused checkpoint import"
-                                        );
-                                    }
-                                    Err(e) => {
-                                        metrics::counter!(
-                                            CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER,
-                                            "result" => "failed",
-                                        )
-                                        .increment(1);
-                                        warn!(
-                                            topic = partition.topic(),
-                                            partition = partition.partition_number(),
-                                            path = %path.display(),
-                                            error = %e,
-                                            "Failed to clean up checkpoint import, orphan cleaner will handle it"
-                                        );
-                                    }
-                                }
-                            }
-                            return;
-                        }
-
-                        // Register imported store
-                        match store_manager.restore_imported_store(
-                            partition.topic(),
-                            partition.partition_number(),
-                            &path,
-                        ) {
-                            Ok(_) => {
-                                metrics::counter!(
-                                    REBALANCE_CHECKPOINT_IMPORT_COUNTER,
-                                    "result" => "success",
-                                )
-                                .increment(1);
-                                info!(
-                                    topic = partition.topic(),
-                                    partition = partition.partition_number(),
-                                    path = %path.display(),
-                                    "Imported checkpoint for partition"
-                                );
-                            }
-                            Err(e) => {
-                                metrics::counter!(
-                                    REBALANCE_CHECKPOINT_IMPORT_COUNTER,
-                                    "result" => "failed",
-                                    "reason" => "restore",
-                                )
-                                .increment(1);
-                                error!(
-                                    topic = partition.topic(),
-                                    partition = partition.partition_number(),
-                                    error = %e,
-                                    "Failed to restore checkpoint"
-                                );
-                                fallback_reasons.insert(partition.clone(), "import_failed");
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        // Only log if not cancelled (expected during revoke)
-                        if !cancel_token.is_cancelled() {
+                            PartitionImportOutcome::Cancelled
+                        } else {
                             metrics::counter!(
                                 REBALANCE_CHECKPOINT_IMPORT_COUNTER,
                                 "result" => "failed",
@@ -408,8 +375,7 @@ where
                                 "Failed to import checkpoint"
                             );
                             fallback_reasons.insert(partition.clone(), "import_failed");
-                        } else {
-                            fallback_reasons.insert(partition.clone(), "import_cancelled");
+                            PartitionImportOutcome::Failed(e.to_string())
                         }
                     }
                 }
@@ -421,6 +387,7 @@ where
                 )
                 .increment(1);
                 fallback_reasons.insert(partition.clone(), "no_importer");
+                PartitionImportOutcome::Cancelled
             }
         })
     }
@@ -444,19 +411,102 @@ where
     ) -> Result<()> {
         info!("Finalizing rebalance cycle - awaiting import tasks");
 
-        // Step 1: Await all pending import tasks in parallel
+        // Step 1: Await all pending import tasks and apply Option A (register if owned, delete if not)
         let owned_partitions = self.rebalance_tracker.get_owned_partitions();
-        let task_futures: Vec<(Partition, SharedTaskHandle)> = owned_partitions
+        let task_pairs: Vec<(Partition, SharedTaskHandle)> = owned_partitions
             .iter()
             .filter_map(|p| {
                 let p = p.clone();
                 self.get_setup_task(&p).map(|h| (p, h))
             })
             .collect();
-        let (partitions, handles): (Vec<_>, Vec<_>) = task_futures.into_iter().unzip();
-        let _ = join_all(handles).await; // Ignore panic results - tasks handle their own errors
-        for partition in &partitions {
+        let results: Vec<(Partition, Result<PartitionImportOutcome, String>)> = join_all(
+            task_pairs
+                .into_iter()
+                .map(|(p, h)| async move { (p, h.await) }),
+        )
+        .await;
+        for (partition, _) in &results {
             self.complete_setup_task(partition);
+        }
+        for (partition, result) in results {
+            match result {
+                Ok(PartitionImportOutcome::Completed(path)) => {
+                    let is_owned = self.rebalance_tracker.is_partition_owned(&partition);
+                    if is_owned {
+                        if let Err(e) = self.store_manager.restore_imported_store(
+                            partition.topic(),
+                            partition.partition_number(),
+                            &path,
+                        ) {
+                            error!(
+                                topic = partition.topic(),
+                                partition = partition.partition_number(),
+                                error = %e,
+                                "Failed to restore checkpoint"
+                            );
+                            self.partition_fallback_reasons
+                                .insert(partition.clone(), "import_failed");
+                        } else {
+                            metrics::counter!(
+                                REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                                "result" => "success",
+                            )
+                            .increment(1);
+                            info!(
+                                topic = partition.topic(),
+                                partition = partition.partition_number(),
+                                path = %path.display(),
+                                "Imported checkpoint for partition"
+                            );
+                        }
+                    } else if path.exists() {
+                        metrics::counter!(
+                            PARTITION_STORE_SETUP_SKIPPED,
+                            "reason" => "not_owned",
+                        )
+                        .increment(1);
+                        if let Err(e) = std::fs::remove_dir_all(&path) {
+                            warn!(
+                                topic = partition.topic(),
+                                partition = partition.partition_number(),
+                                path = %path.display(),
+                                error = %e,
+                                "Failed to clean up checkpoint import, orphan cleaner will handle it"
+                            );
+                            metrics::counter!(
+                                CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER,
+                                "result" => "failed",
+                            )
+                            .increment(1);
+                        } else {
+                            metrics::counter!(
+                                CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER,
+                                "result" => "success",
+                            )
+                            .increment(1);
+                        }
+                    }
+                }
+                Ok(PartitionImportOutcome::Cancelled)
+                | Ok(PartitionImportOutcome::Failed(_))
+                | Ok(PartitionImportOutcome::TimedOut)
+                | Err(_) => {
+                    let variant = match &result {
+                        Ok(PartitionImportOutcome::Cancelled) => "cancelled",
+                        Ok(PartitionImportOutcome::Failed(_)) => "failed",
+                        Ok(PartitionImportOutcome::TimedOut) => "timeout",
+                        Ok(PartitionImportOutcome::Completed(_)) => unreachable!("handled above"),
+                        Err(_) => "panic",
+                    };
+                    debug!(
+                        topic = partition.topic(),
+                        partition = partition.partition_number(),
+                        variant,
+                        "Partition import cancelled, failed, or timed out; fallback will be used if owned"
+                    );
+                }
+            }
         }
 
         // Capture owned BEFORE the count check so we don't use a snapshot from after a new rebalance.
@@ -478,6 +528,11 @@ where
             info!("New rebalance started during finalize - skipping fallback stores, cleanup and resume");
             return Ok(());
         }
+
+        // Cleanup revoked_setup_tasks for partitions not in owned (avoid leaking handles)
+        let owned_set: std::collections::HashSet<_> = owned.iter().collect();
+        self.revoked_setup_tasks
+            .retain(|p, _| owned_set.contains(p));
 
         // Step 3: Create fallback stores for any owned partitions that don't have a registered store
         // This handles cases where checkpoint import failed, was cancelled, or was disabled
@@ -681,6 +736,25 @@ where
             owned_count = owned_partitions.len(),
             "Async setup starting - spawning tasks for owned partitions"
         );
+
+        // Re-attach revoked tasks for owned partitions when still running or Completed(path).
+        // If cancellation took (Cancelled, Failed, TimedOut, or panic), drop and let spawn loop create a fresh task.
+        for partition in &owned_partitions {
+            if let Some((_, task)) = self.revoked_setup_tasks.remove(partition) {
+                let peeked = task.handle.as_ref().and_then(|h| h.peek());
+                let re_attach = match peeked {
+                    None => false,
+                    Some(Ok(PartitionImportOutcome::Completed(_))) => true,
+                    Some(Ok(PartitionImportOutcome::Cancelled))
+                    | Some(Ok(PartitionImportOutcome::Failed(_)))
+                    | Some(Ok(PartitionImportOutcome::TimedOut))
+                    | Some(Err(_)) => false,
+                };
+                if re_attach {
+                    self.partition_setup_tasks.insert(partition.clone(), task);
+                }
+            }
+        }
 
         // Spawn setup tasks for partitions that don't have one yet.
         // Uses atomic two-phase registration to prevent race conditions where overlapping


### PR DESCRIPTION
## Problem
In order to more accurately track and minimize task replacement during successive revoke-assign cycles, let's make the task handle poll-able for status indications.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Expose `PartitionImportOutcome` enum from import task `JoinHandle`s
* Remove unneeded check when an import was cancelled late in the cycle but still completed
* Small change to S3 import/export parallelism caps (defaults only, not used in prod)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; minimal logic/behavior change here and I'll smoke test in PoC env too
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
