### PR TITLE
chore(Insights): Adding events for Add insight to dashboard modal

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -29,6 +29,7 @@ import { AddInsightToDashboardModal } from './AddInsightToDashboardModal'
 import { DashboardHeader } from './DashboardHeader'
 import { DashboardOverridesBanner } from './DashboardOverridesBanner'
 import { EmptyDashboardComponent } from './EmptyDashboardComponent'
+import { addInsightToDashboardLogic } from './addInsightToDashboardModalLogic'
 
 interface DashboardProps {
     id?: string
@@ -70,6 +71,7 @@ function DashboardScene(): JSX.Element {
         hasVariables,
     } = useValues(dashboardLogic)
     const { currentTeamId } = useValues(teamLogic)
+    const { addInsightToDashboardModalVisible } = useValues(addInsightToDashboardLogic)
     const { reportDashboardViewed, abortAnyRunningQuery } = useActions(dashboardLogic)
 
     useFileSystemLogView({
@@ -97,7 +99,7 @@ function DashboardScene(): JSX.Element {
     return (
         <SceneContent className={cn('dashboard')}>
             {placement == DashboardPlacement.Dashboard && <DashboardHeader />}
-            {canEditDashboard && <AddInsightToDashboardModal />}
+            {canEditDashboard && addInsightToDashboardModalVisible && <AddInsightToDashboardModal />}
 
             {dashboardFailedToLoad ? (
                 <InsightErrorState title="There was an error loading this dashboard" />

--- a/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModalNew.tsx
+++ b/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModalNew.tsx
@@ -1,5 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { BindLogic } from 'kea'
+import posthog from 'posthog-js'
 
 import { IconFunnels, IconPlus, IconRetention, IconTrends } from '@posthog/icons'
 
@@ -27,6 +28,17 @@ export function AddInsightToDashboardModalNew(): JSX.Element {
     const { addInsightToDashboardModalVisible, showMoreInsightTypes } = useValues(addInsightToDashboardLogic)
     const { dashboard } = useValues(dashboardLogic)
 
+    const handleClose = (): void => {
+        posthog.capture('insight dashboard modal - closed')
+        hideAddInsightToDashboardModal()
+    }
+
+    const handleNewInsightClicked = (insightType: string): void => {
+        posthog.capture('insight dashboard modal new insight clicked', {
+            insight_type: insightType,
+        })
+    }
+
     const additionalTypes = Object.entries(INSIGHT_TYPES_METADATA).filter(
         ([type, meta]) =>
             meta.inMenu &&
@@ -39,7 +51,7 @@ export function AddInsightToDashboardModalNew(): JSX.Element {
         <BindLogic logic={addSavedInsightsModalLogic} props={{}}>
             <LemonModal
                 title="Add insight to dashboard"
-                onClose={hideAddInsightToDashboardModal}
+                onClose={handleClose}
                 isOpen={addInsightToDashboardModalVisible}
                 width={860}
             >
@@ -61,6 +73,7 @@ export function AddInsightToDashboardModalNew(): JSX.Element {
                                     to={urls.insightNew({ type: type, dashboardId: dashboard?.id })}
                                     tooltip={INSIGHT_TYPES_METADATA[type]?.description}
                                     data-attr={`quick-create-${type.toLowerCase()}`}
+                                    onClick={() => handleNewInsightClicked(type)}
                                 >
                                     {label}
                                 </LemonButton>
@@ -83,6 +96,7 @@ export function AddInsightToDashboardModalNew(): JSX.Element {
                                                         dashboardId: dashboard?.id,
                                                     })}
                                                     data-attr={`create-${type.toLowerCase()}`}
+                                                    onClick={() => handleNewInsightClicked(type)}
                                                 >
                                                     {metadata.name}
                                                 </LemonButton>

--- a/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModalNew.tsx
+++ b/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModalNew.tsx
@@ -34,7 +34,7 @@ export function AddInsightToDashboardModalNew(): JSX.Element {
     }
 
     const handleNewInsightClicked = (insightType: string): void => {
-        posthog.capture('insight dashboard modal new insight clicked', {
+        posthog.capture('insight dashboard modal - new insight clicked', {
             insight_type: insightType,
         })
     }

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
@@ -1,5 +1,6 @@
 import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -149,12 +150,19 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
         setModalPage: async ({ page }) => {
             actions.setModalFilters({ page }, true)
         },
-        setModalFilters: async (_, _breakpoint, __, previousState) => {
+        setModalFilters: async (_, breakpoint, __, previousState) => {
             const oldFilters = selectors.filters(previousState)
             const newFilters = values.filters
 
             if (!objectsEqual(oldFilters, newFilters)) {
                 actions.loadInsights()
+            }
+
+            if (newFilters.search !== undefined && newFilters.search !== oldFilters.search) {
+                await breakpoint(1000)
+                posthog.capture('insight dashboard modal searched', {
+                    search_term: values.filters.search,
+                })
             }
         },
 

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
@@ -161,7 +161,7 @@ export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
             if (newFilters.search !== undefined && newFilters.search !== oldFilters.search) {
                 await breakpoint(1000)
                 posthog.capture('insight dashboard modal searched', {
-                    search_term: values.filters.search,
+                    search_term: newFilters.search,
                 })
             }
         },


### PR DESCRIPTION
## Problem

Want better tracking for  "Add Insight to Dashboard" modal, was struggling to setup insight for what I need.

## Changes

- Added PostHog event tracking for key user interactions in the dashboard modal:
  - Capturing when users close the modal
  - Tracking when users click on "New Insight" options
  - Monitoring search behavior within the modal
- Improved modal rendering logic to only show the modal when it's actually visible
- Added proper event parameters to track which insight types users select

## How did you test this code?

Manually tested the modal interactions to ensure events are properly captured in PostHog:
- Verified events fire when closing the modal
- Confirmed insight type selection events include the correct parameters
- Tested search functionality to ensure search events are captured with the correct search terms

## Publish to changelog?

No