### PR TITLE
chore: add OpenTelemetry tracing to property value API endpoints

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -448,96 +448,107 @@ class EventViewSet(
 
             return self._event_property_values(query_params)
 
-    @tracer.start_as_current_span("events_api_event_property_values")
     def _event_property_values(
         self,
         query_params: EventValueQueryParams,
     ) -> response.Response:
-        date_from = relative_date_parse("-7d", query_params.team.timezone_info).strftime("%Y-%m-%d 00:00:00")
-        date_to = timezone.now().strftime("%Y-%m-%d 23:59:59")
+        with tracer.start_as_current_span("events_api_event_property_values") as span:
+            span.set_attribute("team_id", query_params.team.pk)
+            span.set_attribute("property_key", query_params.key)
+            span.set_attribute("is_column", query_params.is_column)
+            span.set_attribute("has_value_filter", query_params.value is not None)
+            span.set_attribute("event_names_count", len(query_params.event_names) if query_params.event_names else 0)
 
-        chain: list[str | int] = [query_params.key] if query_params.is_column else ["properties", query_params.key]
-        conditions: list[ast.Expr] = [
-            ast.CompareOperation(
-                op=ast.CompareOperationOp.GtEq,
-                left=ast.Field(chain=["timestamp"]),
-                right=ast.Constant(value=date_from),
-            ),
-            ast.CompareOperation(
-                op=ast.CompareOperationOp.LtEq,
-                left=ast.Field(chain=["timestamp"]),
-                right=ast.Constant(value=date_to),
-            ),
-            ast.CompareOperation(
-                op=ast.CompareOperationOp.NotEq,
-                left=ast.Field(chain=chain),
-                right=ast.Constant(value=None),
-            ),
-        ]
-        # Handle property filters from query parameters
-        for param_key, param_value in query_params.items:
-            if param_key.startswith("properties_"):
-                property_key = param_key.replace("properties_", "", 1)
-                try:
-                    # Expect properly encoded JSON from frontend
-                    property_values = (
-                        json.loads(param_value) if isinstance(param_value, str | bytes | bytearray) else param_value
+            date_from = relative_date_parse("-7d", query_params.team.timezone_info).strftime("%Y-%m-%d 00:00:00")
+            date_to = timezone.now().strftime("%Y-%m-%d 23:59:59")
+
+            chain: list[str | int] = [query_params.key] if query_params.is_column else ["properties", query_params.key]
+            conditions: list[ast.Expr] = [
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=["timestamp"]),
+                    right=ast.Constant(value=date_from),
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.LtEq,
+                    left=ast.Field(chain=["timestamp"]),
+                    right=ast.Constant(value=date_to),
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.NotEq,
+                    left=ast.Field(chain=chain),
+                    right=ast.Constant(value=None),
+                ),
+            ]
+            # Handle property filters from query parameters
+            property_filter_count = 0
+            for param_key, param_value in query_params.items:
+                if param_key.startswith("properties_"):
+                    property_filter_count += 1
+                    property_key = param_key.replace("properties_", "", 1)
+                    try:
+                        # Expect properly encoded JSON from frontend
+                        property_values = (
+                            json.loads(param_value) if isinstance(param_value, str | bytes | bytearray) else param_value
+                        )
+                        conditions.append(create_property_conditions(property_key, property_values))
+                    except json.JSONDecodeError:
+                        # If not JSON, treat as single value
+                        conditions.append(create_property_conditions(property_key, param_value))
+            span.set_attribute("property_filter_count", property_filter_count)
+
+            if query_params.event_names and len(query_params.event_names) > 0:
+                event_conditions: list[ast.Expr] = [
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.Eq,
+                        left=ast.Field(chain=["event"]),
+                        right=ast.Constant(value=event_name),
                     )
-                    conditions.append(create_property_conditions(property_key, property_values))
-                except json.JSONDecodeError:
-                    # If not JSON, treat as single value
-                    conditions.append(create_property_conditions(property_key, param_value))
-        if query_params.event_names and len(query_params.event_names) > 0:
-            event_conditions: list[ast.Expr] = [
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Eq,
-                    left=ast.Field(chain=["event"]),
-                    right=ast.Constant(value=event_name),
+                    for event_name in query_params.event_names
+                ]
+                if len(event_conditions) > 1:
+                    conditions.append(ast.Or(exprs=event_conditions))
+                else:
+                    conditions.append(event_conditions[0])
+            if query_params.value:
+                conditions.append(
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.ILike,
+                        left=ast.Call(name="toString", args=[ast.Field(chain=chain)]),
+                        right=ast.Constant(value=f"%{query_params.value}%"),
+                    )
                 )
-                for event_name in query_params.event_names
-            ]
-            if len(event_conditions) > 1:
-                conditions.append(ast.Or(exprs=event_conditions))
-            else:
-                conditions.append(event_conditions[0])
-        if query_params.value:
-            conditions.append(
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.ILike,
-                    left=ast.Call(name="toString", args=[ast.Field(chain=chain)]),
-                    right=ast.Constant(value=f"%{query_params.value}%"),
-                )
+            order_by = []
+            if query_params.value:
+                order_by = [
+                    ast.OrderExpr(
+                        expr=ast.Call(name="length", args=[ast.Call(name="toString", args=[ast.Field(chain=chain)])]),
+                        order="ASC",
+                    )
+                ]
+            query = ast.SelectQuery(
+                select=[ast.Field(chain=chain)],
+                distinct=True,
+                select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+                where=ast.And(exprs=conditions),
+                order_by=order_by,
+                limit=ast.Constant(value=10),
             )
-        order_by = []
-        if query_params.value:
-            order_by = [
-                ast.OrderExpr(
-                    expr=ast.Call(name="length", args=[ast.Call(name="toString", args=[ast.Field(chain=chain)])]),
-                    order="ASC",
-                )
-            ]
-        query = ast.SelectQuery(
-            select=[ast.Field(chain=chain)],
-            distinct=True,
-            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
-            where=ast.And(exprs=conditions),
-            order_by=order_by,
-            limit=ast.Constant(value=10),
-        )
 
-        result = execute_hogql_query(query, team=query_params.team)
+            result = execute_hogql_query(query, team=query_params.team)
 
-        values = []
-        for value in result.results:
-            if isinstance(value[0], float | int | bool | uuid.UUID):
-                values.append(value[0])
-            else:
-                try:
-                    values.append(json.loads(value[0]))
-                except json.JSONDecodeError:
+            values = []
+            for value in result.results:
+                if isinstance(value[0], float | int | bool | uuid.UUID):
                     values.append(value[0])
+                else:
+                    try:
+                        values.append(json.loads(value[0]))
+                    except json.JSONDecodeError:
+                        values.append(value[0])
 
-        return self._return_with_short_cache([{"name": convert_property_value(value)} for value in flatten(values)])
+            span.set_attribute("result_count", len(values))
+            return self._return_with_short_cache([{"name": convert_property_value(value)} for value in flatten(values)])
 
     @staticmethod
     def _return_with_short_cache(values) -> response.Response:

--- a/posthog/queries/property_values.py
+++ b/posthog/queries/property_values.py
@@ -2,12 +2,16 @@ from typing import Optional
 
 from django.utils import timezone
 
+from opentelemetry import trace
+
 from posthog.models.event.sql import SELECT_PROP_VALUES_SQL_WITH_FILTER
 from posthog.models.person.sql import SELECT_PERSON_PROP_VALUES_SQL, SELECT_PERSON_PROP_VALUES_SQL_WITH_FILTER
 from posthog.models.property.util import get_property_string_expr
 from posthog.models.team import Team
 from posthog.queries.insight import insight_sync_execute
 from posthog.utils import relative_date_parse
+
+tracer = trace.get_tracer(__name__)
 
 
 def get_property_values_for_key(
@@ -16,67 +20,85 @@ def get_property_values_for_key(
     event_names: Optional[list[str]] = None,
     value: Optional[str] = None,
 ):
-    property_field, mat_column_exists = get_property_string_expr("events", key, "%(key)s", "properties")
-    parsed_date_from = "AND timestamp >= '{}'".format(
-        relative_date_parse("-7d", team.timezone_info).strftime("%Y-%m-%d 00:00:00")
-    )
-    parsed_date_to = "AND timestamp <= '{}'".format(timezone.now().strftime("%Y-%m-%d 23:59:59"))
-    property_exists_filter = ""
-    event_filter = ""
-    value_filter = ""
-    order_by_clause = ""
-    extra_params = {}
+    with tracer.start_as_current_span("get_property_values_for_key") as span:
+        span.set_attribute("team_id", team.pk)
+        span.set_attribute("property_key", key)
+        span.set_attribute("has_value_filter", value is not None)
+        span.set_attribute("event_names_count", len(event_names) if event_names else 0)
 
-    if mat_column_exists:
-        property_exists_filter = "AND notEmpty({})".format(property_field)
-    else:
-        property_exists_filter = "AND JSONHas(properties, %(key)s)"
-        extra_params["key"] = key
+        property_field, mat_column_exists = get_property_string_expr("events", key, "%(key)s", "properties")
+        span.set_attribute("materialized_column", mat_column_exists)
 
-    if event_names is not None and len(event_names) > 0:
-        event_conditions_list = []
-        for index, event_name in enumerate(event_names):
-            event_conditions_list.append(f"event = %(event_{index})s")
-            extra_params[f"event_{index}"] = event_name
+        parsed_date_from = "AND timestamp >= '{}'".format(
+            relative_date_parse("-7d", team.timezone_info).strftime("%Y-%m-%d 00:00:00")
+        )
+        parsed_date_to = "AND timestamp <= '{}'".format(timezone.now().strftime("%Y-%m-%d 23:59:59"))
+        property_exists_filter = ""
+        event_filter = ""
+        value_filter = ""
+        order_by_clause = ""
+        extra_params = {}
 
-        event_conditions = " OR ".join(event_conditions_list)
-        event_filter = "AND ({})".format(event_conditions)
+        if mat_column_exists:
+            property_exists_filter = "AND notEmpty({})".format(property_field)
+        else:
+            property_exists_filter = "AND JSONHas(properties, %(key)s)"
+            extra_params["key"] = key
 
-    if value:
-        value_filter = "AND {} ILIKE %(value)s".format(property_field)
-        extra_params["value"] = "%{}%".format(value)
+        if event_names is not None and len(event_names) > 0:
+            event_conditions_list = []
+            for index, event_name in enumerate(event_names):
+                event_conditions_list.append(f"event = %(event_{index})s")
+                extra_params[f"event_{index}"] = event_name
 
-        order_by_clause = f"order by length({property_field})"
+            event_conditions = " OR ".join(event_conditions_list)
+            event_filter = "AND ({})".format(event_conditions)
 
-    return insight_sync_execute(
-        SELECT_PROP_VALUES_SQL_WITH_FILTER.format(
-            parsed_date_from=parsed_date_from,
-            parsed_date_to=parsed_date_to,
-            property_field=property_field,
-            event_filter=event_filter,
-            value_filter=value_filter,
-            property_exists_filter=property_exists_filter,
-            order_by_clause=order_by_clause,
-        ),
-        {"team_id": team.pk, "key": key, **extra_params},
-        query_type="get_property_values_with_value",
-        team_id=team.pk,
-    )
+        if value:
+            value_filter = "AND {} ILIKE %(value)s".format(property_field)
+            extra_params["value"] = "%{}%".format(value)
+
+            order_by_clause = f"order by length({property_field})"
+
+        result = insight_sync_execute(
+            SELECT_PROP_VALUES_SQL_WITH_FILTER.format(
+                parsed_date_from=parsed_date_from,
+                parsed_date_to=parsed_date_to,
+                property_field=property_field,
+                event_filter=event_filter,
+                value_filter=value_filter,
+                property_exists_filter=property_exists_filter,
+                order_by_clause=order_by_clause,
+            ),
+            {"team_id": team.pk, "key": key, **extra_params},
+            query_type="get_property_values_with_value",
+            team_id=team.pk,
+        )
+        span.set_attribute("result_count", len(result))
+        return result
 
 
 def get_person_property_values_for_key(key: str, team: Team, value: Optional[str] = None):
-    property_field, _ = get_property_string_expr("person", key, "%(key)s", "properties")
+    with tracer.start_as_current_span("get_person_property_values_for_key") as span:
+        span.set_attribute("team_id", team.pk)
+        span.set_attribute("property_key", key)
+        span.set_attribute("has_value_filter", value is not None)
 
-    if value:
-        return insight_sync_execute(
-            SELECT_PERSON_PROP_VALUES_SQL_WITH_FILTER.format(property_field=property_field),
-            {"team_id": team.pk, "key": key, "value": "%{}%".format(value)},
-            query_type="get_person_property_values_with_value",
-            team_id=team.pk,
-        )
-    return insight_sync_execute(
-        SELECT_PERSON_PROP_VALUES_SQL.format(property_field=property_field),
-        {"team_id": team.pk, "key": key},
-        query_type="get_person_property_values",
-        team_id=team.pk,
-    )
+        property_field, _ = get_property_string_expr("person", key, "%(key)s", "properties")
+
+        if value:
+            result = insight_sync_execute(
+                SELECT_PERSON_PROP_VALUES_SQL_WITH_FILTER.format(property_field=property_field),
+                {"team_id": team.pk, "key": key, "value": "%{}%".format(value)},
+                query_type="get_person_property_values_with_value",
+                team_id=team.pk,
+            )
+        else:
+            result = insight_sync_execute(
+                SELECT_PERSON_PROP_VALUES_SQL.format(property_field=property_field),
+                {"team_id": team.pk, "key": key},
+                query_type="get_person_property_values",
+                team_id=team.pk,
+            )
+        span.set_attribute("result_count", len(result))
+        return result

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -608,7 +608,8 @@ class PropertyDefinitionViewSet(
 
             span.set_attribute("property_type", prop_type or "")
             span.set_attribute("has_search", search is not None and search != "")
-            span.set_attribute("event_names_count", len(event_names) if event_names else 0)
+            parsed_event_names = json.loads(event_names) if event_names else []
+            span.set_attribute("event_names_count", len(parsed_event_names))
             span.set_attribute("filter_by_event_names", bool(filter_by_event_names))
             span.set_attribute("limit", limit)
             span.set_attribute("offset", offset)

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -611,8 +611,8 @@ class PropertyDefinitionViewSet(
             parsed_event_names = json.loads(event_names) if event_names else []
             span.set_attribute("event_names_count", len(parsed_event_names))
             span.set_attribute("filter_by_event_names", bool(filter_by_event_names))
-            span.set_attribute("limit", limit)
-            span.set_attribute("offset", offset)
+            span.set_attribute("limit", limit or 0)
+            span.set_attribute("offset", offset or 0)
 
             search_extra = add_name_alias_to_search_query(search)
 

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -8,6 +8,7 @@ from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404
 
 from loginas.utils import is_impersonated_session
+from opentelemetry import trace
 from rest_framework import mixins, request, response, serializers, status, viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.pagination import LimitOffsetPagination
@@ -24,6 +25,8 @@ from posthog.models.activity_logging.activity_log import Detail, log_activity
 from posthog.models.utils import UUIDT
 from posthog.settings import EE_AVAILABLE
 from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP, PROPERTY_NAME_ALIASES
+
+tracer = trace.get_tracer(__name__)
 
 # list of all event properties defined in the taxonomy, that don't start with $
 EXCLUDED_EVENT_CORE_PROPERTIES = [
@@ -556,88 +559,115 @@ class PropertyDefinitionViewSet(
     ]
 
     def dangerously_get_queryset(self):
-        queryset: Union[QuerySet[PropertyDefinition], Manager[PropertyDefinition]] = PropertyDefinition.objects.all()
-        property_definition_fields = ", ".join(
-            [
-                f'posthog_propertydefinition."{f.column}"'
-                for f in PropertyDefinition._meta.get_fields()
-                if hasattr(f, "column")
-            ]
-        )
+        with tracer.start_as_current_span("property_definitions_get_queryset") as span:
+            span.set_attribute("team_id", self.team_id)
 
-        order_by_verified = False
-        if EE_AVAILABLE:
-            from ee.models.property_definition import EnterprisePropertyDefinition
-
-            # Prevent fetching deprecated `tags` field. Tags are separately fetched in TaggedItemSerializerMixin
+            queryset: Union[QuerySet[PropertyDefinition], Manager[PropertyDefinition]] = (
+                PropertyDefinition.objects.all()
+            )
             property_definition_fields = ", ".join(
                 [
-                    f'{f.cached_col.alias}."{f.column}"'
-                    for f in EnterprisePropertyDefinition._meta.get_fields()
-                    if hasattr(f, "column") and f.column not in ["deprecated_tags", "tags"] and hasattr(f, "cached_col")
+                    f'posthog_propertydefinition."{f.column}"'
+                    for f in PropertyDefinition._meta.get_fields()
+                    if hasattr(f, "column")
                 ]
             )
 
-            queryset = EnterprisePropertyDefinition.objects
+            order_by_verified = False
+            if EE_AVAILABLE:
+                from ee.models.property_definition import EnterprisePropertyDefinition
 
-            order_by_verified = True
+                # Prevent fetching deprecated `tags` field. Tags are separately fetched in TaggedItemSerializerMixin
+                property_definition_fields = ", ".join(
+                    [
+                        f'{f.cached_col.alias}."{f.column}"'
+                        for f in EnterprisePropertyDefinition._meta.get_fields()
+                        if hasattr(f, "column")
+                        and f.column not in ["deprecated_tags", "tags"]
+                        and hasattr(f, "cached_col")
+                    ]
+                )
 
-        assert isinstance(self.paginator, NotCountingLimitOffsetPaginator)
-        limit = self.paginator.get_limit(self.request)
-        offset = self.paginator.get_offset(self.request)
+                queryset = EnterprisePropertyDefinition.objects
 
-        query = PropertyDefinitionQuerySerializer(data=self.request.query_params)
-        query.is_valid(raise_exception=True)
+                order_by_verified = True
 
-        search = query.validated_data.get("search")
-        search_extra = add_name_alias_to_search_query(search)
+            span.set_attribute("ee_available", EE_AVAILABLE)
 
-        if query.validated_data.get("type") == "person":
-            search_extra += add_latest_means_not_initial(search)
+            assert isinstance(self.paginator, NotCountingLimitOffsetPaginator)
+            limit = self.paginator.get_limit(self.request)
+            offset = self.paginator.get_offset(self.request)
 
-        search_query, search_kwargs = term_search_filter_sql(self.search_fields, search, search_extra)
+            query = PropertyDefinitionQuerySerializer(data=self.request.query_params)
+            query.is_valid(raise_exception=True)
 
-        query_context = (
-            QueryContext(
-                project_id=self.project_id,
-                table=(
-                    "ee_enterprisepropertydefinition FULL OUTER JOIN posthog_propertydefinition ON posthog_propertydefinition.id=ee_enterprisepropertydefinition.propertydefinition_ptr_id"
-                    if EE_AVAILABLE
-                    else "posthog_propertydefinition"
-                ),
-                property_definition_fields=property_definition_fields,
-                property_definition_table="posthog_propertydefinition",
-                limit=limit,
-                offset=offset,
+            prop_type = query.validated_data.get("type")
+            search = query.validated_data.get("search")
+            event_names = query.validated_data.get("event_names")
+            filter_by_event_names = query.validated_data.get("filter_by_event_names")
+
+            span.set_attribute("property_type", prop_type or "")
+            span.set_attribute("has_search", search is not None and search != "")
+            span.set_attribute("event_names_count", len(event_names) if event_names else 0)
+            span.set_attribute("filter_by_event_names", bool(filter_by_event_names))
+            span.set_attribute("limit", limit)
+            span.set_attribute("offset", offset)
+
+            search_extra = add_name_alias_to_search_query(search)
+
+            if prop_type == "person":
+                search_extra += add_latest_means_not_initial(search)
+
+            search_query, search_kwargs = term_search_filter_sql(self.search_fields, search, search_extra)
+
+            query_context = (
+                QueryContext(
+                    project_id=self.project_id,
+                    table=(
+                        "ee_enterprisepropertydefinition FULL OUTER JOIN posthog_propertydefinition ON posthog_propertydefinition.id=ee_enterprisepropertydefinition.propertydefinition_ptr_id"
+                        if EE_AVAILABLE
+                        else "posthog_propertydefinition"
+                    ),
+                    property_definition_fields=property_definition_fields,
+                    property_definition_table="posthog_propertydefinition",
+                    limit=limit,
+                    offset=offset,
+                )
+                .with_type_filter(
+                    prop_type,
+                    query.validated_data.get("group_type_index"),
+                )
+                .with_properties_to_filter(query.validated_data.get("properties"))
+                .with_is_numerical_flag(query.validated_data.get("is_numerical"))
+                .with_feature_flags(query.validated_data.get("is_feature_flag"))
+                .with_event_property_filter(
+                    event_names=event_names,
+                    filter_by_event_names=filter_by_event_names,
+                )
+                .with_search(search_query, search_kwargs)
+                .with_excluded_properties(query.validated_data.get("excluded_properties"))
+                .with_excluded_core_properties(
+                    query.validated_data.get("exclude_core_properties", False),
+                    type=prop_type,
+                )
+                .with_hidden_filter(
+                    query.validated_data.get("exclude_hidden", False), use_enterprise_taxonomy=EE_AVAILABLE
+                )
             )
-            .with_type_filter(
-                query.validated_data.get("type"),
-                query.validated_data.get("group_type_index"),
-            )
-            .with_properties_to_filter(query.validated_data.get("properties"))
-            .with_is_numerical_flag(query.validated_data.get("is_numerical"))
-            .with_feature_flags(query.validated_data.get("is_feature_flag"))
-            .with_event_property_filter(
-                event_names=query.validated_data.get("event_names"),
-                filter_by_event_names=query.validated_data.get("filter_by_event_names"),
-            )
-            .with_search(search_query, search_kwargs)
-            .with_excluded_properties(query.validated_data.get("excluded_properties"))
-            .with_excluded_core_properties(
-                query.validated_data.get("exclude_core_properties", False),
-                type=query.validated_data.get("type"),
-            )
-            .with_hidden_filter(query.validated_data.get("exclude_hidden", False), use_enterprise_taxonomy=EE_AVAILABLE)
-        )
 
-        with connection.cursor() as cursor:
-            cursor.execute(query_context.as_count_sql(), query_context.params)
-            full_count = cursor.fetchone()[0]
+            span.set_attribute("joins_event_property", query_context.should_join_event_property)
 
-        self.paginator.set_count(full_count)
+            with tracer.start_as_current_span("property_definitions_count_query") as count_span:
+                with connection.cursor() as cursor:
+                    cursor.execute(query_context.as_count_sql(), query_context.params)
+                    full_count = cursor.fetchone()[0]
+                count_span.set_attribute("full_count", full_count)
 
-        # nosemgrep: python.django.security.audit.custom-expression-as-sql.custom-expression-as-sql (all user input goes through query_context.params)
-        return queryset.raw(query_context.as_sql(order_by_verified), params=query_context.params)
+            self.paginator.set_count(full_count)
+            span.set_attribute("full_count", full_count)
+
+            # nosemgrep: python.django.security.audit.custom-expression-as-sql.custom-expression-as-sql (all user input goes through query_context.params)
+            return queryset.raw(query_context.as_sql(order_by_verified), params=query_context.params)
 
     def get_serializer_class(self) -> type[serializers.ModelSerializer]:
         serializer_class: type[serializers.ModelSerializer] = self.serializer_class


### PR DESCRIPTION
## Problem

We need better observability into the performance and behavior of property value API endpoints across the application. Currently, these endpoints lack distributed tracing instrumentation, making it difficult to debug performance issues and understand query patterns.

## Changes

added some trace spans so we can look and see where the perf problem is (per team)

## Publish to changelog?

no

https://claude.ai/code/session_017sYhVrNdfKmHVfJYD1rhrQ