### PR TITLE
refactor(project-tree): deduplicate product type logic into utils

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/TreeFiltersDropdownMenu.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/TreeFiltersDropdownMenu.tsx
@@ -14,31 +14,12 @@ import {
     DropdownMenuTrigger,
 } from 'lib/ui/DropdownMenu/DropdownMenu'
 
-import { fileSystemTypes } from '~/products'
-import { FileSystemType } from '~/types'
+import { productTypesMapped } from './utils'
 
 interface FiltersDropdownProps {
     setSearchTerm: (searchTerm: string) => void
     searchTerm: string
 }
-
-const missingProductTypes: { value: string; label: string; flag?: string }[] = [
-    { value: 'destination', label: 'Destinations' },
-    { value: 'site_app', label: 'Site apps' },
-    { value: 'source', label: 'Sources' },
-    { value: 'transformation', label: 'Transformations' },
-]
-// TODO: This is a duplicate of TreeSearchField.tsx
-const productTypesMapped = [
-    ...Object.entries(fileSystemTypes as unknown as Record<string, FileSystemType>).map(
-        ([key, value]): { value: string; label: string; flag?: string } => ({
-            value: value.filterKey || key,
-            label: value.name,
-            flag: value.flag,
-        })
-    ),
-    ...missingProductTypes,
-]
 
 export function TreeFiltersDropdownMenu({ setSearchTerm, searchTerm }: FiltersDropdownProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)

--- a/frontend/src/layout/panel-layout/ProjectTree/TreeSearchField.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/TreeSearchField.tsx
@@ -1,36 +1,13 @@
 import { useActions, useValues } from 'kea'
 
-import { IconCdCase, IconDocument, IconPlug, IconUser } from '@posthog/icons'
+import { IconCdCase, IconDocument, IconUser } from '@posthog/icons'
 
 import { SearchAutocomplete } from 'lib/components/SearchAutocomplete/SearchAutocomplete'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
-import { fileSystemTypes } from '~/products'
-import { FileSystemType } from '~/types'
-
 import { panelLayoutLogic } from '../panelLayoutLogic'
-import { iconForType } from './defaultTree'
 import { projectTreeLogic } from './projectTreeLogic'
-
-const missingProductTypes: { value: string; label: string; icon?: React.ReactNode; flag?: string }[] = [
-    { value: 'destination', label: 'Destinations', icon: <IconPlug /> },
-    { value: 'site_app', label: 'Site apps', icon: <IconPlug /> },
-    { value: 'source', label: 'Sources', icon: <IconPlug /> },
-    { value: 'transformation', label: 'Transformations', icon: <IconPlug /> },
-]
-
-// TODO: This is a duplicate of TreeFiltersDropdownMenu.tsx
-const productTypesMapped = [
-    ...Object.entries(fileSystemTypes as unknown as Record<string, FileSystemType>).map(
-        ([key, value]): { value: string; label: string; icon: React.ReactNode; flag?: string } => ({
-            value: value.filterKey || key,
-            label: value.name,
-            icon: iconForType(value.iconType),
-            flag: value.flag,
-        })
-    ),
-    ...missingProductTypes,
-]
+import { productTypesMapped } from './utils'
 
 interface TreeSearchFieldProps {
     root?: string

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -1,12 +1,20 @@
-import { IconPlus, IconShortcut } from '@posthog/icons'
+import React from 'react'
+
+import { IconPlug, IconPlus, IconShortcut } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
 
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 
 import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/SearchHighlight'
 import { RecentResults, SearchResults } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
+// -----------------------------------------------------------------------------
+// NEW SHARED LOGIC FROM THE REFACTOR
+// -----------------------------------------------------------------------------
+
+import { fileSystemTypes } from '~/products'
 import { FileSystemEntry, FileSystemIconType, FileSystemImport } from '~/queries/schema/schema-general'
 import { UserBasicType } from '~/types'
+import { FileSystemType } from '~/types'
 
 import { getCustomIcon } from './customIconRegistry'
 import { iconForType } from './defaultTree'
@@ -384,12 +392,12 @@ export function convertFileSystemEntryToTreeDataItem({
 
 /**
  * Splits `path` by unescaped "/" delimiters.
- *   - splitPath("a/b")            => ["a", "b"]
- *   - splitPath("a\\/b/c")        => ["a/b", "c"]
- *   - splitPath("a\\/b\\\\/c")    => ["a/b\\", "c"]
- *   - splitPath("a\n\t/b")        => ["a\n\t", "b"]
- *   - splitPath("a")              => ["a"]
- *   - splitPath("")               => []
+ * - splitPath("a/b")            => ["a", "b"]
+ * - splitPath("a\\/b/c")        => ["a/b", "c"]
+ * - splitPath("a\\/b\\\\/c")    => ["a/b\\", "c"]
+ * - splitPath("a\n\t/b")        => ["a\n\t", "b"]
+ * - splitPath("a")              => ["a"]
+ * - splitPath("")               => []
  */
 export function splitPath(path: string | undefined): string[] {
     if (!path) {
@@ -513,3 +521,22 @@ export function appendResultsToFolders(
 export const isGroupViewShortcut = (shortcut: FileSystemEntry): boolean => {
     return !!shortcut?.type?.startsWith('group_') && !!shortcut?.type?.endsWith('_view')
 }
+
+export const missingProductTypes: { value: string; label: string; icon?: React.ReactNode; flag?: string }[] = [
+    { value: 'destination', label: 'Destinations', icon: <IconPlug /> },
+    { value: 'site_app', label: 'Site apps', icon: <IconPlug /> },
+    { value: 'source', label: 'Sources', icon: <IconPlug /> },
+    { value: 'transformation', label: 'Transformations', icon: <IconPlug /> },
+]
+
+export const productTypesMapped = [
+    ...Object.entries(fileSystemTypes as unknown as Record<string, FileSystemType>).map(
+        ([key, value]): { value: string; label: string; icon: React.ReactNode; flag?: string } => ({
+            value: value.filterKey || key,
+            label: value.name,
+            icon: iconForType(value.iconType),
+            flag: value.flag,
+        })
+    ),
+    ...missingProductTypes,
+]


### PR DESCRIPTION
## Summary
Extracted duplicated `productTypesMapped` and `missingProductTypes` logic from `TreeSearchField` and `TreeFiltersDropdownMenu` into a shared `utils.tsx` file.

## Changes
- Moved product type arrays to `frontend/src/layout/panel-layout/ProjectTree/utils.tsx`
- Imported shared logic in `TreeSearchField.tsx` and `TreeFiltersDropdownMenu.tsx`
- Removed unused imports (`IconPlug`, `fileSystemTypes`, etc.) from the consuming files.

## Motivation
Fixes TODO comments explicitly marking this code as duplicated. Reduces maintenance burden by keeping product types defined in a single source of truth.