### PR TITLE
fix: handle non-JSON raw_value in InstanceSetting

### DIFF
--- a/posthog/admin/admins/instance_setting_admin.py
+++ b/posthog/admin/admins/instance_setting_admin.py
@@ -1,3 +1,5 @@
+import json
+
 from django.contrib import admin
 
 
@@ -7,3 +9,13 @@ class InstanceSettingAdmin(admin.ModelAdmin):
         "key",
         "value",
     )
+
+    def save_model(self, request, obj, form, change):
+        # Ensure raw_value is valid JSON before saving.
+        # set_instance_setting() does json.dumps() but Django admin bypasses it,
+        # so bare strings like "abc123" get saved instead of '"abc123"'.
+        try:
+            json.loads(obj.raw_value)
+        except (json.JSONDecodeError, ValueError):
+            obj.raw_value = json.dumps(obj.raw_value)
+        super().save_model(request, obj, form, change)

--- a/posthog/models/instance_setting.py
+++ b/posthog/models/instance_setting.py
@@ -17,7 +17,11 @@ class InstanceSetting(models.Model):
 
     @property
     def value(self):
-        return json.loads(self.raw_value)
+        try:
+            return json.loads(self.raw_value)
+        except (json.JSONDecodeError, ValueError):
+            # raw_value may be a bare string (e.g. saved via Django admin without json.dumps wrapping)
+            return self.raw_value
 
 
 @lru_cache

--- a/posthog/models/instance_setting.py
+++ b/posthog/models/instance_setting.py
@@ -18,10 +18,18 @@ class InstanceSetting(models.Model):
     @property
     def value(self):
         try:
-            return json.loads(self.raw_value)
+            parsed = json.loads(self.raw_value)
         except (json.JSONDecodeError, ValueError):
             # raw_value may be a bare string (e.g. saved via Django admin without json.dumps wrapping)
             return self.raw_value
+
+        # Guard against lossy float parsing: if json.loads parsed a bare numeric string
+        # into a float that doesn't round-trip back to the original text, treat it as a
+        # bare string rather than silently losing precision.
+        if isinstance(parsed, float) and str(parsed) != self.raw_value:
+            return self.raw_value
+
+        return parsed
 
 
 @lru_cache

--- a/posthog/test/test_instance_setting_model.py
+++ b/posthog/test/test_instance_setting_model.py
@@ -71,3 +71,70 @@ def test_can_retrieve_multiple_settings(db):
         "MATERIALIZED_COLUMNS_ENABLED": True,
         "ASYNC_MIGRATIONS_AUTO_CONTINUE": True,
     }
+
+
+def test_value_property_handles_bare_strings(db):
+    """raw_value may be a bare string (e.g. saved via Django admin without json.dumps wrapping).
+    The value property should return it as-is instead of raising JSONDecodeError."""
+    instance = InstanceSetting.objects.create(
+        key="constance:posthog:TEST_BARE_HEX", raw_value="1ee937c5cba4da2dbdce84824cfa0e93"
+    )
+    assert instance.value == "1ee937c5cba4da2dbdce84824cfa0e93"
+
+    # String with dots
+    instance2 = InstanceSetting.objects.create(
+        key="constance:posthog:TEST_BARE_DOTTED", raw_value="910200304849.9220719972545"
+    )
+    assert instance2.value == "910200304849.9220719972545"
+
+    # Empty string
+    instance3 = InstanceSetting.objects.create(key="constance:posthog:TEST_BARE_EMPTY", raw_value="")
+    assert instance3.value == ""
+
+    # Valid JSON values still work as before
+    instance4 = InstanceSetting.objects.create(key="constance:posthog:TEST_VALID_JSON_STR", raw_value='"hello"')
+    assert instance4.value == "hello"
+
+    instance5 = InstanceSetting.objects.create(key="constance:posthog:TEST_VALID_JSON_BOOL", raw_value="true")
+    assert instance5.value is True
+
+    instance6 = InstanceSetting.objects.create(key="constance:posthog:TEST_VALID_JSON_INT", raw_value="42")
+    assert instance6.value == 42
+
+
+def test_admin_save_model_wraps_bare_strings(db):
+    """Django admin save_model should auto-wrap bare strings with json.dumps()."""
+
+    from django.contrib.admin.sites import AdminSite
+    from django.test import RequestFactory
+
+    from posthog.admin.admins.instance_setting_admin import InstanceSettingAdmin
+
+    site = AdminSite()
+    admin = InstanceSettingAdmin(InstanceSetting, site)
+    factory = RequestFactory()
+    request = factory.post("/admin/posthog/instancesetting/add/")
+
+    # Bare string should be wrapped
+    obj = InstanceSetting(key="constance:posthog:TEST_ADMIN_BARE", raw_value="abc123")
+    admin.save_model(request, obj, form=None, change=False)
+    assert obj.raw_value == '"abc123"'
+    assert obj.value == "abc123"
+
+    # Already-valid JSON string should be preserved
+    obj2 = InstanceSetting(key="constance:posthog:TEST_ADMIN_VALID_STR", raw_value='"already_valid"')
+    admin.save_model(request, obj2, form=None, change=False)
+    assert obj2.raw_value == '"already_valid"'
+    assert obj2.value == "already_valid"
+
+    # Valid JSON boolean should be preserved
+    obj3 = InstanceSetting(key="constance:posthog:TEST_ADMIN_VALID_BOOL", raw_value="true")
+    admin.save_model(request, obj3, form=None, change=False)
+    assert obj3.raw_value == "true"
+    assert obj3.value is True
+
+    # Valid JSON number should be preserved
+    obj4 = InstanceSetting(key="constance:posthog:TEST_ADMIN_VALID_NUM", raw_value="42")
+    admin.save_model(request, obj4, form=None, change=False)
+    assert obj4.raw_value == "42"
+    assert obj4.value == 42


### PR DESCRIPTION
## Problem

Django admin bypasses `set_instance_setting()` when saving `InstanceSetting` rows, writing bare strings to `raw_value` instead of JSON-encoded values. The `value` property does `json.loads(raw_value)` with no error handling, so any non-JSON value crashes with `JSONDecodeError`. This was impacting dev/deployments because `preflight_check` — called on every page load.

Additionally, `json.loads` can silently lose precision on bare numeric strings (e.g. `"910200304849.9220719972545"` parses as float `910200304849.9221`), which caused a CI test failure.

## Changes

- **`posthog/models/instance_setting.py`**: Add `try/except` around `json.loads()` in the `value` property — falls back to returning the raw string if it's not valid JSON. Also guards against lossy float parsing by checking if `str(parsed) != raw_value` for floats. Prevents 500s from bad data.
- **`posthog/admin/admins/instance_setting_admin.py`**: Override `save_model` to check if `raw_value` is valid JSON before saving. If not, wraps it with `json.dumps()`. Prevents bad data from being written via Django admin.

## How did you test this code?

- Reproduced the 500 on dev by curling `/login` from inside a pod and using Django's test `Client` to get the full traceback
- Verified the fix by correcting the DB rows and confirming 200 responses
- The `value` property fallback handles: bare strings, hex strings starting with digits, strings with dots (like Slack client IDs), lossy float numerics
- `test_value_property_handles_bare_strings` — bare hex, bare dotted numeric, empty string, and valid JSON all handled correctly
- `test_admin_save_model_wraps_bare_strings` — admin save wraps bare strings, preserves already-valid JSON

## Publish to changelog?

no
