### PR TITLE
feat: Approvals GA

### DIFF
--- a/frontend/src/lib/approvals/approvalsGateLogic.ts
+++ b/frontend/src/lib/approvals/approvalsGateLogic.ts
@@ -2,18 +2,17 @@ import { afterMount, connect, kea, path, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { userLogic } from 'scenes/userLogic'
 
-import { ApprovalPolicy } from '~/types'
+import { ApprovalPolicy, AvailableFeature } from '~/types'
 
-import { FEATURE_FLAGS } from '../constants'
 import type { approvalsGateLogicType } from './approvalsGateLogicType'
 
 export const approvalsGateLogic = kea<approvalsGateLogicType>([
     path(['lib', 'approvals', 'approvalsGateLogic']),
 
     connect(() => ({
-        values: [featureFlagLogic, ['featureFlags']],
+        values: [userLogic, ['hasAvailableFeature']],
     })),
 
     loaders(({ values }) => ({
@@ -21,8 +20,7 @@ export const approvalsGateLogic = kea<approvalsGateLogicType>([
             [] as ApprovalPolicy[],
             {
                 loadActivePolicies: async () => {
-                    // Don't load if FF is disabled
-                    if (!values.featureFlags[FEATURE_FLAGS.APPROVALS]) {
+                    if (!values.hasAvailableFeature(AvailableFeature.APPROVALS)) {
                         return []
                     }
 
@@ -39,8 +37,8 @@ export const approvalsGateLogic = kea<approvalsGateLogicType>([
 
     selectors({
         isApprovalsFeatureEnabled: [
-            (s) => [s.featureFlags],
-            (featureFlags: Record<string, boolean | string>): boolean => !!featureFlags[FEATURE_FLAGS.APPROVALS],
+            (s) => [s.hasAvailableFeature],
+            (hasAvailableFeature): boolean => hasAvailableFeature(AvailableFeature.APPROVALS),
         ],
 
         isApprovalRequired: [

--- a/frontend/src/scenes/approvals/ApprovalDetail.tsx
+++ b/frontend/src/scenes/approvals/ApprovalDetail.tsx
@@ -33,9 +33,8 @@ export const scene: SceneExport<ApprovalLogicProps> = {
 }
 
 function ApprovalDetail({ id }: ApprovalLogicProps): JSX.Element {
-    const { changeRequest, changeRequestLoading, changeRequestMissing, proposedChangesTab } = useValues(
-        approvalLogic({ id })
-    )
+    const { changeRequest, changeRequestLoading, changeRequestMissing, proposedChangesTab, isApprovalsFeatureEnabled } =
+        useValues(approvalLogic({ id }))
     const { approveChangeRequest, rejectChangeRequest, cancelChangeRequest, setProposedChangesTab } = useActions(
         approvalLogic({ id })
     )
@@ -43,7 +42,7 @@ function ApprovalDetail({ id }: ApprovalLogicProps): JSX.Element {
     const containerRef = useRef<HTMLDivElement>(null)
     const [width] = useSize(containerRef)
 
-    if (changeRequestMissing) {
+    if (!isApprovalsFeatureEnabled || changeRequestMissing) {
         return <NotFound object="change request" />
     }
 

--- a/frontend/src/scenes/approvals/approvalLogic.tsx
+++ b/frontend/src/scenes/approvals/approvalLogic.tsx
@@ -11,8 +11,9 @@ import { Scene } from 'scenes/sceneTypes'
 import { rolesLogic } from 'scenes/settings/organization/Permissions/Roles/rolesLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
-import { Breadcrumb, ChangeRequest, ChangeRequestState } from '~/types'
+import { AvailableFeature, Breadcrumb, ChangeRequest, ChangeRequestState } from '~/types'
 
 import type { approvalLogicType } from './approvalLogicType'
 
@@ -27,7 +28,7 @@ export const approvalLogic = kea<approvalLogicType>([
     props({} as ApprovalLogicProps),
     key(({ id }) => id),
     connect(() => ({
-        values: [teamLogic, ['currentTeamId']],
+        values: [teamLogic, ['currentTeamId'], userLogic, ['hasAvailableFeature']],
         actions: [membersLogic, ['loadAllMembers'], rolesLogic, ['loadRoles']],
     })),
     actions({
@@ -69,6 +70,10 @@ export const approvalLogic = kea<approvalLogicType>([
         ],
     }),
     selectors({
+        isApprovalsFeatureEnabled: [
+            (s) => [s.hasAvailableFeature],
+            (hasAvailableFeature): boolean => hasAvailableFeature(AvailableFeature.APPROVALS),
+        ],
         breadcrumbs: [
             (s) => [s.changeRequest],
             (changeRequest): Breadcrumb[] => [

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -706,7 +706,6 @@ export const SETTINGS_MAP: SettingSection[] = [
         level: 'environment',
         id: 'environment-approvals',
         title: 'Approvals',
-        flag: 'APPROVALS',
         minimumAccessLevel: OrganizationMembershipLevel.Admin,
         settings: [
             {

--- a/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
@@ -12,6 +12,7 @@ import {
     Tooltip,
 } from '@posthog/lemon-ui'
 
+import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { useRestrictedArea } from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -23,7 +24,7 @@ import { APPROVAL_ACTIONS, ApprovalActionKey, getApprovalActionLabel } from 'sce
 import { membersLogic } from 'scenes/organization/membersLogic'
 import { rolesLogic } from 'scenes/settings/organization/Permissions/Roles/rolesLogic'
 
-import { ApprovalPolicy } from '~/types'
+import { ApprovalPolicy, AvailableFeature } from '~/types'
 
 import { approvalPoliciesLogic } from './approvalPoliciesLogic'
 
@@ -153,25 +154,27 @@ export function ApprovalPolicies(): JSX.Element {
     ]
 
     return (
-        <div className="space-y-4">
-            <div className="flex justify-end items-center">
-                <LemonButton type="primary" onClick={() => setIsCreating(true)} disabledReason={restrictionReason}>
-                    Add policy
-                </LemonButton>
+        <PayGateMini feature={AvailableFeature.APPROVALS}>
+            <div className="space-y-4">
+                <div className="flex justify-end items-center">
+                    <LemonButton type="primary" onClick={() => setIsCreating(true)} disabledReason={restrictionReason}>
+                        Add policy
+                    </LemonButton>
+                </div>
+
+                <LemonTable
+                    dataSource={policies}
+                    columns={columns}
+                    loading={policiesLoading}
+                    rowKey="id"
+                    nouns={['policy', 'policies']}
+                    emptyState="No approval policies configured"
+                />
+
+                {isCreating && <ApprovalPolicyModal onClose={() => setIsCreating(false)} />}
+                {editingPolicy && <ApprovalPolicyModal policy={editingPolicy} onClose={() => setEditingPolicy(null)} />}
             </div>
-
-            <LemonTable
-                dataSource={policies}
-                columns={columns}
-                loading={policiesLoading}
-                rowKey="id"
-                nouns={['policy', 'policies']}
-                emptyState="No approval policies configured"
-            />
-
-            {isCreating && <ApprovalPolicyModal onClose={() => setIsCreating(false)} />}
-            {editingPolicy && <ApprovalPolicyModal policy={editingPolicy} onClose={() => setEditingPolicy(null)} />}
-        </div>
+        </PayGateMini>
     )
 }
 

--- a/frontend/src/scenes/settings/organization/Approvals/ChangeRequestsList.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ChangeRequestsList.tsx
@@ -3,6 +3,7 @@ import { router } from 'kea-router'
 
 import { LemonButton, LemonDialog, LemonInput, LemonSelect, LemonTable, LemonTag, lemonToast } from '@posthog/lemon-ui'
 
+import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { TZLabel } from 'lib/components/TZLabel'
 import { dayjs } from 'lib/dayjs'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -15,7 +16,7 @@ import { getChangeRequestButtonVisibility } from 'scenes/approvals/changeRequest
 import { getApprovalActionLabel, getApprovalResourceName, getApprovalResourceUrl } from 'scenes/approvals/utils'
 import { urls } from 'scenes/urls'
 
-import { ChangeRequest, ChangeRequestState } from '~/types'
+import { AvailableFeature, ChangeRequest, ChangeRequestState } from '~/types'
 
 export function ChangeRequestsList(): JSX.Element {
     const { changeRequests, changeRequestsDataLoading, filters, hasMore } = useValues(approvalsLogic)
@@ -116,57 +117,59 @@ export function ChangeRequestsList(): JSX.Element {
     ]
 
     return (
-        <div className="space-y-4">
-            <div className={cn('flex flex-wrap gap-2 justify-between')}>
-                <div className="flex gap-2 items-center">
-                    <span>
-                        <b>Status</b>
-                    </span>
-                    <LemonSelect
-                        dropdownMatchSelectWidth={false}
-                        onChange={(value) => {
-                            setFilters({ state: value || undefined })
-                        }}
-                        size="small"
-                        options={[
-                            { label: 'All', value: null },
-                            { label: 'Pending', value: ChangeRequestState.Pending },
-                            { label: 'Approved', value: ChangeRequestState.Approved },
-                            { label: 'Applied', value: ChangeRequestState.Applied },
-                            { label: 'Rejected', value: ChangeRequestState.Rejected },
-                            { label: 'Expired', value: ChangeRequestState.Expired },
-                            { label: 'Failed', value: ChangeRequestState.Failed },
-                        ]}
-                        value={filters.state ?? null}
-                    />
+        <PayGateMini feature={AvailableFeature.APPROVALS}>
+            <div className="space-y-4">
+                <div className={cn('flex flex-wrap gap-2 justify-between')}>
+                    <div className="flex gap-2 items-center">
+                        <span>
+                            <b>Status</b>
+                        </span>
+                        <LemonSelect
+                            dropdownMatchSelectWidth={false}
+                            onChange={(value) => {
+                                setFilters({ state: value || undefined })
+                            }}
+                            size="small"
+                            options={[
+                                { label: 'All', value: null },
+                                { label: 'Pending', value: ChangeRequestState.Pending },
+                                { label: 'Approved', value: ChangeRequestState.Approved },
+                                { label: 'Applied', value: ChangeRequestState.Applied },
+                                { label: 'Rejected', value: ChangeRequestState.Rejected },
+                                { label: 'Expired', value: ChangeRequestState.Expired },
+                                { label: 'Failed', value: ChangeRequestState.Failed },
+                            ]}
+                            value={filters.state ?? null}
+                        />
+                    </div>
                 </div>
-            </div>
 
-            <LemonTable
-                dataSource={changeRequests}
-                columns={columns}
-                rowKey="id"
-                loading={changeRequestsDataLoading}
-                nouns={['change request', 'change requests']}
-                data-attr="approvals-table"
-                emptyState="No change requests found"
-                footer={
-                    hasMore && (
-                        <div className="flex justify-center p-1">
-                            <LemonButton
-                                onClick={loadMore}
-                                className="min-w-full text-center"
-                                disabledReason={changeRequestsDataLoading ? 'Loading change requests' : ''}
-                            >
-                                <span className="flex-1 text-center">
-                                    {changeRequestsDataLoading ? 'Loading...' : 'Load more'}
-                                </span>
-                            </LemonButton>
-                        </div>
-                    )
-                }
-            />
-        </div>
+                <LemonTable
+                    dataSource={changeRequests}
+                    columns={columns}
+                    rowKey="id"
+                    loading={changeRequestsDataLoading}
+                    nouns={['change request', 'change requests']}
+                    data-attr="approvals-table"
+                    emptyState="No change requests found"
+                    footer={
+                        hasMore && (
+                            <div className="flex justify-center p-1">
+                                <LemonButton
+                                    onClick={loadMore}
+                                    className="min-w-full text-center"
+                                    disabledReason={changeRequestsDataLoading ? 'Loading change requests' : ''}
+                                >
+                                    <span className="flex-1 text-center">
+                                        {changeRequestsDataLoading ? 'Loading...' : 'Load more'}
+                                    </span>
+                                </LemonButton>
+                            </div>
+                        )
+                    }
+                />
+            </div>
+        </PayGateMini>
     )
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -204,6 +204,7 @@ export enum AvailableFeature {
     PRODUCT_ANALYTICS_AI = 'product_analytics_ai',
     TWOFA_ENFORCEMENT = '2fa_enforcement',
     AUDIT_LOGS = 'audit_logs',
+    APPROVALS = 'approvals',
     HIPAA_BAA = 'hipaa_baa',
     CUSTOM_MSA = 'custom_msa',
     TWOFA = '2fa',

--- a/posthog/approvals/api.py
+++ b/posthog/approvals/api.py
@@ -15,8 +15,13 @@ from posthog.approvals.models import ApprovalPolicy, ChangeRequest
 from posthog.approvals.permissions import CanApprove, CanCancel
 from posthog.approvals.serializers import ApprovalPolicySerializer, ChangeRequestSerializer
 from posthog.approvals.services import ChangeRequestService
+from posthog.constants import AvailableFeature
 from posthog.models import User
-from posthog.permissions import OrganizationAdminWritePermissions, OrganizationMemberPermissions
+from posthog.permissions import (
+    OrganizationAdminWritePermissions,
+    OrganizationMemberPermissions,
+    PremiumFeaturePermission,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +29,9 @@ logger = logging.getLogger(__name__)
 class ChangeRequestViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewSet):
     scope_object = "INTERNAL"
     queryset = ChangeRequest.objects.all().order_by("-created_at")
-    permission_classes = [OrganizationMemberPermissions]
+    permission_classes = [OrganizationMemberPermissions, PremiumFeaturePermission]
     serializer_class = ChangeRequestSerializer
+    premium_feature = AvailableFeature.APPROVALS
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
         filters = self.request.query_params
@@ -153,7 +159,8 @@ class ApprovalPolicyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     scope_object = "INTERNAL"
     queryset = ApprovalPolicy.objects.all().order_by("-created_at")
     serializer_class = ApprovalPolicySerializer
-    permission_classes = [OrganizationMemberPermissions, OrganizationAdminWritePermissions]
+    permission_classes = [OrganizationMemberPermissions, OrganizationAdminWritePermissions, PremiumFeaturePermission]
+    premium_feature = AvailableFeature.APPROVALS
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
         filters = self.request.query_params

--- a/posthog/approvals/decorators.py
+++ b/posthog/approvals/decorators.py
@@ -6,7 +6,6 @@ from typing import Any, Literal, Optional, Union
 from django.conf import settings
 from django.utils import timezone
 
-import posthoganalytics
 from rest_framework import status
 from rest_framework.exceptions import APIException, PermissionDenied, ValidationError
 from rest_framework.response import Response
@@ -17,6 +16,7 @@ from posthog.approvals.models import ChangeRequest, ChangeRequestState
 from posthog.approvals.notifications import send_approval_requested_notification
 from posthog.approvals.policies import PolicyDecision, PolicyEngine
 from posthog.approvals.serializers import ChangeRequestSerializer
+from posthog.constants import AvailableFeature
 from posthog.event_usage import report_user_action
 
 logger = logging.getLogger(__name__)
@@ -53,12 +53,8 @@ def _extract_context(view_or_serializer, request=None) -> tuple[Optional[Any], O
 
 
 def _is_approvals_enabled(organization) -> bool:
-    """Check if the approvals feature flag is enabled for this organization."""
-    return posthoganalytics.feature_enabled(
-        key="approvals",
-        distinct_id=str(organization.id),
-        groups={"organization": str(organization.id)},
-    )
+    """Check if the approvals feature is available for this organization."""
+    return organization.is_feature_available(AvailableFeature.APPROVALS)
 
 
 def _check_policy_for_action(action_class, team, organization) -> Optional[Any]:

--- a/posthog/approvals/tests/test_approvals_api.py
+++ b/posthog/approvals/tests/test_approvals_api.py
@@ -8,10 +8,18 @@ from django.utils import timezone
 from rest_framework import status
 
 from posthog.approvals.models import Approval, ApprovalDecision, ApprovalPolicy, ChangeRequest, ChangeRequestState
+from posthog.constants import AvailableFeature
 from posthog.models import User
 
 
 class TestChangeRequestViewSet(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.APPROVALS, "name": AvailableFeature.APPROVALS}
+        ]
+        self.organization.save()
+
     def _create_change_request(self, **kwargs):
         defaults = {
             "team": self.team,
@@ -159,6 +167,10 @@ class TestChangeRequestViewSet(APIBaseTest):
 class TestApprovalPolicyViewSet(APIBaseTest):
     def setUp(self):
         super().setUp()
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.APPROVALS, "name": AvailableFeature.APPROVALS}
+        ]
+        self.organization.save()
         self.organization_membership.level = 8  # Admin level
         self.organization_membership.save()
 

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -47,6 +47,7 @@ class AvailableFeature(StrEnum):
     ORGANIZATION_APP_QUERY_CONCURRENCY_LIMIT = "organization_app_query_concurrency_limit"
     SESSION_REPLAY_DATA_RETENTION = "session_replay_data_retention"
     AUDIT_LOGS = "audit_logs"
+    APPROVALS = "approvals"
 
 
 TREND_FILTER_TYPE_ACTIONS = "actions"


### PR DESCRIPTION
## Problem

- The Approvals are currently hidden behind a FF and enabled for 4 orgs. Adoption is slow so I'm doing a soft-launch (marketing comms will some a couple of weeks down the line when we have some live use cases and have ironed the kinks). 

## Changes

- Replace `approvals` FF with a [feature entitlement on Scale and Enterprise.](https://github.com/PostHog/billing/pull/1778)

## How did you test this code?

- Clicked around.

## Publish to changelog?

No