### PR TITLE
fix(ph-ai): dashboard url guardrail

### DIFF
--- a/ee/hogai/context/dashboard/context.py
+++ b/ee/hogai/context/dashboard/context.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from posthog.models import Team
 
 from ee.hogai.context.insight.context import InsightContext
+from ee.hogai.utils.helpers import build_dashboard_url
 from ee.hogai.utils.prompt import format_prompt_string
 from ee.hogai.utils.types.base import AnyPydanticModelQuery
 
@@ -60,6 +61,7 @@ class DashboardContext:
         self.name = name
         self.description = description
         self.dashboard_id = dashboard_id
+        self.dashboard_url = build_dashboard_url(team, int(dashboard_id)) if dashboard_id else None
         self.dashboard_filters = dashboard_filters
         self._semaphore = asyncio.Semaphore(max_concurrent_queries)
 
@@ -87,6 +89,7 @@ class DashboardContext:
                 prompt_template,
                 dashboard_name=self.name or "Dashboard",
                 dashboard_id=self.dashboard_id,
+                dashboard_url=self.dashboard_url,
                 description=self.description,
                 insights="",
             )
@@ -99,6 +102,7 @@ class DashboardContext:
             prompt_template,
             dashboard_name=self.name or "Dashboard",
             dashboard_id=self.dashboard_id,
+            dashboard_url=self.dashboard_url,
             description=self.description,
             insights="\n\n".join(insight_results),
         )
@@ -110,6 +114,7 @@ class DashboardContext:
                 prompt_template,
                 dashboard_name=self.name or "Dashboard",
                 dashboard_id=self.dashboard_id,
+                dashboard_url=self.dashboard_url,
                 description=self.description,
             )
 
@@ -125,6 +130,7 @@ class DashboardContext:
             name=self.name or "Dashboard",
             dashboard_name=self.name or "Dashboard",
             dashboard_id=self.dashboard_id,
+            dashboard_url=self.dashboard_url,
             description=self.description,
             insights=insights_text,
         )

--- a/ee/hogai/context/dashboard/prompts.py
+++ b/ee/hogai/context/dashboard/prompts.py
@@ -3,6 +3,9 @@ Dashboard name: {{{dashboard_name}}}
 {{#dashboard_id}}
 Dashboard ID: {{{dashboard_id}}}
 {{/dashboard_id}}
+{{#dashboard_url}}
+Dashboard URL: {{{dashboard_url}}}
+{{/dashboard_url}}
 {{#description}}
 Description: {{{description}}}
 {{/description}}


### PR DESCRIPTION
## Problem

In `prod` we saw that ([trace](https://us.posthog.com/project/2/llm-analytics/traces/0e9c2365-fb29-4b49-ba2a-be73a141244e?event=0e9c2365-fb29-4b49-ba2a-be73a141244e&timestamp=2026-02-11T08:41:45Z)) the `upsert_dashboard` tool created a dashboard, but the dashboard had no URL but just an ID so the agent invented the URL and got it wrong, using the plural `/dashboards/XYZ` instead of the correct `/dashboard/` path.

## Changes

* added the dashboard URL directly to the tool output so the LLM doesn't have to guess anymore.

## How did you test this code?

- [x] manual tests
- [x] unit tests 
