### PR TITLE
feat: reverse order of python lines in before context

### DIFF
--- a/rust/cymbal/src/langs/python.rs
+++ b/rust/cymbal/src/langs/python.rs
@@ -61,6 +61,7 @@ impl RawPythonFrame {
         let before = self
             .pre_context
             .iter()
+            .rev()
             .enumerate()
             .map(|(i, line)| ContextLine::new_rel(lineno, -(i as i32) - 1, line.clone()))
             .collect();


### PR DESCRIPTION
Before:
<img width="607" height="263" alt="image" src="https://github.com/user-attachments/assets/4df3b92e-56d8-488a-8782-c55b8cd98445" />


After:
<img width="718" height="336" alt="image" src="https://github.com/user-attachments/assets/f36095e9-6f60-467c-94a7-ff15b549d025" />
