### PR TITLE
feat(logs): add Related Errors tab to Log Details Modal

### DIFF
--- a/frontend/src/scenes/max/messages/ErrorTrackingIssueCard.tsx
+++ b/frontend/src/scenes/max/messages/ErrorTrackingIssueCard.tsx
@@ -11,9 +11,10 @@ import { RuntimeIcon } from 'products/error_tracking/frontend/components/Runtime
 
 interface ErrorTrackingIssueCardProps {
     issue: MaxErrorTrackingIssuePreview
+    showUserCount?: boolean
 }
 
-export function ErrorTrackingIssueCard({ issue }: ErrorTrackingIssueCardProps): JSX.Element {
+export function ErrorTrackingIssueCard({ issue, showUserCount = true }: ErrorTrackingIssueCardProps): JSX.Element {
     const runtime = getRuntimeFromLib(issue.library)
 
     return (
@@ -31,7 +32,9 @@ export function ErrorTrackingIssueCard({ issue }: ErrorTrackingIssueCardProps): 
                             {issue.status}
                         </LemonTag>
                         <span className="text-xs text-muted">{issue.occurrences.toLocaleString()} occurrences</span>
-                        <span className="text-xs text-muted">{issue.users.toLocaleString()} users</span>
+                        {showUserCount && (
+                            <span className="text-xs text-muted">{issue.users.toLocaleString()} users</span>
+                        )}
                         {issue.last_seen && (
                             <span className="text-xs text-muted">
                                 <TZLabel time={issue.last_seen} />

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
@@ -15,6 +15,7 @@ import { LogDetailsTabContent } from 'products/logs/frontend/components/LogsView
 import { logsViewerLogic } from '../logsViewerLogic'
 import { LogComments } from './LogComments'
 import { LogExploreAI } from './Tabs/ExploreWithAI'
+import { RelatedErrorsTab } from './Tabs/RelatedErrors'
 import { LogDetailsTab, logDetailsModalLogic } from './logDetailsModalLogic'
 
 const SEVERITY_COLORS: Record<string, string> = {
@@ -54,7 +55,7 @@ interface LogDetailsModalProps {
 }
 
 export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element | null {
-    const { isLogDetailsOpen, selectedLog, jsonParseAllFields, activeTab } = useValues(logDetailsModalLogic)
+    const { isLogDetailsOpen, selectedLog, jsonParseAllFields, activeTab, sessionId } = useValues(logDetailsModalLogic)
     const { closeLogDetails, setJsonParseAllFields, setActiveTab } = useActions(logDetailsModalLogic)
     const { addFilter, copyLinkToLog } = useActions(logsViewerLogic)
 
@@ -163,6 +164,17 @@ export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element
                                             <JSONViewer src={displayData} collapsed={2} sortKeys />
                                         </div>
                                     </div>
+                                ),
+                            },
+                            {
+                                key: 'related-errors',
+                                label: 'Related errors',
+                                content: (
+                                    <RelatedErrorsTab
+                                        logUuid={selectedLog.uuid}
+                                        logTimestamp={selectedLog.timestamp}
+                                        sessionId={sessionId}
+                                    />
                                 ),
                             },
                             {

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/RelatedErrors/RelatedErrorsTab.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/RelatedErrors/RelatedErrorsTab.tsx
@@ -1,0 +1,100 @@
+import { BindLogic, useActions, useValues } from 'kea'
+
+import { LemonBanner, LemonSkeleton } from '@posthog/lemon-ui'
+
+import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
+import { ErrorTrackingIssueCard } from 'scenes/max/messages/ErrorTrackingIssueCard'
+
+import { MaxErrorTrackingIssuePreview } from '~/queries/schema/schema-assistant-error-tracking'
+
+import { RelatedErrorsLogicProps, relatedErrorsLogic } from './relatedErrorsLogic'
+
+export interface RelatedErrorsTabProps {
+    logUuid: string
+    logTimestamp: string
+    sessionId: string | null
+}
+
+export function RelatedErrorsTab({ logUuid, logTimestamp, sessionId }: RelatedErrorsTabProps): JSX.Element {
+    if (!sessionId) {
+        return (
+            <div className="flex justify-center w-full py-8">
+                <EmptyMessage
+                    title="No session ID found"
+                    description="To see related errors, link your logs to session replay by including a session ID."
+                    buttonText="Learn more"
+                    buttonTo="https://posthog.com/docs/logs/link-session-replay"
+                    size="small"
+                />
+            </div>
+        )
+    }
+
+    const logicProps: RelatedErrorsLogicProps = { logUuid, logTimestamp, sessionId }
+
+    return (
+        <BindLogic logic={relatedErrorsLogic} props={logicProps}>
+            <RelatedErrorsTabContent />
+        </BindLogic>
+    )
+}
+
+function RelatedErrorsTabContent(): JSX.Element {
+    const { relatedIssues, relatedIssuesLoading, relatedIssuesError } = useValues(relatedErrorsLogic)
+    const { loadRelatedIssues } = useActions(relatedErrorsLogic)
+
+    if (relatedIssuesLoading) {
+        return <LoadingState />
+    }
+
+    if (relatedIssuesError) {
+        return (
+            <LemonBanner type="error" action={{ children: 'Retry', onClick: loadRelatedIssues }}>
+                Failed to load related errors
+            </LemonBanner>
+        )
+    }
+
+    if (relatedIssues.length === 0) {
+        return <EmptyState />
+    }
+
+    return <RelatedIssuesList issues={relatedIssues} />
+}
+
+function LoadingState(): JSX.Element {
+    return (
+        <div className="flex flex-col gap-3">
+            <LemonSkeleton className="h-16 w-full" />
+            <LemonSkeleton className="h-16 w-full" />
+            <LemonSkeleton className="h-16 w-full" />
+        </div>
+    )
+}
+
+function EmptyState(): JSX.Element {
+    return (
+        <EmptyMessage
+            title="No related errors"
+            description="No exceptions were found in this session within 6 hours of this log."
+            size="small"
+        />
+    )
+}
+
+interface RelatedIssuesListProps {
+    issues: MaxErrorTrackingIssuePreview[]
+}
+
+function RelatedIssuesList({ issues }: RelatedIssuesListProps): JSX.Element {
+    return (
+        <div className="flex flex-col">
+            <p className="text-muted text-sm mb-2">
+                {issues.length} error{issues.length !== 1 ? 's' : ''} found in this session
+            </p>
+            {issues.map((issue) => (
+                <ErrorTrackingIssueCard key={issue.id} issue={issue} showUserCount={false} />
+            ))}
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/RelatedErrors/index.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/RelatedErrors/index.ts
@@ -1,0 +1,2 @@
+export { RelatedErrorsTab } from './RelatedErrorsTab'
+export type { RelatedErrorsTabProps } from './RelatedErrorsTab'

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/RelatedErrors/relatedErrorsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/RelatedErrors/relatedErrorsLogic.ts
@@ -1,0 +1,105 @@
+import { afterMount, kea, key, path, props, reducers } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
+
+import { MaxErrorTrackingIssuePreview } from '~/queries/schema/schema-assistant-error-tracking'
+import { ErrorTrackingIssue, ErrorTrackingQuery, NodeKind } from '~/queries/schema/schema-general'
+import { FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
+
+import type { relatedErrorsLogicType } from './relatedErrorsLogicType'
+
+export interface RelatedErrorsLogicProps {
+    logUuid: string
+    logTimestamp: string
+    sessionId: string
+}
+
+export const relatedErrorsLogic = kea<relatedErrorsLogicType>([
+    props({} as RelatedErrorsLogicProps),
+    key((props) => props.logUuid),
+    path((key) => [
+        'products',
+        'logs',
+        'frontend',
+        'components',
+        'LogsViewer',
+        'LogDetailsModal',
+        'Tabs',
+        'RelatedErrors',
+        'relatedErrorsLogic',
+        key,
+    ]),
+
+    loaders(({ props }) => ({
+        relatedIssues: {
+            __default: [] as MaxErrorTrackingIssuePreview[],
+            loadRelatedIssues: async (): Promise<MaxErrorTrackingIssuePreview[]> => {
+                // Handle both ISO strings and epoch timestamps (seconds or milliseconds)
+                const parsed = Number(props.logTimestamp)
+                const timestamp = Number.isNaN(parsed) ? dayjs(props.logTimestamp) : dayjs(parsed)
+
+                const query: ErrorTrackingQuery = {
+                    kind: NodeKind.ErrorTrackingQuery,
+                    orderBy: 'last_seen',
+                    dateRange: {
+                        date_from: timestamp.subtract(6, 'hours').toISOString(),
+                        date_to: timestamp.add(6, 'hours').toISOString(),
+                    },
+                    filterGroup: {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                type: FilterLogicalOperator.And,
+                                values: [
+                                    {
+                                        type: PropertyFilterType.Event,
+                                        key: '$session_id',
+                                        value: props.sessionId,
+                                        operator: PropertyOperator.Exact,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    volumeResolution: 0,
+                    withAggregations: true,
+                    limit: 100,
+                }
+
+                const response = await api.query(query)
+                const issues = response.results as ErrorTrackingIssue[]
+
+                return issues.map(
+                    (issue): MaxErrorTrackingIssuePreview => ({
+                        id: issue.id,
+                        name: issue.name,
+                        description: issue.description,
+                        library: issue.library,
+                        status: issue.status,
+                        occurrences: issue.aggregations?.occurrences ?? 0,
+                        sessions: issue.aggregations?.sessions ?? 0,
+                        users: issue.aggregations?.users ?? 0,
+                        first_seen: issue.first_seen,
+                        last_seen: issue.last_seen,
+                    })
+                )
+            },
+        },
+    })),
+
+    reducers({
+        relatedIssuesError: [
+            null as string | null,
+            {
+                loadRelatedIssues: () => null,
+                loadRelatedIssuesFailure: (_, { error }) => error || 'Failed to load related errors',
+            },
+        ],
+    }),
+
+    afterMount(({ actions }) => {
+        actions.loadRelatedIssues()
+    }),
+])


### PR DESCRIPTION
## Problem

When viewing logs, users need to see related errors that occurred during the same session to better understand the context of issues. Currently, there's no way to see errors associated with a log entry.

## Changes

- Added a new "Related errors" tab to the Log Details Modal that shows error tracking issues from the same session
- The tab displays errors that occurred within 6 hours of the log timestamp
- Added logic to extract session IDs from log attributes
- Made user count display optional in the ErrorTrackingIssueCard component
- Implemented empty states for when no session ID is found or no related errors exist

![image.png](https://app.graphite.com/user-attachments/assets/fa6df877-0d43-45bd-94df-8cc59a1f3f75.png)

![image.png](https://app.graphite.com/user-attachments/assets/d56fab2c-564e-4f67-84fe-20838e94a9db.png)

## How did you test this code?

- Tested with logs that have session IDs to verify related errors are properly displayed
- Verified empty states are shown correctly when no session ID is present or no errors are found
- Confirmed the time window (±6 hours) correctly filters relevant errors
- Tested the UI rendering of error cards with and without user counts

## Publish to changelog?

Yes