### PR TITLE
chore(workflows): revert adding personhog replica to rust build matrix

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -57,9 +57,6 @@ jobs:
                     - image: kafka-deduplicator
                       dockerfile: ./rust/Dockerfile
                       project: vznmbshh6q
-                    - image: personhog-replica
-                      dockerfile: ./rust/Dockerfile
-                      project: vq4lxdfdv2
         runs-on: depot-ubuntu-22.04
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
@@ -81,7 +78,6 @@ jobs:
             feature-flags_digest: ${{ steps.digest.outputs.feature-flags_digest }}
             capture-logs_digest: ${{ steps.digest.outputs.capture-logs_digest }}
             kafka-deduplicator_digest: ${{ steps.digest.outputs.kafka-deduplicator_digest }}
-            personhog-replica_digest: ${{ steps.digest.outputs.personhog-replica_digest }}
         defaults:
             run:
                 working-directory: rust
@@ -232,10 +228,6 @@ jobs:
                       values:
                           image:
                               sha: '${{ needs.build.outputs.sqlx-migrate_digest }}'
-                    - release: personhog-replica
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.personhog-replica_digest }}'
         steps:
             - name: get deployer token
               id: deployer


### PR DESCRIPTION
## Problem

There are some dependencies missing that need to exist for the personhog-replica service build.

Revert adding it to workflow for now to unblock rust deployments.

## Changes

- removes adding the personhog-replica service to rust build matrix

