### PR TITLE
fix(trends): include prop filter in group expression

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -10,9 +10,12 @@ from posthog.schema import (
     Compare,
     CompareFilter,
     DateRange,
+    EventPropertyFilter,
     EventsNode,
+    GroupNode,
     IntervalType,
     MathGroupTypeIndex,
+    PropertyOperator,
     TrendsFilter,
     TrendsQuery,
 )
@@ -438,3 +441,66 @@ class TestTrendsActorsQueryBuilder(BaseTest):
                         )
                     ],
                 )
+
+    def test_group_node_preserves_event_property_filters(self):
+        trends_query = TrendsQuery(
+            series=[
+                GroupNode(
+                    operator="OR",
+                    nodes=[
+                        EventsNode(
+                            event="event_a",
+                            properties=[
+                                EventPropertyFilter(key="state", value=["completed"], operator=PropertyOperator.EXACT)
+                            ],
+                        ),
+                        EventsNode(event="event_b"),
+                    ],
+                )
+            ],
+            dateRange=DateRange(date_from="-7d"),
+        )
+
+        builder = self._get_builder(trends_query=trends_query)
+        result = builder._event_or_action_where_expr()
+
+        assert isinstance(result, ast.Or)
+        assert len(result.exprs) == 2
+
+        # First expression should be AND(event = 'event_a', state = 'completed')
+        first = result.exprs[0]
+        assert isinstance(first, ast.And)
+        assert len(first.exprs) == 2
+        assert isinstance(first.exprs[0], ast.CompareOperation)
+        assert first.exprs[0].right == ast.Constant(value="event_a")
+        assert isinstance(first.exprs[1], ast.CompareOperation)
+        assert first.exprs[1].left.chain == ["properties", "state"]  # type: ignore
+
+        # Second expression should be just event = 'event_b'
+        assert isinstance(result.exprs[1], ast.CompareOperation)
+        assert result.exprs[1].right == ast.Constant(value="event_b")
+
+    def test_group_node_without_property_filters(self):
+        trends_query = TrendsQuery(
+            series=[
+                GroupNode(
+                    operator="OR",
+                    nodes=[
+                        EventsNode(event="event_a"),
+                        EventsNode(event="event_b"),
+                    ],
+                )
+            ],
+            dateRange=DateRange(date_from="-7d"),
+        )
+
+        builder = self._get_builder(trends_query=trends_query)
+        result = builder._event_or_action_where_expr()
+
+        assert isinstance(result, ast.Or)
+        assert len(result.exprs) == 2
+        # Both should be simple event comparisons with no property filter wrapping
+        assert isinstance(result.exprs[0], ast.CompareOperation)
+        assert result.exprs[0].right == ast.Constant(value="event_a")
+        assert isinstance(result.exprs[1], ast.CompareOperation)
+        assert result.exprs[1].right == ast.Constant(value="event_b")

--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -31,7 +31,7 @@ from posthog.hogql_queries.insights.trends.aggregation_operations import (
 )
 from posthog.hogql_queries.insights.trends.breakdown import Breakdown
 from posthog.hogql_queries.insights.trends.display import TrendsDisplay
-from posthog.hogql_queries.insights.trends.utils import is_groups_math
+from posthog.hogql_queries.insights.trends.utils import group_node_to_expr, is_groups_math
 from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.hogql_queries.utils.query_previous_period_date_range import QueryPreviousPeriodDateRange
@@ -355,49 +355,9 @@ class TrendsActorsQueryBuilder:
                     right=ast.Constant(value=str(self.entity.event)),
                 )
         elif isinstance(self.entity, GroupNode):
-            return self._get_group_expr(self.entity)
+            return group_node_to_expr(self.entity, self.team)
         else:
             raise ValueError(f"Invalid entity kind {self.entity.kind}")
-
-        return None
-
-    def _get_group_expr(self, group: GroupNode) -> ast.Expr | None:
-        group_filters: list[ast.Expr] = []
-        for node in group.nodes:
-            if isinstance(node, EventsNode):
-                if node.event is not None:
-                    event_expr: ast.Expr = ast.CompareOperation(
-                        op=ast.CompareOperationOp.Eq,
-                        left=ast.Field(chain=["event"]),
-                        right=ast.Constant(value=str(node.event)),
-                    )
-                    if node.properties is not None and node.properties != []:
-                        properties_expr = property_to_expr(node.properties, self.team)
-                        event_expr = ast.And(exprs=[event_expr, properties_expr])
-                    group_filters.append(event_expr)
-            elif isinstance(node, ActionsNode):
-                try:
-                    action = Action.objects.get(pk=int(node.id), team__project_id=self.team.project_id)
-                    action_expr: ast.Expr = action_to_expr(action)
-                    if node.properties is not None and node.properties != []:
-                        properties_expr = property_to_expr(node.properties, self.team)
-                        action_expr = ast.And(exprs=[action_expr, properties_expr])
-                    group_filters.append(action_expr)
-                except Action.DoesNotExist:
-                    # If an action doesn't exist, skip it
-                    pass
-
-        if len(group_filters) == 0:
-            return None
-
-        if len(group_filters) == 1:
-            return group_filters[0]
-
-        if group.operator == "OR":
-            return ast.Or(exprs=group_filters)
-
-        if group.operator == "AND":
-            return ast.And(exprs=group_filters)
 
         return None
 

--- a/posthog/hogql_queries/insights/trends/utils.py
+++ b/posthog/hogql_queries/insights/trends/utils.py
@@ -1,4 +1,6 @@
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Union
 
 from posthog.schema import (
     ActionsNode,
@@ -10,7 +12,13 @@ from posthog.schema import (
     MultipleBreakdownType,
 )
 
+from posthog.hogql import ast
+from posthog.hogql.property import action_to_expr, property_to_expr
+
 from posthog.constants import UNIQUE_GROUPS
+
+if TYPE_CHECKING:
+    from posthog.models import Team
 
 
 def get_properties_chain(
@@ -52,3 +60,44 @@ def is_groups_math(series: Union[EventsNode, ActionsNode, DataWarehouseNode | Gr
         series.math in {BaseMathType.DAU, UNIQUE_GROUPS, BaseMathType.WEEKLY_ACTIVE, BaseMathType.MONTHLY_ACTIVE}
         and series.math_group_type_index is not None
     )
+
+
+def group_node_to_expr(group: GroupNode, team: Team) -> ast.Expr | None:
+    from posthog.models import Action
+
+    group_filters: list[ast.Expr] = []
+    for node in group.nodes:
+        if isinstance(node, EventsNode):
+            if node.event is None:
+                continue
+            node_expr: ast.Expr = ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ast.Field(chain=["event"]),
+                right=ast.Constant(value=str(node.event)),
+            )
+            if node.properties is not None and node.properties != []:
+                node_expr = ast.And(exprs=[node_expr, property_to_expr(node.properties, team)])
+            group_filters.append(node_expr)
+        elif isinstance(node, ActionsNode):
+            try:
+                action = Action.objects.get(pk=int(node.id), team__project_id=team.project_id)
+                node_expr = action_to_expr(action)
+                if node.properties is not None and node.properties != []:
+                    node_expr = ast.And(exprs=[node_expr, property_to_expr(node.properties, team)])
+                group_filters.append(node_expr)
+            except Action.DoesNotExist:
+                pass
+
+    if len(group_filters) == 0:
+        return None
+
+    if len(group_filters) == 1:
+        return group_filters[0]
+
+    if group.operator == "OR":
+        return ast.Or(exprs=group_filters)
+
+    if group.operator == "AND":
+        return ast.And(exprs=group_filters)
+
+    return None


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Customer reported that clicking into a trend shows a different number of persons than the trend itself. 

This was because of a difference between the where condition between the trends query and the actors query
Trends query: 
```sql
WHERE
...
or(and(equals(e.event, 'Seller Registration'), 
equals(e.properties_group_custom['state'], 'completed')), 
and(equals(e.event, 'Seller Registration'), 
equals(e.properties_group_custom['step'], 'success')), 
equals(e.event, 'PRE_SUBMIT_USER_DETAILS'), 
equals(e.event, 'registration_widget_completed')))
```
Actors query (when you click into the trend):
```sql
WHERE
...
or(equals(e.event, 'Seller Registration'), 
equals(e.event, 'Seller Registration'), 
equals(e.event, 'PRE_SUBMIT_USER_DETAILS'),
equals(e.event, 'registration_widget_completed'))))
```
Notice how the actors query doesn't include the property filters `equals(e.properties_group_custom['state'], 'completed'))` and `equals(e.properties_group_custom['step'], 'success')), equals(e.event, 'PRE_SUBMIT_USER_DETAILS')`

The trends_query_builder.py doesn't have this issue because it checks for properties: 
https://github.com/PostHog/posthog/blob/11c2e14615385747df19e653801079d674b0dcd5/posthog/hogql_queries/insights/trends/trends_query_builder.py#L916-L930


https://posthoghelp.zendesk.com/agent/tickets/50389 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/52499)

## Changes

Unify GroupNode to expression conversion into a single util method used by both trends_query_builder and trends_actor_query_builder. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- Unit test
- Verified locally that the query contains the property filter in the WHERE expression
Trend with grouped events and property filter:
<img width="489" height="523" alt="Screenshot 2026-02-10 at 10 11 19 PM" src="https://github.com/user-attachments/assets/cde4b2f3-eb8a-4d85-bcb7-d9150566059c" />



ActorsQuery WHERE:
```sql
WHERE
or(equals(e.event, 'paid_bill'), 
and(equals(e.event, '$opt_in'), 
equals(e.`mat_$browser`, 'Chrome')))))
```

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
