### PR TITLE
feat(analytics-platform): Add explicit session timestamp to the sessions v3 mv sql (also used for backfill)

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -3521,7 +3521,7 @@
   SELECT
       team_id,
       `$session_id_uuid` AS session_id_v7,
-      fromUnixTimestamp64Milli(toUInt64(bitShiftRight(`$session_id_uuid`, 80))) AS `session_timestamp`,
+      
   
       initializeAggregation('argMaxState', source_table.distinct_id, timestamp) as distinct_id,
       initializeAggregation('groupUniqArrayState', source_table.distinct_id) as distinct_ids,

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -3616,7 +3616,7 @@
   SELECT
       team_id,
       toUInt128(accurateCast(session_id, 'UUID')) AS session_id_v7,
-  
+      fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80))) AS session_timestamp,
       initializeAggregation('argMaxState', source_table.distinct_id, min_ts_64) as distinct_id,
       initializeAggregation('groupUniqArrayState', source_table.distinct_id) as distinct_ids,
   
@@ -4593,7 +4593,7 @@
       -- Ideally we would not need to store this separately, as the ID *is* the timestamp
       -- Unfortunately for now, chaining clickhouse functions to extract the timestamp will break indexes / partition pruning, so do this workaround
       -- again, when the new CH UUID type is released, we should try to switch to that and remove the separate timestamp column
-      session_timestamp DateTime64 MATERIALIZED fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80))),
+      session_timestamp DateTime64 DEFAULT fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80))),
   
       -- ClickHouse will pick the latest value of distinct_id for the session
       -- this is fine since even if the distinct_id changes during a session
@@ -5948,7 +5948,7 @@
       -- Ideally we would not need to store this separately, as the ID *is* the timestamp
       -- Unfortunately for now, chaining clickhouse functions to extract the timestamp will break indexes / partition pruning, so do this workaround
       -- again, when the new CH UUID type is released, we should try to switch to that and remove the separate timestamp column
-      session_timestamp DateTime64 MATERIALIZED fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80))),
+      session_timestamp DateTime64 DEFAULT fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80))),
   
       -- ClickHouse will pick the latest value of distinct_id for the session
       -- this is fine since even if the distinct_id changes during a session
@@ -7527,7 +7527,7 @@
       -- Ideally we would not need to store this separately, as the ID *is* the timestamp
       -- Unfortunately for now, chaining clickhouse functions to extract the timestamp will break indexes / partition pruning, so do this workaround
       -- again, when the new CH UUID type is released, we should try to switch to that and remove the separate timestamp column
-      session_timestamp DateTime64 MATERIALIZED fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80))),
+      session_timestamp DateTime64 DEFAULT fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80))),
   
       -- ClickHouse will pick the latest value of distinct_id for the session
       -- this is fine since even if the distinct_id changes during a session

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -3521,6 +3521,7 @@
   SELECT
       team_id,
       `$session_id_uuid` AS session_id_v7,
+      fromUnixTimestamp64Milli(toUInt64(bitShiftRight(`$session_id_uuid`, 80))) AS `session_timestamp`,
   
       initializeAggregation('argMaxState', source_table.distinct_id, timestamp) as distinct_id,
       initializeAggregation('groupUniqArrayState', source_table.distinct_id) as distinct_ids,

--- a/posthog/clickhouse/test/test_raw_sessions_v3_model.py
+++ b/posthog/clickhouse/test/test_raw_sessions_v3_model.py
@@ -342,6 +342,14 @@ class TestRawSessionsModel(ClickhouseTestMixin, BaseTest):
             ),
             {"team_id": self.team.id},
         )
+        # # this is currently commented out so we can run this on an usual db setup
+        # sync_execute(
+        #     RAW_SESSION_TABLE_BACKFILL_SQL_V3(
+        #         where="team_id = %(team_id)s AND timestamp >= '2024-03-01'",
+        #         target_table=DISTRIBUTED_RAW_SESSIONS_TABLE_V3()
+        #     ),
+        #     {"team_id": self.team.id},
+        # )
 
     def test_max_inserted_at(self):
         distinct_id = create_distinct_id()

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -31,10 +31,10 @@ from posthog.cloud_utils import is_cloud
 from posthog.dags.common.common import JobOwners, dagster_tags
 from posthog.git import get_git_commit_short
 from posthog.models.raw_sessions.sessions_v3 import (
-    DISTRIBUTED_RAW_SESSIONS_TABLE_V3,
     GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS,
     RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3,
     RAW_SESSION_TABLE_BACKFILL_SQL_V3,
+    WRITABLE_RAW_SESSIONS_TABLE_V3,
 )
 
 # This is the number of days to backfill in one SQL operation
@@ -458,7 +458,8 @@ def _do_experimental_backfill(
 
                 backfill_sql = sql_template(
                     where=chunk_where_clause,
-                    target_table=DISTRIBUTED_RAW_SESSIONS_TABLE_V3(),
+                    target_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
+                    include_session_timestamp=False,
                 )
                 context.log.info(backfill_sql)
                 sync_execute(backfill_sql, settings=merged_settings, sync_client=client)

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -31,10 +31,10 @@ from posthog.cloud_utils import is_cloud
 from posthog.dags.common.common import JobOwners, dagster_tags
 from posthog.git import get_git_commit_short
 from posthog.models.raw_sessions.sessions_v3 import (
+    DISTRIBUTED_RAW_SESSIONS_TABLE_V3,
     GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS,
     RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3,
     RAW_SESSION_TABLE_BACKFILL_SQL_V3,
-    WRITABLE_RAW_SESSIONS_TABLE_V3,
 )
 
 # This is the number of days to backfill in one SQL operation
@@ -458,7 +458,7 @@ def _do_experimental_backfill(
 
                 backfill_sql = sql_template(
                     where=chunk_where_clause,
-                    target_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
+                    target_table=DISTRIBUTED_RAW_SESSIONS_TABLE_V3(),  # this is just what the table is called in the experimental cluster, it's not actually distributed
                     include_session_timestamp=False,
                 )
                 context.log.info(backfill_sql)

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -389,7 +389,7 @@ AND {where}
         source_table=source_table,
         where=where,
         PROPERTIES=PROPERTIES,
-        session_timestamp="fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80))),"
+        session_timestamp="fromUnixTimestamp64Milli(toUInt64(bitShiftRight(`$session_id_uuid`, 80))) AS session_timestamp,"
         if include_session_timestamp
         else "",
     )

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS {table_name}
     -- Ideally we would not need to store this separately, as the ID *is* the timestamp
     -- Unfortunately for now, chaining clickhouse functions to extract the timestamp will break indexes / partition pruning, so do this workaround
     -- again, when the new CH UUID type is released, we should try to switch to that and remove the separate timestamp column
-    session_timestamp DateTime64 MATERIALIZED fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80))),
+    session_timestamp DateTime64 {session_timestamp_modifier} fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80))),
 
     -- ClickHouse will pick the latest value of distinct_id for the session
     -- this is fine since even if the distinct_id changes during a session
@@ -211,6 +211,7 @@ SETTINGS {settings}
         table_name=SHARDED_RAW_SESSIONS_TABLE_V3(),
         engine=SHARDED_RAW_SESSIONS_DATA_TABLE_ENGINE_V3(),
         settings=SHARDED_RAW_SESSIONS_DATA_TABLE_SETTINGS_V3(),
+        session_timestamp_modifier="DEFAULT",
     )
 
 
@@ -426,7 +427,7 @@ MODIFY QUERY
     )
 
 
-def RAW_SESSION_TABLE_MV_RECORDINGS_SELECT_SQL_V3(source_table, where="TRUE"):
+def RAW_SESSION_TABLE_MV_RECORDINGS_SELECT_SQL_V3(source_table, where="TRUE", include_session_timestamp=False):
     return """
 WITH
     min_first_timestamp as timestamp,
@@ -438,7 +439,7 @@ WITH
 SELECT
     team_id,
     toUInt128(accurateCast(session_id, 'UUID')) AS session_id_v7,
-
+    {session_timestamp}
     initializeAggregation('argMaxState', source_table.distinct_id, min_ts_64) as distinct_id,
     initializeAggregation('groupUniqArrayState', source_table.distinct_id) as distinct_ids,
 
@@ -514,6 +515,9 @@ AND {where}
     """.format(
         source_table=source_table,
         where=where,
+        session_timestamp="fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80))) AS session_timestamp,"
+        if include_session_timestamp
+        else "",
     )
 
 
@@ -531,28 +535,34 @@ AS
             where=where,
             # use sharded_session_replay_events, this means that the mv MUST be created on every data node
             source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_session_replay_events",
+            include_session_timestamp=True,
         ),
     )
 
 
 def RAW_SESSION_TABLE_BACKFILL_SQL_V3(
-    where: str, shard_index: Optional[int] = None, num_shards: Optional[int] = None, target_table: Optional[str] = None
+    where: str,
+    shard_index: Optional[int] = None,
+    num_shards: Optional[int] = None,
+    target_table: Optional[str] = None,
+    include_session_timestamp: bool = True,
 ):
     """
     Generates SQL to backfill sessions from events.
 
     Each shard should call this with its own shard_index to only SELECT events
     that will end up on that shard, then INSERT directly to the local sharded table.
+
+    include_session_timestamp must be True when the target table has session_timestamp
+    as DEFAULT (sharded/writable tables), and False when it is MATERIALIZED (distributed).
     """
     if not target_table:
         target_table = SHARDED_RAW_SESSIONS_TABLE_V3()
     if shard_index is not None and num_shards is not None:
         shard_filter = f"modulo(cityHash64(`$session_id_uuid`), {num_shards}) = {shard_index}"
         combined_where = f"({where}) AND {shard_filter}"
-        include_session_timestamp = False
     else:
         combined_where = where
-        include_session_timestamp = True
 
     return """
 INSERT INTO {database}.{target_table}
@@ -569,13 +579,20 @@ INSERT INTO {database}.{target_table}
 
 
 def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(
-    where: str, shard_index: Optional[int] = None, num_shards: Optional[int] = None, target_table: Optional[str] = None
+    where: str,
+    shard_index: Optional[int] = None,
+    num_shards: Optional[int] = None,
+    target_table: Optional[str] = None,
+    include_session_timestamp: bool = True,
 ):
     """
     Generates SQL to backfill sessions from session replay events.
 
     Each shard should call this with its own shard_index to only SELECT recordings
     that will end up on that shard, then INSERT directly to the local sharded table.
+
+    include_session_timestamp must be True when the target table has session_timestamp
+    as DEFAULT (sharded/writable tables), and False when it is MATERIALIZED (distributed).
     """
     if not target_table:
         target_table = SHARDED_RAW_SESSIONS_TABLE_V3()
@@ -594,6 +611,7 @@ INSERT INTO {database}.{target_table}
         select_sql=RAW_SESSION_TABLE_MV_RECORDINGS_SELECT_SQL_V3(
             where=combined_where,
             source_table=f"{settings.CLICKHOUSE_DATABASE}.session_replay_events",
+            include_session_timestamp=include_session_timestamp,
         ),
     )
 
@@ -611,6 +629,7 @@ def WRITABLE_RAW_SESSIONS_TABLE_SQL_V3():
             # shard via session_id so that all events for a session are on the same shard
             sharding_key="cityHash64(session_id_v7)",
         ),
+        session_timestamp_modifier="DEFAULT",
     )
 
 
@@ -624,6 +643,7 @@ def DISTRIBUTED_RAW_SESSIONS_TABLE_SQL_V3():
             data_table=SHARDED_RAW_SESSIONS_TABLE_V3(),
             sharding_key="cityHash64(session_id_v7)",
         ),
+        session_timestamp_modifier="MATERIALIZED",
     )
 
 

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -311,6 +311,7 @@ WITH
 SELECT
     team_id,
     `$session_id_uuid` AS session_id_v7,
+    fromUnixTimestamp64Milli(toUInt64(bitShiftRight(`$session_id_uuid`, 80))) AS `session_timestamp`,
 
     initializeAggregation('argMaxState', source_table.distinct_id, timestamp) as distinct_id,
     initializeAggregation('groupUniqArrayState', source_table.distinct_id) as distinct_ids,


### PR DESCRIPTION
## Problem

Fix this problem https://posthog.dagster.plus/prod-us/runs/6d0636a7-5048-4274-b45c-37da64798e14

## Changes

Add the session timestamp to the mv, despite being there as a materialized col, let's add it explicitly during the insert

## How did you test this code?

Existing tests should still pass!

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
