### PR TITLE
fix(signals): Increase stringent session summary limits

### DIFF
--- a/ee/hogai/session_summaries/session/output_data.py
+++ b/ee/hogai/session_summaries/session/output_data.py
@@ -29,7 +29,7 @@ class SessionSummaryExceptionTypes(str, Enum):
 
 
 class RawKeyActionSerializer(serializers.Serializer):
-    description = serializers.CharField(min_length=1, max_length=1024, required=False, allow_null=True)
+    description = serializers.CharField(min_length=1, max_length=10_000, required=False, allow_null=True)
     abandonment = serializers.BooleanField(required=False, default=False, allow_null=True)
     confusion = serializers.BooleanField(required=False, default=False, allow_null=True)
     exception = serializers.ChoiceField(
@@ -132,7 +132,7 @@ class OutcomeSerializer(serializers.Serializer):
     Initial goal and session outcome coming from LLM.
     """
 
-    description = serializers.CharField(min_length=1, max_length=1024, required=False, allow_null=True)
+    description = serializers.CharField(min_length=1, max_length=10_000, required=False, allow_null=True)
     success = serializers.BooleanField(required=False, allow_null=True)
 
 
@@ -142,7 +142,7 @@ class SegmentOutcomeSerializer(serializers.Serializer):
     """
 
     segment_index = serializers.IntegerField(min_value=0, required=False, allow_null=True)
-    summary = serializers.CharField(min_length=1, max_length=1024, required=False, allow_null=True)
+    summary = serializers.CharField(min_length=1, max_length=10_000, required=False, allow_null=True)
     success = serializers.BooleanField(required=False, allow_null=True)
 
 


### PR DESCRIPTION
## Problem

Hitting stringent description/summary size limits in session summary serialization. Like here: [Temporal](https://cloud.temporal.io/namespaces/posthog-prod-eu.usz2o/workflows/video-segment-clustering-team-22002-2026-02-10T15%3A08%3A22.977760%2B00%3A00/019c4818-ae56-7c93-a0bc-12371d02188d/history).

## Changes

Increase the limits.