### PR TITLE
fix(report_utils): move logger initialization to capture_event for correct context usage

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,7 +56,6 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
-                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -80,7 +79,6 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
-                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -97,7 +95,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND (("pmat_email" ILIKE '%g0%'
+                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/posthog/tasks/report_utils.py
+++ b/posthog/tasks/report_utils.py
@@ -15,8 +15,6 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.utils import get_machine_id
 
-logger = structlog.get_logger(__name__)
-
 
 def get_org_owner_or_first_user(organization_id: str) -> Optional[User]:
     # Find the membership object for the org owner
@@ -69,6 +67,9 @@ def capture_event(
         distinct_id = org_owner.distinct_id if org_owner and org_owner.distinct_id else f"org-{organization_id}"
 
     if is_cloud():
+        # Get logger at call time (not module import time) so it uses the correct
+        # structlog configuration in both Temporal and non-Temporal contexts
+        logger = structlog.get_logger(__name__)
         logger.info(
             "[Usage Report] Capturing usage report event",
             event_name=name,


### PR DESCRIPTION
## Problem

Logs from `capture_event()` in `posthog/tasks/report_utils.py` weren't appearing in the PostHog Logs UI when run via Temporal.

## Changes

Moved `structlog.get_logger()` from module level to inside the function so it uses the correct config when running in both Temporal/Django contexts

## How did you test this code?

Needs manual verification after deployment.

## Publish to changelog?

no
