### PR TITLE
fix(signals): Ensure sessions video export uses /tmp correctly

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,7 +56,6 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
-                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -80,7 +79,6 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
-                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -97,7 +95,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND (("pmat_email" ILIKE '%g0%'
+                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/posthog/temporal/exports_video/__init__.py
+++ b/posthog/temporal/exports_video/__init__.py
@@ -1,9 +1,8 @@
-from .activities import build_export_context_activity, persist_exported_asset_activity, record_replay_video_activity
+from .activities import build_export_context_activity, record_and_persist_video_activity
 from .workflow import VideoExportWorkflow
 
 WORKFLOWS = [VideoExportWorkflow]
 ACTIVITIES = [
     build_export_context_activity,
-    record_replay_video_activity,
-    persist_exported_asset_activity,
+    record_and_persist_video_activity,
 ]

--- a/posthog/temporal/exports_video/activities.py
+++ b/posthog/temporal/exports_video/activities.py
@@ -9,7 +9,7 @@ from django.db import close_old_connections
 import structlog
 from temporalio import activity
 
-from posthog.models.exported_asset import ExportedAsset, get_public_access_token, save_content
+from posthog.models.exported_asset import ExportedAsset, get_public_access_token, save_content_from_file
 from posthog.tasks.exports.video_exporter import RecordReplayToFileOptions
 from posthog.utils import absolute_uri
 
@@ -128,9 +128,4 @@ def record_and_persist_video_activity(build: dict[str, Any]) -> None:
             raise RuntimeError(
                 f"Video file too large: {file_size / (1024 * 1024):.1f}MB exceeds {MAX_FILE_SIZE // (1024 * 1024)}MB limit"
             )
-        chunk_size = 64 * 1024  # 64KB chunks for better I/O performance
-        chunks = []
-        with open(tmp_path, "rb") as f:
-            while chunk := f.read(chunk_size):
-                chunks.append(chunk)
-        save_content(asset, b"".join(chunks))
+        save_content_from_file(asset, tmp_path)

--- a/posthog/temporal/exports_video/activities.py
+++ b/posthog/temporal/exports_video/activities.py
@@ -3,7 +3,7 @@ import uuid
 import shutil
 import datetime as dt
 import tempfile
-from typing import Any, cast
+from typing import Any
 
 from django.db import close_old_connections
 
@@ -93,8 +93,14 @@ def build_export_context_activity(exported_asset_id: int) -> dict[str, Any]:
 
 
 @activity.defn
-def record_replay_video_activity(build: dict[str, Any]) -> dict[str, Any]:
+def record_and_persist_video_activity(build: dict[str, Any]) -> None:
+    """Record replay to file and persist in a single activity. Must run on same worker
+    so the temp file exists—passing paths between activities fails when they run on
+    different workers (different /tmp filesystems)."""
     from posthog.tasks.exports.video_exporter import record_replay_to_file
+
+    close_old_connections()
+    asset = ExportedAsset.objects.select_related("team").get(pk=build["exported_asset_id"])
 
     tmp_dir = tempfile.mkdtemp(prefix="ph-video-export-")
     tmp_path = os.path.join(tmp_dir, f"{uuid.uuid4()}.{build['tmp_ext']}")
@@ -103,54 +109,40 @@ def record_replay_video_activity(build: dict[str, Any]) -> dict[str, Any]:
             RecordReplayToFileOptions(
                 image_path=tmp_path,
                 url_to_render=build["url_to_render"],
-                screenshot_width=build.get("width"),  # None if not provided
+                screenshot_width=build.get("width"),
                 wait_for_css_selector=build["css_selector"],
-                screenshot_height=build.get("height"),  # None if not provided
+                screenshot_height=build.get("height"),
                 recording_duration=build["duration"],
-                playback_speed=build.get("playback_speed", 1),  # default to 1 if not provided
+                playback_speed=build.get("playback_speed", 1),
                 use_puppeteer=build.get("use_puppeteer", False),
             ),
         )
-        return {
-            "tmp_path": tmp_path,
-            "inactivity_periods": [x.model_dump() for x in inactivity_periods] if inactivity_periods else None,
-        }
-    except Exception:
-        # Clean up temp directory on failure
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-        raise
+        if inactivity_periods:
+            if asset.export_context is None:
+                asset.export_context = {}
+            asset.export_context["inactivity_periods"] = [x.model_dump() for x in inactivity_periods]
+            asset.save(update_fields=["export_context"])
 
-
-@activity.defn
-def persist_exported_asset_activity(inputs: dict[str, Any]) -> None:
-    close_old_connections()
-    asset = ExportedAsset.objects.select_related("team").get(pk=inputs["exported_asset_id"])
-    tmp_path = inputs["tmp_path"]
-    inactivity_periods = inputs.get("inactivity_periods")
-    if inactivity_periods:
-        if asset.export_context is None:
-            asset.export_context = {}
-        inactivity_periods = cast(list[dict[str, Any]], inactivity_periods)
-        asset.export_context["inactivity_periods"] = inactivity_periods
-        asset.save(update_fields=["export_context"])
-    # Check file size first to prevent OOM
-    file_size = os.path.getsize(tmp_path)
-    MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB limit
-    if file_size > MAX_FILE_SIZE:
-        raise RuntimeError(
-            f"Video file too large: {file_size / (1024 * 1024):.1f}MB exceeds {MAX_FILE_SIZE // (1024 * 1024)}MB limit"
-        )
-    # Read in chunks to avoid loading entire file into memory at once
-    chunk_size = 64 * 1024  # 64KB chunks for better I/O performance
-    chunks = []
-    with open(tmp_path, "rb") as f:
-        while chunk := f.read(chunk_size):
-            chunks.append(chunk)
-    data = b"".join(chunks)
-    save_content(asset, data)
-    # Cleanup
-    try:
-        os.remove(tmp_path)
-        shutil.rmtree(os.path.dirname(tmp_path), ignore_errors=True)
-    except Exception:
-        pass
+        # Check file size first to prevent OOM
+        file_size = os.path.getsize(tmp_path)
+        MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB limit
+        if file_size > MAX_FILE_SIZE:
+            raise RuntimeError(
+                f"Video file too large: {file_size / (1024 * 1024):.1f}MB exceeds {MAX_FILE_SIZE // (1024 * 1024)}MB limit"
+            )
+        # Read in chunks to avoid loading entire file into memory at once
+        chunk_size = 64 * 1024  # 64KB chunks for better I/O performance
+        chunks = []
+        with open(tmp_path, "rb") as f:
+            while chunk := f.read(chunk_size):
+                chunks.append(chunk)
+        save_content(asset, b"".join(chunks))
+    finally:
+        try:
+            os.remove(tmp_path)
+        except Exception:
+            pass
+        try:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        except Exception:
+            pass

--- a/posthog/temporal/exports_video/workflow.py
+++ b/posthog/temporal/exports_video/workflow.py
@@ -8,7 +8,7 @@ from temporalio import common
 
 from posthog.temporal.common.base import PostHogWorkflow  # matches repo conventions
 
-from .activities import build_export_context_activity, persist_exported_asset_activity, record_replay_video_activity
+from .activities import build_export_context_activity, record_and_persist_video_activity
 
 
 @dataclass(frozen=True)
@@ -37,19 +37,9 @@ class VideoExportWorkflow(PostHogWorkflow):
             build["use_puppeteer"] = True
         # Dynamic timeout: base 600s + recording duration + 30s buffer for processing
         recording_timeout = dt.timedelta(seconds=600 + build["duration"] + 30)
-        rec: dict[str, Any] = await wf.execute_activity(
-            record_replay_video_activity,
+        await wf.execute_activity(
+            record_and_persist_video_activity,
             build,
             start_to_close_timeout=recording_timeout,
-            retry_policy=retry_policy,
-        )
-        await wf.execute_activity(
-            persist_exported_asset_activity,
-            {
-                "exported_asset_id": inputs.exported_asset_id,
-                "tmp_path": rec["tmp_path"],
-                "inactivity_periods": rec["inactivity_periods"],
-            },
-            start_to_close_timeout=dt.timedelta(seconds=300),
             retry_policy=retry_policy,
         )


### PR DESCRIPTION
## Problem

Video export workflows _sometimes_ fail in production with `FileNotFoundError` when `persist_exported_asset_activity` tries to read a temp file. See here: [link](https://cloud.temporal.io/namespaces/posthog-prod-eu.usz2o/workflows/session-summary%3Asingle%3Adirect%3A65155%3A019c464a-75ec-74dd-94be-9062d1dc65fd%3A90962%3A85502bca-762d-42b4-bd4e-3582c3c5373a/019c471a-ba3b-7ecb-ba57-00f2732f4d86/history).

Turns out, the file WAS created by `record_replay_video_activity` – but on a different Temporal worker, as in Temporal activities can run on any available worker. Each worker has its own `/tmp` filesystem, so passing local file paths between activities is wrong.

## Changes

Merged `record_replay_video_activity` and `persist_exported_asset_activity` into a single `record_and_persist_video_activity` so the temp file never crosses worker boundaries.

## How did you test this code?

`pytest posthog/api/test/test_exports.py -k video -v` passes.