### PR TITLE
fix: use dvh units instead of vh for proper iPadOS Safari viewport height

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.scss
+++ b/frontend/src/layout/navigation-3000/Navigation.scss
@@ -17,13 +17,13 @@
     position: relative;
     display: flex;
     width: 100%;
-    height: 100vh;
+    height: 100dvh;
     overflow: hidden;
     background: var(--color-bg-primary);
 
     .storybook-test-runner & {
         height: auto;
-        min-height: 100vh;
+        min-height: 100dvh;
     }
 
     > main {
@@ -57,7 +57,7 @@
 .Navigation3000__scene {
     // `relative` is for positioning of the scene-level spinner
     position: relative;
-    min-height: calc(100vh - var(--breadcrumbs-height-full) - var(--scene-padding) - var(--scene-padding-bottom));
+    min-height: calc(100dvh - var(--breadcrumbs-height-full) - var(--scene-padding) - var(--scene-padding-bottom));
     margin: var(--scene-padding);
     margin-bottom: var(--scene-padding-bottom);
 
@@ -75,7 +75,7 @@
 
         display: flex;
         flex-direction: column;
-        height: 100vh;
+        height: 100dvh;
     }
 }
 
@@ -85,7 +85,7 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    max-height: 100vh;
+    max-height: 100dvh;
     border-right-width: 1px;
 
     // This terrible hack makes it so that the .Navbar3000__overlay background is rendered also _underneath_ .Navbar3000
@@ -169,7 +169,7 @@
             line-height: 0.5625rem;
             color: var(--text-3000);
             text-align: center;
-            content: '•';
+            content: '\2022';
         }
 
         .LemonButton__icon {
@@ -711,7 +711,7 @@
     grid-template:
         'left top right' var(--scene-layout-header-height) 'left content right' 1fr / var(--left-nav-width)
         minmax(0, 1fr) var(--side-panel-width);
-    height: 100vh;
+    height: 100dvh;
     overflow: hidden;
 
     .storybook-test-runner & {

--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.scss
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.scss
@@ -38,7 +38,7 @@
     flex-direction: column;
     align-items: center;
     width: var(--side-panel-bar-width);
-    height: 100vh;
+    height: 100dvh;
     overflow: hidden;
     user-select: none;
     background: var(--color-bg-surface-tertiary);
@@ -116,7 +116,7 @@
     display: flex;
     flex: 1;
     flex-direction: column;
-    height: 100vh;
+    height: 100dvh;
     overflow-y: auto;
     border-left-width: 1px;
 }


### PR DESCRIPTION
## Problem

On iPadOS Safari, the viewport has a variable height depending on whether the user has scrolled or minimized the tab bar. Safari computes the `vh` unit based on the **largest** possible viewport size, which causes content at the bottom of the page to be cut off when the tab bar is visible.

This affects the main navigation layout, the side panel bar, and the content area.

## Changes

Replace `100vh` with `100dvh` in the two core navigation SCSS files:

### `Navigation.scss`
- `.Navigation3000` height: `100vh` → `100dvh`
- `.Navigation3000` storybook min-height: `100vh` → `100dvh`
- `.Navigation3000__scene` min-height calc: `100vh` → `100dvh`
- `.Navigation3000__scene--raw-no-header` height: `100vh` → `100dvh`
- `.Navbar3000` max-height: `100vh` → `100dvh`
- `.app-layout` height: `100vh` → `100dvh`

### `SidePanel.scss`
- `.SidePanel3000__bar` height: `100vh` → `100dvh`
- `.SidePanel3000__content` height: `100vh` → `100dvh`

## Why `dvh`?

The [`dvh` (dynamic viewport height)](https://developer.mozilla.org/en-US/docs/Web/CSS/length#dynamic_viewport_units) unit correctly adapts to the **current** viewport size, including when browser chrome (tab bar, address bar) is visible or hidden. This is the modern CSS solution for this long-standing mobile Safari issue.

Browser support: [95%+](https://caniuse.com/viewport-unit-variants) across all modern browsers.

## Does this affect desktop?

No. On desktop browsers, `dvh` and `vh` resolve to the same value since there is no dynamic browser chrome that changes the viewport size.

Fixes #47460