### PR TITLE
fix(llma): gracefully skip teams not found in local database

### DIFF
--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -47,7 +47,11 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
     def _sample_items(
         team_id: int, window_start: str, window_end: str, max_items: int, analysis_level: str
     ) -> list[SampledItem]:
-        team = Team.objects.get(id=team_id)
+        try:
+            team = Team.objects.get(id=team_id)
+        except Team.DoesNotExist:
+            logger.info("Team not found in local database, skipping", team_id=team_id)
+            return []
 
         start_dt_str = format_datetime_for_clickhouse(window_start)
         end_dt_str = format_datetime_for_clickhouse(window_end)


### PR DESCRIPTION
## Problem

Team discovery queries ClickHouse which can return teams from any region. When a child summarization workflow runs on a regional worker (EU or US), `Team.objects.get()` fails for teams that only exist in the other region's Postgres. This causes noisy failures with retries that will never succeed.

## Changes

Catch `Team.DoesNotExist` in `sample_items_in_window_activity` and return an empty list instead of raising. The workflow then completes cleanly with zero items processed for that team.

## How did you test this code?

Observed the error in prod-eu Temporal workflows (e.g. team 30xxx exists in US but not EU). Verified the workflow handles an empty sampling result correctly -- `items_queried=0`, no downstream activities are spawned, workflow completes with status `completed`.

## Publish to changelog?

no