### PR TITLE
feat(logs): Allow querying logs table in HogQL

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -15,21 +15,9 @@ from clickhouse_connect.driver import (
 from clickhouse_driver import Client as SyncClient
 from clickhouse_pool import ChPool
 
+from posthog.clickhouse.workload import Workload
 from posthog.settings import data_stores
 from posthog.utils import patchable
-
-
-class Workload(StrEnum):
-    # Default workload
-    DEFAULT = "DEFAULT"
-    # Analytics queries, other 'lively' queries
-    ONLINE = "ONLINE"
-    # Historical exports, other long-running processes where latency is less critical
-    OFFLINE = "OFFLINE"
-    # Logs queries
-    LOGS = "LOGS"
-    # Endpoints (the product) queries
-    ENDPOINTS = "ENDPOINTS"
 
 
 class NodeRole(StrEnum):

--- a/posthog/clickhouse/workload.py
+++ b/posthog/clickhouse/workload.py
@@ -1,0 +1,14 @@
+from enum import StrEnum
+
+
+class Workload(StrEnum):
+    # Default workload
+    DEFAULT = "DEFAULT"
+    # Analytics queries, other 'lively' queries
+    ONLINE = "ONLINE"
+    # Historical exports, other long-running processes where latency is less critical
+    OFFLINE = "OFFLINE"
+    # Logs queries
+    LOGS = "LOGS"
+    # Endpoints (the product) queries
+    ENDPOINTS = "ENDPOINTS"

--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -181,7 +181,7 @@ class CHQueryErrorUnknownIdentifier(InternalCHQueryError):
     pass
 
 
-class CHQueryErrorTooManyBytes(InternalCHQueryError):
+class CHQueryErrorTooManyBytes(ExposedCHQueryError):
     pass
 
 

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -115,6 +115,8 @@ class HogQLQuerySettings(BaseModel):
     force_data_skipping_indices: Optional[list[str]] = None
     load_balancing: Optional[str] = None
     optimize_skip_unused_shards: Optional[bool] = None
+    read_overflow_mode: Optional[str] = None
+    max_bytes_to_read: Optional[int] = None
 
 
 # Settings applied on top of all HogQL queries.
@@ -141,5 +143,3 @@ class HogQLGlobalSettings(HogQLQuerySettings):
     allow_experimental_join_condition: Optional[bool] = True
     preferred_block_size_bytes: Optional[int] = None
     use_hive_partitioning: Optional[int] = 0
-    read_overflow_mode: Optional[str] = None
-    max_bytes_to_read: Optional[int] = None

--- a/posthog/hogql/context.py
+++ b/posthog/hogql/context.py
@@ -7,6 +7,8 @@ from posthog.schema import HogQLNotice, HogQLQueryModifiers
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.timings import HogQLTimings
 
+from posthog.clickhouse.workload import Workload
+
 if TYPE_CHECKING:
     from posthog.hogql.database.database import Database
     from posthog.hogql.transforms.property_types import PropertySwapper
@@ -62,6 +64,8 @@ class HogQLContext:
     debug: bool = False
 
     property_swapper: Optional["PropertySwapper"] = None
+    # Workload detected during AST resolution (set by prepare_ast_for_printing)
+    workload: Optional[Workload] = None
 
     def __post_init__(self):
         if self.team:

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -328,6 +328,7 @@ class Database(BaseModel):
             "groups",
             "persons",
             "sessions",
+            "logs",
             *self.get_system_table_names(),
         ]
 

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -9,6 +9,9 @@ from posthog.hogql.base import Expr
 from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.errors import NotImplementedError, ResolutionError
 
+# Import Workload at module level for Pydantic (needed at runtime)
+from posthog.clickhouse.workload import Workload
+
 if TYPE_CHECKING:
     from posthog.hogql.ast import LazyJoinType, SelectQuery
     from posthog.hogql.base import ConstantType
@@ -165,6 +168,7 @@ class FieldTraverser(FieldOrTable):
 class Table(FieldOrTable):
     fields: dict[str, FieldOrTable]
     top_level_settings: Optional[HogQLQuerySettings] = None
+    workload: Optional[Workload] = None
     model_config = ConfigDict(extra="forbid")
 
     def has_field(self, name: str | int) -> bool:

--- a/posthog/hogql/database/schema/logs.py
+++ b/posthog/hogql/database/schema/logs.py
@@ -8,8 +8,15 @@ from posthog.hogql.database.models import (
     Table,
 )
 
+from posthog.clickhouse.workload import Workload
+
+# 50GB - limit for user-provided HogQL queries on log tables to prevent expensive full scans
+HOGQL_MAX_BYTES_TO_READ_FOR_LOGS_USER_QUERIES = 50_000_000_000
+
 
 class LogsTable(Table):
+    workload: Workload | None = Workload.LOGS
+
     fields: dict[str, FieldOrTable] = {
         "uuid": StringDatabaseField(name="uuid", nullable=False),
         "team_id": IntegerDatabaseField(name="team_id", nullable=False),
@@ -19,7 +26,6 @@ class LogsTable(Table):
         "body": StringDatabaseField(name="body", nullable=False),
         "attributes": StringJSONDatabaseField(name="attributes", nullable=False),
         "time_bucket": DateTimeDatabaseField(name="time_bucket", nullable=False),
-        "time_minute": DateTimeDatabaseField(name="time_minute", nullable=False),
         "timestamp": DateTimeDatabaseField(name="timestamp", nullable=False),
         "observed_timestamp": DateTimeDatabaseField(name="observed_timestamp", nullable=False),
         "severity_text": StringDatabaseField(name="severity_text", nullable=False),
@@ -44,6 +50,7 @@ class LogsTable(Table):
 
 
 class LogAttributesTable(Table):
+    workload: Workload | None = Workload.LOGS
     fields: dict[str, FieldOrTable] = {
         "team_id": IntegerDatabaseField(name="team_id", nullable=False),
         "time_bucket": DateTimeDatabaseField(name="time_bucket", nullable=False),
@@ -69,6 +76,7 @@ class LogsKafkaMetricsTable(DANGEROUS_NoTeamIdCheckTable):
     This is so we can find out the overall lag per partition and filter live logs accordingly
     """
 
+    workload: Workload | None = Workload.LOGS
     fields: dict[str, FieldOrTable] = {
         "_partition": IntegerDatabaseField(name="_partition", nullable=False),
         "_topic": StringDatabaseField(name="_topic", nullable=False),

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -2072,6 +2072,184 @@
           "row_count": null,
           "type": "posthog"
       },
+      "logs": {
+          "fields": {
+              "uuid": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "uuid",
+                  "id": null,
+                  "name": "uuid",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "trace_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "trace_id",
+                  "id": null,
+                  "name": "trace_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "span_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "span_id",
+                  "id": null,
+                  "name": "span_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "message": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "message",
+                  "id": null,
+                  "name": "message",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "body": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "body",
+                  "id": null,
+                  "name": "body",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "attributes": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "attributes",
+                  "id": null,
+                  "name": "attributes",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "time_bucket": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "time_bucket",
+                  "id": null,
+                  "name": "time_bucket",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "timestamp": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "timestamp",
+                  "id": null,
+                  "name": "timestamp",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "observed_timestamp": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "observed_timestamp",
+                  "id": null,
+                  "name": "observed_timestamp",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "severity_text": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "severity_text",
+                  "id": null,
+                  "name": "severity_text",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "severity_number": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "severity_number",
+                  "id": null,
+                  "name": "severity_number",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "level": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "level",
+                  "id": null,
+                  "name": "level",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "resource_attributes": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "resource_attributes",
+                  "id": null,
+                  "name": "resource_attributes",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "resource_fingerprint": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "resource_fingerprint",
+                  "id": null,
+                  "name": "resource_fingerprint",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "instrumentation_scope": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "instrumentation_scope",
+                  "id": null,
+                  "name": "instrumentation_scope",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "event_name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "event_name",
+                  "id": null,
+                  "name": "event_name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "service_name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "service_name",
+                  "id": null,
+                  "name": "service_name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              }
+          },
+          "id": "logs",
+          "name": "logs",
+          "row_count": null,
+          "type": "posthog"
+      },
       "query_log": {
           "fields": {
               "event_date": {
@@ -5005,6 +5183,184 @@
           },
           "id": "sessions",
           "name": "sessions",
+          "row_count": null,
+          "type": "posthog"
+      },
+      "logs": {
+          "fields": {
+              "uuid": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "uuid",
+                  "id": null,
+                  "name": "uuid",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "trace_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "trace_id",
+                  "id": null,
+                  "name": "trace_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "span_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "span_id",
+                  "id": null,
+                  "name": "span_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "message": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "message",
+                  "id": null,
+                  "name": "message",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "body": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "body",
+                  "id": null,
+                  "name": "body",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "attributes": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "attributes",
+                  "id": null,
+                  "name": "attributes",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "time_bucket": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "time_bucket",
+                  "id": null,
+                  "name": "time_bucket",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "timestamp": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "timestamp",
+                  "id": null,
+                  "name": "timestamp",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "observed_timestamp": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "observed_timestamp",
+                  "id": null,
+                  "name": "observed_timestamp",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "severity_text": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "severity_text",
+                  "id": null,
+                  "name": "severity_text",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "severity_number": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "severity_number",
+                  "id": null,
+                  "name": "severity_number",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "level": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "level",
+                  "id": null,
+                  "name": "level",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "resource_attributes": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "resource_attributes",
+                  "id": null,
+                  "name": "resource_attributes",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "resource_fingerprint": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "resource_fingerprint",
+                  "id": null,
+                  "name": "resource_fingerprint",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "instrumentation_scope": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "instrumentation_scope",
+                  "id": null,
+                  "name": "instrumentation_scope",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "event_name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "event_name",
+                  "id": null,
+                  "name": "event_name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "service_name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "service_name",
+                  "id": null,
+                  "name": "service_name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              }
+          },
+          "id": "logs",
+          "name": "logs",
           "row_count": null,
           "type": "posthog"
       },

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -148,7 +148,8 @@
                           }
                         },
                         hidden: False,
-                        top_level_settings: None
+                        top_level_settings: None,
+                        workload: None
                       }
                     }
                   }
@@ -960,7 +961,8 @@
                                       }
                                     },
                                     hidden: False,
-                                    top_level_settings: None
+                                    top_level_settings: None,
+                                    workload: None
                                   },
                                   to_field: None
                                 }
@@ -1037,7 +1039,8 @@
                               }
                             },
                             hidden: False,
-                            top_level_settings: None
+                            top_level_settings: None,
+                            workload: None
                           },
                           to_field: None
                         }
@@ -1291,7 +1294,8 @@
                                       }
                                     },
                                     hidden: False,
-                                    top_level_settings: None
+                                    top_level_settings: None,
+                                    workload: None
                                   },
                                   to_field: None
                                 }
@@ -1365,7 +1369,8 @@
                               }
                             },
                             hidden: False,
-                            top_level_settings: None
+                            top_level_settings: None,
+                            workload: None
                           },
                           to_field: None
                         }
@@ -1639,7 +1644,8 @@
                   }
                 },
                 hidden: False,
-                top_level_settings: None
+                top_level_settings: None,
+                workload: None
               }
             }
           }
@@ -1864,7 +1870,8 @@
                                   }
                                 },
                                 hidden: False,
-                                top_level_settings: None
+                                top_level_settings: None,
+                                workload: None
                               },
                               to_field: None
                             }
@@ -1944,7 +1951,8 @@
                           }
                         },
                         hidden: False,
-                        top_level_settings: None
+                        top_level_settings: None,
+                        workload: None
                       },
                       to_field: None
                     }
@@ -2293,7 +2301,8 @@
                                   }
                                 },
                                 hidden: False,
-                                top_level_settings: None
+                                top_level_settings: None,
+                                workload: None
                               },
                               to_field: None
                             }
@@ -2370,7 +2379,8 @@
                           }
                         },
                         hidden: False,
-                        top_level_settings: None
+                        top_level_settings: None,
+                        workload: None
                       },
                       to_field: None
                     }
@@ -2621,7 +2631,8 @@
                     }
                   },
                   hidden: False,
-                  top_level_settings: None
+                  top_level_settings: None,
+                  workload: None
                 }
               }
             }
@@ -3186,7 +3197,8 @@
                           }
                         },
                         hidden: False,
-                        top_level_settings: None
+                        top_level_settings: None,
+                        workload: None
                       }
                     }
                   }
@@ -3656,7 +3668,8 @@
                           }
                         },
                         hidden: False,
-                        top_level_settings: None
+                        top_level_settings: None,
+                        workload: None
                       }
                     }
                   }
@@ -4469,7 +4482,8 @@
                                         }
                                       },
                                       hidden: False,
-                                      top_level_settings: None
+                                      top_level_settings: None,
+                                      workload: None
                                     },
                                     to_field: None
                                   }
@@ -4546,7 +4560,8 @@
                                 }
                               },
                               hidden: False,
-                              top_level_settings: None
+                              top_level_settings: None,
+                              workload: None
                             },
                             to_field: None
                           }
@@ -4800,7 +4815,8 @@
                                         }
                                       },
                                       hidden: False,
-                                      top_level_settings: None
+                                      top_level_settings: None,
+                                      workload: None
                                     },
                                     to_field: None
                                   }
@@ -4874,7 +4890,8 @@
                                 }
                               },
                               hidden: False,
-                              top_level_settings: None
+                              top_level_settings: None,
+                              workload: None
                             },
                             to_field: None
                           }
@@ -5106,7 +5123,8 @@
                             }
                           },
                           hidden: False,
-                          top_level_settings: None
+                          top_level_settings: None,
+                          workload: None
                         }
                       }
                     }
@@ -5331,7 +5349,8 @@
                                             }
                                           },
                                           hidden: False,
-                                          top_level_settings: None
+                                          top_level_settings: None,
+                                          workload: None
                                         },
                                         to_field: None
                                       }
@@ -5411,7 +5430,8 @@
                                     }
                                   },
                                   hidden: False,
-                                  top_level_settings: None
+                                  top_level_settings: None,
+                                  workload: None
                                 },
                                 to_field: None
                               }
@@ -5760,7 +5780,8 @@
                                             }
                                           },
                                           hidden: False,
-                                          top_level_settings: None
+                                          top_level_settings: None,
+                                          workload: None
                                         },
                                         to_field: None
                                       }
@@ -5837,7 +5858,8 @@
                                     }
                                   },
                                   hidden: False,
-                                  top_level_settings: None
+                                  top_level_settings: None,
+                                  workload: None
                                 },
                                 to_field: None
                               }
@@ -6401,7 +6423,8 @@
                   }
                 },
                 hidden: False,
-                top_level_settings: None
+                top_level_settings: None,
+                workload: None
               }
             }
           }
@@ -6626,7 +6649,8 @@
                                   }
                                 },
                                 hidden: False,
-                                top_level_settings: None
+                                top_level_settings: None,
+                                workload: None
                               },
                               to_field: None
                             }
@@ -6706,7 +6730,8 @@
                           }
                         },
                         hidden: False,
-                        top_level_settings: None
+                        top_level_settings: None,
+                        workload: None
                       },
                       to_field: None
                     }
@@ -7055,7 +7080,8 @@
                                   }
                                 },
                                 hidden: False,
-                                top_level_settings: None
+                                top_level_settings: None,
+                                workload: None
                               },
                               to_field: None
                             }
@@ -7132,7 +7158,8 @@
                           }
                         },
                         hidden: False,
-                        top_level_settings: None
+                        top_level_settings: None,
+                        workload: None
                       },
                       to_field: None
                     }
@@ -7421,7 +7448,8 @@
                     }
                   },
                   hidden: False,
-                  top_level_settings: None
+                  top_level_settings: None,
+                  workload: None
                 }
               }
             }
@@ -7647,7 +7675,8 @@
                                   }
                                 },
                                 hidden: False,
-                                top_level_settings: None
+                                top_level_settings: None,
+                                workload: None
                               },
                               to_field: None
                             }
@@ -7727,7 +7756,8 @@
                           }
                         },
                         hidden: False,
-                        top_level_settings: None
+                        top_level_settings: None,
+                        workload: None
                       },
                       to_field: None
                     }
@@ -8076,7 +8106,8 @@
                                   }
                                 },
                                 hidden: False,
-                                top_level_settings: None
+                                top_level_settings: None,
+                                workload: None
                               },
                               to_field: None
                             }
@@ -8153,7 +8184,8 @@
                           }
                         },
                         hidden: False,
-                        top_level_settings: None
+                        top_level_settings: None,
+                        workload: None
                       },
                       to_field: None
                     }
@@ -8443,7 +8475,8 @@
                       }
                     },
                     hidden: False,
-                    top_level_settings: None
+                    top_level_settings: None,
+                    workload: None
                   }
                 }
               }
@@ -8646,7 +8679,8 @@
                       }
                     },
                     hidden: False,
-                    top_level_settings: None
+                    top_level_settings: None,
+                    workload: None
                   }
                 }
               }
@@ -8724,7 +8758,8 @@
                     },
                     filter: None,
                     hidden: False,
-                    top_level_settings: None
+                    top_level_settings: None,
+                    workload: None
                   }
                 }
               }
@@ -9166,7 +9201,8 @@
                   }
                 },
                 hidden: False,
-                top_level_settings: None
+                top_level_settings: None,
+                workload: None
               }
             }
           }
@@ -9402,7 +9438,8 @@
                     }
                   },
                   hidden: False,
-                  top_level_settings: None
+                  top_level_settings: None,
+                  workload: None
                 }
               }
             }
@@ -9642,7 +9679,8 @@
                       }
                     },
                     hidden: False,
-                    top_level_settings: None
+                    top_level_settings: None,
+                    workload: None
                   }
                 }
               }
@@ -9922,7 +9960,8 @@
                               }
                             },
                             hidden: False,
-                            top_level_settings: None
+                            top_level_settings: None,
+                            workload: None
                           }
                         }
                       }
@@ -10208,7 +10247,8 @@
                   }
                 },
                 hidden: False,
-                top_level_settings: None
+                top_level_settings: None,
+                workload: None
               }
             }
           }
@@ -10266,7 +10306,8 @@
                       }
                     },
                     hidden: False,
-                    top_level_settings: None
+                    top_level_settings: None,
+                    workload: None
                   },
                   to_field: None
                 }
@@ -10452,7 +10493,8 @@
                     }
                   },
                   hidden: False,
-                  top_level_settings: None
+                  top_level_settings: None,
+                  workload: None
                 }
               }
             }
@@ -10512,7 +10554,8 @@
                       }
                     },
                     hidden: False,
-                    top_level_settings: None
+                    top_level_settings: None,
+                    workload: None
                   },
                   to_field: None
                 }
@@ -10697,7 +10740,8 @@
                   }
                 },
                 hidden: False,
-                top_level_settings: None
+                top_level_settings: None,
+                workload: None
               }
             }
           }
@@ -10743,7 +10787,8 @@
                     }
                   },
                   hidden: False,
-                  top_level_settings: None
+                  top_level_settings: None,
+                  workload: None
                 },
                 to_field: None
               }
@@ -10928,7 +10973,8 @@
                     }
                   },
                   hidden: False,
-                  top_level_settings: None
+                  top_level_settings: None,
+                  workload: None
                 }
               }
             }
@@ -10976,7 +11022,8 @@
                     }
                   },
                   hidden: False,
-                  top_level_settings: None
+                  top_level_settings: None,
+                  workload: None
                 },
                 to_field: None
               }
@@ -11049,7 +11096,8 @@
                   }
                 },
                 hidden: False,
-                top_level_settings: None
+                top_level_settings: None,
+                workload: None
               }
             }
           }
@@ -11262,7 +11310,8 @@
                     }
                   },
                   hidden: False,
-                  top_level_settings: None
+                  top_level_settings: None,
+                  workload: None
                 }
               }
             }
@@ -11459,7 +11508,8 @@
                         }
                       },
                       hidden: False,
-                      top_level_settings: None
+                      top_level_settings: None,
+                      workload: None
                     }
                   }
                 }
@@ -11668,7 +11718,8 @@
                   }
                 },
                 hidden: False,
-                top_level_settings: None
+                top_level_settings: None,
+                workload: None
               }
             }
           }
@@ -11721,7 +11772,8 @@
                   }
                 },
                 hidden: False,
-                top_level_settings: None
+                top_level_settings: None,
+                workload: None
               }
             }
           }

--- a/posthog/hogql/test/test_log_query_settings.py
+++ b/posthog/hogql/test/test_log_query_settings.py
@@ -1,0 +1,119 @@
+import pytest
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from clickhouse_driver.errors import ServerException
+
+from posthog.hogql.constants import HogQLGlobalSettings
+from posthog.hogql.errors import QueryError
+from posthog.hogql.query import HogQLQueryExecutor
+
+from posthog.errors import CHQueryErrorTooManyBytes, ExposedCHQueryError, wrap_clickhouse_query_error
+
+
+class TestLogQuerySettings(ClickhouseTestMixin, APIBaseTest):
+    """Tests that user HogQL queries on log tables get max_bytes_to_read settings applied."""
+
+    def _get_clickhouse_sql_for(self, query: str, query_type: str = "HogQLQuery") -> str:
+        executor = HogQLQueryExecutor(
+            query=query,
+            team=self.team,
+            query_type=query_type,
+        )
+        sql, _context = executor.generate_clickhouse_sql()
+        return sql
+
+    # --- User HogQL queries on log tables ---
+    def test_user_query_on_logs_table_has_max_bytes_to_read(self):
+        sql = self._get_clickhouse_sql_for("SELECT * FROM logs LIMIT 10")
+        assert f"max_bytes_to_read=" in sql.replace(" ", "")
+
+    def test_user_query_on_logs_table_has_throw_overflow_mode(self):
+        sql = self._get_clickhouse_sql_for("SELECT * FROM logs LIMIT 10")
+        assert "read_overflow_mode" in sql
+        assert "throw" in sql
+
+    def test_user_query_on_log_attributes_table_has_max_bytes_to_read(self):
+        sql = self._get_clickhouse_sql_for("SELECT * FROM log_attributes LIMIT 10")
+        assert f"max_bytes_to_read=" in sql.replace(" ", "")
+
+    def test_user_query_on_logs_kafka_metrics_table_has_max_bytes_to_read(self):
+        sql = self._get_clickhouse_sql_for("SELECT * FROM logs_kafka_metrics LIMIT 10")
+        assert f"max_bytes_to_read=" in sql.replace(" ", "")
+
+    # --- Non-log user queries should NOT have log settings ---
+    def test_user_query_on_events_table_has_no_max_bytes_to_read(self):
+        sql = self._get_clickhouse_sql_for("SELECT * FROM events LIMIT 10")
+        assert "max_bytes_to_read" not in sql
+
+    def test_user_query_on_persons_table_has_no_max_bytes_to_read(self):
+        sql = self._get_clickhouse_sql_for("SELECT * FROM persons LIMIT 10")
+        assert "max_bytes_to_read" not in sql
+
+    def test_user_query_on_sessions_table_has_no_max_bytes_to_read(self):
+        sql = self._get_clickhouse_sql_for("SELECT * FROM sessions LIMIT 10")
+        assert "max_bytes_to_read" not in sql
+
+    # --- Internal query runners should NOT get log settings ---
+    def test_internal_logs_query_type_has_no_max_bytes_to_read(self):
+        sql = self._get_clickhouse_sql_for(
+            "SELECT * FROM logs LIMIT 10",
+            query_type="LogsQuery",
+        )
+        assert "max_bytes_to_read" not in sql
+
+    def test_internal_has_logs_query_type_has_no_max_bytes_to_read(self):
+        sql = self._get_clickhouse_sql_for(
+            "SELECT * FROM logs LIMIT 10",
+            query_type="HasLogsQuery",
+        )
+        assert "max_bytes_to_read" not in sql
+
+    def test_user_query_on_logs_applies_settings_even_with_custom_settings(self):
+        executor = HogQLQueryExecutor(
+            query="SELECT * FROM logs LIMIT 10",
+            team=self.team,
+            query_type="HogQLQuery",
+            settings=HogQLGlobalSettings(max_execution_time=30),
+        )
+        sql, _context = executor.generate_clickhouse_sql()
+        assert f"max_bytes_to_read=" in sql.replace(" ", "")
+        # The user's other settings should still be preserved
+        assert "max_execution_time" in sql
+
+    def test_mixed_events_and_logs_join_raises_workload_error(self):
+        with pytest.raises(QueryError):
+            self._get_clickhouse_sql_for("SELECT * FROM events e JOIN logs l ON e.uuid = l.uuid LIMIT 10")
+
+
+class TestTooManyBytesError(ClickhouseTestMixin, APIBaseTest):
+    """Tests that TOO_MANY_BYTES error is exposed to users."""
+
+    def test_wrap_clickhouse_query_error_returns_exposed_error_for_too_many_bytes(self):
+        server_error = ServerException(
+            "DB::Exception: Limit for result exceeded, max bytes: 5000000000. Stack trace: ...",
+            code=307,
+        )
+        wrapped = wrap_clickhouse_query_error(server_error)
+        assert isinstance(wrapped, CHQueryErrorTooManyBytes)
+        assert isinstance(wrapped, ExposedCHQueryError)
+
+    def test_wrap_clickhouse_query_error_too_many_bytes_has_friendly_message(self):
+        server_error = ServerException(
+            "DB::Exception: Limit for result exceeded, max bytes: 5000000000. Stack trace: ...",
+            code=307,
+        )
+        wrapped = wrap_clickhouse_query_error(server_error)
+        message = str(wrapped)
+        # Should NOT contain raw ClickHouse internals
+        assert "DB::Exception" not in message
+        assert "Stack trace" not in message
+
+        assert "limit for result exceeded" in message.lower()
+
+    def test_wrap_clickhouse_query_error_too_many_bytes_has_code_name(self):
+        server_error = ServerException(
+            "DB::Exception: Limit for result exceeded, max bytes: 5000000000.",
+            code=307,
+        )
+        wrapped = wrap_clickhouse_query_error(server_error)
+        assert getattr(wrapped, "code_name", None) == "too_many_bytes"

--- a/posthog/hogql/test/test_workload.py
+++ b/posthog/hogql/test/test_workload.py
@@ -1,0 +1,98 @@
+import pytest
+
+from posthog.hogql import ast
+from posthog.hogql.database.schema.events import EventsTable
+from posthog.hogql.database.schema.logs import LogAttributesTable, LogsKafkaMetricsTable, LogsTable
+from posthog.hogql.errors import QueryError
+from posthog.hogql.workload import WorkloadCollector
+
+from posthog.clickhouse.workload import Workload
+
+
+class TestWorkloadCollector:
+    """Test the WorkloadCollector visitor for detecting table workloads."""
+
+    def test_logs_table_has_logs_workload(self):
+        """LogsTable should have LOGS workload set."""
+        logs_table = LogsTable()
+        assert logs_table.workload == Workload.LOGS
+
+    def test_log_attributes_table_has_logs_workload(self):
+        """LogAttributesTable should have LOGS workload set."""
+        log_attributes_table = LogAttributesTable()
+        assert log_attributes_table.workload == Workload.LOGS
+
+    def test_logs_kafka_metrics_table_has_logs_workload(self):
+        """LogsKafkaMetricsTable should have LOGS workload set."""
+        logs_kafka_metrics_table = LogsKafkaMetricsTable()
+        assert logs_kafka_metrics_table.workload == Workload.LOGS
+
+    def test_events_table_has_no_workload(self):
+        """EventsTable should not have a workload set."""
+        events_table = EventsTable()
+        assert events_table.workload is None
+
+    def test_collector_detects_logs_workload(self):
+        """WorkloadCollector should detect LOGS workload from LogsTable."""
+        collector = WorkloadCollector()
+
+        # Create a TableType node with LogsTable
+        table_type = ast.TableType(table=LogsTable())
+        collector.visit(table_type)
+
+        assert Workload.LOGS in collector.workloads
+        assert collector.get_workload() == Workload.LOGS
+
+    def test_collector_detects_no_workload_for_events(self):
+        """WorkloadCollector should return default for EventsTable."""
+        collector = WorkloadCollector()
+
+        # Create a TableType node with EventsTable
+        table_type = ast.TableType(table=EventsTable())
+        collector.visit(table_type)
+
+        assert len(collector.workloads) == 1
+        assert collector.get_workload() == Workload.DEFAULT
+
+    def test_collector_raises_error_for_multiple_workloads(self):
+        """WorkloadCollector should raise error when multiple workloads detected."""
+        collector = WorkloadCollector()
+
+        # Add logs table
+        logs_type = ast.TableType(table=LogsTable())
+        collector.visit(logs_type)
+
+        # Manually add a different workload to simulate cross-cluster query
+        collector.workloads.add(Workload.ENDPOINTS)
+
+        with pytest.raises(QueryError) as exc_info:
+            collector.get_workload()
+
+        assert "Cannot query tables from different clusters" in str(exc_info.value)
+
+    def test_collector_handles_table_alias_type(self):
+        """WorkloadCollector should detect workload through TableAliasType."""
+        collector = WorkloadCollector()
+
+        # Create a TableAliasType wrapping a TableType with LogsTable
+        table_type = ast.TableType(table=LogsTable())
+        alias_type = ast.TableAliasType(alias="l", table_type=table_type)
+        collector.visit(alias_type)
+
+        assert Workload.LOGS in collector.workloads
+        assert collector.get_workload() == Workload.LOGS
+
+    def test_collector_handles_virtual_table_type(self):
+        """WorkloadCollector should detect workload through VirtualTableType."""
+        collector = WorkloadCollector()
+
+        # Create a VirtualTableType wrapping a TableType with LogsTable
+        from posthog.hogql.database.models import VirtualTable
+
+        table_type = ast.TableType(table=LogsTable())
+        virtual_table = VirtualTable(fields={})
+        virtual_type = ast.VirtualTableType(table_type=table_type, virtual_table=virtual_table, field="test_field")
+        collector.visit(virtual_type)
+
+        assert Workload.LOGS in collector.workloads
+        assert collector.get_workload() == Workload.LOGS

--- a/posthog/hogql/workload.py
+++ b/posthog/hogql/workload.py
@@ -1,0 +1,46 @@
+from posthog.hogql import ast
+from posthog.hogql.database.models import FunctionCallTable
+from posthog.hogql.errors import QueryError
+from posthog.hogql.visitor import TraversingVisitor
+
+from posthog.clickhouse.workload import Workload
+
+
+class WorkloadCollector(TraversingVisitor):
+    """Collects workload requirements from tables in a resolved AST."""
+
+    def __init__(self, *, default_workload: Workload = Workload.DEFAULT):
+        self.workloads: set[Workload] = set()
+        self.default_workload = default_workload
+
+    def visit_table_type(self, node: ast.TableType):
+        if isinstance(node.table, FunctionCallTable):
+            return
+
+        self.workloads.add(node.table.workload or self.default_workload)
+
+    def visit_lazy_table_type(self, node: ast.TableType):
+        if isinstance(node.table, FunctionCallTable):
+            return
+
+        if hasattr(node.table, "workload"):
+            self.workloads.add(node.table.workload or self.default_workload)
+
+    def get_workload(self) -> Workload:
+        """
+        Returns the workload to use for query execution.
+
+        If no workloads are found, returns the default.
+        If exactly one workload is found, returns it.
+        If multiple workloads are found, raises an error.
+        """
+        if not self.workloads:
+            return self.default_workload
+
+        if len(self.workloads) == 1:
+            return next(iter(self.workloads))
+
+        raise QueryError(
+            f"Cannot query tables from different clusters in the same query. "
+            f"Found tables requiring clusters: {', '.join(sorted(w.value.capitalize() for w in self.workloads))}"
+        )

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -97,7 +97,7 @@
   
   This is a list of all the available tables in the database:
   ```
-  ['events', 'groups', 'persons', 'sessions', 'query_log', 'system.actions', 'system.cohort_calculation_history', 'system.cohorts', 'system.dashboards', 'system.data_warehouse_sources', 'system.data_warehouse_tables', 'system.error_tracking_issues', 'system.experiments', 'system.exports', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.ingestion_warnings', 'system.insight_variables', 'system.insights', 'system.notebooks', 'system.surveys', 'system.teams']
+  ['events', 'groups', 'persons', 'sessions', 'logs', 'query_log', 'system.actions', 'system.cohort_calculation_history', 'system.cohorts', 'system.dashboards', 'system.data_warehouse_sources', 'system.data_warehouse_tables', 'system.error_tracking_issues', 'system.experiments', 'system.exports', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.ingestion_warnings', 'system.insight_variables', 'system.insights', 'system.notebooks', 'system.surveys', 'system.teams']
   ```
   
   `person` or `event` metadata unspecified above (emails, names, etc.) is stored in `properties` fields, accessed like: `properties.foo.bar`.

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -123,6 +123,13 @@ def _generate_resource_attribute_filters(
 
 
 class LogsQueryRunnerMixin(QueryRunner):
+    @cached_property
+    def settings(self):
+        return HogQLGlobalSettings(
+            max_bytes_to_read=None,
+            read_overflow_mode=None,
+        )
+
     def __init__(self, query, *args, **kwargs):
         super().__init__(query, *args, **kwargs)
 
@@ -471,4 +478,6 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMi
             allow_experimental_join_condition=False,
             transform_null_in=False,
             allow_experimental_analyzer=True,
+            max_bytes_to_read=None,
+            read_overflow_mode=None,
         )

--- a/products/logs/backend/sparkline_query_runner.py
+++ b/products/logs/backend/sparkline_query_runner.py
@@ -83,7 +83,12 @@ class SparklineQueryRunner(LogsQueryRunner):
         """,
             placeholders={
                 **self.query_date_range.to_placeholders(),
-                "time_field": ast.Field(chain=["timestamp"]),
+                # The sparkline projection is aggregated over "toStartOfMinute(timestamp)"
+                # so if we use `timestamp` we don't use the projection (even if we're calling toStartOfInterval on it)
+                # explicitly use toStartOfMinute(timestamp) as the time field unless we're using a sub-minute interval
+                "time_field": ast.Call(name="toStartOfMinute", args=[ast.Field(chain=["timestamp"])])
+                if self.query_date_range.interval_name != "second"
+                else ast.Field(chain=["timestamp"]),
                 "where": self.where(),
                 "breakdown_field": ast.Field(
                     chain=[BREAKDOWN_DB_FIELD[self.query.sparklineBreakdownBy or DEFAULT_BREAKDOWN]]

--- a/products/logs/backend/sparkline_query_runner.py
+++ b/products/logs/backend/sparkline_query_runner.py
@@ -83,9 +83,7 @@ class SparklineQueryRunner(LogsQueryRunner):
         """,
             placeholders={
                 **self.query_date_range.to_placeholders(),
-                "time_field": ast.Field(chain=["time_minute"])
-                if self.query_date_range.interval_name != "second"
-                else ast.Field(chain=["timestamp"]),
+                "time_field": ast.Field(chain=["timestamp"]),
                 "where": self.where(),
                 "breakdown_field": ast.Field(
                     chain=[BREAKDOWN_DB_FIELD[self.query.sparklineBreakdownBy or DEFAULT_BREAKDOWN]]


### PR DESCRIPTION
## Problem

Currently HogQL queries all go to our main cluster, so we are unable to query the logs table - lots of customers are requesting the ability to query logs

## Changes

Allow tables to route to different "Workloads" which will allow queries to be routed to the logs cluster for the logs table

Logic is in place to prevent cross-cluster joins

Also added a limit to the amount of data that can be queried in a HogQL query to prevent customers doing full table scans and killing us

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

locally, tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
yes
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
