### PR TITLE
chore(session-recording): add session recording pipeline

### DIFF
--- a/nodejs/src/ingestion/session_replay/index.ts
+++ b/nodejs/src/ingestion/session_replay/index.ts
@@ -1,7 +1,7 @@
 export {
-    applyRestrictions,
-    createRestrictionPipeline,
-    RestrictionPipelineConfig,
-    RestrictionPipelineInput,
-    RestrictionPipelineOutput,
-} from './restriction-pipeline'
+    createSessionReplayPipeline,
+    runSessionReplayPipeline,
+    SessionReplayPipelineConfig,
+    SessionReplayPipelineInput,
+    SessionReplayPipelineOutput,
+} from './session-replay-pipeline'

--- a/nodejs/src/session-recording/consumer.ts
+++ b/nodejs/src/session-recording/consumer.ts
@@ -297,7 +297,7 @@ export class SessionRecordingIngester {
         SessionRecordingIngesterMetrics.observeKafkaBatchSize(batchSize)
         SessionRecordingIngesterMetrics.observeKafkaBatchSizeKb(batchSizeKb)
 
-        // Apply event procssessing pipeline steps first
+        // Apply event processing pipeline steps first
         const messagesToProcess = await instrumentFn(
             `recordingingesterv2.handleEachBatch.runPipeline`,
             async () => await runSessionReplayPipeline(this.sessionReplayPipeline, messages)


### PR DESCRIPTION
## Problem

we'd like to migrate the session recording service to leverage the pipelines framework - this can be a large refactor, so we'll start by just introducing a pipeline to the consumer for the existing steps.

## Changes

- rename restriction-pipeline to be more generic for incremental migration of functions to steps
- disclaimer: by calling the restriction code as a step, we've removed the extra instrumentation for `applyRestrictions`. this will break the existing dashboard metrics, but from my understanding is redundant as the pipeline code should have out of the box / per step metrics (please correct me if i'm wrong though!).

## How did you test this code?

ran unit + integration tests.

## Publish to changelog?

no
