### PR TITLE
fix: drop self managed sources double page header

### DIFF
--- a/frontend/src/scenes/data-pipelines/DataPipelinesSelfManagedSource.tsx
+++ b/frontend/src/scenes/data-pipelines/DataPipelinesSelfManagedSource.tsx
@@ -11,11 +11,11 @@ interface SelfManagedProps {
 
 export const DataPipelinesSelfManagedSource = ({ id }: SelfManagedProps): JSX.Element => {
     const { table } = useValues(dataWarehouseTableLogic({ id }))
-    const { updateTable, editingTable } = useActions(dataWarehouseTableLogic({ id }))
+    const { updateTable } = useActions(dataWarehouseTableLogic({ id }))
 
     return (
         <BindLogic logic={dataWarehouseTableLogic} props={{ id }}>
-            <DataPipelinesSelfManagedSourceTable table={table} updateTable={updateTable} editingTable={editingTable} />
+            <DataPipelinesSelfManagedSourceTable table={table} updateTable={updateTable} />
         </BindLogic>
     )
 }
@@ -23,7 +23,6 @@ export const DataPipelinesSelfManagedSource = ({ id }: SelfManagedProps): JSX.El
 interface Props {
     table: DataWarehouseTable
     updateTable: (tablePayload: any) => void
-    editingTable: (editing: boolean) => void
 }
 
 export function DataPipelinesSelfManagedSourceTable({ table, updateTable }: Props): JSX.Element {

--- a/frontend/src/scenes/data-pipelines/DataPipelinesSelfManagedSource.tsx
+++ b/frontend/src/scenes/data-pipelines/DataPipelinesSelfManagedSource.tsx
@@ -1,13 +1,8 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { router } from 'kea-router'
-
-import { LemonButton } from '@posthog/lemon-ui'
 
 import { DatawarehouseTableForm } from 'scenes/data-warehouse/new/DataWarehouseTableForm'
 import { dataWarehouseTableLogic } from 'scenes/data-warehouse/new/dataWarehouseTableLogic'
-import { urls } from 'scenes/urls'
 
-import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { DataWarehouseTable } from '~/types'
 
 interface SelfManagedProps {
@@ -20,23 +15,6 @@ export const DataPipelinesSelfManagedSource = ({ id }: SelfManagedProps): JSX.El
 
     return (
         <BindLogic logic={dataWarehouseTableLogic} props={{ id }}>
-            <SceneTitleSection
-                name={table.name}
-                description={table.url_pattern}
-                resourceType={{ type: 'data_pipeline' }}
-                actions={
-                    <LemonButton
-                        type="secondary"
-                        onClick={() => {
-                            editingTable(false)
-                            router.actions.push(urls.sources())
-                        }}
-                        size="small"
-                    >
-                        Cancel
-                    </LemonButton>
-                }
-            />
             <DataPipelinesSelfManagedSourceTable table={table} updateTable={updateTable} editingTable={editingTable} />
         </BindLogic>
     )


### PR DESCRIPTION
## Problem

The self-managed sources page displayed a double header. This was due to the `DataPipelinesSelfManagedSource` component including its own `SceneTitleSection` while being rendered within `DataWarehouseSourceScene`, which already provides a header at the parent level.

<img width="3264" height="274" alt="image" src="https://github.com/user-attachments/assets/effc062c-a868-47a2-a7f2-f8a0a5df7c8f" />


## Changes

*   Removed the duplicate `SceneTitleSection` from `frontend/src/scenes/data-pipelines/DataPipelinesSelfManagedSource.tsx`.
*   Removed associated unused imports and the "Cancel" button.
*   The parent `DataWarehouseSourceScene` now exclusively handles the header rendering for this page.

## How did you test this code?

Manually verified that the double header is no longer present on the self-managed sources page. Ran lint and TypeScript checks.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1770684078083739?thread_ts=1770684078.083739&cid=D0ACMC57HDE)

<p><a href="https://cursor.com/background-agent?bcId=bc-61dc6422-8f3f-565d-a1df-87808db22f94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61dc6422-8f3f-565d-a1df-87808db22f94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

