### PR TITLE
feat(analytics-platform): Add dagster job for experimental sessions backfill

### DIFF
--- a/posthog/dags/locations/analytics_platform.py
+++ b/posthog/dags/locations/analytics_platform.py
@@ -1,15 +1,16 @@
 import dagster
 
 from posthog.dags import sessions, sessions_v1_cleanup
-from posthog.dags.sessions import sessions_backfill_job
+from posthog.dags.sessions import (
+    experimental_sessions_backfill_job,
+    experimental_sessions_v3_backfill,
+    sessions_backfill_job,
+)
 
 from . import resources
 
 defs = dagster.Definitions(
-    assets=[sessions.sessions_v3_backfill, sessions.sessions_v3_backfill_replay],
-    jobs=[
-        sessions_backfill_job,
-        sessions_v1_cleanup.sessions_v1_cleanup_job,
-    ],
+    assets=[sessions.sessions_v3_backfill, sessions.sessions_v3_backfill_replay, experimental_sessions_v3_backfill],
+    jobs=[sessions_backfill_job, sessions_v1_cleanup.sessions_v1_cleanup_job, experimental_sessions_backfill_job],
     resources=resources,
 )

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -120,7 +120,7 @@ class ExperimentalSessionsBackfillConfig(Config):
     max_unmerged_parts: int = 100
     parts_check_poll_frequency_seconds: int = 30
     parts_check_max_wait_seconds: int = 3600
-    host_ip: str
+    client_overrides: dict[str, Any]
 
 
 daily_partitions = DailyPartitionsDefinition(
@@ -441,8 +441,7 @@ def _do_experimental_backfill(
     kwargs = get_kwargs_for_client(
         workload=Workload.OFFLINE, team_id=None, readonly=False, ch_user=ClickHouseUser.DEFAULT
     )
-    overrides = {"host": config.host_ip}
-    with get_http_client(**kwargs, **overrides) as client:
+    with get_http_client(**kwargs, **config.client_overrides) as client:
         # this loop is largely copied from _do_backfill, but not writing per shard
         for chunk_i in range(team_id_chunks):
             wait_for_parts_to_merge(context, config, sync_client=client)

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -402,7 +402,7 @@ def experimental_sessions_v3_backfill(
 
 
 experimental_sessions_backfill_job = define_asset_job(
-    name="sessions_v3_backfill_job",
+    name="experimental_sessions_v3_backfill_job",
     selection=["experimental_sessions_v3_backfill"],
     config=sessions_backfill_partitioned_config,
     tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **CONCURRENCY_TAG},

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -18,13 +18,20 @@ from dagster import (
 )
 
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.client.connection import NodeRole, Workload
+from posthog.clickhouse.client.connection import (
+    ClickHouseUser,
+    NodeRole,
+    Workload,
+    get_http_client,
+    get_kwargs_for_client,
+)
 from posthog.clickhouse.cluster import get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
 from posthog.dags.common.common import JobOwners, dagster_tags
 from posthog.git import get_git_commit_short
 from posthog.models.raw_sessions.sessions_v3 import (
+    DISTRIBUTED_RAW_SESSIONS_TABLE_V3,
     GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS,
     RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3,
     RAW_SESSION_TABLE_BACKFILL_SQL_V3,
@@ -107,6 +114,15 @@ class SessionsBackfillConfig(Config):
     parts_check_max_wait_seconds: int = 3600
 
 
+class ExperimentalSessionsBackfillConfig(Config):
+    clickhouse_settings: dict[str, Any] | None = None
+    team_id_chunks: int | None = 16
+    max_unmerged_parts: int = 100
+    parts_check_poll_frequency_seconds: int = 30
+    parts_check_max_wait_seconds: int = 3600
+    host_ip: str
+
+
 daily_partitions = DailyPartitionsDefinition(
     start_date="2019-01-01",  # this is a year before posthog was founded, so should be early enough even including data imports
     timezone="UTC",
@@ -165,7 +181,7 @@ def get_db_partitions_to_check(context: AssetExecutionContext) -> list[str]:
 
 def wait_for_parts_to_merge(
     context: AssetExecutionContext,
-    config: SessionsBackfillConfig,
+    config: SessionsBackfillConfig | ExperimentalSessionsBackfillConfig,
     sync_client: Optional[Client] = None,
 ) -> None:
     """Check for unmerged parts and wait if there are too many.
@@ -366,3 +382,87 @@ WHERE
 ORDER BY event_time DESC;
 """
     return f"http://localhost:8123/play?user=default#{base64.b64encode(sql.encode('utf-8')).decode('utf-8')}"
+
+
+# Create a copy of the sessions backfill job to be used for backfilling experimental setups
+
+
+@asset(
+    partitions_def=daily_partitions,
+    name="experimental_sessions_v3_backfill",
+    backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=MAX_PARTITIONS_PER_RUN),
+    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **CONCURRENCY_TAG},
+)
+def experimental_sessions_v3_backfill(
+    context: AssetExecutionContext, config: ExperimentalSessionsBackfillConfig
+) -> None:
+    _do_experimental_backfill(
+        timestamp_field="timestamp", sql_template=RAW_SESSION_TABLE_BACKFILL_SQL_V3, config=config, context=context
+    )
+
+
+experimental_sessions_backfill_job = define_asset_job(
+    name="sessions_v3_backfill_job",
+    selection=["experimental_sessions_v3_backfill"],
+    config=sessions_backfill_partitioned_config,
+    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **CONCURRENCY_TAG},
+)
+
+
+def _do_experimental_backfill(
+    sql_template: Callable,
+    timestamp_field: str,
+    context: AssetExecutionContext,
+    config: ExperimentalSessionsBackfillConfig,
+):
+    where_clause = get_partition_where_clause(context, timestamp_field=timestamp_field)
+
+    partition_range = context.partition_key_range
+    partition_range_str = f"{partition_range.start} to {partition_range.end}"
+
+    context.log.info(f"Config: {config}")
+
+    # Merge custom clickhouse settings with defaults
+    merged_settings = clickhouse_settings.copy()
+    if config.clickhouse_settings:
+        merged_settings.update(config.clickhouse_settings)
+        context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
+
+    team_id_chunks = max(1, config.team_id_chunks or 1)
+
+    context.log.info(
+        f"Running backfill for Dagster partitions {partition_range_str} "
+        f"(where='{where_clause}') "
+        f"using commit {get_git_commit_short() or 'unknown'}"
+    )
+    if debug_url := metabase_debug_query_url(context.run_id):
+        context.log.info(f"Debug query: {debug_url}")
+
+    kwargs = get_kwargs_for_client(
+        workload=Workload.OFFLINE, team_id=None, readonly=False, ch_user=ClickHouseUser.DEFAULT
+    )
+    overrides = {"host": config.host_ip}
+    with get_http_client(**kwargs, **overrides) as client:
+        # this loop is largely copied from _do_backfill, but not writing per shard
+        for chunk_i in range(team_id_chunks):
+            wait_for_parts_to_merge(context, config, sync_client=client)
+
+            if team_id_chunks > 1:
+                chunk_where_clause = f"({where_clause}) AND team_id % {team_id_chunks} = {chunk_i}"
+                context.log.info(
+                    f"Processing chunk {chunk_i + 1}/{team_id_chunks} (team_id % {team_id_chunks} = {chunk_i})"
+                )
+            else:
+                chunk_where_clause = where_clause
+
+            backfill_sql = sql_template(
+                where=chunk_where_clause,
+                target_table=DISTRIBUTED_RAW_SESSIONS_TABLE_V3(),
+            )
+            context.log.info(backfill_sql)
+            sync_execute(backfill_sql, settings=merged_settings, sync_client=client)
+
+            if team_id_chunks > 1:
+                context.log.info(f"Completed chunk {chunk_i + 1}/{team_id_chunks}")
+
+        context.log.info(f"Successfully backfilled sessions_v3 for Dagster partitions {partition_range_str}")

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -540,7 +540,8 @@ def RAW_SESSION_TABLE_BACKFILL_SQL_V3(
     Each shard should call this with its own shard_index to only SELECT events
     that will end up on that shard, then INSERT directly to the local sharded table.
     """
-    target_table |= SHARDED_RAW_SESSIONS_TABLE_V3()
+    if not target_table:
+        target_table = SHARDED_RAW_SESSIONS_TABLE_V3()
     if shard_index is not None and num_shards is not None:
         shard_filter = f"modulo(cityHash64(`$session_id_uuid`), {num_shards}) = {shard_index}"
         combined_where = f"({where}) AND {shard_filter}"
@@ -569,7 +570,8 @@ def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(
     Each shard should call this with its own shard_index to only SELECT recordings
     that will end up on that shard, then INSERT directly to the local sharded table.
     """
-    target_table |= SHARDED_RAW_SESSIONS_TABLE_V3()
+    if not target_table:
+        target_table = SHARDED_RAW_SESSIONS_TABLE_V3()
     if shard_index is not None and num_shards is not None:
         shard_filter = f"modulo(cityHash64(toUInt128(accurateCast(session_id, 'UUID'))), {num_shards}) = {shard_index}"
         combined_where = f"({where}) AND {shard_filter}"

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -562,7 +562,7 @@ INSERT INTO {database}.{target_table}
 
 
 def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(
-    where: str, shard_index: int, num_shards: int, target_table: Optional[str]
+    where: str, shard_index: Optional[int] = None, num_shards: Optional[int] = None, target_table: Optional[str] = None
 ):
     """
     Generates SQL to backfill sessions from session replay events.

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.conf import settings
 
 from posthog.clickhouse.table_engines import AggregatingMergeTree, Distributed, ReplicationScheme
@@ -529,22 +531,28 @@ AS
     )
 
 
-def RAW_SESSION_TABLE_BACKFILL_SQL_V3(where: str, shard_index: int, num_shards: int):
+def RAW_SESSION_TABLE_BACKFILL_SQL_V3(
+    where: str, shard_index: Optional[int] = None, num_shards: Optional[int] = None, target_table: Optional[str] = None
+):
     """
     Generates SQL to backfill sessions from events.
 
     Each shard should call this with its own shard_index to only SELECT events
     that will end up on that shard, then INSERT directly to the local sharded table.
     """
-    shard_filter = f"modulo(cityHash64(`$session_id_uuid`), {num_shards}) = {shard_index}"
-    combined_where = f"({where}) AND {shard_filter}"
+    target_table |= SHARDED_RAW_SESSIONS_TABLE_V3()
+    if shard_index is not None and num_shards is not None:
+        shard_filter = f"modulo(cityHash64(`$session_id_uuid`), {num_shards}) = {shard_index}"
+        combined_where = f"({where}) AND {shard_filter}"
+    else:
+        combined_where = where
 
     return """
 INSERT INTO {database}.{target_table}
 {select_sql}
 """.format(
         database=settings.CLICKHOUSE_DATABASE,
-        target_table=SHARDED_RAW_SESSIONS_TABLE_V3(),
+        target_table=target_table,
         select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(
             where=combined_where,
             source_table=f"{settings.CLICKHOUSE_DATABASE}.events",
@@ -552,22 +560,28 @@ INSERT INTO {database}.{target_table}
     )
 
 
-def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(where: str, shard_index: int, num_shards: int):
+def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(
+    where: str, shard_index: int, num_shards: int, target_table: Optional[str]
+):
     """
     Generates SQL to backfill sessions from session replay events.
 
     Each shard should call this with its own shard_index to only SELECT recordings
     that will end up on that shard, then INSERT directly to the local sharded table.
     """
-    shard_filter = f"modulo(cityHash64(toUInt128(accurateCast(session_id, 'UUID'))), {num_shards}) = {shard_index}"
-    combined_where = f"({where}) AND {shard_filter}"
+    target_table |= SHARDED_RAW_SESSIONS_TABLE_V3()
+    if shard_index is not None and num_shards is not None:
+        shard_filter = f"modulo(cityHash64(toUInt128(accurateCast(session_id, 'UUID'))), {num_shards}) = {shard_index}"
+        combined_where = f"({where}) AND {shard_filter}"
+    else:
+        combined_where = where
 
     return """
 INSERT INTO {database}.{target_table}
 {select_sql}
 """.format(
         database=settings.CLICKHOUSE_DATABASE,
-        target_table=SHARDED_RAW_SESSIONS_TABLE_V3(),
+        target_table=target_table,
         select_sql=RAW_SESSION_TABLE_MV_RECORDINGS_SELECT_SQL_V3(
             where=combined_where,
             source_table=f"{settings.CLICKHOUSE_DATABASE}.session_replay_events",


### PR DESCRIPTION
## Problem

We want to backfill this on a new cluster, on a separate IP

## Changes
Add a copy of the dagster job but with a different client initialisation and skipping the sharded magic

## How did you test this code?

n/a

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
