### PR TITLE
fix(mcp): register test resources for cleanup before assertions

### DIFF
--- a/services/mcp/tests/tools/experiments.integration.test.ts
+++ b/services/mcp/tests/tools/experiments.integration.test.ts
@@ -81,14 +81,13 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
             expect(experiment.name).toBe(params.name)
             expect(experiment.feature_flag_key).toBe(params.feature_flag_key)
             expect(experiment.start_date).toBeNull() // Draft experiments have no start date
             expect(experiment.url).toContain('/experiments/')
-
-            trackExperiment(experiment)
         })
 
         it('should create an experiment with description and type', async () => {
@@ -104,12 +103,11 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
             expect(experiment.name).toBe(params.name)
             expect(experiment.feature_flag_key).toBe(params.feature_flag_key)
-
-            trackExperiment(experiment)
         })
 
         it('should create an experiment with custom variants', async () => {
@@ -128,13 +126,12 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
             expect(experiment.parameters?.feature_flag_variants).toHaveLength(3)
             expect(experiment.parameters?.feature_flag_variants?.[0]?.key).toBe('control')
             expect(experiment.parameters?.feature_flag_variants?.[0]?.rollout_percentage).toBe(33)
-
-            trackExperiment(experiment)
         })
 
         it('should create an experiment with mean metric', async () => {
@@ -157,11 +154,10 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
             expect(experiment.metrics).toHaveLength(1)
-
-            trackExperiment(experiment)
         })
 
         it('should create an experiment with funnel metric', async () => {
@@ -184,11 +180,10 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
             expect(experiment.metrics).toHaveLength(1)
-
-            trackExperiment(experiment)
         })
 
         it('should create an experiment with ratio metric', async () => {
@@ -210,11 +205,10 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
             expect(experiment.metrics).toHaveLength(1)
-
-            trackExperiment(experiment)
         })
 
         it('should create an experiment with multiple metrics', async () => {
@@ -253,12 +247,11 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
             expect(experiment.metrics).toHaveLength(2)
             expect(experiment.metrics_secondary).toHaveLength(2)
-
-            trackExperiment(experiment)
         })
 
         it('should create an experiment with minimum detectable effect', async () => {
@@ -273,10 +266,9 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
-
-            trackExperiment(experiment)
         })
 
         it('should create an experiment with filter test accounts enabled', async () => {
@@ -291,10 +283,9 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
-
-            trackExperiment(experiment)
         })
 
         it("should create experiment when feature flag doesn't exist (API creates it)", async () => {
@@ -331,8 +322,8 @@ describe('Experiments', { concurrent: false }, () => {
 
                 const result = await createTool.handler(context, params as any)
                 const experiment = parseToolResponse(result)
-                testExperiments.push(experiment)
                 trackExperiment(experiment)
+                testExperiments.push(experiment)
             }
 
             // Get all experiments
@@ -602,12 +593,11 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
             expect(experiment.metrics).toHaveLength(1)
             expect(experiment.metrics_secondary).toHaveLength(1)
-
-            trackExperiment(experiment)
         })
 
         it('should create experiment with target properties', async () => {
@@ -626,10 +616,9 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
-
-            trackExperiment(experiment)
         })
 
         it('should create experiment without holdout group', async () => {
@@ -644,10 +633,9 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
-
-            trackExperiment(experiment)
         })
     })
 
@@ -667,12 +655,11 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
             expect(experiment.metrics || []).toHaveLength(0)
             expect(experiment.metrics_secondary || []).toHaveLength(0)
-
-            trackExperiment(experiment)
         })
 
         it('should handle invalid experiment ID in get operations', async () => {
@@ -733,11 +720,10 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
             expect(experiment.metrics).toHaveLength(1)
-
-            trackExperiment(experiment)
         })
 
         it('should handle empty funnel steps array', async () => {
@@ -759,10 +745,9 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.id).toBeTruthy()
-
-            trackExperiment(experiment)
         })
 
         it('should handle very long experiment names', async () => {
@@ -778,8 +763,8 @@ describe('Experiments', { concurrent: false }, () => {
             try {
                 const result = await createTool.handler(context, params as any)
                 const experiment = parseToolResponse(result)
-                expect(experiment.id).toBeTruthy()
                 trackExperiment(experiment)
+                expect(experiment.id).toBeTruthy()
             } catch (error) {
                 // Some APIs might reject very long names
                 expect(error).toBeTruthy()
@@ -803,8 +788,9 @@ describe('Experiments', { concurrent: false }, () => {
 
             const createResult = await createTool.handler(context, createParams as any)
             const experiment = parseToolResponse(createResult)
-            expect(experiment.id).toBeTruthy()
             trackExperiment(experiment)
+
+            expect(experiment.id).toBeTruthy()
 
             // Delete the experiment
             const deleteParams = { experimentId: experiment.id }
@@ -912,8 +898,9 @@ describe('Experiments', { concurrent: false }, () => {
 
             const createResult = await createTool.handler(context, createParams as any)
             const experiment = parseToolResponse(createResult)
-            expect(experiment.id).toBeTruthy()
             trackExperiment(experiment)
+
+            expect(experiment.id).toBeTruthy()
 
             // Update basic fields
             const updateParams = {
@@ -947,8 +934,9 @@ describe('Experiments', { concurrent: false }, () => {
 
             const createResult = await createTool.handler(context, createParams as any)
             const experiment = parseToolResponse(createResult)
-            expect(experiment.start_date).toBeNull() // Draft experiments have no start date
             trackExperiment(experiment)
+
+            expect(experiment.start_date).toBeNull() // Draft experiments have no start date
 
             // Launch the experiment
             const launchParams = {
@@ -1242,10 +1230,9 @@ describe('Experiments', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params as any)
             const experiment = parseToolResponse(result)
+            trackExperiment(experiment)
 
             expect(experiment.start_date).toBeNull() // Draft experiments have no start date
-
-            trackExperiment(experiment)
         })
 
         it('should handle immediate launch (non-draft) experiments', async () => {
@@ -1260,11 +1247,10 @@ describe('Experiments', { concurrent: false }, () => {
             try {
                 const result = await createTool.handler(context, params as any)
                 const experiment = parseToolResponse(result)
+                trackExperiment(experiment)
 
                 // Check actual date fields instead of computed status
                 expect(experiment.start_date).toBeTruthy() // Should have start date if launched
-
-                trackExperiment(experiment)
             } catch (error) {
                 // Some environments might not allow immediate launch
                 expect(error).toBeTruthy()

--- a/services/mcp/tests/tools/experiments.integration.test.ts
+++ b/services/mcp/tests/tools/experiments.integration.test.ts
@@ -918,8 +918,6 @@ describe('Experiments', { concurrent: false }, () => {
             expect(updatedExperiment.description).toBe('Updated description with new hypothesis')
             expect(updatedExperiment.url).toContain('/experiments/')
             expect(updatedExperiment.start_date).toBeNull() // Draft experiments have no start date
-
-            trackExperiment(experiment)
         })
 
         it('should launch a draft experiment (draft → running)', async () => {
@@ -951,8 +949,6 @@ describe('Experiments', { concurrent: false }, () => {
 
             expect(launchedExperiment.start_date).toBeTruthy() // Running experiments have start date
             expect(launchedExperiment.end_date).toBeNull() // But no end date yet
-
-            trackExperiment(experiment)
         })
 
         it('should stop a running experiment', async () => {
@@ -984,8 +980,6 @@ describe('Experiments', { concurrent: false }, () => {
             expect(stoppedExperiment.end_date).toBeTruthy()
             expect(stoppedExperiment.conclusion).toBe('stopped_early')
             // The end_date is automatically set when conclude is provided
-
-            trackExperiment(experiment)
         })
 
         it('should restart a concluded experiment', async () => {
@@ -1031,8 +1025,6 @@ describe('Experiments', { concurrent: false }, () => {
             expect(restartedExperiment.conclusion_comment).toBeNull()
             expect(restartedExperiment.start_date).toBeTruthy() // Restarted experiments have start date
             expect(restartedExperiment.end_date).toBeNull() // But no end date
-
-            trackExperiment(experiment)
         })
 
         it('should restart experiment as draft', async () => {
@@ -1073,8 +1065,6 @@ describe('Experiments', { concurrent: false }, () => {
             expect(restartedExperiment.end_date).toBeNull()
             expect(restartedExperiment.conclusion).toBeNull()
             expect(restartedExperiment.start_date).toBeNull() // Draft experiments have no start date
-
-            trackExperiment(experiment)
         })
 
         it('should archive and unarchive experiment', async () => {
@@ -1116,8 +1106,6 @@ describe('Experiments', { concurrent: false }, () => {
             const unarchivedExperiment = parseToolResponse(unarchiveResult)
 
             expect(unarchivedExperiment.archived).toBe(false)
-
-            trackExperiment(experiment)
         })
 
         it('should update experiment variants', async () => {
@@ -1150,8 +1138,6 @@ describe('Experiments', { concurrent: false }, () => {
             const updatedExperiment = parseToolResponse(updateResult)
 
             expect(updatedExperiment.parameters?.minimum_detectable_effect).toBe(25)
-
-            trackExperiment(experiment)
         })
 
         it('should handle invalid experiment ID', async () => {
@@ -1211,8 +1197,6 @@ describe('Experiments', { concurrent: false }, () => {
             expect(updatedExperiment.name).toBe('Updated Name Only')
             // Description should remain unchanged
             expect(updatedExperiment.description).toBe('Original description')
-
-            trackExperiment(experiment)
         })
     })
 

--- a/services/mcp/tests/tools/featureFlags.integration.test.ts
+++ b/services/mcp/tests/tools/featureFlags.integration.test.ts
@@ -62,14 +62,14 @@ describe('Feature Flags', { concurrent: false }, () => {
             const result = await createTool.handler(context, params)
 
             const flagData = parseToolResponse(result)
+            createdResources.featureFlags.push(flagData.id)
+
             expect(flagData.id).toBeTruthy()
             expect(flagData.key).toBe(params.key)
             expect(flagData.name).toBe(params.name)
             expect(flagData.active).toBe(params.active)
             expect(flagData.url).toContain('/feature_flags/')
             expect(flagData.updated_at).toBeTruthy()
-
-            createdResources.featureFlags.push(flagData.id)
         })
 
         it('should create a feature flag with tags', async () => {
@@ -91,12 +91,11 @@ describe('Feature Flags', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params)
             const flagData = parseToolResponse(result)
+            createdResources.featureFlags.push(flagData.id)
 
             expect(flagData.id).toBeTruthy()
             expect(flagData.key).toBe(params.key)
             expect(flagData.name).toBe(params.name)
-
-            createdResources.featureFlags.push(flagData.id)
         })
 
         it('should create a feature flag with complex filters', async () => {
@@ -125,12 +124,11 @@ describe('Feature Flags', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params)
             const flagData = parseToolResponse(result)
+            createdResources.featureFlags.push(flagData.id)
 
             expect(flagData.id).toBeTruthy()
             expect(flagData.key).toBe(params.key)
             expect(flagData.name).toBe(params.name)
-
-            createdResources.featureFlags.push(flagData.id)
         })
 
         it('should create a multivariate feature flag', async () => {
@@ -157,6 +155,7 @@ describe('Feature Flags', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params)
             const flagData = parseToolResponse(result)
+            createdResources.featureFlags.push(flagData.id)
 
             expect(flagData.id).toBeTruthy()
             expect(flagData.key).toBe(params.key)
@@ -165,8 +164,6 @@ describe('Feature Flags', { concurrent: false }, () => {
             expect(flagData.filters.multivariate.variants).toHaveLength(2)
             expect(flagData.filters.multivariate.variants[0].key).toBe('control')
             expect(flagData.filters.multivariate.variants[1].key).toBe('test')
-
-            createdResources.featureFlags.push(flagData.id)
         })
 
         it('should create a multivariate flag with variant-specific targeting', async () => {
@@ -205,13 +202,12 @@ describe('Feature Flags', { concurrent: false }, () => {
 
             const result = await createTool.handler(context, params)
             const flagData = parseToolResponse(result)
+            createdResources.featureFlags.push(flagData.id)
 
             expect(flagData.id).toBeTruthy()
             expect(flagData.key).toBe(params.key)
             expect(flagData.filters.multivariate.variants).toHaveLength(2)
             expect(flagData.filters.groups[0].variant).toBe('test')
-
-            createdResources.featureFlags.push(flagData.id)
         })
     })
 


### PR DESCRIPTION
## Summary

- Move cleanup registration immediately after parsing the response, before any assertions
- This ensures resources are properly cleaned up even if assertions fail, preventing orphaned test resources

### Pattern change

**Before (buggy):**
```typescript
const experiment = parseToolResponse(result)
expect(experiment.id).toBeTruthy()     // Could fail here
expect(experiment.name).toBe(params.name) // Resource orphaned if this fails
trackExperiment(experiment)  // Too late!
```

**After (fixed):**
```typescript
const experiment = parseToolResponse(result)
trackExperiment(experiment)  // Register immediately
expect(experiment.id).toBeTruthy()
expect(experiment.name).toBe(params.name)
```

## Test plan

- [ ] Run MCP integration tests and verify they pass
- [ ] Verify resources are cleaned up even when assertions fail