### PR TITLE
feat(workflows): add animation for edges

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -395,456 +395,470 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
             },
         ],
     })),
-    listeners(({ values, actions }) => ({
-        onEdgesChange: ({ edges }) => {
-            actions.setEdges(applyEdgeChanges(edges, values.edges))
-        },
-        onNodesChange: ({ nodes }) => {
-            actions.setNodes(applyNodeChanges(nodes, values.nodes))
-        },
-        setAnimatingEdgePair: () => {
-            setTimeout(() => actions.clearAnimatingEdgePair(), 1500)
-        },
-
-        resetFlowFromHogFlow: ({ hogFlow }) => {
-            try {
-                const edges: HogFlowActionEdge[] = hogFlow.edges.map((edge) => {
-                    const isOnlyEdgeForNode = hogFlow.edges.filter((e) => e.from === edge.from).length === 1
-                    const edgeSourceAction = hogFlow.actions.find((action) => action.id === edge.from)
-
-                    return {
-                        // Only these values are set by the user
-                        source: edge.from,
-                        target: edge.to,
-
-                        // All other values are derived
-                        id: getEdgeId(edge),
-                        type: 'smart',
-                        deletable: false,
-                        reconnectable: false,
-                        selectable: false,
-                        focusable: false,
-                        markerEnd: {
-                            type: MarkerType.ArrowClosed,
-                        },
-                        data: {
-                            edge,
-                            label: isOnlyEdgeForNode
-                                ? undefined
-                                : edge.type === 'continue'
-                                  ? `No match`
-                                  : getBranchLabel(edgeSourceAction, edge),
-                        },
-                        labelShowBg: false,
-                        targetHandle: `target_${edge.to}`,
-                        sourceHandle:
-                            edge.type === 'continue' ? `continue_${edge.from}` : `branch_${edge.from}_${edge.index}`,
-                    }
-                })
-
-                const handlesByIdByNodeId: Record<string, Record<string, StepViewNodeHandle>> = {}
-
-                edges.forEach((edge) => {
-                    if (!handlesByIdByNodeId[edge.source]) {
-                        handlesByIdByNodeId[edge.source] = {}
-                    }
-                    if (!handlesByIdByNodeId[edge.target]) {
-                        handlesByIdByNodeId[edge.target] = {}
-                    }
-
-                    handlesByIdByNodeId[edge.source][edge.sourceHandle ?? ''] = {
-                        id: edge.sourceHandle,
-                        type: 'source',
-                        position: Position.Bottom,
-                        ...BOTTOM_HANDLE_POSITION,
-                    }
-
-                    handlesByIdByNodeId[edge.target][edge.targetHandle ?? ''] = {
-                        id: edge.targetHandle,
-                        type: 'target',
-                        position: Position.Top,
-                        ...TOP_HANDLE_POSITION,
-                    }
-                })
-
-                const nodes: HogFlowActionNode[] = hogFlow.actions.map((action: HogFlowAction) => {
-                    const step = getHogFlowStep(action, values.hogFunctionTemplatesById)
-
-                    if (!step) {
-                        // Migrate old function actions to the basic functon action type
-                        if (action.type.startsWith('function_')) {
-                            action.type = 'function'
-                        }
-                    }
-
-                    return {
-                        id: action.id,
-                        type: 'action',
-                        data: action,
-                        position: { x: 0, y: 0 },
-                        handles: Object.values(handlesByIdByNodeId[action.id] ?? {}),
-                        deletable: !['trigger', 'exit'].includes(action.type),
-                        selectable: true,
-                        draggable: false,
-                        connectable: false,
-                    }
-                })
-
-                actions.setEdges(edges)
-                actions.setNodes(nodes)
-            } catch (error) {
-                console.error('Error resetting flow from hog flow', error)
-                lemonToast.error('Error updating workflow')
-            }
-        },
-
-        setNodes: async ({ nodes }) => {
-            const formattedNodes = await getFormattedNodes(nodes, values.edges)
-
-            actions.setNodesRaw(formattedNodes)
-        },
-
-        onNodesDelete: ({ deleted }) => {
-            if (deleted.some((node) => node.id === values.selectedNodeId)) {
-                actions.setSelectedNodeId(null)
-            }
-
-            const deletedNodeIds = deleted.map((node) => node.id)
-
-            // Find all edges connected to the deleted node then reconnect them to avoid orphaned nodes
-            const updatedEdges = values.workflow.edges
-                .map((hogFlowEdge) => {
-                    if (deletedNodeIds.includes(hogFlowEdge.to)) {
-                        // Find the deleted node
-                        const deletedNode = deleted.find((node) => node.id === hogFlowEdge.to)
-                        if (deletedNode) {
-                            // Find the first outgoer of the deleted node
-                            const outgoers = getOutgoers(deletedNode, values.nodes, values.edges)
-                            if (outgoers.length > 0) {
-                                // Change target to the first outgoer
-                                return {
-                                    ...hogFlowEdge,
-                                    to: outgoers[0].id,
-                                }
-                            }
-                        }
-                    }
-                    return hogFlowEdge
-                })
-                .filter(
-                    (hogFlowEdge) =>
-                        !deletedNodeIds.includes(hogFlowEdge.from) && !deletedNodeIds.includes(hogFlowEdge.to)
-                )
-
-            // Update workflow actions to match the new flow
-            const updatedActions = values.workflow.actions.filter((action) => !deletedNodeIds.includes(action.id))
-
-            actions.setWorkflowInfo({ actions: updatedActions, edges: updatedEdges })
-        },
-
-        showDropzones: () => {
-            const { nodes, edges, isMovingNode, movingNodeId } = values
-
-            const dropzoneNodes: DropzoneNode[] = []
-
-            const skipEdgeIds: Set<string> = new Set()
-            if (isMovingNode && movingNodeId) {
-                const incomingEdges = edges.filter((e) => e.target === movingNodeId)
-                const outgoingEdges = edges.filter((e) => e.source === movingNodeId)
-                // Only skip in the simple linear case (1 incoming, 1 outgoing)
-                // where placing on adjacent edges would result in the same position
-                if (incomingEdges.length === 1 && outgoingEdges.length === 1) {
-                    skipEdgeIds.add(incomingEdges[0].id)
-                    skipEdgeIds.add(outgoingEdges[0].id)
+    listeners(({ values, actions }) => {
+        let animationTimeout: ReturnType<typeof setTimeout> | null = null
+        return {
+            onEdgesChange: ({ edges }) => {
+                actions.setEdges(applyEdgeChanges(edges, values.edges))
+            },
+            onNodesChange: ({ nodes }) => {
+                actions.setNodes(applyNodeChanges(nodes, values.nodes))
+            },
+            setAnimatingEdgePair: () => {
+                if (animationTimeout) {
+                    clearTimeout(animationTimeout)
                 }
-            }
+                animationTimeout = setTimeout(() => {
+                    animationTimeout = null
+                    actions.clearAnimatingEdgePair()
+                }, 1500)
+            },
 
-            edges.forEach((edge) => {
-                if (skipEdgeIds.has(edge.id)) {
-                    return
-                }
-                const sourceNode = nodes.find((n) => n.id === edge.source)
-                const targetNode = nodes.find((n) => n.id === edge.target)
+            resetFlowFromHogFlow: ({ hogFlow }) => {
+                try {
+                    const edges: HogFlowActionEdge[] = hogFlow.edges.map((edge) => {
+                        const isOnlyEdgeForNode = hogFlow.edges.filter((e) => e.from === edge.from).length === 1
+                        const edgeSourceAction = hogFlow.actions.find((action) => action.id === edge.from)
 
-                if (sourceNode && targetNode) {
-                    const sourceHandle = sourceNode.handles?.find((h) => h.id === edge.sourceHandle)
-                    const targetHandle = targetNode.handles?.find((h) => h.id === edge.targetHandle)
+                        return {
+                            // Only these values are set by the user
+                            source: edge.from,
+                            target: edge.to,
 
-                    const [, labelX, labelY] = getSmartStepPath({
-                        sourceX: sourceNode.position.x + (sourceHandle?.x || 0),
-                        sourceY: sourceNode.position.y + (sourceHandle?.y || 0),
-                        targetX: targetNode.position.x + (targetHandle?.x || 0),
-                        targetY: targetNode.position.y + (targetHandle?.y || 0),
-                        edges,
-                        currentEdgeId: edge.id,
-                    })
-
-                    dropzoneNodes.push({
-                        id: `dropzone_edge_${edge.id}`,
-                        type: 'dropzone',
-                        position: { x: labelX - NODE_WIDTH / 2, y: labelY - NODE_HEIGHT / 2 },
-                        data: {
-                            edge,
-                        },
-                        draggable: false,
-                        selectable: false,
-                    })
-
-                    // If this branch edge has same target as other edges, we also add a single dropzone near the target node
-                    const hasSiblingEdges = edges.filter((e) => e.data?.edge.to === edge.target).length > 1
-                    if (edge.data?.edge.type === 'branch' && hasSiblingEdges) {
-                        // Use an ID that we can consistently look up for the branch join point to avoid duplicate dropzones
-                        const branchJoinDropzoneTargetId = `dropzone_target_${edge.target}_branch_join`
-                        // Avoid duplicating dropzones for multiple branch edges to the same target
-                        if (dropzoneNodes.find((n) => n.id === branchJoinDropzoneTargetId)) {
-                            return
-                        }
-
-                        // For branch edges, we also add a dropzone near the target node to allow easier dropping
-                        dropzoneNodes.push({
-                            id: branchJoinDropzoneTargetId,
-                            type: 'dropzone',
-                            position: {
-                                x: targetNode.position.x,
-                                y: targetNode.position.y - NODE_HEIGHT,
+                            // All other values are derived
+                            id: getEdgeId(edge),
+                            type: 'smart',
+                            deletable: false,
+                            reconnectable: false,
+                            selectable: false,
+                            focusable: false,
+                            markerEnd: {
+                                type: MarkerType.ArrowClosed,
                             },
                             data: {
                                 edge,
-                                isBranchJoinDropzone: true,
+                                label: isOnlyEdgeForNode
+                                    ? undefined
+                                    : edge.type === 'continue'
+                                      ? `No match`
+                                      : getBranchLabel(edgeSourceAction, edge),
+                            },
+                            labelShowBg: false,
+                            targetHandle: `target_${edge.to}`,
+                            sourceHandle:
+                                edge.type === 'continue'
+                                    ? `continue_${edge.from}`
+                                    : `branch_${edge.from}_${edge.index}`,
+                        }
+                    })
+
+                    const handlesByIdByNodeId: Record<string, Record<string, StepViewNodeHandle>> = {}
+
+                    edges.forEach((edge) => {
+                        if (!handlesByIdByNodeId[edge.source]) {
+                            handlesByIdByNodeId[edge.source] = {}
+                        }
+                        if (!handlesByIdByNodeId[edge.target]) {
+                            handlesByIdByNodeId[edge.target] = {}
+                        }
+
+                        handlesByIdByNodeId[edge.source][edge.sourceHandle ?? ''] = {
+                            id: edge.sourceHandle,
+                            type: 'source',
+                            position: Position.Bottom,
+                            ...BOTTOM_HANDLE_POSITION,
+                        }
+
+                        handlesByIdByNodeId[edge.target][edge.targetHandle ?? ''] = {
+                            id: edge.targetHandle,
+                            type: 'target',
+                            position: Position.Top,
+                            ...TOP_HANDLE_POSITION,
+                        }
+                    })
+
+                    const nodes: HogFlowActionNode[] = hogFlow.actions.map((action: HogFlowAction) => {
+                        const step = getHogFlowStep(action, values.hogFunctionTemplatesById)
+
+                        if (!step) {
+                            // Migrate old function actions to the basic functon action type
+                            if (action.type.startsWith('function_')) {
+                                action.type = 'function'
+                            }
+                        }
+
+                        return {
+                            id: action.id,
+                            type: 'action',
+                            data: action,
+                            position: { x: 0, y: 0 },
+                            handles: Object.values(handlesByIdByNodeId[action.id] ?? {}),
+                            deletable: !['trigger', 'exit'].includes(action.type),
+                            selectable: true,
+                            draggable: false,
+                            connectable: false,
+                        }
+                    })
+
+                    actions.setEdges(edges)
+                    actions.setNodes(nodes)
+                } catch (error) {
+                    console.error('Error resetting flow from hog flow', error)
+                    lemonToast.error('Error updating workflow')
+                }
+            },
+
+            setNodes: async ({ nodes }) => {
+                const formattedNodes = await getFormattedNodes(nodes, values.edges)
+
+                actions.setNodesRaw(formattedNodes)
+            },
+
+            onNodesDelete: ({ deleted }) => {
+                if (deleted.some((node) => node.id === values.selectedNodeId)) {
+                    actions.setSelectedNodeId(null)
+                }
+
+                const deletedNodeIds = deleted.map((node) => node.id)
+
+                // Find all edges connected to the deleted node then reconnect them to avoid orphaned nodes
+                const updatedEdges = values.workflow.edges
+                    .map((hogFlowEdge) => {
+                        if (deletedNodeIds.includes(hogFlowEdge.to)) {
+                            // Find the deleted node
+                            const deletedNode = deleted.find((node) => node.id === hogFlowEdge.to)
+                            if (deletedNode) {
+                                // Find the first outgoer of the deleted node
+                                const outgoers = getOutgoers(deletedNode, values.nodes, values.edges)
+                                if (outgoers.length > 0) {
+                                    // Change target to the first outgoer
+                                    return {
+                                        ...hogFlowEdge,
+                                        to: outgoers[0].id,
+                                    }
+                                }
+                            }
+                        }
+                        return hogFlowEdge
+                    })
+                    .filter(
+                        (hogFlowEdge) =>
+                            !deletedNodeIds.includes(hogFlowEdge.from) && !deletedNodeIds.includes(hogFlowEdge.to)
+                    )
+
+                // Update workflow actions to match the new flow
+                const updatedActions = values.workflow.actions.filter((action) => !deletedNodeIds.includes(action.id))
+
+                actions.setWorkflowInfo({ actions: updatedActions, edges: updatedEdges })
+            },
+
+            showDropzones: () => {
+                const { nodes, edges, isMovingNode, movingNodeId } = values
+
+                const dropzoneNodes: DropzoneNode[] = []
+
+                const skipEdgeIds: Set<string> = new Set()
+                if (isMovingNode && movingNodeId) {
+                    const incomingEdges = edges.filter((e) => e.target === movingNodeId)
+                    const outgoingEdges = edges.filter((e) => e.source === movingNodeId)
+                    // Only skip in the simple linear case (1 incoming, 1 outgoing)
+                    // where placing on adjacent edges would result in the same position
+                    if (incomingEdges.length === 1 && outgoingEdges.length === 1) {
+                        skipEdgeIds.add(incomingEdges[0].id)
+                        skipEdgeIds.add(outgoingEdges[0].id)
+                    }
+                }
+
+                edges.forEach((edge) => {
+                    if (skipEdgeIds.has(edge.id)) {
+                        return
+                    }
+                    const sourceNode = nodes.find((n) => n.id === edge.source)
+                    const targetNode = nodes.find((n) => n.id === edge.target)
+
+                    if (sourceNode && targetNode) {
+                        const sourceHandle = sourceNode.handles?.find((h) => h.id === edge.sourceHandle)
+                        const targetHandle = targetNode.handles?.find((h) => h.id === edge.targetHandle)
+
+                        const [, labelX, labelY] = getSmartStepPath({
+                            sourceX: sourceNode.position.x + (sourceHandle?.x || 0),
+                            sourceY: sourceNode.position.y + (sourceHandle?.y || 0),
+                            targetX: targetNode.position.x + (targetHandle?.x || 0),
+                            targetY: targetNode.position.y + (targetHandle?.y || 0),
+                            edges,
+                            currentEdgeId: edge.id,
+                        })
+
+                        dropzoneNodes.push({
+                            id: `dropzone_edge_${edge.id}`,
+                            type: 'dropzone',
+                            position: { x: labelX - NODE_WIDTH / 2, y: labelY - NODE_HEIGHT / 2 },
+                            data: {
+                                edge,
                             },
                             draggable: false,
                             selectable: false,
                         })
+
+                        // If this branch edge has same target as other edges, we also add a single dropzone near the target node
+                        const hasSiblingEdges = edges.filter((e) => e.data?.edge.to === edge.target).length > 1
+                        if (edge.data?.edge.type === 'branch' && hasSiblingEdges) {
+                            // Use an ID that we can consistently look up for the branch join point to avoid duplicate dropzones
+                            const branchJoinDropzoneTargetId = `dropzone_target_${edge.target}_branch_join`
+                            // Avoid duplicating dropzones for multiple branch edges to the same target
+                            if (dropzoneNodes.find((n) => n.id === branchJoinDropzoneTargetId)) {
+                                return
+                            }
+
+                            // For branch edges, we also add a dropzone near the target node to allow easier dropping
+                            dropzoneNodes.push({
+                                id: branchJoinDropzoneTargetId,
+                                type: 'dropzone',
+                                position: {
+                                    x: targetNode.position.x,
+                                    y: targetNode.position.y - NODE_HEIGHT,
+                                },
+                                data: {
+                                    edge,
+                                    isBranchJoinDropzone: true,
+                                },
+                                draggable: false,
+                                selectable: false,
+                            })
+                        }
                     }
-                }
-            })
-
-            actions.setDropzoneNodes(dropzoneNodes)
-        },
-
-        hideDropzones: () => {
-            actions.setDropzoneNodes([])
-        },
-
-        onDragOver: ({ event }) => {
-            event.preventDefault()
-            event.dataTransfer.dropEffect = 'move'
-        },
-
-        onDrop: ({ event }) => {
-            event?.preventDefault()
-            const dropzoneNode = values.dropzoneNodes.find((x) => x.id === values.highlightedDropzoneNodeId)
-
-            if (values.nodeToBeAdded && dropzoneNode) {
-                const edgeToInsertNodeInto = dropzoneNode?.data.edge
-
-                // Check if nodeToBeAdded is a HogFlowActionNode (has 'data' property) or CreateActionType
-                const isHogFlowActionNode = 'data' in values.nodeToBeAdded
-                const partialNewAction = isHogFlowActionNode
-                    ? (values.nodeToBeAdded as HogFlowActionNode).data
-                    : (values.nodeToBeAdded as CreateActionType)
-
-                const newAction = {
-                    id: isHogFlowActionNode
-                        ? (values.nodeToBeAdded as HogFlowActionNode).id
-                        : `action_${partialNewAction.type}_${uuid()}`,
-                    type: partialNewAction.type,
-                    name: partialNewAction.name,
-                    description: partialNewAction.description,
-                    config: partialNewAction.config,
-                    created_at: Date.now(),
-                    updated_at: Date.now(),
-                } as HogFlowAction
-
-                const step = getHogFlowStep(newAction, values.hogFunctionTemplatesById)
-
-                const branchEdges = isHogFlowActionNode ? 0 : ((partialNewAction as CreateActionType).branchEdges ?? 0)
-                const isBranchJoinDropzone = dropzoneNode?.data.isBranchJoinDropzone ?? false
-
-                if (!step) {
-                    throw new Error(`Step not found for action type: ${newAction}`)
-                }
-
-                let edgesToBeReplacedIndexes = []
-
-                if (isBranchJoinDropzone) {
-                    // There are multiple edges that need to be replaced here to join the branches on new node
-
-                    /**
-                     * If isBranchJoinDropzone is set, we know to connect this new node on top with all previous target's sources
-                     * and below with the original edges' shared target
-                     */
-                    edgesToBeReplacedIndexes = values.workflow.edges
-                        .map((edge, index) => ({
-                            edge,
-                            index,
-                        }))
-                        .filter(({ edge }) => edge.to === edgeToInsertNodeInto.target)
-                        .map(({ index }) => index)
-                } else {
-                    // There is just the one *very specific* (i.e. getEdgeId must be used) target edge that needs to be replaced
-                    edgesToBeReplacedIndexes = [
-                        values.workflow.edges.findIndex((edge) => getEdgeId(edge) === edgeToInsertNodeInto.id),
-                    ]
-                }
-
-                if (edgesToBeReplacedIndexes.length === 0) {
-                    throw new Error('Edge to be replaced not found')
-                }
-
-                // We add the new action with two new edges - the continue edge and the target edge
-                // We also then check for any other missing edges based on the type of edge being replaced
-
-                const newEdges: HogFlow['edges'] = [...values.workflow.edges]
-
-                // First remove the edge to be replaced
-                const edgesToBeReplaced = edgesToBeReplacedIndexes.map((index) => values.workflow.edges[index])
-
-                // Sort indexes in descending order to avoid index shifting during removal
-                edgesToBeReplacedIndexes
-                    .sort((a, b) => b - a)
-                    .forEach((index) => {
-                        newEdges.splice(index, 1)
-                    })
-
-                for (const edgeToBeReplaced of edgesToBeReplaced) {
-                    // Push the source edge first
-                    newEdges.push({
-                        ...edgeToBeReplaced,
-                        to: newAction.id,
-                    })
-                }
-
-                // Then any branch edges (once, not per incoming edge)
-                for (let i = 0; i < branchEdges; i++) {
-                    // Add in branching edges
-                    newEdges.push({
-                        ...edgesToBeReplaced[0],
-                        index: i,
-                        type: 'branch',
-                        from: newAction.id,
-                    })
-                }
-
-                // Finally the last continue edge
-                newEdges.push({
-                    ...edgesToBeReplaced[0],
-                    index: undefined,
-                    type: 'continue',
-                    from: newAction.id,
                 })
 
-                const oldActions = values.workflow.actions
-                const newActions = [...oldActions.slice(0, -1), newAction, oldActions[oldActions.length - 1]]
+                actions.setDropzoneNodes(dropzoneNodes)
+            },
 
-                actions.setWorkflowInfo({ actions: newActions, edges: newEdges })
-                actions.setNodeToBeAdded(null)
-                actions.setSelectedNodeId(newAction.id)
-            }
-            // We can clear the dropzones now
-            actions.hideDropzones()
-        },
-        setReactFlowInstance: () => {
-            // TRICKY: Slight race condition here where the react flow instance is not set yet
-            setTimeout(() => {
-                actions.fitView({ duration: 0 })
-            }, 100)
-        },
-        setSelectedNodeId: ({ selectedNodeId }) => {
-            if (selectedNodeId) {
-                actions.fitView({ noZoom: true })
-            }
-        },
-        fitView: ({ duration, noZoom }) => {
-            const { reactFlowWrapper, reactFlowInstance } = values
-            if (!reactFlowWrapper?.current || !reactFlowInstance) {
-                return
-            }
-            // This is a rough estimate which we could improve by getting from the actual panel
-            const PANEL_WIDTH = 580
-            // Get the width of the wrapper
-            const wrapperWidth = reactFlowWrapper.current.getBoundingClientRect()?.width ?? 0
-            // Get the width of the thing we are going to fit to the view
-            const nodesWidth =
-                reactFlowInstance.getNodesBounds(values.selectedNode ? [values.selectedNode] : values.nodes)?.width ?? 0
-            // Adjust the width for the zoom factor to be relative to the wrapper width
-            const nodesWidthAdjusted = nodesWidth * reactFlowInstance.getZoom()
-            // Calculate the padding right to fit the panel width to the wrapper width
-            // Looks complicated but its basically the difference between the wrapper width and the nodes width adjusted for the zoom factor
-            const paddingRight = wrapperWidth - nodesWidthAdjusted / 2 - (wrapperWidth - PANEL_WIDTH) / 2
+            hideDropzones: () => {
+                actions.setDropzoneNodes([])
+            },
 
-            reactFlowInstance.fitView({
-                padding: {
-                    right: `${paddingRight}px`,
-                },
-                maxZoom: noZoom ? reactFlowInstance.getZoom() : undefined,
-                minZoom: noZoom ? reactFlowInstance.getZoom() : undefined,
-                nodes: values.selectedNode ? [values.selectedNode] : values.nodes,
-                duration: duration ?? 100,
-            })
-        },
-        startCopyingNode: () => {
-            actions.showDropzones()
-        },
-        stopCopyingNode: () => {
-            actions.hideDropzones()
-        },
-        copyNodeToHighlightedDropzone: () => {
-            actions.onDrop()
-            actions.stopCopyingNode()
-        },
-        startMovingNode: () => {
-            actions.showDropzones()
-        },
-        stopMovingNode: () => {
-            actions.hideDropzones()
-        },
-        moveNodeToHighlightedDropzone: () => {
-            // Uses computeMoveEdges (pure function) to manipulate edges in a single
-            // setWorkflowInfo call rather than onNodesDelete + onDrop (like copy does).
-            // This preserves node identity and avoids a race condition where two async
-            // layout computations from separate setWorkflowInfo calls complete out of order.
-            const movingNodeId = values.movingNodeId!
-            const dropzoneNode = values.dropzoneNodes.find((x) => x.id === values.highlightedDropzoneNodeId)
-            if (!dropzoneNode) {
-                actions.stopMovingNode()
-                return
-            }
+            onDragOver: ({ event }) => {
+                event.preventDefault()
+                event.dataTransfer.dropEffect = 'move'
+            },
 
-            const targetHogFlowEdge = dropzoneNode.data.edge.data?.edge
-            if (!targetHogFlowEdge) {
-                actions.stopMovingNode()
-                return
-            }
+            onDrop: ({ event }) => {
+                event?.preventDefault()
+                const dropzoneNode = values.dropzoneNodes.find((x) => x.id === values.highlightedDropzoneNodeId)
 
-            const isBranchJoinDropzone = dropzoneNode.data.isBranchJoinDropzone ?? false
-            const newEdges = computeMoveEdges(
-                values.workflow.edges,
-                movingNodeId,
-                targetHogFlowEdge,
-                isBranchJoinDropzone
-            )
+                if (values.nodeToBeAdded && dropzoneNode) {
+                    const edgeToInsertNodeInto = dropzoneNode?.data.edge
 
-            if (!newEdges) {
-                actions.stopMovingNode()
-                return
-            }
+                    // Check if nodeToBeAdded is a HogFlowActionNode (has 'data' property) or CreateActionType
+                    const isHogFlowActionNode = 'data' in values.nodeToBeAdded
+                    const partialNewAction = isHogFlowActionNode
+                        ? (values.nodeToBeAdded as HogFlowActionNode).data
+                        : (values.nodeToBeAdded as CreateActionType)
 
-            actions.setWorkflowInfo({ actions: values.workflow.actions, edges: newEdges })
-            actions.setSelectedNodeId(movingNodeId)
-            actions.hideDropzones()
-            actions.stopMovingNode()
-        },
-        handlePaneClick: () => {
-            actions.setSelectedNodeId(null)
-            if (values.isCopyingNode) {
+                    const newAction = {
+                        id: isHogFlowActionNode
+                            ? (values.nodeToBeAdded as HogFlowActionNode).id
+                            : `action_${partialNewAction.type}_${uuid()}`,
+                        type: partialNewAction.type,
+                        name: partialNewAction.name,
+                        description: partialNewAction.description,
+                        config: partialNewAction.config,
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                    } as HogFlowAction
+
+                    const step = getHogFlowStep(newAction, values.hogFunctionTemplatesById)
+
+                    const branchEdges = isHogFlowActionNode
+                        ? 0
+                        : ((partialNewAction as CreateActionType).branchEdges ?? 0)
+                    const isBranchJoinDropzone = dropzoneNode?.data.isBranchJoinDropzone ?? false
+
+                    if (!step) {
+                        throw new Error(`Step not found for action type: ${newAction}`)
+                    }
+
+                    let edgesToBeReplacedIndexes = []
+
+                    if (isBranchJoinDropzone) {
+                        // There are multiple edges that need to be replaced here to join the branches on new node
+
+                        /**
+                         * If isBranchJoinDropzone is set, we know to connect this new node on top with all previous target's sources
+                         * and below with the original edges' shared target
+                         */
+                        edgesToBeReplacedIndexes = values.workflow.edges
+                            .map((edge, index) => ({
+                                edge,
+                                index,
+                            }))
+                            .filter(({ edge }) => edge.to === edgeToInsertNodeInto.target)
+                            .map(({ index }) => index)
+                    } else {
+                        // There is just the one *very specific* (i.e. getEdgeId must be used) target edge that needs to be replaced
+                        edgesToBeReplacedIndexes = [
+                            values.workflow.edges.findIndex((edge) => getEdgeId(edge) === edgeToInsertNodeInto.id),
+                        ]
+                    }
+
+                    if (edgesToBeReplacedIndexes.length === 0) {
+                        throw new Error('Edge to be replaced not found')
+                    }
+
+                    // We add the new action with two new edges - the continue edge and the target edge
+                    // We also then check for any other missing edges based on the type of edge being replaced
+
+                    const newEdges: HogFlow['edges'] = [...values.workflow.edges]
+
+                    // First remove the edge to be replaced
+                    const edgesToBeReplaced = edgesToBeReplacedIndexes.map((index) => values.workflow.edges[index])
+
+                    // Sort indexes in descending order to avoid index shifting during removal
+                    edgesToBeReplacedIndexes
+                        .sort((a, b) => b - a)
+                        .forEach((index) => {
+                            newEdges.splice(index, 1)
+                        })
+
+                    for (const edgeToBeReplaced of edgesToBeReplaced) {
+                        // Push the source edge first
+                        newEdges.push({
+                            ...edgeToBeReplaced,
+                            to: newAction.id,
+                        })
+                    }
+
+                    // Then any branch edges (once, not per incoming edge)
+                    for (let i = 0; i < branchEdges; i++) {
+                        // Add in branching edges
+                        newEdges.push({
+                            ...edgesToBeReplaced[0],
+                            index: i,
+                            type: 'branch',
+                            from: newAction.id,
+                        })
+                    }
+
+                    // Finally the last continue edge
+                    newEdges.push({
+                        ...edgesToBeReplaced[0],
+                        index: undefined,
+                        type: 'continue',
+                        from: newAction.id,
+                    })
+
+                    const oldActions = values.workflow.actions
+                    const newActions = [...oldActions.slice(0, -1), newAction, oldActions[oldActions.length - 1]]
+
+                    actions.setWorkflowInfo({ actions: newActions, edges: newEdges })
+                    actions.setNodeToBeAdded(null)
+                    actions.setSelectedNodeId(newAction.id)
+                }
+                // We can clear the dropzones now
+                actions.hideDropzones()
+            },
+            setReactFlowInstance: () => {
+                // TRICKY: Slight race condition here where the react flow instance is not set yet
+                setTimeout(() => {
+                    actions.fitView({ duration: 0 })
+                }, 100)
+            },
+            setSelectedNodeId: ({ selectedNodeId }) => {
+                if (selectedNodeId) {
+                    actions.fitView({ noZoom: true })
+                }
+            },
+            fitView: ({ duration, noZoom }) => {
+                const { reactFlowWrapper, reactFlowInstance } = values
+                if (!reactFlowWrapper?.current || !reactFlowInstance) {
+                    return
+                }
+                // This is a rough estimate which we could improve by getting from the actual panel
+                const PANEL_WIDTH = 580
+                // Get the width of the wrapper
+                const wrapperWidth = reactFlowWrapper.current.getBoundingClientRect()?.width ?? 0
+                // Get the width of the thing we are going to fit to the view
+                const nodesWidth =
+                    reactFlowInstance.getNodesBounds(values.selectedNode ? [values.selectedNode] : values.nodes)
+                        ?.width ?? 0
+                // Adjust the width for the zoom factor to be relative to the wrapper width
+                const nodesWidthAdjusted = nodesWidth * reactFlowInstance.getZoom()
+                // Calculate the padding right to fit the panel width to the wrapper width
+                // Looks complicated but its basically the difference between the wrapper width and the nodes width adjusted for the zoom factor
+                const paddingRight = wrapperWidth - nodesWidthAdjusted / 2 - (wrapperWidth - PANEL_WIDTH) / 2
+
+                reactFlowInstance.fitView({
+                    padding: {
+                        right: `${paddingRight}px`,
+                    },
+                    maxZoom: noZoom ? reactFlowInstance.getZoom() : undefined,
+                    minZoom: noZoom ? reactFlowInstance.getZoom() : undefined,
+                    nodes: values.selectedNode ? [values.selectedNode] : values.nodes,
+                    duration: duration ?? 100,
+                })
+            },
+            startCopyingNode: () => {
+                actions.showDropzones()
+            },
+            stopCopyingNode: () => {
+                actions.hideDropzones()
+            },
+            copyNodeToHighlightedDropzone: () => {
+                actions.onDrop()
                 actions.stopCopyingNode()
-            }
-            if (values.isMovingNode) {
+            },
+            startMovingNode: () => {
+                actions.showDropzones()
+            },
+            stopMovingNode: () => {
+                actions.hideDropzones()
+            },
+            moveNodeToHighlightedDropzone: () => {
+                // Uses computeMoveEdges (pure function) to manipulate edges in a single
+                // setWorkflowInfo call rather than onNodesDelete + onDrop (like copy does).
+                // This preserves node identity and avoids a race condition where two async
+                // layout computations from separate setWorkflowInfo calls complete out of order.
+                const movingNodeId = values.movingNodeId!
+                const dropzoneNode = values.dropzoneNodes.find((x) => x.id === values.highlightedDropzoneNodeId)
+                if (!dropzoneNode) {
+                    actions.stopMovingNode()
+                    return
+                }
+
+                const targetHogFlowEdge = dropzoneNode.data.edge.data?.edge
+                if (!targetHogFlowEdge) {
+                    actions.stopMovingNode()
+                    return
+                }
+
+                const isBranchJoinDropzone = dropzoneNode.data.isBranchJoinDropzone ?? false
+                const newEdges = computeMoveEdges(
+                    values.workflow.edges,
+                    movingNodeId,
+                    targetHogFlowEdge,
+                    isBranchJoinDropzone
+                )
+
+                if (!newEdges) {
+                    actions.stopMovingNode()
+                    return
+                }
+
+                actions.setWorkflowInfo({ actions: values.workflow.actions, edges: newEdges })
+                actions.setSelectedNodeId(movingNodeId)
+                actions.hideDropzones()
                 actions.stopMovingNode()
-            }
-        },
-    })),
+            },
+            handlePaneClick: () => {
+                actions.setSelectedNodeId(null)
+                if (values.isCopyingNode) {
+                    actions.stopCopyingNode()
+                }
+                if (values.isMovingNode) {
+                    actions.stopMovingNode()
+                }
+            },
+        }
+    }),
 
     subscriptions(({ actions }) => ({
         workflow: (hogFlow?: HogFlow) => {

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -184,6 +184,8 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
         setNodeToBeAdded: (nodeToBeAdded: CreateActionType | HogFlowActionNode | null) => ({ nodeToBeAdded }),
         setHighlightedDropzoneNodeId: (highlightedDropzoneNodeId: string | null) => ({ highlightedDropzoneNodeId }),
         setMode: (mode: HogFlowEditorMode) => ({ mode }),
+        setAnimatingEdgePair: (from: string, to: string) => ({ from, to }),
+        clearAnimatingEdgePair: true,
         startCopyingNode: (node: HogFlowActionNode) => ({ node }),
         stopCopyingNode: true,
         copyNodeToHighlightedDropzone: true,
@@ -272,6 +274,15 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
             null as RefObject<HTMLDivElement> | null,
             {
                 setReactFlowWrapper: (_, { reactFlowWrapper }) => reactFlowWrapper,
+            },
+        ],
+        animatingEdgePair: [
+            null as string | null,
+            {
+                setAnimatingEdgePair: (_: string | null, { from, to }: { from: string; to: string }) =>
+                    `${from}->${to}`,
+                clearAnimatingEdgePair: () => null,
+                setMode: () => null,
             },
         ],
     })),
@@ -390,6 +401,9 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
         },
         onNodesChange: ({ nodes }) => {
             actions.setNodes(applyNodeChanges(nodes, values.nodes))
+        },
+        setAnimatingEdgePair: () => {
+            setTimeout(() => actions.clearAnimatingEdgePair(), 1500)
         },
 
         resetFlowFromHogFlow: ({ hogFlow }) => {

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
@@ -122,7 +122,7 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
             hogFlowEditorLogic,
             ['selectedNodeId'],
         ],
-        actions: [hogFlowEditorLogic, ['setSelectedNodeId']],
+        actions: [hogFlowEditorLogic, ['setSelectedNodeId', 'setAnimatingEdgePair']],
     })),
     actions({
         setTestResult: (testResult: HogflowTestResult | null) => ({ testResult }),
@@ -531,6 +531,11 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
         },
     })),
     listeners(({ values, actions }) => ({
+        setTestResult: ({ testResult }) => {
+            if (testResult?.nextActionId && values.selectedNodeId) {
+                actions.setAnimatingEdgePair(values.selectedNodeId, testResult.nextActionId)
+            }
+        },
         loadSampleGlobalsSuccess: () => {
             actions.setTestInvocationValue('globals', JSON.stringify(values.sampleGlobals, null, 2))
         },

--- a/products/workflows/frontend/Workflows/hogflows/react_flow_utils/SmartEdge.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/react_flow_utils/SmartEdge.tsx
@@ -1,7 +1,10 @@
 import { BaseEdge, Edge, EdgeLabelRenderer, EdgeProps, useEdges } from '@xyflow/react'
+import { useValues } from 'kea'
+import { useEffect, useRef } from 'react'
 
 import { LemonTag } from '@posthog/lemon-ui'
 
+import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { HogFlowEdge } from '../types'
 import { MINIMUM_EDGE_SPACING } from './constants'
 
@@ -214,8 +217,12 @@ function getPointAtYValue(pathString: string, distance: number, targetY?: number
     }
 }
 
+const ANIMATION_DURATION_S = 1.5
+
 export function SmartEdge({
     id,
+    source,
+    target,
     sourceX,
     sourceY,
     targetX,
@@ -228,6 +235,10 @@ export function SmartEdge({
     ...props
 }: EdgeProps): JSX.Element {
     const edges = useEdges()
+    const { animatingEdgePair, mode } = useValues(hogFlowEditorLogic)
+
+    const isAnimating = mode === 'test' && animatingEdgePair === `${source}->${target}`
+    const animPathRef = useRef<SVGPathElement>(null)
 
     // Use the programmatic function to get the smart step path
     const [edgePath] = getSmartStepPath({
@@ -239,11 +250,36 @@ export function SmartEdge({
         currentEdgeId: id,
     })
 
+    useEffect(() => {
+        if (isAnimating && animPathRef.current) {
+            animPathRef.current.animate(
+                [
+                    { strokeDashoffset: '1', opacity: 0.8 },
+                    { strokeDashoffset: '0', opacity: 0.8, offset: 0.7 },
+                    { strokeDashoffset: '0', opacity: 0 },
+                ],
+                { duration: ANIMATION_DURATION_S * 1000, easing: 'ease-out', fill: 'forwards' }
+            )
+        }
+    }, [isAnimating, edgePath])
+
     const labelPoint = getPointAtYValue(edgePath, 20, sourceY + 20)
 
     return (
         <>
             <BaseEdge {...props} path={edgePath} markerEnd={markerEnd} markerStart={markerStart} />
+            {isAnimating && (
+                <path
+                    ref={animPathRef}
+                    d={edgePath}
+                    pathLength={1}
+                    stroke="var(--success)"
+                    strokeWidth={1.5}
+                    fill="none"
+                    strokeDasharray={1}
+                    strokeDashoffset={1}
+                />
+            )}
             <EdgeLabelRenderer>
                 {data?.label ? (
                     <EdgeLabel

--- a/products/workflows/frontend/Workflows/hogflows/react_flow_utils/SmartEdge.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/react_flow_utils/SmartEdge.tsx
@@ -251,8 +251,9 @@ export function SmartEdge({
     })
 
     useEffect(() => {
+        let animation: Animation | null = null
         if (isAnimating && animPathRef.current) {
-            animPathRef.current.animate(
+            animation = animPathRef.current.animate(
                 [
                     { strokeDashoffset: '1', opacity: 0.8 },
                     { strokeDashoffset: '0', opacity: 0.8, offset: 0.7 },
@@ -261,6 +262,7 @@ export function SmartEdge({
                 { duration: ANIMATION_DURATION_S * 1000, easing: 'ease-out', fill: 'forwards' }
             )
         }
+        return () => animation?.cancel()
     }, [isAnimating, edgePath])
 
     const labelPoint = getPointAtYValue(edgePath, 20, sourceY + 20)

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -18,8 +18,14 @@ import { StepViewMetrics } from './StepViewMetrics'
 import { StepViewLogicProps, stepViewLogic } from './stepViewLogic'
 
 export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
-    const { selectedNode, mode, nodesById, selectedNodeCanBeDeleted, selectedNodeCanBeCopiedOrMoved } =
-        useValues(hogFlowEditorLogic)
+    const {
+        selectedNode,
+        mode,
+        nodesById,
+        selectedNodeCanBeDeleted,
+        selectedNodeCanBeCopiedOrMoved,
+        animatingEdgePair,
+    } = useValues(hogFlowEditorLogic)
     const { setSelectedNodeId, startCopyingNode, startMovingNode } = useActions(hogFlowEditorLogic)
     const { actionValidationErrorsById, logicProps } = useValues(workflowLogic)
     const { deleteElements } = useReactFlow()
@@ -61,15 +67,16 @@ export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
     }, [action, isSelected, Step])
 
     const hasValidationError = actionValidationErrorsById[action.id]?.valid === false
+    const isAnimationTarget = mode === 'test' && animatingEdgePair?.endsWith(`->${action.id}`)
 
     return (
         <div
-            className="relative flex flex-col cursor-pointer rounded user-select-none bg-surface-primary"
+            className="relative flex flex-col cursor-pointer rounded user-select-none bg-surface-primary transition-[border-color] duration-300"
             style={{
                 width: NODE_WIDTH,
                 height,
                 borderWidth: 1,
-                borderColor: selectedColor,
+                borderColor: isAnimationTarget ? 'var(--success)' : selectedColor,
                 boxShadow: `0px 2px 0px 0px ${colorLight}`,
                 zIndex: 0,
             }}


### PR DESCRIPTION
## Problem

In testing mode sometimes its hard to understand which path the workflow would go down and which action would be next .. especially in conditional branches. 

## Changes

![2026-02-10 11 30 32](https://github.com/user-attachments/assets/0c379e66-d070-4b08-8789-2516b7d069ce)


give visual guidance to which edge would have been taken and which action it would move to

## How did you test this code?

- local dev
