### PR TITLE
fix(llma): stabilize trace view tabs and fix badge active state

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTabs/LemonTabs.scss
+++ b/frontend/src/lib/lemon-ui/LemonTabs/LemonTabs.scss
@@ -103,6 +103,11 @@
             .reduce-visual-noise & {
                 color: var(--color-accent) !important;
             }
+
+            .LemonTag {
+                color: var(--color-accent);
+                border-color: var(--color-accent);
+            }
         }
 
         a {

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -82,7 +82,6 @@ import {
     getSessionStartTimestamp,
     getTraceTimestamp,
     isLLMEvent,
-    isTraceLevel,
     removeMilliseconds,
 } from './utils'
 
@@ -781,9 +780,9 @@ const EventContent = React.memo(
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SUMMARIZATION] ||
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
 
-        const showClustersTab = !!event && isTraceLevel(event) && featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB]
+        const showClustersTab = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB]
 
-        const showFeedbackTab = !!event && isTraceLevel(event)
+        const showFeedbackTab = true
 
         // Check if we're viewing a trace with actual content vs. a pseudo-trace (grouping of generations w/o input/output state)
         const isTopLevelTraceWithoutContent = !event || (!isLLMEvent(event) && !event.inputState && !event.outputState)


### PR DESCRIPTION
## Problem

Clusters and Feedback tabs in the LLMA trace view disappear when clicking on a span in the tree, then reappear when clicking the trace node. This is because the tab visibility was gated on `isTraceLevel(event)` which checks the currently selected node, not the trace itself. Both tab components (`ClustersTabContent`, `FeedbackViewDisplay`) already pull data from the trace-level logic via `traceId`, so they work fine regardless of which tree node is selected.

Additionally, the Beta/Alpha badge (LemonTag) inside active tabs stays purple while the tab text turns to the accent color, creating a visual clash.

## Changes

- Remove `isTraceLevel(event)` checks from `showClustersTab` and `showFeedbackTab` so tabs stay visible regardless of selected tree node
- Clusters tab remains gated by its feature flag
- Clean up unused `isTraceLevel` import
- Add CSS rule in `LemonTabs.scss` so `LemonTag` badges inside active tabs inherit the accent color

## How did you test this code?

Manual testing — verified tabs stay visible when navigating between spans and trace nodes.

## Publish to changelog?

no