### PR TITLE
feat(flags): add cache size metric to HyperCache

### DIFF
--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -360,8 +360,8 @@ def update_flag_caches(team: Team):
 
     start_time = time.time()
     success = False
-    size_with_cohorts = 0
-    size_without_cohorts = 0
+    size_with_cohorts: int | None = None
+    size_without_cohorts: int | None = None
     try:
         with_cohorts, without_cohorts = _get_both_flags_responses_for_local_evaluation(team)
         size_with_cohorts = flags_hypercache.set_cache_value(team, with_cohorts)

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -20,7 +20,7 @@ from posthog.models.surveys.survey import Survey
 from posthog.models.tag import Tag
 from posthog.models.team import Team
 from posthog.person_db_router import PERSONS_DB_FOR_READ
-from posthog.storage.hypercache import CACHE_SYNC_COUNTER, CACHE_SYNC_DURATION_HISTOGRAM, HyperCache
+from posthog.storage.hypercache import HyperCache, emit_cache_sync_metrics
 
 logger = structlog.get_logger(__name__)
 
@@ -360,10 +360,12 @@ def update_flag_caches(team: Team):
 
     start_time = time.time()
     success = False
+    size_with_cohorts = 0
+    size_without_cohorts = 0
     try:
         with_cohorts, without_cohorts = _get_both_flags_responses_for_local_evaluation(team)
-        flags_hypercache.set_cache_value(team, with_cohorts)
-        flags_without_cohorts_hypercache.set_cache_value(team, without_cohorts)
+        size_with_cohorts = flags_hypercache.set_cache_value(team, with_cohorts)
+        size_without_cohorts = flags_without_cohorts_hypercache.set_cache_value(team, without_cohorts)
         success = True
     except Exception as e:
         capture_exception(e)
@@ -372,12 +374,13 @@ def update_flag_caches(team: Team):
         duration = time.time() - start_time
         result = "success" if success else "failure"
         # Duration uses combined label since both caches are updated in one operation.
-        # Counters use individual labels since each cache is actually updated.
-        CACHE_SYNC_DURATION_HISTOGRAM.labels(
-            result=result, namespace="feature_flags", value="flags_local_eval.json"
-        ).observe(duration)
-        CACHE_SYNC_COUNTER.labels(result=result, namespace="feature_flags", value="flags_with_cohorts.json").inc()
-        CACHE_SYNC_COUNTER.labels(result=result, namespace="feature_flags", value="flags_without_cohorts.json").inc()
+        # Duration-only call doesn't increment counter since the individual caches handle that.
+        emit_cache_sync_metrics(
+            result, "feature_flags", "flags_local_eval.json", duration=duration, increment_counter=False
+        )
+        # Size and counter use individual labels since each cache is actually updated.
+        emit_cache_sync_metrics(result, "feature_flags", "flags_with_cohorts.json", size=size_with_cohorts)
+        emit_cache_sync_metrics(result, "feature_flags", "flags_without_cohorts.json", size=size_without_cohorts)
 
 
 def clear_flag_caches(team: Team, kinds: list[str] | None = None):

--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -68,7 +68,7 @@ CACHE_SYNC_SIZE_HISTOGRAM = Histogram(
         256_000,  # 256KB - half of per-flag limit
         512_000,  # 512KB - per-flag limit (MAX_FEATURE_FLAG_FILTER_SIZE_BYTES)
         1_000_000,  # 1MB - approaching total limit
-        1_536_000,  # 1.5MB - total filter limit (MAX_FEATURE_FLAG_TOTAL_FILTERS_BYTES)
+        1_500_000,  # 1.5MB - total filter limit (MAX_FEATURE_FLAG_TOTAL_FILTERS_BYTES)
         3_000_000,  # 3MB - 2x limit (for overhead/outliers)
         5_000_000,  # 5MB - safety bucket
         float("inf"),

--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -58,6 +58,23 @@ CACHE_SYNC_DURATION_HISTOGRAM = Histogram(
     buckets=(0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, float("inf")),
 )
 
+CACHE_SYNC_SIZE_HISTOGRAM = Histogram(
+    "posthog_hypercache_sync_size_bytes",
+    "Size of hypercache entries in bytes",
+    labelnames=["result", "namespace", "value"],
+    buckets=(
+        10_000,  # 10KB - small caches
+        100_000,  # 100KB - medium caches
+        256_000,  # 256KB - half of per-flag limit
+        512_000,  # 512KB - per-flag limit (MAX_FEATURE_FLAG_FILTER_SIZE_BYTES)
+        1_000_000,  # 1MB - approaching total limit
+        1_536_000,  # 1.5MB - total filter limit (MAX_FEATURE_FLAG_TOTAL_FILTERS_BYTES)
+        3_000_000,  # 3MB - 2x limit (for overhead/outliers)
+        5_000_000,  # 5MB - safety bucket
+        float("inf"),
+    ),
+)
+
 HYPERCACHE_CACHE_COUNTER = Counter(
     "posthog_hypercache_get_from_cache",
     "Metric tracking whether a hypercache was fetched from cache or not",
@@ -66,6 +83,37 @@ HYPERCACHE_CACHE_COUNTER = Counter(
 
 
 _HYPER_CACHE_EMPTY_VALUE = "__missing__"
+
+
+def emit_cache_sync_metrics(
+    result: str,
+    namespace: str,
+    value: str,
+    duration: float | None = None,
+    size: int | None = None,
+    increment_counter: bool = True,
+) -> None:
+    """
+    Emit cache sync metrics for HyperCache operations.
+
+    Args:
+        result: "success" or "failure"
+        namespace: Cache namespace (e.g., "feature_flags")
+        value: Cache value identifier (e.g., "flags_with_cohorts.json")
+        duration: Time taken in seconds; pass None to skip duration metric
+        size: Cache entry size in bytes; pass None or 0 to skip size metric
+        increment_counter: Whether to increment the sync counter (default True)
+
+    Duration and size histograms are only observed when their respective values
+    are provided (size must also be > 0). The counter is incremented unless
+    increment_counter is False.
+    """
+    if duration is not None:
+        CACHE_SYNC_DURATION_HISTOGRAM.labels(result=result, namespace=namespace, value=value).observe(duration)
+    if size is not None and size > 0:
+        CACHE_SYNC_SIZE_HISTOGRAM.labels(result=result, namespace=namespace, value=value).observe(size)
+    if increment_counter:
+        CACHE_SYNC_COUNTER.labels(result=result, namespace=namespace, value=value).inc()
 
 
 class HyperCacheStoreMissing:
@@ -294,9 +342,10 @@ class HyperCache:
 
         start_time = time.time()
         success = False
+        size = 0
         try:
             data = self.load_fn(key)
-            self.set_cache_value(key, data, ttl=ttl)
+            size = self.set_cache_value(key, data, ttl=ttl)
             success = True
             return True
         except Exception as e:
@@ -306,19 +355,20 @@ class HyperCache:
         finally:
             duration = time.time() - start_time
             result = "success" if success else "failure"
-            CACHE_SYNC_DURATION_HISTOGRAM.labels(result=result, namespace=self.namespace, value=self.value).observe(
-                duration
-            )
-            CACHE_SYNC_COUNTER.labels(result=result, namespace=self.namespace, value=self.value).inc()
+            emit_cache_sync_metrics(result, self.namespace, self.value, duration=duration, size=size)
 
     def set_cache_value(
         self, key: KeyType, data: dict | None | HyperCacheStoreMissing, ttl: Optional[int] = None
-    ) -> None:
-        self._set_cache_value_redis(key, data, ttl=ttl)
+    ) -> int:
+        """
+        Set cache value in Redis and S3, returning the serialized size in bytes.
+        """
+        size = self._set_cache_value_redis(key, data, ttl=ttl)
         self._set_cache_value_s3(key, data, ttl=ttl)
         # Only track expiry when we have a Team object (avoids DB lookup)
         if isinstance(key, Team):
             self._track_expiry(key, data, ttl=ttl)
+        return size
 
     def clear_cache(self, key: KeyType, kinds: Optional[list[str]] = None):
         """
@@ -334,13 +384,19 @@ class HyperCache:
 
     def _set_cache_value_redis(
         self, key: KeyType, data: dict | None | HyperCacheStoreMissing, ttl: Optional[int] = None
-    ):
+    ) -> int:
+        """
+        Set cache value in Redis and return the serialized size in bytes.
+
+        Returns 0 for None/missing values, otherwise returns len(json_data).
+        """
         cache_key = self.get_cache_key(key)
         etag_key = self.get_etag_key(key)
         if data is None or isinstance(data, HyperCacheStoreMissing):
             self.cache_client.set(cache_key, _HYPER_CACHE_EMPTY_VALUE, timeout=self.cache_miss_ttl)
             # Always delete ETag key to clean up stale ETags from when enable_etag was True
             self.cache_client.delete(etag_key)
+            return 0
         else:
             timeout = ttl if ttl is not None else self.cache_ttl
             # Use sort_keys for deterministic serialization (consistent ETags)
@@ -354,6 +410,7 @@ class HyperCache:
                 self.cache_client.set(cache_key, json_data, timeout=timeout)
                 # Clean up stale ETag if ETags were previously enabled
                 self.cache_client.delete(etag_key)
+            return len(json_data)
 
     def _set_cache_value_s3(self, key: KeyType, data: dict | None | HyperCacheStoreMissing, ttl: Optional[int] = None):
         """


### PR DESCRIPTION
## Problem

When building a HyperCache entry, we emit a duration metric `posthog_hypercache_sync_duration_seconds`. We want to emit a corresponding `posthog_hypercache_sync_size_bytes` metric to track cache entry sizes, enabling us to monitor teams approaching filter size limits via Grafana dashboards.

## Changes

- Add `posthog_hypercache_sync_size_bytes` histogram metric to track cache entry sizes
- Emit size metrics for all feature flag HyperCaches:
  - `flags.json` (via generic `update_cache()` method)
  - `flags_with_cohorts.json` (explicit emission in `update_flag_caches`)
  - `flags_without_cohorts.json` (explicit emission in `update_flag_caches`)
- Align histogram buckets with feature flag limits from #47428:
  - 512KB (`MAX_FEATURE_FLAG_FILTER_SIZE_BYTES`)
  - 1.5MB (`MAX_FEATURE_FLAG_TOTAL_FILTERS_BYTES`)

## How did you test this code?

- [x] Existing hypercache tests pass (`pytest posthog/storage/test/test_hypercache.py`)
- [ ] Deploy and verify metrics appear in Prometheus/Grafana

## Publish to changelog?

No