### PR TITLE
chore(Signup): Fixing flaky signup test

### DIFF
--- a/playwright/e2e/signup.spec.ts
+++ b/playwright/e2e/signup.spec.ts
@@ -116,7 +116,7 @@ test.describe('Signup', () => {
 
     test('Can submit the signup form multiple times if there is a generic email set', async ({ page }) => {
         let signupRequestBody: string | null = null
-        const email = `new_user+generic_error_test@posthog.com`
+        const email = `new_user+generic_error_test_${Math.floor(Math.random() * 10000)}@posthog.com`
 
         await page.route('/api/signup/', async (route) => {
             signupRequestBody = route.request().postData()


### PR DESCRIPTION
## Problem
This test is flaky, just failed on [this run](https://github.com/PostHog/posthog/actions/runs/21863918035/job/63100963688) 

It's running into this screen:
<img width="1280" height="720" alt="test-failed-1" src="https://github.com/user-attachments/assets/9a5498b0-0a74-4fa2-91e9-78f2b9c4206e" />

## Changes
Use a randomly generated email, so we don't run into this error

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Ran the tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
