### PR TITLE
chore(personhog): adds personhog replica to rust build matrix

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -57,6 +57,9 @@ jobs:
                     - image: kafka-deduplicator
                       dockerfile: ./rust/Dockerfile
                       project: vznmbshh6q
+                    - image: personhog-replica
+                      dockerfile: ./rust/Dockerfile
+                      project: vq4lxdfdv2
         runs-on: depot-ubuntu-22.04
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
@@ -78,6 +81,7 @@ jobs:
             feature-flags_digest: ${{ steps.digest.outputs.feature-flags_digest }}
             capture-logs_digest: ${{ steps.digest.outputs.capture-logs_digest }}
             kafka-deduplicator_digest: ${{ steps.digest.outputs.kafka-deduplicator_digest }}
+            personhog-replica_digest: ${{ steps.digest.outputs.personhog-replica_digest }}
         defaults:
             run:
                 working-directory: rust
@@ -89,8 +93,13 @@ jobs:
               # Turning off cone mode ensures that files in the project root are not included during checkout
               uses: actions/checkout@v6
               with:
-                  sparse-checkout: 'rust/'
+                  sparse-checkout: |
+                      rust/
+                      proto/
                   sparse-checkout-cone-mode: false
+
+            - name: Copy proto files into rust build context
+              run: cp -r proto rust/proto
 
             - name: Set up Depot CLI
               uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
@@ -228,6 +237,10 @@ jobs:
                       values:
                           image:
                               sha: '${{ needs.build.outputs.sqlx-migrate_digest }}'
+                    - release: personhog-replica
+                      values:
+                          image:
+                              sha: '${{ needs.build.outputs.personhog-replica_digest }}'
         steps:
             - name: get deployer token
               id: deployer

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -99,6 +99,7 @@ jobs:
                   sparse-checkout-cone-mode: false
 
             - name: Copy proto files into rust build context
+              working-directory: .
               run: cp -r proto rust/proto
 
             - name: Set up Depot CLI

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -7,6 +7,7 @@ ENV RUSTC_WRAPPER=sccache SCCACHE_LOG=debug SCCACHE_DIR=/sccache
 FROM base AS planner
 WORKDIR /app
 ARG BIN
+ENV PROTO_ROOT=../proto
 
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json --bin $BIN
@@ -14,11 +15,12 @@ RUN cargo chef prepare --recipe-path recipe.json --bin $BIN
 FROM base AS builder
 WORKDIR /app
 ARG BIN
+ENV PROTO_ROOT=../proto
 
 # Ensure working C compile setup (not installed by default in arm64 images)
 # libclang-dev is required for bindgen (used by librocksdb-sys)
 # pkg-config is required for openssl-sys to find system OpenSSL
-RUN apt-get update && apt-get install build-essential libssl-dev pkg-config cmake libclang-dev -y
+RUN apt-get update && apt-get install build-essential libssl-dev pkg-config cmake libclang-dev protobuf-compiler -y
 
 COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \

--- a/rust/personhog-proto/build.rs
+++ b/rust/personhog-proto/build.rs
@@ -1,5 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let proto_root = "../../proto";
+    let proto_root = std::env::var("PROTO_ROOT").unwrap_or_else(|_| "../../proto".to_string());
 
     tonic_build::configure()
         .build_server(true)


### PR DESCRIPTION
## Problem

The personhog-replica Rust service exists in the workspace but isn't built, tested, or deployed by CI. It also depends on personhog-proto, which requires protoc and access to the proto/ directory at the repo root — neither of which are available in the current Docker build.  

## Changes


  - Add personhog-replica to the Docker build matrix, outputs, and deploy matrix
  (rust-docker-build.yml)
  - Install protobuf-compiler in the Dockerfile for proto compilation
  - Include proto/ in the sparse checkout and copy it into the rust/ build context
  - Set PROTO_ROOT env var in the Dockerfile so personhog-proto's build.rs can find proto files in
  both local dev and Docker builds
  - Update personhog-proto/build.rs to read PROTO_ROOT, defaulting to ../../proto for local dev

## How did you test this code?

Will be tested by seeing if hte CI can build this