### PR TITLE
fix(surveys): escape double quotes in generated survey sql

### DIFF
--- a/frontend/src/scenes/surveys/SurveySQLHelper.tsx
+++ b/frontend/src/scenes/surveys/SurveySQLHelper.tsx
@@ -13,6 +13,10 @@ import { Survey, SurveyEventName, SurveyEventProperties, SurveyQuestion } from '
 
 import { buildPartialResponsesFilter, createAnswerFilterHogQLExpression } from './utils'
 
+function escapeSqlIdentifier(value: string): string {
+    return value.replace(/"/g, '""')
+}
+
 interface SurveySQLHelperProps {
     isOpen: boolean
     onClose: () => void
@@ -28,7 +32,7 @@ export function SurveySQLHelper({ isOpen, onClose }: SurveySQLHelperProps): JSX.
     distinct_id,
     getSurveyResponse(${index}, '${question.id}'${
         question.type === SurveyQuestionType.MultipleChoice ? ', true' : ''
-    }) AS "${question.question}",
+    }) AS "${escapeSqlIdentifier(question.question)}",
     timestamp
 FROM
     events
@@ -48,7 +52,7 @@ LIMIT
             .map((question: SurveyQuestion, index: number) => {
                 return `    getSurveyResponse(${index}, '${question.id}'${
                     question.type === SurveyQuestionType.MultipleChoice ? ', true' : ''
-                }) AS "${question.question}"`
+                }) AS "${escapeSqlIdentifier(question.question)}"`
             })
             .join(',\n')
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
