### PR TITLE
feat: Improve OAuth authorization server redirects

### DIFF
--- a/services/mcp/src/lib/routing.ts
+++ b/services/mcp/src/lib/routing.ts
@@ -1,0 +1,24 @@
+// Authorization server redirect routes.
+// MCP clients sometimes hit OAuth endpoints directly on this server instead of following
+// the authorization server URLs from the protected resource metadata. Each entry defines
+// a path pattern that should be redirected to the PostHog authorization server.
+
+type RedirectStatus = 301 | 302
+type AuthRedirect = { match: string; status: RedirectStatus } | { prefix: string; status: RedirectStatus }
+
+const AUTH_SERVER_REDIRECTS: AuthRedirect[] = [
+    // OAuth Authorization Server Metadata (RFC 8414) - clients fetch this directly
+    // instead of using the authorization_servers field from protected resource metadata
+    { match: '/.well-known/oauth-authorization-server', status: 302 },
+    // JWKS endpoint for token verification
+    { match: '/.well-known/jwks.json', status: 301 },
+    // OAuth endpoints (authorize, token, register, revoke, introspect, userinfo)
+    { prefix: '/oauth/', status: 301 },
+]
+
+export function matchAuthServerRedirect(pathname: string): AuthRedirect | undefined {
+    return AUTH_SERVER_REDIRECTS.find(
+        (route) =>
+            ('match' in route && pathname === route.match) || ('prefix' in route && pathname.startsWith(route.prefix))
+    )
+}

--- a/services/mcp/tests/unit/routing.test.ts
+++ b/services/mcp/tests/unit/routing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { matchAuthServerRedirect } from '@/lib/routing'
+
+describe('Authorization server redirects', () => {
+    const redirectCases = [
+        { pathname: '/.well-known/oauth-authorization-server', expectedStatus: 302 },
+        { pathname: '/.well-known/jwks.json', expectedStatus: 301 },
+        { pathname: '/oauth/authorize/', expectedStatus: 301 },
+        { pathname: '/oauth/token/', expectedStatus: 301 },
+        { pathname: '/oauth/register/', expectedStatus: 301 },
+        { pathname: '/oauth/revoke/', expectedStatus: 301 },
+        { pathname: '/oauth/introspect/', expectedStatus: 301 },
+        { pathname: '/oauth/userinfo/', expectedStatus: 301 },
+    ]
+
+    it.each(redirectCases)('redirects $pathname with status $expectedStatus', ({ pathname, expectedStatus }) => {
+        const redirect = matchAuthServerRedirect(pathname)
+        expect(redirect).not.toBeUndefined()
+        expect(redirect!.status).toBe(expectedStatus)
+    })
+
+    const noRedirectCases = [
+        { pathname: '/' },
+        { pathname: '/mcp' },
+        { pathname: '/sse' },
+        { pathname: '/.well-known/oauth-protected-resource' },
+        { pathname: '/.well-known/oauth-protected-resource/mcp' },
+    ]
+
+    it.each(noRedirectCases)('does not redirect $pathname', ({ pathname }) => {
+        expect(matchAuthServerRedirect(pathname)).toBeUndefined()
+    })
+})


### PR DESCRIPTION
## Problem

OAuth redirects in the MCP service are not handling all necessary authorization server endpoints. Clients sometimes hit OAuth endpoints directly on the MCP server instead of following the authorization server URLs from the protected resource metadata.

## Changes

- Created a new routing system to handle authorization server redirects
- Added support for redirecting additional OAuth endpoints to the correct PostHog authorization server
- Implemented different HTTP status codes (301/302) for different redirect types
- Refactored region detection logic into a dedicated function
- Added comprehensive tests for the new routing functionality

## How did you test this code?

- Added unit tests that verify all supported redirect paths and status codes
- Tested that non-OAuth paths are not redirected
- Verified that both exact matches and prefix-based matches work correctly

## Publish to changelog?

No