### PR TITLE
fix: ensure conversation query is scoped to team

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -233,7 +233,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
         conversation_id = request.data.get("conversation")
         if conversation_id:
             try:
-                conversation = Conversation.objects.get(id=conversation_id)
+                conversation = Conversation.objects.get(id=conversation_id, team=self.team)
                 if conversation.type == Conversation.Type.DEEP_RESEARCH:
                     return True
             except (Conversation.DoesNotExist, ValidationError):


### PR DESCRIPTION
This is minor but the query should be properly scoped.