### PR TITLE
fix(experiments): transform old-style metric properties

### DIFF
--- a/posthog/templates/admin/posthog/experiment/change_form.html
+++ b/posthog/templates/admin/posthog/experiment/change_form.html
@@ -3,6 +3,14 @@
 
 {% block after_field_sets %}
     {{ block.super }}
+    {% if show_fix_properties %}
+        <div class="submit-row" style="margin-top: 20px; padding: 20px; border-radius: 5px; border: 1px solid #dc3545; color: #dc3545; display: flex; align-items: center; gap: 10px;">
+            <div class="info">This experiment has malformed metric properties (dict instead of list format).</div>
+            <a class="button" style="padding:10px 15px; background-color: #dc3545; color: white;" href="{% url 'admin:experiment_fix_properties' object_id=original.pk %}">
+                Fix Properties
+            </a>
+        </div>
+    {% endif %}
     {% if show_migration %}
         {% if shared_metrics_status %}
             <div class="submit-row" style="margin-top: 20px; padding: 10px; border-radius: 5px; border: 1px solid #f7a501; color: #f7a501; display: flex; align-items: center; gap: 10px;">


### PR DESCRIPTION
## Problem

API, MCP, etc are able to create malformed experiment metrics with format: `{"key": "value"}` instead of `[{key, value, type, operator}]` causing "Last refreshed" loading state to get stuck are caused.

## Changes

Add a django admin option to fix malformed experiment metrics

## How did you test this code?

locally, wrote tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
