### PR TITLE
chore(cli): rename release args

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.5.28
+
+- chore: introduce `--release-name` and `--release-version` options (backwards compatible)
+
 # 0.5.27
 
 - fix: only warns on release id mismatch errors

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1566,7 +1566,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.27"
+version = "0.5.28"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.27"
+version = "0.5.28"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/api/releases.rs
+++ b/cli/src/api/releases.rs
@@ -123,10 +123,10 @@ impl ReleaseBuilder {
         let mut missing = Vec::new();
 
         if self.version.is_none() {
-            missing.push("version");
+            missing.push("release-version");
         }
         if self.name.is_none() {
-            missing.push("project");
+            missing.push("release-name");
         }
         missing
     }

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -37,7 +37,7 @@ pub fn upload(args: &Args) -> Result<()> {
     } = args;
 
     let ReleaseArgs {
-        project,
+        name,
         version,
         skip_release_on_fail,
     } = release;
@@ -53,8 +53,8 @@ pub fn upload(args: &Args) -> Result<()> {
         .map(ReleaseBuilder::init_from_git)
         .unwrap_or_default();
 
-    if let Some(project) = project {
-        release_builder.with_project(project);
+    if let Some(name) = name {
+        release_builder.with_name(name);
     }
     if let Some(version) = version {
         release_builder.with_version(version);

--- a/cli/src/sourcemaps/args.rs
+++ b/cli/src/sourcemaps/args.rs
@@ -53,14 +53,14 @@ pub struct ReleaseArgs {
     /// The project name associated with the uploaded chunks. Required to have the uploaded chunks associated with
     /// a specific release. We will try to auto-derive this from git information if not provided. Strongly recommended
     /// to be set explicitly during release CD workflows
-    #[arg(long, name = "release-name", alias = "project")]
+    #[arg(long = "release-name", alias = "project")]
     // deprecated alias for backwards compatibility
     pub name: Option<String>,
 
     /// The version of the project - this can be a version number, semantic version, or a git commit hash. Required
     /// to have the uploaded chunks associated with a specific release. We will try to auto-derive this from git information
     /// if not provided.
-    #[arg(long, name = "release-version", alias = "version")]
+    #[arg(long = "release-version", alias = "version")]
     // deprecated alias for backwards compatibility
     pub version: Option<String>,
 

--- a/cli/src/sourcemaps/args.rs
+++ b/cli/src/sourcemaps/args.rs
@@ -53,13 +53,15 @@ pub struct ReleaseArgs {
     /// The project name associated with the uploaded chunks. Required to have the uploaded chunks associated with
     /// a specific release. We will try to auto-derive this from git information if not provided. Strongly recommended
     /// to be set explicitly during release CD workflows
-    #[arg(long)]
-    pub project: Option<String>,
+    #[arg(long, name = "release-name", alias = "project")]
+    // deprecated alias for backwards compatibility
+    pub name: Option<String>,
 
     /// The version of the project - this can be a version number, semantic version, or a git commit hash. Required
     /// to have the uploaded chunks associated with a specific release. We will try to auto-derive this from git information
     /// if not provided.
-    #[arg(long)]
+    #[arg(long, name = "release-version", alias = "version")]
+    // deprecated alias for backwards compatibility
     pub version: Option<String>,
 
     /// If the server returns a release_id_mismatch error (symbol set already exists with a different release),
@@ -71,9 +73,7 @@ pub struct ReleaseArgs {
 impl From<ReleaseArgs> for ReleaseBuilder {
     fn from(args: ReleaseArgs) -> Self {
         let mut builder = ReleaseBuilder::default();
-        args.project
-            .as_ref()
-            .map(|project| builder.with_project(project));
+        args.name.as_ref().map(|project| builder.with_name(project));
         args.version
             .as_ref()
             .map(|version| builder.with_version(version));

--- a/cli/src/sourcemaps/inject.rs
+++ b/cli/src/sourcemaps/inject.rs
@@ -99,7 +99,7 @@ pub fn get_release_for_maps<'a>(
 ) -> Result<Option<Release>> {
     // We need to fetch or create a release if: the user specified one, any pair is missing one, or the user
     // forced release overriding
-    let needs_release = release.project.is_some()
+    let needs_release = release.name.is_some()
         || release.version.is_some()
         || maps.into_iter().any(|p| !p.has_release_id());
 


### PR DESCRIPTION
## Problem

- project option is confusing, as we might think it is the posthog project.

## Changes

- Introduce `release-name` and `release-version`