### PR TITLE
chore(e2e): fix local mprocs-e2e.yaml

### DIFF
--- a/bin/mprocs-e2e.yaml
+++ b/bin/mprocs-e2e.yaml
@@ -35,7 +35,7 @@ procs:
             E2E_TESTING: '1'
 
     docker-compose:
-        shell: 'docker compose -f docker-compose.dev-minimal.yml up --pull always -d && docker compose -f docker-compose.dev-minimal.yml logs --tail=0 -f'
+        shell: 'docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml up --pull always -d && docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml logs --tail=0 -f'
 
     reset-db:
         shell: |-
@@ -64,6 +64,7 @@ procs:
             CLOUD_DEPLOYMENT: 'E2E'
             SECRET_KEY: 'e2e_test'
             DEBUG: '1'
+            E2E_TESTING: '1'
 
 mouse_scroll_speed: 1
 scrollback: 10000

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -1,22 +1,23 @@
 # End-to-End Testing
 
-## `/e2e/` directory contains all the end-to-end tests
+## Running tests
 
-to run the new playwright tests, run the following command:
+Spin up a full local E2E environment (backend, frontend, docker services, Playwright UI):
 
 ```bash
 ./bin/e2e-test-runner
 ```
 
-to run the new playwright tests against an already locally running PostHog instance
+This uses `bin/mprocs-e2e.yaml` under the hood. If you need to reset the E2E database,
+trigger the `reset-db` process in the mprocs UI.
+
+To run tests against an already-running PostHog instance:
 
 ```bash
 LOGIN_USERNAME='my@email.address' LOGIN_PASSWORD="the-password" BASE_URL='http://localhost:8010' pnpm --filter=@posthog/playwright exec playwright test --ui
 ```
 
-### For all of these
-
-you might need to install playwright with `pnpm --filter=@posthog/playwright exec playwright install`
+You might need to install Playwright first: `pnpm --filter=@posthog/playwright exec playwright install`
 
 ## Writing tests
 
@@ -24,14 +25,12 @@ you might need to install playwright with `pnpm --filter=@posthog/playwright exe
 
 Consider adding a better selector, an intermediate step like waiting for URL or page title to change, or waiting for a critical network request to complete.
 
-### Useful output from playwright
+### Useful output from Playwright
 
-If you write a selector that is too loose and matches multiple elements, playwright will output all the matches. With a better selector for each
+If you write a selector that is too loose and matches multiple elements, Playwright will output all the matches. With a better selector for each:
 
 ```text
 Error: locator.click: Error: strict mode violation: locator('text=Set a billing limit') resolved to 2 elements:
 1) <span class="LemonButton__content">Set a billing limit</span> aka getByTestId('billing-limit-input-wrapper-product_analytics').getByRole('button', { name: 'Set a billing limit' })
 2) <span class="LemonButton__content">Set a billing limit</span> aka getByTestId('billing-limit-input-wrapper-session_replay').getByRole('button', { name: 'Set a billing limit' })
 ```
-
-<!-- Test 4-core runner performance -->


### PR DESCRIPTION
Fix two bugs in `bin/mprocs-e2e.yaml` that prevented local E2E from working:
- docker-compose referenced deleted `dev-minimal.yml`, switched to `dev.yml` with profiles overlay
- `reset-db` was missing `E2E_TESTING` env var