### PR TITLE
fix: Copy packages for transpiler plugin during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -305,6 +305,8 @@ COPY --from=fetch-geoip-db --chown=posthog:posthog /code/share/GeoLite2-City.mmd
 COPY --from=node-scripts-build --chown=posthog:posthog /code/nodejs/src/scripts /code/nodejs/src/scripts
 
 # Copy plugin transpiler (used by Django for site destinations/apps).
+# pnpm stores packages in node_modules/.pnpm/, workspace node_modules contain symlinks there.
+COPY --from=node-scripts-build --chown=posthog:posthog /code/node_modules /code/node_modules
 COPY --from=node-scripts-build --chown=posthog:posthog /code/common/plugin_transpiler/dist /code/common/plugin_transpiler/dist
 COPY --from=node-scripts-build --chown=posthog:posthog /code/common/plugin_transpiler/node_modules /code/common/plugin_transpiler/node_modules
 COPY --from=node-scripts-build --chown=posthog:posthog /code/common/plugin_transpiler/package.json /code/common/plugin_transpiler/package.json


### PR DESCRIPTION
## Problem

PR #47131 added back the plugin transpiler but missed copying `/code/node_modules`. With pnpm, workspace `node_modules` contain symlinks that point to the root `node_modules/.pnpm/` where the actual packages live. Without copying the root, the symlinks are broken and the transpiler fails with `Cannot read properties of undefined (reading 'setEncoding')`

Context here: https://posthog.slack.com/archives/C06GG249PR6/p1770386380681419

## Changes

Copy `/code/node_modules` from the build stage (contains packages installed by `pnpm --filter=@posthog/plugin-transpiler...`)

## How did you test this code?

Ran a local docker build and tested output:

```
docker build --target node-scripts-build -t transpiler-test -f Dockerfile . 2>&1 | tail -30
docker run --rm transpiler-test sh -c "echo 'const x: number = 1; export default x;' | node /code/common/plugin_transpiler/dist/index.js --type site"
```
