### PR TITLE
feat(experiments): correctly display breakdowns for shared metrics.

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -8,10 +8,11 @@ import experimentJson from '~/mocks/fixtures/api/experiments/_experiment_launche
 import experimentMetricResultsErrorJson from '~/mocks/fixtures/api/experiments/_experiment_metric_results_error.json'
 import experimentMetricResultsSuccessJson from '~/mocks/fixtures/api/experiments/_experiment_metric_results_success.json'
 import { useMocks } from '~/mocks/jest'
+import { Breakdown, ExperimentMetric, ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { Experiment } from '~/types'
 
-import { experimentLogic } from './experimentLogic'
+import { ExperimentSavedMetric, experimentLogic } from './experimentLogic'
 
 const RUNNING_EXP_ID = 45
 const RUNNING_FUNNEL_EXP_ID = 46
@@ -393,6 +394,274 @@ describe('experimentLogic', () => {
 
             // Verify that loadExperiment was called which will fetch the experiment again
             expect(logic.values.experiment).not.toBeNull()
+        })
+    })
+
+    describe('breakdown management', () => {
+        it('should add breakdown to inline metric', () => {
+            const breakdown: Breakdown = { property: '$browser', type: 'event' }
+            const testExperiment: Experiment = {
+                ...experiment,
+                metrics: [
+                    {
+                        uuid: 'test-metric-uuid',
+                        metric_type: ExperimentMetricType.MEAN,
+                        source: { kind: NodeKind.EventsNode, event: '$pageview' },
+                        breakdownFilter: { breakdowns: [] },
+                    },
+                ] as unknown as ExperimentMetric[],
+            }
+
+            logic.actions.setExperiment(testExperiment)
+            logic.actions.updateMetricBreakdown('test-metric-uuid', breakdown)
+
+            const updatedMetric = logic.values.experiment.metrics[0] as ExperimentMetric
+            expect(updatedMetric.breakdownFilter?.breakdowns).toEqual([breakdown])
+        })
+
+        it('should add breakdown to shared metric metadata', () => {
+            const breakdown: Breakdown = { property: '$browser', type: 'event' }
+            const testExperiment: Experiment = {
+                ...experiment,
+                saved_metrics: [
+                    {
+                        id: 1,
+                        experiment: experiment.id as number,
+                        saved_metric: 123,
+                        name: 'Shared Metric',
+                        query: {
+                            uuid: 'shared-metric-uuid',
+                            kind: NodeKind.ExperimentMetric,
+                            metric_type: ExperimentMetricType.MEAN,
+                            source: { kind: NodeKind.EventsNode, event: '$pageview' },
+                        },
+                        metadata: { type: 'primary' },
+                        created_at: '2024-01-01T00:00:00Z',
+                    } satisfies ExperimentSavedMetric,
+                ],
+                metrics: [],
+            }
+
+            logic.actions.setExperiment(testExperiment)
+            logic.actions.updateMetricBreakdown('shared-metric-uuid', breakdown)
+
+            expect(logic.values.experiment.saved_metrics[0].metadata.breakdowns).toEqual([breakdown])
+        })
+
+        it('should remove breakdown from inline metric', () => {
+            const testExperiment: Experiment = {
+                ...experiment,
+                metrics: [
+                    {
+                        uuid: 'test-metric-uuid',
+                        metric_type: ExperimentMetricType.MEAN,
+                        source: { kind: NodeKind.EventsNode, event: '$pageview' },
+                        breakdownFilter: {
+                            breakdowns: [
+                                { property: '$browser', type: 'event' },
+                                { property: '$os', type: 'event' },
+                            ],
+                        },
+                    },
+                ] as unknown as ExperimentMetric[],
+            }
+
+            logic.actions.setExperiment(testExperiment)
+            const breakdownToRemove: Breakdown = { property: '$browser', type: 'event' }
+            logic.actions.removeMetricBreakdown('test-metric-uuid', 0, breakdownToRemove)
+
+            const updatedMetric = logic.values.experiment.metrics[0] as ExperimentMetric
+            expect(updatedMetric.breakdownFilter?.breakdowns).toEqual([{ property: '$os', type: 'event' }])
+        })
+
+        it('should remove breakdown from shared metric metadata', () => {
+            const testExperiment: Experiment = {
+                ...experiment,
+                saved_metrics: [
+                    {
+                        id: 1,
+                        experiment: experiment.id as number,
+                        saved_metric: 123,
+                        name: 'Shared Metric',
+                        query: {
+                            uuid: 'shared-metric-uuid',
+                            kind: NodeKind.ExperimentMetric,
+                            metric_type: ExperimentMetricType.MEAN,
+                            source: { kind: NodeKind.EventsNode, event: '$pageview' },
+                        },
+                        metadata: {
+                            type: 'primary',
+                            breakdowns: [
+                                { property: '$browser', type: 'event' } satisfies Breakdown,
+                                { property: '$os', type: 'event' } satisfies Breakdown,
+                            ],
+                        },
+                        created_at: '2024-01-01T00:00:00Z',
+                    } satisfies ExperimentSavedMetric,
+                ],
+                metrics: [],
+            }
+
+            logic.actions.setExperiment(testExperiment)
+            const breakdownToRemove: Breakdown = { property: '$browser', type: 'event' }
+            logic.actions.removeMetricBreakdown('shared-metric-uuid', 0, breakdownToRemove)
+
+            expect(logic.values.experiment.saved_metrics[0].metadata.breakdowns).toEqual([
+                { property: '$os', type: 'event' },
+            ])
+        })
+
+        it('should include breakdowns when preparing shared metrics for loading', () => {
+            const testExperiment: Experiment = {
+                ...experiment,
+                saved_metrics: [
+                    {
+                        id: 1,
+                        experiment: experiment.id as number,
+                        saved_metric: 123,
+                        name: 'Shared Metric',
+                        query: {
+                            uuid: 'shared-metric-uuid',
+                            kind: NodeKind.ExperimentMetric,
+                            metric_type: ExperimentMetricType.MEAN,
+                            source: { kind: NodeKind.EventsNode, event: '$pageview' },
+                        },
+                        metadata: {
+                            type: 'primary',
+                            breakdowns: [
+                                { property: '$browser', type: 'event' } satisfies Breakdown,
+                                { property: '$os', type: 'event' } satisfies Breakdown,
+                            ],
+                        },
+                        created_at: '2024-01-01T00:00:00Z',
+                    } satisfies ExperimentSavedMetric,
+                ],
+                metrics: [],
+                primary_metrics_ordered_uuids: ['shared-metric-uuid'],
+                start_date: '2024-01-01',
+            }
+
+            logic.actions.setExperiment(testExperiment)
+
+            // Check that orderedPrimaryMetricsWithResults includes breakdowns
+            const metricsWithResults = logic.values.orderedPrimaryMetricsWithResults
+            expect(metricsWithResults.length).toBe(1)
+            const enrichedMetric = metricsWithResults[0].metric
+            expect(enrichedMetric.breakdownFilter?.breakdowns).toEqual([
+                { property: '$browser', type: 'event' },
+                { property: '$os', type: 'event' },
+            ])
+        })
+
+        it('should add breakdown to secondary shared metric metadata', () => {
+            const breakdown: Breakdown = { property: '$browser', type: 'event' }
+            const testExperiment: Experiment = {
+                ...experiment,
+                saved_metrics: [
+                    {
+                        id: 1,
+                        experiment: experiment.id as number,
+                        saved_metric: 123,
+                        name: 'Secondary Shared Metric',
+                        query: {
+                            uuid: 'secondary-metric-uuid',
+                            kind: NodeKind.ExperimentMetric,
+                            metric_type: ExperimentMetricType.MEAN,
+                            source: { kind: NodeKind.EventsNode, event: '$pageview' },
+                        },
+                        metadata: { type: 'secondary' },
+                        created_at: '2024-01-01T00:00:00Z',
+                    } satisfies ExperimentSavedMetric,
+                ],
+                metrics: [],
+                metrics_secondary: [],
+            }
+
+            logic.actions.setExperiment(testExperiment)
+            logic.actions.updateMetricBreakdown('secondary-metric-uuid', breakdown)
+
+            expect(logic.values.experiment.saved_metrics[0].metadata.breakdowns).toEqual([breakdown])
+        })
+
+        it('should remove breakdown from secondary shared metric metadata', () => {
+            const testExperiment: Experiment = {
+                ...experiment,
+                saved_metrics: [
+                    {
+                        id: 1,
+                        experiment: experiment.id as number,
+                        saved_metric: 123,
+                        name: 'Secondary Shared Metric',
+                        query: {
+                            uuid: 'secondary-metric-uuid',
+                            kind: NodeKind.ExperimentMetric,
+                            metric_type: ExperimentMetricType.MEAN,
+                            source: { kind: NodeKind.EventsNode, event: '$pageview' },
+                        },
+                        metadata: {
+                            type: 'secondary',
+                            breakdowns: [
+                                { property: '$browser', type: 'event' } satisfies Breakdown,
+                                { property: '$os', type: 'event' } satisfies Breakdown,
+                            ],
+                        },
+                        created_at: '2024-01-01T00:00:00Z',
+                    } satisfies ExperimentSavedMetric,
+                ],
+                metrics: [],
+                metrics_secondary: [],
+            }
+
+            logic.actions.setExperiment(testExperiment)
+            const breakdownToRemove: Breakdown = { property: '$browser', type: 'event' }
+            logic.actions.removeMetricBreakdown('secondary-metric-uuid', 0, breakdownToRemove)
+
+            expect(logic.values.experiment.saved_metrics[0].metadata.breakdowns).toEqual([
+                { property: '$os', type: 'event' },
+            ])
+        })
+
+        it('should include breakdowns when preparing secondary shared metrics for loading', () => {
+            const testExperiment: Experiment = {
+                ...experiment,
+                saved_metrics: [
+                    {
+                        id: 1,
+                        experiment: experiment.id as number,
+                        saved_metric: 123,
+                        name: 'Secondary Shared Metric',
+                        query: {
+                            uuid: 'secondary-metric-uuid',
+                            kind: NodeKind.ExperimentMetric,
+                            metric_type: ExperimentMetricType.MEAN,
+                            source: { kind: NodeKind.EventsNode, event: '$pageview' },
+                        },
+                        metadata: {
+                            type: 'secondary',
+                            breakdowns: [
+                                { property: '$browser', type: 'event' } satisfies Breakdown,
+                                { property: '$os', type: 'event' } satisfies Breakdown,
+                            ],
+                        },
+                        created_at: '2024-01-01T00:00:00Z',
+                    } satisfies ExperimentSavedMetric,
+                ],
+                metrics: [],
+                metrics_secondary: [],
+                secondary_metrics_ordered_uuids: ['secondary-metric-uuid'],
+                start_date: '2024-01-01',
+            }
+
+            logic.actions.setExperiment(testExperiment)
+
+            // Check that orderedSecondaryMetricsWithResults includes breakdowns
+            const metricsWithResults = logic.values.orderedSecondaryMetricsWithResults
+            expect(metricsWithResults.length).toBe(1)
+            const enrichedMetric = metricsWithResults[0].metric
+            expect(enrichedMetric.breakdownFilter?.breakdowns).toEqual([
+                { property: '$browser', type: 'event' },
+                { property: '$os', type: 'event' },
+            ])
         })
     })
 })


### PR DESCRIPTION
## Problem

Breakdowns for shared metrics are not being persisted, so adding a breakdown to a shared metric has no effect.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Here, we update the `metadata` when the breakdowns for a shared metric change and remap `breakdowns` afterward to ensure the UI remains consistent.

For practical purposes, we've added a new `ExperimentSavedMetric` at the experiment metric level. This type should eventually be refactored into the schema general.

There's some code duplication because we have to handle both primary and secondary metrics.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest src/scenes/experiments/experimentLogic.test.ts
```

![cat-type](https://github.com/user-attachments/assets/07601d6c-100d-4aa8-8d34-11f0582a1411)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
