### PR TITLE
feat(experiments): merge breakdowns from saved metric metadata.

### DIFF
--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -868,7 +868,7 @@ export function initializeMetricOrdering(experiment: Experiment): Experiment {
  * Maps metrics to their results and errors in the correct display order
  * This handles the complex logic of:
  * 1. Mapping results by index to original metrics array (including shared metrics)
- * 2. Enriching shared metrics with metadata
+ * 2. Enriching shared metrics with metadata, including breakdowns
  * 3. Reordering everything according to the ordered UUIDs
  */
 export function getOrderedMetricsWithResults(
@@ -901,6 +901,11 @@ export function getOrderedMetricsWithResults(
             name: sharedMetric.name,
             sharedMetricId: sharedMetric.saved_metric,
             isSharedMetric: true,
+            // Merge breakdowns from metadata into breakdownFilter
+            breakdownFilter: {
+                ...sharedMetric.query?.breakdownFilter,
+                breakdowns: sharedMetric.metadata?.breakdowns || [],
+            },
         })) as ExperimentMetric[]
 
     const allMetrics = [...regularMetrics, ...enrichedSharedMetrics]

--- a/posthog/models/experiment.py
+++ b/posthog/models/experiment.py
@@ -157,8 +157,8 @@ class ExperimentToSavedMetric(models.Model):
     saved_metric = models.ForeignKey("ExperimentSavedMetric", on_delete=models.CASCADE)
 
     # Metadata for the saved metric at the time of the experiment creation
-    # has stuff like whether this metric is primary, and any other information
-    # we need for the metric, other than the query.
+    # has stuff like whether this metric is primary, it has breakdowns,
+    # and any other information we need for the metric, other than the query.
     metadata = models.JSONField(default=dict)
     created_at = models.DateTimeField(default=timezone.now)
     updated_at = models.DateTimeField(auto_now=True)


### PR DESCRIPTION
## Problem

Breakdowns for shared metrics are not being persisted, so adding a breakdown to a shared metric has no effect.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We need to persist the breakdowns, scoped to the experiment for shared metrics. Using the `metadata` field on the `ExperimentToSavedMetric` model seems the natural option.
Since the backend is using a `models.JSONField(default=dict)` for the `metadata` field, we just updated the comment and added a test suite to handle the new `breakdowns` property of the field.

On the frontend, we need to hydrate the final query with the breakdowns from the `metadata`, and for that we'll use the `getOrderedMetricsWithResults` function.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
hogli test:python ee/clickhouse/views/test/test_experiment_saved_metrics.py
pnpm --filter=@posthog/frontend jest src/scenes/experiments/utils.test.ts
```

![cat-type](https://github.com/user-attachments/assets/708fe13e-c442-4df7-a700-8c5e0641d45e)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
