### PR TITLE
feat(deduplicator): apply S3 prefix hash to object uploads

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -7,8 +7,7 @@ pub struct CheckpointConfig {
     pub checkpoint_interval: Duration,
 
     /// How many incremental checkpoint attempts to perform between full
-    /// uploads of all checkpoint files. If 0, we allways perform a
-    /// full upload on every attempt
+    /// uploads of all checkpoint files. If 0, we always perform a full upload on every attempt.
     pub checkpoint_full_upload_interval: u32,
 
     /// Base directory for local checkpoints

--- a/rust/kafka-deduplicator/src/checkpoint/export.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/export.rs
@@ -177,7 +177,7 @@ mod tests {
         let timestamp = Utc.with_ymd_and_hms(2025, 6, 15, 12, 0, 0).unwrap();
         let metadata =
             CheckpointMetadata::new("test-topic".to_string(), 0, timestamp, 12345, 100, 50);
-        let info = CheckpointInfo::new(metadata, "checkpoints".to_string());
+        let info = CheckpointInfo::new(metadata, "checkpoints".to_string(), None);
         CheckpointPlan {
             info,
             files_to_upload: vec![],

--- a/rust/kafka-deduplicator/src/checkpoint/metadata.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/metadata.rs
@@ -196,8 +196,8 @@ impl CheckpointInfo {
         match &self.hash_prefix {
             Some(h) => format!(
                 "{}/{}/{}/{}",
-                self.s3_key_prefix,
                 h,
+                self.s3_key_prefix,
                 self.metadata.get_attempt_path(),
                 relative_file_path
             ),
@@ -218,7 +218,7 @@ impl CheckpointInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckpointFile {
     /// Fully-qualified remote path from original upload (latest or previous attempt).
-    /// Object files: <namespace>/<hash>/<topic>/<partition>/<id>/<filename> (new exports) or unhashed (legacy).
+    /// Object files: <hash>/<namespace>/<topic>/<partition>/<id>/<filename> (new exports) or unhashed (legacy).
     /// Importer GETs using this path; metadata.json is always at unhashed path.
     pub remote_filepath: String,
 
@@ -491,7 +491,7 @@ mod tests {
         assert!(file_key.contains(&hash));
         assert_eq!(
             file_key,
-            format!("{bucket_namespace}/{hash}/{topic}/{partition}/{checkpoint_id}/000001.sst")
+            format!("{hash}/{bucket_namespace}/{topic}/{partition}/{checkpoint_id}/000001.sst")
         );
     }
 

--- a/rust/kafka-deduplicator/src/checkpoint/metadata.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/metadata.rs
@@ -2,11 +2,23 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use chrono::{DateTime, Utc};
 use tracing::info;
 
 use crate::utils::format_store_path;
+
+/// Deterministic 8-hex-char prefix for spreading S3 object keys across internal partitions.
+/// Applied ONLY to checkpoint object file paths, NEVER to metadata.json paths.
+pub fn hash_prefix_for_partition(topic: &str, partition: i32) -> String {
+    let input = format!("{topic}/{partition}");
+    let hash = Sha256::digest(input.as_bytes());
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}",
+        hash[0], hash[1], hash[2], hash[3]
+    )
+}
 
 // filename of metadata tracking file in each remote checkpoint attempt directory
 pub const METADATA_FILENAME: &str = "metadata.json";
@@ -150,19 +162,25 @@ pub struct CheckpointInfo {
     pub metadata: CheckpointMetadata,
     /// App-level S3 bucket namespace under which all checkpoint attempts are stored remotely
     pub s3_key_prefix: String,
+    /// Optional hash prefix for object file keys only (never for metadata.json)
+    pub hash_prefix: Option<String>,
 }
 
 impl CheckpointInfo {
-    /// Create new checkpoint info that wraps in the app-level bucket
-    /// namespace under which all checkpoint attempts are stored remotely
-    pub fn new(metadata: CheckpointMetadata, s3_key_prefix: String) -> Self {
+    /// New checkpoint info. hash_prefix: when Some, get_file_key() uses hashed path for object files; get_metadata_key() never does.
+    pub fn new(
+        metadata: CheckpointMetadata,
+        s3_key_prefix: String,
+        hash_prefix: Option<String>,
+    ) -> Self {
         Self {
             metadata,
             s3_key_prefix,
+            hash_prefix,
         }
     }
 
-    /// Get the fully-qualified remote metadata file path for this checkpoint attempt
+    /// Fully-qualified remote path for metadata.json (unhashed; used for list/discovery).
     pub fn get_metadata_key(&self) -> String {
         format!(
             "{}/{}",
@@ -171,17 +189,20 @@ impl CheckpointInfo {
         )
     }
 
-    /// Get fully-qualified remote file path for a specific file
-    /// to be uploaded as part of this checkpoint attempt. the
-    /// relative_file_path is assumed to have been stripped of all
-    /// local path elements common to a checkpoint attempt dir tree
-    ///
-    /// NOTE! Files tracked in metadata.files that were not uploaded
-    /// as part of this attempt already contain their fully-qualified
-    /// remote paths as of time of original upload attempt, and can be
-    /// used directly in import/DR flows.
+    /// Fully-qualified remote path for a file in this attempt (relative_file_path = filename only).
+    /// When hash_prefix is Some, path includes it (object files only; metadata.json never).
+    /// metadata.files entries from prior attempts already have full paths; use as-is for import.
     pub fn get_file_key(&self, relative_file_path: &str) -> String {
-        format!("{}/{}", self.get_remote_attempt_path(), relative_file_path)
+        match &self.hash_prefix {
+            Some(h) => format!(
+                "{}/{}/{}/{}",
+                self.s3_key_prefix,
+                h,
+                self.metadata.get_attempt_path(),
+                relative_file_path
+            ),
+            None => format!("{}/{}", self.get_remote_attempt_path(), relative_file_path),
+        }
     }
 
     // The fully qualified remote base path for this checkpoint attempt
@@ -196,10 +217,9 @@ impl CheckpointInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckpointFile {
-    /// The fully-qualified remote file path, as of the time of its
-    /// original upload during a checkpoint attempt (latest or previous)
-    /// Example:
-    /// <remote_namespace>/<topic_name>/<partition_number>/<checkpoint_id>/<filename>
+    /// Fully-qualified remote path from original upload (latest or previous attempt).
+    /// Object files: <namespace>/<hash>/<topic>/<partition>/<id>/<filename> (new exports) or unhashed (legacy).
+    /// Importer GETs using this path; metadata.json is always at unhashed path.
     pub remote_filepath: String,
 
     /// SHA256 checksum of the file's contents. Used during checkpoint
@@ -402,7 +422,7 @@ mod tests {
             50,
         );
 
-        let info = CheckpointInfo::new(metadata, bucket_namespace.to_string());
+        let info = CheckpointInfo::new(metadata, bucket_namespace.to_string(), None);
 
         assert_eq!(
             info.get_metadata_key(),
@@ -415,6 +435,63 @@ mod tests {
         assert_eq!(
             info.get_file_key(local_file_relative_path),
             format!("{bucket_namespace}/{topic}/{partition}/{checkpoint_id}/000001.sst")
+        );
+    }
+
+    #[test]
+    fn test_hash_prefix_deterministic() {
+        let h1 = hash_prefix_for_partition("events", 0);
+        let h2 = hash_prefix_for_partition("events", 0);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_hash_prefix_different_partitions() {
+        let h0 = hash_prefix_for_partition("events", 0);
+        let h1 = hash_prefix_for_partition("events", 1);
+        let h2 = hash_prefix_for_partition("other-topic", 0);
+        assert_ne!(h0, h1);
+        assert_ne!(h0, h2);
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn test_hash_prefix_format() {
+        let h = hash_prefix_for_partition("t", 0);
+        assert_eq!(h.len(), 8);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_checkpoint_info_with_hash_prefix() {
+        let attempt_timestamp = Utc::now();
+        let bucket_namespace = "checkpoints";
+        let topic = "events";
+        let partition = 3;
+        let checkpoint_id = CheckpointMetadata::generate_id(attempt_timestamp);
+        let metadata = CheckpointMetadata::new(
+            topic.to_string(),
+            partition,
+            attempt_timestamp,
+            1234567890,
+            100,
+            50,
+        );
+        let hash = hash_prefix_for_partition(topic, partition);
+        let info = CheckpointInfo::new(metadata, bucket_namespace.to_string(), Some(hash.clone()));
+
+        let meta_key = info.get_metadata_key();
+        assert!(!meta_key.contains(&hash));
+        assert_eq!(
+            meta_key,
+            format!("{bucket_namespace}/{topic}/{partition}/{checkpoint_id}/{METADATA_FILENAME}")
+        );
+
+        let file_key = info.get_file_key("000001.sst");
+        assert!(file_key.contains(&hash));
+        assert_eq!(
+            file_key,
+            format!("{bucket_namespace}/{hash}/{topic}/{partition}/{checkpoint_id}/000001.sst")
         );
     }
 

--- a/rust/kafka-deduplicator/src/checkpoint/mod.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/mod.rs
@@ -17,7 +17,7 @@ pub use config::CheckpointConfig;
 pub use downloader::CheckpointDownloader;
 pub use export::CheckpointExporter;
 pub use import::CheckpointImporter;
-pub use metadata::{CheckpointFile, CheckpointInfo, CheckpointMetadata};
+pub use metadata::{hash_prefix_for_partition, CheckpointFile, CheckpointInfo, CheckpointMetadata};
 pub use planner::{plan_checkpoint, CheckpointPlan, LocalCheckpointFile};
 pub use s3_downloader::S3Downloader;
 pub use s3_uploader::S3Uploader;

--- a/rust/kafka-deduplicator/src/checkpoint/planner.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/planner.rs
@@ -301,7 +301,7 @@ mod tests {
         assert_eq!(plan.info.metadata.files.len(), 2);
         let hash = hash_prefix_for_partition(topic, partition_number);
         let expected_remote_path =
-            format!("{remote_bucket_namespace}/{hash}/{topic}/{partition_number}/{checkpoint_id}");
+            format!("{hash}/{remote_bucket_namespace}/{topic}/{partition_number}/{checkpoint_id}");
         assert!(plan
             .info
             .metadata
@@ -445,7 +445,7 @@ mod tests {
         // Check that file3 is in metadata as a reference (new files use hashed path)
         let hash = hash_prefix_for_partition(topic, partition_number);
         let current_attempt_remote_path =
-            format!("{remote_bucket_namespace}/{hash}/{topic}/{partition_number}/{checkpoint_id}");
+            format!("{hash}/{remote_bucket_namespace}/{topic}/{partition_number}/{checkpoint_id}");
 
         let sst1_remote_path = format!("{prev_remote_path}/00001.sst");
         let sst2_remote_path = format!("{prev_remote_path}/00002.sst");
@@ -756,7 +756,7 @@ mod tests {
         // new files (sst3, CURRENT, log) use hashed path; retained use prev (unhashed)
         let hash = hash_prefix_for_partition(topic, partition_number);
         let current_attempt_remote_path =
-            format!("{remote_bucket_namespace}/{hash}/{topic}/{partition_number}/{checkpoint_id}");
+            format!("{hash}/{remote_bucket_namespace}/{topic}/{partition_number}/{checkpoint_id}");
         let sst1_remote_path = format!("{prev_remote_path}/00001.sst");
         let sst2_remote_path = format!("{prev_remote_path}/00002.sst");
         let sst3_remote_path = format!("{current_attempt_remote_path}/00003.sst");

--- a/rust/kafka-deduplicator/src/checkpoint/planner.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/planner.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use super::{CheckpointFile, CheckpointInfo, CheckpointMetadata};
+use super::{hash_prefix_for_partition, CheckpointFile, CheckpointInfo, CheckpointMetadata};
 use crate::kafka::types::Partition;
 use crate::metrics_const::CHECKPOINT_PLAN_FILE_TRACKED_COUNTER;
 
@@ -39,7 +39,8 @@ pub fn plan_checkpoint(
         consumer_offset,
         producer_offset,
     );
-    let mut info = CheckpointInfo::new(metadata, remote_bucket_namespace);
+    let hash = hash_prefix_for_partition(partition.topic(), partition.partition_number());
+    let mut info = CheckpointInfo::new(metadata, remote_bucket_namespace, Some(hash));
     let mut files_to_upload: Vec<LocalCheckpointFile> = Vec::new();
 
     // Collect all files in local checkpoint directory
@@ -82,17 +83,7 @@ pub fn plan_checkpoint(
         prev_meta.id
     );
 
-    // For each local file, check if it exists in previous metadata fileset
-    // IMPORTANT: each type must be handled differently to maintain
-    // a useable backup:
-    // - .sst files: upload all new files, and skip uploading old ones (retain original paths)
-    // - .log (WAL) files: upload only new files. drop old if missing from new checkpoint.
-    //                     if same-named, keep newer or disambiguate w/checksum
-    // - MANIFEST-* files: upload new files. drop old if missing from new checkpoint.
-    //                     if same-named, keep newer or disambiguate w/checksum
-    // - CURRENT    file:  upload the new file, drop the old one
-    // - OPTIONS-*  files: upload new files. drop old if missing from new checkpoint.
-    //                     if same-named, keep newer or disambiguate w/checksum
+    // Per-file rules: .sst retain old path; .log/MANIFEST/OPTIONS replace if checksum changed; CURRENT always upload new.
     for candidate in local_files {
         let filename = &candidate.filename;
         if let Some(prev_file) = prev_file_map.get(filename) {
@@ -306,10 +297,11 @@ mod tests {
         assert_eq!(got_sst1, &expected_sst1);
         assert_eq!(got_sst2, &expected_sst2);
 
-        // With no previous metadata, all files should be tracked in metadata
+        // With no previous metadata, all files should be tracked in metadata with hashed paths
         assert_eq!(plan.info.metadata.files.len(), 2);
+        let hash = hash_prefix_for_partition(topic, partition_number);
         let expected_remote_path =
-            format!("{remote_bucket_namespace}/{topic}/{partition_number}/{checkpoint_id}");
+            format!("{remote_bucket_namespace}/{hash}/{topic}/{partition_number}/{checkpoint_id}");
         assert!(plan
             .info
             .metadata
@@ -328,6 +320,13 @@ mod tests {
             .files
             .iter()
             .any(|f| f.remote_filepath.ends_with("file2.sst")));
+        // metadata key (for metadata.json) must not contain hash
+        let meta_key = plan.info.get_metadata_key();
+        assert!(!meta_key.contains(&hash));
+        assert_eq!(
+            meta_key,
+            format!("{remote_bucket_namespace}/{topic}/{partition_number}/{checkpoint_id}/metadata.json")
+        );
     }
 
     #[test]
@@ -443,9 +442,10 @@ mod tests {
         assert_eq!(&sst1_file_meta.checksum, &expected_prev_sst1.checksum);
         assert_eq!(&sst2_file_meta.checksum, &expected_prev_sst2.checksum);
 
-        // Check that file3 is in metadata as a reference
+        // Check that file3 is in metadata as a reference (new files use hashed path)
+        let hash = hash_prefix_for_partition(topic, partition_number);
         let current_attempt_remote_path =
-            format!("{remote_bucket_namespace}/{topic}/{partition_number}/{checkpoint_id}");
+            format!("{remote_bucket_namespace}/{hash}/{topic}/{partition_number}/{checkpoint_id}");
 
         let sst1_remote_path = format!("{prev_remote_path}/00001.sst");
         let sst2_remote_path = format!("{prev_remote_path}/00002.sst");
@@ -753,8 +753,10 @@ mod tests {
         assert_eq!(plan.info.metadata.files.len(), 7);
 
         // validate the right checkpoint metadata was retained from previous vs. current checkpoint attempts
+        // new files (sst3, CURRENT, log) use hashed path; retained use prev (unhashed)
+        let hash = hash_prefix_for_partition(topic, partition_number);
         let current_attempt_remote_path =
-            format!("{remote_bucket_namespace}/{topic}/{partition_number}/{checkpoint_id}");
+            format!("{remote_bucket_namespace}/{hash}/{topic}/{partition_number}/{checkpoint_id}");
         let sst1_remote_path = format!("{prev_remote_path}/00001.sst");
         let sst2_remote_path = format!("{prev_remote_path}/00002.sst");
         let sst3_remote_path = format!("{current_attempt_remote_path}/00003.sst");

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -57,7 +57,7 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
     // Clean up any previous test data (unhashed metadata path and hashed object path)
     let test_prefix = format!("checkpoints/{test_topic}/{test_partition}");
     let hash = hash_prefix_for_partition(test_topic, test_partition);
-    let hashed_prefix = format!("checkpoints/{hash}/{test_topic}/{test_partition}");
+    let hashed_prefix = format!("{hash}/checkpoints/{test_topic}/{test_partition}");
     cleanup_bucket(&minio_client, TEST_BUCKET, &test_prefix).await;
     cleanup_bucket(&minio_client, TEST_BUCKET, &hashed_prefix).await;
 
@@ -708,7 +708,7 @@ async fn test_export_cancellation_via_minio() -> Result<()> {
     // Clean up any previous test data (unhashed metadata path and hashed object path)
     let test_prefix = format!("checkpoints/{test_topic}/{test_partition}");
     let hash = hash_prefix_for_partition(test_topic, test_partition);
-    let hashed_prefix = format!("checkpoints/{hash}/{test_topic}/{test_partition}");
+    let hashed_prefix = format!("{hash}/checkpoints/{test_topic}/{test_partition}");
     cleanup_bucket(&minio_client, TEST_BUCKET, &test_prefix).await;
     cleanup_bucket(&minio_client, TEST_BUCKET, &hashed_prefix).await;
 

--- a/rust/kafka-deduplicator/tests/checkpoint_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_tests.rs
@@ -401,8 +401,8 @@ async fn test_checkpoint_from_plan_with_no_previous_metadata() {
     let hash = hash_prefix_for_partition(partition.topic(), partition.partition_number());
     let expected_object_prefix = format!(
         "{}/{}/{}/{}/{}",
-        config.s3_key_prefix,
         hash,
+        config.s3_key_prefix,
         partition.topic(),
         partition.partition_number(),
         CheckpointMetadata::generate_id(attempt_timestamp),
@@ -509,8 +509,8 @@ async fn test_checkpoint_from_plan_with_previous_metadata() {
     let hash = hash_prefix_for_partition(partition.topic(), partition.partition_number());
     let orig_expected_object_prefix = format!(
         "{}/{}/{}/{}/{}",
-        config.s3_key_prefix,
         hash,
+        config.s3_key_prefix,
         partition.topic(),
         partition.partition_number(),
         CheckpointMetadata::generate_id(attempt_timestamp),
@@ -561,8 +561,8 @@ async fn test_checkpoint_from_plan_with_previous_metadata() {
     );
     let next_expected_object_prefix = format!(
         "{}/{}/{}/{}/{}",
-        config.s3_key_prefix,
         hash,
+        config.s3_key_prefix,
         partition.topic(),
         partition.partition_number(),
         next_checkpoint_id,

--- a/rust/kafka-deduplicator/tests/checkpoint_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_tests.rs
@@ -8,8 +8,8 @@ use chrono::Utc;
 use tokio_util::sync::CancellationToken;
 
 use kafka_deduplicator::checkpoint::{
-    CheckpointConfig, CheckpointExporter, CheckpointMetadata, CheckpointPlan, CheckpointUploader,
-    CheckpointWorker,
+    hash_prefix_for_partition, CheckpointConfig, CheckpointExporter, CheckpointMetadata,
+    CheckpointPlan, CheckpointUploader, CheckpointWorker,
 };
 use kafka_deduplicator::kafka::types::Partition;
 use kafka_deduplicator::store::TimestampMetadata;
@@ -151,6 +151,9 @@ impl CheckpointUploader for MockUploader {
                 }
             }
             let remote_file_path = self.upload_dir.join(&remote_file_path_str);
+            if let Some(parent) = remote_file_path.parent() {
+                tokio::fs::create_dir_all(parent).await?;
+            }
             tokio::fs::copy(&local_file_path, &remote_file_path).await?;
             uploaded_keys.push(remote_file_path_str);
         }
@@ -382,8 +385,7 @@ async fn test_checkpoint_from_plan_with_no_previous_metadata() {
     assert!(result.is_some());
     let info = result.unwrap();
 
-    // manually construct expected remote attempt path as CheckpointInfo
-    // would have to apply to all *new* files tracked in metadata.files
+    // manually construct expected remote attempt path (unhashed, for metadata.json)
     let expected_remote_path = format!(
         "{}/{}/{}/{}",
         config.s3_key_prefix,
@@ -395,9 +397,29 @@ async fn test_checkpoint_from_plan_with_no_previous_metadata() {
 
     let remote_checkpoint_files = uploader.get_stored_files().await.unwrap();
     assert!(!remote_checkpoint_files.is_empty());
-    assert!(remote_checkpoint_files
-        .keys()
-        .all(|k| k.contains(&expected_remote_path)));
+    // metadata.json at unhashed path; object files at hashed path
+    let hash = hash_prefix_for_partition(partition.topic(), partition.partition_number());
+    let expected_object_prefix = format!(
+        "{}/{}/{}/{}/{}",
+        config.s3_key_prefix,
+        hash,
+        partition.topic(),
+        partition.partition_number(),
+        CheckpointMetadata::generate_id(attempt_timestamp),
+    );
+    for k in remote_checkpoint_files.keys() {
+        if k.ends_with("metadata.json") {
+            assert!(
+                !k.contains(&hash),
+                "metadata.json must not contain hash, got: {k}"
+            );
+        } else {
+            assert!(
+                k.starts_with(&expected_object_prefix),
+                "object file key must have hashed path, got: {k}"
+            );
+        }
+    }
 
     // Verify exported files contain expected RocksDB checkpoint files
     assert!(remote_checkpoint_files
@@ -469,8 +491,7 @@ async fn test_checkpoint_from_plan_with_previous_metadata() {
     assert!(result.is_some());
     let orig_info = result.unwrap();
 
-    // manually construct expected remote attempt path as CheckpointInfo
-    // would have to apply to all *new* files tracked in metadata.files
+    // manually construct expected remote attempt path (unhashed)
     let orig_expected_remote_path = format!(
         "{}/{}/{}/{}",
         config.s3_key_prefix,
@@ -485,9 +506,28 @@ async fn test_checkpoint_from_plan_with_previous_metadata() {
 
     let orig_remote_checkpoint_files = uploader.get_stored_files().await.unwrap();
     assert!(!orig_remote_checkpoint_files.is_empty());
-    assert!(orig_remote_checkpoint_files
-        .keys()
-        .all(|k| k.contains(&orig_expected_remote_path)));
+    let hash = hash_prefix_for_partition(partition.topic(), partition.partition_number());
+    let orig_expected_object_prefix = format!(
+        "{}/{}/{}/{}/{}",
+        config.s3_key_prefix,
+        hash,
+        partition.topic(),
+        partition.partition_number(),
+        CheckpointMetadata::generate_id(attempt_timestamp),
+    );
+    for k in orig_remote_checkpoint_files.keys() {
+        if k.ends_with("metadata.json") {
+            assert!(
+                !k.contains(&hash),
+                "metadata.json must not contain hash, got: {k}"
+            );
+        } else {
+            assert!(
+                k.starts_with(&orig_expected_object_prefix),
+                "object file key must have hashed path, got: {k}"
+            );
+        }
+    }
 
     // Verify exported files contain expected RocksDB checkpoint files, including SSTs
     assert!(orig_remote_checkpoint_files
@@ -519,6 +559,14 @@ async fn test_checkpoint_from_plan_with_previous_metadata() {
         partition.partition_number(),
         next_checkpoint_id,
     );
+    let next_expected_object_prefix = format!(
+        "{}/{}/{}/{}/{}",
+        config.s3_key_prefix,
+        hash,
+        partition.topic(),
+        partition.partition_number(),
+        next_checkpoint_id,
+    );
 
     assert!(uploader.clear().await.is_ok());
 
@@ -544,9 +592,19 @@ async fn test_checkpoint_from_plan_with_previous_metadata() {
     let next_remote_checkpoint_files = uploader.get_stored_files().await.unwrap();
 
     assert!(!next_remote_checkpoint_files.is_empty());
-    assert!(next_remote_checkpoint_files
-        .keys()
-        .all(|k| k.contains(&next_expected_remote_path)));
+    for k in next_remote_checkpoint_files.keys() {
+        if k.ends_with("metadata.json") {
+            assert!(
+                !k.contains(&hash),
+                "metadata.json must not contain hash, got: {k}"
+            );
+        } else {
+            assert!(
+                k.starts_with(&next_expected_object_prefix),
+                "object file key must have hashed path, got: {k}"
+            );
+        }
+    }
 
     // there should be no new SST files uploaded in this checkpoint
     // because the original checkpoint uploaded them already


### PR DESCRIPTION
## Problem
Checkpoint object uploads/downloads require more throughput during burst activity. Speeding up checkpoint imports during rebalancing is critical for our use case.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Prefix all object paths (non-`CheckpointMetadata` files) with a short hash
* Related changes to tests etc.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
