### PR TITLE
feat(support): add AI conversation context to Zendesk tickets

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -701,7 +701,12 @@ export const supportLogic = kea<supportLogicType>([
                 request: {
                     requester: { name: name, email: email },
                     subject: subject,
-                    tags: [planLevelTag, accountOwnerTag, ...(tags || []), ...(aiConversationData ? [aiConversationData.tag] : [])],
+                    tags: [
+                        planLevelTag,
+                        accountOwnerTag,
+                        ...(tags || []),
+                        ...(aiConversationData ? [aiConversationData.tag] : []),
+                    ],
                     custom_fields: [
                         {
                             id: 22084126888475,

--- a/frontend/src/scenes/max/TicketPrompt.tsx
+++ b/frontend/src/scenes/max/TicketPrompt.tsx
@@ -27,12 +27,7 @@ interface TicketPromptProps {
  * - If `summary` is provided: shows "Create support ticket" button with pre-filled summary
  * - If no `summary`: shows input field for user to describe their issue
  */
-export function TicketPrompt({
-    conversationId,
-    traceId,
-    summary,
-    initialText,
-}: TicketPromptProps): JSX.Element {
+export function TicketPrompt({ conversationId, traceId, summary, initialText }: TicketPromptProps): JSX.Element {
     const [issueText, setIssueText] = useState(initialText ?? '')
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [isSupportModalOpen, setIsSupportModalOpen] = useState(false)

--- a/frontend/src/scenes/max/TicketPrompt.tsx
+++ b/frontend/src/scenes/max/TicketPrompt.tsx
@@ -27,7 +27,12 @@ interface TicketPromptProps {
  * - If `summary` is provided: shows "Create support ticket" button with pre-filled summary
  * - If no `summary`: shows input field for user to describe their issue
  */
-export function TicketPrompt({ conversationId, traceId, summary, initialText }: TicketPromptProps): JSX.Element {
+export function TicketPrompt({
+    conversationId,
+    traceId,
+    summary,
+    initialText,
+}: TicketPromptProps): JSX.Element {
     const [issueText, setIssueText] = useState(initialText ?? '')
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [isSupportModalOpen, setIsSupportModalOpen] = useState(false)

--- a/frontend/src/scenes/max/__tests__/ticketUtils.test.ts
+++ b/frontend/src/scenes/max/__tests__/ticketUtils.test.ts
@@ -44,10 +44,7 @@ describe('ticketUtils', () => {
             },
             {
                 description: 'returns true when AI mentions "support ticket"',
-                thread: [
-                    createHumanMessage('I need help'),
-                    createAIMessage('I can help you create a support ticket'),
-                ],
+                thread: [createHumanMessage('I need help'), createAIMessage('I can help you create a support ticket')],
                 expected: true,
             },
             {
@@ -60,10 +57,7 @@ describe('ticketUtils', () => {
             },
             {
                 description: 'returns true when AI mentions "support team"',
-                thread: [
-                    createHumanMessage('help'),
-                    createAIMessage('I recommend reaching out to the support team'),
-                ],
+                thread: [createHumanMessage('help'), createAIMessage('I recommend reaching out to the support team')],
                 expected: true,
             },
             {
@@ -85,10 +79,7 @@ describe('ticketUtils', () => {
             },
             {
                 description: 'matches case-insensitively',
-                thread: [
-                    createHumanMessage('help'),
-                    createAIMessage('You should Contact Support about this'),
-                ],
+                thread: [createHumanMessage('help'), createAIMessage('You should Contact Support about this')],
                 expected: true,
             },
             {

--- a/frontend/src/scenes/max/__tests__/ticketUtils.test.ts
+++ b/frontend/src/scenes/max/__tests__/ticketUtils.test.ts
@@ -1,0 +1,437 @@
+import { AssistantMessageType, RootAssistantMessage } from '~/queries/schema/schema-assistant-messages'
+
+import {
+    getTicketPromptData,
+    getTicketSummaryData,
+    isTicketConfirmationMessage,
+    wasTicketAISuggested,
+} from '../ticketUtils'
+
+type MessageStatus = 'loading' | 'completed' | 'error'
+type ThreadMessage = RootAssistantMessage & { status: MessageStatus }
+
+describe('ticketUtils', () => {
+    describe('wasTicketAISuggested', () => {
+        const createHumanMessage = (content: string): ThreadMessage => ({
+            type: AssistantMessageType.Human,
+            content,
+            status: 'completed',
+            id: `human-${Math.random()}`,
+        })
+
+        const createAIMessage = (content: string): ThreadMessage => ({
+            type: AssistantMessageType.Assistant,
+            content,
+            status: 'completed',
+            id: `ai-${Math.random()}`,
+        })
+
+        it.each([
+            {
+                description: 'returns false when thread is empty',
+                thread: [],
+                expected: false,
+            },
+            {
+                description: 'returns false when no escalation language is present',
+                thread: [
+                    createHumanMessage('help'),
+                    createAIMessage('I can help you with that'),
+                    createHumanMessage('thanks'),
+                    createAIMessage('You are welcome'),
+                ],
+                expected: false,
+            },
+            {
+                description: 'returns true when AI mentions "support ticket"',
+                thread: [
+                    createHumanMessage('I need help'),
+                    createAIMessage('I can help you create a support ticket'),
+                ],
+                expected: true,
+            },
+            {
+                description: 'returns true when AI mentions "contact support"',
+                thread: [
+                    createHumanMessage('this is broken'),
+                    createAIMessage('You may want to contact support about this'),
+                ],
+                expected: true,
+            },
+            {
+                description: 'returns true when AI mentions "support team"',
+                thread: [
+                    createHumanMessage('help'),
+                    createAIMessage('I recommend reaching out to the support team'),
+                ],
+                expected: true,
+            },
+            {
+                description: 'returns true when AI says "report this"',
+                thread: [
+                    createHumanMessage('I found a bug'),
+                    createAIMessage('This looks like a bug. You should report this.'),
+                ],
+                expected: true,
+            },
+            {
+                description: 'returns true when user mentions wanting to raise a ticket',
+                thread: [
+                    createHumanMessage('help'),
+                    createAIMessage('Let me look into this'),
+                    createHumanMessage('I think I need to raise a ticket about this'),
+                ],
+                expected: true,
+            },
+            {
+                description: 'matches case-insensitively',
+                thread: [
+                    createHumanMessage('help'),
+                    createAIMessage('You should Contact Support about this'),
+                ],
+                expected: true,
+            },
+            {
+                description: 'scans the last 5 messages',
+                thread: [
+                    createAIMessage('You should contact support'),
+                    createHumanMessage('msg1'),
+                    createAIMessage('response1'),
+                    createHumanMessage('msg2'),
+                    createAIMessage('response2'),
+                ],
+                expected: true,
+            },
+            {
+                description: 'does not scan beyond the last 5 messages',
+                thread: [
+                    createAIMessage('You should contact support'),
+                    createHumanMessage('msg0'),
+                    createAIMessage('response0'),
+                    createHumanMessage('msg1'),
+                    createAIMessage('response1'),
+                    createHumanMessage('msg2'),
+                ],
+                expected: false,
+            },
+            {
+                description: 'detects escalation in conversations without /ticket command',
+                thread: [
+                    createHumanMessage('my dashboard is broken'),
+                    createAIMessage('I see the issue. You may want to contact support about this.'),
+                    createHumanMessage('ok thanks'),
+                ],
+                expected: true,
+            },
+        ])('$description', ({ thread, expected }) => {
+            expect(wasTicketAISuggested(thread)).toBe(expected)
+        })
+    })
+
+    describe('getTicketPromptData', () => {
+        const createHumanMessage = (content: string): ThreadMessage => ({
+            type: AssistantMessageType.Human,
+            content,
+            status: 'completed',
+            id: `human-${Math.random()}`,
+        })
+
+        const createAIMessage = (content: string): ThreadMessage => ({
+            type: AssistantMessageType.Assistant,
+            content,
+            status: 'completed',
+            id: `ai-${Math.random()}`,
+        })
+
+        it.each([
+            {
+                description: 'returns needed=false when thread has less than 2 messages',
+                thread: [createHumanMessage('/ticket')],
+                streamingActive: false,
+                expected: { needed: false },
+            },
+            {
+                description: 'returns needed=false when streaming is active',
+                thread: [createHumanMessage('/ticket'), createAIMessage("I'll help you create a support ticket")],
+                streamingActive: true,
+                expected: { needed: false },
+            },
+            {
+                description: 'returns needed=true for initial ticket prompt without confirmation',
+                thread: [createHumanMessage('/ticket'), createAIMessage("I'll help you create a support ticket")],
+                streamingActive: false,
+                expected: { needed: true, initialText: undefined },
+            },
+            {
+                description: 'returns needed=true with initialText when ticket has description',
+                thread: [
+                    createHumanMessage('/ticket My issue description'),
+                    createAIMessage("I'll help you create a support ticket"),
+                ],
+                streamingActive: false,
+                expected: { needed: true, initialText: 'My issue description' },
+            },
+            {
+                description: 'returns needed=false when confirmation message exists',
+                thread: [
+                    createHumanMessage('/ticket'),
+                    createAIMessage("I'll help you create a support ticket"),
+                    createAIMessage("I've created a support ticket for you"),
+                ],
+                streamingActive: false,
+                expected: { needed: false },
+            },
+            {
+                description: 'returns needed=false when first message is not /ticket',
+                thread: [createHumanMessage('hello'), createAIMessage('hi there')],
+                streamingActive: false,
+                expected: { needed: false },
+            },
+            {
+                description: 'returns needed=false when first message is not human',
+                thread: [createAIMessage('hello'), createHumanMessage('/ticket')],
+                streamingActive: false,
+                expected: { needed: false },
+            },
+            {
+                description: 'returns needed=false when last message is not AI prompt response',
+                thread: [
+                    createHumanMessage('/ticket'),
+                    createAIMessage('some other response'),
+                    createHumanMessage('more chat'),
+                ],
+                streamingActive: false,
+                expected: { needed: false },
+            },
+            {
+                description: 'returns initialText=undefined when /ticket has only whitespace after it',
+                thread: [createHumanMessage('/ticket   '), createAIMessage("I'll help you create a support ticket")],
+                streamingActive: false,
+                expected: { needed: true, initialText: undefined },
+            },
+        ])('$description', ({ thread, streamingActive, expected }) => {
+            expect(getTicketPromptData(thread, streamingActive)).toEqual(expected)
+        })
+    })
+
+    describe('getTicketSummaryData', () => {
+        const createHumanMessage = (content: string): ThreadMessage => ({
+            type: AssistantMessageType.Human,
+            content,
+            status: 'completed',
+            id: `human-${Math.random()}`,
+        })
+
+        const createAIMessage = (content: string): ThreadMessage => ({
+            type: AssistantMessageType.Assistant,
+            content,
+            status: 'completed',
+            id: `ai-${Math.random()}`,
+        })
+
+        it.each([
+            {
+                description: 'returns null when thread has less than 3 messages',
+                thread: [createHumanMessage('/ticket'), createAIMessage('response')],
+                streamingActive: false,
+                expected: null,
+            },
+            {
+                description: 'returns null when streaming is active',
+                thread: [
+                    createHumanMessage('hello'),
+                    createAIMessage('hi'),
+                    createHumanMessage('/ticket'),
+                    createAIMessage('summary'),
+                ],
+                streamingActive: true,
+                expected: null,
+            },
+            {
+                description: 'returns null when no ticket command exists',
+                thread: [createHumanMessage('hello'), createAIMessage('hi'), createHumanMessage('more')],
+                streamingActive: false,
+                expected: null,
+            },
+            {
+                description: 'returns null when ticket command is first message',
+                thread: [
+                    createHumanMessage('/ticket'),
+                    createAIMessage("I'll help you"),
+                    createHumanMessage('more info'),
+                ],
+                streamingActive: false,
+                expected: null,
+            },
+            {
+                description: 'returns null when ticket command is last message',
+                thread: [createHumanMessage('hello'), createAIMessage('hi'), createHumanMessage('/ticket')],
+                streamingActive: false,
+                expected: null,
+            },
+            {
+                description: 'returns summary when ticket command has AI response',
+                thread: [
+                    createHumanMessage('I have an issue'),
+                    createAIMessage('Tell me more'),
+                    createHumanMessage('/ticket'),
+                    createAIMessage('Here is a summary of the issue'),
+                ],
+                streamingActive: false,
+                expected: {
+                    summary: 'Here is a summary of the issue',
+                    messageIndex: 3,
+                },
+            },
+            {
+                description: 'returns null when AI response is the initial ticket prompt',
+                thread: [
+                    createHumanMessage('hello'),
+                    createAIMessage('hi'),
+                    createHumanMessage('/ticket'),
+                    createAIMessage("I'll help you create a support ticket"),
+                ],
+                streamingActive: false,
+                expected: null,
+            },
+            {
+                description: 'returns discarded when user continued conversation after summary',
+                thread: [
+                    createHumanMessage('I have an issue'),
+                    createAIMessage('Tell me more'),
+                    createHumanMessage('/ticket'),
+                    createAIMessage('Here is a summary'),
+                    createHumanMessage('Actually, I have more to add'),
+                ],
+                streamingActive: false,
+                expected: {
+                    discarded: true,
+                    messageIndex: 3,
+                },
+            },
+            {
+                description: 'returns null when ticket confirmation already exists',
+                thread: [
+                    createHumanMessage('issue'),
+                    createAIMessage('response'),
+                    createHumanMessage('/ticket'),
+                    createAIMessage('summary'),
+                    createAIMessage("I've created a support ticket for you"),
+                ],
+                streamingActive: false,
+                expected: null,
+            },
+            {
+                description: 'combines user text with AI summary when ticket has description',
+                thread: [
+                    createHumanMessage('I have an issue'),
+                    createAIMessage('Tell me more'),
+                    createHumanMessage('/ticket My additional notes'),
+                    createAIMessage('AI generated summary'),
+                ],
+                streamingActive: false,
+                expected: {
+                    summary: 'User notes: My additional notes\n\nAI generated summary',
+                    messageIndex: 3,
+                },
+            },
+            {
+                description: 'finds last ticket command when multiple exist',
+                thread: [
+                    createHumanMessage('/ticket first'),
+                    createAIMessage('first summary'),
+                    createHumanMessage('more chat'),
+                    createAIMessage('response'),
+                    createHumanMessage('/ticket second'),
+                    createAIMessage('second summary'),
+                ],
+                streamingActive: false,
+                expected: {
+                    summary: 'User notes: second\n\nsecond summary',
+                    messageIndex: 5,
+                },
+            },
+            {
+                description: 'returns summary without user text when ticket command has no description',
+                thread: [
+                    createHumanMessage('issue'),
+                    createAIMessage('response'),
+                    createHumanMessage('/ticket'),
+                    createAIMessage('AI summary'),
+                ],
+                streamingActive: false,
+                expected: {
+                    summary: 'AI summary',
+                    messageIndex: 3,
+                },
+            },
+            {
+                description: 'returns summary when only whitespace follows ticket command',
+                thread: [
+                    createHumanMessage('issue'),
+                    createAIMessage('response'),
+                    createHumanMessage('/ticket   '),
+                    createAIMessage('AI summary'),
+                ],
+                streamingActive: false,
+                expected: {
+                    summary: 'AI summary',
+                    messageIndex: 3,
+                },
+            },
+        ])('$description', ({ thread, streamingActive, expected }) => {
+            expect(getTicketSummaryData(thread, streamingActive)).toEqual(expected)
+        })
+    })
+
+    describe('isTicketConfirmationMessage', () => {
+        const createHumanMessage = (content: string): ThreadMessage => ({
+            type: AssistantMessageType.Human,
+            content,
+            status: 'completed',
+            id: `human-${Math.random()}`,
+        })
+
+        const createAIMessage = (content: string): ThreadMessage => ({
+            type: AssistantMessageType.Assistant,
+            content,
+            status: 'completed',
+            id: `ai-${Math.random()}`,
+        })
+
+        it.each([
+            {
+                description: 'returns true for AI message with confirmation text',
+                message: createAIMessage("I've created a support ticket for you"),
+                expected: true,
+            },
+            {
+                description: 'returns true when confirmation text is in middle of message',
+                message: createAIMessage("Great! I've created a support ticket for you. Here are the details."),
+                expected: true,
+            },
+            {
+                description: 'returns false for human message with confirmation text',
+                message: createHumanMessage("I've created a support ticket for you"),
+                expected: false,
+            },
+            {
+                description: 'returns false for AI message without confirmation text',
+                message: createAIMessage('Here is a summary of your issue'),
+                expected: false,
+            },
+            {
+                description: 'returns false for AI message with similar but different text',
+                message: createAIMessage('I will create a support ticket for you'),
+                expected: false,
+            },
+            {
+                description: 'returns false for empty AI message',
+                message: createAIMessage(''),
+                expected: false,
+            },
+        ])('$description', ({ message, expected }) => {
+            expect(isTicketConfirmationMessage(message)).toBe(expected)
+        })
+    })
+})

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -93,6 +93,9 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
         registerTool: (tool: ToolRegistration) => ({ tool }),
         deregisterTool: (key: string) => ({ key }),
         prependOrReplaceConversation: (conversation: ConversationDetail | Conversation) => ({ conversation }),
+        setLastActiveAIConversation: (data: { conversationId: string; aiSuggested: boolean; timestamp: number }) => ({
+            data,
+        }),
         dismissLiabilityNotice: true,
     }),
 
@@ -146,6 +149,13 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
                     delete newState[key]
                     return newState
                 },
+            },
+        ],
+        lastActiveAIConversation: [
+            null as { conversationId: string; aiSuggested: boolean; timestamp: number } | null,
+            { persist: true, storageKey: 'posthog_ai_last_active_conversation' },
+            {
+                setLastActiveAIConversation: (_, { data }) => data,
             },
         ],
         liabilityNoticeDismissed: [

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -3,6 +3,7 @@ import {
     BuiltLogic,
     actions,
     afterMount,
+    beforeUnmount,
     connect,
     kea,
     key,
@@ -73,6 +74,7 @@ import { maxLogic } from './maxLogic'
 import type { maxThreadLogicType } from './maxThreadLogicType'
 import { MaxUIContext } from './maxTypes'
 import { MAX_SLASH_COMMANDS, SlashCommand } from './slash-commands'
+import { wasTicketAISuggested } from './ticketUtils'
 import {
     getAgentModeForScene,
     isAssistantMessage,
@@ -1616,6 +1618,16 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             setTimeout(() => {
                 actions.reconnectToStream()
             }, 0)
+        }
+    }),
+
+    beforeUnmount(({ values }) => {
+        if (values.conversationId && values.threadGrouped.length > 0) {
+            maxGlobalLogic.findMounted()?.actions.setLastActiveAIConversation({
+                conversationId: values.conversationId,
+                aiSuggested: wasTicketAISuggested(values.threadGrouped),
+                timestamp: Date.now(),
+            })
         }
     }),
 

--- a/frontend/src/scenes/max/ticketUtils.ts
+++ b/frontend/src/scenes/max/ticketUtils.ts
@@ -135,6 +135,43 @@ export function getTicketSummaryData(
     return null
 }
 
+const ESCALATION_PHRASES = [
+    'support ticket',
+    'raise a ticket',
+    'create a ticket',
+    'file a ticket',
+    'open a ticket',
+    'contact support',
+    'support team',
+    'support engineer',
+    'reach out to support',
+    'report this',
+]
+
+/**
+ * Checks whether the recent conversation contained escalation-related language,
+ * indicating that ticket creation was suggested by the AI or discussed by the user.
+ * Scans the last 5 messages for phrases suggesting ticket creation or contacting support.
+ */
+export function wasTicketAISuggested(threadGrouped: ThreadMessage[]): boolean {
+    if (threadGrouped.length === 0) {
+        return false
+    }
+
+    const startIndex = Math.max(0, threadGrouped.length - 5)
+    for (let i = threadGrouped.length - 1; i >= startIndex; i--) {
+        const msg = threadGrouped[i]
+        if ('content' in msg && typeof msg.content === 'string') {
+            const contentLower = msg.content.toLowerCase()
+            if (ESCALATION_PHRASES.some((phrase) => contentLower.includes(phrase))) {
+                return true
+            }
+        }
+    }
+
+    return false
+}
+
 /**
  * Checks if a message is a ticket confirmation message.
  */


### PR DESCRIPTION
## Problem

When users create Zendesk support tickets after chatting with PostHog AI, support agents have no way to know that the user was just talking to AI, what they discussed, or whether the AI itself suggested they create a ticket. This makes it harder to triage and provide context-aware support.

I want to:
1. **Tag tickets** so support can report on AI-originated tickets in Zendesk (including when PostHog AI suggests a ticket).
2. **Link to the AI conversation** so support agents can see what the user discussed before raising the ticket

## Changes

### 1. AI conversation detection in `supportLogic.ts`
Added `getAIConversationData()` which runs at ticket submission time. It checks whether the user was recently chatting with PostHog AI and returns:
- A **Zendesk tag**: `raised_from_posthog_ai_chat` (user decided to create ticket on their own, but had recently chatted with AI) or `ai_suggested_support_ticket` (recent conversation contained escalation language like "contact support", "support ticket", etc.)
- A **link** to the AI conversation (`https://us.posthog.com/project/2/ai?chat={conversationId}`) appended to the ticket's internal comment body alongside existing metadata (session replay link, error tracking link, etc.)

This works for **all** ticket creation paths — `/ticket` command in AI chat, bad feedback → "Open support ticket", and navigating to the general Support form after chatting with AI.

### 2. Escalation phrase detection in `ticketUtils.ts`
Added `wasTicketAISuggested()` which scans the last 5 messages for phrases like "support ticket", "contact support", "report this", etc. This is a simple heuristic — see open questions below.

### 3. State caching for tab switches in `maxGlobalLogic.tsx` + `maxThreadLogic.tsx`
The side panel only renders one tab at a time, so switching from the AI tab to the Support tab **unmounts** `maxThreadLogic`. To handle this:
- `maxThreadLogic` snapshots conversation state to `maxGlobalLogic` in `beforeUnmount`
- `maxGlobalLogic` stores it in a `persist: true` reducer (survives page reloads too)
- `getAIConversationData()` tries the mounted thread logic first, then falls back to this cache with a **30-minute staleness check**

### 4. Tests in `ticketUtils.test.ts`
39 parameterized tests covering `wasTicketAISuggested`, `getTicketPromptData`, `getTicketSummaryData`, and `isTicketConfirmationMessage`.

### Files changed
- `frontend/src/lib/components/Support/supportLogic.ts` — AI data injection into Zendesk payload
- `frontend/src/scenes/max/ticketUtils.ts` — `wasTicketAISuggested()` + escalation phrases
- `frontend/src/scenes/max/maxGlobalLogic.tsx` — `lastActiveAIConversation` persisted reducer
- `frontend/src/scenes/max/maxThreadLogic.tsx` — `beforeUnmount` cache snapshot
- `frontend/src/scenes/max/TicketPrompt.tsx` — whitespace-only reformatting
- `frontend/src/scenes/max/__tests__/ticketUtils.test.ts` — new test file

## Open questions

1. **30-minute staleness timeout** — The cache expires after 30 minutes so that old AI conversations don't get attached to unrelated tickets. Is 30 minutes the right window? Too short and we miss legitimate cases (user takes a while filling out the form); too long and we get false positives.

2. **Escalation phrase heuristic** — `wasTicketAISuggested()` does simple substring matching on the last 5 messages. This could produce false positives (e.g. user says "I don't need a support ticket") or false negatives (AI uses different phrasing). Is this good enough for the initial version, or should we take a different approach?

3. **kea cache vs plain localStorage for surviving tab switches** — The current approach uses `beforeUnmount` in `maxThreadLogic` to snapshot state into a `persist: true` reducer in `maxGlobalLogic`. This works but adds complexity across 3 files. A simpler alternative: write `{ conversationId, timestamp }` to localStorage directly in `maxThreadLogic`'s `afterMount`, and read it in `supportLogic` when submitting a ticket. I went with the kea approach because the codebase uses `persist: true` reducers extensively (~82 files) while direct `localStorage.setItem` is rarely but it might be overkill for caching a single conversationId that no logic needs to react to.

4. **Tag on the TicketPrompt path** — `TicketPrompt.tsx` already passes `tags: ['raised_from_posthog_ai_chat']` via `resetSendSupportRequest`. The new `supportLogic` code also adds an AI tag. This means tickets from the `/ticket` command path could end up with **both** `raised_from_posthog_ai_chat` (from TicketPrompt) and `ai_suggested_support_ticket` (from supportLogic) if escalation language was detected. Should we deduplicate, or is having both tags acceptable?

## How did you test this code?

- 39 parameterized unit tests for `wasTicketAISuggested` and related utils — all passing
- TypeScript check passes (no new errors)
- Manual verification plan (not tested yet, will wait for feedback on approach):
  - [ ] Chat with AI → type `/ticket` → submit → verify tag + link in Zendesk
  - [ ] Chat with AI → rate response as bad → "Open support ticket" → submit → verify tag + link
  - [ ] Chat with AI → switch to Support tab → submit ticket → verify cached state is used
  - [ ] Open Support form without any AI chat → verify no AI tag/link attached
  - [ ] Wait >30 min after AI chat → open Support form → verify no AI tag/link attached

## Publish to changelog?

No