### PR TITLE
fix: revert multi-value contains operators (UI)

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/utils.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.test.ts
@@ -218,15 +218,10 @@ describe('normalizePropertyFilterValue()', () => {
         expect(normalizePropertyFilterValue(['a', 'b'], PropertyOperator.Exact)).toEqual(['a', 'b'])
     })
 
-    it('wraps values for multi-select contains operators', () => {
-        expect(normalizePropertyFilterValue('test', PropertyOperator.IContains)).toEqual(['test'])
-        expect(normalizePropertyFilterValue('test', PropertyOperator.NotIContains)).toEqual(['test'])
-    })
-
     it('does not wrap values for non-multi-select operators', () => {
+        expect(normalizePropertyFilterValue('test', PropertyOperator.IContains)).toEqual('test')
         expect(normalizePropertyFilterValue('test', PropertyOperator.Regex)).toEqual('test')
         expect(normalizePropertyFilterValue('test', PropertyOperator.IsSet)).toEqual('test')
-        expect(normalizePropertyFilterValue('test', PropertyOperator.GreaterThan)).toEqual('test')
     })
 
     it('handles null and undefined values', () => {

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -2,7 +2,7 @@ import tk from 'timekeeper'
 
 import { dayjs } from 'lib/dayjs'
 
-import { ElementType, EventType, PropertyOperator, PropertyType, TimeUnitType } from '~/types'
+import { ElementType, EventType, PropertyType, TimeUnitType } from '~/types'
 
 import {
     areDatesValidForInterval,
@@ -38,7 +38,6 @@ import {
     is12HoursOrLess,
     isExternalLink,
     isLessThan2Days,
-    isOperatorMulti,
     isURL,
     median,
     midEllipsis,
@@ -1504,23 +1503,6 @@ describe('lib/utils', () => {
                 'test-error'
             )
             expect(shouldRetry).toHaveBeenCalledWith(testError)
-        })
-    })
-
-    describe('isOperatorMulti', () => {
-        it('returns true for operators that support multiple values', () => {
-            expect(isOperatorMulti(PropertyOperator.Exact)).toBe(true)
-            expect(isOperatorMulti(PropertyOperator.IsNot)).toBe(true)
-            expect(isOperatorMulti(PropertyOperator.IContains)).toBe(true)
-            expect(isOperatorMulti(PropertyOperator.NotIContains)).toBe(true)
-        })
-
-        it('returns false for operators that do not support multiple values', () => {
-            expect(isOperatorMulti(PropertyOperator.GreaterThan)).toBe(false)
-            expect(isOperatorMulti(PropertyOperator.LessThan)).toBe(false)
-            expect(isOperatorMulti(PropertyOperator.IsSet)).toBe(false)
-            expect(isOperatorMulti(PropertyOperator.IsNotSet)).toBe(false)
-            expect(isOperatorMulti(PropertyOperator.Regex)).toBe(false)
         })
     })
 })

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -416,12 +416,7 @@ export function chooseOperatorMap(propertyType: PropertyType | undefined): Recor
 }
 
 export function isOperatorMulti(operator: PropertyOperator): boolean {
-    return [
-        PropertyOperator.Exact,
-        PropertyOperator.IsNot,
-        PropertyOperator.IContains,
-        PropertyOperator.NotIContains,
-    ].includes(operator)
+    return [PropertyOperator.Exact, PropertyOperator.IsNot].includes(operator)
 }
 
 export function isOperatorFlag(operator: PropertyOperator): boolean {


### PR DESCRIPTION
Reverts the UI from https://github.com/PostHog/posthog/pull/47158

Context: https://posthog.slack.com/archives/C07Q2U4BH4L/p1770745704743959