### PR TITLE
chore: configure pyright to use flox venv

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - Build:
   - Frontend: `pnpm --filter=@posthog/frontend build`
   - Start dev: `./bin/start`
+- LSP: Pyright is configured against the flox venv. Prefer LSP (`goToDefinition`, `findReferences`, `hover`) over grep when navigating or refactoring Python code.
 
 ## Commits and Pull Requests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -403,6 +403,11 @@ django_settings_module = "posthog.settings"
 sort_baseline = true
 ignore_categories = ["note"]
 
+[tool.pyright]
+venvPath = ".flox/cache"
+venv = "venv"
+pythonVersion = "3.12"
+
 [tool.ty.environment]
 python-version = "3.12"
 


### PR DESCRIPTION
Configures Pyright to use the flox venv at `.flox/cache/venv` so LSP-based tooling (e.g. Claude Code) can resolve imports out of the box. Without this, Pyright has no idea where the venv is.

Also adds a nudge in AGENTS.md to prefer LSP over grep for Python navigation.