### PR TITLE
fix(nodejs): add last_seen_at field to person types and queries

### DIFF
--- a/nodejs/src/cdp/services/managers/persons-manager.service.test.ts
+++ b/nodejs/src/cdp/services/managers/persons-manager.service.test.ts
@@ -232,6 +232,7 @@ describe('PersonsManager', () => {
                     properties_last_operation: {},
                     created_at: TIMESTAMP,
                     version: 0,
+                    last_seen_at: null,
                 },
                 {
                     id: '2',
@@ -245,6 +246,7 @@ describe('PersonsManager', () => {
                     properties_last_operation: {},
                     created_at: TIMESTAMP,
                     version: 0,
+                    last_seen_at: null,
                 },
                 {
                     id: '3',
@@ -258,6 +260,7 @@ describe('PersonsManager', () => {
                     properties_last_operation: {},
                     created_at: TIMESTAMP,
                     version: 0,
+                    last_seen_at: null,
                 },
             ]
 
@@ -302,6 +305,7 @@ describe('PersonsManager', () => {
                 properties_last_operation: {},
                 created_at: TIMESTAMP,
                 version: 0,
+                last_seen_at: null,
             }))
             const batch2 = Array.from({ length: 300 }, (_, i) => ({
                 id: `${i + 500}`,
@@ -315,6 +319,7 @@ describe('PersonsManager', () => {
                 properties_last_operation: {},
                 created_at: TIMESTAMP,
                 version: 0,
+                last_seen_at: null,
             }))
 
             let callCount = 0
@@ -360,6 +365,7 @@ describe('PersonsManager', () => {
                 properties_last_operation: {},
                 created_at: TIMESTAMP,
                 version: 0,
+                last_seen_at: null,
             }))
 
             const fetchSpy = jest.spyOn(hub.personRepository, 'fetchPersonsByProperties').mockResolvedValueOnce(batch)
@@ -400,6 +406,7 @@ describe('PersonsManager', () => {
                 properties_last_operation: {},
                 created_at: TIMESTAMP,
                 version: 0,
+                last_seen_at: null,
             }))
             const batch2 = Array.from({ length: 50 }, (_, i) => ({
                 id: `${i + 100}`,
@@ -413,6 +420,7 @@ describe('PersonsManager', () => {
                 properties_last_operation: {},
                 created_at: TIMESTAMP,
                 version: 0,
+                last_seen_at: null,
             }))
 
             let callCount = 0

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -852,6 +852,7 @@ export interface BasePerson {
     uuid: string
     properties_last_updated_at: PropertiesLastUpdatedAt
     properties_last_operation: PropertiesLastOperation | null
+    last_seen_at: string | null
 }
 
 /** Raw Person row from database. */

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -66,6 +66,7 @@ describe('BatchWritingPersonStore', () => {
             is_user_id: null,
             is_identified: false,
             uuid: '1',
+            last_seen_at: null,
         }
 
         mockPostgres = {

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -1618,6 +1618,7 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
             version: currentPerson.version,
             is_identified: currentPerson.is_identified || personUpdate.is_identified,
             is_user_id: personUpdate.is_user_id,
+            last_seen_at: currentPerson.last_seen_at,
             needs_write: personUpdate.needs_write,
             properties_to_set: personUpdate.properties_to_set,
             properties_to_unset: personUpdate.properties_to_unset,

--- a/nodejs/src/worker/ingestion/persons/person-update-batch.ts
+++ b/nodejs/src/worker/ingestion/persons/person-update-batch.ts
@@ -16,6 +16,7 @@ export interface PersonUpdate {
     version: number
     is_identified: boolean
     is_user_id: number | null
+    last_seen_at: string | null
     needs_write: boolean
     // Fine-grained property tracking
     properties_to_set: Properties // Properties to set/update
@@ -46,6 +47,7 @@ export function fromInternalPerson(person: InternalPerson, distinctId: string): 
         version: person.version,
         is_identified: person.is_identified,
         is_user_id: person.is_user_id,
+        last_seen_at: person.last_seen_at,
         needs_write: false,
         properties_to_set: {},
         properties_to_unset: [],
@@ -80,5 +82,6 @@ export function toInternalPerson(personUpdate: PersonUpdate): InternalPerson {
         version: personUpdate.version,
         is_identified: personUpdate.is_identified,
         is_user_id: personUpdate.is_user_id,
+        last_seen_at: personUpdate.last_seen_at,
     }
 }

--- a/nodejs/src/worker/ingestion/persons/repositories/clickhouse-person-repository.test.ts
+++ b/nodejs/src/worker/ingestion/persons/repositories/clickhouse-person-repository.test.ts
@@ -1111,6 +1111,7 @@ describe('ClickHousePersonRepository', () => {
                 is_identified: false,
                 created_at: TIMESTAMP,
                 version: 0,
+                last_seen_at: null,
             }
             await expect(repository.updatePerson(person, {} as any)).rejects.toThrow(
                 'Write operations not supported in ClickHousePersonRepository'
@@ -1129,6 +1130,7 @@ describe('ClickHousePersonRepository', () => {
                 is_identified: false,
                 created_at: TIMESTAMP,
                 version: 0,
+                last_seen_at: null,
             }
             await expect(repository.deletePerson(person)).rejects.toThrow(
                 'Write operations not supported in ClickHousePersonRepository'
@@ -1147,6 +1149,7 @@ describe('ClickHousePersonRepository', () => {
                 is_identified: false,
                 created_at: TIMESTAMP,
                 version: 0,
+                last_seen_at: null,
             }
             await expect(repository.addDistinctId(person, 'new-distinct-id', 0)).rejects.toThrow(
                 'Write operations not supported in ClickHousePersonRepository'

--- a/nodejs/src/worker/ingestion/persons/repositories/clickhouse-person-repository.ts
+++ b/nodejs/src/worker/ingestion/persons/repositories/clickhouse-person-repository.ts
@@ -329,6 +329,7 @@ export class ClickHousePersonRepository implements PersonRepository {
             is_identified: Boolean(row.is_identified),
             created_at: DateTime.fromSQL(row.created_at, { zone: 'UTC' }),
             version: typeof row.version === 'string' ? parseInt(row.version) : row.version || 0,
+            last_seen_at: null,
         }
     }
 

--- a/nodejs/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
+++ b/nodejs/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
@@ -104,6 +104,7 @@ describe('PostgresPersonRepository', () => {
                         is_user_id: createdPerson.is_user_id,
                         version: createdPerson.version,
                         is_identified: createdPerson.is_identified,
+                        last_seen_at: createdPerson.last_seen_at,
                     },
                 ],
                 command: 'SELECT',
@@ -140,6 +141,7 @@ describe('PostgresPersonRepository', () => {
                         is_user_id: createdPerson.is_user_id,
                         version: createdPerson.version,
                         is_identified: createdPerson.is_identified,
+                        last_seen_at: createdPerson.last_seen_at,
                     },
                 ],
                 command: 'SELECT',
@@ -420,6 +422,7 @@ describe('PostgresPersonRepository', () => {
                 is_user_id: null,
                 version: 0,
                 is_identified: false,
+                last_seen_at: null,
             }
 
             const messages = await repository.deletePerson(nonExistentPerson)
@@ -475,6 +478,7 @@ describe('PostgresPersonRepository', () => {
                 is_user_id: null,
                 version: 0,
                 is_identified: false,
+                last_seen_at: null,
             }
 
             const result = await repository.moveDistinctIds(sourcePerson, nonExistentTargetPerson, undefined)
@@ -499,6 +503,7 @@ describe('PostgresPersonRepository', () => {
                 is_user_id: null,
                 version: 0,
                 is_identified: false,
+                last_seen_at: null,
             }
 
             const result = await repository.moveDistinctIds(nonExistentSourcePerson, targetPerson, undefined)
@@ -1335,6 +1340,7 @@ describe('PostgresPersonRepository', () => {
                 is_user_id: null,
                 properties_last_updated_at: {},
                 properties_last_operation: {},
+                last_seen_at: null,
             }
 
             const update = { properties: { name: 'Jane' } }
@@ -1360,6 +1366,7 @@ describe('PostgresPersonRepository', () => {
                 version: person.version,
                 is_identified: person.is_identified,
                 is_user_id: person.is_user_id,
+                last_seen_at: person.last_seen_at,
                 needs_write: true,
                 properties_to_set: { name: 'Jane', age: 30 },
                 properties_to_unset: [],
@@ -1396,6 +1403,7 @@ describe('PostgresPersonRepository', () => {
                 version: person.version - 1, // Outdated version
                 is_identified: person.is_identified,
                 is_user_id: person.is_user_id,
+                last_seen_at: person.last_seen_at,
                 needs_write: true,
                 properties_to_set: { name: 'Jane', age: 30 },
                 properties_to_unset: [],
@@ -1431,6 +1439,7 @@ describe('PostgresPersonRepository', () => {
                 version: 0,
                 is_identified: false,
                 is_user_id: null,
+                last_seen_at: null,
                 needs_write: true,
                 properties_to_set: { name: 'Jane' },
                 properties_to_unset: [],
@@ -1461,6 +1470,7 @@ describe('PostgresPersonRepository', () => {
                 version: person.version,
                 is_identified: person.is_identified,
                 is_user_id: person.is_user_id,
+                last_seen_at: person.last_seen_at,
                 needs_write: true,
                 properties_to_set: { new_prop: 'new_value', to_update: 'new' }, // New properties to merge
                 properties_to_unset: [],
@@ -1500,6 +1510,7 @@ describe('PostgresPersonRepository', () => {
                 version: person.version,
                 is_identified: person.is_identified,
                 is_user_id: person.is_user_id,
+                last_seen_at: person.last_seen_at,
                 needs_write: true,
                 properties_to_set: {},
                 properties_to_unset: ['remove_me'],
@@ -1537,6 +1548,7 @@ describe('PostgresPersonRepository', () => {
                 version: person.version,
                 is_identified: person.is_identified,
                 is_user_id: person.is_user_id,
+                last_seen_at: person.last_seen_at,
                 needs_write: true,
                 properties_to_set: { update: 'new', added: 'fresh' },
                 properties_to_unset: ['remove'],
@@ -2160,6 +2172,7 @@ describe('PostgresPersonRepository', () => {
                     version: person.version,
                     is_identified: person.is_identified,
                     is_user_id: person.is_user_id,
+                    last_seen_at: person.last_seen_at,
                     needs_write: true,
                     properties_to_set: { description: 'x'.repeat(150) },
                     properties_to_unset: [],
@@ -2414,6 +2427,7 @@ describe('PostgresPersonRepository', () => {
                 version: person.version,
                 is_identified: person.is_identified,
                 is_user_id: person.is_user_id,
+                last_seen_at: person.last_seen_at,
                 needs_write: true,
                 properties_to_set: { name: 'Jane', age: 30, data: 'y'.repeat(2500) },
                 properties_to_unset: [],

--- a/nodejs/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/nodejs/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -234,7 +234,8 @@ export class PostgresPersonRepository
                 posthog_person.properties_last_operation,
                 posthog_person.is_user_id,
                 posthog_person.version,
-                posthog_person.is_identified
+                posthog_person.is_identified,
+                posthog_person.last_seen_at
             FROM posthog_person
             JOIN posthog_persondistinctid ON (
                 posthog_persondistinctid.person_id = posthog_person.id
@@ -298,6 +299,7 @@ export class PostgresPersonRepository
                 posthog_person.is_user_id,
                 posthog_person.version,
                 posthog_person.is_identified,
+                posthog_person.last_seen_at,
                 posthog_persondistinctid.distinct_id
             FROM posthog_person
             JOIN posthog_persondistinctid ON (
@@ -494,6 +496,7 @@ export class PostgresPersonRepository
                 posthog_person.properties_last_operation,
                 posthog_person.is_user_id,
                 posthog_person.is_identified,
+                posthog_person.last_seen_at,
                 posthog_persondistinctid.distinct_id
             FROM posthog_person
             JOIN posthog_persondistinctid ON (

--- a/nodejs/tests/worker/ingestion/person-state-batch.test.ts
+++ b/nodejs/tests/worker/ingestion/person-state-batch.test.ts
@@ -1050,6 +1050,7 @@ describe('PersonState.processEvent()', () => {
                 uuid: uuidFromDistinctId(teamId, 'deleted-user'),
                 properties_last_updated_at: {},
                 properties_last_operation: null,
+                last_seen_at: null,
             }
             await createPerson(
                 hub,
@@ -4364,6 +4365,7 @@ describe('PersonState.processEvent()', () => {
                             is_user_id: null,
                             properties_last_updated_at: {},
                             properties_last_operation: {},
+                            last_seen_at: null,
                         }
                         jest.spyOn(mergeService, 'handleIdentifyOrAlias').mockResolvedValue({
                             success: true,

--- a/nodejs/tests/worker/ingestion/postgres-parity.test.ts
+++ b/nodejs/tests/worker/ingestion/postgres-parity.test.ts
@@ -144,6 +144,7 @@ describe('postgres parity', () => {
                 is_identified: true,
                 uuid: uuid,
                 version: 0,
+                last_seen_at: null,
             },
         ])
         const postgresDistinctIds = await fetchDistinctIdValues(hub.postgres, person)


### PR DESCRIPTION
## Summary

The Rust migration `20260206000001_add_last_seen_at_to_person.sql` added `last_seen_at` to the `posthog_person` table, but the TypeScript types and queries were missing this field, causing test failures.

## Changes

- Add `last_seen_at: string | null` to `BasePerson` interface in `types.ts`
- Update 3 PostgreSQL SELECT queries in `postgres-person-repository.ts` to include `last_seen_at`
- Update ClickHouse repository to return `last_seen_at: null` (ClickHouse doesn't have this column)
- Add `last_seen_at` to `PersonUpdate` interface and `fromInternalPerson`/`toInternalPerson` functions
- Update `batch-writing-person-store.ts` to include `last_seen_at` in person update objects
- Update all test mock objects across 6 test files to include `last_seen_at: null`
