### PR TITLE
refactor: avoid event data duplication in ingestion pipeline

### DIFF
--- a/nodejs/src/ingestion/analytics/client-ingestion-warning-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/client-ingestion-warning-subpipeline.ts
@@ -1,9 +1,10 @@
-import { PipelineEvent } from '../../types'
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
 import { createHandleClientIngestionWarningStep } from '../event-processing/handle-client-ingestion-warning-step'
 import { PipelineBuilder, StartPipelineBuilder } from '../pipelines/builders/pipeline-builders'
 
 export interface ClientIngestionWarningSubpipelineInput {
-    event: PipelineEvent
+    event: PluginEvent
 }
 
 export function createClientIngestionWarningSubpipeline<

--- a/nodejs/src/ingestion/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/event-subpipeline.ts
@@ -1,8 +1,10 @@
 import { Message } from 'node-rdkafka'
 
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
-import { EventHeaders, PipelineEvent, Team } from '../../types'
+import { EventHeaders, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
 import { EventPipelineRunnerOptions } from '../../worker/ingestion/event-pipeline/runner'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
@@ -17,7 +19,7 @@ import { PipelineBuilder, StartPipelineBuilder } from '../pipelines/builders/pip
 
 export interface EventSubpipelineInput {
     message: Message
-    event: PipelineEvent
+    event: PluginEvent
     team: Team
     headers: EventHeaders
     groupStoreForBatch: GroupStoreForBatch

--- a/nodejs/src/ingestion/analytics/heatmap-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/heatmap-subpipeline.ts
@@ -1,6 +1,8 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
-import { EventHeaders, PipelineEvent, Team } from '../../types'
+import { EventHeaders, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
 import { EventPipelineRunnerOptions } from '../../worker/ingestion/event-pipeline/runner'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
@@ -14,7 +16,7 @@ import { createSkipEmitEventStep } from '../event-processing/skip-emit-event-ste
 import { PipelineBuilder, StartPipelineBuilder } from '../pipelines/builders/pipeline-builders'
 
 export interface HeatmapSubpipelineInput {
-    event: PipelineEvent
+    event: PluginEvent
     team: Team
     headers: EventHeaders
     groupStoreForBatch: GroupStoreForBatch

--- a/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
@@ -2,7 +2,6 @@ import { Message } from 'node-rdkafka'
 
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
-import { PipelineEvent } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restrictions'
 import { PromiseScheduler } from '../../utils/promise-scheduler'
 import { TeamManager } from '../../utils/team-manager'
@@ -58,7 +57,7 @@ type PreprocessedEventWithGroupStore = PostTeamPreprocessingSubpipelineInput & {
 }
 
 function getTokenAndDistinctId(input: PerEventProcessingInput): string {
-    const token = input.event.token ?? ''
+    const token = input.headers.token ?? ''
     const distinctId = input.event.distinct_id ?? ''
     return `${token}:${distinctId}`
 }
@@ -69,8 +68,8 @@ function mapToPerEventInput<C>(
     const input = element.result.value
     return {
         result: ok({
-            message: input.eventWithTeam.message,
-            event: input.eventWithTeam.event as PipelineEvent,
+            message: input.message,
+            event: input.event,
             team: input.team,
             headers: input.headers,
             groupStoreForBatch: input.groupStoreForBatch,

--- a/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
@@ -1,4 +1,8 @@
-import { EventHeaders, IncomingEventWithTeam, Team } from '../../types'
+import { Message } from 'node-rdkafka'
+
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { EventHeaders, Team } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restrictions'
 import {
     createApplyPersonProcessingRestrictionsStep,
@@ -10,8 +14,9 @@ import { createDropOldEventsStep } from '../event-processing/drop-old-events-ste
 import { PipelineBuilder, StartPipelineBuilder } from '../pipelines/builders/pipeline-builders'
 
 export interface PostTeamPreprocessingSubpipelineInput {
+    message: Message
     headers: EventHeaders
-    eventWithTeam: IncomingEventWithTeam
+    event: PluginEvent
     team: Team
 }
 

--- a/nodejs/src/ingestion/analytics/pre-team-preprocessing-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/pre-team-preprocessing-subpipeline.ts
@@ -1,8 +1,10 @@
 import { Message } from 'node-rdkafka'
 
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
 import { TeamManager } from '~/utils/team-manager'
 
-import { EventHeaders, IncomingEvent, IncomingEventWithTeam, Team } from '../../types'
+import { EventHeaders, Team } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restrictions'
 import {
     createApplyEventRestrictionsStep,
@@ -14,7 +16,7 @@ import {
     createValidateAiEventTokensStep,
     createValidateHistoricalMigrationStep,
 } from '../event-preprocessing'
-import { PipelineBuilder, StartPipelineBuilder } from '../pipelines/builders/pipeline-builders'
+import { StartPipelineBuilder } from '../pipelines/builders/pipeline-builders'
 
 export interface PreTeamPreprocessingSubpipelineInput {
     message: Message
@@ -23,8 +25,7 @@ export interface PreTeamPreprocessingSubpipelineInput {
 export interface PreTeamPreprocessingSubpipelineOutput {
     message: Message
     headers: EventHeaders
-    event: IncomingEvent
-    eventWithTeam: IncomingEventWithTeam
+    event: PluginEvent
     team: Team
 }
 
@@ -39,7 +40,7 @@ export interface PreTeamPreprocessingSubpipelineConfig {
 export function createPreTeamPreprocessingSubpipeline<TInput extends PreTeamPreprocessingSubpipelineInput, TContext>(
     builder: StartPipelineBuilder<TInput, TContext>,
     config: PreTeamPreprocessingSubpipelineConfig
-): PipelineBuilder<TInput, TInput & PreTeamPreprocessingSubpipelineOutput, TContext> {
+) {
     const { teamManager, eventIngestionRestrictionManager, overflowEnabled, overflowTopic, preservePartitionLocality } =
         config
 

--- a/nodejs/src/ingestion/event-preprocessing/apply-cookieless-processing.ts
+++ b/nodejs/src/ingestion/event-preprocessing/apply-cookieless-processing.ts
@@ -23,6 +23,7 @@ export function createApplyCookielessProcessingStep<T extends ApplyCookielessPro
                     event: cookielessResult.value.event,
                 })
             } else {
+                // Return the drop/dlq/redirect result from cookieless processing
                 return cookielessResult
             }
         })

--- a/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.test.ts
@@ -9,22 +9,6 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     let eventIngestionRestrictionManager: EventIngestionRestrictionManager
     let step: ReturnType<typeof createApplyPersonProcessingRestrictionsStep>
 
-    const createEvent = (overrides = {}) =>
-        createTestPipelineEvent({
-            token: 'default-token-123',
-            distinct_id: 'default-user-456',
-            event: 'test-event',
-            properties: { defaultProp: 'defaultValue' },
-            ...overrides,
-        })
-
-    const createHeaders = (overrides = {}) =>
-        createTestEventHeaders({
-            token: 'default-token',
-            distinct_id: 'default-distinct-id',
-            ...overrides,
-        })
-
     beforeEach(() => {
         eventIngestionRestrictionManager = {
             getAppliedRestrictions: jest.fn().mockReturnValue(new Set()),
@@ -34,9 +18,9 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should not modify event if no skip conditions', async () => {
-        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const event = createTestPipelineEvent({ properties: { defaultProp: 'defaultValue' } })
         const team = createTestTeam({ person_processing_opt_out: false })
-        const headers = createHeaders({ token: 'valid-token-abc', distinct_id: 'user-123' })
+        const headers = createTestEventHeaders({ token: 'valid-token-abc', distinct_id: 'user-123' })
         const input = { event, team, headers }
 
         const result = await step(input)
@@ -52,9 +36,9 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should set $process_person_profile to false if there is a restriction', async () => {
-        const event = createEvent()
+        const event = createTestPipelineEvent()
         const team = createTestTeam({ person_processing_opt_out: false })
-        const headers = createHeaders({ token: 'restricted-token-def', distinct_id: 'restricted-user-456' })
+        const headers = createTestEventHeaders({ token: 'restricted-token-def', distinct_id: 'restricted-user-456' })
         const input = { event, team, headers }
         jest.mocked(eventIngestionRestrictionManager.getAppliedRestrictions).mockReturnValue(
             new Set([Restriction.SKIP_PERSON_PROCESSING])
@@ -73,9 +57,9 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should set $process_person_profile to false if team opted out of person processing', async () => {
-        const event = createEvent()
+        const event = createTestPipelineEvent()
         const team = createTestTeam({ person_processing_opt_out: true })
-        const headers = createHeaders({ token: 'opt-out-token-ghi', distinct_id: 'opt-out-user-789' })
+        const headers = createTestEventHeaders({ token: 'opt-out-token-ghi', distinct_id: 'opt-out-user-789' })
         const input = { event, team, headers }
 
         const result = await step(input)
@@ -91,11 +75,11 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should preserve existing properties when setting $process_person_profile', async () => {
-        const event = createEvent({
+        const event = createTestPipelineEvent({
             properties: { customProp: 'customValue', $set: { a: 1, b: 2 } },
         })
         const team = createTestTeam()
-        const headers = createHeaders({ token: 'preserve-token-jkl', distinct_id: 'preserve-user-012' })
+        const headers = createTestEventHeaders({ token: 'preserve-token-jkl', distinct_id: 'preserve-user-012' })
         const input = { event, team, headers }
         jest.mocked(eventIngestionRestrictionManager.getAppliedRestrictions).mockReturnValue(
             new Set([Restriction.SKIP_PERSON_PROCESSING])
@@ -118,11 +102,11 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should call getAppliedRestrictions when token is undefined', async () => {
-        const event = createEvent({
+        const event = createTestPipelineEvent({
             properties: { customProp: 'customValue' },
         })
         const team = createTestTeam()
-        const headers = createHeaders({ token: undefined, distinct_id: 'undefined-token-user-999' })
+        const headers = createTestEventHeaders({ token: undefined, distinct_id: 'undefined-token-user-999' })
         const input = { event, team, headers }
 
         const result = await step(input)
@@ -138,11 +122,11 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should set $process_person_profile to false when token is undefined and restriction is applied', async () => {
-        const event = createEvent({
+        const event = createTestPipelineEvent({
             properties: { customProp: 'customValue' },
         })
         const team = createTestTeam()
-        const headers = createHeaders({ token: undefined, distinct_id: 'undefined-token-user-888' })
+        const headers = createTestEventHeaders({ token: undefined, distinct_id: 'undefined-token-user-888' })
         const input = { event, team, headers }
         jest.mocked(eventIngestionRestrictionManager.getAppliedRestrictions).mockReturnValue(
             new Set([Restriction.SKIP_PERSON_PROCESSING])
@@ -164,9 +148,9 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should pass session_id from headers to getAppliedRestrictions', async () => {
-        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const event = createTestPipelineEvent({ properties: { defaultProp: 'defaultValue' } })
         const team = createTestTeam({ person_processing_opt_out: false })
-        const headers = createHeaders({
+        const headers = createTestEventHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             session_id: 'session-456',
@@ -186,9 +170,9 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should pass event name from headers to getAppliedRestrictions', async () => {
-        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const event = createTestPipelineEvent({ properties: { defaultProp: 'defaultValue' } })
         const team = createTestTeam({ person_processing_opt_out: false })
-        const headers = createHeaders({
+        const headers = createTestEventHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             event: '$pageview',
@@ -208,9 +192,9 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should pass uuid from headers to getAppliedRestrictions', async () => {
-        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const event = createTestPipelineEvent({ properties: { defaultProp: 'defaultValue' } })
         const team = createTestTeam({ person_processing_opt_out: false })
-        const headers = createHeaders({
+        const headers = createTestEventHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             uuid: 'event-uuid-789',
@@ -230,9 +214,9 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should skip person processing when session_id is restricted', async () => {
-        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const event = createTestPipelineEvent({ properties: { defaultProp: 'defaultValue' } })
         const team = createTestTeam({ person_processing_opt_out: false })
-        const headers = createHeaders({
+        const headers = createTestEventHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             session_id: 'restricted-session',
@@ -256,9 +240,9 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should skip person processing when event_name is restricted', async () => {
-        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const event = createTestPipelineEvent({ properties: { defaultProp: 'defaultValue' } })
         const team = createTestTeam({ person_processing_opt_out: false })
-        const headers = createHeaders({
+        const headers = createTestEventHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             event: '$restricted_event',
@@ -282,9 +266,9 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should skip person processing when uuid is restricted', async () => {
-        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const event = createTestPipelineEvent({ properties: { defaultProp: 'defaultValue' } })
         const team = createTestTeam({ person_processing_opt_out: false })
-        const headers = createHeaders({
+        const headers = createTestEventHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             uuid: 'restricted-uuid-789',

--- a/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.test.ts
@@ -1,4 +1,4 @@
-import { EventHeaders, IncomingEventWithTeam } from '../../types'
+import { EventHeaders, PipelineEvent, Team } from '../../types'
 import { EventIngestionRestrictionManager, Restriction } from '../../utils/event-ingestion-restrictions'
 import { ok } from '../pipelines/results'
 import { createApplyPersonProcessingRestrictionsStep } from './apply-person-processing-restrictions'
@@ -7,31 +7,25 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     let eventIngestionRestrictionManager: EventIngestionRestrictionManager
     let step: ReturnType<typeof createApplyPersonProcessingRestrictionsStep>
 
-    const createEventWithTeam = (overrides: any = {}): IncomingEventWithTeam => {
-        const defaultEvent = {
+    const createEvent = (overrides: Partial<PipelineEvent> = {}): PipelineEvent =>
+        ({
             token: 'default-token-123',
             distinct_id: 'default-user-456',
+            event: 'test-event',
+            ip: '127.0.0.1',
+            site_url: 'https://example.com',
+            now: '2021-01-01T00:00:00Z',
+            uuid: '123e4567-e89b-12d3-a456-426614174000',
             properties: { defaultProp: 'defaultValue' },
-        }
-
-        const defaultTeam = {
-            person_processing_opt_out: false,
-        }
-
-        return {
-            event: {
-                ...defaultEvent,
-                ...overrides.event,
-            },
-            team: {
-                ...defaultTeam,
-                ...overrides.team,
-            } as unknown as any,
-            message: {} as any,
-            headers: {} as EventHeaders,
             ...overrides,
-        } as IncomingEventWithTeam
-    }
+        }) as PipelineEvent
+
+    const createTeam = (overrides: Partial<Team> = {}): Team =>
+        ({
+            id: 1,
+            person_processing_opt_out: false,
+            ...overrides,
+        }) as unknown as Team
 
     const createHeaders = (overrides: Partial<EventHeaders> = {}): EventHeaders => ({
         token: 'default-token',
@@ -50,17 +44,15 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should not modify event if no skip conditions', async () => {
-        const eventWithTeam = createEventWithTeam({
-            event: { properties: { defaultProp: 'defaultValue' } },
-            team: { person_processing_opt_out: false },
-        })
+        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const team = createTeam({ person_processing_opt_out: false })
         const headers = createHeaders({ token: 'valid-token-abc', distinct_id: 'user-123' })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
 
         const result = await step(input)
 
         expect(result).toEqual(ok(input))
-        expect(input.eventWithTeam.event.properties).toEqual({ defaultProp: 'defaultValue' })
+        expect(input.event.properties).toEqual({ defaultProp: 'defaultValue' })
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'valid-token-abc',
             expect.objectContaining({
@@ -70,11 +62,10 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should set $process_person_profile to false if there is a restriction', async () => {
-        const eventWithTeam = createEventWithTeam({
-            team: { person_processing_opt_out: false },
-        })
+        const event = createEvent()
+        const team = createTeam({ person_processing_opt_out: false })
         const headers = createHeaders({ token: 'restricted-token-def', distinct_id: 'restricted-user-456' })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
         jest.mocked(eventIngestionRestrictionManager.getAppliedRestrictions).mockReturnValue(
             new Set([Restriction.SKIP_PERSON_PROCESSING])
         )
@@ -82,7 +73,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
         const result = await step(input)
 
         expect(result).toEqual(ok(input))
-        expect(input.eventWithTeam.event.properties?.$process_person_profile).toBe(false)
+        expect(input.event.properties?.$process_person_profile).toBe(false)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'restricted-token-def',
             expect.objectContaining({
@@ -92,16 +83,15 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should set $process_person_profile to false if team opted out of person processing', async () => {
-        const eventWithTeam = createEventWithTeam({
-            team: { person_processing_opt_out: true },
-        })
+        const event = createEvent()
+        const team = createTeam({ person_processing_opt_out: true })
         const headers = createHeaders({ token: 'opt-out-token-ghi', distinct_id: 'opt-out-user-789' })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
 
         const result = await step(input)
 
         expect(result).toEqual(ok(input))
-        expect(input.eventWithTeam.event.properties?.$process_person_profile).toBe(false)
+        expect(input.event.properties?.$process_person_profile).toBe(false)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'opt-out-token-ghi',
             expect.objectContaining({
@@ -111,13 +101,12 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should preserve existing properties when setting $process_person_profile', async () => {
-        const eventWithTeam = createEventWithTeam({
-            event: {
-                properties: { customProp: 'customValue', $set: { a: 1, b: 2 } },
-            },
+        const event = createEvent({
+            properties: { customProp: 'customValue', $set: { a: 1, b: 2 } },
         })
+        const team = createTeam()
         const headers = createHeaders({ token: 'preserve-token-jkl', distinct_id: 'preserve-user-012' })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
         jest.mocked(eventIngestionRestrictionManager.getAppliedRestrictions).mockReturnValue(
             new Set([Restriction.SKIP_PERSON_PROCESSING])
         )
@@ -125,7 +114,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
         const result = await step(input)
 
         expect(result).toEqual(ok(input))
-        expect(input.eventWithTeam.event.properties).toMatchObject({
+        expect(input.event.properties).toMatchObject({
             customProp: 'customValue',
             $set: { a: 1, b: 2 },
             $process_person_profile: false,
@@ -139,18 +128,17 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should call getAppliedRestrictions when token is undefined', async () => {
-        const eventWithTeam = createEventWithTeam({
-            event: {
-                properties: { customProp: 'customValue' },
-            },
+        const event = createEvent({
+            properties: { customProp: 'customValue' },
         })
+        const team = createTeam()
         const headers = createHeaders({ token: undefined, distinct_id: 'undefined-token-user-999' })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
 
         const result = await step(input)
 
         expect(result).toEqual(ok(input))
-        expect(input.eventWithTeam.event.properties).toEqual({ customProp: 'customValue' })
+        expect(input.event.properties).toEqual({ customProp: 'customValue' })
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             undefined,
             expect.objectContaining({
@@ -160,13 +148,12 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should set $process_person_profile to false when token is undefined and restriction is applied', async () => {
-        const eventWithTeam = createEventWithTeam({
-            event: {
-                properties: { customProp: 'customValue' },
-            },
+        const event = createEvent({
+            properties: { customProp: 'customValue' },
         })
+        const team = createTeam()
         const headers = createHeaders({ token: undefined, distinct_id: 'undefined-token-user-888' })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
         jest.mocked(eventIngestionRestrictionManager.getAppliedRestrictions).mockReturnValue(
             new Set([Restriction.SKIP_PERSON_PROCESSING])
         )
@@ -174,7 +161,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
         const result = await step(input)
 
         expect(result).toEqual(ok(input))
-        expect(input.eventWithTeam.event.properties).toMatchObject({
+        expect(input.event.properties).toMatchObject({
             customProp: 'customValue',
             $process_person_profile: false,
         })
@@ -187,16 +174,14 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should pass session_id from headers to getAppliedRestrictions', async () => {
-        const eventWithTeam = createEventWithTeam({
-            event: { properties: { defaultProp: 'defaultValue' } },
-            team: { person_processing_opt_out: false },
-        })
+        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const team = createTeam({ person_processing_opt_out: false })
         const headers = createHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             session_id: 'session-456',
         })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
 
         const result = await step(input)
 
@@ -211,16 +196,14 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should pass event name from headers to getAppliedRestrictions', async () => {
-        const eventWithTeam = createEventWithTeam({
-            event: { properties: { defaultProp: 'defaultValue' } },
-            team: { person_processing_opt_out: false },
-        })
+        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const team = createTeam({ person_processing_opt_out: false })
         const headers = createHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             event: '$pageview',
         })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
 
         const result = await step(input)
 
@@ -235,16 +218,14 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should pass uuid from headers to getAppliedRestrictions', async () => {
-        const eventWithTeam = createEventWithTeam({
-            event: { properties: { defaultProp: 'defaultValue' } },
-            team: { person_processing_opt_out: false },
-        })
+        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const team = createTeam({ person_processing_opt_out: false })
         const headers = createHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             uuid: 'event-uuid-789',
         })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
 
         const result = await step(input)
 
@@ -259,16 +240,14 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should skip person processing when session_id is restricted', async () => {
-        const eventWithTeam = createEventWithTeam({
-            event: { properties: { defaultProp: 'defaultValue' } },
-            team: { person_processing_opt_out: false },
-        })
+        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const team = createTeam({ person_processing_opt_out: false })
         const headers = createHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             session_id: 'restricted-session',
         })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
         jest.mocked(eventIngestionRestrictionManager.getAppliedRestrictions).mockReturnValue(
             new Set([Restriction.SKIP_PERSON_PROCESSING])
         )
@@ -276,7 +255,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
         const result = await step(input)
 
         expect(result).toEqual(ok(input))
-        expect(input.eventWithTeam.event.properties?.$process_person_profile).toBe(false)
+        expect(input.event.properties?.$process_person_profile).toBe(false)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'valid-token-abc',
             expect.objectContaining({
@@ -287,16 +266,14 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should skip person processing when event_name is restricted', async () => {
-        const eventWithTeam = createEventWithTeam({
-            event: { properties: { defaultProp: 'defaultValue' } },
-            team: { person_processing_opt_out: false },
-        })
+        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const team = createTeam({ person_processing_opt_out: false })
         const headers = createHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             event: '$restricted_event',
         })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
         jest.mocked(eventIngestionRestrictionManager.getAppliedRestrictions).mockReturnValue(
             new Set([Restriction.SKIP_PERSON_PROCESSING])
         )
@@ -304,7 +281,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
         const result = await step(input)
 
         expect(result).toEqual(ok(input))
-        expect(input.eventWithTeam.event.properties?.$process_person_profile).toBe(false)
+        expect(input.event.properties?.$process_person_profile).toBe(false)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'valid-token-abc',
             expect.objectContaining({
@@ -315,16 +292,14 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
     })
 
     it('should skip person processing when uuid is restricted', async () => {
-        const eventWithTeam = createEventWithTeam({
-            event: { properties: { defaultProp: 'defaultValue' } },
-            team: { person_processing_opt_out: false },
-        })
+        const event = createEvent({ properties: { defaultProp: 'defaultValue' } })
+        const team = createTeam({ person_processing_opt_out: false })
         const headers = createHeaders({
             token: 'valid-token-abc',
             distinct_id: 'user-123',
             uuid: 'restricted-uuid-789',
         })
-        const input = { eventWithTeam, headers }
+        const input = { event, team, headers }
         jest.mocked(eventIngestionRestrictionManager.getAppliedRestrictions).mockReturnValue(
             new Set([Restriction.SKIP_PERSON_PROCESSING])
         )
@@ -332,7 +307,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
         const result = await step(input)
 
         expect(result).toEqual(ok(input))
-        expect(input.eventWithTeam.event.properties?.$process_person_profile).toBe(false)
+        expect(input.event.properties?.$process_person_profile).toBe(false)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'valid-token-abc',
             expect.objectContaining({

--- a/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.ts
+++ b/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.ts
@@ -1,15 +1,13 @@
-import { EventHeaders, IncomingEventWithTeam } from '../../types'
+import { EventHeaders, PipelineEvent, Team } from '../../types'
 import { EventIngestionRestrictionManager, RestrictionType } from '../../utils/event-ingestion-restrictions'
 import { ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 function applyPersonProcessingRestrictions(
-    eventWithTeam: IncomingEventWithTeam,
+    event: PipelineEvent,
     restrictions: ReadonlySet<RestrictionType>,
     team_person_processing_opt_out: boolean
 ): void {
-    const { event } = eventWithTeam
-
     const shouldSkipPerson = restrictions.has(RestrictionType.SKIP_PERSON_PROCESSING) || team_person_processing_opt_out
 
     if (shouldSkipPerson) {
@@ -22,17 +20,13 @@ function applyPersonProcessingRestrictions(
 }
 
 export function createApplyPersonProcessingRestrictionsStep<
-    T extends { eventWithTeam: IncomingEventWithTeam; headers: EventHeaders },
+    T extends { event: PipelineEvent; team: Team; headers: EventHeaders },
 >(eventIngestionRestrictionManager: EventIngestionRestrictionManager): ProcessingStep<T, T> {
     return async function applyPersonProcessingRestrictionsStep(input) {
-        const { eventWithTeam, headers } = input
+        const { event, team, headers } = input
 
         const restrictions = eventIngestionRestrictionManager.getAppliedRestrictions(headers.token, headers)
-        applyPersonProcessingRestrictions(
-            eventWithTeam,
-            restrictions,
-            eventWithTeam.team.person_processing_opt_out ?? false
-        )
+        applyPersonProcessingRestrictions(event, restrictions, team.person_processing_opt_out ?? false)
         return Promise.resolve(ok(input))
     }
 }

--- a/nodejs/src/ingestion/event-preprocessing/enrich-survey-person-properties.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/enrich-survey-person-properties.test.ts
@@ -1,5 +1,3 @@
-import { createTestEventHeaders } from '~/tests/helpers/event-headers'
-
 import { PipelineResultType } from '../pipelines/results'
 import {
     SURVEY_EVENTS,
@@ -12,22 +10,15 @@ describe('createEnrichSurveyPersonPropertiesStep', () => {
 
     const createEvent = (eventName: string, properties?: Record<string, unknown>, timestamp?: string) => ({
         event: {
-            event: {
-                event: eventName,
-                distinct_id: 'user123',
-                team_id: 1,
-                ip: '127.0.0.1',
-                site_url: 'https://example.com',
-                now: '2021-01-01T00:00:00Z',
-                uuid: '123e4567-e89b-12d3-a456-426614174000',
-                timestamp: timestamp || '2021-01-01T12:00:00Z',
-                properties,
-            },
-            headers: createTestEventHeaders({
-                token: 'token123',
-                distinct_id: 'user123',
-                timestamp: '2021-01-01T00:00:00Z',
-            }),
+            event: eventName,
+            distinct_id: 'user123',
+            team_id: 1,
+            ip: '127.0.0.1',
+            site_url: 'https://example.com',
+            now: '2021-01-01T00:00:00Z',
+            uuid: '123e4567-e89b-12d3-a456-426614174000',
+            timestamp: timestamp || '2021-01-01T12:00:00Z',
+            properties,
         },
     })
 
@@ -36,7 +27,7 @@ describe('createEnrichSurveyPersonPropertiesStep', () => {
         const result = await step(input)
 
         expect(result.type).toBe(PipelineResultType.OK)
-        expect(input.event.event.properties!['$set']).toEqual({
+        expect(input.event.properties!['$set']).toEqual({
             [SURVEY_PERSON_PROPERTIES.LAST_SEEN_DATE]: '2021-01-01T12:00:00Z',
         })
     })
@@ -53,7 +44,7 @@ describe('createEnrichSurveyPersonPropertiesStep', () => {
         const result = await step(input)
 
         expect(result.type).toBe(PipelineResultType.OK)
-        expect(input.event.event.properties!['$set']).toEqual({
+        expect(input.event.properties!['$set']).toEqual({
             [SURVEY_PERSON_PROPERTIES.LAST_SEEN_DATE]: 'custom-override',
             existing_prop: 'value',
         })
@@ -64,7 +55,7 @@ describe('createEnrichSurveyPersonPropertiesStep', () => {
         const result = await step(input)
 
         expect(result.type).toBe(PipelineResultType.OK)
-        expect(input.event.event.properties!['$set']).toBeUndefined()
+        expect(input.event.properties!['$set']).toBeUndefined()
     })
 
     it('handles survey shown events with no properties', async () => {
@@ -72,7 +63,7 @@ describe('createEnrichSurveyPersonPropertiesStep', () => {
         const result = await step(input)
 
         expect(result.type).toBe(PipelineResultType.OK)
-        expect(input.event.event.properties!['$set']).toEqual({
+        expect(input.event.properties!['$set']).toEqual({
             [SURVEY_PERSON_PROPERTIES.LAST_SEEN_DATE]: '2021-01-01T12:00:00Z',
         })
     })

--- a/nodejs/src/ingestion/event-preprocessing/enrich-survey-person-properties.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/enrich-survey-person-properties.test.ts
@@ -1,3 +1,4 @@
+import { createTestPipelineEvent } from '../../../tests/helpers/pipeline-event'
 import { PipelineResultType } from '../pipelines/results'
 import {
     SURVEY_EVENTS,
@@ -9,17 +10,13 @@ describe('createEnrichSurveyPersonPropertiesStep', () => {
     const step = createEnrichSurveyPersonPropertiesStep()
 
     const createEvent = (eventName: string, properties?: Record<string, unknown>, timestamp?: string) => ({
-        event: {
+        event: createTestPipelineEvent({
             event: eventName,
             distinct_id: 'user123',
             team_id: 1,
-            ip: '127.0.0.1',
-            site_url: 'https://example.com',
-            now: '2021-01-01T00:00:00Z',
-            uuid: '123e4567-e89b-12d3-a456-426614174000',
             timestamp: timestamp || '2021-01-01T12:00:00Z',
             properties,
-        },
+        }),
     })
 
     it('adds $survey_last_seen_date to $set for survey shown events', async () => {

--- a/nodejs/src/ingestion/event-preprocessing/enrich-survey-person-properties.ts
+++ b/nodejs/src/ingestion/event-preprocessing/enrich-survey-person-properties.ts
@@ -1,4 +1,4 @@
-import { IncomingEvent } from '../../types'
+import { PipelineEvent } from '../../types'
 import { ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
@@ -10,16 +10,16 @@ export const SURVEY_PERSON_PROPERTIES = {
     LAST_SEEN_DATE: '$survey_last_seen_date',
 } as const
 
-export function createEnrichSurveyPersonPropertiesStep<T extends { event: IncomingEvent }>(): ProcessingStep<T, T> {
+export function createEnrichSurveyPersonPropertiesStep<T extends { event: PipelineEvent }>(): ProcessingStep<T, T> {
     return async function enrichSurveyPersonPropertiesStep(input) {
         const { event } = input
 
-        if (event.event.event === SURVEY_EVENTS.SHOWN) {
-            event.event.properties = event.event.properties || {}
-            event.event.properties['$set'] = event.event.properties['$set'] || {}
+        if (event.event === SURVEY_EVENTS.SHOWN) {
+            event.properties = event.properties || {}
+            event.properties['$set'] = event.properties['$set'] || {}
             // Only set if not already present (allows explicit $set to override)
-            if (!(SURVEY_PERSON_PROPERTIES.LAST_SEEN_DATE in event.event.properties['$set'])) {
-                event.event.properties['$set'][SURVEY_PERSON_PROPERTIES.LAST_SEEN_DATE] = event.event.timestamp
+            if (!(SURVEY_PERSON_PROPERTIES.LAST_SEEN_DATE in event.properties['$set'])) {
+                event.properties['$set'][SURVEY_PERSON_PROPERTIES.LAST_SEEN_DATE] = event.timestamp
             }
         }
 

--- a/nodejs/src/ingestion/event-preprocessing/overflow-lane-ttl-refresh-step.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/overflow-lane-ttl-refresh-step.test.ts
@@ -1,5 +1,4 @@
-import { createTestMessage } from '../../../tests/helpers/kafka-message'
-import { EventHeaders, PipelineEvent, Team } from '../../types'
+import { PipelineEvent } from '../../types'
 import { PipelineResultType } from '../pipelines/results'
 import { OverflowRedirectService } from '../utils/overflow-redirect/overflow-redirect-service'
 import { createOverflowLaneTTLRefreshStep } from './overflow-lane-ttl-refresh-step'
@@ -13,12 +12,7 @@ const createMockEvent = (token: string, distinctId: string, now?: Date): RateLim
         force_disable_person_processing: false,
         historical_migration: false,
     },
-    eventWithTeam: {
-        message: createTestMessage(),
-        event: { distinct_id: distinctId, token } as PipelineEvent,
-        team: { id: 1 } as Team,
-        headers: {} as EventHeaders,
-    },
+    event: { distinct_id: distinctId, token } as PipelineEvent,
 })
 
 const createMockService = (): jest.Mocked<OverflowRedirectService> => ({

--- a/nodejs/src/ingestion/event-preprocessing/overflow-lane-ttl-refresh-step.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/overflow-lane-ttl-refresh-step.test.ts
@@ -1,4 +1,4 @@
-import { PipelineEvent } from '../../types'
+import { createTestPipelineEvent } from '../../../tests/helpers/pipeline-event'
 import { PipelineResultType } from '../pipelines/results'
 import { OverflowRedirectService } from '../utils/overflow-redirect/overflow-redirect-service'
 import { createOverflowLaneTTLRefreshStep } from './overflow-lane-ttl-refresh-step'
@@ -12,7 +12,7 @@ const createMockEvent = (token: string, distinctId: string, now?: Date): RateLim
         force_disable_person_processing: false,
         historical_migration: false,
     },
-    event: { distinct_id: distinctId, token } as PipelineEvent,
+    event: createTestPipelineEvent({ distinct_id: distinctId, token }),
 })
 
 const createMockService = (): jest.Mocked<OverflowRedirectService> => ({

--- a/nodejs/src/ingestion/event-preprocessing/overflow-lane-ttl-refresh-step.ts
+++ b/nodejs/src/ingestion/event-preprocessing/overflow-lane-ttl-refresh-step.ts
@@ -1,10 +1,10 @@
-import { EventHeaders, IncomingEventWithTeam } from '../../types'
+import { EventHeaders, PipelineEvent } from '../../types'
 import { PipelineResult, ok } from '../pipelines/results'
 import { OverflowEventBatch, OverflowRedirectService } from '../utils/overflow-redirect/overflow-redirect-service'
 
 export interface OverflowLaneTTLRefreshStepInput {
     headers: EventHeaders
-    eventWithTeam: IncomingEventWithTeam
+    event: PipelineEvent
 }
 
 /**
@@ -25,9 +25,9 @@ export function createOverflowLaneTTLRefreshStep<T extends OverflowLaneTTLRefres
         // Group events by token:distinct_id for batch TTL refresh
         const keyStats = new Map<string, { token: string; distinctId: string; count: number; firstTimestamp: number }>()
 
-        for (const { headers, eventWithTeam } of inputs) {
+        for (const { headers, event } of inputs) {
             const token = headers.token ?? ''
-            const distinctId = eventWithTeam.event.distinct_id ?? ''
+            const distinctId = event.distinct_id ?? ''
             const eventKey = `${token}:${distinctId}`
             const timestamp = headers.now?.getTime() ?? Date.now()
 

--- a/nodejs/src/ingestion/event-preprocessing/rate-limit-to-overflow-step.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/rate-limit-to-overflow-step.test.ts
@@ -1,4 +1,4 @@
-import { PipelineEvent } from '../../types'
+import { createTestPipelineEvent } from '../../../tests/helpers/pipeline-event'
 import { PipelineResultType } from '../pipelines/results'
 import { OverflowRedirectService } from '../utils/overflow-redirect/overflow-redirect-service'
 import { RateLimitToOverflowStepInput, createRateLimitToOverflowStep } from './rate-limit-to-overflow-step'
@@ -11,7 +11,7 @@ const createMockEvent = (token: string, distinctId: string, now?: Date): RateLim
         force_disable_person_processing: false,
         historical_migration: false,
     },
-    event: { distinct_id: distinctId, token } as PipelineEvent,
+    event: createTestPipelineEvent({ distinct_id: distinctId, token }),
 })
 
 const createMockOverflowRedirectService = (

--- a/nodejs/src/ingestion/event-preprocessing/rate-limit-to-overflow-step.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/rate-limit-to-overflow-step.test.ts
@@ -1,5 +1,4 @@
-import { createTestMessage } from '../../../tests/helpers/kafka-message'
-import { EventHeaders, PipelineEvent, Team } from '../../types'
+import { PipelineEvent } from '../../types'
 import { PipelineResultType } from '../pipelines/results'
 import { OverflowRedirectService } from '../utils/overflow-redirect/overflow-redirect-service'
 import { RateLimitToOverflowStepInput, createRateLimitToOverflowStep } from './rate-limit-to-overflow-step'
@@ -12,12 +11,7 @@ const createMockEvent = (token: string, distinctId: string, now?: Date): RateLim
         force_disable_person_processing: false,
         historical_migration: false,
     },
-    eventWithTeam: {
-        message: createTestMessage(),
-        event: { distinct_id: distinctId, token } as PipelineEvent,
-        team: { id: 1 } as Team,
-        headers: {} as EventHeaders,
-    },
+    event: { distinct_id: distinctId, token } as PipelineEvent,
 })
 
 const createMockOverflowRedirectService = (

--- a/nodejs/src/ingestion/event-preprocessing/resolve-team.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/resolve-team.test.ts
@@ -105,8 +105,7 @@ describe('createResolveTeamStep()', () => {
         const response = await step(input)
         expect(response).toEqual(
             ok({
-                message: input.message,
-                headers: input.headers,
+                ...input,
                 event: { ...pipelineEvent, token: teamTwoToken, team_id: teamTwo.id },
                 team: teamTwo,
             })
@@ -148,8 +147,7 @@ describe('createResolveTeamStep()', () => {
         const response = await step(input)
         expect(response).toEqual(
             ok({
-                message: input.message,
-                headers: input.headers,
+                ...input,
                 event: { ...pipelineEvent, team_id: teamTwo.id, token: teamTwoToken },
                 team: teamTwo,
             })

--- a/nodejs/src/ingestion/event-preprocessing/resolve-team.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/resolve-team.test.ts
@@ -96,7 +96,7 @@ describe('createResolveTeamStep()', () => {
         ])
     })
 
-    it('event with a valid token calls getTeamByToken with correct token', async () => {
+    it('event with a valid token replaces event with PluginEvent and adds team', async () => {
         const input = {
             message: {} as Message,
             headers: {} as EventHeaders,
@@ -105,14 +105,10 @@ describe('createResolveTeamStep()', () => {
         const response = await step(input)
         expect(response).toEqual(
             ok({
-                ...input,
+                message: input.message,
+                headers: input.headers,
+                event: { ...pipelineEvent, token: teamTwoToken, team_id: teamTwo.id },
                 team: teamTwo,
-                eventWithTeam: {
-                    event: { ...pipelineEvent, token: teamTwoToken },
-                    team: teamTwo,
-                    message: input.message,
-                    headers: input.headers,
-                },
             })
         )
         expect(teamManager.getTeamByToken).toHaveBeenCalledWith(teamTwoToken)
@@ -152,14 +148,10 @@ describe('createResolveTeamStep()', () => {
         const response = await step(input)
         expect(response).toEqual(
             ok({
-                ...input,
+                message: input.message,
+                headers: input.headers,
+                event: { ...pipelineEvent, team_id: teamTwo.id, token: teamTwoToken },
                 team: teamTwo,
-                eventWithTeam: {
-                    event: { ...pipelineEvent, team_id: 3, token: teamTwoToken },
-                    team: teamTwo,
-                    message: input.message,
-                    headers: input.headers,
-                },
             })
         )
         expect(teamManager.getTeamByToken).toHaveBeenCalledWith(teamTwoToken)

--- a/nodejs/src/ingestion/event-preprocessing/resolve-team.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/resolve-team.test.ts
@@ -1,35 +1,31 @@
-import { Message } from 'node-rdkafka'
-
 import { TeamManager } from '~/utils/team-manager'
 
+import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
+import { createTestMessage } from '../../../tests/helpers/kafka-message'
 import { getMetricValues, resetMetrics } from '../../../tests/helpers/metrics'
-import { EventHeaders, IncomingEvent, Team } from '../../types'
+import { createTestPipelineEvent } from '../../../tests/helpers/pipeline-event'
+import { createTestTeam } from '../../../tests/helpers/team'
+import { IncomingEvent } from '../../types'
 import { drop, ok } from '../pipelines/results'
 import { createResolveTeamStep } from './resolve-team'
 
-const pipelineEvent = {
+const pipelineEvent = createTestPipelineEvent({
     event: '$pageview',
     properties: { foo: 'bar' },
     timestamp: '2020-02-23T02:15:00Z',
     now: '2020-02-23T02:15:00Z',
     distinct_id: 'my_id',
-    ip: '127.0.0.1',
-    site_url: 'https://example.com',
-    uuid: '123e4567-e89b-12d3-a456-426614174000',
-}
+})
 
-// @ts-expect-error TODO: fix underlying type
-const teamTwo: Team = {
+const teamTwo = createTestTeam({
     id: 2,
     uuid: 'af95d312-1a0a-4208-b80f-562ddafc9bcd',
     organization_id: '66f3f7bf-44e2-45dd-9901-5dbd93744e3a',
     name: 'testTeam',
-    anonymize_ips: false,
     api_token: 'token',
     slack_incoming_webhook: '',
     session_recording_opt_in: false,
-    ingested_event: true,
-}
+})
 
 const teamTwoToken = 'token'
 
@@ -60,9 +56,9 @@ beforeEach(() => {
 describe('createResolveTeamStep()', () => {
     it('event with no token is not processed and the step returns drop', async () => {
         const input = {
-            message: {} as Message,
-            headers: {} as EventHeaders,
-            event: { event: { ...pipelineEvent }, message: {} as Message } as IncomingEvent,
+            message: createTestMessage(),
+            headers: createTestEventHeaders(),
+            event: { event: { ...pipelineEvent }, message: createTestMessage() } as IncomingEvent,
         }
         const response = await step(input)
         expect(response).toEqual(drop('no_token'))
@@ -79,9 +75,9 @@ describe('createResolveTeamStep()', () => {
 
     it('event with an invalid token is not processed and the step returns drop', async () => {
         const input = {
-            message: {} as Message,
-            headers: {} as EventHeaders,
-            event: { event: { ...pipelineEvent, token: 'unknown' }, message: {} as Message } as IncomingEvent,
+            message: createTestMessage(),
+            headers: createTestEventHeaders(),
+            event: { event: { ...pipelineEvent, token: 'unknown' }, message: createTestMessage() } as IncomingEvent,
         }
         const response = await step(input)
         expect(response).toEqual(drop('invalid_token'))
@@ -98,9 +94,9 @@ describe('createResolveTeamStep()', () => {
 
     it('event with a valid token replaces event with PluginEvent and adds team', async () => {
         const input = {
-            message: {} as Message,
-            headers: {} as EventHeaders,
-            event: { event: { ...pipelineEvent, token: teamTwoToken }, message: {} as Message } as IncomingEvent,
+            message: createTestMessage(),
+            headers: createTestEventHeaders(),
+            event: { event: { ...pipelineEvent, token: teamTwoToken }, message: createTestMessage() } as IncomingEvent,
         }
         const response = await step(input)
         expect(response).toEqual(
@@ -116,9 +112,9 @@ describe('createResolveTeamStep()', () => {
 
     it('event with team_id but no token is dropped', async () => {
         const input = {
-            message: {} as Message,
-            headers: {} as EventHeaders,
-            event: { event: { ...pipelineEvent, team_id: 3 }, message: {} as Message } as IncomingEvent,
+            message: createTestMessage(),
+            headers: createTestEventHeaders(),
+            event: { event: { ...pipelineEvent, team_id: 3 }, message: createTestMessage() } as IncomingEvent,
         }
         const response = await step(input)
         expect(response).toEqual(drop('no_token'))
@@ -137,11 +133,11 @@ describe('createResolveTeamStep()', () => {
 
     it('event with both team_id and token uses token for team resolution', async () => {
         const input = {
-            message: {} as Message,
-            headers: {} as EventHeaders,
+            message: createTestMessage(),
+            headers: createTestEventHeaders(),
             event: {
                 event: { ...pipelineEvent, team_id: 3, token: teamTwoToken },
-                message: {} as Message,
+                message: createTestMessage(),
             } as IncomingEvent,
         }
         const response = await step(input)
@@ -159,9 +155,9 @@ describe('createResolveTeamStep()', () => {
     it('PG errors are propagated up to trigger retries', async () => {
         jest.mocked(teamManager.getTeamByToken).mockRejectedValueOnce(new Error('retry me'))
         const input = {
-            message: {} as Message,
-            headers: {} as EventHeaders,
-            event: { event: { ...pipelineEvent, token: teamTwoToken }, message: {} as Message } as IncomingEvent,
+            message: createTestMessage(),
+            headers: createTestEventHeaders(),
+            event: { event: { ...pipelineEvent, token: teamTwoToken }, message: createTestMessage() } as IncomingEvent,
         }
         await expect(async () => {
             await step(input)

--- a/nodejs/src/ingestion/event-preprocessing/resolve-team.ts
+++ b/nodejs/src/ingestion/event-preprocessing/resolve-team.ts
@@ -1,9 +1,11 @@
 import { Message } from 'node-rdkafka'
 
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
 import { TeamManager } from '~/utils/team-manager'
 
 import { eventDroppedCounter } from '../../common/metrics'
-import { EventHeaders, IncomingEvent, IncomingEventWithTeam, Team } from '../../types'
+import { EventHeaders, IncomingEvent, PipelineEvent, Team } from '../../types'
 import { tokenOrTeamPresentCounter } from '../../worker/ingestion/event-pipeline/metrics'
 import { drop, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
@@ -14,21 +16,11 @@ export interface ResolveTeamStepInput {
     event: IncomingEvent
 }
 
-export interface ResolveTeamStepOutput {
-    eventWithTeam: IncomingEventWithTeam
-    team: Team
-}
-
 type ResolveTeamError = { error: true; cause: 'no_token' | 'invalid_token' }
-type ResolveTeamSuccess = { error: false } & ResolveTeamStepOutput
+type ResolveTeamSuccess = { error: false; team: Team }
 type ResolveTeamResult = ResolveTeamSuccess | ResolveTeamError
 
-async function resolveTeam(
-    teamManager: TeamManager,
-    message: Message,
-    headers: EventHeaders,
-    event: IncomingEvent['event']
-): Promise<ResolveTeamResult> {
+async function resolveTeam(teamManager: TeamManager, event: PipelineEvent): Promise<ResolveTeamResult> {
     tokenOrTeamPresentCounter
         .labels({
             team_id_present: event.team_id ? 'true' : 'false',
@@ -58,30 +50,22 @@ async function resolveTeam(
         return { error: true, cause: 'invalid_token' }
     }
 
-    return {
-        error: false,
-        team,
-        eventWithTeam: {
-            event,
-            team,
-            message,
-            headers,
-        },
-    }
+    return { error: false, team }
 }
 
 export function createResolveTeamStep<TInput extends ResolveTeamStepInput>(
     teamManager: TeamManager
-): ProcessingStep<TInput, TInput & ResolveTeamStepOutput> {
+): ProcessingStep<TInput, Omit<TInput, 'event'> & { event: PluginEvent; team: Team }> {
     return async function resolveTeamStep(input) {
-        const { message, headers, event } = input
+        const { event: incomingEvent, ...restInput } = input
 
-        const result = await resolveTeam(teamManager, message, headers, event.event)
+        const result = await resolveTeam(teamManager, incomingEvent.event)
 
         if (result.error) {
             return drop(result.cause)
         }
 
-        return ok({ ...input, eventWithTeam: result.eventWithTeam, team: result.team })
+        const pluginEvent: PluginEvent = { ...incomingEvent.event, team_id: result.team.id }
+        return ok({ ...restInput, event: pluginEvent, team: result.team })
     }
 }

--- a/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.test.ts
@@ -1,3 +1,4 @@
+import { createTestPipelineEvent } from '../../../tests/helpers/pipeline-event'
 import { PipelineResultType, ok } from '../pipelines/results'
 import { createValidateAiEventTokensStep } from './validate-ai-event-tokens'
 
@@ -47,16 +48,12 @@ describe('createValidateAiEventTokensStep', () => {
     const step = createValidateAiEventTokensStep()
 
     const createEvent = (eventName: string, properties?: Record<string, unknown>) => ({
-        event: {
+        event: createTestPipelineEvent({
             event: eventName,
             distinct_id: 'user123',
             team_id: 1,
-            ip: '127.0.0.1',
-            site_url: 'https://example.com',
-            now: '2021-01-01T00:00:00Z',
-            uuid: '123e4567-e89b-12d3-a456-426614174000',
             properties,
-        },
+        }),
     })
 
     const expectAllowed = async (input: ReturnType<typeof createEvent>) => {

--- a/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.test.ts
@@ -1,5 +1,3 @@
-import { createTestEventHeaders } from '~/tests/helpers/event-headers'
-
 import { PipelineResultType, ok } from '../pipelines/results'
 import { createValidateAiEventTokensStep } from './validate-ai-event-tokens'
 
@@ -50,21 +48,14 @@ describe('createValidateAiEventTokensStep', () => {
 
     const createEvent = (eventName: string, properties?: Record<string, unknown>) => ({
         event: {
-            event: {
-                event: eventName,
-                distinct_id: 'user123',
-                team_id: 1,
-                ip: '127.0.0.1',
-                site_url: 'https://example.com',
-                now: '2021-01-01T00:00:00Z',
-                uuid: '123e4567-e89b-12d3-a456-426614174000',
-                properties,
-            },
-            headers: createTestEventHeaders({
-                token: 'token123',
-                distinct_id: 'user123',
-                timestamp: '2021-01-01T00:00:00Z',
-            }),
+            event: eventName,
+            distinct_id: 'user123',
+            team_id: 1,
+            ip: '127.0.0.1',
+            site_url: 'https://example.com',
+            now: '2021-01-01T00:00:00Z',
+            uuid: '123e4567-e89b-12d3-a456-426614174000',
+            properties,
         },
     })
 

--- a/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.ts
@@ -1,4 +1,4 @@
-import { IncomingEvent } from '../../types'
+import { PipelineEvent } from '../../types'
 import { AI_EVENT_TYPES } from '../ai'
 import { drop, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
@@ -38,15 +38,15 @@ function isValidBigDecimalInput(value: unknown): boolean {
     return false
 }
 
-export function createValidateAiEventTokensStep<T extends { event: IncomingEvent }>(): ProcessingStep<T, T> {
+export function createValidateAiEventTokensStep<T extends { event: PipelineEvent }>(): ProcessingStep<T, T> {
     return async function validateAiEventTokensStep(input) {
         const { event } = input
 
-        if (!AI_EVENT_TYPES.has(event.event.event)) {
+        if (!AI_EVENT_TYPES.has(event.event)) {
             return Promise.resolve(ok(input))
         }
 
-        const properties = event.event.properties
+        const properties = event.properties
 
         if (!properties) {
             return Promise.resolve(ok(input))

--- a/nodejs/src/ingestion/event-preprocessing/validate-event-properties.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-event-properties.test.ts
@@ -1,4 +1,4 @@
-import { IncomingEventWithTeam } from '../../types'
+import { PipelineEvent } from '../../types'
 import { drop, ok } from '../pipelines/results'
 import { createValidateEventPropertiesStep } from './validate-event-properties'
 
@@ -21,26 +21,18 @@ describe('createValidateEventPropertiesStep', () => {
         it('should drop $groupidentify events with group_key longer than 400 characters', async () => {
             const longGroupKey = 'a'.repeat(401)
             const input = {
-                eventWithTeam: {
-                    event: {
-                        event: '$groupidentify',
-                        distinct_id: 'user123',
-                        team_id: 1,
-                        uuid: '123e4567-e89b-12d3-a456-426614174000',
-                        ip: '127.0.0.1',
-                        site_url: 'https://example.com',
-                        now: '2021-01-01T00:00:00Z',
-                        properties: {
-                            $group_key: longGroupKey,
-                        },
+                event: {
+                    event: '$groupidentify',
+                    distinct_id: 'user123',
+                    team_id: 1,
+                    uuid: '123e4567-e89b-12d3-a456-426614174000',
+                    ip: '127.0.0.1',
+                    site_url: 'https://example.com',
+                    now: '2021-01-01T00:00:00Z',
+                    properties: {
+                        $group_key: longGroupKey,
                     },
-                    team: {
-                        id: 1,
-                        name: 'Test Team',
-                    },
-                    message: {} as any,
-                    headers: {} as any,
-                } as unknown as IncomingEventWithTeam,
+                } as PipelineEvent,
             }
 
             const result = await step(input)
@@ -69,26 +61,18 @@ describe('createValidateEventPropertiesStep', () => {
         it('should allow $groupidentify events with group_key shorter than 400 characters', async () => {
             const shortGroupKey = 'a'.repeat(399)
             const input = {
-                eventWithTeam: {
-                    event: {
-                        event: '$groupidentify',
-                        distinct_id: 'user123',
-                        team_id: 1,
-                        uuid: '123e4567-e89b-12d3-a456-426614174000',
-                        ip: '127.0.0.1',
-                        site_url: 'https://example.com',
-                        now: '2021-01-01T00:00:00Z',
-                        properties: {
-                            $group_key: shortGroupKey,
-                        },
+                event: {
+                    event: '$groupidentify',
+                    distinct_id: 'user123',
+                    team_id: 1,
+                    uuid: '123e4567-e89b-12d3-a456-426614174000',
+                    ip: '127.0.0.1',
+                    site_url: 'https://example.com',
+                    now: '2021-01-01T00:00:00Z',
+                    properties: {
+                        $group_key: shortGroupKey,
                     },
-                    team: {
-                        id: 1,
-                        name: 'Test Team',
-                    },
-                    message: {} as any,
-                    headers: {} as any,
-                } as unknown as IncomingEventWithTeam,
+                } as PipelineEvent,
             }
 
             const result = await step(input)
@@ -99,26 +83,18 @@ describe('createValidateEventPropertiesStep', () => {
         it('should allow $groupidentify events with group_key exactly 400 characters', async () => {
             const exactGroupKey = 'a'.repeat(400)
             const input = {
-                eventWithTeam: {
-                    event: {
-                        event: '$groupidentify',
-                        distinct_id: 'user123',
-                        team_id: 1,
-                        uuid: '123e4567-e89b-12d3-a456-426614174000',
-                        ip: '127.0.0.1',
-                        site_url: 'https://example.com',
-                        now: '2021-01-01T00:00:00Z',
-                        properties: {
-                            $group_key: exactGroupKey,
-                        },
+                event: {
+                    event: '$groupidentify',
+                    distinct_id: 'user123',
+                    team_id: 1,
+                    uuid: '123e4567-e89b-12d3-a456-426614174000',
+                    ip: '127.0.0.1',
+                    site_url: 'https://example.com',
+                    now: '2021-01-01T00:00:00Z',
+                    properties: {
+                        $group_key: exactGroupKey,
                     },
-                    team: {
-                        id: 1,
-                        name: 'Test Team',
-                    },
-                    message: {} as any,
-                    headers: {} as any,
-                } as unknown as IncomingEventWithTeam,
+                } as PipelineEvent,
             }
 
             const result = await step(input)
@@ -128,24 +104,16 @@ describe('createValidateEventPropertiesStep', () => {
 
         it('should allow $groupidentify events without group_key', async () => {
             const input = {
-                eventWithTeam: {
-                    event: {
-                        event: '$groupidentify',
-                        distinct_id: 'user123',
-                        team_id: 1,
-                        uuid: '123e4567-e89b-12d3-a456-426614174000',
-                        ip: '127.0.0.1',
-                        site_url: 'https://example.com',
-                        now: '2021-01-01T00:00:00Z',
-                        properties: {},
-                    },
-                    team: {
-                        id: 1,
-                        name: 'Test Team',
-                    },
-                    message: {} as any,
-                    headers: {} as any,
-                } as unknown as IncomingEventWithTeam,
+                event: {
+                    event: '$groupidentify',
+                    distinct_id: 'user123',
+                    team_id: 1,
+                    uuid: '123e4567-e89b-12d3-a456-426614174000',
+                    ip: '127.0.0.1',
+                    site_url: 'https://example.com',
+                    now: '2021-01-01T00:00:00Z',
+                    properties: {},
+                } as PipelineEvent,
             }
 
             const result = await step(input)
@@ -157,23 +125,15 @@ describe('createValidateEventPropertiesStep', () => {
     describe('other event types', () => {
         it('should allow non-groupidentify events', async () => {
             const input = {
-                eventWithTeam: {
-                    event: {
-                        event: '$pageview',
-                        distinct_id: 'user123',
-                        team_id: 1,
-                        uuid: '123e4567-e89b-12d3-a456-426614174000',
-                        ip: '127.0.0.1',
-                        site_url: 'https://example.com',
-                        now: '2021-01-01T00:00:00Z',
-                    },
-                    team: {
-                        id: 1,
-                        name: 'Test Team',
-                    },
-                    message: {} as any,
-                    headers: {} as any,
-                } as unknown as IncomingEventWithTeam,
+                event: {
+                    event: '$pageview',
+                    distinct_id: 'user123',
+                    team_id: 1,
+                    uuid: '123e4567-e89b-12d3-a456-426614174000',
+                    ip: '127.0.0.1',
+                    site_url: 'https://example.com',
+                    now: '2021-01-01T00:00:00Z',
+                } as PipelineEvent,
             }
 
             const result = await step(input)
@@ -183,23 +143,15 @@ describe('createValidateEventPropertiesStep', () => {
 
         it('should allow regular events', async () => {
             const input = {
-                eventWithTeam: {
-                    event: {
-                        event: 'button_clicked',
-                        distinct_id: 'user123',
-                        team_id: 1,
-                        uuid: '123e4567-e89b-12d3-a456-426614174000',
-                        ip: '127.0.0.1',
-                        site_url: 'https://example.com',
-                        now: '2021-01-01T00:00:00Z',
-                    },
-                    team: {
-                        id: 1,
-                        name: 'Test Team',
-                    },
-                    message: {} as any,
-                    headers: {} as any,
-                } as unknown as IncomingEventWithTeam,
+                event: {
+                    event: 'button_clicked',
+                    distinct_id: 'user123',
+                    team_id: 1,
+                    uuid: '123e4567-e89b-12d3-a456-426614174000',
+                    ip: '127.0.0.1',
+                    site_url: 'https://example.com',
+                    now: '2021-01-01T00:00:00Z',
+                } as PipelineEvent,
             }
 
             const result = await step(input)

--- a/nodejs/src/ingestion/event-preprocessing/validate-event-properties.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-event-properties.test.ts
@@ -1,4 +1,4 @@
-import { PipelineEvent } from '../../types'
+import { createTestPipelineEvent } from '../../../tests/helpers/pipeline-event'
 import { drop, ok } from '../pipelines/results'
 import { createValidateEventPropertiesStep } from './validate-event-properties'
 
@@ -21,18 +21,14 @@ describe('createValidateEventPropertiesStep', () => {
         it('should drop $groupidentify events with group_key longer than 400 characters', async () => {
             const longGroupKey = 'a'.repeat(401)
             const input = {
-                event: {
+                event: createTestPipelineEvent({
                     event: '$groupidentify',
                     distinct_id: 'user123',
                     team_id: 1,
-                    uuid: '123e4567-e89b-12d3-a456-426614174000',
-                    ip: '127.0.0.1',
-                    site_url: 'https://example.com',
-                    now: '2021-01-01T00:00:00Z',
                     properties: {
                         $group_key: longGroupKey,
                     },
-                } as PipelineEvent,
+                }),
             }
 
             const result = await step(input)
@@ -61,18 +57,14 @@ describe('createValidateEventPropertiesStep', () => {
         it('should allow $groupidentify events with group_key shorter than 400 characters', async () => {
             const shortGroupKey = 'a'.repeat(399)
             const input = {
-                event: {
+                event: createTestPipelineEvent({
                     event: '$groupidentify',
                     distinct_id: 'user123',
                     team_id: 1,
-                    uuid: '123e4567-e89b-12d3-a456-426614174000',
-                    ip: '127.0.0.1',
-                    site_url: 'https://example.com',
-                    now: '2021-01-01T00:00:00Z',
                     properties: {
                         $group_key: shortGroupKey,
                     },
-                } as PipelineEvent,
+                }),
             }
 
             const result = await step(input)
@@ -83,18 +75,14 @@ describe('createValidateEventPropertiesStep', () => {
         it('should allow $groupidentify events with group_key exactly 400 characters', async () => {
             const exactGroupKey = 'a'.repeat(400)
             const input = {
-                event: {
+                event: createTestPipelineEvent({
                     event: '$groupidentify',
                     distinct_id: 'user123',
                     team_id: 1,
-                    uuid: '123e4567-e89b-12d3-a456-426614174000',
-                    ip: '127.0.0.1',
-                    site_url: 'https://example.com',
-                    now: '2021-01-01T00:00:00Z',
                     properties: {
                         $group_key: exactGroupKey,
                     },
-                } as PipelineEvent,
+                }),
             }
 
             const result = await step(input)
@@ -104,16 +92,12 @@ describe('createValidateEventPropertiesStep', () => {
 
         it('should allow $groupidentify events without group_key', async () => {
             const input = {
-                event: {
+                event: createTestPipelineEvent({
                     event: '$groupidentify',
                     distinct_id: 'user123',
                     team_id: 1,
-                    uuid: '123e4567-e89b-12d3-a456-426614174000',
-                    ip: '127.0.0.1',
-                    site_url: 'https://example.com',
-                    now: '2021-01-01T00:00:00Z',
                     properties: {},
-                } as PipelineEvent,
+                }),
             }
 
             const result = await step(input)
@@ -125,15 +109,10 @@ describe('createValidateEventPropertiesStep', () => {
     describe('other event types', () => {
         it('should allow non-groupidentify events', async () => {
             const input = {
-                event: {
-                    event: '$pageview',
+                event: createTestPipelineEvent({
                     distinct_id: 'user123',
                     team_id: 1,
-                    uuid: '123e4567-e89b-12d3-a456-426614174000',
-                    ip: '127.0.0.1',
-                    site_url: 'https://example.com',
-                    now: '2021-01-01T00:00:00Z',
-                } as PipelineEvent,
+                }),
             }
 
             const result = await step(input)
@@ -143,15 +122,11 @@ describe('createValidateEventPropertiesStep', () => {
 
         it('should allow regular events', async () => {
             const input = {
-                event: {
+                event: createTestPipelineEvent({
                     event: 'button_clicked',
                     distinct_id: 'user123',
                     team_id: 1,
-                    uuid: '123e4567-e89b-12d3-a456-426614174000',
-                    ip: '127.0.0.1',
-                    site_url: 'https://example.com',
-                    now: '2021-01-01T00:00:00Z',
-                } as PipelineEvent,
+                }),
             }
 
             const result = await step(input)

--- a/nodejs/src/ingestion/event-preprocessing/validate-event-properties.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-event-properties.ts
@@ -1,14 +1,10 @@
-import { IncomingEventWithTeam } from '../../types'
+import { PipelineEvent } from '../../types'
 import { drop, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
-export function createValidateEventPropertiesStep<T extends { eventWithTeam: IncomingEventWithTeam }>(): ProcessingStep<
-    T,
-    T
-> {
+export function createValidateEventPropertiesStep<T extends { event: PipelineEvent }>(): ProcessingStep<T, T> {
     return async function validateEventPropertiesStep(input) {
-        const { eventWithTeam } = input
-        const { event } = eventWithTeam
+        const { event } = input
 
         // Validate $groupidentify group_key length
         if (event.event === '$groupidentify') {

--- a/nodejs/src/ingestion/event-preprocessing/validate-event-uuid.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-event-uuid.test.ts
@@ -1,3 +1,4 @@
+import { createTestPipelineEvent } from '../../../tests/helpers/pipeline-event'
 import { PipelineEvent } from '../../types'
 import { PipelineResultType, drop, ok } from '../pipelines/results'
 import { createValidateEventUuidStep } from './validate-event-uuid'
@@ -7,16 +8,13 @@ describe('createValidateEventUuidStep', () => {
     let step: ReturnType<typeof createValidateEventUuidStep>
 
     beforeEach(() => {
-        mockEvent = {
+        mockEvent = createTestPipelineEvent({
             token: 'test-token-123',
             distinct_id: 'test-user-456',
             event: 'test-event',
             properties: { testProp: 'testValue' },
-            ip: '127.0.0.1',
-            site_url: 'https://example.com',
             now: '2020-02-23T02:15:00Z',
-            uuid: '123e4567-e89b-12d3-a456-426614174000',
-        }
+        })
 
         step = createValidateEventUuidStep()
         jest.clearAllMocks()

--- a/nodejs/src/ingestion/event-preprocessing/validate-event-uuid.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-event-uuid.test.ts
@@ -1,33 +1,21 @@
-import { IncomingEventWithTeam } from '../../types'
+import { PipelineEvent } from '../../types'
 import { PipelineResultType, drop, ok } from '../pipelines/results'
 import { createValidateEventUuidStep } from './validate-event-uuid'
 
 describe('createValidateEventUuidStep', () => {
-    let mockEventWithTeam: IncomingEventWithTeam
+    let mockEvent: PipelineEvent
     let step: ReturnType<typeof createValidateEventUuidStep>
 
     beforeEach(() => {
-        mockEventWithTeam = {
-            event: {
-                token: 'test-token-123',
-                distinct_id: 'test-user-456',
-                event: 'test-event',
-                properties: { testProp: 'testValue' },
-                ip: '127.0.0.1',
-                site_url: 'https://example.com',
-                now: '2020-02-23T02:15:00Z',
-                uuid: '123e4567-e89b-12d3-a456-426614174000',
-            },
-            team: {
-                id: 1,
-                name: 'Test Team',
-                person_processing_opt_out: false,
-            } as any,
-            message: {} as any,
-            headers: {
-                force_disable_person_processing: false,
-                historical_migration: false,
-            },
+        mockEvent = {
+            token: 'test-token-123',
+            distinct_id: 'test-user-456',
+            event: 'test-event',
+            properties: { testProp: 'testValue' },
+            ip: '127.0.0.1',
+            site_url: 'https://example.com',
+            now: '2020-02-23T02:15:00Z',
+            uuid: '123e4567-e89b-12d3-a456-426614174000',
         }
 
         step = createValidateEventUuidStep()
@@ -35,15 +23,15 @@ describe('createValidateEventUuidStep', () => {
     })
 
     it('should return success when UUID is valid', async () => {
-        const input = { eventWithTeam: mockEventWithTeam }
+        const input = { event: mockEvent }
         const result = await step(input)
 
         expect(result).toEqual(ok(input))
     })
 
     it('should return drop when UUID is invalid', async () => {
-        mockEventWithTeam.event.uuid = 'invalid-uuid'
-        const input = { eventWithTeam: mockEventWithTeam }
+        mockEvent.uuid = 'invalid-uuid'
+        const input = { event: mockEvent }
 
         const result = await step(input)
 
@@ -62,8 +50,8 @@ describe('createValidateEventUuidStep', () => {
     })
 
     it('should return drop when UUID is null', async () => {
-        mockEventWithTeam.event.uuid = null as any
-        const input = { eventWithTeam: mockEventWithTeam }
+        mockEvent.uuid = null as any
+        const input = { event: mockEvent }
 
         const result = await step(input)
 
@@ -82,8 +70,8 @@ describe('createValidateEventUuidStep', () => {
     })
 
     it('should return drop when UUID is undefined', async () => {
-        mockEventWithTeam.event.uuid = undefined as any
-        const input = { eventWithTeam: mockEventWithTeam }
+        mockEvent.uuid = undefined as any
+        const input = { event: mockEvent }
 
         const result = await step(input)
 
@@ -102,8 +90,8 @@ describe('createValidateEventUuidStep', () => {
     })
 
     it('should return drop when UUID is empty string', async () => {
-        mockEventWithTeam.event.uuid = ''
-        const input = { eventWithTeam: mockEventWithTeam }
+        mockEvent.uuid = ''
+        const input = { event: mockEvent }
 
         const result = await step(input)
 
@@ -122,9 +110,8 @@ describe('createValidateEventUuidStep', () => {
     })
 
     it('should include warning in result when UUID is invalid', async () => {
-        mockEventWithTeam.team.id = 999
-        mockEventWithTeam.event.uuid = 'invalid-uuid'
-        const input = { eventWithTeam: mockEventWithTeam }
+        mockEvent.uuid = 'invalid-uuid'
+        const input = { event: mockEvent }
 
         const result = await step(input)
 
@@ -143,24 +130,20 @@ describe('createValidateEventUuidStep', () => {
     })
 
     it('should preserve event data when UUID is valid', async () => {
-        const input = { eventWithTeam: mockEventWithTeam }
+        const input = { event: mockEvent }
         const result = await step(input)
 
         expect(result).toEqual(ok(input))
 
         if (result.type === PipelineResultType.OK) {
-            expect(result.value.eventWithTeam.event.token).toBe('test-token-123')
-            expect(result.value.eventWithTeam.event.distinct_id).toBe('test-user-456')
-            expect(result.value.eventWithTeam.event.event).toBe('test-event')
-            expect(result.value.eventWithTeam.event.properties).toEqual({ testProp: 'testValue' })
-            expect(result.value.eventWithTeam.event.ip).toBe('127.0.0.1')
-            expect(result.value.eventWithTeam.event.site_url).toBe('https://example.com')
-            expect(result.value.eventWithTeam.event.now).toBe(mockEventWithTeam.event.now)
-            expect(result.value.eventWithTeam.event.uuid).toBe('123e4567-e89b-12d3-a456-426614174000')
-            expect(result.value.eventWithTeam.team.id).toBe(1)
-            expect(result.value.eventWithTeam.team.name).toBe('Test Team')
-            expect(result.value.eventWithTeam.team.person_processing_opt_out).toBe(false)
-            expect(result.value.eventWithTeam.message).toBe(mockEventWithTeam.message)
+            expect(result.value.event.token).toBe('test-token-123')
+            expect(result.value.event.distinct_id).toBe('test-user-456')
+            expect(result.value.event.event).toBe('test-event')
+            expect(result.value.event.properties).toEqual({ testProp: 'testValue' })
+            expect(result.value.event.ip).toBe('127.0.0.1')
+            expect(result.value.event.site_url).toBe('https://example.com')
+            expect(result.value.event.now).toBe(mockEvent.now)
+            expect(result.value.event.uuid).toBe('123e4567-e89b-12d3-a456-426614174000')
         }
     })
 })

--- a/nodejs/src/ingestion/event-preprocessing/validate-event-uuid.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-event-uuid.ts
@@ -1,4 +1,4 @@
-import { IncomingEventWithTeam } from '../../types'
+import { PipelineEvent } from '../../types'
 import { UUID } from '../../utils/utils'
 import { PipelineWarning } from '../pipelines/pipeline.interface'
 import { drop, ok } from '../pipelines/results'
@@ -8,9 +8,7 @@ type ValidateEventUuidError = { error: true; cause: 'empty_uuid' | 'invalid_uuid
 type ValidateEventUuidSuccess = { error: false }
 type ValidateEventUuidResult = ValidateEventUuidSuccess | ValidateEventUuidError
 
-function validateEventUuid(eventWithTeam: IncomingEventWithTeam): ValidateEventUuidResult {
-    const { event } = eventWithTeam
-
+function validateEventUuid(event: PipelineEvent): ValidateEventUuidResult {
     if (!event.uuid) {
         return {
             error: true,
@@ -40,13 +38,10 @@ function validateEventUuid(eventWithTeam: IncomingEventWithTeam): ValidateEventU
     return { error: false }
 }
 
-export function createValidateEventUuidStep<T extends { eventWithTeam: IncomingEventWithTeam }>(): ProcessingStep<
-    T,
-    T
-> {
+export function createValidateEventUuidStep<T extends { event: PipelineEvent }>(): ProcessingStep<T, T> {
     return async function validateEventUuidStep(input) {
-        const { eventWithTeam } = input
-        const result = validateEventUuid(eventWithTeam)
+        const { event } = input
+        const result = validateEventUuid(event)
         if (result.error) {
             return drop(result.cause, [], [result.warning])
         }

--- a/nodejs/src/ingestion/event-processing/drop-old-events-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/drop-old-events-step.test.ts
@@ -1,7 +1,9 @@
 import { DateTime } from 'luxon'
-import { v4 } from 'uuid'
 
-import { EventHeaders, PipelineEvent, ProjectId, Team } from '../../types'
+import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
+import { createTestPipelineEvent } from '../../../tests/helpers/pipeline-event'
+import { createTestTeam } from '../../../tests/helpers/team'
+import { EventHeaders, PipelineEvent, Team } from '../../types'
 import { PipelineResultType, isDropResult } from '../pipelines/results'
 import { DropOldEventsInput, createDropOldEventsStep } from './drop-old-events-step'
 
@@ -165,63 +167,22 @@ function createTestInput(options: {
 
     const resolvedHeaders = headersExplicitlyNull
         ? (options.headers as unknown as Pick<EventHeaders, 'timestamp' | 'now'>)
-        : createTestHeaders({
+        : createTestEventHeaders({
               timestamp: eventTimestamp.toMillis().toString(),
               now: now.toJSDate(),
               ...options.headers,
           })
 
     return {
-        event: createTestEvent(event),
+        event: createTestPipelineEvent({
+            event: '$pageview',
+            distinct_id: 'user-1',
+            ip: null,
+            site_url: 'https://test.posthog.com',
+            now: DateTime.utc().toISO()!,
+            ...event,
+        }),
         team: createTestTeam({ drop_events_older_than_seconds: dropThreshold, ...team }),
         headers: resolvedHeaders,
-    }
-}
-
-function createTestTeam(overrides: Partial<Team> = {}): Team {
-    return {
-        id: 1,
-        project_id: 1 as ProjectId,
-        uuid: v4(),
-        organization_id: v4(),
-        name: 'Test Team',
-        anonymize_ips: false,
-        api_token: 'test-token',
-        slack_incoming_webhook: null,
-        session_recording_opt_in: false,
-        person_processing_opt_out: null,
-        heatmaps_opt_in: null,
-        ingested_event: true,
-        person_display_name_properties: null,
-        test_account_filters: null,
-        cookieless_server_hash_mode: null,
-        timezone: 'UTC',
-        available_features: [],
-        drop_events_older_than_seconds: null,
-        ...overrides,
-    }
-}
-
-function createTestEvent(overrides: Partial<PipelineEvent> = {}): PipelineEvent {
-    return {
-        uuid: v4(),
-        event: '$pageview',
-        distinct_id: 'user-1',
-        ip: null,
-        site_url: 'https://test.posthog.com',
-        now: DateTime.utc().toISO()!,
-        properties: {},
-        ...overrides,
-    }
-}
-
-function createTestHeaders(overrides: Partial<EventHeaders> = {}): EventHeaders {
-    const now = DateTime.utc()
-    return {
-        timestamp: now.toMillis().toString(),
-        now: now.toJSDate(),
-        force_disable_person_processing: false,
-        historical_migration: false,
-        ...overrides,
     }
 }

--- a/nodejs/src/ingestion/event-processing/drop-old-events-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/drop-old-events-step.test.ts
@@ -1,5 +1,4 @@
 import { DateTime } from 'luxon'
-import { Message } from 'node-rdkafka'
 import { v4 } from 'uuid'
 
 import { EventHeaders, PipelineEvent, ProjectId, Team } from '../../types'
@@ -34,7 +33,7 @@ describe('createDropOldEventsStep', () => {
         expect(result.warnings[0]).toMatchObject({
             type: 'event_dropped_too_old',
             details: {
-                eventUuid: input.eventWithTeam.event.uuid,
+                eventUuid: input.event.uuid,
                 event: '$pageview',
                 distinctId: 'user-1',
                 dropThresholdSeconds: 3600,
@@ -173,12 +172,8 @@ function createTestInput(options: {
           })
 
     return {
-        eventWithTeam: {
-            message: createTestMessage(),
-            event: createTestEvent(event),
-            team: createTestTeam({ drop_events_older_than_seconds: dropThreshold, ...team }),
-            headers: createTestHeaders(),
-        },
+        event: createTestEvent(event),
+        team: createTestTeam({ drop_events_older_than_seconds: dropThreshold, ...team }),
         headers: resolvedHeaders,
     }
 }
@@ -216,17 +211,6 @@ function createTestEvent(overrides: Partial<PipelineEvent> = {}): PipelineEvent 
         site_url: 'https://test.posthog.com',
         now: DateTime.utc().toISO()!,
         properties: {},
-        ...overrides,
-    }
-}
-
-function createTestMessage(overrides: Partial<Message> = {}): Message {
-    return {
-        value: Buffer.from('{}'),
-        size: 2,
-        topic: 'test-topic',
-        offset: 0,
-        partition: 0,
         ...overrides,
     }
 }

--- a/nodejs/src/ingestion/event-processing/drop-old-events-step.ts
+++ b/nodejs/src/ingestion/event-processing/drop-old-events-step.ts
@@ -1,12 +1,13 @@
 import { DateTime } from 'luxon'
 
-import { EventHeaders, IncomingEventWithTeam } from '../../types'
+import { EventHeaders, PipelineEvent, Team } from '../../types'
 import { PipelineWarning } from '../pipelines/pipeline.interface'
 import { PipelineResult, drop, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export interface DropOldEventsInput {
-    eventWithTeam: IncomingEventWithTeam
+    event: PipelineEvent
+    team: Team
     headers: Pick<EventHeaders, 'timestamp' | 'now'>
 }
 
@@ -22,8 +23,7 @@ export interface DropOldEventsInput {
  */
 export function createDropOldEventsStep<T extends DropOldEventsInput>(): ProcessingStep<T, T> {
     return function dropOldEventsStep(input: T): Promise<PipelineResult<T>> {
-        const { eventWithTeam, headers } = input
-        const { event, team } = eventWithTeam
+        const { event, team, headers } = input
 
         // If no drop threshold is set (null) or set to 0, don't drop any events
         // Zero threshold is ignored to protect from misconfiguration bugs

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
@@ -139,7 +139,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            normalizedEvent: mockEvent,
+            event: mockEvent,
             timestamp: mockTimestamp,
             team: mockTeam,
             headers: mockHeaders,
@@ -182,7 +182,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            normalizedEvent: mockEvent,
+            event: mockEvent,
             timestamp: mockTimestamp,
             team: mockTeam,
             headers: mockHeaders,
@@ -211,7 +211,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            normalizedEvent: mockEvent,
+            event: mockEvent,
             timestamp: mockTimestamp,
             team: mockTeam,
             headers: mockHeaders,
@@ -241,7 +241,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            normalizedEvent: mockEvent,
+            event: mockEvent,
             timestamp: mockTimestamp,
             team: mockTeam,
             headers: customHeaders,
@@ -277,7 +277,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            normalizedEvent: mockEvent,
+            event: mockEvent,
             timestamp: mockTimestamp,
             team: teamWithOptOut,
             headers: mockHeaders,
@@ -309,7 +309,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            normalizedEvent: mockEvent,
+            event: mockEvent,
             timestamp: mockTimestamp,
             team: teamWithNull,
             headers: mockHeaders,

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
@@ -2,6 +2,8 @@ import { DateTime } from 'luxon'
 import { v4 } from 'uuid'
 
 import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
+import { createTestPipelineEvent } from '../../../tests/helpers/pipeline-event'
+import { createTestTeam } from '../../../tests/helpers/team'
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, ISOTimestamp, PipelineEvent, PreIngestionEvent, ProjectId, Team } from '../../types'
@@ -34,28 +36,6 @@ jest.mock('../../utils/logger', () => ({
 jest.mock('../../utils/posthog', () => ({
     captureException: jest.fn(),
 }))
-
-const createTestTeam = (overrides: Partial<Team> = {}): Team => ({
-    id: 1,
-    project_id: 1 as ProjectId,
-    organization_id: 'test-org-id',
-    uuid: v4(),
-    name: 'Test Team',
-    anonymize_ips: false,
-    api_token: 'test-api-token',
-    slack_incoming_webhook: null,
-    session_recording_opt_in: true,
-    person_processing_opt_out: null,
-    heatmaps_opt_in: null,
-    ingested_event: true,
-    person_display_name_properties: null,
-    test_account_filters: null,
-    cookieless_server_hash_mode: null,
-    timezone: 'UTC',
-    available_features: [],
-    drop_events_older_than_seconds: null,
-    ...overrides,
-})
 
 const createTestPreIngestionEvent = (overrides: Partial<PreIngestionEvent> = {}): PreIngestionEvent => {
     return {
@@ -104,7 +84,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         mockPersonsStore = {} as PersonsStore
         mockGroupStore = {} as GroupStoreForBatch
 
-        mockEvent = {
+        mockEvent = createTestPipelineEvent({
             uuid: v4(),
             distinct_id: 'test-distinct-id',
             ip: null,
@@ -113,7 +93,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
             now: new Date().toISOString(),
             event: '$$heatmap',
             properties: { $elements: [{ tag_name: 'div' }] },
-        }
+        })
 
         mockTeam = createTestTeam()
         mockHeaders = createTestEventHeaders()

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
@@ -119,7 +119,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            event: mockEvent,
+            normalizedEvent: mockEvent,
             timestamp: mockTimestamp,
             team: mockTeam,
             headers: mockHeaders,
@@ -162,7 +162,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            event: mockEvent,
+            normalizedEvent: mockEvent,
             timestamp: mockTimestamp,
             team: mockTeam,
             headers: mockHeaders,
@@ -191,7 +191,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            event: mockEvent,
+            normalizedEvent: mockEvent,
             timestamp: mockTimestamp,
             team: mockTeam,
             headers: mockHeaders,
@@ -221,7 +221,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            event: mockEvent,
+            normalizedEvent: mockEvent,
             timestamp: mockTimestamp,
             team: mockTeam,
             headers: customHeaders,
@@ -257,7 +257,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            event: mockEvent,
+            normalizedEvent: mockEvent,
             timestamp: mockTimestamp,
             team: teamWithOptOut,
             headers: mockHeaders,
@@ -289,7 +289,7 @@ describe('event-pipeline-runner-heatmap-step', () => {
         )
 
         const input = {
-            event: mockEvent,
+            normalizedEvent: mockEvent,
             timestamp: mockTimestamp,
             team: teamWithNull,
             headers: mockHeaders,

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
@@ -12,7 +12,7 @@ import { PipelineResult, drop, isOkResult } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export interface EventPipelineRunnerHeatmapStepInput {
-    normalizedEvent: PipelineEvent
+    event: PipelineEvent
     timestamp: DateTime
     team: Team
     headers: EventHeaders
@@ -34,7 +34,7 @@ export function createEventPipelineRunnerHeatmapStep<TInput extends EventPipelin
     return async function eventPipelineRunnerHeatmapStep(
         input: TInput
     ): Promise<PipelineResult<EventPipelineRunnerHeatmapStepResult<TInput>>> {
-        const { normalizedEvent, timestamp, team, headers, groupStoreForBatch } = input
+        const { event, timestamp, team, headers, groupStoreForBatch } = input
 
         // Skip heatmap processing if team has explicitly opted out
         if (team.heatmaps_opt_in === false) {
@@ -46,13 +46,13 @@ export function createEventPipelineRunnerHeatmapStep<TInput extends EventPipelin
             kafkaProducer,
             teamManager,
             groupTypeManager,
-            normalizedEvent,
+            event,
             hogTransformer,
             personsStore,
             groupStoreForBatch,
             headers
         )
-        const result = await runner.runHeatmapPipeline(normalizedEvent, timestamp, team)
+        const result = await runner.runHeatmapPipeline(event, timestamp, team)
 
         if (!isOkResult(result)) {
             return result

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
@@ -12,7 +12,7 @@ import { PipelineResult, drop, isOkResult } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export interface EventPipelineRunnerHeatmapStepInput {
-    event: PipelineEvent
+    normalizedEvent: PipelineEvent
     timestamp: DateTime
     team: Team
     headers: EventHeaders
@@ -34,7 +34,7 @@ export function createEventPipelineRunnerHeatmapStep<TInput extends EventPipelin
     return async function eventPipelineRunnerHeatmapStep(
         input: TInput
     ): Promise<PipelineResult<EventPipelineRunnerHeatmapStepResult<TInput>>> {
-        const { event, timestamp, team, headers, groupStoreForBatch } = input
+        const { normalizedEvent, timestamp, team, headers, groupStoreForBatch } = input
 
         // Skip heatmap processing if team has explicitly opted out
         if (team.heatmaps_opt_in === false) {
@@ -46,13 +46,13 @@ export function createEventPipelineRunnerHeatmapStep<TInput extends EventPipelin
             kafkaProducer,
             teamManager,
             groupTypeManager,
-            event,
+            normalizedEvent,
             hogTransformer,
             personsStore,
             groupStoreForBatch,
             headers
         )
-        const result = await runner.runHeatmapPipeline(event, timestamp, team)
+        const result = await runner.runHeatmapPipeline(normalizedEvent, timestamp, team)
 
         if (!isOkResult(result)) {
             return result

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-v1-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-v1-step.test.ts
@@ -1,9 +1,11 @@
 import { Message } from 'node-rdkafka'
 import { v4 } from 'uuid'
 
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
-import { PipelineEvent, ProjectId, Team, TimestampFormat } from '../../types'
+import { ProjectId, Team, TimestampFormat } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
 import { castTimestampOrNow } from '../../utils/utils'
 import {
@@ -89,7 +91,7 @@ describe('event-pipeline-runner-v1-step', () => {
     let mockGroupStore: GroupStoreForBatch
     let mockEventPipelineRunner: jest.Mocked<EventPipelineRunner>
     let mockMessage: Message
-    let mockEvent: PipelineEvent
+    let mockEvent: PluginEvent
     let mockTeam: Team
     let mockHeaders: any
 
@@ -127,12 +129,13 @@ describe('event-pipeline-runner-v1-step', () => {
             uuid: 'test-uuid',
             event: 'test-event',
             distinct_id: 'test-distinct-id',
+            team_id: 1,
             properties: { test: 'property' },
             timestamp: '2023-01-01T00:00:00.000Z',
             ip: '127.0.0.1',
             site_url: 'https://test.com',
             now: '2023-01-01T00:00:00.000Z',
-        } as PipelineEvent
+        } as PluginEvent
 
         mockTeam = createTestTeam()
 

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-v1-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-v1-step.test.ts
@@ -1,8 +1,10 @@
 import { Message } from 'node-rdkafka'
-import { v4 } from 'uuid'
 
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
+import { createTestMessage } from '../../../tests/helpers/kafka-message'
+import { createTestPluginEvent } from '../../../tests/helpers/plugin-event'
+import { createTestTeam } from '../../../tests/helpers/team'
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { ProjectId, Team, TimestampFormat } from '../../types'
@@ -36,28 +38,6 @@ jest.mock('../../utils/logger', () => ({
 jest.mock('../../utils/posthog', () => ({
     captureException: jest.fn(),
 }))
-
-const createTestTeam = (overrides: Partial<Team> = {}): Team => ({
-    id: 1,
-    project_id: 1 as ProjectId,
-    organization_id: 'test-org-id',
-    uuid: v4(),
-    name: 'Test Team',
-    anonymize_ips: false,
-    api_token: 'test-api-token',
-    slack_incoming_webhook: null,
-    session_recording_opt_in: true,
-    person_processing_opt_out: null,
-    heatmaps_opt_in: null,
-    ingested_event: true,
-    person_display_name_properties: null,
-    test_account_filters: null,
-    cookieless_server_hash_mode: null,
-    timezone: 'UTC',
-    available_features: [],
-    drop_events_older_than_seconds: null,
-    ...overrides,
-})
 
 const createTestEventPipelineResult = (): EventPipelineResult => ({
     lastStep: 'test-step',
@@ -116,16 +96,14 @@ describe('event-pipeline-runner-v1-step', () => {
         mockPersonsStore = {} as PersonsStore
         mockGroupStore = {} as GroupStoreForBatch
 
-        mockMessage = {
+        mockMessage = createTestMessage({
             value: Buffer.from('test message'),
             key: Buffer.from('test key'),
-            headers: {},
             partition: 0,
             offset: 123,
-            timestamp: Date.now(),
-        } as Message
+        })
 
-        mockEvent = {
+        mockEvent = createTestPluginEvent({
             uuid: 'test-uuid',
             event: 'test-event',
             distinct_id: 'test-distinct-id',
@@ -135,7 +113,7 @@ describe('event-pipeline-runner-v1-step', () => {
             ip: '127.0.0.1',
             site_url: 'https://test.com',
             now: '2023-01-01T00:00:00.000Z',
-        } as PluginEvent
+        })
 
         mockTeam = createTestTeam()
 

--- a/nodejs/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
@@ -1,8 +1,10 @@
 import { Message } from 'node-rdkafka'
 
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
-import { EventHeaders, IncomingEventWithTeam } from '../../types'
+import { EventHeaders, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
 import {
     EventPipelineResult,
@@ -15,7 +17,10 @@ import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { PipelineResult, isOkResult, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
-export interface EventPipelineRunnerInput extends IncomingEventWithTeam {
+export interface EventPipelineRunnerInput {
+    message: Message
+    event: PluginEvent
+    team: Team
     headers: EventHeaders
     groupStoreForBatch: GroupStoreForBatch
     processPerson: boolean

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
@@ -1,53 +1,29 @@
-import { Message } from 'node-rdkafka'
 import { v4 } from 'uuid'
 
-import { PluginEvent } from '@posthog/plugin-scaffold'
-
 import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
-import { ProjectId, Team } from '../../types'
+import { createTestMessage } from '../../../tests/helpers/kafka-message'
+import { createTestPluginEvent } from '../../../tests/helpers/plugin-event'
+import { createTestTeam } from '../../../tests/helpers/team'
 import { PipelineResultType } from '../pipelines/results'
 import { EventPipelineRunnerInput } from './event-pipeline-runner-v1-step'
 import { createHandleClientIngestionWarningStep } from './handle-client-ingestion-warning-step'
-
-const createTestTeam = (overrides: Partial<Team> = {}): Team => ({
-    id: 1,
-    project_id: 1 as ProjectId,
-    organization_id: 'test-org-id',
-    uuid: v4(),
-    name: 'Test Team',
-    anonymize_ips: false,
-    api_token: 'test-api-token',
-    slack_incoming_webhook: null,
-    session_recording_opt_in: true,
-    person_processing_opt_out: null,
-    heatmaps_opt_in: null,
-    ingested_event: true,
-    person_display_name_properties: null,
-    test_account_filters: null,
-    cookieless_server_hash_mode: null,
-    timezone: 'UTC',
-    available_features: [],
-    drop_events_older_than_seconds: null,
-    ...overrides,
-})
 
 describe('handleClientIngestionWarningStep', () => {
     const team = createTestTeam()
     const eventUuid = v4()
 
-    const baseEvent: PluginEvent = {
+    const baseEvent = createTestPluginEvent({
         distinct_id: 'my_id',
-        ip: null,
         site_url: '',
         team_id: 1,
         now: new Date().toISOString(),
         event: '$pageview',
         properties: {},
         uuid: eventUuid,
-    }
+    })
 
     const baseInput: EventPipelineRunnerInput = {
-        message: {} as Message,
+        message: createTestMessage(),
         event: baseEvent,
         team,
         headers: createTestEventHeaders(),

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
@@ -1,8 +1,10 @@
 import { Message } from 'node-rdkafka'
 import { v4 } from 'uuid'
 
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
 import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
-import { PipelineEvent, ProjectId, Team } from '../../types'
+import { ProjectId, Team } from '../../types'
 import { PipelineResultType } from '../pipelines/results'
 import { EventPipelineRunnerInput } from './event-pipeline-runner-v1-step'
 import { createHandleClientIngestionWarningStep } from './handle-client-ingestion-warning-step'
@@ -33,7 +35,7 @@ describe('handleClientIngestionWarningStep', () => {
     const team = createTestTeam()
     const eventUuid = v4()
 
-    const baseEvent: PipelineEvent = {
+    const baseEvent: PluginEvent = {
         distinct_id: 'my_id',
         ip: null,
         site_url: '',

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
@@ -1,9 +1,10 @@
-import { PipelineEvent } from '../../types'
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
 import { PipelineResult, dlq, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export interface HandleClientIngestionWarningStepInput {
-    event: PipelineEvent
+    event: PluginEvent
 }
 
 export function createHandleClientIngestionWarningStep<

--- a/nodejs/src/ingestion/event-processing/normalize-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-event-step.test.ts
@@ -1,35 +1,13 @@
 import { DateTime } from 'luxon'
-import { v4 } from 'uuid'
 
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
-import { ProjectId, Team } from '../../types'
+import { createTestPluginEvent } from '../../../tests/helpers/plugin-event'
+import { createTestTeam } from '../../../tests/helpers/team'
 import { UUIDT } from '../../utils/utils'
 import { PipelineResultType } from '../pipelines/results'
 import { createNormalizeEventStep } from './normalize-event-step'
-
-const createTestTeam = (overrides: Partial<Team> = {}): Team => ({
-    id: 1,
-    project_id: 1 as ProjectId,
-    organization_id: 'test-org-id',
-    uuid: v4(),
-    name: 'Test Team',
-    anonymize_ips: false,
-    api_token: 'test-api-token',
-    slack_incoming_webhook: null,
-    session_recording_opt_in: true,
-    person_processing_opt_out: null,
-    heatmaps_opt_in: null,
-    ingested_event: true,
-    person_display_name_properties: null,
-    test_account_filters: null,
-    cookieless_server_hash_mode: null,
-    timezone: 'UTC',
-    available_features: [],
-    drop_events_older_than_seconds: null,
-    ...overrides,
-})
 
 describe('normalizeEventStep wrapper', () => {
     const timestampComparisonLoggingSampleRate = 0
@@ -131,15 +109,14 @@ describe('normalizeEventStep wrapper', () => {
     it('sanitizes token with null bytes', async () => {
         const uuid = new UUIDT().toString()
         const event = {
-            distinct_id: 'my_id',
-            ip: null,
-            site_url: 'http://localhost',
-            team_id: team.id,
+            ...createTestPluginEvent({
+                distinct_id: 'my_id',
+                team_id: team.id,
+                timestamp: '2020-02-23T02:15:00Z',
+                event: 'test event',
+                uuid: uuid,
+            }),
             token: '\u0000token',
-            now: '2020-02-23T02:15:00Z',
-            timestamp: '2020-02-23T02:15:00Z',
-            event: 'test event',
-            uuid: uuid,
         } as PluginEvent
 
         const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)

--- a/nodejs/src/ingestion/event-processing/normalize-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-event-step.test.ts
@@ -289,9 +289,6 @@ describe('normalizeEventStep wrapper', () => {
             // Verify required fields are present
             expect(result.value.team).toBe(team)
             expect(result.value.headers).toEqual(createTestEventHeaders())
-
-            // Verify event field is removed
-            expect('event' in result.value).toBe(false)
         }
     })
 
@@ -331,9 +328,6 @@ describe('normalizeEventStep wrapper', () => {
             // Verify required fields are present
             expect(result.value.team).toBe(team)
             expect(result.value.headers).toEqual(createTestEventHeaders())
-
-            // Verify event field is removed
-            expect('event' in result.value).toBe(false)
         }
     })
 
@@ -395,9 +389,6 @@ describe('normalizeEventStep wrapper', () => {
             // Verify required fields are present
             expect(result.value.team).toBe(team)
             expect(result.value.headers).toEqual(createTestEventHeaders())
-
-            // Verify event field is removed
-            expect('event' in result.value).toBe(false)
         }
     })
 
@@ -720,10 +711,7 @@ describe('normalizeEventStep wrapper', () => {
             expect((result.value as any).customField).toBe('custom value')
             expect((result.value as any).anotherField).toBe(123)
 
-            // Verify event field is removed
-            expect('event' in result.value).toBe(false)
-
-            // Verify normalized fields are added
+            // Verify normalized event is present
             expect(result.value.event).toBeDefined()
             expect(result.value.timestamp).toBeDefined()
         }

--- a/nodejs/src/ingestion/event-processing/normalize-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-event-step.test.ts
@@ -1,8 +1,10 @@
 import { DateTime } from 'luxon'
 import { v4 } from 'uuid'
 
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
 import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
-import { PipelineEvent, ProjectId, Team } from '../../types'
+import { ProjectId, Team } from '../../types'
 import { UUIDT } from '../../utils/utils'
 import { PipelineResultType } from '../pipelines/results'
 import { createNormalizeEventStep } from './normalize-event-step'
@@ -36,7 +38,7 @@ describe('normalizeEventStep wrapper', () => {
     describe('distinctId conversion', () => {
         it('converts number distinct_id to string', async () => {
             const uuid = new UUIDT().toString()
-            const event: PipelineEvent = {
+            const event: PluginEvent = {
                 distinct_id: 123 as any,
                 ip: null,
                 site_url: 'http://localhost',
@@ -66,7 +68,7 @@ describe('normalizeEventStep wrapper', () => {
 
         it('converts boolean distinct_id to string', async () => {
             const uuid = new UUIDT().toString()
-            const event: PipelineEvent = {
+            const event: PluginEvent = {
                 distinct_id: true as any,
                 ip: null,
                 site_url: 'http://localhost',
@@ -97,7 +99,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('initializes empty properties object when missing', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -128,7 +130,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('sanitizes token with null bytes', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -138,7 +140,7 @@ describe('normalizeEventStep wrapper', () => {
             timestamp: '2020-02-23T02:15:00Z',
             event: 'test event',
             uuid: uuid,
-        }
+        } as PluginEvent
 
         const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
@@ -158,7 +160,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('merges $set with priority: root level overrides properties', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -196,7 +198,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('merges $set_once with priority: root level overrides properties', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -234,7 +236,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('normalizes with processPerson=true and preserves person properties', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -295,7 +297,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('replaces null byte with unicode replacement character in distinct_id (processPerson=true)', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: '\u0000foo',
             ip: null,
             site_url: 'http://localhost',
@@ -337,7 +339,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('normalizes events with processPerson=false by dropping person-related properties', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -401,7 +403,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('merges $set from root level into properties.$set', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -442,7 +444,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('merges $set_once from root level into properties.$set_once', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -483,7 +485,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('adds $ip from event.ip to properties if not already present', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: '192.168.1.1',
             site_url: 'http://localhost',
@@ -515,7 +517,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('does not override existing $ip in properties', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: '192.168.1.1',
             site_url: 'http://localhost',
@@ -548,7 +550,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('adds $sent_at to properties from event.sent_at', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -579,7 +581,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('deletes $unset for processPerson=false', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -612,7 +614,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('handles $groupidentify event with processPerson=true by removing person properties', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -653,7 +655,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('removes $process_person_profile when processPerson=true', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',
@@ -688,7 +690,7 @@ describe('normalizeEventStep wrapper', () => {
 
     it('passes through additional input fields to the output', async () => {
         const uuid = new UUIDT().toString()
-        const event: PipelineEvent = {
+        const event: PluginEvent = {
             distinct_id: 'my_id',
             ip: null,
             site_url: 'http://localhost',

--- a/nodejs/src/ingestion/event-processing/normalize-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-event-step.test.ts
@@ -39,8 +39,8 @@ describe('normalizeEventStep wrapper', () => {
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
-                expect(result.value.event.distinct_id).toBe('123')
-                expect(typeof result.value.event.distinct_id).toBe('string')
+                expect(result.value.normalizedEvent.distinct_id).toBe('123')
+                expect(typeof result.value.normalizedEvent.distinct_id).toBe('string')
             }
         })
 
@@ -69,8 +69,8 @@ describe('normalizeEventStep wrapper', () => {
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
-                expect(result.value.event.distinct_id).toBe('true')
-                expect(typeof result.value.event.distinct_id).toBe('string')
+                expect(result.value.normalizedEvent.distinct_id).toBe('true')
+                expect(typeof result.value.normalizedEvent.distinct_id).toBe('string')
             }
         })
     })
@@ -101,8 +101,8 @@ describe('normalizeEventStep wrapper', () => {
 
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
-            expect(result.value.event.properties).toBeDefined()
-            expect(typeof result.value.event.properties).toBe('object')
+            expect(result.value.normalizedEvent.properties).toBeDefined()
+            expect(typeof result.value.normalizedEvent.properties).toBe('object')
         }
     })
 
@@ -131,7 +131,7 @@ describe('normalizeEventStep wrapper', () => {
 
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
-            expect(result.value.event.token).toBe('\uFFFDtoken')
+            expect(result.value.normalizedEvent.token).toBe('\uFFFDtoken')
         }
     })
 
@@ -165,7 +165,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Root level $set should override properties.$set for same keys
-            expect(result.value.event.properties!.$set).toEqual({
+            expect(result.value.normalizedEvent.properties!.$set).toEqual({
                 key1: 'value1',
                 key2: 'value2', // overridden from root level
                 key3: 'value4',
@@ -203,7 +203,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Root level $set_once should override properties.$set_once for same keys
-            expect(result.value.event.properties!.$set_once).toEqual({
+            expect(result.value.normalizedEvent.properties!.$set_once).toEqual({
                 key1_once: 'value1',
                 key2_once: 'value2', // overridden from root level
                 key3_once: 'value4',
@@ -246,7 +246,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Since processPerson=true, person properties should be preserved and merged
-            expect(result.value.event).toEqual({
+            expect(result.value.normalizedEvent).toEqual({
                 ...event,
                 properties: {
                     $browser: 'Chrome',
@@ -294,7 +294,7 @@ describe('normalizeEventStep wrapper', () => {
 
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
-            expect(result.value.event).toEqual({
+            expect(result.value.normalizedEvent).toEqual({
                 ...event,
                 distinct_id: '\uFFFDfoo',
                 properties: {},
@@ -350,7 +350,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // The step always uses processPerson=false, so person-related properties should be dropped
-            expect(result.value.event).toEqual({
+            expect(result.value.normalizedEvent).toEqual({
                 ...event,
                 // $set and $set_once at root level should be gone
                 $set: undefined,
@@ -403,7 +403,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Root level $set should merge into properties.$set
-            expect(result.value.event.properties!.$set).toEqual({
+            expect(result.value.normalizedEvent.properties!.$set).toEqual({
                 propA: 'valueA',
                 propB: 'valueB',
             })
@@ -444,7 +444,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Root level $set_once should merge into properties.$set_once
-            expect(result.value.event.properties!.$set_once).toEqual({
+            expect(result.value.normalizedEvent.properties!.$set_once).toEqual({
                 onceA: 'valueA',
                 onceB: 'valueB',
             })
@@ -477,9 +477,9 @@ describe('normalizeEventStep wrapper', () => {
 
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
-            expect(result.value.event.properties!.$ip).toBe('192.168.1.1')
+            expect(result.value.normalizedEvent.properties!.$ip).toBe('192.168.1.1')
             // ip field should be set to null
-            expect(result.value.event.ip).toBe(null)
+            expect(result.value.normalizedEvent.ip).toBe(null)
         }
     })
 
@@ -512,7 +512,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Should keep the original $ip from properties
-            expect(result.value.event.properties!.$ip).toBe('10.0.0.1')
+            expect(result.value.normalizedEvent.properties!.$ip).toBe('10.0.0.1')
         }
     })
 
@@ -543,7 +543,7 @@ describe('normalizeEventStep wrapper', () => {
 
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
-            expect(result.value.event.properties!.$sent_at).toBe('2020-02-23T02:14:00Z')
+            expect(result.value.normalizedEvent.properties!.$sent_at).toBe('2020-02-23T02:14:00Z')
         }
     })
 
@@ -576,7 +576,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // $unset should be removed for processPerson=false
-            expect(result.value.event.properties!.$unset).toBeUndefined()
+            expect(result.value.normalizedEvent.properties!.$unset).toBeUndefined()
         }
     })
 
@@ -614,10 +614,10 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // $groupidentify always has person properties removed
-            expect(result.value.event.$set).toBeUndefined()
-            expect(result.value.event.properties!.$set).toBeUndefined()
+            expect(result.value.normalizedEvent.$set).toBeUndefined()
+            expect(result.value.normalizedEvent.properties!.$set).toBeUndefined()
             // But $process_person_profile is not added since processPerson=true
-            expect(result.value.event.properties!.$process_person_profile).toBeUndefined()
+            expect(result.value.normalizedEvent.properties!.$process_person_profile).toBeUndefined()
         }
     })
 
@@ -651,8 +651,8 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // $process_person_profile should be removed when processPerson=true (it's the default)
-            expect(result.value.event.properties!.$process_person_profile).toBeUndefined()
-            expect(result.value.event.properties!.other).toBe('value')
+            expect(result.value.normalizedEvent.properties!.$process_person_profile).toBeUndefined()
+            expect(result.value.normalizedEvent.properties!.other).toBe('value')
         }
     })
 
@@ -689,7 +689,7 @@ describe('normalizeEventStep wrapper', () => {
             expect((result.value as any).anotherField).toBe(123)
 
             // Verify normalized event is present
-            expect(result.value.event).toBeDefined()
+            expect(result.value.normalizedEvent).toBeDefined()
             expect(result.value.timestamp).toBeDefined()
         }
     })

--- a/nodejs/src/ingestion/event-processing/normalize-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-event-step.test.ts
@@ -61,8 +61,8 @@ describe('normalizeEventStep wrapper', () => {
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
-                expect(result.value.normalizedEvent.distinct_id).toBe('123')
-                expect(typeof result.value.normalizedEvent.distinct_id).toBe('string')
+                expect(result.value.event.distinct_id).toBe('123')
+                expect(typeof result.value.event.distinct_id).toBe('string')
             }
         })
 
@@ -91,8 +91,8 @@ describe('normalizeEventStep wrapper', () => {
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
-                expect(result.value.normalizedEvent.distinct_id).toBe('true')
-                expect(typeof result.value.normalizedEvent.distinct_id).toBe('string')
+                expect(result.value.event.distinct_id).toBe('true')
+                expect(typeof result.value.event.distinct_id).toBe('string')
             }
         })
     })
@@ -123,8 +123,8 @@ describe('normalizeEventStep wrapper', () => {
 
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
-            expect(result.value.normalizedEvent.properties).toBeDefined()
-            expect(typeof result.value.normalizedEvent.properties).toBe('object')
+            expect(result.value.event.properties).toBeDefined()
+            expect(typeof result.value.event.properties).toBe('object')
         }
     })
 
@@ -154,7 +154,7 @@ describe('normalizeEventStep wrapper', () => {
 
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
-            expect(result.value.normalizedEvent.token).toBe('\uFFFDtoken')
+            expect(result.value.event.token).toBe('\uFFFDtoken')
         }
     })
 
@@ -188,7 +188,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Root level $set should override properties.$set for same keys
-            expect(result.value.normalizedEvent.properties!.$set).toEqual({
+            expect(result.value.event.properties!.$set).toEqual({
                 key1: 'value1',
                 key2: 'value2', // overridden from root level
                 key3: 'value4',
@@ -226,7 +226,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Root level $set_once should override properties.$set_once for same keys
-            expect(result.value.normalizedEvent.properties!.$set_once).toEqual({
+            expect(result.value.event.properties!.$set_once).toEqual({
                 key1_once: 'value1',
                 key2_once: 'value2', // overridden from root level
                 key3_once: 'value4',
@@ -269,7 +269,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Since processPerson=true, person properties should be preserved and merged
-            expect(result.value.normalizedEvent).toEqual({
+            expect(result.value.event).toEqual({
                 ...event,
                 properties: {
                     $browser: 'Chrome',
@@ -320,7 +320,7 @@ describe('normalizeEventStep wrapper', () => {
 
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
-            expect(result.value.normalizedEvent).toEqual({
+            expect(result.value.event).toEqual({
                 ...event,
                 distinct_id: '\uFFFDfoo',
                 properties: {},
@@ -379,7 +379,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // The step always uses processPerson=false, so person-related properties should be dropped
-            expect(result.value.normalizedEvent).toEqual({
+            expect(result.value.event).toEqual({
                 ...event,
                 // $set and $set_once at root level should be gone
                 $set: undefined,
@@ -435,7 +435,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Root level $set should merge into properties.$set
-            expect(result.value.normalizedEvent.properties!.$set).toEqual({
+            expect(result.value.event.properties!.$set).toEqual({
                 propA: 'valueA',
                 propB: 'valueB',
             })
@@ -476,7 +476,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Root level $set_once should merge into properties.$set_once
-            expect(result.value.normalizedEvent.properties!.$set_once).toEqual({
+            expect(result.value.event.properties!.$set_once).toEqual({
                 onceA: 'valueA',
                 onceB: 'valueB',
             })
@@ -509,9 +509,9 @@ describe('normalizeEventStep wrapper', () => {
 
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
-            expect(result.value.normalizedEvent.properties!.$ip).toBe('192.168.1.1')
+            expect(result.value.event.properties!.$ip).toBe('192.168.1.1')
             // ip field should be set to null
-            expect(result.value.normalizedEvent.ip).toBe(null)
+            expect(result.value.event.ip).toBe(null)
         }
     })
 
@@ -544,7 +544,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // Should keep the original $ip from properties
-            expect(result.value.normalizedEvent.properties!.$ip).toBe('10.0.0.1')
+            expect(result.value.event.properties!.$ip).toBe('10.0.0.1')
         }
     })
 
@@ -575,7 +575,7 @@ describe('normalizeEventStep wrapper', () => {
 
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
-            expect(result.value.normalizedEvent.properties!.$sent_at).toBe('2020-02-23T02:14:00Z')
+            expect(result.value.event.properties!.$sent_at).toBe('2020-02-23T02:14:00Z')
         }
     })
 
@@ -608,7 +608,7 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // $unset should be removed for processPerson=false
-            expect(result.value.normalizedEvent.properties!.$unset).toBeUndefined()
+            expect(result.value.event.properties!.$unset).toBeUndefined()
         }
     })
 
@@ -646,10 +646,10 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // $groupidentify always has person properties removed
-            expect(result.value.normalizedEvent.$set).toBeUndefined()
-            expect(result.value.normalizedEvent.properties!.$set).toBeUndefined()
+            expect(result.value.event.$set).toBeUndefined()
+            expect(result.value.event.properties!.$set).toBeUndefined()
             // But $process_person_profile is not added since processPerson=true
-            expect(result.value.normalizedEvent.properties!.$process_person_profile).toBeUndefined()
+            expect(result.value.event.properties!.$process_person_profile).toBeUndefined()
         }
     })
 
@@ -683,8 +683,8 @@ describe('normalizeEventStep wrapper', () => {
         expect(result.type).toBe(PipelineResultType.OK)
         if (result.type === PipelineResultType.OK) {
             // $process_person_profile should be removed when processPerson=true (it's the default)
-            expect(result.value.normalizedEvent.properties!.$process_person_profile).toBeUndefined()
-            expect(result.value.normalizedEvent.properties!.other).toBe('value')
+            expect(result.value.event.properties!.$process_person_profile).toBeUndefined()
+            expect(result.value.event.properties!.other).toBe('value')
         }
     })
 
@@ -724,7 +724,7 @@ describe('normalizeEventStep wrapper', () => {
             expect('event' in result.value).toBe(false)
 
             // Verify normalized fields are added
-            expect(result.value.normalizedEvent).toBeDefined()
+            expect(result.value.event).toBeDefined()
             expect(result.value.timestamp).toBeDefined()
         }
     })

--- a/nodejs/src/ingestion/event-processing/normalize-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-event-step.ts
@@ -11,22 +11,20 @@ export function createNormalizeEventStep<
     TInput extends { event: PluginEvent; headers: EventHeaders; team: Team; processPerson: boolean },
 >(
     timestampComparisonLoggingSampleRate: number
-): ProcessingStep<TInput, Omit<TInput, 'event'> & { event: PipelineEvent; timestamp: DateTime }> {
+): ProcessingStep<TInput, TInput & { normalizedEvent: PipelineEvent; timestamp: DateTime }> {
     return async function normalizeEventStepWrapper(
         input: TInput
-    ): Promise<PipelineResult<Omit<TInput, 'event'> & { event: PipelineEvent; timestamp: DateTime }>> {
-        const { event, ...restInput } = input
-
+    ): Promise<PipelineResult<TInput & { normalizedEvent: PipelineEvent; timestamp: DateTime }>> {
         const [normalizedEvent, timestamp] = await normalizeEventStep(
-            event,
+            input.event,
             input.processPerson,
             input.headers,
             timestampComparisonLoggingSampleRate
         )
 
         return ok({
-            ...restInput,
-            event: normalizedEvent,
+            ...input,
+            normalizedEvent,
             timestamp,
         })
     }

--- a/nodejs/src/ingestion/event-processing/normalize-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-event-step.ts
@@ -8,22 +8,17 @@ import { PipelineResult, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export function createNormalizeEventStep<
-    TInput extends { event: PipelineEvent; headers: EventHeaders; team: Team; processPerson: boolean },
+    TInput extends { event: PluginEvent; headers: EventHeaders; team: Team; processPerson: boolean },
 >(
     timestampComparisonLoggingSampleRate: number
-): ProcessingStep<TInput, Omit<TInput, 'event'> & { normalizedEvent: PipelineEvent; timestamp: DateTime }> {
+): ProcessingStep<TInput, Omit<TInput, 'event'> & { event: PipelineEvent; timestamp: DateTime }> {
     return async function normalizeEventStepWrapper(
         input: TInput
-    ): Promise<PipelineResult<Omit<TInput, 'event'> & { normalizedEvent: PipelineEvent; timestamp: DateTime }>> {
-        const { event: event, ...restInput } = input
-
-        const pluginEvent: PluginEvent = {
-            ...event,
-            team_id: input.team.id,
-        }
+    ): Promise<PipelineResult<Omit<TInput, 'event'> & { event: PipelineEvent; timestamp: DateTime }>> {
+        const { event, ...restInput } = input
 
         const [normalizedEvent, timestamp] = await normalizeEventStep(
-            pluginEvent,
+            event,
             input.processPerson,
             input.headers,
             timestampComparisonLoggingSampleRate
@@ -31,7 +26,7 @@ export function createNormalizeEventStep<
 
         return ok({
             ...restInput,
-            normalizedEvent,
+            event: normalizedEvent,
             timestamp,
         })
     }

--- a/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
@@ -1,52 +1,28 @@
-import { Message } from 'node-rdkafka'
 import { v4 } from 'uuid'
 
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
-import { ProjectId, Team } from '../../types'
+import { createTestMessage } from '../../../tests/helpers/kafka-message'
+import { createTestPluginEvent } from '../../../tests/helpers/plugin-event'
+import { createTestTeam } from '../../../tests/helpers/team'
 import { PerDistinctIdPipelineInput } from '../analytics'
 import { PipelineResultType } from '../pipelines/results'
 import { createNormalizeProcessPersonFlagStep } from './normalize-process-person-flag-step'
 
-const createTestTeam = (overrides: Partial<Team> = {}): Team => ({
-    id: 1,
-    project_id: 1 as ProjectId,
-    organization_id: 'test-org-id',
-    uuid: v4(),
-    name: 'Test Team',
-    anonymize_ips: false,
-    api_token: 'test-api-token',
-    slack_incoming_webhook: null,
-    session_recording_opt_in: true,
-    person_processing_opt_out: null,
-    heatmaps_opt_in: null,
-    ingested_event: true,
-    person_display_name_properties: null,
-    test_account_filters: null,
-    cookieless_server_hash_mode: null,
-    timezone: 'UTC',
-    available_features: [],
-    drop_events_older_than_seconds: null,
-    ...overrides,
-})
-
 describe('normalizeProcessPersonFlagStep', () => {
     const team = createTestTeam()
 
-    const baseEvent: PluginEvent = {
+    const baseEvent: PluginEvent = createTestPluginEvent({
         distinct_id: 'my_id',
-        ip: null,
         site_url: '',
         team_id: 1,
         now: new Date().toISOString(),
-        event: '$pageview',
-        properties: {},
         uuid: v4(),
-    }
+    })
 
     const baseInput: PerDistinctIdPipelineInput = {
-        message: {} as Message,
+        message: createTestMessage(),
         event: baseEvent,
         team,
         headers: createTestEventHeaders(),

--- a/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
@@ -1,8 +1,10 @@
 import { Message } from 'node-rdkafka'
 import { v4 } from 'uuid'
 
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
 import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
-import { PipelineEvent, ProjectId, Team } from '../../types'
+import { ProjectId, Team } from '../../types'
 import { PerDistinctIdPipelineInput } from '../analytics'
 import { PipelineResultType } from '../pipelines/results'
 import { createNormalizeProcessPersonFlagStep } from './normalize-process-person-flag-step'
@@ -32,7 +34,7 @@ const createTestTeam = (overrides: Partial<Team> = {}): Team => ({
 describe('normalizeProcessPersonFlagStep', () => {
     const team = createTestTeam()
 
-    const baseEvent: PipelineEvent = {
+    const baseEvent: PluginEvent = {
         distinct_id: 'my_id',
         ip: null,
         site_url: '',

--- a/nodejs/src/worker/ingestion/event-pipeline/prefetchPersonsStep.ts
+++ b/nodejs/src/worker/ingestion/event-pipeline/prefetchPersonsStep.ts
@@ -1,9 +1,9 @@
 import { PipelineResult, ok } from '~/ingestion/pipelines/results'
-import { IncomingEventWithTeam } from '~/types'
+import { PipelineEvent, Team } from '~/types'
 
 import { PersonsStore } from '../persons/persons-store'
 
-type PrefetchPersonsStepInput = { eventWithTeam: IncomingEventWithTeam }
+type PrefetchPersonsStepInput = { event: PipelineEvent; team: Team }
 
 export function prefetchPersonsStep<T extends PrefetchPersonsStepInput>(personsStore: PersonsStore, enabled: boolean) {
     return function prefetchPersonsStep(events: T[]): Promise<PipelineResult<T>[]> {
@@ -11,7 +11,7 @@ export function prefetchPersonsStep<T extends PrefetchPersonsStepInput>(personsS
             // Fire prefetch without awaiting. fetchForChecking/fetchForUpdate will wait
             // on the pending promises if they need data that's still being fetched
             void personsStore.prefetchPersons(
-                events.map((x) => ({ teamId: x.eventWithTeam.team.id, distinctId: x.eventWithTeam.event.distinct_id }))
+                events.map((x) => ({ teamId: x.team.id, distinctId: x.event.distinct_id }))
             )
         }
         return Promise.resolve(events.map((event) => ok(event)))

--- a/nodejs/tests/helpers/pipeline-event.ts
+++ b/nodejs/tests/helpers/pipeline-event.ts
@@ -1,0 +1,14 @@
+import { PipelineEvent } from '../../src/types'
+
+export function createTestPipelineEvent(overrides: Partial<PipelineEvent> = {}): PipelineEvent {
+    return {
+        distinct_id: 'test-distinct-id',
+        ip: '127.0.0.1',
+        site_url: 'https://example.com',
+        now: '2021-01-01T00:00:00Z',
+        event: '$pageview',
+        uuid: '123e4567-e89b-12d3-a456-426614174000',
+        properties: {},
+        ...overrides,
+    }
+}

--- a/nodejs/tests/helpers/plugin-event.ts
+++ b/nodejs/tests/helpers/plugin-event.ts
@@ -1,0 +1,15 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+export function createTestPluginEvent(overrides: Partial<PluginEvent> = {}): PluginEvent {
+    return {
+        distinct_id: 'test-distinct-id',
+        ip: null,
+        site_url: 'http://localhost',
+        team_id: 1,
+        now: '2020-02-23T02:15:00Z',
+        event: '$pageview',
+        uuid: '123e4567-e89b-12d3-a456-426614174000',
+        properties: {},
+        ...overrides,
+    }
+}

--- a/nodejs/tests/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.test.ts
+++ b/nodejs/tests/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.test.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { PipelineResultType } from '~/ingestion/pipelines/results'
-import { IncomingEventWithTeam, Team } from '~/types'
+import { Team } from '~/types'
 
 import { PersonsStore } from '../../../../src/worker/ingestion/persons/persons-store'
 
@@ -31,10 +31,10 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
         } as unknown as jest.Mocked<PersonsStore>
     })
 
-    const createEventWithTeam = (
+    const createInput = (
         distinctId: string,
         processPerson: boolean | undefined = undefined
-    ): { eventWithTeam: IncomingEventWithTeam } => {
+    ): { event: PluginEvent; team: Team } => {
         const event: PluginEvent = {
             distinct_id: distinctId,
             ip: null,
@@ -47,27 +47,13 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
             uuid: `uuid-${distinctId}`,
         }
 
-        return {
-            eventWithTeam: {
-                event,
-                team,
-                message: {} as any,
-                headers: {
-                    force_disable_person_processing: false,
-                    historical_migration: false,
-                },
-            },
-        }
+        return { event, team }
     }
 
     describe('when enabled', () => {
         it('should process personless events and call batch insert', async () => {
             const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
-            const events = [
-                createEventWithTeam('user-1', false),
-                createEventWithTeam('user-2', false),
-                createEventWithTeam('user-3', false),
-            ]
+            const events = [createInput('user-1', false), createInput('user-2', false), createInput('user-3', false)]
 
             const results = await step(events)
 
@@ -83,9 +69,9 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
         it('should skip non-personless events', async () => {
             const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
             const events = [
-                createEventWithTeam('user-1', true), // processPerson=true
-                createEventWithTeam('user-2', false), // processPerson=false (personless)
-                createEventWithTeam('user-3'), // processPerson=undefined (default, not personless)
+                createInput('user-1', true), // processPerson=true
+                createInput('user-2', false), // processPerson=false (personless)
+                createInput('user-3'), // processPerson=undefined (default, not personless)
             ]
 
             const results = await step(events)
@@ -98,7 +84,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
 
         it('should not call batch insert when no personless events', async () => {
             const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
-            const events = [createEventWithTeam('user-1', true), createEventWithTeam('user-2')]
+            const events = [createInput('user-1', true), createInput('user-2')]
 
             const results = await step(events)
 
@@ -110,7 +96,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
             mockPersonsStore.processPersonlessDistinctIdsBatch.mockRejectedValue(new Error('DB error'))
 
             const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
-            const events = [createEventWithTeam('user-1', false)]
+            const events = [createInput('user-1', false)]
 
             // The step should throw since we don't handle errors gracefully
             await expect(step(events)).rejects.toThrow('DB error')
@@ -120,7 +106,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
     describe('when disabled', () => {
         it('should not process any events', async () => {
             const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, false)
-            const events = [createEventWithTeam('user-1', false), createEventWithTeam('user-2', false)]
+            const events = [createInput('user-1', false), createInput('user-2', false)]
 
             const results = await step(events)
 
@@ -134,9 +120,9 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
         it('should deduplicate entries within same batch before hitting cache', async () => {
             const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
             const events = [
-                createEventWithTeam('user-1', false),
-                createEventWithTeam('user-1', false), // Duplicate - deduped before cache/insert
-                createEventWithTeam('user-2', false),
+                createInput('user-1', false),
+                createInput('user-1', false), // Duplicate - deduped before cache/insert
+                createInput('user-2', false),
             ]
 
             await step(events)
@@ -152,7 +138,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
             const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
 
             // First batch
-            await step([createEventWithTeam('user-1', false)])
+            await step([createInput('user-1', false)])
             expect(mockPersonsStore.processPersonlessDistinctIdsBatch).toHaveBeenCalledWith([
                 { teamId: team.id, distinctId: 'user-1' },
             ])
@@ -160,7 +146,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
             mockPersonsStore.processPersonlessDistinctIdsBatch.mockClear()
 
             // Second batch - user-1 should be cached, only user-2 should be inserted
-            await step([createEventWithTeam('user-1', false), createEventWithTeam('user-2', false)])
+            await step([createInput('user-1', false), createInput('user-2', false)])
             expect(mockPersonsStore.processPersonlessDistinctIdsBatch).toHaveBeenCalledWith([
                 { teamId: team.id, distinctId: 'user-2' },
             ])

--- a/nodejs/tests/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.test.ts
+++ b/nodejs/tests/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.test.ts
@@ -4,6 +4,8 @@ import { PipelineResultType } from '~/ingestion/pipelines/results'
 import { Team } from '~/types'
 
 import { PersonsStore } from '../../../../src/worker/ingestion/persons/persons-store'
+import { createTestPluginEvent } from '../../../helpers/plugin-event'
+import { createTestTeam } from '../../../helpers/team'
 
 describe('processPersonlessDistinctIdsBatchStep', () => {
     let mockPersonsStore: jest.Mocked<PersonsStore>
@@ -18,12 +20,7 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
         )
         processPersonlessDistinctIdsBatchStep = module.processPersonlessDistinctIdsBatchStep
 
-        team = {
-            id: 1,
-            uuid: 'test-team-uuid',
-            organization_id: 'test-org',
-            name: 'Test Team',
-        } as Team
+        team = createTestTeam()
 
         mockPersonsStore = {
             processPersonlessDistinctIdsBatch: jest.fn().mockResolvedValue(undefined),
@@ -34,21 +31,15 @@ describe('processPersonlessDistinctIdsBatchStep', () => {
     const createInput = (
         distinctId: string,
         processPerson: boolean | undefined = undefined
-    ): { event: PluginEvent; team: Team } => {
-        const event: PluginEvent = {
+    ): { event: PluginEvent; team: Team } => ({
+        event: createTestPluginEvent({
             distinct_id: distinctId,
-            ip: null,
-            site_url: 'http://localhost',
             team_id: team.id,
-            now: '2020-02-23T02:15:00Z',
-            timestamp: '2020-02-23T02:15:00Z',
-            event: '$pageview',
             properties: processPerson === undefined ? {} : { $process_person_profile: processPerson },
             uuid: `uuid-${distinctId}`,
-        }
-
-        return { event, team }
-    }
+        }),
+        team,
+    })
 
     describe('when enabled', () => {
         it('should process personless events and call batch insert', async () => {


### PR DESCRIPTION
## Problem

Event pipeline is currently duplicating data as events flow through the different steps.

## Changes

Change the return type of resolve team step so that it overwrites the existing event with a wider type, rather than keeping old and adding new.

## How did you test this code?

Unit/Integration tests

## Publish to changelog?