### PR TITLE
feat(security): Add semgrep rules for preventing IDOR

### DIFF
--- a/.github/scripts/check-idor-model-coverage.py
+++ b/.github/scripts/check-idor-model-coverage.py
@@ -315,6 +315,11 @@ def main() -> int:
         "user_scoped": "User-scoped",
     }
 
+    # Union of all code models across scopes for staleness checks.
+    # A model is only stale if it doesn't exist in ANY scope (cross-scope
+    # categorization differences between script and semgrep are fine).
+    all_code_models = code_models["team_scoped"] | code_models["org_scoped"] | code_models["user_scoped"]
+
     print("=" * 60)
     print("IDOR Semgrep Rule Coverage Check")
     print("=" * 60)
@@ -328,8 +333,8 @@ def main() -> int:
         to_check = all_in_code - excluded_models
 
         missing = to_check - semgrep_set
-        # Models in semgrep that don't exist in code at all (excluding intentionally excluded models)
-        stale = semgrep_set - all_in_code - excluded_models
+        # Models in semgrep that don't exist in code at all (in any scope)
+        stale = semgrep_set - all_code_models
 
         print(f"\n{label} models:")
         print(f"  In code: {len(all_in_code)} ({len(excluded_in_scope)} excluded)")

--- a/.github/scripts/check-idor-model-coverage.py
+++ b/.github/scripts/check-idor-model-coverage.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201 allow print statements
+"""
+CI script to verify all Django models with team/org/user FKs
+are listed in the semgrep IDOR rule regex patterns.
+
+Usage:
+    python scripts/check_idor_model_coverage.py
+
+Exit codes:
+    0 - All models covered
+    1 - Missing models found (ERROR)
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def setup_django() -> None:
+    """Initialize Django settings for model introspection."""
+    repo_root = str(Path(__file__).resolve().parent.parent.parent)
+    sys.path.insert(0, repo_root)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+    import django
+
+    django.setup()
+
+
+def get_scoped_models() -> tuple[dict[str, set[str]], set[str]]:
+    """
+    Scan all Django models and categorize by scope.
+
+    The semgrep rules use these categories:
+        - team_scoped: models with team FK (primary IDOR protection)
+        - org_scoped: models with organization FK (but not team)
+        - user_scoped: models with user FK only (no team/org)
+
+    Note: Models with both user and team FKs are treated as team_scoped
+    since the team filter is the primary access control mechanism.
+
+    Returns:
+        Tuple of (scoped_models_dict, excluded_models_set)
+    """
+    from django.apps import apps
+    from django.db.models import ForeignKey
+
+    # Models to exclude from coverage checking.
+    # Every entry here means "this model does NOT need to appear in semgrep IDOR rules."
+    # When adding a model to a semgrep rule, remove it from here so CI verifies coverage.
+    EXCLUDED_MODELS: set[str] = {
+        # --- Core identity (not tenant-scoped themselves) ---
+        "Organization",
+        "Team",
+        "User",
+        # --- Abstract models / base classes (no table) ---
+        "UUIDModel",
+        "UUIDClassicModel",
+        "CreatedMetaFields",
+        "DeletedMetaFields",
+        # --- Through/junction tables (access controlled by parent) ---
+        "CohortPeople",
+        "DashboardTile",
+        "ExperimentToSavedMetric",
+        "FeatureFlagHashKeyOverride",
+        "GroupTypeMapping",
+        "TaggedItem",
+        "Tile",
+        # --- Categorization mismatch ---
+        # PersonalAPIKey has a deprecated team FK so the script sees it as team_scoped,
+        # but the semgrep rule correctly lists it under user_scoped. Excluding prevents
+        # a false "missing from team_scoped" error.
+        "PersonalAPIKey",
+        # RoleMembership has a direct user FK but org is indirect (via role), so the
+        # script sees it as user_scoped while semgrep correctly has it in org_scoped.
+        "RoleMembership",
+        # --- Ingestion/event tables (not queried by user-supplied ID) ---
+        "CoreEvent",
+        "ElementGroup",
+        "Event",
+        "PersonlessDistinctId",
+        "SessionRecordingEvent",
+        # --- Persons system (managed separately, not looked up by user input) ---
+        "Group",
+        "PendingPersonOverride",
+        "Person",
+        "PersonDistinctId",
+        "PersonOverride",
+        "PersonOverrideMapping",
+        # --- Schema/definition models (read-only, synced from events) ---
+        "EventDefinition",
+        "EventProperty",
+        "PropertyDefinition",
+        # --- Plugin system deprecated internals ---
+        "PluginAttachment",
+        "PluginLogEntry",
+        "PluginSourceFile",
+        "PluginStorage",
+        # --- Third-party/external models ---
+        "LogEntry",
+        "OAuthAccessToken",
+        "OAuthApplication",
+        "OAuthGrant",
+        "OAuthIDToken",
+        "OAuthRefreshToken",
+        "StaticDevice",
+        "TOTPDevice",
+        "UserSocialAuth",
+        # --- Internal infra (audit, async, caching, scheduling) ---
+        "ActivityLog",
+        "AsyncDeletion",
+        "AsyncMigration",
+        "AsyncMigrationError",
+        "InsightCachingState",
+        "InstanceSetting",
+        "Schedule",
+        # --- Accessed via parent FK (no direct team-scoped lookup needed) ---
+        "AlertSubscription",
+        "Approval",
+        "ApprovalRequest",
+        "BatchExportLogEntry",
+        "BatchExportRun",
+        "EndpointVersion",
+        "ErrorTrackingIssueAssignment",
+        "TicketAssignment",
+        # --- Internal config / OneToOne settings ---
+        "DuckLakeCatalog",
+        "EvaluationConfig",
+        "RemoteConfig",
+        "TeamCustomerAnalyticsConfig",
+        "TeamDefaultEvaluationTag",
+        "TeamMarketingAnalyticsConfig",
+        "TeamRevenueAnalyticsConfig",
+        # --- User preferences with no IDOR risk (read own data only) ---
+        "FeatureFlagOverride",
+        "NotificationViewed",
+        "SessionRecordingPlaylistViewed",
+        "UserPromptState",
+        # --- Deprecated / special ---
+        "DataWarehouseViewLink",
+        "ErrorTrackingGroup",
+        "ExplicitTeamMembership",
+        # --- Other internal (no user-facing lookup by ID) ---
+        "AlertCheck",
+        "CohortCalculationHistory",
+        "ColumnConfiguration",
+        "ErrorTrackingIssueFingerprint",
+        "ExperimentTimeseriesRecalculation",
+        "GroupUsageMetric",
+        "HogFunctionInvocationLog",
+        "HostDefinition",
+        "MaterializedColumnSlot",
+        "MessagingRecord",
+        "OrganizationResourceAccess",
+        "PreaggregationJob",
+        "ProductIntent",
+        "SCIMDirectory",
+        "SCIMProvisionedUser",
+        "SchemaPropertyGroup",
+        "SessionRecordingComment",
+        "SessionSummary",
+        "SharePassword",
+        "UserActivity",
+        "UserGroup",
+        "UserGroupMembership",
+    }
+
+    team_scoped: set[str] = set()
+    org_scoped: set[str] = set()
+    user_scoped: set[str] = set()
+
+    for model in apps.get_models():
+        model_name = model.__name__
+
+        # Skip abstract models
+        if model._meta.abstract:
+            continue
+
+        # Skip proxy models
+        if model._meta.proxy:
+            continue
+
+        # Check for FK fields
+        has_team_fk = False
+        has_org_fk = False
+        has_user_fk = False
+
+        for field in model._meta.get_fields():
+            if not isinstance(field, ForeignKey):
+                continue
+
+            related_model_name = field.related_model.__name__
+
+            if related_model_name == "Team":
+                has_team_fk = True
+            elif related_model_name == "Organization":
+                has_org_fk = True
+            elif related_model_name == "User":
+                has_user_fk = True
+
+        # Categorize based on FK combinations
+        # Team FK takes precedence (even if user FK also exists)
+        # Include ALL models (excluded ones tracked separately)
+        if has_team_fk:
+            team_scoped.add(model_name)
+        elif has_org_fk:
+            org_scoped.add(model_name)
+        elif has_user_fk:
+            user_scoped.add(model_name)
+
+    return (
+        {
+            "team_scoped": team_scoped,
+            "org_scoped": org_scoped,
+            "user_scoped": user_scoped,
+        },
+        EXCLUDED_MODELS,
+    )
+
+
+def parse_semgrep_models(yaml_path: Path) -> dict[str, set[str]]:
+    """
+    Parse the semgrep YAML file and extract model names from regex patterns.
+
+    Returns dict matching the scope categories.
+    """
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+
+    # Map rule IDs to scope categories
+    # Note: user+team scoped models are treated as team_scoped in semgrep
+    rule_scope_map = {
+        "idor-taint-user-input-to-model-get": "team_scoped",
+        "idor-lookup-without-team": "team_scoped",
+        "idor-taint-user-input-to-org-model": "org_scoped",
+        "idor-lookup-without-org": "org_scoped",
+        "idor-taint-user-input-to-user-model": "user_scoped",
+        "idor-lookup-without-user": "user_scoped",
+        # User+team models are treated as team_scoped for comparison
+        "idor-taint-user-input-to-user-team-model": "team_scoped",
+        "idor-lookup-without-user-and-team": "team_scoped",
+    }
+
+    result: dict[str, set[str]] = {
+        "team_scoped": set(),
+        "org_scoped": set(),
+        "user_scoped": set(),
+    }
+
+    for rule in data.get("rules", []):
+        rule_id = rule.get("id", "")
+        scope = rule_scope_map.get(rule_id)
+
+        if not scope:
+            continue
+
+        # Extract regex from rule - handle both taint and pattern rules
+        regex_pattern = None
+
+        # For taint rules, look in pattern-sinks
+        if "pattern-sinks" in rule:
+            for sink in rule["pattern-sinks"]:
+                if "metavariable-regex" in sink:
+                    regex_pattern = sink["metavariable-regex"].get("regex", "")
+                    break
+                # Handle patterns list with metavariable-regex inside
+                for pattern_item in sink.get("patterns", []):
+                    if "metavariable-regex" in pattern_item:
+                        regex_pattern = pattern_item["metavariable-regex"].get("regex", "")
+                        break
+
+        # For non-taint rules, look in patterns list
+        if not regex_pattern and "patterns" in rule:
+            for pattern_item in rule["patterns"]:
+                if "metavariable-regex" in pattern_item:
+                    regex_pattern = pattern_item["metavariable-regex"].get("regex", "")
+                    break
+
+        if regex_pattern:
+            # Extract model names from regex like (?x)(Model1|Model2|...)
+            # Remove (?x) extended mode flag and whitespace
+            clean_pattern = re.sub(r"\s+", "", regex_pattern)
+            clean_pattern = clean_pattern.replace("(?x)", "")
+
+            # Extract names from alternation group
+            match = re.search(r"\(([^)]+)\)", clean_pattern)
+            if match:
+                models_str = match.group(1)
+                models = [m.strip() for m in models_str.split("|") if m.strip()]
+                result[scope].update(models)
+
+    return result
+
+
+def main() -> int:
+    setup_django()
+
+    # Get models from code
+    code_models, excluded_models = get_scoped_models()
+
+    # Get models from semgrep rules
+    semgrep_path = Path(__file__).parent.parent.parent / ".semgrep/rules/idor-team-scoped-models.yaml"
+    semgrep_models = parse_semgrep_models(semgrep_path)
+
+    # Compare and report
+    has_errors = False
+    has_warnings = False
+
+    scope_labels = {
+        "team_scoped": "Team-scoped",
+        "org_scoped": "Organization-scoped",
+        "user_scoped": "User-scoped",
+    }
+
+    print("=" * 60)
+    print("IDOR Semgrep Rule Coverage Check")
+    print("=" * 60)
+
+    for scope, label in scope_labels.items():
+        all_in_code = code_models[scope]
+        semgrep_set = semgrep_models[scope]
+
+        # Split into excluded vs needs-checking
+        excluded_in_scope = all_in_code & excluded_models
+        to_check = all_in_code - excluded_models
+
+        missing = to_check - semgrep_set
+        # Models in semgrep that don't exist in code at all (excluding intentionally excluded models)
+        stale = semgrep_set - all_in_code - excluded_models
+
+        print(f"\n{label} models:")
+        print(f"  In code: {len(all_in_code)} ({len(excluded_in_scope)} excluded)")
+        print(f"  In semgrep: {len(semgrep_set)}")
+
+        if missing:
+            has_errors = True
+            print(f"\n  ❌ ERROR: Models missing from semgrep rules:")
+            for model in sorted(missing):
+                print(f"     - {model}")
+
+        if stale:
+            has_warnings = True
+            print(f"\n  ⚠️  WARNING: Models in semgrep but not found in code (may be stale):")
+            for model in sorted(stale):
+                print(f"     - {model}")
+
+        if not missing and not stale:
+            print("  ✅ All models covered")
+
+    print("\n" + "=" * 60)
+
+    if has_errors:
+        print("\n❌ FAILED: Some models are missing from semgrep IDOR rules.")
+        print("\nTo fix:")
+        print("  1. Add the missing models to .semgrep/rules/idor-team-scoped-models.yaml")
+        print("  2. Or add them to EXCLUDED_MODELS in this script if they don't need IDOR protection")
+        return 1
+
+    if has_warnings:
+        print("\n⚠️  PASSED with warnings: Some models in semgrep may be stale.")
+
+    print("\n✅ All scoped models are covered by semgrep IDOR rules.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -167,6 +167,27 @@ jobs:
                     fi
                   fi
 
+    check-idor-coverage:
+        needs: [changes]
+        if: needs.changes.outputs.backend == 'true'
+        timeout-minutes: 5
+        name: Check IDOR semgrep rule coverage
+        runs-on: depot-ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: Set up Python
+              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              with:
+                  python-version: 3.12.12
+            - name: Install uv
+              uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+              with:
+                  version: 0.9.9
+            - name: Install Python dependencies
+              run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
+            - name: Check IDOR model coverage
+              run: python .github/scripts/check-idor-model-coverage.py
+
     check-migrations:
         needs: [changes]
         if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.openapi_types == 'true'
@@ -1148,7 +1169,7 @@ jobs:
     # Job just to collate the status of the matrix jobs for requiring passing status
     # Must depend on handle-snapshots to prevent auto-merge before commits complete
     django_tests:
-        needs: [django, clickhouse-compat, check-migrations, async-migrations, handle-snapshots]
+        needs: [django, clickhouse-compat, check-migrations, async-migrations, handle-snapshots, check-idor-coverage]
         name: Django Tests Pass
         runs-on: ubuntu-latest
         if: always()
@@ -1176,6 +1197,12 @@ jobs:
                   # Check async migrations - must pass for Django Tests to be green
                   if [[ "${{ needs.async-migrations.result }}" != "success" && "${{ needs.async-migrations.result }}" != "skipped" ]]; then
                     echo "Async migrations tests failed."
+                    exit 1
+                  fi
+
+                  # Check IDOR coverage - must pass for Django Tests to be green
+                  if [[ "${{ needs.check-idor-coverage.result }}" != "success" && "${{ needs.check-idor-coverage.result }}" != "skipped" ]]; then
+                    echo "IDOR coverage check failed."
                     exit 1
                   fi
 

--- a/.semgrep/rules/idor-team-scoped-models.py
+++ b/.semgrep/rules/idor-team-scoped-models.py
@@ -1,0 +1,814 @@
+from django.shortcuts import get_object_or_404
+
+from posthog.models import Action, ChangeRequest, Cohort, Insight, Notebook
+from posthog.models.personal_api_key import PersonalAPIKey
+from posthog.models.project import Project
+from posthog.models.user_scene_personalisation import UserScenePersonalisation
+
+from ee.models.rbac.role import Role, RoleMembership
+
+# ============================================================
+# idor-taint-user-input-to-model-get (ERROR - user input flows to lookup)
+# ============================================================
+
+
+def vulnerable_get_from_request(request):
+    cohort_id = request.GET.get("cohort_id")
+    # ruleid: idor-taint-user-input-to-model-get, idor-lookup-without-team
+    return Cohort.objects.get(pk=cohort_id)
+
+
+def vulnerable_get_from_kwargs(kwargs):
+    action_id = kwargs.get("action_id")
+    # ruleid: idor-taint-user-input-to-model-get, idor-lookup-without-team
+    return Action.objects.get(id=action_id)
+
+
+def vulnerable_filter_from_data(request):
+    insight_id = request.data.get("insight_id")
+    # ruleid: idor-taint-user-input-to-model-get, idor-lookup-without-team
+    return Insight.objects.filter(pk=insight_id)
+
+
+# ok: idor-taint-user-input-to-model-get
+def safe_get_with_team(request, team):
+    cohort_id = request.GET.get("cohort_id")
+    # ok: idor-lookup-without-team
+    return Cohort.objects.get(pk=cohort_id, team__project_id=team.project_id)
+
+
+# ok: idor-taint-user-input-to-model-get
+def safe_get_with_team_id(request, team_id):
+    cohort_id = request.GET.get("cohort_id")
+    # ok: idor-lookup-without-team
+    return Cohort.objects.get(pk=cohort_id, team_id=team_id)
+
+
+# ok: idor-taint-user-input-to-model-get
+def safe_filter_with_team(request, team):
+    insight_id = request.data.get("insight_id")
+    # ok: idor-lookup-without-team
+    return Insight.objects.filter(pk=insight_id, team=team)
+
+
+# ok: idor-taint-user-input-to-model-get
+def not_user_input():
+    # ruleid: idor-lookup-without-team
+    return Cohort.objects.get(pk=123)
+
+
+# ============================================================
+# idor-lookup-without-team (WARNING - pattern rule)
+# ============================================================
+
+# ruleid: idor-lookup-without-team
+cohort = Cohort.objects.get(pk=cohort_id)
+
+# ruleid: idor-lookup-without-team
+action = Action.objects.get(id=action_id)
+
+# ruleid: idor-lookup-without-team
+cohort = Cohort.objects.get(pk=cohort_id, deleted=False)
+
+# ok: idor-lookup-without-team
+cohort = Cohort.objects.get(pk=cohort_id, team__project_id=team.project_id)
+
+# ok: idor-lookup-without-team
+cohort = Cohort.objects.get(pk=cohort_id, team=team)
+
+# ok: idor-lookup-without-team
+cohort = Cohort.objects.get(pk=cohort_id, team_id=team_id)
+
+# ok: idor-lookup-without-team
+cohort = Cohort.objects.annotate(effective_project_id=1).filter(id=cohort_id, effective_project_id=project_id)
+
+# ok: idor-lookup-without-team
+cohort = Cohort.objects.annotate(effective_project_id=1).get(pk=cohort_id, effective_project_id=project_id)
+
+# ok: idor-lookup-without-team
+ChangeRequest.objects.select_for_update().get(pk=self.change_request.pk)
+
+# ok: idor-lookup-without-team
+Notebook.objects.get(pk=instance.pk)
+
+# ok: idor-lookup-without-team
+Notebook.objects.select_for_update().get(pk=instance.id)
+
+# ============================================================
+# idor-lookup-without-team (WARNING - pattern rule)
+# ============================================================
+
+# ruleid: idor-lookup-without-team
+insights = Insight.objects.filter(pk=insight_id)
+
+# ruleid: idor-lookup-without-team
+cohorts = Cohort.objects.filter(pk__in=cohort_ids)
+
+# ruleid: idor-lookup-without-team
+actions = Action.objects.filter(id=action_id, deleted=False)
+
+# ok: idor-lookup-without-team
+insights = Insight.objects.filter(pk=insight_id, team_id=team_id)
+
+# ok: idor-lookup-without-team
+cohorts = Cohort.objects.filter(pk__in=cohort_ids, team__project_id=team.project_id)
+
+# ok: idor-lookup-without-team
+actions = Action.objects.filter(id=action_id, team=team)
+
+# ============================================================
+# idor-lookup-without-team (WARNING - pattern rule)
+# ============================================================
+
+# ruleid: idor-lookup-without-team
+obj, created = Cohort.objects.get_or_create(name="test")
+
+# ruleid: idor-lookup-without-team
+obj, created = Action.objects.update_or_create(name="test", defaults={"deleted": False})
+
+# ok: idor-lookup-without-team
+obj, created = Cohort.objects.get_or_create(name="test", team_id=team_id)
+
+# ok: idor-lookup-without-team
+obj, created = Action.objects.update_or_create(name="test", team=team, defaults={"deleted": False})
+
+# ok: idor-lookup-without-team
+obj, created = Insight.objects.get_or_create(name="test", team__project_id=team.project_id)
+
+# ruleid: idor-lookup-without-team
+obj = Cohort.objects.aget_or_create(name="test")
+
+# ok: idor-lookup-without-team
+obj = Cohort.objects.aget_or_create(name="test", team_id=team_id)
+
+# ============================================================
+# NEW: get_object_or_404 — team-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-team
+get_object_or_404(Cohort, pk=cohort_id)
+
+# ruleid: idor-lookup-without-team
+get_object_or_404(Action, id=action_id)
+
+# ok: idor-lookup-without-team
+get_object_or_404(Cohort, pk=cohort_id, team_id=team_id)
+
+# ok: idor-lookup-without-team
+get_object_or_404(Action, id=action_id, team__project_id=team.project_id)
+
+# ok: idor-lookup-without-team
+get_object_or_404(Cohort, pk=cohort_id, team=team)
+
+
+def vulnerable_get_object_or_404_from_request(request):
+    cohort_id = request.GET.get("cohort_id")
+    # ruleid: idor-taint-user-input-to-model-get, idor-lookup-without-team
+    return get_object_or_404(Cohort, pk=cohort_id)
+
+
+# ok: idor-taint-user-input-to-model-get
+def safe_get_object_or_404_with_team(request, team_id):
+    cohort_id = request.GET.get("cohort_id")
+    # ok: idor-lookup-without-team
+    return get_object_or_404(Cohort, pk=cohort_id, team_id=team_id)
+
+
+# ============================================================
+# NEW: select_related/prefetch_related chains — team-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-team
+cohort = Cohort.objects.select_related("team").get(pk=cohort_id)
+
+# ruleid: idor-lookup-without-team
+cohort = Cohort.objects.prefetch_related("team").get(pk=cohort_id)
+
+# ruleid: idor-lookup-without-team
+insights = Insight.objects.select_related("team").filter(pk=insight_id)
+
+# ruleid: idor-lookup-without-team
+insights = Insight.objects.prefetch_related("team").filter(id=insight_id)
+
+# ok: idor-lookup-without-team
+cohort = Cohort.objects.select_related("team").get(pk=cohort_id, team_id=team_id)
+
+# ok: idor-lookup-without-team
+cohort = Cohort.objects.prefetch_related("team").get(pk=cohort_id, team=team)
+
+# ok: idor-lookup-without-team
+insights = Insight.objects.select_related("team").filter(pk=insight_id, team__project_id=team.project_id)
+
+# ok: idor-lookup-without-team
+insights = Insight.objects.prefetch_related("team").filter(id=insight_id, team_id=team_id)
+
+
+def vulnerable_select_related_from_request(request):
+    cohort_id = request.GET.get("cohort_id")
+    # ruleid: idor-taint-user-input-to-model-get, idor-lookup-without-team
+    return Cohort.objects.select_related("team").get(pk=cohort_id)
+
+
+# ok: idor-taint-user-input-to-model-get
+def safe_select_related_with_team(request, team_id):
+    cohort_id = request.GET.get("cohort_id")
+    # ok: idor-lookup-without-team
+    return Cohort.objects.select_related("team").get(pk=cohort_id, team_id=team_id)
+
+
+# ============================================================
+# NEW: async aget — team-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-team
+cohort = Cohort.objects.aget(pk=cohort_id)
+
+# ruleid: idor-lookup-without-team
+action = Action.objects.aget(id=action_id)
+
+# ok: idor-lookup-without-team
+cohort = Cohort.objects.aget(pk=cohort_id, team_id=team_id)
+
+# ok: idor-lookup-without-team
+action = Action.objects.aget(id=action_id, team=team)
+
+# ruleid: idor-lookup-without-team
+cohort = Cohort.objects.select_related("team").aget(pk=cohort_id)
+
+# ruleid: idor-lookup-without-team
+cohort = Cohort.objects.prefetch_related("team").aget(pk=cohort_id)
+
+# ok: idor-lookup-without-team
+cohort = Cohort.objects.select_related("team").aget(pk=cohort_id, team_id=team_id)
+
+# ok: idor-lookup-without-team
+cohort = Cohort.objects.prefetch_related("team").aget(pk=cohort_id, team=team)
+
+
+def vulnerable_aget_from_request(request):
+    cohort_id = request.GET.get("cohort_id")
+    # ruleid: idor-taint-user-input-to-model-get, idor-lookup-without-team
+    return Cohort.objects.aget(pk=cohort_id)
+
+
+# ok: idor-taint-user-input-to-model-get
+def safe_aget_with_team(request, team_id):
+    cohort_id = request.GET.get("cohort_id")
+    # ok: idor-lookup-without-team
+    return Cohort.objects.aget(pk=cohort_id, team_id=team_id)
+
+
+# ============================================================
+# Methods that should NOT be flagged (exclude, create, etc.)
+# ============================================================
+
+# ok: idor-lookup-without-team
+Cohort.objects.exclude(id=cohort_id)
+
+# ok: idor-lookup-without-team
+Cohort.objects.create(id=cohort_id, name="test")
+
+# ok: idor-lookup-without-team
+Cohort.objects.filter(team__project_id=project_id).exclude(id=cohort_id)
+
+# ok: idor-lookup-without-team
+Cohort.objects.select_related("team").exclude(id=cohort_id)
+
+
+# ok: idor-taint-user-input-to-model-get
+def safe_exclude_from_request(request):
+    cohort_id = request.GET.get("cohort_id")
+    # ok: idor-lookup-without-team
+    return Cohort.objects.exclude(id=cohort_id)
+
+
+# ok: idor-taint-user-input-to-model-get
+def safe_create_from_request(request):
+    cohort_id = request.GET.get("cohort_id")
+    # ok: idor-lookup-without-team
+    return Cohort.objects.create(id=cohort_id, name="test")
+
+
+# ============================================================
+# Models whose names are superstrings of listed models should NOT match
+# ============================================================
+
+# ok: idor-lookup-without-team, idor-taint-user-input-to-model-get
+DashboardTile.objects.get(pk=tile_id)
+
+# ok: idor-lookup-without-team, idor-taint-user-input-to-model-get
+ActionStep.objects.filter(id=step_id)
+
+# ok: idor-lookup-without-team, idor-taint-user-input-to-model-get
+TaggedItem.objects.get(pk=item_id)
+
+
+# ============================================================
+# idor-taint-user-input-to-org-model (ERROR - user input flows to org model lookup)
+# ============================================================
+
+
+def vulnerable_org_get_from_request(request):
+    project_id = request.GET.get("project_id")
+    # ruleid: idor-taint-user-input-to-org-model, idor-lookup-without-org
+    return Project.objects.get(pk=project_id)
+
+
+def vulnerable_org_get_from_kwargs(kwargs):
+    role_id = kwargs.get("role_id")
+    # ruleid: idor-taint-user-input-to-org-model, idor-lookup-without-org
+    return Role.objects.get(id=role_id)
+
+
+def vulnerable_org_filter_from_data(request):
+    membership_id = request.data.get("membership_id")
+    # ruleid: idor-taint-user-input-to-org-model, idor-lookup-without-org
+    return RoleMembership.objects.filter(pk=membership_id)
+
+
+# ok: idor-taint-user-input-to-org-model
+def safe_org_get_with_organization(request, organization):
+    project_id = request.GET.get("project_id")
+    # ok: idor-lookup-without-org
+    return Project.objects.get(pk=project_id, organization=organization)
+
+
+# ok: idor-taint-user-input-to-org-model
+def safe_org_get_with_organization_id(request, organization_id):
+    role_id = request.GET.get("role_id")
+    # ok: idor-lookup-without-org
+    return Role.objects.get(pk=role_id, organization_id=organization_id)
+
+
+# ok: idor-taint-user-input-to-org-model
+def safe_org_filter_with_role_organization(request, organization):
+    membership_id = request.data.get("membership_id")
+    # ok: idor-lookup-without-org
+    return RoleMembership.objects.filter(pk=membership_id, role__organization=organization)
+
+
+# ============================================================
+# idor-lookup-without-org (WARNING - pattern rule)
+# ============================================================
+
+# ruleid: idor-lookup-without-org
+project = Project.objects.get(pk=project_id)
+
+# ruleid: idor-lookup-without-org
+role = Role.objects.get(id=role_id)
+
+# ruleid: idor-lookup-without-org
+membership = RoleMembership.objects.filter(pk=membership_id)
+
+# ok: idor-lookup-without-org
+project = Project.objects.get(pk=project_id, organization=organization)
+
+# ok: idor-lookup-without-org
+role = Role.objects.get(id=role_id, organization_id=organization_id)
+
+# ok: idor-lookup-without-org
+membership = RoleMembership.objects.filter(pk=membership_id, role__organization=organization)
+
+# ok: idor-lookup-without-org
+membership = RoleMembership.objects.filter(pk=membership_id, role__organization_id=organization_id)
+
+# ruleid: idor-lookup-without-org
+obj, created = Role.objects.get_or_create(name="test")
+
+# ok: idor-lookup-without-org
+obj, created = Role.objects.get_or_create(name="test", organization=organization)
+
+# ruleid: idor-lookup-without-org
+obj = Role.objects.aget_or_create(name="test")
+
+# ok: idor-lookup-without-org
+obj = Role.objects.aget_or_create(name="test", organization=organization)
+
+# ok: idor-lookup-without-org
+Project.objects.get(pk=instance.pk)
+
+# ok: idor-lookup-without-org
+Role.objects.select_for_update().get(pk=self.role.id)
+
+# ============================================================
+# NEW: get_object_or_404 — org-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-org
+get_object_or_404(Project, pk=project_id)
+
+# ok: idor-lookup-without-org
+get_object_or_404(Project, pk=project_id, organization=organization)
+
+# ok: idor-lookup-without-org
+get_object_or_404(Project, pk=project_id, organization_id=organization_id)
+
+# ok: idor-lookup-without-org
+get_object_or_404(RoleMembership, pk=membership_id, role__organization=organization)
+
+
+def vulnerable_org_get_object_or_404(request):
+    project_id = request.GET.get("project_id")
+    # ruleid: idor-taint-user-input-to-org-model, idor-lookup-without-org
+    return get_object_or_404(Project, pk=project_id)
+
+
+# ok: idor-taint-user-input-to-org-model
+def safe_org_get_object_or_404(request, organization):
+    project_id = request.GET.get("project_id")
+    # ok: idor-lookup-without-org
+    return get_object_or_404(Project, pk=project_id, organization=organization)
+
+
+# ============================================================
+# NEW: select_related/prefetch_related — org-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-org
+project = Project.objects.select_related("organization").get(pk=project_id)
+
+# ruleid: idor-lookup-without-org
+role = Role.objects.prefetch_related("organization").get(id=role_id)
+
+# ok: idor-lookup-without-org
+project = Project.objects.select_related("organization").get(pk=project_id, organization=organization)
+
+# ok: idor-lookup-without-org
+role = Role.objects.prefetch_related("organization").get(id=role_id, organization_id=organization_id)
+
+
+def vulnerable_org_select_related(request):
+    project_id = request.GET.get("project_id")
+    # ruleid: idor-taint-user-input-to-org-model, idor-lookup-without-org
+    return Project.objects.select_related("organization").get(pk=project_id)
+
+
+# ok: idor-taint-user-input-to-org-model
+def safe_org_select_related(request, organization):
+    project_id = request.GET.get("project_id")
+    # ok: idor-lookup-without-org
+    return Project.objects.select_related("organization").get(pk=project_id, organization=organization)
+
+
+# ============================================================
+# NEW: async aget — org-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-org
+project = Project.objects.aget(pk=project_id)
+
+# ok: idor-lookup-without-org
+project = Project.objects.aget(pk=project_id, organization=organization)
+
+# ruleid: idor-lookup-without-org
+project = Project.objects.select_related("organization").aget(pk=project_id)
+
+# ok: idor-lookup-without-org
+project = Project.objects.select_related("organization").aget(pk=project_id, organization=organization)
+
+
+def vulnerable_org_aget(request):
+    project_id = request.GET.get("project_id")
+    # ruleid: idor-taint-user-input-to-org-model, idor-lookup-without-org
+    return Project.objects.aget(pk=project_id)
+
+
+# ok: idor-taint-user-input-to-org-model
+def safe_org_aget(request, organization):
+    project_id = request.GET.get("project_id")
+    # ok: idor-lookup-without-org
+    return Project.objects.aget(pk=project_id, organization=organization)
+
+
+# ============================================================
+# idor-taint-user-input-to-user-model (ERROR - user input flows to user model lookup)
+# ============================================================
+
+
+def vulnerable_user_get_from_request(request):
+    key_id = request.GET.get("key_id")
+    # ruleid: idor-taint-user-input-to-user-model, idor-lookup-without-user
+    return PersonalAPIKey.objects.get(pk=key_id)
+
+
+def vulnerable_user_filter_from_data(request):
+    key_id = request.data.get("key_id")
+    # ruleid: idor-taint-user-input-to-user-model, idor-lookup-without-user
+    return PersonalAPIKey.objects.filter(id=key_id)
+
+
+# ok: idor-taint-user-input-to-user-model
+def safe_user_get_with_user(request, user):
+    key_id = request.GET.get("key_id")
+    # ok: idor-lookup-without-user
+    return PersonalAPIKey.objects.get(pk=key_id, user=user)
+
+
+# ok: idor-taint-user-input-to-user-model
+def safe_user_get_with_user_id(request, user_id):
+    key_id = request.GET.get("key_id")
+    # ok: idor-lookup-without-user
+    return PersonalAPIKey.objects.get(pk=key_id, user_id=user_id)
+
+
+# ============================================================
+# idor-lookup-without-user (WARNING - pattern rule)
+# ============================================================
+
+# ruleid: idor-lookup-without-user
+key = PersonalAPIKey.objects.get(pk=key_id)
+
+# ruleid: idor-lookup-without-user
+key = PersonalAPIKey.objects.filter(id=key_id)
+
+# ok: idor-lookup-without-user
+key = PersonalAPIKey.objects.get(pk=key_id, user=user)
+
+# ok: idor-lookup-without-user
+key = PersonalAPIKey.objects.filter(id=key_id, user_id=user_id)
+
+# ruleid: idor-lookup-without-user
+obj, created = PersonalAPIKey.objects.get_or_create(label="test")
+
+# ok: idor-lookup-without-user
+obj, created = PersonalAPIKey.objects.get_or_create(label="test", user=user)
+
+# ruleid: idor-lookup-without-user
+obj = PersonalAPIKey.objects.aget_or_create(label="test")
+
+# ok: idor-lookup-without-user
+obj = PersonalAPIKey.objects.aget_or_create(label="test", user=user)
+
+# ok: idor-lookup-without-user
+PersonalAPIKey.objects.get(pk=instance.pk)
+
+# ok: idor-lookup-without-user
+PersonalAPIKey.objects.select_for_update().get(id=self.key.id)
+
+# ============================================================
+# NEW: get_object_or_404 — user-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-user
+get_object_or_404(PersonalAPIKey, pk=key_id)
+
+# ok: idor-lookup-without-user
+get_object_or_404(PersonalAPIKey, pk=key_id, user=user)
+
+# ok: idor-lookup-without-user
+get_object_or_404(PersonalAPIKey, pk=key_id, user_id=user_id)
+
+
+def vulnerable_user_get_object_or_404(request):
+    key_id = request.GET.get("key_id")
+    # ruleid: idor-taint-user-input-to-user-model, idor-lookup-without-user
+    return get_object_or_404(PersonalAPIKey, pk=key_id)
+
+
+# ok: idor-taint-user-input-to-user-model
+def safe_user_get_object_or_404(request, user):
+    key_id = request.GET.get("key_id")
+    # ok: idor-lookup-without-user
+    return get_object_or_404(PersonalAPIKey, pk=key_id, user=user)
+
+
+# ============================================================
+# NEW: select_related/prefetch_related — user-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-user
+key = PersonalAPIKey.objects.select_related("user").get(pk=key_id)
+
+# ok: idor-lookup-without-user
+key = PersonalAPIKey.objects.select_related("user").get(pk=key_id, user=user)
+
+# ruleid: idor-lookup-without-user
+key = PersonalAPIKey.objects.prefetch_related("user").filter(id=key_id)
+
+# ok: idor-lookup-without-user
+key = PersonalAPIKey.objects.prefetch_related("user").filter(id=key_id, user_id=user_id)
+
+
+def vulnerable_user_select_related(request):
+    key_id = request.GET.get("key_id")
+    # ruleid: idor-taint-user-input-to-user-model, idor-lookup-without-user
+    return PersonalAPIKey.objects.select_related("user").get(pk=key_id)
+
+
+# ok: idor-taint-user-input-to-user-model
+def safe_user_select_related(request, user):
+    key_id = request.GET.get("key_id")
+    # ok: idor-lookup-without-user
+    return PersonalAPIKey.objects.select_related("user").get(pk=key_id, user=user)
+
+
+# ============================================================
+# NEW: async aget — user-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-user
+key = PersonalAPIKey.objects.aget(pk=key_id)
+
+# ok: idor-lookup-without-user
+key = PersonalAPIKey.objects.aget(pk=key_id, user=user)
+
+# ruleid: idor-lookup-without-user
+key = PersonalAPIKey.objects.select_related("user").aget(pk=key_id)
+
+# ok: idor-lookup-without-user
+key = PersonalAPIKey.objects.select_related("user").aget(pk=key_id, user_id=user_id)
+
+
+def vulnerable_user_aget(request):
+    key_id = request.GET.get("key_id")
+    # ruleid: idor-taint-user-input-to-user-model, idor-lookup-without-user
+    return PersonalAPIKey.objects.aget(pk=key_id)
+
+
+# ok: idor-taint-user-input-to-user-model
+def safe_user_aget(request, user):
+    key_id = request.GET.get("key_id")
+    # ok: idor-lookup-without-user
+    return PersonalAPIKey.objects.aget(pk=key_id, user=user)
+
+
+# ============================================================
+# idor-taint-user-input-to-user-team-model (ERROR - user input flows without BOTH filters)
+# ============================================================
+
+
+def vulnerable_user_team_get_from_request(request):
+    settings_id = request.GET.get("settings_id")
+    # ruleid: idor-taint-user-input-to-user-team-model, idor-lookup-without-user-and-team
+    return UserScenePersonalisation.objects.get(pk=settings_id)
+
+
+def vulnerable_user_team_only_user(request, user):
+    settings_id = request.GET.get("settings_id")
+    # ruleid: idor-taint-user-input-to-user-team-model, idor-lookup-without-user-and-team
+    return UserScenePersonalisation.objects.get(pk=settings_id, user=user)
+
+
+def vulnerable_user_team_only_team(request, team):
+    settings_id = request.GET.get("settings_id")
+    # ruleid: idor-taint-user-input-to-user-team-model, idor-lookup-without-user-and-team
+    return UserScenePersonalisation.objects.get(pk=settings_id, team=team)
+
+
+# ok: idor-taint-user-input-to-user-team-model
+def safe_user_team_with_both(request, user, team):
+    settings_id = request.GET.get("settings_id")
+    # ok: idor-lookup-without-user-and-team
+    return UserScenePersonalisation.objects.get(pk=settings_id, user=user, team=team)
+
+
+# ok: idor-taint-user-input-to-user-team-model
+def safe_user_team_with_both_ids(request, user_id, team_id):
+    settings_id = request.GET.get("settings_id")
+    # ok: idor-lookup-without-user-and-team
+    return UserScenePersonalisation.objects.get(pk=settings_id, user_id=user_id, team_id=team_id)
+
+
+# ok: idor-taint-user-input-to-user-team-model
+def safe_user_team_reversed_order(request, user, team):
+    settings_id = request.GET.get("settings_id")
+    # ok: idor-lookup-without-user-and-team
+    return UserScenePersonalisation.objects.get(pk=settings_id, team=team, user=user)
+
+
+# ============================================================
+# idor-lookup-without-user-and-team (WARNING - pattern rule)
+# ============================================================
+
+# ruleid: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.get(pk=settings_id)
+
+# ruleid: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.get(pk=settings_id, user=user)
+
+# ruleid: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.get(pk=settings_id, team=team)
+
+# ok: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.get(pk=settings_id, user=user, team=team)
+
+# ok: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.get(pk=settings_id, team_id=team_id, user_id=user_id)
+
+# ruleid: idor-lookup-without-user-and-team
+obj, created = UserScenePersonalisation.objects.get_or_create(scene="test")
+
+# ruleid: idor-lookup-without-user-and-team
+obj, created = UserScenePersonalisation.objects.get_or_create(scene="test", user=user)
+
+# ok: idor-lookup-without-user-and-team
+obj, created = UserScenePersonalisation.objects.get_or_create(scene="test", user=user, team=team)
+
+# ruleid: idor-lookup-without-user-and-team
+obj = UserScenePersonalisation.objects.aget_or_create(scene="test")
+
+# ok: idor-lookup-without-user-and-team
+obj = UserScenePersonalisation.objects.aget_or_create(scene="test", user=user, team=team)
+
+# ok: idor-lookup-without-user-and-team
+UserScenePersonalisation.objects.get(pk=instance.pk)
+
+# ok: idor-lookup-without-user-and-team
+UserScenePersonalisation.objects.select_for_update().get(id=self.settings.id)
+
+# ============================================================
+# NEW: get_object_or_404 — user+team-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-user-and-team
+get_object_or_404(UserScenePersonalisation, pk=settings_id)
+
+# ruleid: idor-lookup-without-user-and-team
+get_object_or_404(UserScenePersonalisation, pk=settings_id, user=user)
+
+# ruleid: idor-lookup-without-user-and-team
+get_object_or_404(UserScenePersonalisation, pk=settings_id, team=team)
+
+# ok: idor-lookup-without-user-and-team
+get_object_or_404(UserScenePersonalisation, pk=settings_id, user=user, team=team)
+
+# ok: idor-lookup-without-user-and-team
+get_object_or_404(UserScenePersonalisation, pk=settings_id, user_id=user_id, team_id=team_id)
+
+
+def vulnerable_user_team_get_object_or_404(request):
+    settings_id = request.GET.get("settings_id")
+    # ruleid: idor-taint-user-input-to-user-team-model, idor-lookup-without-user-and-team
+    return get_object_or_404(UserScenePersonalisation, pk=settings_id)
+
+
+# ok: idor-taint-user-input-to-user-team-model
+def safe_user_team_get_object_or_404(request, user, team):
+    settings_id = request.GET.get("settings_id")
+    # ok: idor-lookup-without-user-and-team
+    return get_object_or_404(UserScenePersonalisation, pk=settings_id, user=user, team=team)
+
+
+# ============================================================
+# NEW: select_related/prefetch_related — user+team-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.select_related("user", "team").get(pk=settings_id)
+
+# ruleid: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.select_related("user", "team").get(pk=settings_id, user=user)
+
+# ok: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.select_related("user", "team").get(pk=settings_id, user=user, team=team)
+
+# ok: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.prefetch_related("user", "team").get(
+    pk=settings_id, team_id=team_id, user_id=user_id
+)
+
+
+def vulnerable_user_team_select_related(request):
+    settings_id = request.GET.get("settings_id")
+    # ruleid: idor-taint-user-input-to-user-team-model, idor-lookup-without-user-and-team
+    return UserScenePersonalisation.objects.select_related("user", "team").get(pk=settings_id)
+
+
+# ok: idor-taint-user-input-to-user-team-model
+def safe_user_team_select_related(request, user, team):
+    settings_id = request.GET.get("settings_id")
+    # ok: idor-lookup-without-user-and-team
+    return UserScenePersonalisation.objects.select_related("user", "team").get(pk=settings_id, user=user, team=team)
+
+
+# ============================================================
+# NEW: async aget — user+team-scoped
+# ============================================================
+
+# ruleid: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.aget(pk=settings_id)
+
+# ruleid: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.aget(pk=settings_id, user=user)
+
+# ok: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.aget(pk=settings_id, user=user, team=team)
+
+# ruleid: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.select_related("user").aget(pk=settings_id)
+
+# ok: idor-lookup-without-user-and-team
+settings = UserScenePersonalisation.objects.select_related("user").aget(pk=settings_id, user=user, team_id=team_id)
+
+
+def vulnerable_user_team_aget(request):
+    settings_id = request.GET.get("settings_id")
+    # ruleid: idor-taint-user-input-to-user-team-model, idor-lookup-without-user-and-team
+    return UserScenePersonalisation.objects.aget(pk=settings_id)
+
+
+# ok: idor-taint-user-input-to-user-team-model
+def safe_user_team_aget(request, user, team):
+    settings_id = request.GET.get("settings_id")
+    # ok: idor-lookup-without-user-and-team
+    return UserScenePersonalisation.objects.aget(pk=settings_id, user=user, team=team)

--- a/.semgrep/rules/idor-team-scoped-models.yaml
+++ b/.semgrep/rules/idor-team-scoped-models.yaml
@@ -1,0 +1,801 @@
+# Metavariable conventions used in these rules:
+#   $METHOD — in sinks/lookups, matches queryset lookup methods; constrained by metavariable-regex to (get|filter|aget)
+#   $METHOD / $METHOD2 — in sanitizers/pattern-nots, matches any queryset method (get, filter, aget, exclude, etc.)
+#   . ... . (chain ellipsis) — matches zero or more intermediate calls (select_related, prefetch_related, only, defer, etc.)
+# The $METHOD regex is nested inside pattern-either so it only applies to patterns that bind $METHOD.
+# $GOC — in lookups, matches create-like methods; constrained by metavariable-regex to (get_or_create|update_or_create|aget_or_create).
+# In pattern-nots, $METHOD2 with `. ... .` (zero or more calls) covers all methods including
+# get_or_create and update_or_create, so no separate pattern-nots are needed for those.
+rules:
+    - id: idor-taint-user-input-to-model-get
+      mode: taint
+      languages: [python]
+      severity: ERROR
+      message: |
+          IDOR: User input flows to team-scoped model lookup without team filter.
+          Fix: Add team__project_id=team.project_id to the query.
+      pattern-sources:
+          - patterns:
+                - pattern-either:
+                      # Django request params
+                      - pattern: $REQ.GET.get(...)
+                      - pattern: $REQ.POST.get(...)
+                      - pattern: $REQ.GET[...]
+                      - pattern: $REQ.POST[...]
+                      - pattern: $REQ.data.get(...)
+                      - pattern: $REQ.data[...]
+                      - pattern: $REQ.query_params.get(...)
+                      - pattern: $REQ.query_params[...]
+                      # DRF serializer
+                      - pattern: $SER.validated_data.get(...)
+                      - pattern: $SER.validated_data[...]
+                      # URL kwargs (common in DRF)
+                      - pattern: kwargs.get(...)
+                      - pattern: kwargs[...]
+                      # self.kwargs in viewsets
+                      - pattern: self.kwargs.get(...)
+                      - pattern: self.kwargs[...]
+      pattern-sinks:
+          - patterns:
+                - pattern-either:
+                      - patterns:
+                            - pattern-either:
+                                  - pattern: $MODEL.objects. ... .$METHOD(pk=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(id=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(pk__in=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(id__in=$SINK, ...)
+                            - metavariable-regex:
+                                  metavariable: $METHOD
+                                  regex: ^(get|filter|aget)$
+                      # get_object_or_404
+                      - pattern: get_object_or_404($MODEL, pk=$SINK, ...)
+                      - pattern: get_object_or_404($MODEL, id=$SINK, ...)
+                - metavariable-regex:
+                      metavariable: $MODEL
+                      regex: |
+                          (?x)(
+                              AccessControl
+                              |Action
+                              |AgentArtifact
+                              |Alert
+                              |AlertConfiguration
+                              |Annotation
+                              |ApprovalPolicy
+                              |BatchExport
+                              |BatchExportBackfill
+                              |BatchImport
+                              |ChangeRequest
+                              |Cohort
+                              |Comment
+                              |Conversation
+                              |CoreMemory
+                              |CustomerProfileConfig
+                              |Dashboard
+                              |DashboardTemplate
+                              |DataColorTheme
+                              |DataModelingJob
+                              |Dataset
+                              |DatasetItem
+                              |DataWarehouseCredential
+                              |DataWarehouseJoin
+                              |DataWarehouseManagedViewSet
+                              |DataWarehouseModelPath
+                              |DataWarehouseSavedQuery
+                              |DataWarehouseSavedQueryDraft
+                              |DataWarehouseTable
+                              |DesktopRecording
+                              |EarlyAccessFeature
+                              |Edge
+                              |Endpoint
+                              |EnterpriseEventDefinition
+                              |EnterprisePropertyDefinition
+                              |ErrorTrackingAssignmentRule
+                              |ErrorTrackingAutoCaptureControls
+                              |ErrorTrackingGroupingRule
+                              |ErrorTrackingIssue
+                              |ErrorTrackingIssueFingerprintV2
+                              |ErrorTrackingRelease
+                              |ErrorTrackingStackFrame
+                              |ErrorTrackingSuppressionRule
+                              |ErrorTrackingSymbolSet
+                              |Evaluation
+                              |Experiment
+                              |ExperimentHoldout
+                              |ExperimentSavedMetric
+                              |ExportedAsset
+                              |ExportedRecording
+                              |ExternalDataJob
+                              |ExternalDataSchema
+                              |ExternalDataSource
+                              |FeatureFlag
+                              |FileSystem
+                              |HealthIssue
+                              |HogFlow
+                              |HogFlowBatchJob
+                              |HogFlowTemplate
+                              |HogFunction
+                              |Hook
+                              |Insight
+                              |InsightVariable
+                              |Integration
+                              |Link
+                              |LiveDebuggerBreakpoint
+                              |LLMModelConfiguration
+                              |LLMPrompt
+                              |LLMProviderKey
+                              |LLMTraceSummary
+                              |MarketingAnalyticsGoalMapping
+                              |MessageCategory
+                              |MessageRecipientPreference
+                              |MessageTemplate
+                              |Node
+                              |Notebook
+                              |PluginConfig
+                              |ProductTour
+                              |ProjectSecretAPIKey
+                              |QueryTabState
+                              |QuickFilter
+                              |QuickFilterContext
+                              |SandboxEnvironment
+                              |SavedHeatmap
+                              |ScheduledChange
+                              |SessionGroupSummary
+                              |SessionRecording
+                              |SessionRecordingPlaylist
+                              |SharingConfiguration
+                              |SignalReport
+                              |SignalReportArtefact
+                              |SingleSessionSummary
+                              |Subscription
+                              |Survey
+                              |SurveyResponseArchive
+                              |Tag
+                              |Task
+                              |TaskRun
+                              |Text
+                              |Threshold
+                              |Ticket
+                              |UploadedMedia
+                              |UserInterview
+                              |WebAnalyticsFilterPreset
+                          )$
+                - focus-metavariable: $SINK
+      pattern-sanitizers:
+          - pattern: $M.objects. ... .$METHOD(..., team__project_id=$T, ...)
+          - pattern: $M.objects. ... .$METHOD(..., effective_project_id=$T, ...)
+          - pattern: $M.objects. ... .$METHOD(..., team=$T, ...)
+          - pattern: $M.objects. ... .$METHOD(..., team_id=$T, ...)
+          # get_object_or_404
+          - pattern: get_object_or_404($M, ..., team__project_id=$T, ...)
+          - pattern: get_object_or_404($M, ..., effective_project_id=$T, ...)
+          - pattern: get_object_or_404($M, ..., team=$T, ...)
+          - pattern: get_object_or_404($M, ..., team_id=$T, ...)
+      metadata:
+          category: security
+          cwe: 'CWE-639: Authorization Bypass Through User-Controlled Key'
+          owasp: 'A01:2021 - Broken Access Control'
+          confidence: HIGH
+      paths:
+          exclude:
+              - '**/test*/**'
+              - '**/migrations/**'
+              - '**/management/**'
+              - '**/.semgrep/**'
+
+    # Combined pattern rule: any lookup without team filter
+    - id: idor-lookup-without-team
+      patterns:
+          - pattern-either:
+                - patterns:
+                      - pattern-either:
+                            - pattern: $MODEL.objects. ... .$METHOD(pk=$ID, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(id=$ID, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(pk__in=$IDS, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(id__in=$IDS, ...)
+                      - metavariable-regex:
+                            metavariable: $METHOD
+                            regex: ^(get|filter|aget)$
+                # get_or_create / update_or_create
+                - patterns:
+                      - pattern: $MODEL.objects.$GOC(...)
+                      - metavariable-regex:
+                            metavariable: $GOC
+                            regex: ^(get_or_create|update_or_create|aget_or_create)$
+                # get_object_or_404
+                - pattern: get_object_or_404($MODEL, pk=$ID, ...)
+                - pattern: get_object_or_404($MODEL, id=$ID, ...)
+          - metavariable-regex:
+                metavariable: $MODEL
+                regex: |
+                    (?x)(
+                        AccessControl
+                        |Action
+                        |AgentArtifact
+                        |Alert
+                        |AlertConfiguration
+                        |Annotation
+                        |ApprovalPolicy
+                        |BatchExport
+                        |BatchExportBackfill
+                        |BatchImport
+                        |ChangeRequest
+                        |Cohort
+                        |Comment
+                        |Conversation
+                        |CoreMemory
+                        |CustomerProfileConfig
+                        |Dashboard
+                        |DashboardTemplate
+                        |DataColorTheme
+                        |DataModelingJob
+                        |Dataset
+                        |DatasetItem
+                        |DataWarehouseCredential
+                        |DataWarehouseJoin
+                        |DataWarehouseManagedViewSet
+                        |DataWarehouseModelPath
+                        |DataWarehouseSavedQuery
+                        |DataWarehouseSavedQueryDraft
+                        |DataWarehouseTable
+                        |DesktopRecording
+                        |EarlyAccessFeature
+                        |Edge
+                        |Endpoint
+                        |EnterpriseEventDefinition
+                        |EnterprisePropertyDefinition
+                        |ErrorTrackingAssignmentRule
+                        |ErrorTrackingAutoCaptureControls
+                        |ErrorTrackingGroupingRule
+                        |ErrorTrackingIssue
+                        |ErrorTrackingIssueFingerprintV2
+                        |ErrorTrackingRelease
+                        |ErrorTrackingStackFrame
+                        |ErrorTrackingSuppressionRule
+                        |ErrorTrackingSymbolSet
+                        |Evaluation
+                        |Experiment
+                        |ExperimentHoldout
+                        |ExperimentSavedMetric
+                        |ExportedAsset
+                        |ExportedRecording
+                        |ExternalDataJob
+                        |ExternalDataSchema
+                        |ExternalDataSource
+                        |FeatureFlag
+                        |FileSystem
+                        |HealthIssue
+                        |HogFlow
+                        |HogFlowBatchJob
+                        |HogFlowTemplate
+                        |HogFunction
+                        |Hook
+                        |Insight
+                        |InsightVariable
+                        |Integration
+                        |Link
+                        |LiveDebuggerBreakpoint
+                        |LLMModelConfiguration
+                        |LLMPrompt
+                        |LLMProviderKey
+                        |LLMTraceSummary
+                        |MarketingAnalyticsGoalMapping
+                        |MessageCategory
+                        |MessageRecipientPreference
+                        |MessageTemplate
+                        |Node
+                        |Notebook
+                        |PluginConfig
+                        |ProductTour
+                        |ProjectSecretAPIKey
+                        |QueryTabState
+                        |QuickFilter
+                        |QuickFilterContext
+                        |SandboxEnvironment
+                        |SavedHeatmap
+                        |ScheduledChange
+                        |SessionGroupSummary
+                        |SessionRecording
+                        |SessionRecordingPlaylist
+                        |SharingConfiguration
+                        |SignalReport
+                        |SignalReportArtefact
+                        |SingleSessionSummary
+                        |Subscription
+                        |Survey
+                        |SurveyResponseArchive
+                        |Tag
+                        |Task
+                        |TaskRun
+                        |Text
+                        |Threshold
+                        |Ticket
+                        |UploadedMedia
+                        |UserInterview
+                        |WebAnalyticsFilterPreset
+                    )$
+          # Exclude when team filter is present
+          - pattern-not: $M.objects. ... .$METHOD2(..., team__project_id=$T, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., effective_project_id=$T, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., team=$T, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., team_id=$T, ...)
+          # get_object_or_404
+          - pattern-not: get_object_or_404($M, ..., team__project_id=$T, ...)
+          - pattern-not: get_object_or_404($M, ..., effective_project_id=$T, ...)
+          - pattern-not: get_object_or_404($M, ..., team=$T, ...)
+          - pattern-not: get_object_or_404($M, ..., team_id=$T, ...)
+          # Refetching an existing instance by its pk/id attribute
+          - pattern-not: $M.objects. ... .$METHOD2(pk=$X.pk, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(pk=$X.id, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(id=$X.pk, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(id=$X.id, ...)
+      message: |
+          IDOR risk: Lookup on team-scoped model without team filter.
+          Fix: Add team_id=team_id or team__project_id=team.project_id to the query.
+      languages: [python]
+      severity: WARNING
+      metadata:
+          category: security
+          cwe: 'CWE-639: Authorization Bypass Through User-Controlled Key'
+          confidence: MEDIUM
+          subcategory: audit
+      paths:
+          exclude:
+              - '**/test*/**'
+              - '**/migrations/**'
+              - '**/management/**'
+              - '**/.semgrep/**'
+              - '**/tasks/**'
+              - '**/temporal/**'
+              - '**/dags/**'
+              - '**/models/**'
+              - '**/signals.py'
+
+    # Organization-scoped model taint rule
+    - id: idor-taint-user-input-to-org-model
+      mode: taint
+      languages: [python]
+      severity: ERROR
+      message: |
+          IDOR: User input flows to organization-scoped model lookup without organization filter.
+          Fix: Add organization=organization or organization_id=organization_id to the query.
+          For RoleMembership, use role__organization= or role__organization_id=.
+      pattern-sources:
+          - patterns:
+                - pattern-either:
+                      - pattern: $REQ.GET.get(...)
+                      - pattern: $REQ.POST.get(...)
+                      - pattern: $REQ.GET[...]
+                      - pattern: $REQ.POST[...]
+                      - pattern: $REQ.data.get(...)
+                      - pattern: $REQ.data[...]
+                      - pattern: $REQ.query_params.get(...)
+                      - pattern: $REQ.query_params[...]
+                      - pattern: $SER.validated_data.get(...)
+                      - pattern: $SER.validated_data[...]
+                      - pattern: kwargs.get(...)
+                      - pattern: kwargs[...]
+                      - pattern: self.kwargs.get(...)
+                      - pattern: self.kwargs[...]
+      pattern-sinks:
+          - patterns:
+                - pattern-either:
+                      - patterns:
+                            - pattern-either:
+                                  - pattern: $MODEL.objects. ... .$METHOD(pk=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(id=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(pk__in=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(id__in=$SINK, ...)
+                            - metavariable-regex:
+                                  metavariable: $METHOD
+                                  regex: ^(get|filter|aget)$
+                      # get_object_or_404
+                      - pattern: get_object_or_404($MODEL, pk=$SINK, ...)
+                      - pattern: get_object_or_404($MODEL, id=$SINK, ...)
+                - metavariable-regex:
+                      metavariable: $MODEL
+                      regex: |
+                          (?x)(
+                              OrganizationMembership
+                              |OrganizationDomain
+                              |OrganizationIntegration
+                              |OrganizationInvite
+                              |Plugin
+                              |Project
+                              |ProxyRecord
+                              |Role
+                              |RoleMembership
+                          )$
+                - focus-metavariable: $SINK
+      pattern-sanitizers:
+          - pattern: $M.objects. ... .$METHOD(..., organization=$O, ...)
+          - pattern: $M.objects. ... .$METHOD(..., organization_id=$O, ...)
+          - pattern: $M.objects. ... .$METHOD(..., organization__id=$O, ...)
+          - pattern: $M.objects. ... .$METHOD(..., role__organization=$O, ...)
+          - pattern: $M.objects. ... .$METHOD(..., role__organization_id=$O, ...)
+          # get_object_or_404
+          - pattern: get_object_or_404($M, ..., organization=$O, ...)
+          - pattern: get_object_or_404($M, ..., organization_id=$O, ...)
+          - pattern: get_object_or_404($M, ..., organization__id=$O, ...)
+          - pattern: get_object_or_404($M, ..., role__organization=$O, ...)
+          - pattern: get_object_or_404($M, ..., role__organization_id=$O, ...)
+      metadata:
+          category: security
+          cwe: 'CWE-639: Authorization Bypass Through User-Controlled Key'
+          owasp: 'A01:2021 - Broken Access Control'
+          confidence: HIGH
+      paths:
+          exclude:
+              - '**/test*/**'
+              - '**/migrations/**'
+              - '**/management/**'
+              - '**/.semgrep/**'
+
+    # Organization-scoped model lookup rule
+    - id: idor-lookup-without-org
+      patterns:
+          - pattern-either:
+                - patterns:
+                      - pattern-either:
+                            - pattern: $MODEL.objects. ... .$METHOD(pk=$ID, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(id=$ID, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(pk__in=$IDS, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(id__in=$IDS, ...)
+                      - metavariable-regex:
+                            metavariable: $METHOD
+                            regex: ^(get|filter|aget)$
+                - patterns:
+                      - pattern: $MODEL.objects.$GOC(...)
+                      - metavariable-regex:
+                            metavariable: $GOC
+                            regex: ^(get_or_create|update_or_create|aget_or_create)$
+                # get_object_or_404
+                - pattern: get_object_or_404($MODEL, pk=$ID, ...)
+                - pattern: get_object_or_404($MODEL, id=$ID, ...)
+          - metavariable-regex:
+                metavariable: $MODEL
+                regex: |
+                    (?x)(
+                        OrganizationMembership
+                        |OrganizationDomain
+                        |OrganizationIntegration
+                        |OrganizationInvite
+                        |Plugin
+                        |Project
+                        |ProxyRecord
+                        |Role
+                        |RoleMembership
+                    )$
+          - pattern-not: $M.objects. ... .$METHOD2(..., organization=$O, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., organization_id=$O, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., organization__id=$O, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., role__organization=$O, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., role__organization_id=$O, ...)
+          # get_object_or_404
+          - pattern-not: get_object_or_404($M, ..., organization=$O, ...)
+          - pattern-not: get_object_or_404($M, ..., organization_id=$O, ...)
+          - pattern-not: get_object_or_404($M, ..., organization__id=$O, ...)
+          - pattern-not: get_object_or_404($M, ..., role__organization=$O, ...)
+          - pattern-not: get_object_or_404($M, ..., role__organization_id=$O, ...)
+          # Refetching an existing instance by its pk/id attribute
+          - pattern-not: $M.objects. ... .$METHOD2(pk=$X.pk, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(pk=$X.id, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(id=$X.pk, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(id=$X.id, ...)
+      message: |
+          IDOR risk: Lookup on organization-scoped model without organization filter.
+          Fix: Add organization_id=organization_id or organization=organization to the query.
+          For RoleMembership, use role__organization= or role__organization_id=.
+      languages: [python]
+      severity: WARNING
+      metadata:
+          category: security
+          cwe: 'CWE-639: Authorization Bypass Through User-Controlled Key'
+          confidence: MEDIUM
+          subcategory: audit
+      paths:
+          exclude:
+              - '**/test*/**'
+              - '**/migrations/**'
+              - '**/management/**'
+              - '**/.semgrep/**'
+              - '**/tasks/**'
+              - '**/temporal/**'
+              - '**/dags/**'
+              - '**/models/**'
+              - '**/signals.py'
+
+    # User-scoped model taint rule
+    - id: idor-taint-user-input-to-user-model
+      mode: taint
+      languages: [python]
+      severity: ERROR
+      message: |
+          IDOR: User input flows to user-scoped model lookup without user filter.
+          Fix: Add user=user or user_id=user_id to the query.
+      pattern-sources:
+          - patterns:
+                - pattern-either:
+                      - pattern: $REQ.GET.get(...)
+                      - pattern: $REQ.POST.get(...)
+                      - pattern: $REQ.GET[...]
+                      - pattern: $REQ.POST[...]
+                      - pattern: $REQ.data.get(...)
+                      - pattern: $REQ.data[...]
+                      - pattern: $REQ.query_params.get(...)
+                      - pattern: $REQ.query_params[...]
+                      - pattern: $SER.validated_data.get(...)
+                      - pattern: $SER.validated_data[...]
+                      - pattern: kwargs.get(...)
+                      - pattern: kwargs[...]
+                      - pattern: self.kwargs.get(...)
+                      - pattern: self.kwargs[...]
+      pattern-sinks:
+          - patterns:
+                - pattern-either:
+                      - patterns:
+                            - pattern-either:
+                                  - pattern: $MODEL.objects. ... .$METHOD(pk=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(id=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(pk__in=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(id__in=$SINK, ...)
+                            - metavariable-regex:
+                                  metavariable: $METHOD
+                                  regex: ^(get|filter|aget)$
+                      # get_object_or_404
+                      - pattern: get_object_or_404($MODEL, pk=$SINK, ...)
+                      - pattern: get_object_or_404($MODEL, id=$SINK, ...)
+                - metavariable-regex:
+                      metavariable: $MODEL
+                      regex: |
+                          (?x)(
+                              DashboardPrivilege
+                              |PersonalAPIKey
+                              |WebauthnCredential
+                          )$
+                - focus-metavariable: $SINK
+      pattern-sanitizers:
+          - pattern: $M.objects. ... .$METHOD(..., user=$U, ...)
+          - pattern: $M.objects. ... .$METHOD(..., user_id=$U, ...)
+          # get_object_or_404
+          - pattern: get_object_or_404($M, ..., user=$U, ...)
+          - pattern: get_object_or_404($M, ..., user_id=$U, ...)
+      metadata:
+          category: security
+          cwe: 'CWE-639: Authorization Bypass Through User-Controlled Key'
+          owasp: 'A01:2021 - Broken Access Control'
+          confidence: HIGH
+      paths:
+          exclude:
+              - '**/test*/**'
+              - '**/migrations/**'
+              - '**/management/**'
+              - '**/.semgrep/**'
+
+    # User-scoped model lookup rule
+    - id: idor-lookup-without-user
+      patterns:
+          - pattern-either:
+                - patterns:
+                      - pattern-either:
+                            - pattern: $MODEL.objects. ... .$METHOD(pk=$ID, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(id=$ID, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(pk__in=$IDS, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(id__in=$IDS, ...)
+                      - metavariable-regex:
+                            metavariable: $METHOD
+                            regex: ^(get|filter|aget)$
+                - patterns:
+                      - pattern: $MODEL.objects.$GOC(...)
+                      - metavariable-regex:
+                            metavariable: $GOC
+                            regex: ^(get_or_create|update_or_create|aget_or_create)$
+                # get_object_or_404
+                - pattern: get_object_or_404($MODEL, pk=$ID, ...)
+                - pattern: get_object_or_404($MODEL, id=$ID, ...)
+          - metavariable-regex:
+                metavariable: $MODEL
+                regex: |
+                    (?x)(
+                        DashboardPrivilege
+                        |PersonalAPIKey
+                        |WebauthnCredential
+                    )$
+          - pattern-not: $M.objects. ... .$METHOD2(..., user=$U, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., user_id=$U, ...)
+          # get_object_or_404
+          - pattern-not: get_object_or_404($M, ..., user=$U, ...)
+          - pattern-not: get_object_or_404($M, ..., user_id=$U, ...)
+          # Refetching an existing instance by its pk/id attribute
+          - pattern-not: $M.objects. ... .$METHOD2(pk=$X.pk, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(pk=$X.id, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(id=$X.pk, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(id=$X.id, ...)
+      message: |
+          IDOR risk: Lookup on user-scoped model without user filter.
+          Fix: Add user_id=user_id or user=user to the query.
+      languages: [python]
+      severity: WARNING
+      metadata:
+          category: security
+          cwe: 'CWE-639: Authorization Bypass Through User-Controlled Key'
+          confidence: MEDIUM
+          subcategory: audit
+      paths:
+          exclude:
+              - '**/test*/**'
+              - '**/migrations/**'
+              - '**/management/**'
+              - '**/.semgrep/**'
+              - '**/tasks/**'
+              - '**/temporal/**'
+              - '**/dags/**'
+              - '**/models/**'
+              - '**/signals.py'
+
+    # Composite user+team scoped model taint rule
+    - id: idor-taint-user-input-to-user-team-model
+      mode: taint
+      languages: [python]
+      severity: ERROR
+      message: |
+          IDOR: User input flows to user+team-scoped model lookup without both filters.
+          Fix: Add BOTH user= (or user_id=) AND team= (or team_id=) to the query.
+      pattern-sources:
+          - patterns:
+                - pattern-either:
+                      - pattern: $REQ.GET.get(...)
+                      - pattern: $REQ.POST.get(...)
+                      - pattern: $REQ.GET[...]
+                      - pattern: $REQ.POST[...]
+                      - pattern: $REQ.data.get(...)
+                      - pattern: $REQ.data[...]
+                      - pattern: $REQ.query_params.get(...)
+                      - pattern: $REQ.query_params[...]
+                      - pattern: $SER.validated_data.get(...)
+                      - pattern: $SER.validated_data[...]
+                      - pattern: kwargs.get(...)
+                      - pattern: kwargs[...]
+                      - pattern: self.kwargs.get(...)
+                      - pattern: self.kwargs[...]
+      pattern-sinks:
+          - patterns:
+                - pattern-either:
+                      - patterns:
+                            - pattern-either:
+                                  - pattern: $MODEL.objects. ... .$METHOD(pk=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(id=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(pk__in=$SINK, ...)
+                                  - pattern: $MODEL.objects. ... .$METHOD(id__in=$SINK, ...)
+                            - metavariable-regex:
+                                  metavariable: $METHOD
+                                  regex: ^(get|filter|aget)$
+                      # get_object_or_404
+                      - pattern: get_object_or_404($MODEL, pk=$SINK, ...)
+                      - pattern: get_object_or_404($MODEL, id=$SINK, ...)
+                - metavariable-regex:
+                      metavariable: $MODEL
+                      regex: |
+                          (?x)(
+                              AgentMemory
+                              |FileSystemShortcut
+                              |FileSystemViewLog
+                              |InsightViewed
+                              |KernelRuntime
+                              |PersistedFolder
+                              |SessionRecordingViewed
+                              |UserHomeSettings
+                              |UserProductList
+                              |UserScenePersonalisation
+                          )$
+                - focus-metavariable: $SINK
+      pattern-sanitizers:
+          # Must have BOTH user AND team filters (all orderings)
+          - pattern: $M.objects. ... .$METHOD(..., user=$U, ..., team=$T, ...)
+          - pattern: $M.objects. ... .$METHOD(..., user=$U, ..., team_id=$T, ...)
+          - pattern: $M.objects. ... .$METHOD(..., user_id=$U, ..., team=$T, ...)
+          - pattern: $M.objects. ... .$METHOD(..., user_id=$U, ..., team_id=$T, ...)
+          - pattern: $M.objects. ... .$METHOD(..., team=$T, ..., user=$U, ...)
+          - pattern: $M.objects. ... .$METHOD(..., team=$T, ..., user_id=$U, ...)
+          - pattern: $M.objects. ... .$METHOD(..., team_id=$T, ..., user=$U, ...)
+          - pattern: $M.objects. ... .$METHOD(..., team_id=$T, ..., user_id=$U, ...)
+          # get_object_or_404
+          - pattern: get_object_or_404($M, ..., user=$U, ..., team=$T, ...)
+          - pattern: get_object_or_404($M, ..., user=$U, ..., team_id=$T, ...)
+          - pattern: get_object_or_404($M, ..., user_id=$U, ..., team=$T, ...)
+          - pattern: get_object_or_404($M, ..., user_id=$U, ..., team_id=$T, ...)
+          - pattern: get_object_or_404($M, ..., team=$T, ..., user=$U, ...)
+          - pattern: get_object_or_404($M, ..., team=$T, ..., user_id=$U, ...)
+          - pattern: get_object_or_404($M, ..., team_id=$T, ..., user=$U, ...)
+          - pattern: get_object_or_404($M, ..., team_id=$T, ..., user_id=$U, ...)
+      metadata:
+          category: security
+          cwe: 'CWE-639: Authorization Bypass Through User-Controlled Key'
+          owasp: 'A01:2021 - Broken Access Control'
+          confidence: HIGH
+      paths:
+          exclude:
+              - '**/test*/**'
+              - '**/migrations/**'
+              - '**/management/**'
+              - '**/.semgrep/**'
+
+    # Composite user+team scoped model lookup rule
+    - id: idor-lookup-without-user-and-team
+      patterns:
+          - pattern-either:
+                - patterns:
+                      - pattern-either:
+                            - pattern: $MODEL.objects. ... .$METHOD(pk=$ID, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(id=$ID, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(pk__in=$IDS, ...)
+                            - pattern: $MODEL.objects. ... .$METHOD(id__in=$IDS, ...)
+                      - metavariable-regex:
+                            metavariable: $METHOD
+                            regex: ^(get|filter|aget)$
+                - patterns:
+                      - pattern: $MODEL.objects.$GOC(...)
+                      - metavariable-regex:
+                            metavariable: $GOC
+                            regex: ^(get_or_create|update_or_create|aget_or_create)$
+                # get_object_or_404
+                - pattern: get_object_or_404($MODEL, pk=$ID, ...)
+                - pattern: get_object_or_404($MODEL, id=$ID, ...)
+          - metavariable-regex:
+                metavariable: $MODEL
+                regex: |
+                    (?x)(
+                        AgentMemory
+                        |FileSystemShortcut
+                        |FileSystemViewLog
+                        |InsightViewed
+                        |KernelRuntime
+                        |PersistedFolder
+                        |SessionRecordingViewed
+                        |UserHomeSettings
+                        |UserProductList
+                        |UserScenePersonalisation
+                    )$
+          # Exclude when BOTH user AND team filters are present
+          - pattern-not: $M.objects. ... .$METHOD2(..., user=$U, ..., team=$T, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., user=$U, ..., team_id=$T, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., user_id=$U, ..., team=$T, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., user_id=$U, ..., team_id=$T, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., team=$T, ..., user=$U, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., team=$T, ..., user_id=$U, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., team_id=$T, ..., user=$U, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(..., team_id=$T, ..., user_id=$U, ...)
+          # get_object_or_404
+          - pattern-not: get_object_or_404($M, ..., user=$U, ..., team=$T, ...)
+          - pattern-not: get_object_or_404($M, ..., user=$U, ..., team_id=$T, ...)
+          - pattern-not: get_object_or_404($M, ..., user_id=$U, ..., team=$T, ...)
+          - pattern-not: get_object_or_404($M, ..., user_id=$U, ..., team_id=$T, ...)
+          - pattern-not: get_object_or_404($M, ..., team=$T, ..., user=$U, ...)
+          - pattern-not: get_object_or_404($M, ..., team=$T, ..., user_id=$U, ...)
+          - pattern-not: get_object_or_404($M, ..., team_id=$T, ..., user=$U, ...)
+          - pattern-not: get_object_or_404($M, ..., team_id=$T, ..., user_id=$U, ...)
+          # Refetching an existing instance by its pk/id attribute
+          - pattern-not: $M.objects. ... .$METHOD2(pk=$X.pk, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(pk=$X.id, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(id=$X.pk, ...)
+          - pattern-not: $M.objects. ... .$METHOD2(id=$X.id, ...)
+      message: |
+          IDOR risk: Lookup on user+team-scoped model without BOTH user AND team filters.
+          Fix: Add BOTH user_id= (or user=) AND team_id= (or team=) to the query.
+      languages: [python]
+      severity: WARNING
+      metadata:
+          category: security
+          cwe: 'CWE-639: Authorization Bypass Through User-Controlled Key'
+          confidence: MEDIUM
+          subcategory: audit
+      paths:
+          exclude:
+              - '**/test*/**'
+              - '**/migrations/**'
+              - '**/management/**'
+              - '**/.semgrep/**'
+              - '**/tasks/**'
+              - '**/temporal/**'
+              - '**/dags/**'
+              - '**/models/**'
+              - '**/signals.py'

--- a/ee/api/authentication.py
+++ b/ee/api/authentication.py
@@ -105,6 +105,7 @@ class MultitenantSAMLAuth(SAMLAuth):
             organization_domain = (
                 organization_domain_or_id
                 if isinstance(organization_domain_or_id, OrganizationDomain)
+                # nosemgrep: idor-lookup-without-org (pre-auth SAML flow, lookup by UUID on verified domains)
                 else OrganizationDomain.objects.verified_domains().get(id=organization_domain_or_id)
             )
         except (OrganizationDomain.DoesNotExist, DjangoValidationError):
@@ -246,6 +247,7 @@ class MultitenantSAMLAuth(SAMLAuth):
             raise AuthFailed(self, "Authentication request is invalid. Missing IdP identifier.")
 
         try:
+            # nosemgrep: idor-lookup-without-org (pre-auth SAML validation, UUID from IdP round-trip)
             organization_domain = OrganizationDomain.objects.verified_domains().get(id=idp_name)
         except (OrganizationDomain.DoesNotExist, DjangoValidationError):
             saml_logger.warning(

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -190,6 +190,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
 
     def _ensure_queue_access(self, request: Request, conversation_id: str) -> Response | None:
         try:
+            # nosemgrep: idor-lookup-without-team (instance scoped to team via get_queryset)
             conversation = Conversation.objects.get(id=conversation_id)
         except Conversation.DoesNotExist:
             return Response({"error": "Conversation not found"}, status=status.HTTP_404_NOT_FOUND)
@@ -320,6 +321,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
         if self.lookup_url_kwarg:
             self.kwargs[self.lookup_url_kwarg] = conversation_id
         try:
+            # nosemgrep: idor-lookup-without-team, idor-taint-user-input-to-model-get (user+team check immediately after)
             conversation = Conversation.objects.get(id=conversation_id)
             if conversation.user != request.user or conversation.team != self.team:
                 return Response(

--- a/ee/api/dashboard_collaborator.py
+++ b/ee/api/dashboard_collaborator.py
@@ -21,6 +21,7 @@ class CanEditDashboardCollaborator(BasePermission):
         if request.method in SAFE_METHODS:
             return True
         try:
+            # nosemgrep: idor-lookup-without-team (dashboard access validated by parent viewset)
             dashboard: Dashboard = Dashboard.objects.get(id=view.parents_query_dict["dashboard_id"])
         except Dashboard.DoesNotExist:
             raise exceptions.NotFound("Dashboard not found.")
@@ -101,6 +102,7 @@ class DashboardCollaboratorViewSet(
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
         try:
+            # nosemgrep: idor-lookup-without-team (dashboard access validated by parent viewset)
             context["dashboard"] = Dashboard.objects.get(id=context["dashboard_id"])
         except Dashboard.DoesNotExist:
             raise exceptions.NotFound("Dashboard not found.")

--- a/ee/api/rbac/role.py
+++ b/ee/api/rbac/role.py
@@ -101,6 +101,7 @@ class RoleMembershipSerializer(serializers.ModelSerializer):
         user_uuid = validated_data.pop("user_uuid")
 
         try:
+            # nosemgrep: idor-lookup-without-org (organization filter on next line)
             role = Role.objects.get(id=self.context["role_id"])
         except Role.DoesNotExist:
             raise serializers.ValidationError("Role does not exist.")

--- a/ee/api/scim/auth.py
+++ b/ee/api/scim/auth.py
@@ -49,6 +49,7 @@ class SCIMBearerTokenAuthentication(BaseAuthentication):
             raise exceptions.AuthenticationFailed("Invalid SCIM URL format")
 
         try:
+            # nosemgrep: idor-lookup-without-org (SCIM bearer token auth, domain_id is tenant identifier)
             domain = OrganizationDomain.objects.get(id=domain_id)
         except OrganizationDomain.DoesNotExist:
             raise exceptions.AuthenticationFailed("Invalid organization domain")

--- a/ee/api/scim/group.py
+++ b/ee/api/scim/group.py
@@ -129,6 +129,7 @@ class PostHogSCIMGroup(SCIMGroup):
                 ).first()
 
                 if org_membership:
+                    # nosemgrep: idor-lookup-without-org (SCIM bearer token auth, org gated by middleware)
                     RoleMembership.objects.get_or_create(
                         role=role, user=user, defaults={"organization_member": org_membership}
                     )
@@ -222,6 +223,7 @@ class PostHogSCIMGroup(SCIMGroup):
                             defaults={"level": OrganizationMembership.Level.MEMBER},
                         )
 
+                        # nosemgrep: idor-lookup-without-org (SCIM bearer token auth, org gated by middleware)
                         RoleMembership.objects.get_or_create(
                             role=self.obj, user=user, defaults={"organization_member": org_membership}
                         )

--- a/ee/hogai/chat_agent/slash_commands/commands/usage/queries.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/usage/queries.py
@@ -110,6 +110,7 @@ def get_ga_launch_date() -> datetime:
 def get_conversation_start_time(conversation_id: UUID) -> Optional[datetime]:
     """Get the start time of a conversation."""
     try:
+        # nosemgrep: idor-lookup-without-team (internal AI pipeline, IDs from team-scoped context)
         conversation = Conversation.objects.get(id=conversation_id)
         return conversation.created_at
     except Conversation.DoesNotExist:

--- a/ee/hogai/core/executor.py
+++ b/ee/hogai/core/executor.py
@@ -219,6 +219,7 @@ class AgentExecutor:
         if isinstance(message.event, MessageEvent):
             return (AssistantEventType.MESSAGE, message.event.payload)
         elif isinstance(message.event, ConversationEvent):
+            # nosemgrep: idor-lookup-without-team (ID from internal Redis stream, caller validates user+team ownership)
             conversation = await Conversation.objects.select_related("user").aget(id=message.event.payload)
             return (AssistantEventType.CONVERSATION, conversation)
         elif isinstance(message.event, UpdateEvent):

--- a/ee/hogai/django_checkpoint/checkpointer.py
+++ b/ee/hogai/django_checkpoint/checkpointer.py
@@ -250,6 +250,7 @@ class DjangoCheckpointer(BaseCheckpointSaver[str]):
         }
 
         with transaction.atomic():
+            # nosemgrep: idor-lookup-without-team (internal LangGraph checkpoint)
             updated_checkpoint, _ = ConversationCheckpoint.objects.update_or_create(
                 id=checkpoint["id"],
                 thread_id=thread_id,
@@ -315,6 +316,7 @@ class DjangoCheckpointer(BaseCheckpointSaver[str]):
             # `put_writes` and `put` are concurrently called without guaranteeing the call order
             # so we need to ensure the checkpoint is created before creating writes.
             # Thread.lock() will prevent race conditions though to the same checkpoints within a single pod.
+            # nosemgrep: idor-lookup-without-team (internal LangGraph checkpoint)
             checkpoint, _ = ConversationCheckpoint.objects.get_or_create(
                 id=checkpoint_id, thread_id=thread_id, checkpoint_ns=checkpoint_ns
             )

--- a/ee/hogai/eval/ci/eval_surveys.py
+++ b/ee/hogai/eval/ci/eval_surveys.py
@@ -146,6 +146,7 @@ async def eval_surveys(pytestconfig, demo_org_team_user):
 
         # Check if survey was created
         if artifact and "survey_id" in artifact:
+            # nosemgrep: idor-lookup-without-team (CI eval script, IDs from test fixtures)
             survey_exists = await Survey.objects.filter(id=artifact["survey_id"], archived=False).aexists()
             result["survey_created"] = survey_exists
             result["survey_id"] = artifact["survey_id"]
@@ -153,6 +154,7 @@ async def eval_surveys(pytestconfig, demo_org_team_user):
 
             # Fetch the created survey for detailed checks
             if survey_exists:
+                # nosemgrep: idor-lookup-without-team (CI eval script, IDs from test fixtures)
                 survey = await Survey.objects.aget(id=artifact["survey_id"])
                 result["question_count"] = len(survey.questions) if survey.questions else 0
                 result["is_launched"] = survey.start_date is not None

--- a/ee/hogai/tools/manage_memories.py
+++ b/ee/hogai/tools/manage_memories.py
@@ -238,6 +238,7 @@ class ManageMemoriesTool(MaxTool):
         @database_sync_to_async
         def update():
             try:
+                # nosemgrep: idor-lookup-without-user-and-team (team-scoped shared memory, not per-user)
                 memory = AgentMemory.objects.get(id=memory_id, team=self._team)
             except AgentMemory.DoesNotExist:
                 return None
@@ -266,6 +267,7 @@ class ManageMemoriesTool(MaxTool):
         @database_sync_to_async
         def delete():
             try:
+                # nosemgrep: idor-lookup-without-user-and-team (team-scoped shared memory, not per-user)
                 memory = AgentMemory.objects.get(id=memory_id, team=self._team)
             except AgentMemory.DoesNotExist:
                 return None

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -311,6 +311,7 @@ class UpsertDashboardTool(MaxTool):
             t.id for t in all_tiles if t.id not in active_tile_ids and not t.deleted and t.insight_id is not None
         ]
         if tiles_to_delete:
+            # nosemgrep: idor-lookup-without-team
             DashboardTile.objects.filter(id__in=tiles_to_delete).update(deleted=True)
 
         # 4. Update coordinates based on insight_ids order, keeping original sizes

--- a/ee/hogai/videos/session_moments.py
+++ b/ee/hogai/videos/session_moments.py
@@ -128,6 +128,7 @@ class SessionMomentsLLMAnalyzer:
             logger.exception(exception_message)
             # Remove all the generated videos to not bloat the database
             asset_ids = list(moment_to_asset_id.values())
+            # nosemgrep: idor-lookup-without-team (internal AI pipeline, IDs from team-scoped context)
             await ExportedAsset.objects.filter(id__in=asset_ids).adelete()
             raise Exception(exception_message)
         return moment_to_asset_id
@@ -187,6 +188,7 @@ class SessionMomentsLLMAnalyzer:
         try:
             content: bytes | None = None
             # Fetch the asset from the database
+            # nosemgrep: idor-lookup-without-team (asset_id from internal _export_moment_video, not user input)
             asset = await ExportedAsset.objects.aget(id=asset_id)
             # Get content from either database or object storage
             if asset.content:
@@ -249,6 +251,7 @@ class SessionMomentsLLMAnalyzer:
             )
             # If the LLM validation fails - ensure to remove the generated video to not bloat the database,
             # as it would be linked to the summary (to reuse) only after the LLM video validation is completed
+            # nosemgrep: idor-lookup-without-team (internal AI pipeline, IDs from team-scoped context)
             await ExportedAsset.objects.filter(id=asset_id).adelete()
             return err  # Let caller handle the error
 

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -157,6 +157,7 @@ class VercelIntegration:
     @staticmethod
     def _get_resource(resource_id: str) -> Integration:
         try:
+            # nosemgrep: idor-lookup-without-team (Vercel integration auth validates ownership)
             return Integration.objects.get(pk=resource_id, kind=Integration.IntegrationKind.VERCEL)
         except Integration.DoesNotExist:
             raise exceptions.NotFound("Resource not found")
@@ -1197,6 +1198,7 @@ class VercelIntegration:
 
     @staticmethod
     def set_active_project(user: User, resource_id: str):
+        # nosemgrep: idor-lookup-without-team (Vercel integration auth validates ownership)
         resource = Integration.objects.filter(pk=resource_id, kind=Integration.IntegrationKind.VERCEL).first()
         if not resource:
             raise exceptions.NotFound(f"Vercel resource not found: {resource_id}")

--- a/posthog/admin/admins/experiment_admin.py
+++ b/posthog/admin/admins/experiment_admin.py
@@ -142,6 +142,7 @@ class ExperimentAdmin(admin.ModelAdmin):
     def migrate_experiment(self, request, object_id):
         try:
             with transaction.atomic():
+                # nosemgrep: idor-lookup-without-team (Django admin, staff-only)
                 original = Experiment.objects.select_for_update().get(pk=object_id)
 
                 if original.stats_config and original.stats_config.get("migrated_to"):
@@ -192,6 +193,7 @@ class ExperimentAdmin(admin.ModelAdmin):
                     # if is legacy, get the migrated metric, otherwise, keep the id from the original experiment
                     metric_id = metric.metadata["migrated_to"] if is_legacy else metric.id
 
+                    # nosemgrep: idor-lookup-without-team (admin-only, staff access required)
                     saved_metric = ExperimentSavedMetric.objects.get(id=metric_id)
 
                     # Create the new through object with the same metadata

--- a/posthog/admin/admins/experiment_saved_metric_admin.py
+++ b/posthog/admin/admins/experiment_saved_metric_admin.py
@@ -78,6 +78,7 @@ class ExperimentSavedMetricAdmin(admin.ModelAdmin):
     def migrate_metric(self, request, object_id):
         try:
             with transaction.atomic():
+                # nosemgrep: idor-lookup-without-team (Django admin, staff-only)
                 original = ExperimentSavedMetric.objects.select_for_update().get(pk=object_id)
 
                 if original.metadata and original.metadata.get("migrated_to"):

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -241,6 +241,7 @@ class AlertSerializer(serializers.ModelSerializer):
         if subscribed_users is not None:
             AlertSubscription.objects.filter(alert_configuration=instance).exclude(user__in=subscribed_users).delete()
             for user in subscribed_users:
+                # nosemgrep: idor-lookup-without-team (user team membership validated by viewset)
                 AlertSubscription.objects.get_or_create(
                     user=user, alert_configuration=instance, defaults={"created_by": self.context["request"].user}
                 )

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1310,6 +1310,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
             # Using to_dict() here serializer.save() was changing the instance in memory,
             # so we need to get the before state in a "detached" manner that won't be
             # affected by the serializer.save() call.
+            # nosemgrep: idor-lookup-without-team (ID from already team-scoped instance)
             before_update = Cohort.objects.get(pk=instance_id).to_dict()
         except Cohort.DoesNotExist:
             before_update = {}

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -472,6 +472,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
 
         duplicate_tiles = initial_data.pop("duplicate_tiles", [])
         for tile_data in duplicate_tiles:
+            # nosemgrep: idor-lookup-without-team (scoped via parent viewset get_queryset)
             existing_tile = DashboardTile.objects.get(dashboard=instance, id=tile_data["id"])
             existing_tile.layouts = tile_data.get("layouts", {})
             self._deep_duplicate_tiles(instance, existing_tile)
@@ -546,6 +547,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             )
 
             if insight_ids_to_delete:
+                # nosemgrep: idor-lookup-without-team
                 Insight.objects.filter(id__in=insight_ids_to_delete).update(deleted=True)
 
         DashboardTile.objects_including_soft_deleted.filter(dashboard__id=instance.id).update(deleted=True)
@@ -695,6 +697,7 @@ class DashboardsViewSet(
                     "caching_states",
                     Prefetch(
                         "insight__dashboards",
+                        # nosemgrep: idor-lookup-without-team (scoped via prefetch on team-scoped queryset)
                         queryset=Dashboard.objects.filter(
                             id__in=DashboardTile.objects.values_list("dashboard_id", flat=True)
                         ),

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -251,6 +251,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
         dashboard_id = instance.dashboard_id
         if insight_id and not dashboard_id:  # we don't log dashboard activity ¯\_(ツ)_/¯
             try:
+                # nosemgrep: idor-lookup-without-team (insight_id validated as team-owned in validate())
                 insight: Insight = Insight.objects.select_related("team__organization").get(id=insight_id)
                 log_activity(
                     organization_id=insight.team.organization.id,

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -559,6 +559,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         self._retroactively_fix_folders_and_depth(cast(User, request.user))
 
         if self.user_access_control:
+            # nosemgrep: idor-lookup-without-team, idor-taint-user-input-to-model-get (IDs from prior team-scoped query)
             qs = FileSystem.objects.filter(id__in=[f.id for f in files])
             qs = self.user_access_control.filter_and_annotate_file_system_queryset(qs)
             file_count = qs.count()

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -337,6 +337,7 @@ class HogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, vie
         instance_id = serializer.instance.id
 
         try:
+            # nosemgrep: idor-lookup-without-team (re-fetch of already-authorized instance for activity logging)
             before_update = HogFlow.objects.get(pk=instance_id)
         except HogFlow.DoesNotExist:
             before_update = None

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -518,6 +518,7 @@ class HogFunctionViewSet(
         instance_id = serializer.instance.id
 
         try:
+            # nosemgrep: idor-lookup-without-team (ID from already team-scoped instance)
             before_update = HogFunction.objects.get(pk=instance_id)
         except HogFunction.DoesNotExist:
             before_update = None

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -469,6 +469,7 @@ class InsightSerializer(InsightBasicSerializer):
         InsightViewed.objects.create(team_id=team_id, user=request.user, insight=insight, last_viewed_at=now())
 
         if dashboards is not None:
+            # nosemgrep: idor-lookup-without-team
             for dashboard in Dashboard.objects.filter(id__in=[d.id for d in dashboards]).all():
                 if dashboard.team != insight.team:
                     raise serializers.ValidationError("Dashboard not found")
@@ -611,6 +612,7 @@ class InsightSerializer(InsightBasicSerializer):
 
         ids_to_add = [id for id in new_dashboard_ids if id not in old_dashboard_ids]
         ids_to_remove = [id for id in old_dashboard_ids if id not in new_dashboard_ids]
+        # nosemgrep: idor-lookup-without-team (team check after lookup)
         candidate_dashboards = Dashboard.objects.filter(id__in=ids_to_add)
         dashboard: Dashboard
         for dashboard in candidate_dashboards:
@@ -633,6 +635,7 @@ class InsightSerializer(InsightBasicSerializer):
 
         if ids_to_remove:
             # Check permission before removing insight from dashboards
+            # nosemgrep: idor-lookup-without-team (team check after lookup)
             dashboards_to_remove = Dashboard.objects.filter(id__in=ids_to_remove)
             for dashboard in dashboards_to_remove:
                 if (

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -722,6 +722,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         person = get_pk_or_uuid(self.get_queryset(), request.GET["person_id"]).get()
         cohort_ids = get_all_cohort_ids_by_person_uuid(person.uuid, team.pk)
 
+        # nosemgrep: idor-lookup-without-team, idor-taint-user-input-to-model-get (IDs from team-scoped ClickHouse query)
         cohorts = Cohort.objects.filter(pk__in=cohort_ids, deleted=False)
 
         return response.Response({"results": CohortMinimalSerializer(cohorts, many=True).data})

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -331,6 +331,7 @@ class PluginViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             # Modifying our underyling permissions system too much.
             try:
                 lookup_value = self.kwargs.get(self.lookup_field)
+                # nosemgrep: idor-lookup-without-org, idor-taint-user-input-to-org-model (permission check only; returns NotFound for non-global plugins)
                 obj = Plugin.objects.get(pk=lookup_value)
                 if obj.is_global:
                     return [IsAuthenticated(), APIScopePermission(), PluginsAccessLevelPermission()]

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -305,6 +305,7 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" 
             assert team.project is not None
             return team.project
         try:
+            # nosemgrep: idor-lookup-without-org (routing validates org access via permissions)
             return Project.objects.get(id=self.project_id)
         except (Project.DoesNotExist, ValueError):
             raise NotFound(detail="Project not found.")

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -375,6 +375,7 @@ class InviteSignupSerializer(serializers.Serializer):
         invite_id = self.context["view"].kwargs.get("invite_id")
 
         try:
+            # nosemgrep: idor-lookup-without-org, idor-taint-user-input-to-org-model (invite UUID serves as auth token)
             invite: OrganizationInvite = OrganizationInvite.objects.select_related("organization").get(id=invite_id)
         except OrganizationInvite.DoesNotExist:
             raise serializers.ValidationError("The provided invite ID is not valid.")
@@ -503,6 +504,7 @@ class InviteSignupViewset(generics.CreateAPIView):
             raise exceptions.ValidationError("Please provide an invite ID to continue.")
 
         try:
+            # nosemgrep: idor-lookup-without-org, idor-taint-user-input-to-org-model (invite UUID serves as auth token)
             invite: OrganizationInvite = OrganizationInvite.objects.get(id=invite_id)
         except (OrganizationInvite.DoesNotExist, ValidationError):
             raise serializers.ValidationError("The provided invite ID is not valid.")
@@ -602,6 +604,7 @@ class CompanyNameForm(forms.Form):
 
 
 def lookup_invite_for_saml(email: str, organization_domain_id: str) -> Optional[OrganizationInvite]:
+    # nosemgrep: idor-lookup-without-org (ID from SAML response)
     organization_domain = OrganizationDomain.objects.get(id=organization_domain_id)
     if not organization_domain:
         return None
@@ -616,6 +619,7 @@ def process_social_invite_signup(
     strategy: DjangoStrategy, invite_id: str, email: str, full_name: str, user: Optional[User] = None
 ) -> User:
     try:
+        # nosemgrep: idor-lookup-without-org (invite UUID from server session serves as auth token)
         invite: Union[OrganizationInvite, TeamInviteSurrogate] = OrganizationInvite.objects.select_related(
             "organization"
         ).get(id=invite_id)

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -2077,6 +2077,7 @@ def public_survey_page(request, survey_id: str):
 
     # Database query with minimal fields and timeout protection
     try:
+        # nosemgrep: idor-lookup-without-team (public survey page, intentionally unauthenticated)
         survey = Survey.objects.select_related("team").get(id=survey_id)
     except Survey.DoesNotExist:
         logger.info("survey_page_not_found", survey_id=survey_id)

--- a/posthog/api/uploaded_media.py
+++ b/posthog/api/uploaded_media.py
@@ -60,6 +60,7 @@ def download(request, *args, **kwargs) -> HttpResponse:
     """
     instance: Optional[UploadedMedia] = None
     try:
+        # nosemgrep: idor-lookup-without-team, idor-taint-user-input-to-model-get (intentionally public endpoint)
         instance = UploadedMedia.objects.get(pk=kwargs["image_uuid"])
     except UploadedMedia.DoesNotExist:
         return HttpResponse(status=404)

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -337,6 +337,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
             raise serializers.ValidationError({"hash": ["This hash is invalid or has expired."]}, code="invalid_hash")
 
         try:
+            # nosemgrep: idor-lookup-without-org, idor-taint-user-input-to-org-model (permission check after lookup)
             project = Project.objects.get(id=project_id)
 
             # Verify user has access to this project

--- a/posthog/approvals/actions/feature_flags.py
+++ b/posthog/approvals/actions/feature_flags.py
@@ -104,6 +104,7 @@ class FeatureFlagActionBase(BaseAction):
     @classmethod
     def apply(cls, validated_intent: dict[str, Any], user, context: Optional[dict[str, Any]] = None) -> FeatureFlag:
         with transaction.atomic():
+            # nosemgrep: idor-lookup-without-team (flag_id from validated change request intent, originally team-scoped)
             flag = FeatureFlag.objects.select_for_update().get(id=validated_intent["flag_id"])
 
             if flag.version != validated_intent["preconditions"]["version"]:
@@ -382,6 +383,7 @@ class UpdateFeatureFlagAction(BaseAction):
     @classmethod
     def apply(cls, validated_intent: dict[str, Any], user, context: Optional[dict[str, Any]] = None) -> FeatureFlag:
         with transaction.atomic():
+            # nosemgrep: idor-lookup-without-team (flag_id from validated change request intent, originally team-scoped)
             flag = FeatureFlag.objects.select_for_update().get(id=validated_intent["flag_id"])
 
             if flag.version != validated_intent["preconditions"]["version"]:

--- a/posthog/approvals/models.py
+++ b/posthog/approvals/models.py
@@ -197,6 +197,7 @@ class ApprovalPolicy(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
         except ImportError:
             pass
         else:
+            # nosemgrep: idor-lookup-without-org (org validation after lookup)
             roles = Role.objects.filter(id__in=role_ids)
             invalid_roles = [r for r in roles if r.organization_id != self.organization_id]
             if invalid_roles:

--- a/posthog/approvals/serializers.py
+++ b/posthog/approvals/serializers.py
@@ -201,6 +201,7 @@ class ApprovalPolicySerializer(serializers.ModelSerializer):
             # Create: get organization from view
             organization_id = self.context["view"].organization.id
 
+        # nosemgrep: idor-lookup-without-org (org validation after lookup)
         roles = Role.objects.filter(id__in=value)
 
         # Check all submitted IDs exist

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -410,6 +410,7 @@ def pause_batch_export(temporal: Client, batch_export_id: str, note: str | None 
         `True` if the batch export was paused, `False` if it was already paused.
     """
     try:
+        # nosemgrep: idor-lookup-without-team (internal service, team_id passed as parameter)
         batch_export = BatchExport.objects.get(id=batch_export_id)
     except BatchExport.DoesNotExist:
         raise BatchExportIdError(batch_export_id)
@@ -438,6 +439,7 @@ async def apause_batch_export(temporal: Client, batch_export_id: str, note: str 
         `True` if the batch export was paused, `False` if it was already paused.
     """
     try:
+        # nosemgrep: idor-lookup-without-team (internal service called from Temporal, not user-facing)
         batch_export = await BatchExport.objects.aget(id=batch_export_id)
     except BatchExport.DoesNotExist:
         raise BatchExportIdError(batch_export_id)
@@ -478,6 +480,7 @@ def unpause_batch_export(
         BatchExportIdError: If the provided batch_export_id doesn't point to an existing BatchExport.
     """
     try:
+        # nosemgrep: idor-lookup-without-team (internal service, team_id passed as parameter)
         batch_export = BatchExport.objects.get(id=batch_export_id)
     except BatchExport.DoesNotExist:
         raise BatchExportIdError(batch_export_id)
@@ -730,6 +733,7 @@ def update_batch_export_run(
     Arguments:
         run_id: The id of the BatchExportRun to update.
     """
+    # nosemgrep: idor-lookup-without-team (internal service, team_id passed as parameter)
     model = BatchExportRun.objects.filter(id=run_id)
     update_at = dt.datetime.now(dt.UTC)
 
@@ -753,6 +757,7 @@ async def aupdate_batch_export_run(
     Arguments:
         run_id: The id of the BatchExportRun to update.
     """
+    # nosemgrep: idor-lookup-without-team (internal service, team_id passed as parameter)
     model = BatchExportRun.objects.filter(id=run_id)
     update_at = dt.datetime.now(dt.UTC)
 
@@ -770,6 +775,7 @@ async def aupdate_batch_export_run(
 def count_failed_batch_export_runs(batch_export_id: UUID, last_n: int) -> int:
     """Count failed batch export runs in the 'last_n' runs."""
     count_of_failures = (
+        # nosemgrep: idor-lookup-without-team (internal service, team_id passed as parameter)
         BatchExportRun.objects.filter(
             id__in=BatchExportRun.objects.filter(batch_export_id=batch_export_id)
             .order_by("-last_updated_at")
@@ -785,6 +791,7 @@ def count_failed_batch_export_runs(batch_export_id: UUID, last_n: int) -> int:
 async def acount_failed_batch_export_runs(batch_export_id: UUID, last_n: int) -> int:
     """Count failed batch export runs in the 'last_n' runs."""
     count_of_failures = (
+        # nosemgrep: idor-lookup-without-team (internal service, team_id passed as parameter)
         await BatchExportRun.objects.filter(
             id__in=BatchExportRun.objects.filter(batch_export_id=batch_export_id)
             .order_by("-last_updated_at")
@@ -985,6 +992,7 @@ def update_batch_export_backfill_status(
         status: The new status to assign to the BatchExportBackfill.
         finished_at: The time the BatchExportBackfill finished.
     """
+    # nosemgrep: idor-lookup-without-team (internal service, team_id passed as parameter)
     model = BatchExportBackfill.objects.filter(id=backfill_id)
     updated = model.update(status=status, finished_at=finished_at)
 

--- a/posthog/caching/insight_cache.py
+++ b/posthog/caching/insight_cache.py
@@ -40,6 +40,7 @@ CACHE_UPDATE_SHARED_GAUGE = Gauge(
 
 
 def update_cache(caching_state_id: UUID):
+    # nosemgrep: idor-lookup-without-team (Celery task, ID from internal scheduling)
     caching_state = InsightCachingState.objects.get(pk=caching_state_id)
 
     if caching_state.target_cache_age_seconds is None or (
@@ -110,6 +111,7 @@ def update_cache(caching_state_id: UUID):
         if caching_state.refresh_attempt < MAX_ATTEMPTS:
             update_cache_task.apply_async(args=[caching_state_id], countdown=timedelta(minutes=10).total_seconds())
 
+        # nosemgrep: idor-lookup-without-team (Celery task, ID from internal scheduling)
         InsightCachingState.objects.filter(pk=caching_state.pk).update(
             refresh_attempt=caching_state.refresh_attempt + 1,
             last_refresh_queued_at=now(),

--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -198,6 +198,7 @@ def schedule_warming_for_teams_task():
 )
 def warm_insight_cache_task(insight_id: int, dashboard_id: Optional[int]):
     try:
+        # nosemgrep: idor-lookup-without-team (Celery task, ID from internal scheduling)
         insight = Insight.objects.get(pk=insight_id)
     except Insight.DoesNotExist:
         logger.info(f"Warming insight cache failed 404 insight not found: {insight_id}")

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -123,6 +123,7 @@ def compile_filters_expr(filters: Optional[dict], team: Team, actions: Optional[
 
     if actions is None:
         # If not provided as an optimization we fetch all actions
+        # nosemgrep: idor-lookup-without-team (already scoped by team__project_id)
         actions_list = (
             Action.objects.select_related("team")
             .filter(team__project_id=team.project_id)

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -133,6 +133,7 @@ def migrate_batch(legacy_plugins: Any, kind: str, test_mode: bool, dry_run: bool
         if not test_mode:
             print("Disabling old plugins")  # noqa: T201
             # Disable the old plugins
+            # nosemgrep: idor-lookup-without-team (internal migration; IDs from prior team-scoped query)
             PluginConfig.objects.filter(id__in=[plugin_config["id"] for plugin_config in legacy_plugins]).update(
                 enabled=False
             )
@@ -171,6 +172,7 @@ def migrate_legacy_plugins(
 
     for i in range(0, len(legacy_plugin_ids), batch_size):
         batch = legacy_plugin_ids[i : i + batch_size]
+        # nosemgrep: idor-lookup-without-team (internal migration; IDs from prior team-scoped query)
         legacy_plugins = PluginConfig.objects.values(
             "id",
             "config",

--- a/posthog/cdp/templates/helpers.py
+++ b/posthog/cdp/templates/helpers.py
@@ -197,6 +197,7 @@ class BaseSiteDestinationFunctionTest(APIBaseTest):
             function_id = response.json()["id"]
 
             # load from the DB based on the created ID
+            # nosemgrep: idor-lookup-without-team (test helper only)
             hog_function = HogFunction.objects.get(id=function_id)
 
             return get_transpiled_function(hog_function)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -242,6 +242,7 @@ class AutoProjectMiddleware:
             if path_parts[0] == "dashboard":
                 dashboard_id = path_parts[1]
                 if dashboard_id.isnumeric():
+                    # nosemgrep: idor-lookup-without-team (permission check via middleware prevents access)
                     return Dashboard.objects.filter(deleted=False, id=dashboard_id)
             elif path_parts[0] == "insights":
                 insight_short_id = path_parts[1]
@@ -252,14 +253,17 @@ class AutoProjectMiddleware:
             elif path_parts[0] == "feature_flags":
                 feature_flag_id = path_parts[1]
                 if feature_flag_id.isnumeric():
+                    # nosemgrep: idor-lookup-without-team (permission check via middleware prevents access)
                     return FeatureFlag.objects.filter(deleted=False, id=feature_flag_id)
             elif path_parts[0] == "action":
                 action_id = path_parts[1]
                 if action_id.isnumeric():
+                    # nosemgrep: idor-lookup-without-team (permission check via middleware prevents access)
                     return Action.objects.filter(deleted=False, id=action_id)
             elif path_parts[0] == "cohorts":
                 cohort_id = path_parts[1]
                 if cohort_id.isnumeric():
+                    # nosemgrep: idor-lookup-without-team (permission check via middleware prevents access)
                     return Cohort.objects.filter(deleted=False, id=cohort_id)
         return None
 

--- a/posthog/plugins/site.py
+++ b/posthog/plugins/site.py
@@ -36,6 +36,7 @@ def get_transpiled_site_source(id: int, token: str) -> Optional[WebJsSource]:
     from posthog.models import PluginConfig, PluginSourceFile
 
     response = (
+        # nosemgrep: idor-lookup-without-team (token-based auth; web_token acts as secret access key)
         PluginConfig.objects.filter(
             id=id,
             web_token=token,

--- a/posthog/queries/funnels/funnel_trends.py
+++ b/posthog/queries/funnels/funnel_trends.py
@@ -186,6 +186,7 @@ class ClickhouseFunnelTrends(ClickhouseFunnelBase):
                 ):
                     serialized_result.update({"breakdown_value": (period_row[-1])})
                 else:
+                    # nosemgrep: idor-lookup-without-team (ID from team-scoped ClickHouse result)
                     serialized_result.update({"breakdown_value": Cohort.objects.get(pk=period_row[-1]).name})
 
             summary.append(serialized_result)

--- a/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -401,6 +401,7 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
     query: RecordingsQuery | None = None
     try:
         with REPLAY_PLAYLIST_COUNT_TIMER.time():
+            # nosemgrep: idor-lookup-without-team (Celery task, ID from internal scheduling)
             playlist = SessionRecordingPlaylist.objects.get(id=playlist_id)
             redis_client = get_client()
 

--- a/posthog/session_recordings/session_recording_playlist_api.py
+++ b/posthog/session_recordings/session_recording_playlist_api.py
@@ -602,6 +602,7 @@ class SessionRecordingPlaylistViewSet(
                 team=self.team,
                 defaults={"deleted": False},
             )
+            # nosemgrep: idor-lookup-without-team (scoped via DRF parent viewset)
             playlist_item, created = SessionRecordingPlaylistItem.objects.get_or_create(
                 playlist=playlist, recording=recording
             )
@@ -652,6 +653,7 @@ class SessionRecordingPlaylistViewSet(
                     team=self.team,
                     defaults={"deleted": False},
                 )
+                # nosemgrep: idor-lookup-without-team (scoped via DRF parent viewset)
                 playlist_item, created = SessionRecordingPlaylistItem.objects.get_or_create(
                     playlist=playlist, recording=recording
                 )

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -157,6 +157,7 @@ class UserPermissions:
             return None
 
         dashboard_ids = {tile.dashboard_id for tile in self._tiles}
+        # nosemgrep: idor-lookup-without-team (IDs from internal FK query)
         return list(Dashboard.objects.filter(pk__in=dashboard_ids))
 
     def reset_insights_dashboard_cached_results(self):
@@ -345,6 +346,7 @@ class UserInsightPermissions:
         dashboard_ids = set(
             DashboardTile.objects.filter(insight=self.insight.pk).values_list("dashboard_id", flat=True)
         )
+        # nosemgrep: idor-lookup-without-team (IDs from internal FK query)
         return list(Dashboard.objects.filter(pk__in=dashboard_ids))
 
 

--- a/products/customer_analytics/backend/api/test_views.py
+++ b/products/customer_analytics/backend/api/test_views.py
@@ -38,6 +38,7 @@ class TestCustomerProfileConfigViewSet(APIBaseTest):
         self.assertIn("created_at", response_data)
         self.assertIn("updated_at", response_data)
 
+        # nosemgrep: idor-lookup-without-team (test assertion)
         config = CustomerProfileConfig.objects.get(id=response_data["id"])
         self.assertEqual(config.scope, "person", "Should persist data")
         self.assertEqual(config.team, self.team)

--- a/products/data_modeling/backend/api/node.py
+++ b/products/data_modeling/backend/api/node.py
@@ -179,6 +179,7 @@ class NodeViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             workflow_id = f"execute-dag-{node.dag_id}-{uuid4()}"
         else:
             saved_query_ids = list(
+                # nosemgrep: idor-lookup-without-team (node_ids from prior team-scoped graph traversal)
                 Node.objects.filter(
                     id__in=node_ids,
                     saved_query_id__isnull=False,

--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -617,6 +617,7 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                 .values_list("id", flat=True)
             )
 
+            # nosemgrep: idor-lookup-without-team (IDs from team-scoped queryset)
             failed_runs = BatchExportRun.objects.filter(
                 id__in=latest_run_ids,
                 status__in=[

--- a/products/data_warehouse/backend/api/saved_query_draft.py
+++ b/products/data_warehouse/backend/api/saved_query_draft.py
@@ -34,6 +34,7 @@ class DataWarehouseSavedQueryDraftSerializer(serializers.ModelSerializer):
                 team_id=validated_data["team_id"],
                 created_by=validated_data["created_by"],
             ).count()
+            # nosemgrep: idor-lookup-without-team (internal endpoint; only reads name for draft naming)
             saved_query = DataWarehouseSavedQuery.objects.get(id=saved_query_id)
             name = f"({count + 1}) {saved_query.name}"
 

--- a/products/data_warehouse/backend/data_load/create_table.py
+++ b/products/data_warehouse/backend/data_load/create_table.py
@@ -56,6 +56,7 @@ async def create_table_from_saved_query(
     saved_query_id_converted = str(uuid.UUID(saved_query_id))
     saved_query = await aget_saved_query_by_id(saved_query_id=saved_query_id_converted, team_id=team_id)
 
+    # nosemgrep: idor-lookup-without-team (internal Temporal activity, not API-exposed)
     job = await DataModelingJob.objects.aget(id=job_id)
 
     try:

--- a/products/data_warehouse/backend/data_load/source_templates.py
+++ b/products/data_warehouse/backend/data_load/source_templates.py
@@ -61,6 +61,7 @@ def create_warehouse_templates_for_source(team_id: int, run_id: str) -> None:
     logger = LOGGER.bind(team_id=team_id)
     close_old_connections()
 
+    # nosemgrep: idor-lookup-without-team (internal Temporal activity, not API-exposed)
     job: ExternalDataJob = ExternalDataJob.objects.get(pk=run_id)
     last_successful_job: ExternalDataJob | None = (
         ExternalDataJob.objects.filter(

--- a/products/error_tracking/backend/api/issues.py
+++ b/products/error_tracking/backend/api/issues.py
@@ -185,6 +185,7 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
 
         try:
             ## Upsert cohort_id as a cohort might have been soft deleted
+            # nosemgrep: idor-lookup-without-team (cohort scoped to team before use)
             _ = ErrorTrackingIssueCohort.objects.update_or_create(issue=issue, defaults={"cohort_id": cohort.id})
         except Exception as e:
             posthoganalytics.capture_exception(
@@ -297,6 +298,7 @@ def assign_issue(issue: ErrorTrackingIssue, assignee, organization, user, team_i
             if not Role.objects.filter(id=assignee["id"], organization=organization).exists():
                 raise ValidationError("Assignee role does not belong to this organization.")
 
+        # nosemgrep: idor-lookup-without-team (assignee validated against org above)
         assignment_after, _ = ErrorTrackingIssueAssignment.objects.update_or_create(
             issue_id=issue.id,
             defaults={

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -46,6 +46,7 @@ class SlackThreadHandler:
 
     def _get_integration(self) -> Integration:
         if self._integration is None:
+            # nosemgrep: idor-lookup-without-team (internal context, ID from Slack event mapping)
             self._integration = Integration.objects.get(id=self.context.integration_id)
         return self._integration
 


### PR DESCRIPTION
These semgrep rules flag model queries that lack an appropriate ownership check. For ex, `Experiment` is owned by a team and should always include a `team` or `team_id` when queried. `Experiment` queries that don't include a team will generate a semgrep error.