### PR TITLE
chore(dags): rename duckling sensors for clarity

### DIFF
--- a/posthog/dags/README_DUCKLINGS.md
+++ b/posthog/dags/README_DUCKLINGS.md
@@ -26,21 +26,21 @@ Duckling RDS Catalog (PostgreSQL)
 
 ### Events Backfill
 
-| Component                            | Description                                         |
-| ------------------------------------ | --------------------------------------------------- |
-| `duckling_events_backfill`           | Asset that exports events for a team/date partition |
-| `duckling_events_backfill_job`       | Job wrapping the asset                              |
-| `duckling_backfill_discovery_sensor` | Hourly sensor for yesterday's data (top-up)         |
-| `duckling_full_backfill_sensor`      | Daily sensor for historical backfill                |
+| Component                               | Description                                         |
+| --------------------------------------- | --------------------------------------------------- |
+| `duckling_events_backfill`              | Asset that exports events for a team/date partition |
+| `duckling_events_backfill_job`          | Job wrapping the asset                              |
+| `duckling_events_daily_backfill_sensor` | Hourly sensor for yesterday's data (top-up)         |
+| `duckling_events_full_backfill_sensor`  | Sensor for historical backfill (monthly batches)    |
 
 ### Persons Backfill
 
-| Component                               | Description                                          |
-| --------------------------------------- | ---------------------------------------------------- |
-| `duckling_persons_backfill`             | Asset that exports persons for a team/date partition |
-| `duckling_persons_backfill_job`         | Job wrapping the asset                               |
-| `duckling_persons_discovery_sensor`     | Hourly sensor for yesterday's data (top-up)          |
-| `duckling_persons_full_backfill_sensor` | Daily sensor for historical backfill                 |
+| Component                                | Description                                          |
+| ---------------------------------------- | ---------------------------------------------------- |
+| `duckling_persons_backfill`              | Asset that exports persons for a team/date partition |
+| `duckling_persons_backfill_job`          | Job wrapping the asset                               |
+| `duckling_persons_daily_backfill_sensor` | Hourly sensor for yesterday's data (top-up)          |
+| `duckling_persons_full_backfill_sensor`  | Sensor for historical backfill (full export)         |
 
 ## Partition Strategy
 
@@ -71,7 +71,7 @@ Example: `12345_2024-01-15` for team 12345's data on January 15, 2024.
 To run the full backfill immediately (without waiting for tomorrow):
 
 1. Go to Dagster UI → Sensors
-2. Find `duckling_full_backfill_sensor` (or `duckling_persons_full_backfill_sensor`)
+2. Find the relevant sensor (e.g., `duckling_events_full_backfill_sensor` or `duckling_persons_full_backfill_sensor`)
 3. Click "Reset cursor"
 4. The sensor will run on its next tick (within 60 seconds)
 

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1714,11 +1714,11 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
 
 
 @sensor(
-    name="duckling_backfill_discovery_sensor",
+    name="duckling_events_daily_backfill_sensor",
     minimum_interval_seconds=3600,  # Run hourly
     job_name="duckling_events_backfill_job",
 )
-def duckling_backfill_discovery_sensor(context: SensorEvaluationContext) -> SensorResult:
+def duckling_events_daily_backfill_sensor(context: SensorEvaluationContext) -> SensorResult:
     """Discover teams with DuckLakeCatalog entries and create daily backfill partitions.
 
     This sensor runs periodically to:
@@ -1831,12 +1831,12 @@ def get_months_in_range(start_date: date, end_date: date) -> list[str]:
 
 
 @sensor(
-    name="duckling_full_backfill_sensor",
+    name="duckling_events_full_backfill_sensor",
     minimum_interval_seconds=600,  # Run every 10 minutes
     job_name="duckling_events_backfill_job",
     default_status=DefaultSensorStatus.RUNNING,
 )
-def duckling_full_backfill_sensor(context: SensorEvaluationContext) -> SensorResult:
+def duckling_events_full_backfill_sensor(context: SensorEvaluationContext) -> SensorResult:
     """Full historical backfill sensor - creates MONTHLY partitions for efficiency.
 
     Uses monthly partitions (YYYY-MM) instead of daily to reduce partition count.
@@ -1849,7 +1849,7 @@ def duckling_full_backfill_sensor(context: SensorEvaluationContext) -> SensorRes
 
     Manual trigger:
         To restart from scratch, reset the cursor in Dagster UI:
-        Sensors -> duckling_full_backfill_sensor -> Reset cursor
+        Sensors -> duckling_events_full_backfill_sensor -> Reset cursor
     """
     yesterday = (timezone.now() - timedelta(days=1)).date()
 
@@ -1986,14 +1986,14 @@ duckling_events_backfill_job = define_asset_job(
 
 
 @sensor(
-    name="duckling_persons_discovery_sensor",
+    name="duckling_persons_daily_backfill_sensor",
     minimum_interval_seconds=3600,  # Run hourly
     job_name="duckling_persons_backfill_job",
 )
-def duckling_persons_discovery_sensor(context: SensorEvaluationContext) -> SensorResult:
+def duckling_persons_daily_backfill_sensor(context: SensorEvaluationContext) -> SensorResult:
     """Discover teams with DuckLakeCatalog entries and create daily persons partitions.
 
-    Similar to duckling_backfill_discovery_sensor but for persons data.
+    Similar to duckling_events_daily_backfill_sensor but for persons data.
     Uses _timestamp (Kafka ingestion time) for date filtering.
     """
     yesterday = (timezone.now() - timedelta(days=1)).strftime("%Y-%m-%d")

--- a/posthog/dags/locations/data_stack.py
+++ b/posthog/dags/locations/data_stack.py
@@ -19,9 +19,9 @@ defs = dagster.Definitions(
         events_backfill_to_duckling.duckling_persons_backfill_job,
     ],
     sensors=[
-        events_backfill_to_duckling.duckling_backfill_discovery_sensor,
-        events_backfill_to_duckling.duckling_full_backfill_sensor,
-        events_backfill_to_duckling.duckling_persons_discovery_sensor,
+        events_backfill_to_duckling.duckling_events_daily_backfill_sensor,
+        events_backfill_to_duckling.duckling_events_full_backfill_sensor,
+        events_backfill_to_duckling.duckling_persons_daily_backfill_sensor,
         events_backfill_to_duckling.duckling_persons_full_backfill_sensor,
     ],
     resources=resources,


### PR DESCRIPTION
## Summary
- Rename sensors to a consistent `duckling_{entity}_{daily|full}_backfill_sensor` pattern:
  - `duckling_backfill_discovery_sensor` → `duckling_events_daily_backfill_sensor`
  - `duckling_full_backfill_sensor` → `duckling_events_full_backfill_sensor`
  - `duckling_persons_discovery_sensor` → `duckling_persons_daily_backfill_sensor`
  - `duckling_persons_full_backfill_sensor` (unchanged, already clear)
- Update `data_stack.py` and `README_DUCKLINGS.md` references

## Test plan
- [x] All 79 existing tests pass
- [x] No stale references to old sensor names in codebase


🤖 Generated with [Claude Code](https://claude.com/claude-code)