### PR TITLE
fix(ba): bust depot cache

### DIFF
--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
@@ -71,10 +71,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 ###
 
 # Set up /scripts as a Node.js project and install @posthog/agent
+# COMMIT_HASH changes every build, busting the cache so we always get @latest
+ARG COMMIT_HASH
 RUN mkdir -p /scripts && \
     cd /scripts && \
     npm init -y && \
-    npm install @posthog/agent@latest
+    CACHE_BUST=${COMMIT_HASH} npm install @posthog/agent@latest
 
 # Configure git for commits - TODO: Use user's email and name
 RUN git config --global user.email "array@posthog.com" && \


### PR DESCRIPTION
Depot caches layers, and we want the latest version of the agent package on a new build, this busts the cache for that layer by adding the commit hash to the command.