### PR TITLE
feat(llma): drive team discovery config from feature flag payload

### DIFF
--- a/posthog/temporal/llm_analytics/team_discovery.py
+++ b/posthog/temporal/llm_analytics/team_discovery.py
@@ -86,11 +86,11 @@ def _get_llma_workflow_config() -> LLMAWorkflowConfig:
             guaranteed = DEFAULT_GUARANTEED_TEAM_IDS
 
         sample_pct = payload.get("sample_percentage", DEFAULT_SAMPLE_PERCENTAGE)
-        if not isinstance(sample_pct, (int, float)):
+        if not isinstance(sample_pct, (int, float)) or not (0.0 <= float(sample_pct) <= 1.0):
             sample_pct = DEFAULT_SAMPLE_PERCENTAGE
 
         lookback = payload.get("discovery_lookback_days", DEFAULT_DISCOVERY_LOOKBACK_DAYS)
-        if not isinstance(lookback, int):
+        if not isinstance(lookback, int) or lookback <= 0:
             lookback = DEFAULT_DISCOVERY_LOOKBACK_DAYS
 
         logger.info(
@@ -139,7 +139,10 @@ async def get_team_ids_for_llm_analytics(inputs: TeamDiscoveryInput) -> list[int
         config = _get_llma_workflow_config()
         guaranteed = set(config.guaranteed_team_ids)
 
-        # FF payload overrides input defaults
+        # FF payload is the source of truth, intentionally overriding
+        # TeamDiscoveryInput so config can be tuned from the PostHog UI
+        # without a deploy. TeamDiscoveryInput is kept for Temporal's
+        # serialization contract but its values are not used at runtime.
         sample_percentage = config.sample_percentage
         lookback_days = config.discovery_lookback_days
 

--- a/posthog/temporal/llm_analytics/team_discovery.py
+++ b/posthog/temporal/llm_analytics/team_discovery.py
@@ -136,7 +136,7 @@ async def get_team_ids_for_llm_analytics(inputs: TeamDiscoveryInput) -> list[int
     On failure, falls back to guaranteed teams only.
     """
     async with Heartbeater():
-        config = _get_llma_workflow_config()
+        config = await asyncio.to_thread(_get_llma_workflow_config)
         guaranteed = set(config.guaranteed_team_ids)
 
         # FF payload is the source of truth, intentionally overriding

--- a/posthog/temporal/llm_analytics/team_discovery.py
+++ b/posthog/temporal/llm_analytics/team_discovery.py
@@ -3,6 +3,10 @@ Team discovery activity for LLM analytics workflows.
 
 Provides dynamic team discovery that combines a guaranteed allowlist
 with a configurable random sample of teams that have AI events.
+
+Config is read from the `llm-analytics-clustering-workflows` feature flag
+payload so it can be changed from the PostHog UI without a deploy.
+Falls back to hardcoded defaults when the payload is missing or invalid.
 """
 
 import math
@@ -12,6 +16,7 @@ import dataclasses
 from datetime import UTC, datetime, timedelta
 
 import structlog
+import posthoganalytics
 import temporalio.activity
 from temporalio.common import RetryPolicy
 
@@ -19,9 +24,10 @@ from posthog.temporal.common.heartbeat import Heartbeater
 
 logger = structlog.get_logger(__name__)
 
-# Guaranteed teams that are always included (the original hardcoded allowlist).
-# Single source of truth for both clustering and summarization workflows.
-GUARANTEED_TEAM_IDS: list[int] = [
+FEATURE_FLAG_KEY = "llm-analytics-clustering-workflows"
+
+# Default fallbacks — used when the feature flag payload is missing or invalid.
+DEFAULT_GUARANTEED_TEAM_IDS: list[int] = [
     1,  # Local development
     2,  # Internal PostHog project
     # Dogfooding projects
@@ -40,15 +46,73 @@ GUARANTEED_TEAM_IDS: list[int] = [
     39143,
     240730,
 ]
-
 # Default sample percentage for gradual rollout.
 # 0.0 = only guaranteed teams, 0.5 = 50% of remaining, 1.0 = all teams with AI events.
-SAMPLE_PERCENTAGE: float = 0.5
+DEFAULT_SAMPLE_PERCENTAGE: float = 0.5
+DEFAULT_DISCOVERY_LOOKBACK_DAYS: int = 30
 
-# How far back to look for teams with AI events. Intentionally wider than any
-# individual workflow's data window (e.g. 7 days for clustering, 60 min for
-# summarization) so we discover teams that have been active recently.
-DISCOVERY_LOOKBACK_DAYS: int = 30
+# Backward-compatible aliases for coordinator imports.
+# Coordinators use these only in the last-resort fallback path (when the
+# activity itself fails), so pointing at defaults is fine.
+GUARANTEED_TEAM_IDS = DEFAULT_GUARANTEED_TEAM_IDS
+SAMPLE_PERCENTAGE = DEFAULT_SAMPLE_PERCENTAGE
+DISCOVERY_LOOKBACK_DAYS = DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+
+@dataclasses.dataclass
+class LLMAWorkflowConfig:
+    guaranteed_team_ids: list[int]
+    sample_percentage: float
+    discovery_lookback_days: int
+
+
+def _get_llma_workflow_config() -> LLMAWorkflowConfig:
+    """Read LLMA team-discovery config from the feature flag payload, falling back to defaults."""
+    try:
+        payload: dict | None = posthoganalytics.get_feature_flag_payload(  # type: ignore[assignment]
+            FEATURE_FLAG_KEY, "internal_llma_team_discovery"
+        )
+
+        if not isinstance(payload, dict):
+            logger.info("No valid FF payload, using defaults", payload_type=type(payload).__name__)
+            return LLMAWorkflowConfig(
+                guaranteed_team_ids=DEFAULT_GUARANTEED_TEAM_IDS,
+                sample_percentage=DEFAULT_SAMPLE_PERCENTAGE,
+                discovery_lookback_days=DEFAULT_DISCOVERY_LOOKBACK_DAYS,
+            )
+
+        guaranteed = payload.get("guaranteed_team_ids", DEFAULT_GUARANTEED_TEAM_IDS)
+        if not isinstance(guaranteed, list) or not all(isinstance(t, int) for t in guaranteed):
+            guaranteed = DEFAULT_GUARANTEED_TEAM_IDS
+
+        sample_pct = payload.get("sample_percentage", DEFAULT_SAMPLE_PERCENTAGE)
+        if not isinstance(sample_pct, (int, float)):
+            sample_pct = DEFAULT_SAMPLE_PERCENTAGE
+
+        lookback = payload.get("discovery_lookback_days", DEFAULT_DISCOVERY_LOOKBACK_DAYS)
+        if not isinstance(lookback, int):
+            lookback = DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+        logger.info(
+            "Loaded LLMA config from feature flag",
+            guaranteed_count=len(guaranteed),
+            sample_percentage=sample_pct,
+            discovery_lookback_days=lookback,
+        )
+
+        return LLMAWorkflowConfig(
+            guaranteed_team_ids=guaranteed,
+            sample_percentage=float(sample_pct),
+            discovery_lookback_days=lookback,
+        )
+    except Exception:
+        logger.warning("Failed to read LLMA config from feature flag, using defaults", exc_info=True)
+        return LLMAWorkflowConfig(
+            guaranteed_team_ids=DEFAULT_GUARANTEED_TEAM_IDS,
+            sample_percentage=DEFAULT_SAMPLE_PERCENTAGE,
+            discovery_lookback_days=DEFAULT_DISCOVERY_LOOKBACK_DAYS,
+        )
+
 
 # Activity timeout for team discovery. Must exceed the underlying ClickHouse
 # query's max_execution_time (5 min in CH_LLM_ANALYTICS_SETTINGS) plus retry
@@ -59,8 +123,8 @@ DISCOVERY_ACTIVITY_RETRY_POLICY = RetryPolicy(maximum_attempts=2)
 
 @dataclasses.dataclass
 class TeamDiscoveryInput:
-    lookback_days: int = DISCOVERY_LOOKBACK_DAYS
-    sample_percentage: float = SAMPLE_PERCENTAGE
+    lookback_days: int = DEFAULT_DISCOVERY_LOOKBACK_DAYS
+    sample_percentage: float = DEFAULT_SAMPLE_PERCENTAGE
 
 
 @temporalio.activity.defn
@@ -72,11 +136,16 @@ async def get_team_ids_for_llm_analytics(inputs: TeamDiscoveryInput) -> list[int
     On failure, falls back to guaranteed teams only.
     """
     async with Heartbeater():
-        guaranteed = set(GUARANTEED_TEAM_IDS)
+        config = _get_llma_workflow_config()
+        guaranteed = set(config.guaranteed_team_ids)
+
+        # FF payload overrides input defaults
+        sample_percentage = config.sample_percentage
+        lookback_days = config.discovery_lookback_days
 
         try:
             end = datetime.now(UTC)
-            begin = end - timedelta(days=inputs.lookback_days)
+            begin = end - timedelta(days=lookback_days)
 
             from posthog.tasks.llm_analytics_usage_report import get_teams_with_ai_events
 
@@ -84,7 +153,7 @@ async def get_team_ids_for_llm_analytics(inputs: TeamDiscoveryInput) -> list[int
 
             remaining = [t for t in ai_event_teams if t not in guaranteed]
 
-            sample_size = math.ceil(len(remaining) * inputs.sample_percentage)
+            sample_size = math.ceil(len(remaining) * sample_percentage)
             sampled = random.sample(remaining, min(sample_size, len(remaining)))
 
             result = sorted(guaranteed | set(sampled))
@@ -96,7 +165,7 @@ async def get_team_ids_for_llm_analytics(inputs: TeamDiscoveryInput) -> list[int
                 remaining_count=len(remaining),
                 sampled_count=len(sampled),
                 total_count=len(result),
-                sample_percentage=inputs.sample_percentage,
+                sample_percentage=sample_percentage,
             )
 
             return result

--- a/posthog/temporal/llm_analytics/test_team_discovery.py
+++ b/posthog/temporal/llm_analytics/test_team_discovery.py
@@ -7,8 +7,11 @@ from unittest.mock import patch
 from parameterized import parameterized
 
 from posthog.temporal.llm_analytics.team_discovery import (
-    GUARANTEED_TEAM_IDS,
+    DEFAULT_DISCOVERY_LOOKBACK_DAYS,
+    DEFAULT_GUARANTEED_TEAM_IDS,
+    DEFAULT_SAMPLE_PERCENTAGE,
     TeamDiscoveryInput,
+    _get_llma_workflow_config,
     get_team_ids_for_llm_analytics,
 )
 
@@ -18,91 +21,188 @@ async def _noop_heartbeater(*args, **kwargs):
     yield
 
 
+FF_PAYLOAD_PATH = "posthog.temporal.llm_analytics.team_discovery.posthoganalytics.get_feature_flag_payload"
+
+
+class TestGetLlmaWorkflowConfig:
+    @parameterized.expand(
+        [
+            ("none_payload", None),
+            ("string_payload", "not a dict"),
+            ("list_payload", [1, 2, 3]),
+            ("int_payload", 42),
+        ]
+    )
+    @patch(FF_PAYLOAD_PATH)
+    def test_non_dict_payload_returns_defaults(self, _name, payload, mock_ff):
+        mock_ff.return_value = payload
+
+        config = _get_llma_workflow_config()
+
+        assert config.guaranteed_team_ids == DEFAULT_GUARANTEED_TEAM_IDS
+        assert config.sample_percentage == DEFAULT_SAMPLE_PERCENTAGE
+        assert config.discovery_lookback_days == DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+    @patch(FF_PAYLOAD_PATH)
+    def test_valid_payload(self, mock_ff):
+        mock_ff.return_value = {
+            "guaranteed_team_ids": [100, 200],
+            "sample_percentage": 0.5,
+            "discovery_lookback_days": 7,
+        }
+
+        config = _get_llma_workflow_config()
+
+        assert config.guaranteed_team_ids == [100, 200]
+        assert config.sample_percentage == 0.5
+        assert config.discovery_lookback_days == 7
+
+    @patch(FF_PAYLOAD_PATH)
+    def test_partial_payload_fills_missing_with_defaults(self, mock_ff):
+        mock_ff.return_value = {"guaranteed_team_ids": [42]}
+
+        config = _get_llma_workflow_config()
+
+        assert config.guaranteed_team_ids == [42]
+        assert config.sample_percentage == DEFAULT_SAMPLE_PERCENTAGE
+        assert config.discovery_lookback_days == DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+    @parameterized.expand(
+        [
+            ("string_ids", {"guaranteed_team_ids": "not a list"}, "guaranteed_team_ids"),
+            ("mixed_ids", {"guaranteed_team_ids": [1, "two", 3]}, "guaranteed_team_ids"),
+            ("string_pct", {"sample_percentage": "high"}, "sample_percentage"),
+            ("float_lookback", {"discovery_lookback_days": 7.5}, "discovery_lookback_days"),
+        ]
+    )
+    @patch(FF_PAYLOAD_PATH)
+    def test_invalid_field_types_fall_back_per_field(self, _name, payload, bad_field, mock_ff):
+        mock_ff.return_value = payload
+
+        config = _get_llma_workflow_config()
+
+        if bad_field == "guaranteed_team_ids":
+            assert config.guaranteed_team_ids == DEFAULT_GUARANTEED_TEAM_IDS
+        if bad_field == "sample_percentage":
+            assert config.sample_percentage == DEFAULT_SAMPLE_PERCENTAGE
+        if bad_field == "discovery_lookback_days":
+            assert config.discovery_lookback_days == DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+    @patch(FF_PAYLOAD_PATH)
+    def test_exception_returns_defaults(self, mock_ff):
+        mock_ff.side_effect = Exception("network error")
+
+        config = _get_llma_workflow_config()
+
+        assert config.guaranteed_team_ids == DEFAULT_GUARANTEED_TEAM_IDS
+        assert config.sample_percentage == DEFAULT_SAMPLE_PERCENTAGE
+        assert config.discovery_lookback_days == DEFAULT_DISCOVERY_LOOKBACK_DAYS
+
+    @patch(FF_PAYLOAD_PATH)
+    def test_int_sample_percentage_cast_to_float(self, mock_ff):
+        mock_ff.return_value = {"sample_percentage": 1}
+
+        config = _get_llma_workflow_config()
+
+        assert config.sample_percentage == 1.0
+        assert isinstance(config.sample_percentage, float)
+
+
+@patch(FF_PAYLOAD_PATH, return_value=None)
 @patch("posthog.temporal.llm_analytics.team_discovery.Heartbeater", _noop_heartbeater)
 @pytest.mark.asyncio
 class TestGetTeamIdsForLlmAnalytics:
-    @parameterized.expand(
-        [
-            ("zero_percent", 0.0),
-            ("ten_percent", 0.1),
-            ("fifty_percent", 0.5),
-            ("hundred_percent", 1.0),
-        ]
-    )
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_guaranteed_teams_always_included(self, _name, sample_pct, mock_get_teams):
+    async def test_guaranteed_teams_always_included(self, mock_get_teams, _mock_ff):
         mock_get_teams.return_value = [9999, 8888]
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=sample_pct)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        for team_id in GUARANTEED_TEAM_IDS:
+        for team_id in DEFAULT_GUARANTEED_TEAM_IDS:
             assert team_id in result
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_no_duplicates_when_guaranteed_in_ai_events(self, mock_get_teams):
-        mock_get_teams.return_value = [GUARANTEED_TEAM_IDS[0], 9999]
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=1.0)
+    async def test_no_duplicates_when_guaranteed_in_ai_events(self, mock_get_teams, _mock_ff):
+        mock_get_teams.return_value = [DEFAULT_GUARANTEED_TEAM_IDS[0], 9999]
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
         assert len(result) == len(set(result))
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_result_is_sorted(self, mock_get_teams):
+    async def test_result_is_sorted(self, mock_get_teams, mock_ff):
+        mock_ff.return_value = {"sample_percentage": 1.0}
         mock_get_teams.return_value = [9999, 5555, 3333]
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=1.0)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
         assert result == sorted(result)
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_zero_sample_returns_only_guaranteed(self, mock_get_teams):
+    async def test_zero_sample_returns_only_guaranteed(self, mock_get_teams, mock_ff):
+        mock_ff.return_value = {"sample_percentage": 0.0}
         extra_teams = [9999, 8888, 7777]
         mock_get_teams.return_value = extra_teams
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.0)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        assert set(result) == set(GUARANTEED_TEAM_IDS)
+        assert set(result) == set(DEFAULT_GUARANTEED_TEAM_IDS)
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_full_sample_returns_all(self, mock_get_teams):
+    async def test_full_sample_returns_all(self, mock_get_teams, mock_ff):
+        mock_ff.return_value = {"sample_percentage": 1.0}
         extra_teams = [9999, 8888, 7777]
         mock_get_teams.return_value = extra_teams
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=1.0)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        assert set(result) == set(GUARANTEED_TEAM_IDS) | set(extra_teams)
+        assert set(result) == set(DEFAULT_GUARANTEED_TEAM_IDS) | set(extra_teams)
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_sampling_math(self, mock_get_teams):
+    async def test_sampling_math(self, mock_get_teams, _mock_ff):
         extra_teams = list(range(10000, 10100))  # 100 non-guaranteed teams
         mock_get_teams.return_value = extra_teams
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.1)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        sampled_non_guaranteed = [t for t in result if t not in GUARANTEED_TEAM_IDS]
-        expected_sample_size = math.ceil(len(extra_teams) * 0.1)
+        sampled_non_guaranteed = [t for t in result if t not in DEFAULT_GUARANTEED_TEAM_IDS]
+        expected_sample_size = math.ceil(len(extra_teams) * DEFAULT_SAMPLE_PERCENTAGE)
         assert len(sampled_non_guaranteed) == expected_sample_size
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_empty_ai_events_returns_guaranteed(self, mock_get_teams):
+    async def test_empty_ai_events_returns_guaranteed(self, mock_get_teams, _mock_ff):
         mock_get_teams.return_value = []
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.1)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        assert set(result) == set(GUARANTEED_TEAM_IDS)
+        assert set(result) == set(DEFAULT_GUARANTEED_TEAM_IDS)
 
     @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
-    async def test_fallback_on_exception(self, mock_get_teams):
+    async def test_fallback_on_exception(self, mock_get_teams, _mock_ff):
         mock_get_teams.side_effect = Exception("ClickHouse down")
-        inputs = TeamDiscoveryInput(lookback_days=30, sample_percentage=0.1)
+        inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_llm_analytics(inputs)
 
-        assert set(result) == set(GUARANTEED_TEAM_IDS)
+        assert set(result) == set(DEFAULT_GUARANTEED_TEAM_IDS)
+
+    @patch("posthog.tasks.llm_analytics_usage_report.get_teams_with_ai_events")
+    async def test_feature_flag_overrides_config(self, mock_get_teams, mock_ff):
+        mock_ff.return_value = {
+            "guaranteed_team_ids": [42],
+            "sample_percentage": 0.0,
+            "discovery_lookback_days": 7,
+        }
+        mock_get_teams.return_value = [9999, 8888]
+        inputs = TeamDiscoveryInput()
+
+        result = await get_team_ids_for_llm_analytics(inputs)
+
+        assert result == [42]

--- a/posthog/temporal/llm_analytics/test_team_discovery.py
+++ b/posthog/temporal/llm_analytics/test_team_discovery.py
@@ -72,7 +72,13 @@ class TestGetLlmaWorkflowConfig:
             ("string_ids", {"guaranteed_team_ids": "not a list"}, "guaranteed_team_ids"),
             ("mixed_ids", {"guaranteed_team_ids": [1, "two", 3]}, "guaranteed_team_ids"),
             ("string_pct", {"sample_percentage": "high"}, "sample_percentage"),
+            ("negative_pct", {"sample_percentage": -0.1}, "sample_percentage"),
+            ("pct_above_one", {"sample_percentage": 1.5}, "sample_percentage"),
+            ("nan_pct", {"sample_percentage": float("nan")}, "sample_percentage"),
+            ("inf_pct", {"sample_percentage": float("inf")}, "sample_percentage"),
             ("float_lookback", {"discovery_lookback_days": 7.5}, "discovery_lookback_days"),
+            ("zero_lookback", {"discovery_lookback_days": 0}, "discovery_lookback_days"),
+            ("negative_lookback", {"discovery_lookback_days": -5}, "discovery_lookback_days"),
         ]
     )
     @patch(FF_PAYLOAD_PATH)


### PR DESCRIPTION
## Problem

Changing LLMA team discovery config (guaranteed team IDs, sample percentage, lookback days) currently requires a code change and deploy. This slows down rollout tuning and adds unnecessary PR overhead for config-only changes.

Closes #47127

## Changes

Read `guaranteed_team_ids`, `sample_percentage`, and `discovery_lookback_days` from the `llm-analytics-clustering-workflows` feature flag payload at runtime. Falls back to hardcoded defaults per-field when the payload is missing or invalid.

- Renamed `GUARANTEED_TEAM_IDS` to `DEFAULT_GUARANTEED_TEAM_IDS` with backward-compat alias for coordinator fallback paths
- Added `LLMAWorkflowConfig` dataclass and `_get_llma_workflow_config()` that reads from `posthoganalytics.get_feature_flag_payload()`
- Per-field validation with fallback to defaults (handles missing keys, wrong types, exceptions)
- Updated `get_team_ids_for_llm_analytics` activity to use FF-driven config
- No changes to coordinators needed (backward-compat aliases)

Feature flag: https://us.posthog.com/project/2/feature_flags/560786

## How did you test this code?

- 21 unit tests pass (7 new for `_get_llma_workflow_config`, 1 new integration test, existing tests updated)
- Parameterized tests cover: non-dict payloads, valid payload, partial payload, invalid field types per-field, exception handling, int-to-float casting
- All 92 clustering tests pass
- Lint clean

## Publish to changelog?

Do not publish to changelog.