### PR TITLE
feat(analytics-platform): The experimental sessions backfill should include the timestamp

### DIFF
--- a/posthog/clickhouse/test/test_raw_sessions_v3_model.py
+++ b/posthog/clickhouse/test/test_raw_sessions_v3_model.py
@@ -332,6 +332,7 @@ class TestRawSessionsModel(ClickhouseTestMixin, BaseTest):
                 where="team_id = %(team_id)s AND timestamp >= '2024-03-01'",
                 shard_index=1,
                 num_shards=2,
+                include_session_timestamp=True,
             ),
             {"team_id": self.team.id},
         )

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -459,7 +459,7 @@ def _do_experimental_backfill(
                 backfill_sql = sql_template(
                     where=chunk_where_clause,
                     target_table=DISTRIBUTED_RAW_SESSIONS_TABLE_V3(),  # this is just what the table is called in the experimental cluster, it's not actually distributed
-                    include_session_timestamp=False,
+                    include_session_timestamp=True,
                 )
                 context.log.info(backfill_sql)
                 sync_execute(backfill_sql, settings=merged_settings, sync_client=client)


### PR DESCRIPTION
## Problem

See https://github.com/PostHog/posthog/pull/47495, but I missed this one-line change that I needed

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
