### PR TITLE
feat(analytics-platform): Add support for HogQL tables to specify top-level query settings

### DIFF
--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -113,6 +113,8 @@ class HogQLQuerySettings(BaseModel):
     date_time_input_format: Optional[str] = None
     join_algorithm: Optional[str] = None
     force_data_skipping_indices: Optional[list[str]] = None
+    load_balancing: Optional[str] = None
+    optimize_skip_unused_shards: Optional[bool] = None
 
 
 # Settings applied on top of all HogQL queries.

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional
 from pydantic import BaseModel, ConfigDict
 
 from posthog.hogql.base import Expr
+from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.errors import NotImplementedError, ResolutionError
 
 if TYPE_CHECKING:
@@ -163,6 +164,7 @@ class FieldTraverser(FieldOrTable):
 
 class Table(FieldOrTable):
     fields: dict[str, FieldOrTable]
+    top_level_settings: Optional[HogQLQuerySettings] = None
     model_config = ConfigDict(extra="forbid")
 
     def has_field(self, name: str | int) -> bool:

--- a/posthog/hogql/database/schema/experiment_exposures_preaggregated.py
+++ b/posthog/hogql/database/schema/experiment_exposures_preaggregated.py
@@ -1,3 +1,4 @@
+from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.database.models import (
     DateTimeDatabaseField,
     FieldOrTable,
@@ -11,6 +12,8 @@ from posthog.clickhouse.preaggregation.experiment_exposures_sql import DISTRIBUT
 
 
 class ExperimentExposuresPreaggregatedTable(Table):
+    top_level_settings: HogQLQuerySettings | None = HogQLQuerySettings(load_balancing="in_order")
+
     fields: dict[str, FieldOrTable] = {
         "team_id": IntegerDatabaseField(name="team_id"),
         "job_id": StringDatabaseField(name="job_id"),

--- a/posthog/hogql/database/schema/experiment_exposures_preaggregated.py
+++ b/posthog/hogql/database/schema/experiment_exposures_preaggregated.py
@@ -1,3 +1,5 @@
+from pydantic import Field
+
 from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.database.models import (
     DateTimeDatabaseField,
@@ -12,7 +14,9 @@ from posthog.clickhouse.preaggregation.experiment_exposures_sql import DISTRIBUT
 
 
 class ExperimentExposuresPreaggregatedTable(Table):
-    top_level_settings: HogQLQuerySettings | None = HogQLQuerySettings(load_balancing="in_order")
+    top_level_settings: HogQLQuerySettings | None = Field(
+        default_factory=lambda: HogQLQuerySettings(load_balancing="in_order")
+    )
 
     fields: dict[str, FieldOrTable] = {
         "team_id": IntegerDatabaseField(name="team_id"),

--- a/posthog/hogql/database/schema/preaggregation_results.py
+++ b/posthog/hogql/database/schema/preaggregation_results.py
@@ -1,3 +1,5 @@
+from pydantic import Field
+
 from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.database.models import (
     DatabaseField,
@@ -18,7 +20,9 @@ class PreaggregationResultsTable(Table):
     Used for on-demand preaggregation of queries like uniqExact(person_id) GROUP BY day.
     """
 
-    top_level_settings: HogQLQuerySettings | None = HogQLQuerySettings(load_balancing="in_order")
+    top_level_settings: HogQLQuerySettings | None = Field(
+        default_factory=lambda: HogQLQuerySettings(load_balancing="in_order")
+    )
 
     fields: dict[str, FieldOrTable] = {
         "team_id": IntegerDatabaseField(name="team_id"),

--- a/posthog/hogql/database/schema/preaggregation_results.py
+++ b/posthog/hogql/database/schema/preaggregation_results.py
@@ -1,3 +1,4 @@
+from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.database.models import (
     DatabaseField,
     DateTimeDatabaseField,
@@ -16,6 +17,8 @@ class PreaggregationResultsTable(Table):
     HogQL schema for the sharded_preaggregation_results table.
     Used for on-demand preaggregation of queries like uniqExact(person_id) GROUP BY day.
     """
+
+    top_level_settings: HogQLQuerySettings | None = HogQLQuerySettings(load_balancing="in_order")
 
     fields: dict[str, FieldOrTable] = {
         "team_id": IntegerDatabaseField(name="team_id"),

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -12,7 +12,13 @@ from posthog.schema import MaterializationMode, PersonsOnEventsMode, PropertyGro
 from posthog.hogql import ast
 from posthog.hogql.ast import Constant, StringType
 from posthog.hogql.base import AST
-from posthog.hogql.constants import HogQLDialect, HogQLGlobalSettings, LimitContext, get_max_limit_for_context
+from posthog.hogql.constants import (
+    HogQLDialect,
+    HogQLGlobalSettings,
+    HogQLQuerySettings,
+    LimitContext,
+    get_max_limit_for_context,
+)
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import FunctionCallTable, Table
 from posthog.hogql.errors import ImpossibleASTError, QueryError, ResolutionError
@@ -1342,7 +1348,7 @@ class HogQLPrinter(Visitor[str]):
                 )
             self._table_top_level_settings[key] = value
 
-    def _merge_table_top_level_settings(self, settings) -> dict | None:
+    def _merge_table_top_level_settings(self, settings: HogQLQuerySettings | None) -> dict | None:
         """Copy settings and merge in collected table-level settings with conflict detection.
 
         Returns a merged {key: value} dict, or None if there are no table settings to merge.
@@ -1359,9 +1365,10 @@ class HogQLPrinter(Visitor[str]):
             merged[key] = value
         return merged
 
-    def _print_settings(self, settings):
+    def _print_settings(self, settings: HogQLQuerySettings | dict[str, Any]) -> str | None:
         pairs = []
-        for key, value in settings:
+        items = settings.items() if isinstance(settings, dict) else settings
+        for key, value in items:
             if value is None:
                 continue
             if not re.match(r"^[a-zA-Z0-9_]+$", key):

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -1348,10 +1348,9 @@ class HogQLPrinter(Visitor[str]):
                 )
             self._table_top_level_settings[key] = value
 
-    def _merge_table_top_level_settings(self, settings: HogQLQuerySettings | None) -> dict[str, Any] | None:
+    def _merge_table_top_level_settings(self, settings: HogQLQuerySettings | None) -> dict[str, Any]:
         merged = dict(settings.model_dump()) if settings else {}
         if not self._table_top_level_settings:
-            # if there weren't any settings at the top level, stop here
             return merged
         for key, value in self._table_top_level_settings.items():
             existing = merged.get(key)

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -1348,14 +1348,11 @@ class HogQLPrinter(Visitor[str]):
                 )
             self._table_top_level_settings[key] = value
 
-    def _merge_table_top_level_settings(self, settings: HogQLQuerySettings | None) -> dict | None:
-        """Copy settings and merge in collected table-level settings with conflict detection.
-
-        Returns a merged {key: value} dict, or None if there are no table settings to merge.
-        """
+    def _merge_table_top_level_settings(self, settings: HogQLQuerySettings | None) -> dict[str, Any] | None:
+        merged = dict(settings.model_dump()) if settings else {}
         if not self._table_top_level_settings:
-            return None
-        merged = {k: v for k, v in settings.model_dump().items() if v is not None} if settings else {}
+            # if there weren't any settings at the top level, stop here
+            return merged
         for key, value in self._table_top_level_settings.items():
             existing = merged.get(key)
             if existing is not None and existing != value:

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -68,8 +68,7 @@ class ClickHousePrinter(HogQLPrinter):
             if not isinstance(node, ast.SelectQuery) and not isinstance(node, ast.SelectSetQuery):
                 raise QueryError("Settings can only be applied to SELECT queries")
             merged = self._merge_table_top_level_settings(self.settings)
-            to_print = merged.items() if merged is not None else self.settings
-            printed = self._print_settings(to_print)
+            printed = self._print_settings(merged if merged is not None else self.settings)
             if printed is not None:
                 response += " " + printed
 
@@ -957,14 +956,13 @@ class ClickHousePrinter(HogQLPrinter):
 
         # At top level, merge table-level settings into a copy of node.settings.
         # self.settings (global) is handled separately in visit().
-        settings_to_print = node.settings
-        if is_top_level_query:
-            merged = self._merge_table_top_level_settings(node.settings)
-            if merged is not None:
-                settings_to_print = merged.items()
-
-        if settings_to_print is not None:
-            printed = self._print_settings(settings_to_print)
+        merged = self._merge_table_top_level_settings(node.settings) if is_top_level_query else None
+        if merged is not None:
+            printed = self._print_settings(merged)
+            if printed is not None:
+                clauses.append(printed)
+        elif node.settings is not None:
+            printed = self._print_settings(node.settings)
             if printed is not None:
                 clauses.append(printed)
 

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -954,7 +954,12 @@ class ClickHousePrinter(HogQLPrinter):
         if self.context.output_format and is_top_level_query and (not part_of_select_union or is_last_query_in_union):
             clauses.append(f"FORMAT{space}{self.context.output_format}")
 
-        merged = self._merge_table_top_level_settings(node.settings) if is_top_level_query else node.settings
+        # When self.settings exists, table-level settings are merged in visit() instead
+        merged = (
+            self._merge_table_top_level_settings(node.settings)
+            if is_top_level_query and not self.settings
+            else node.settings
+        )
         if merged is not None:
             printed = self._print_settings(merged)
             if printed is not None:

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -954,15 +954,9 @@ class ClickHousePrinter(HogQLPrinter):
         if self.context.output_format and is_top_level_query and (not part_of_select_union or is_last_query_in_union):
             clauses.append(f"FORMAT{space}{self.context.output_format}")
 
-        # At top level, merge table-level settings into a copy of node.settings.
-        # self.settings (global) is handled separately in visit().
-        merged = self._merge_table_top_level_settings(node.settings) if is_top_level_query else None
+        merged = self._merge_table_top_level_settings(node.settings) if is_top_level_query else node.settings
         if merged is not None:
             printed = self._print_settings(merged)
-            if printed is not None:
-                clauses.append(printed)
-        elif node.settings is not None:
-            printed = self._print_settings(node.settings)
             if printed is not None:
                 clauses.append(printed)
 

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -68,7 +68,7 @@ class ClickHousePrinter(HogQLPrinter):
             if not isinstance(node, ast.SelectQuery) and not isinstance(node, ast.SelectSetQuery):
                 raise QueryError("Settings can only be applied to SELECT queries")
             merged = self._merge_table_top_level_settings(self.settings)
-            printed = self._print_settings(merged if merged is not None else self.settings)
+            printed = self._print_settings(merged)
             if printed is not None:
                 response += " " + printed
 

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -2364,6 +2364,18 @@ class TestPrinter(BaseTest):
         assert "load_balancing='in_order'" in printed
         assert printed.count("load_balancing") == 1
 
+    def test_table_top_level_settings_with_global_settings_single_clause(self):
+        query = parse_select("SELECT job_id FROM preaggregation_results")
+        printed, _ = prepare_and_print_ast(
+            query,
+            HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+            "clickhouse",
+            settings=HogQLGlobalSettings(max_execution_time=30),
+        )
+        assert "load_balancing='in_order'" in printed
+        assert printed.count("SETTINGS") == 1
+        assert printed.count("load_balancing") == 1
+
     def test_subquery_table_settings_bubble_up(self):
         printed = self._print("SELECT job_id FROM (SELECT job_id FROM preaggregation_results)")
         assert "load_balancing='in_order'" in printed

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -2300,6 +2300,74 @@ class TestPrinter(BaseTest):
             f"SELECT 1 FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS optimize_aggregation_in_order=1, readonly=2, max_execution_time=10, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0",
         )
 
+    def test_table_top_level_settings_added_to_query(self):
+        printed = self._print("SELECT job_id FROM preaggregation_results")
+        assert "load_balancing='in_order'" in printed
+
+    def test_table_top_level_settings_not_added_for_regular_tables(self):
+        printed = self._print("SELECT event FROM events")
+        assert "load_balancing" not in printed
+
+    def test_table_top_level_settings_deduplication(self):
+        printed = self._print(
+            "SELECT a.job_id, b.job_id "
+            "FROM preaggregation_results a "
+            "JOIN experiment_exposures_preaggregated b ON a.job_id = b.job_id"
+        )
+        assert printed.count("load_balancing") == 1
+
+    def test_table_top_level_settings_conflict_between_tables(self):
+        db = Database()
+        db.get_table("preaggregation_results").top_level_settings = HogQLQuerySettings(load_balancing="round_robin")
+        context = HogQLContext(team_id=self.team.pk, enable_select_queries=True, database=db)
+        query_both = parse_select(
+            "SELECT a.job_id, b.job_id "
+            "FROM preaggregation_results a "
+            "JOIN experiment_exposures_preaggregated b ON a.job_id = b.job_id"
+        )
+        with self.assertRaises(QueryError) as cm:
+            prepare_and_print_ast(query_both, context, "clickhouse")
+        assert "Conflicting" in str(cm.exception)
+
+    def test_table_top_level_settings_conflict_with_query_settings(self):
+        query = parse_select("SELECT job_id FROM preaggregation_results")
+        assert isinstance(query, ast.SelectQuery)
+        query.settings = HogQLQuerySettings(load_balancing="round_robin")
+        with self.assertRaises(QueryError) as cm:
+            prepare_and_print_ast(
+                query,
+                HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+                "clickhouse",
+            )
+        assert "Conflicting" in str(cm.exception)
+
+    def test_table_top_level_settings_conflict_with_global_settings(self):
+        query = parse_select("SELECT job_id FROM preaggregation_results")
+        with self.assertRaises(QueryError) as cm:
+            prepare_and_print_ast(
+                query,
+                HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+                "clickhouse",
+                settings=HogQLGlobalSettings(load_balancing="round_robin"),
+            )
+        assert "Conflicting" in str(cm.exception)
+
+    def test_table_top_level_settings_same_value_in_query_settings(self):
+        query = parse_select("SELECT job_id FROM preaggregation_results")
+        assert isinstance(query, ast.SelectQuery)
+        query.settings = HogQLQuerySettings(load_balancing="in_order")
+        printed, _ = prepare_and_print_ast(
+            query,
+            HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+            "clickhouse",
+        )
+        assert "load_balancing='in_order'" in printed
+        assert printed.count("load_balancing") == 1
+
+    def test_subquery_table_settings_bubble_up(self):
+        printed = self._print("SELECT job_id FROM (SELECT job_id FROM preaggregation_results)")
+        assert "load_balancing='in_order'" in printed
+
     def test_pretty_print(self):
         printed = self._pretty("SELECT 1, event FROM events")
         self.assertEqual(

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -147,7 +147,8 @@
                             hidden: False
                           }
                         },
-                        hidden: False
+                        hidden: False,
+                        top_level_settings: None
                       }
                     }
                   }
@@ -958,7 +959,8 @@
                                         hidden: False
                                       }
                                     },
-                                    hidden: False
+                                    hidden: False,
+                                    top_level_settings: None
                                   },
                                   to_field: None
                                 }
@@ -1034,7 +1036,8 @@
                                 hidden: False
                               }
                             },
-                            hidden: False
+                            hidden: False,
+                            top_level_settings: None
                           },
                           to_field: None
                         }
@@ -1287,7 +1290,8 @@
                                         hidden: False
                                       }
                                     },
-                                    hidden: False
+                                    hidden: False,
+                                    top_level_settings: None
                                   },
                                   to_field: None
                                 }
@@ -1360,7 +1364,8 @@
                                 hidden: False
                               }
                             },
-                            hidden: False
+                            hidden: False,
+                            top_level_settings: None
                           },
                           to_field: None
                         }
@@ -1633,7 +1638,8 @@
                     hidden: False
                   }
                 },
-                hidden: False
+                hidden: False,
+                top_level_settings: None
               }
             }
           }
@@ -1857,7 +1863,8 @@
                                     hidden: False
                                   }
                                 },
-                                hidden: False
+                                hidden: False,
+                                top_level_settings: None
                               },
                               to_field: None
                             }
@@ -1936,7 +1943,8 @@
                             hidden: False
                           }
                         },
-                        hidden: False
+                        hidden: False,
+                        top_level_settings: None
                       },
                       to_field: None
                     }
@@ -2284,7 +2292,8 @@
                                     hidden: False
                                   }
                                 },
-                                hidden: False
+                                hidden: False,
+                                top_level_settings: None
                               },
                               to_field: None
                             }
@@ -2360,7 +2369,8 @@
                             hidden: False
                           }
                         },
-                        hidden: False
+                        hidden: False,
+                        top_level_settings: None
                       },
                       to_field: None
                     }
@@ -2610,7 +2620,8 @@
                       hidden: False
                     }
                   },
-                  hidden: False
+                  hidden: False,
+                  top_level_settings: None
                 }
               }
             }
@@ -3174,7 +3185,8 @@
                             hidden: False
                           }
                         },
-                        hidden: False
+                        hidden: False,
+                        top_level_settings: None
                       }
                     }
                   }
@@ -3643,7 +3655,8 @@
                             hidden: False
                           }
                         },
-                        hidden: False
+                        hidden: False,
+                        top_level_settings: None
                       }
                     }
                   }
@@ -4455,7 +4468,8 @@
                                           hidden: False
                                         }
                                       },
-                                      hidden: False
+                                      hidden: False,
+                                      top_level_settings: None
                                     },
                                     to_field: None
                                   }
@@ -4531,7 +4545,8 @@
                                   hidden: False
                                 }
                               },
-                              hidden: False
+                              hidden: False,
+                              top_level_settings: None
                             },
                             to_field: None
                           }
@@ -4784,7 +4799,8 @@
                                           hidden: False
                                         }
                                       },
-                                      hidden: False
+                                      hidden: False,
+                                      top_level_settings: None
                                     },
                                     to_field: None
                                   }
@@ -4857,7 +4873,8 @@
                                   hidden: False
                                 }
                               },
-                              hidden: False
+                              hidden: False,
+                              top_level_settings: None
                             },
                             to_field: None
                           }
@@ -5088,7 +5105,8 @@
                               hidden: False
                             }
                           },
-                          hidden: False
+                          hidden: False,
+                          top_level_settings: None
                         }
                       }
                     }
@@ -5312,7 +5330,8 @@
                                               hidden: False
                                             }
                                           },
-                                          hidden: False
+                                          hidden: False,
+                                          top_level_settings: None
                                         },
                                         to_field: None
                                       }
@@ -5391,7 +5410,8 @@
                                       hidden: False
                                     }
                                   },
-                                  hidden: False
+                                  hidden: False,
+                                  top_level_settings: None
                                 },
                                 to_field: None
                               }
@@ -5739,7 +5759,8 @@
                                               hidden: False
                                             }
                                           },
-                                          hidden: False
+                                          hidden: False,
+                                          top_level_settings: None
                                         },
                                         to_field: None
                                       }
@@ -5815,7 +5836,8 @@
                                       hidden: False
                                     }
                                   },
-                                  hidden: False
+                                  hidden: False,
+                                  top_level_settings: None
                                 },
                                 to_field: None
                               }
@@ -6378,7 +6400,8 @@
                     hidden: False
                   }
                 },
-                hidden: False
+                hidden: False,
+                top_level_settings: None
               }
             }
           }
@@ -6602,7 +6625,8 @@
                                     hidden: False
                                   }
                                 },
-                                hidden: False
+                                hidden: False,
+                                top_level_settings: None
                               },
                               to_field: None
                             }
@@ -6681,7 +6705,8 @@
                             hidden: False
                           }
                         },
-                        hidden: False
+                        hidden: False,
+                        top_level_settings: None
                       },
                       to_field: None
                     }
@@ -7029,7 +7054,8 @@
                                     hidden: False
                                   }
                                 },
-                                hidden: False
+                                hidden: False,
+                                top_level_settings: None
                               },
                               to_field: None
                             }
@@ -7105,7 +7131,8 @@
                             hidden: False
                           }
                         },
-                        hidden: False
+                        hidden: False,
+                        top_level_settings: None
                       },
                       to_field: None
                     }
@@ -7393,7 +7420,8 @@
                       hidden: False
                     }
                   },
-                  hidden: False
+                  hidden: False,
+                  top_level_settings: None
                 }
               }
             }
@@ -7618,7 +7646,8 @@
                                     hidden: False
                                   }
                                 },
-                                hidden: False
+                                hidden: False,
+                                top_level_settings: None
                               },
                               to_field: None
                             }
@@ -7697,7 +7726,8 @@
                             hidden: False
                           }
                         },
-                        hidden: False
+                        hidden: False,
+                        top_level_settings: None
                       },
                       to_field: None
                     }
@@ -8045,7 +8075,8 @@
                                     hidden: False
                                   }
                                 },
-                                hidden: False
+                                hidden: False,
+                                top_level_settings: None
                               },
                               to_field: None
                             }
@@ -8121,7 +8152,8 @@
                             hidden: False
                           }
                         },
-                        hidden: False
+                        hidden: False,
+                        top_level_settings: None
                       },
                       to_field: None
                     }
@@ -8410,7 +8442,8 @@
                         hidden: False
                       }
                     },
-                    hidden: False
+                    hidden: False,
+                    top_level_settings: None
                   }
                 }
               }
@@ -8612,7 +8645,8 @@
                         hidden: False
                       }
                     },
-                    hidden: False
+                    hidden: False,
+                    top_level_settings: None
                   }
                 }
               }
@@ -8686,7 +8720,8 @@
                       }
                     },
                     filter: None,
-                    hidden: False
+                    hidden: False,
+                    top_level_settings: None
                   }
                 }
               }
@@ -9127,7 +9162,8 @@
                     hidden: False
                   }
                 },
-                hidden: False
+                hidden: False,
+                top_level_settings: None
               }
             }
           }
@@ -9362,7 +9398,8 @@
                       hidden: False
                     }
                   },
-                  hidden: False
+                  hidden: False,
+                  top_level_settings: None
                 }
               }
             }
@@ -9601,7 +9638,8 @@
                         hidden: False
                       }
                     },
-                    hidden: False
+                    hidden: False,
+                    top_level_settings: None
                   }
                 }
               }
@@ -9880,7 +9918,8 @@
                                 hidden: False
                               }
                             },
-                            hidden: False
+                            hidden: False,
+                            top_level_settings: None
                           }
                         }
                       }
@@ -10165,7 +10204,8 @@
                     hidden: False
                   }
                 },
-                hidden: False
+                hidden: False,
+                top_level_settings: None
               }
             }
           }
@@ -10222,7 +10262,8 @@
                         hidden: False
                       }
                     },
-                    hidden: False
+                    hidden: False,
+                    top_level_settings: None
                   },
                   to_field: None
                 }
@@ -10407,7 +10448,8 @@
                       hidden: False
                     }
                   },
-                  hidden: False
+                  hidden: False,
+                  top_level_settings: None
                 }
               }
             }
@@ -10466,7 +10508,8 @@
                         hidden: False
                       }
                     },
-                    hidden: False
+                    hidden: False,
+                    top_level_settings: None
                   },
                   to_field: None
                 }
@@ -10650,7 +10693,8 @@
                     hidden: False
                   }
                 },
-                hidden: False
+                hidden: False,
+                top_level_settings: None
               }
             }
           }
@@ -10695,7 +10739,8 @@
                       hidden: False
                     }
                   },
-                  hidden: False
+                  hidden: False,
+                  top_level_settings: None
                 },
                 to_field: None
               }
@@ -10879,7 +10924,8 @@
                       hidden: False
                     }
                   },
-                  hidden: False
+                  hidden: False,
+                  top_level_settings: None
                 }
               }
             }
@@ -10926,7 +10972,8 @@
                       hidden: False
                     }
                   },
-                  hidden: False
+                  hidden: False,
+                  top_level_settings: None
                 },
                 to_field: None
               }
@@ -10998,7 +11045,8 @@
                     hidden: False
                   }
                 },
-                hidden: False
+                hidden: False,
+                top_level_settings: None
               }
             }
           }
@@ -11210,7 +11258,8 @@
                       hidden: False
                     }
                   },
-                  hidden: False
+                  hidden: False,
+                  top_level_settings: None
                 }
               }
             }
@@ -11406,7 +11455,8 @@
                           hidden: False
                         }
                       },
-                      hidden: False
+                      hidden: False,
+                      top_level_settings: None
                     }
                   }
                 }
@@ -11614,7 +11664,8 @@
                     hidden: False
                   }
                 },
-                hidden: False
+                hidden: False,
+                top_level_settings: None
               }
             }
           }
@@ -11666,7 +11717,8 @@
                     hidden: False
                   }
                 },
-                hidden: False
+                hidden: False,
+                top_level_settings: None
               }
             }
           }

--- a/products/analytics_platform/backend/lazy_preaggregation/lazy_preaggregation_executor.py
+++ b/products/analytics_platform/backend/lazy_preaggregation/lazy_preaggregation_executor.py
@@ -853,7 +853,7 @@ def ensure_preaggregated(
             table=table,
             base_placeholders=base_placeholders,
         )
-        sync_execute(insert_sql, values, settings={"load_balancing": "in_order"})
+    sync_execute(insert_sql, values, settings=HogQLQuerySettings(load_balancing="in_order"))
 
     executor = PreaggregationExecutor(ttl_seconds=ttl_seconds)
     return executor.execute(team, query_info, time_range_start, time_range_end, run_insert=_run_manual_insert)

--- a/products/analytics_platform/backend/lazy_preaggregation/lazy_preaggregation_executor.py
+++ b/products/analytics_platform/backend/lazy_preaggregation/lazy_preaggregation_executor.py
@@ -15,6 +15,7 @@ from django.utils import timezone as django_timezone
 from clickhouse_driver.errors import ServerException
 
 from posthog.hogql import ast
+from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_and_print_ast
@@ -428,7 +429,9 @@ def run_preaggregation_insert(
         expires_at=job.expires_at,
     )
 
-    sync_execute(insert_sql, values, settings=HogQLQuerySettings(load_balancing="in_order"))
+    sync_execute(
+        insert_sql, values, settings=HogQLQuerySettings(load_balancing="in_order").model_dump(exclude_none=True)
+    )
 
 
 class PreaggregationExecutor:
@@ -853,7 +856,9 @@ def ensure_preaggregated(
             table=table,
             base_placeholders=base_placeholders,
         )
-    sync_execute(insert_sql, values, settings=HogQLQuerySettings(load_balancing="in_order"))
+        sync_execute(
+            insert_sql, values, settings=HogQLQuerySettings(load_balancing="in_order").model_dump(exclude_none=True)
+        )
 
     executor = PreaggregationExecutor(ttl_seconds=ttl_seconds)
     return executor.execute(team, query_info, time_range_start, time_range_end, run_insert=_run_manual_insert)

--- a/products/analytics_platform/backend/lazy_preaggregation/lazy_preaggregation_executor.py
+++ b/products/analytics_platform/backend/lazy_preaggregation/lazy_preaggregation_executor.py
@@ -428,7 +428,7 @@ def run_preaggregation_insert(
         expires_at=job.expires_at,
     )
 
-    sync_execute(insert_sql, values, settings={"load_balancing": "in_order"})
+    sync_execute(insert_sql, values, settings=HogQLQuerySettings(load_balancing="in_order"))
 
 
 class PreaggregationExecutor:

--- a/products/analytics_platform/backend/lazy_preaggregation/lazy_preaggregation_executor.py
+++ b/products/analytics_platform/backend/lazy_preaggregation/lazy_preaggregation_executor.py
@@ -428,7 +428,7 @@ def run_preaggregation_insert(
         expires_at=job.expires_at,
     )
 
-    sync_execute(insert_sql, values)
+    sync_execute(insert_sql, values, settings={"load_balancing": "in_order"})
 
 
 class PreaggregationExecutor:
@@ -853,7 +853,7 @@ def ensure_preaggregated(
             table=table,
             base_placeholders=base_placeholders,
         )
-        sync_execute(insert_sql, values)
+        sync_execute(insert_sql, values, settings={"load_balancing": "in_order"})
 
     executor = PreaggregationExecutor(ttl_seconds=ttl_seconds)
     return executor.execute(team, query_info, time_range_start, time_range_end, run_insert=_run_manual_insert)


### PR DESCRIPTION
## Problem

I need to specifiy some table-level clickhouse settings.

The problem is that clickhouse seems to have a bug where some settings are silently ignored if set at the subquery level

e.g. https://github.com/ClickHouse/ClickHouse/issues/64263, https://github.com/ClickHouse/ClickHouse/issues/63078

(It's not certain that this will happen, maybe it does just work, but given the failure mode is a race condition that is extremely hard to replicate in unit tests, I'm being abundantly cautious)

The solution I went for is to let the tables that are selected have control over the top-level clickhouse query settings. If there are any conflicts, raise an error

## Changes

Collect the top-level settings for all tables in the query. Merge these settings into the top-level settings during printing. If there are any conflicts, raise an error

## How did you test this code?

Added some tests, also see how snapshots have changed or not changed

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
