### PR TITLE
fix(dags): use static structlog event names in duckling backfill

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -468,16 +468,18 @@ def _set_table_partitioning(
         conn.execute(f"ALTER TABLE {alias}.posthog.{table} SET PARTITIONED BY ({partition_expr})")
         context.log.info(f"Successfully set partitioning on {table} table")
         logger.info(
-            f"duckling_{table}_partitioning_set",
+            "duckling_table_partitioning_set",
             team_id=team_id,
+            table=table,
             partition_expr=partition_expr,
         )
         return True
     except Exception as exc:
         context.log.warning(f"Failed to set partitioning on {table} table: {exc}")
         logger.warning(
-            f"duckling_{table}_partitioning_failed",
+            "duckling_table_partitioning_failed",
             team_id=team_id,
+            table=table,
             partition_expr=partition_expr,
             error=str(exc),
             error_type=type(exc).__name__,


### PR DESCRIPTION
## Summary
- Replace dynamic f-string structlog event names (`f"duckling_{table}_partitioning_set"`) with static event names and a `table` field
- Dynamic event names make log filtering/alerting unreliable since the event name varies per call

## Test plan
- [x] All 79 existing tests pass (`pytest posthog/dags/test_events_backfill_to_duckling.py`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)