### PR TITLE
feat(funnels): trendlines in funnel historical trends

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -115,7 +115,7 @@ export function InsightDisplayConfig(): JSX.Element {
                               ? [{ label: () => <ShowAlertThresholdLinesFilter /> }]
                               : []),
                           ...(showMultipleYAxesConfig ? [{ label: () => <ShowMultipleYAxesFilter /> }] : []),
-                          ...((isTrends || isRetention) && !isNonTimeSeriesDisplay
+                          ...((isTrends || isRetention || isTrendsFunnel) && !isNonTimeSeriesDisplay
                               ? [{ label: () => <ShowTrendLinesFilter /> }]
                               : []),
                       ],

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -16436,6 +16436,10 @@
                     "description": "Customizations for the appearance of result datasets.",
                     "type": "object"
                 },
+                "showTrendLines": {
+                    "description": "Display linear regression trend lines on the chart (only for historical trends viz)",
+                    "type": "boolean"
+                },
                 "showValuesOnSeries": {
                     "default": false,
                     "type": "boolean"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1472,6 +1472,8 @@ export type FunnelsFilter = {
     resultCustomizations?: Record<string, ResultCustomizationByValue>
     /** Goal Lines */
     goalLines?: GoalLine[]
+    /** Display linear regression trend lines on the chart (only for historical trends viz) */
+    showTrendLines?: boolean
     /** @default false */
     showValuesOnSeries?: boolean
     /** Breakdown table sorting. Format: 'column_key' or '-column_key' (descending) */

--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -39,6 +39,7 @@ export function FunnelLineGraph({
         interval,
         insightData,
         showValuesOnSeries,
+        funnelsFilter,
     } = useValues(funnelDataLogic(insightProps))
     const { weekStartDay, timezone } = useValues(teamLogic)
     const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))
@@ -61,6 +62,7 @@ export function FunnelLineGraph({
                 inSharedMode={!!inSharedMode}
                 showPersonsModal={showPersonsModal}
                 showValuesOnSeries={showValuesOnSeries}
+                showTrendLines={funnelsFilter?.showTrendLines ?? false}
                 goalLines={goalLines ?? []}
                 tooltip={{
                     showHeader: false,

--- a/frontend/src/scenes/insights/EditorFilters/ShowTrendLinesFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ShowTrendLinesFilter.tsx
@@ -2,9 +2,10 @@ import { useActions, useValues } from 'kea'
 
 import { LemonCheckbox } from '@posthog/lemon-ui'
 
+import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
-import { isRetentionQuery, isTrendsQuery } from '~/queries/utils'
+import { isFunnelsQuery, isRetentionQuery, isTrendsQuery } from '~/queries/utils'
 import { ChartDisplayType } from '~/types'
 
 import { insightVizDataLogic } from '../insightVizDataLogic'
@@ -12,6 +13,7 @@ import { insightVizDataLogic } from '../insightVizDataLogic'
 export function ShowTrendLinesFilter(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { querySource, trendsFilter, yAxisScaleType } = useValues(insightVizDataLogic(insightProps))
+    const { isTrendsFunnel } = useValues(funnelDataLogic(insightProps))
     const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
 
     // Get the current state based on query type
@@ -19,14 +21,18 @@ export function ShowTrendLinesFilter(): JSX.Element {
         ? querySource.retentionFilter.showTrendLines
         : isTrendsQuery(querySource)
           ? querySource.trendsFilter?.showTrendLines
-          : false
+          : isFunnelsQuery(querySource)
+            ? querySource.funnelsFilter?.showTrendLines
+            : false
 
     // Determine if trend lines should be disabled based on chart type and scale
     const isLinearScale = !yAxisScaleType || yAxisScaleType === 'linear'
     const isLineGraph = isTrendsQuery(querySource)
         ? (trendsFilter?.display || ChartDisplayType.ActionsLineGraph) === ChartDisplayType.ActionsLineGraph ||
           (trendsFilter?.display || ChartDisplayType.ActionsLineGraph) === ChartDisplayType.ActionsLineGraphCumulative
-        : true // Retention graphs are always line graphs
+        : isFunnelsQuery(querySource)
+          ? isTrendsFunnel
+          : true // Retention graphs are always line graphs
 
     const disabledReason = !isLineGraph
         ? 'Trend lines are only available for line graphs'
@@ -41,6 +47,10 @@ export function ShowTrendLinesFilter(): JSX.Element {
             } as any)
         } else if (isTrendsQuery(querySource)) {
             updateQuerySource({ trendsFilter: { ...querySource.trendsFilter, showTrendLines: !showTrendLines } } as any)
+        } else if (isFunnelsQuery(querySource)) {
+            updateQuerySource({
+                funnelsFilter: { ...querySource.funnelsFilter, showTrendLines: !showTrendLines },
+            } as any)
         }
     }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -15356,6 +15356,10 @@ class FunnelsFilter(BaseModel):
         default=None,
         description="Customizations for the appearance of result datasets.",
     )
+    showTrendLines: bool | None = Field(
+        default=None,
+        description=("Display linear regression trend lines on the chart (only for historical trends viz)"),
+    )
     showValuesOnSeries: bool | None = False
     useUdf: bool | None = None
 

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -2261,6 +2261,11 @@ export interface FunnelsFilterApi {
      * @nullable
      */
     resultCustomizations?: FunnelsFilterApiResultCustomizations
+    /**
+     * Display linear regression trend lines on the chart (only for historical trends viz)
+     * @nullable
+     */
+    showTrendLines?: boolean | null
     /** @nullable */
     showValuesOnSeries?: boolean | null
     /** @nullable */


### PR DESCRIPTION
## Problem
https://posthog.slack.com/archives/C045L1VEG87/p1770372885048389
Trend lines were only supported in trends and retention but also make sense in funnel historical trends mode.

## Changes
<img width="1034" height="516" alt="image" src="https://github.com/user-attachments/assets/4f36c2bb-7676-4a8b-9a27-5290b1a8cf9b" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
