### PR TITLE
fix(phai): more obvious upsert_dashboard warning prompt

### DIFF
--- a/ee/hogai/tools/upsert_dashboard/prompts.py
+++ b/ee/hogai/tools/upsert_dashboard/prompts.py
@@ -87,21 +87,25 @@ Note: The following insight IDs could not be added (not found or not saved): {mi
 """.strip()
 
 PERMISSION_REQUEST_PROMPT = """
-Dashboard: {{{dashboard_name}}}
+Updating dashboard: {{{dashboard_name}}}
 {{#new_dashboard_name}}
-Rename to: {{{new_dashboard_name}}}
+
+Renaming to: {{{new_dashboard_name}}}
 {{/new_dashboard_name}}
 {{#new_dashboard_description}}
-Update description to: {{{new_dashboard_description}}}
+
+Updating description to: {{{new_dashboard_description}}}
 {{/new_dashboard_description}}
-{{#new_insights}}
-This action will add the following insights:
-{{{new_insights}}}
-{{/new_insights}}
 {{#deleted_insights}}
-This action will remove the following insights:
+
+**Removing {{{deleted_count}}} from this dashboard:**
 {{{deleted_insights}}}
 {{/deleted_insights}}
+{{#new_insights}}
+
+**Adding {{{added_count}}} to this dashboard:**
+{{{new_insights}}}
+{{/new_insights}}
 """.strip()
 
 MISSING_INSIGHT_IDS_PROMPT = """

--- a/frontend/src/scenes/max/components/InputFormArea.tsx
+++ b/frontend/src/scenes/max/components/InputFormArea.tsx
@@ -182,7 +182,7 @@ function DangerousOperationInput({ operation }: DangerousOperationInputProps): J
                 <span className="font-medium">Approval required</span>
             </div>
             {operation.toolName !== 'finalize_plan' && (
-                <p className="text-xs text-secondary m-0">This operation will make the following changes:</p>
+                <p className="text-xs text-secondary m-0">Review the changes below before approving:</p>
             )}
             <LemonDivider className="my-0 -mx-3 w-[calc(100%+var(--spacing)*6)]" />
             <div className="max-h-60 overflow-y-auto">
@@ -193,7 +193,7 @@ function DangerousOperationInput({ operation }: DangerousOperationInputProps): J
                 options={options}
                 onSelect={handleSelect}
                 allowCustom
-                customPlaceholder="Type something..."
+                customPlaceholder="Explain what you'd like instead..."
                 onCustomSubmit={handleCustomSubmit}
                 loading={isLoading}
                 loadingMessage={

--- a/frontend/src/scenes/max/components/OptionSelector.tsx
+++ b/frontend/src/scenes/max/components/OptionSelector.tsx
@@ -167,7 +167,7 @@ export function OptionSelector({
                             </LemonButton>
                         </div>
                     ) : (
-                        <span className="my-1.5">Type something...</span>
+                        <span className="my-1.5">Explain what you'd like instead..</span>
                     )}
                 </label>
             )}


### PR DESCRIPTION
## Problem

Some customers don't notice that the upsert_dashboard would remove their insights. This PR implements another wording and formatting to make it more obvious.

<img width="498" height="356" alt="Screenshot 2026-02-10 at 17 55 03" src="https://github.com/user-attachments/assets/b7c69b58-ed50-4404-979d-16e22cb2d0f9" />

## Changes

- Updated the copy.

