### PR TITLE
fix(ph-ai): upsert_dashboards persists existing text cards

### DIFF
--- a/ee/hogai/tools/upsert_dashboard/test/test_tool.py
+++ b/ee/hogai/tools/upsert_dashboard/test/test_tool.py
@@ -23,6 +23,7 @@ from posthog.schema import (
 )
 
 from posthog.models import Dashboard, DashboardTile, Insight
+from posthog.models.dashboard_tile import Text
 
 from ee.hogai.artifacts.types import ModelArtifactResult
 from ee.hogai.context.context import AssistantContextManager
@@ -805,6 +806,44 @@ class TestUpsertDashboardTool(BaseTest):
         active_tiles = [t async for t in DashboardTile.objects.filter(dashboard=dashboard)]
         self.assertEqual(len(active_tiles), 3)
         self.assertEqual({t.insight_id for t in active_tiles}, {insights[k].id for k in ["A", "B", "C"]})
+
+    @parameterized.expand(
+        [
+            ("add_insight_to_dashboard_with_text", None),
+            ("replace_insights_on_dashboard_with_text", "Old Insight"),
+        ]
+    )
+    async def test_update_dashboard_preserves_text_tiles(self, _name: str, existing_insight_name: str | None):
+        dashboard = await Dashboard.objects.acreate(team=self.team, name="Dashboard", created_by=self.user)
+
+        text = await Text.objects.acreate(body="Hello World", team=self.team)
+        text_tile = await DashboardTile.objects.acreate(
+            dashboard=dashboard, text=text, layouts={"sm": {"x": 0, "y": 0, "w": 6, "h": 3}}
+        )
+
+        if existing_insight_name:
+            old_insight = await self._create_insight(existing_insight_name)
+            await DashboardTile.objects.acreate(dashboard=dashboard, insight=old_insight, layouts={})
+
+        new_insight = await self._create_insight("New Insight")
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[new_insight.short_id],
+        )
+
+        await tool._arun_impl(action)
+
+        await text_tile.arefresh_from_db()
+        self.assertFalse(text_tile.deleted)
+
+        active_tiles = [t async for t in DashboardTile.objects.filter(dashboard=dashboard)]
+        text_tiles = [t for t in active_tiles if t.text_id is not None]
+        insight_tiles = [t for t in active_tiles if t.insight_id is not None]
+        self.assertEqual(len(text_tiles), 1)
+        self.assertEqual(text_tiles[0].text_id, text.id)
+        self.assertEqual(len(insight_tiles), 1)
+        self.assertEqual(insight_tiles[0].insight_id, new_insight.id)
 
 
 class TestGetDashboardAndSortedTiles(BaseTest):

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -305,8 +305,10 @@ class UpsertDashboardTool(MaxTool):
                 active_tile_ids.add(new_tile.id)
                 tiles_to_update.append(new_tile)
 
-        # 3. Soft delete tiles not in the new list
-        tiles_to_delete = [t.id for t in all_tiles if t.id not in active_tile_ids and not t.deleted]
+        # 3. Soft delete insight tiles not in the new list (preserve text tiles)
+        tiles_to_delete = [
+            t.id for t in all_tiles if t.id not in active_tile_ids and not t.deleted and t.insight_id is not None
+        ]
         if tiles_to_delete:
             DashboardTile.objects.filter(id__in=tiles_to_delete).update(deleted=True)
 


### PR DESCRIPTION
## Problem

Text cards in dashboards were lost during `upsert_dashboard` tool calls ([slack thread](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1770682531613699)).
Text cards had `insight_id=None` so never reallyu  processed as insight-based artifacts, ending up being treated as tiles to remove. This is not good.

**Before**:

https://github.com/user-attachments/assets/3d8d8d79-b7db-48f6-8cfb-cdf3dbe5b8c4

**After**:

https://github.com/user-attachments/assets/b4b35e75-9beb-4066-94cc-b2a13eae7d8d

## Changes

* text tiles are now preserved

## How did you test this code?

- [x] manual tests
- [x] unit tests

## Publish to changelog?

Nope