### PR TITLE
fix(dags): clamp earliest backfill date to 2015 for duckling events sensor

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1812,6 +1812,9 @@ def duckling_events_daily_backfill_sensor(context: SensorEvaluationContext) -> S
 # Number of monthly partitions to create per sensor tick (to avoid timeout)
 BACKFILL_MONTHS_PER_TICK = 3
 
+# Ignore events before this date — pre-2015 data is typically junk timestamps
+EARLIEST_BACKFILL_DATE = datetime(2015, 1, 1)
+
 
 def get_months_in_range(start_date: date, end_date: date) -> list[str]:
     """Generate list of month strings (YYYY-MM) between start and end dates."""
@@ -1902,6 +1905,7 @@ def duckling_events_full_backfill_sensor(context: SensorEvaluationContext) -> Se
             if earliest_dt is None:
                 context.log.info(f"No events found for team_id={team_id}, skipping")
                 continue
+            earliest_dt = max(earliest_dt, EARLIEST_BACKFILL_DATE)
             earliest_month = earliest_dt.strftime("%Y-%m")
             current_month = earliest_month
 

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -696,6 +696,7 @@ class TestFullBackfillSensorEarliestDate:
         context = build_sensor_context(instance=instance)
         result = duckling_events_full_backfill_sensor(context)
         assert isinstance(result, SensorResult)
+        assert result.run_requests is not None
 
         assert len(result.run_requests) > 0
         first_key = result.run_requests[0].partition_key
@@ -718,6 +719,7 @@ class TestFullBackfillSensorEarliestDate:
         context = build_sensor_context(instance=instance)
         result = duckling_events_full_backfill_sensor(context)
         assert isinstance(result, SensorResult)
+        assert result.run_requests is not None
 
         assert len(result.run_requests) == 0
 

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -7,6 +7,7 @@ import duckdb
 from parameterized import parameterized
 
 from posthog.dags.events_backfill_to_duckling import (
+    EARLIEST_BACKFILL_DATE,
     EVENTS_COLUMNS,
     EVENTS_TABLE_DDL,
     EXPECTED_DUCKLAKE_COLUMNS,
@@ -20,6 +21,7 @@ from posthog.dags.events_backfill_to_duckling import (
     _validate_identifier,
     delete_events_partition_data,
     delete_persons_partition_data,
+    duckling_events_full_backfill_sensor,
     get_months_in_range,
     get_s3_url_for_clickhouse,
     is_full_export_partition,
@@ -664,3 +666,58 @@ class TestDeletePersonsRetry:
             ((4,),),
             ((8,),),
         ]
+
+
+class TestFullBackfillSensorEarliestDate:
+    @parameterized.expand(
+        [
+            # (earliest_dt_from_clickhouse, expected_first_month)
+            ("pre-2015 clamped to 2015-01", datetime(2010, 3, 1), "2015-01"),
+            ("exactly 2015-01-01 unchanged", datetime(2015, 1, 1), "2015-01"),
+            ("post-2015 unchanged", datetime(2020, 6, 15), "2020-06"),
+        ]
+    )
+    @patch("posthog.dags.events_backfill_to_duckling.get_earliest_event_date_for_team")
+    @patch("posthog.dags.events_backfill_to_duckling.DuckLakeCatalog")
+    @patch("posthog.dags.events_backfill_to_duckling.timezone")
+    def test_earliest_date_clamped(
+        self, _name, earliest_dt, expected_first_month, mock_tz, mock_catalog_cls, mock_get_earliest
+    ):
+        from dagster import DagsterInstance, build_sensor_context
+
+        mock_tz.now.return_value = datetime(2025, 2, 10, 12, 0, 0)
+        mock_get_earliest.return_value = earliest_dt
+
+        catalog = MagicMock()
+        catalog.team_id = 1
+        mock_catalog_cls.objects.all.return_value.order_by.return_value = [catalog]
+
+        instance = DagsterInstance.ephemeral()
+        context = build_sensor_context(instance=instance)
+        result = duckling_events_full_backfill_sensor(context)
+
+        assert len(result.run_requests) > 0
+        first_key = result.run_requests[0].partition_key
+        assert first_key == f"1_{expected_first_month}"
+
+    @patch("posthog.dags.events_backfill_to_duckling.get_earliest_event_date_for_team")
+    @patch("posthog.dags.events_backfill_to_duckling.DuckLakeCatalog")
+    @patch("posthog.dags.events_backfill_to_duckling.timezone")
+    def test_no_events_returns_empty(self, mock_tz, mock_catalog_cls, mock_get_earliest):
+        from dagster import DagsterInstance, build_sensor_context
+
+        mock_tz.now.return_value = datetime(2025, 2, 10, 12, 0, 0)
+        mock_get_earliest.return_value = None
+
+        catalog = MagicMock()
+        catalog.team_id = 1
+        mock_catalog_cls.objects.all.return_value.order_by.return_value = [catalog]
+
+        instance = DagsterInstance.ephemeral()
+        context = build_sensor_context(instance=instance)
+        result = duckling_events_full_backfill_sensor(context)
+
+        assert len(result.run_requests) == 0
+
+    def test_earliest_backfill_date_is_2015(self):
+        assert EARLIEST_BACKFILL_DATE == datetime(2015, 1, 1)

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -683,7 +683,7 @@ class TestFullBackfillSensorEarliestDate:
     def test_earliest_date_clamped(
         self, _name, earliest_dt, expected_first_month, mock_tz, mock_catalog_cls, mock_get_earliest
     ):
-        from dagster import DagsterInstance, build_sensor_context
+        from dagster import DagsterInstance, SensorResult, build_sensor_context
 
         mock_tz.now.return_value = datetime(2025, 2, 10, 12, 0, 0)
         mock_get_earliest.return_value = earliest_dt
@@ -695,6 +695,7 @@ class TestFullBackfillSensorEarliestDate:
         instance = DagsterInstance.ephemeral()
         context = build_sensor_context(instance=instance)
         result = duckling_events_full_backfill_sensor(context)
+        assert isinstance(result, SensorResult)
 
         assert len(result.run_requests) > 0
         first_key = result.run_requests[0].partition_key
@@ -704,7 +705,7 @@ class TestFullBackfillSensorEarliestDate:
     @patch("posthog.dags.events_backfill_to_duckling.DuckLakeCatalog")
     @patch("posthog.dags.events_backfill_to_duckling.timezone")
     def test_no_events_returns_empty(self, mock_tz, mock_catalog_cls, mock_get_earliest):
-        from dagster import DagsterInstance, build_sensor_context
+        from dagster import DagsterInstance, SensorResult, build_sensor_context
 
         mock_tz.now.return_value = datetime(2025, 2, 10, 12, 0, 0)
         mock_get_earliest.return_value = None
@@ -716,6 +717,7 @@ class TestFullBackfillSensorEarliestDate:
         instance = DagsterInstance.ephemeral()
         context = build_sensor_context(instance=instance)
         result = duckling_events_full_backfill_sensor(context)
+        assert isinstance(result, SensorResult)
 
         assert len(result.run_requests) == 0
 


### PR DESCRIPTION
## Summary
- Adds `EARLIEST_BACKFILL_DATE = datetime(2015, 1, 1)` constant
- Clamps `earliest_dt` in `duckling_events_full_backfill_sensor` so it never creates monthly partitions for pre-2015 data (typically junk timestamps)

## Test plan
- [ ] Verify sensor skips pre-2015 partitions for teams with old junk timestamps
- [ ] Verify sensor still works normally for teams with post-2015 data

🤖 Generated with [Claude Code](https://claude.com/claude-code)