### PR TITLE
fix(phai): side panel chat styling in safari

### DIFF
--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -133,7 +133,7 @@ export const MaxInstance = React.memo(function MaxInstance({
                             !sidePanel && 'min-h-[calc(100vh-var(--scene-layout-header-height)-120px)]'
                         )}
                     >
-                        <div className="flex-1 items-center justify-center flex flex-col gap-3 relative z-50">
+                        <div className="grow items-center justify-center flex flex-col gap-3 relative z-50">
                             <Intro />
                             <SidebarQuestionInputWithSuggestions />
                         </div>


### PR DESCRIPTION
## Problem

A tentative fix for Safari 18.7 for [this](https://posthoghelp.zendesk.com/agent/tickets/50335) issue.

## Changes

- Change flex-1 to grow.

## How did you test this code?

Manual testing. I couldn't test Safari 18.7, but it works on the latest versions of Safari and Chrome.
