### PR TITLE
chore(llma): Analytics empty clustering event

### DIFF
--- a/products/llm_analytics/frontend/clusters/clustersLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clustersLogic.ts
@@ -445,6 +445,13 @@ export const clustersLogic = kea<clustersLogicType>([
             }
             // Load all trace summaries when a run is loaded for scatter plot tooltips
             if (currentRun) {
+                if (currentRun.clusters.length === 0) {
+                    posthog.capture('llma clusters empty state shown', {
+                        reason: 'no_clusters_in_run',
+                        clustering_level: currentRun.level || values.clusteringLevel,
+                        run_id: currentRun.runId,
+                    })
+                }
                 actions.loadTraceSummariesForRun(currentRun)
                 // Load cluster metrics for displaying averages in cluster cards
                 actions.loadClusterMetricsForRun(currentRun)
@@ -456,6 +463,12 @@ export const clustersLogic = kea<clustersLogicType>([
         },
 
         loadClusteringRunsSuccess: ({ clusteringRuns }) => {
+            if (clusteringRuns.length === 0) {
+                posthog.capture('llma clusters empty state shown', {
+                    reason: 'no_clustering_runs',
+                    clustering_level: values.clusteringLevel,
+                })
+            }
             // Auto-load the first run if available and no run is selected
             if (clusteringRuns.length > 0 && !values.selectedRunId) {
                 actions.loadClusteringRun(clusteringRuns[0].runId)

--- a/products/llm_analytics/frontend/components/clustersTabContentLogic.ts
+++ b/products/llm_analytics/frontend/components/clustersTabContentLogic.ts
@@ -1,5 +1,6 @@
-import { actions, afterMount, kea, key, path, props } from 'kea'
+import { actions, afterMount, kea, key, listeners, path, props } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 
@@ -79,6 +80,17 @@ export const clustersTabContentLogic = kea<clustersTabContentLogicType>([
                 },
             },
         ],
+    })),
+
+    listeners(({ props: logicProps }) => ({
+        loadClustersSuccess: ({ clusters }) => {
+            if (clusters.length === 0) {
+                posthog.capture('llma clusters empty state shown', {
+                    reason: 'trace_not_in_clusters',
+                    trace_id: logicProps.traceId,
+                })
+            }
+        },
     })),
 
     afterMount(({ actions }) => {


### PR DESCRIPTION
## Problem

Users are encountering empty states in the LLM Analytics clustering tab, indicating a potentially poor experience. This change adds instrumentation to measure these occurrences directly.

## Changes

Fires a new `llma clusters empty state shown` event from kea logic listeners in three scenarios:
1.  No clustering runs available (`reason: 'no_clustering_runs'`).
2.  A selected run has no clusters (`reason: 'no_clusters_in_run'`).
3.  A specific trace's "Clusters" tab shows no clusters (`reason: 'trace_not_in_clusters'`).
The event includes relevant properties like `clustering_level`, `run_id`, and `trace_id`.

## How did you test this code?

- Ran existing unit tests (all passed).
- Manually verified event capture in a development environment for each empty state.

## Publish to changelog?

no

---
<p><a href="https://cursor.com/background-agent?bcId=bc-7bef0fd7-9d8a-4374-97a9-52a616b12095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7bef0fd7-9d8a-4374-97a9-52a616b12095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

