### PR TITLE
fix(flags): handle null values in migration filter iteration

### DIFF
--- a/posthog/migrations/1001_fix_person_property_in_operator.py
+++ b/posthog/migrations/1001_fix_person_property_in_operator.py
@@ -28,15 +28,15 @@ def fix_person_property_in_operators(apps, schema_editor):
         modified = False
 
         # Check groups
-        for group in filters.get("groups", []):
-            for prop in group.get("properties", []):
+        for group in filters.get("groups") or []:
+            for prop in group.get("properties") or []:
                 if prop.get("type") == "person" and prop.get("operator") in ("in", "not_in"):
                     prop["operator"] = "exact" if prop["operator"] == "in" else "is_not"
                     modified = True
 
         # Also check super_groups if present
-        for group in filters.get("super_groups", []):
-            for prop in group.get("properties", []):
+        for group in filters.get("super_groups") or []:
+            for prop in group.get("properties") or []:
                 if prop.get("type") == "person" and prop.get("operator") in ("in", "not_in"):
                     prop["operator"] = "exact" if prop["operator"] == "in" else "is_not"
                     modified = True


### PR DESCRIPTION
## Problem

The migration `1001_fix_person_property_in_operator` was failing in production with:

```
TypeError: 'NoneType' object is not iterable
```

This occurred when feature flag filters contained explicit `null` values for `groups`, `super_groups`, or `properties` keys.

## Changes

Changed `.get("key", [])` to `.get("key") or []` to handle both missing keys and explicit null values.

The difference:
- `.get("key", [])` returns `[]` only when the key is **missing** from the dict
- `.get("key") or []` returns `[]` when the key is missing **or** when the value is `None`

## How did you test this code?

The fix is straightforward - handles the edge case where JSON contains `"super_groups": null` instead of omitting the key entirely.