### PR TITLE
fix(dags): retry on ClickHouse cluster discovery timeout in duckling backfill

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -56,10 +56,10 @@ from dagster import (
     define_asset_job,
     sensor,
 )
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_fixed
 
 from posthog.clickhouse.client.connection import NodeRole, Workload
-from posthog.clickhouse.cluster import RetryPolicy, get_cluster
+from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
 from posthog.dags.common.common import JobOwners, dagster_tags, settings_with_log_comment
@@ -79,9 +79,21 @@ logger = structlog.get_logger(__name__)
 # for Python, Dagster framework, and ClickHouse client overhead.
 DUCKDB_MEMORY_LIMIT = "4GB"
 
-# Retry policy for ClickHouse cluster bootstrap connections which can
-# intermittently time out under load.
-CLUSTER_RETRY_POLICY = RetryPolicy(max_attempts=3, delay=5.0, exceptions=(TimeoutError, OSError))
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(5),
+    retry=retry_if_exception_type((TimeoutError, OSError)),
+    reraise=True,
+)
+def _get_cluster() -> ClickhouseCluster:
+    """get_cluster() with retry for transient bootstrap timeouts.
+
+    Retries the cluster discovery query only — does not affect subsequent
+    per-host query execution, avoiding stacked retries with Tenacity
+    export retry decorators.
+    """
+    return get_cluster()
 
 
 def _connect_duckdb() -> duckdb.DuckDBPyConnection:
@@ -330,7 +342,7 @@ def get_earliest_event_date_for_team(team_id: int) -> datetime | None:
     Returns:
         The date of the earliest event, or None if no events exist for this team.
     """
-    cluster = get_cluster(retry_policy=CLUSTER_RETRY_POLICY)
+    cluster = _get_cluster()
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
     def query_earliest(client: Client) -> datetime | None:
@@ -370,7 +382,7 @@ def get_earliest_person_date_for_team(team_id: int) -> datetime | None:
     Returns:
         The date of the earliest person modification, or None if no persons exist.
     """
-    cluster = get_cluster(retry_policy=CLUSTER_RETRY_POLICY)
+    cluster = _get_cluster()
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
     def query_earliest(client: Client) -> datetime | None:
@@ -1460,7 +1472,7 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
         merged_settings.update(config.clickhouse_settings)
         context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
-    cluster = get_cluster(retry_policy=CLUSTER_RETRY_POLICY)
+    cluster = _get_cluster()
     tags = dagster_tags(context)
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
@@ -1596,7 +1608,7 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
         merged_settings.update(config.clickhouse_settings)
         context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
-    cluster = get_cluster(retry_policy=CLUSTER_RETRY_POLICY)
+    cluster = _get_cluster()
     tags = dagster_tags(context)
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -59,7 +59,7 @@ from dagster import (
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from posthog.clickhouse.client.connection import NodeRole, Workload
-from posthog.clickhouse.cluster import get_cluster
+from posthog.clickhouse.cluster import RetryPolicy, get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
 from posthog.dags.common.common import JobOwners, dagster_tags, settings_with_log_comment
@@ -78,6 +78,10 @@ logger = structlog.get_logger(__name__)
 # The Dagster pod has 16Gi total; we cap DuckDB at 4Gi to leave headroom
 # for Python, Dagster framework, and ClickHouse client overhead.
 DUCKDB_MEMORY_LIMIT = "4GB"
+
+# Retry policy for ClickHouse cluster bootstrap connections which can
+# intermittently time out under load.
+CLUSTER_RETRY_POLICY = RetryPolicy(max_attempts=3, delay=5.0, exceptions=(TimeoutError, OSError))
 
 
 def _connect_duckdb() -> duckdb.DuckDBPyConnection:
@@ -326,7 +330,7 @@ def get_earliest_event_date_for_team(team_id: int) -> datetime | None:
     Returns:
         The date of the earliest event, or None if no events exist for this team.
     """
-    cluster = get_cluster()
+    cluster = get_cluster(retry_policy=CLUSTER_RETRY_POLICY)
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
     def query_earliest(client: Client) -> datetime | None:
@@ -366,7 +370,7 @@ def get_earliest_person_date_for_team(team_id: int) -> datetime | None:
     Returns:
         The date of the earliest person modification, or None if no persons exist.
     """
-    cluster = get_cluster()
+    cluster = get_cluster(retry_policy=CLUSTER_RETRY_POLICY)
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
     def query_earliest(client: Client) -> datetime | None:
@@ -1456,7 +1460,7 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
         merged_settings.update(config.clickhouse_settings)
         context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
-    cluster = get_cluster()
+    cluster = get_cluster(retry_policy=CLUSTER_RETRY_POLICY)
     tags = dagster_tags(context)
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
@@ -1592,7 +1596,7 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
         merged_settings.update(config.clickhouse_settings)
         context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
-    cluster = get_cluster()
+    cluster = get_cluster(retry_policy=CLUSTER_RETRY_POLICY)
     tags = dagster_tags(context)
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -16,6 +16,7 @@ from posthog.dags.events_backfill_to_duckling import (
     PERSONS_COLUMNS,
     PERSONS_TABLE_DDL,
     _connect_duckdb,
+    _get_cluster,
     _is_transaction_conflict,
     _set_table_partitioning,
     _validate_identifier,
@@ -725,3 +726,36 @@ class TestFullBackfillSensorEarliestDate:
 
     def test_earliest_backfill_date_is_2015(self):
         assert EARLIEST_BACKFILL_DATE == datetime(2015, 1, 1)
+
+
+class TestGetClusterRetry:
+    @patch("posthog.dags.events_backfill_to_duckling.get_cluster")
+    def test_retries_on_timeout_then_succeeds(self, mock_get_cluster):
+        mock_cluster = MagicMock()
+        mock_get_cluster.side_effect = [TimeoutError("timed out"), TimeoutError("timed out"), mock_cluster]
+
+        no_wait = _get_cluster.retry_with(wait=None)
+        result = no_wait()
+
+        assert result is mock_cluster
+        assert mock_get_cluster.call_count == 3
+
+    @patch("posthog.dags.events_backfill_to_duckling.get_cluster")
+    def test_raises_non_retryable_exception_immediately(self, mock_get_cluster):
+        mock_get_cluster.side_effect = ValueError("bad config")
+
+        no_wait = _get_cluster.retry_with(wait=None)
+        with pytest.raises(ValueError, match="bad config"):
+            no_wait()
+
+        assert mock_get_cluster.call_count == 1
+
+    @patch("posthog.dags.events_backfill_to_duckling.get_cluster")
+    def test_raises_after_max_retries_exhausted(self, mock_get_cluster):
+        mock_get_cluster.side_effect = TimeoutError("timed out")
+
+        no_wait = _get_cluster.retry_with(wait=None)
+        with pytest.raises(TimeoutError):
+            no_wait()
+
+        assert mock_get_cluster.call_count == 3


### PR DESCRIPTION
## Summary
- Adds `CLUSTER_RETRY_POLICY = RetryPolicy(max_attempts=3, delay=5s, exceptions=(TimeoutError, OSError))` 
- Applies it to all 4 `get_cluster()` calls in the duckling backfill
- Fixes intermittent `TimeoutError` during ClickHouse cluster bootstrap under load

Supersedes #47408.

## Test plan
- [ ] 84 existing tests pass
- [ ] Verify duckling backfill jobs recover from transient ClickHouse timeouts instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)