### PR TITLE
chore(workflows): adds personhog replica to rust docker build workflow

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -132,6 +132,7 @@ jobs:
                     - hook-worker
                     - kafka-deduplicator
                     - limiters
+                    - personhog-replica
                     - posthog-symbol-data
                     - property-defs-rs
                     - serve-metrics

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -57,6 +57,9 @@ jobs:
                     - image: kafka-deduplicator
                       dockerfile: ./rust/Dockerfile
                       project: vznmbshh6q
+                    - image: personhog-replica
+                      dockerfile: ./rust/Dockerfile
+                      project: vq4lxdfdv2
         runs-on: depot-ubuntu-22.04
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
@@ -78,6 +81,7 @@ jobs:
             feature-flags_digest: ${{ steps.digest.outputs.feature-flags_digest }}
             capture-logs_digest: ${{ steps.digest.outputs.capture-logs_digest }}
             kafka-deduplicator_digest: ${{ steps.digest.outputs.kafka-deduplicator_digest }}
+            personhog-replica_digest: ${{ steps.digest.outputs.personhog-replica_digest }}
         defaults:
             run:
                 working-directory: rust
@@ -228,6 +232,10 @@ jobs:
                       values:
                           image:
                               sha: '${{ needs.build.outputs.sqlx-migrate_digest }}'
+                    - release: personhog-replica
+                      values:
+                          image:
+                              sha: '${{ needs.build.outputs.personhog-replica_digest }}'
         steps:
             - name: get deployer token
               id: deployer


### PR DESCRIPTION
## Problem

The personhog-replica Rust service is not built, tested, or deployed as part of CI. It exists in the workspace but is missing from both the test matrix and the Docker build/deploy pipeline. 

## Changes

  - Add personhog-replica to the CI test matrix in ci-rust.yml
  - Add personhog-replica to the Docker build matrix in rust-docker-build.yml with a dedicated Depot
  project
  - Add the build digest output and deploy matrix entry so the image is pushed to ghcr.io and
  deployed via PostHog/charts on merge to master

## How did you test this code?

Will be tested by the CI running and building this image when merged

