### PR TITLE
fix(web-analytics): Fix heatmap display when using toolbar

### DIFF
--- a/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
@@ -10,6 +10,7 @@ import { cn } from 'lib/utils/css-classes'
 import { HeatmapEventsPanel } from './HeatmapEventsPanel'
 import { ScrollDepthCanvas } from './ScrollDepthCanvas'
 import { useMousePosition } from './useMousePosition'
+import { useScrollSync } from './useScrollSync'
 
 // Radius in pixels to search for nearby heatmap elements when clicking
 const CLICK_RADIUS_PX = 15
@@ -94,13 +95,14 @@ export function HeatmapCanvas({
         heightOverride,
         heatmapFixedPositionMode,
         heatmapElements,
-        heatmapScrollY,
         windowWidthOverride,
     } = useValues(heatmapDataLogic({ context, exportToken }))
     const { setSelectedArea } = useActions(heatmapDataLogic({ context, exportToken }))
 
     const heatmapsJsRef = useRef<HeatmapJS<'value', 'x', 'y'>>()
     const heatmapsJsContainerRef = useRef<HTMLDivElement | null>()
+    const isToolbar = context === 'toolbar'
+    const { innerRef, scrollYRef } = useScrollSync(isToolbar)
     const [hasValueUnderMouse, setHasValueUnderMouse] = useState(false)
 
     const heatmapJSColorGradient = useMemo((): Record<string, string> => {
@@ -122,7 +124,7 @@ export function HeatmapCanvas({
         (e: React.MouseEvent<HTMLDivElement>): void => {
             const rect = e.currentTarget.getBoundingClientRect()
             const clickX = e.clientX - rect.left
-            const clickY = e.clientY - rect.top
+            const clickY = isToolbar ? e.clientY - rect.top + scrollYRef.current : e.clientY - rect.top
 
             const width = windowWidthOverride ?? windowWidth
 
@@ -131,12 +133,8 @@ export function HeatmapCanvas({
             let totalCount = 0
 
             for (const element of heatmapElements) {
-                // Calculate visual position (same logic as heatmapJsData selector)
-                const visualY =
-                    element.targetFixed && heatmapFixedPositionMode === 'fixed' ? element.y : element.y - heatmapScrollY
                 const visualX = element.xPercentage * width
-
-                const distance = Math.sqrt(Math.pow(clickX - visualX, 2) + Math.pow(clickY - visualY, 2))
+                const distance = Math.sqrt(Math.pow(clickX - visualX, 2) + Math.pow(clickY - element.y, 2))
 
                 if (distance <= CLICK_RADIUS_PX) {
                     nearbyElements.push({
@@ -157,7 +155,7 @@ export function HeatmapCanvas({
                 })
             }
         },
-        [heatmapElements, heatmapScrollY, windowWidth, windowWidthOverride, heatmapFixedPositionMode, setSelectedArea]
+        [heatmapElements, windowWidth, windowWidthOverride, setSelectedArea, isToolbar]
     )
 
     const updateHeatmapData = useCallback((): void => {
@@ -183,7 +181,7 @@ export function HeatmapCanvas({
 
             updateHeatmapData()
         },
-        [updateHeatmapData, heatmapJSColorGradient] // oxlint-disable-line react-hooks/exhaustive-deps
+        [updateHeatmapData, heatmapJSColorGradient]
     )
 
     useEffect(() => {
@@ -217,6 +215,39 @@ export function HeatmapCanvas({
         )
     }
 
+    if (isToolbar) {
+        return (
+            <div
+                className={cn(
+                    'fixed inset-0 overflow-hidden',
+                    isReady ? 'heatmaps-ready' : 'heatmaps-loading',
+                    hasValueUnderMouse && 'cursor-pointer'
+                )}
+                data-attr="heatmap-canvas"
+                onClick={handleCanvasClick}
+            >
+                <div
+                    ref={innerRef}
+                    className="absolute top-0 left-0 w-full"
+                    style={{ height: heightOverride, willChange: 'transform' }}
+                >
+                    <div
+                        key={`${widthOverride ?? windowWidth}x${heightOverride}x${heatmapFixedPositionMode}`}
+                        className="absolute top-0 left-0 w-full h-full"
+                        ref={setHeatmapContainer}
+                    />
+                </div>
+                <HeatmapMouseInfo
+                    heatmapJsRef={heatmapsJsRef}
+                    containerRef={heatmapsJsContainerRef}
+                    context={context}
+                    onHasValue={setHasValueUnderMouse}
+                />
+                <HeatmapEventsPanel context={context} exportToken={exportToken} />
+            </div>
+        )
+    }
+
     return (
         <div
             className={cn(
@@ -228,7 +259,6 @@ export function HeatmapCanvas({
             data-attr="heatmap-canvas"
             onClick={handleCanvasClick}
         >
-            {/* NOTE: We key on the window dimensions and fixed position mode which triggers a recreation of the canvas */}
             <div
                 key={
                     exportToken

--- a/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
@@ -155,7 +155,7 @@ export function HeatmapCanvas({
                 })
             }
         },
-        [heatmapElements, windowWidth, windowWidthOverride, setSelectedArea, isToolbar]
+        [heatmapElements, windowWidth, windowWidthOverride, setSelectedArea, isToolbar, scrollYRef]
     )
 
     const updateHeatmapData = useCallback((): void => {

--- a/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
+++ b/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
@@ -55,7 +55,6 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
         setHeatmapColorPalette: (palette: string | null) => ({ palette }),
         setHref: (href: string) => ({ href }),
         setHrefMatchType: (matchType: HrefMatchType) => ({ matchType }),
-        setHeatmapScrollY: (scrollY: number) => ({ scrollY }),
         setWindowWidthOverride: (widthOverride: number | null) => ({ widthOverride }),
         setIsReady: (isReady: boolean) => ({ isReady }),
         // Click-to-view-events actions
@@ -111,12 +110,6 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
                 setHref: (_, { href }) => {
                     return href
                 },
-            },
-        ],
-        heatmapScrollY: [
-            0,
-            {
-                setHeatmapScrollY: (_, { scrollY }) => scrollY,
             },
         ],
         windowWidthOverride: [
@@ -359,32 +352,15 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
         ],
 
         heatmapJsData: [
-            (s) => [
-                s.heatmapElements,
-                s.heatmapScrollY,
-                s.windowWidth,
-                s.windowWidthOverride,
-                s.heatmapFixedPositionMode,
-            ],
-            (
-                heatmapElements,
-                heatmapScrollY,
-                windowWidth,
-                windowWidthOverride,
-                heatmapFixedPositionMode
-            ): HeatmapJsData => {
+            (s) => [s.heatmapElements, s.windowWidth, s.windowWidthOverride, s.heatmapFixedPositionMode],
+            (heatmapElements, windowWidth, windowWidthOverride, heatmapFixedPositionMode): HeatmapJsData => {
                 const width = windowWidthOverride ?? windowWidth
-                // We want to account for all the fixed position elements, the scroll of the context and the browser width
                 const data = heatmapElements.reduce((acc, element) => {
                     if (heatmapFixedPositionMode === 'hidden' && element.targetFixed) {
                         return acc
                     }
 
-                    const y = Math.round(
-                        element.targetFixed && heatmapFixedPositionMode === 'fixed'
-                            ? element.y
-                            : element.y - heatmapScrollY
-                    )
+                    const y = Math.round(element.y)
                     const x = Math.round(element.xPercentage * width)
 
                     acc.push({ x, y, value: element.count })

--- a/frontend/src/lib/components/heatmaps/useScrollSync.ts
+++ b/frontend/src/lib/components/heatmaps/useScrollSync.ts
@@ -2,23 +2,6 @@ import { useEffect, useRef } from 'react'
 
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 
-/**
- * Provides scroll-synced positioning for heatmap overlays.
- *
- * In 'absolute' mode, polls posthog.scrollManager.scrollY() via rAF to
- * track scroll position — even on sites with custom scroll containers
- * where window.scrollY stays 0. Updates the element's CSS transform
- * directly for compositor-only animation (no React re-renders).
- *
- * In 'fixed' mode, the overlay fills the viewport and needs no scroll sync.
- *
- * We access toolbarConfigLogic.values.posthog directly rather than via
- * useValues/connect. This is intentional: toolbarConfigLogic is only
- * mounted in the toolbar context, and we need the instance reference
- * for rAF polling — not reactivity. The try-catch handles the in-app
- * context where this logic isn't mounted. The posthog instance never
- * changes after initialization.
- */
 export function useScrollSync(enabled: boolean = true): {
     innerRef: React.RefObject<HTMLDivElement>
     scrollYRef: React.MutableRefObject<number>
@@ -36,7 +19,7 @@ export function useScrollSync(enabled: boolean = true): {
         try {
             posthogInstance = toolbarConfigLogic.values.posthog
         } catch {
-            // toolbarConfigLogic not mounted (in-app context) — fall back to window.scrollY
+            // toolbarConfigLogic not mounted — fall back to window.scrollY
         }
 
         let rafId: number

--- a/frontend/src/lib/components/heatmaps/useScrollSync.ts
+++ b/frontend/src/lib/components/heatmaps/useScrollSync.ts
@@ -1,3 +1,4 @@
+import { PostHog } from 'posthog-js'
 import { useEffect, useRef } from 'react'
 
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
@@ -6,7 +7,7 @@ export function useScrollSync(enabled: boolean = true): {
     innerRef: React.RefObject<HTMLDivElement>
     scrollYRef: React.MutableRefObject<number>
 } {
-    const innerRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>
+    const innerRef = useRef<HTMLDivElement>(null)
     const scrollYRef = useRef<number>(0)
 
     useEffect(() => {
@@ -15,14 +16,14 @@ export function useScrollSync(enabled: boolean = true): {
             return
         }
 
-        let posthogInstance: any = null
+        let posthogInstance: PostHog | null = null
         try {
             posthogInstance = toolbarConfigLogic.values.posthog
         } catch {
             // toolbarConfigLogic not mounted — fall back to window.scrollY
         }
 
-        let rafId: number
+        let rafId: number | undefined
         let lastScrollY = -1
 
         const onFrame = (): void => {
@@ -40,7 +41,11 @@ export function useScrollSync(enabled: boolean = true): {
 
         rafId = requestAnimationFrame(onFrame)
 
-        return () => cancelAnimationFrame(rafId)
+        return () => {
+            if (rafId !== undefined) {
+                cancelAnimationFrame(rafId)
+            }
+        }
     }, [enabled])
 
     return { innerRef, scrollYRef }

--- a/frontend/src/lib/components/heatmaps/useScrollSync.ts
+++ b/frontend/src/lib/components/heatmaps/useScrollSync.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react'
+
+import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
+
+/**
+ * Provides scroll-synced positioning for heatmap overlays.
+ *
+ * In 'absolute' mode, polls posthog.scrollManager.scrollY() via rAF to
+ * track scroll position — even on sites with custom scroll containers
+ * where window.scrollY stays 0. Updates the element's CSS transform
+ * directly for compositor-only animation (no React re-renders).
+ *
+ * In 'fixed' mode, the overlay fills the viewport and needs no scroll sync.
+ *
+ * We access toolbarConfigLogic.values.posthog directly rather than via
+ * useValues/connect. This is intentional: toolbarConfigLogic is only
+ * mounted in the toolbar context, and we need the instance reference
+ * for rAF polling — not reactivity. The try-catch handles the in-app
+ * context where this logic isn't mounted. The posthog instance never
+ * changes after initialization.
+ */
+export function useScrollSync(enabled: boolean = true): {
+    innerRef: React.RefObject<HTMLDivElement>
+    scrollYRef: React.MutableRefObject<number>
+} {
+    const innerRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>
+    const scrollYRef = useRef<number>(0)
+
+    useEffect(() => {
+        if (!enabled) {
+            scrollYRef.current = 0
+            return
+        }
+
+        let posthogInstance: any = null
+        try {
+            posthogInstance = toolbarConfigLogic.values.posthog
+        } catch {
+            // toolbarConfigLogic not mounted (in-app context) — fall back to window.scrollY
+        }
+
+        let rafId: number
+        let lastScrollY = -1
+
+        const onFrame = (): void => {
+            const scrollY = posthogInstance?.scrollManager?.scrollY() ?? window.scrollY
+            if (scrollY !== lastScrollY) {
+                lastScrollY = scrollY
+                scrollYRef.current = scrollY
+                const inner = innerRef.current
+                if (inner) {
+                    inner.style.transform = `translateY(${-scrollY}px)`
+                }
+            }
+            rafId = requestAnimationFrame(onFrame)
+        }
+
+        rafId = requestAnimationFrame(onFrame)
+
+        return () => cancelAnimationFrame(rafId)
+    }, [enabled])
+
+    return { innerRef, scrollYRef }
+}

--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -69,7 +69,7 @@ export function Elements(): JSX.Element {
                 }}
             >
                 <ScrollDepth />
-                {activeToolbarMode === 'heatmap' && <HeatmapCanvas context="toolbar" />}
+                {activeToolbarMode === 'heatmap' && <HeatmapCanvas positioning="absolute" context="toolbar" />}
                 {highlightElementMeta?.rect ? <FocusRect rect={highlightElementMeta.rect} /> : null}
                 {productToursSelecting && productToursHoverRect && <ElementHighlight rect={productToursHoverRect} />}
                 {productToursSelectedStepRect && <ElementHighlight rect={productToursSelectedStepRect} isSelected />}


### PR DESCRIPTION
## Problem
When using the toolbar to view heatmaps, scrolling moves the points with the screen. This results in users not being able to see an accurate heatmap of their site.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds a new toolbar mode that uses a fixed outer container with an `absolute` positioned inner div whose `translateY` is updated via `requestAnimationFrame`, keeping the canvas in sync with the page scroll
  
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
