### PR TITLE
refactor: Log usage event for every single user in org

### DIFF
--- a/posthog/tasks/report_utils.py
+++ b/posthog/tasks/report_utils.py
@@ -43,7 +43,6 @@ def capture_event(
     organization_id: Optional[str] = None,
     team_id: Optional[int] = None,
     properties: dict[str, Any],
-    group_properties: Optional[dict[str, Any]] = None,
     timestamp: Optional[Union[datetime, str]] = None,
     distinct_id: Optional[str] = None,
 ) -> None:
@@ -74,7 +73,6 @@ def capture_event(
             "[Usage Report] Capturing usage report event",
             event_name=name,
             organization_id=organization_id,
-            group_properties=group_properties,
         )
 
         pha_client.capture(
@@ -84,13 +82,6 @@ def capture_event(
             groups={"organization": str(organization_id), "instance": settings.SITE_URL},
             timestamp=timestamp,
         )
-
-        if group_properties and organization_id:
-            pha_client.group_identify(
-                "organization",
-                str(organization_id),
-                properties=group_properties,
-            )
     else:
         pha_client.capture(
             distinct_id=get_machine_id(),

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -3784,26 +3784,6 @@ class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
         assert mock_client.capture.call_args[1]["timestamp"] == datetime(2021, 10, 10, 23, 1, tzinfo=tzutc())
 
     @patch("posthog.tasks.report_utils.is_cloud", return_value=True)
-    def test_capture_event_calls_group_identify_with_group_properties(self, mock_is_cloud: MagicMock) -> None:
-        organization = Organization.objects.create()
-        mock_client = MagicMock()
-        group_props = {"org_name": "Test Org", "plan": "enterprise"}
-
-        capture_event(
-            pha_client=mock_client,
-            name="test event",
-            organization_id=str(organization.id),
-            properties={"prop1": "val1"},
-            group_properties=group_props,
-        )
-
-        mock_client.group_identify.assert_called_once_with(
-            "organization",
-            str(organization.id),
-            properties=group_props,
-        )
-
-    @patch("posthog.tasks.report_utils.is_cloud", return_value=True)
     def test_capture_event_skips_group_identify_without_group_properties(self, mock_is_cloud: MagicMock) -> None:
         organization = Organization.objects.create()
         mock_client = MagicMock()

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1691,17 +1691,17 @@ def capture_report(
 ) -> None:
     if not organization_id:
         raise ValueError("Organization_id must be provided")
+
+    pha_client = get_ph_client(sync_mode=True)
+
     try:
-        pha_client = get_ph_client(sync_mode=True)
         capture_event(
             pha_client=pha_client,
             name="organization usage report",
             organization_id=organization_id,
             properties=full_report_dict,
-            group_properties={"has_non_zero_usage": full_report_dict.get("has_non_zero_usage")},
             timestamp=at_date,
         )
-
     except Exception as err:
         logger.exception(
             f"UsageReport sent to PostHog for organization {organization_id} failed: {str(err)}",
@@ -1712,6 +1712,35 @@ def capture_report(
             organization_id=organization_id,
             properties={"error": str(err)},
         )
+
+    # There are some billing-related flags we wanna set in customer.io
+    # and for that to work properly we need to make sure we include that
+    # for every single person in the organization, otherwise we might end up
+    # with some people having the property and some not,
+    # which makes it harder to filter on in customer.io
+    per_person_properties = {
+        "has_non_zero_usage": full_report_dict.get("has_non_zero_usage"),
+    }
+
+    for membership in OrganizationMembership.objects.filter(organization_id=organization_id).select_related("user"):
+        distinct_id = membership.user.distinct_id
+        if not distinct_id:
+            continue
+
+        try:
+            capture_event(
+                pha_client=pha_client,
+                name="organization usage report per person",
+                organization_id=organization_id,
+                distinct_id=distinct_id,
+                properties=per_person_properties,
+                timestamp=at_date,
+            )
+        except Exception as err:
+            logger.exception(
+                f"UsageReport sent to PostHog for user {distinct_id} in organization {organization_id} failed: {str(err)}",
+            )
+            capture_exception(err, {"distinct_id": distinct_id, "organization_id": organization_id})
 
 
 # extend this with future usage based products


### PR DESCRIPTION
Rather than logging only one event and attempting to add this as an organization property, let's instead log this as part of each individual user in the org, this will make it easier sending the data over to Customer.io