### PR TITLE
chore: add banner on endpoints docs

### DIFF
--- a/products/endpoints/frontend/EndpointsScene.tsx
+++ b/products/endpoints/frontend/EndpointsScene.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconPlusSmall } from '@posthog/icons'
+import { IconBook, IconPlusSmall } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
@@ -80,7 +80,7 @@ export function EndpointsScene({ tabId }: { tabId?: string }): JSX.Element {
                                                 placement: 'bottom-end',
                                                 className: 'new-endpoint-overlay',
                                                 actionable: true,
-                                                overlay: <OverlayForNewEndpointMenu dataAttr="new-endpoint-option" />,
+                                                overlay: <OverlayForNewEndpointMenu />,
                                             },
                                             'data-attr': 'new-endpoint-dropdown',
                                         }}
@@ -103,6 +103,19 @@ export function EndpointsScene({ tabId }: { tabId?: string }): JSX.Element {
                                 it may change while we work with you on what works best. Please let us know what you'd
                                 like to see here and/or report any issues directly to us!
                             </p>
+                        </LemonBanner>
+                        <LemonBanner
+                            type="success"
+                            dismissKey="endpoints-docs-upgrade-banner"
+                            action={{
+                                children: 'View docs',
+                                to: 'https://posthog.com/docs/endpoints',
+                                targetBlank: true,
+                            }}
+                            icon={<IconBook />}
+                        >
+                            We've leveled up our endpoints documentation. Check out the new docs for detailed guides and
+                            examples.
                         </LemonBanner>
                         <ProductIntroduction
                             productName="endpoints"

--- a/products/endpoints/frontend/newEndpointMenu.tsx
+++ b/products/endpoints/frontend/newEndpointMenu.tsx
@@ -11,6 +11,7 @@ interface EndpointTypeOption {
     name: string
     description: string
     url: string
+    dataAttr: string
 }
 
 const ENDPOINT_TYPE_OPTIONS: EndpointTypeOption[] = [
@@ -19,16 +20,18 @@ const ENDPOINT_TYPE_OPTIONS: EndpointTypeOption[] = [
         name: 'HogQL endpoint',
         description: 'Create an endpoint from a HogQL query in the SQL editor.',
         url: urls.sqlEditor({ outputTab: OutputTab.Endpoint }),
+        dataAttr: 'new-endpoint-overlay-hogql',
     },
     {
         icon: IconGraph,
         name: 'Insight endpoint',
         description: 'Create an endpoint from a new insight.',
         url: urls.insightNew(),
+        dataAttr: 'new-endpoint-overlay-insight',
     },
 ]
 
-export function OverlayForNewEndpointMenu({ dataAttr }: { dataAttr: string }): JSX.Element {
+export function OverlayForNewEndpointMenu(): JSX.Element {
     return (
         <>
             {ENDPOINT_TYPE_OPTIONS.map((option) => (
@@ -38,7 +41,7 @@ export function OverlayForNewEndpointMenu({ dataAttr }: { dataAttr: string }): J
                     onClick={() => {
                         router.actions.push(option.url)
                     }}
-                    data-attr={dataAttr}
+                    data-attr={option.dataAttr}
                     data-attr-endpoint-type={option.name}
                     fullWidth
                 >


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
we've got some old users already, let's make sure they see the docs.

also - can't create a product tour easily without a proper data-attr on the new endpoint overlay

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- banner
- data-attr on overlay
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no