### PR TITLE
fix(experiments): add sanitization to transformation on web experiments.

### DIFF
--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -285,3 +285,55 @@ class TestWebExperiment(APIBaseTest):
 
         # New variant should not have transforms (not in original experiment)
         assert "transforms" not in variants["new_variant"]
+
+    @patch("posthog.api.feature_flag.report_user_action")
+    def test_sanitizes_xss_in_transforms(self, mock_capture):
+        """Test that XSS attacks in text and html fields are sanitized"""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/web_experiments/",
+            data={
+                "name": "XSS Test Experiment",
+                "variants": {
+                    "control": {
+                        "transforms": [
+                            {
+                                "html": "",
+                                "text": "Safe text",
+                                "selector": "#page > #body > .header h1",
+                            }
+                        ],
+                        "rollout_percentage": 50,
+                    },
+                    "test": {
+                        "transforms": [
+                            {
+                                "html": "<img src=x onerror=\"alert('XSS')\">",
+                                "text": '<script>alert("XSS")</script>Hello',
+                                "selector": "#page > #body > .header h1",
+                            }
+                        ],
+                        "rollout_percentage": 50,
+                    },
+                },
+            },
+            format="json",
+        )
+        response_data = response.json()
+        assert response.status_code == status.HTTP_201_CREATED, response_data
+
+        # Verify the experiment was created and XSS was sanitized
+        experiment_id = response_data["id"]
+        web_experiment = WebExperiment.objects.get(id=experiment_id)
+
+        # Check that the script tags and event handlers were removed
+        test_variant = web_experiment.variants["test"]
+        transforms = test_variant["transforms"][0]
+
+        # Script tags should be removed but safe text should remain
+        assert "<script>" not in transforms["text"]
+        assert "alert" not in transforms["text"]
+        assert "Hello" in transforms["text"]
+
+        # Event handlers should be removed but img tag may remain
+        assert "onerror" not in transforms["html"]
+        assert "alert" not in transforms["html"]

--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -326,6 +326,7 @@ class TestWebExperiment(APIBaseTest):
         web_experiment = WebExperiment.objects.get(id=experiment_id)
 
         # Check that the script tags and event handlers were removed
+        assert web_experiment.variants is not None
         test_variant = web_experiment.variants["test"]
         transforms = test_variant["transforms"][0]
 

--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -12,6 +12,7 @@ from rest_framework.request import Request
 
 from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.api.survey import nh3_clean_with_allow_list
 from posthog.api.utils import get_token
 from posthog.auth import TemporaryTokenAuthentication
 from posthog.exceptions import generate_exception_response
@@ -130,6 +131,12 @@ class WebExperimentsAPISerializer(serializers.ModelSerializer):
                         raise ValidationError(
                             f"Experiment transform [${idx}] variant '{name}' does not have a valid selector"
                         )
+
+                    # Sanitize text and html fields to prevent XSS attacks
+                    if "text" in transform and isinstance(transform["text"], str):
+                        transform["text"] = nh3_clean_with_allow_list(transform["text"])
+                    if "html" in transform and isinstance(transform["html"], str):
+                        transform["html"] = nh3_clean_with_allow_list(transform["html"])
 
         return attrs
 


### PR DESCRIPTION
## Problem

User input for `transformation` on web experiments is not properly sanitized.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Adding sanitization to the API endpoint used by the toolbar to create web experiments.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
hogli test:python posthog/api/test/test_web_experiment.py
```

![cat-type](https://github.com/user-attachments/assets/da804585-814d-4640-b183-34a976fd6ae3)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
