### PR TITLE
fix: Fix insert with http client

### DIFF
--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -218,6 +218,10 @@ intents:
         description: 'MCP server for AI assistant integration'
         capabilities: [mcp_server]
 
+    dagster:
+        description: 'Dagster for clickhouse maintenance, system workflows'
+        capabilities: [dagster_pipelines]
+
 # Always-required processes regardless of intent
 # This is the core stack needed for any development
 always_required:

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -259,7 +259,11 @@ def sync_execute(
                 with_column_types=with_column_types,
                 query_id=query_id,
             )
-            if "INSERT INTO" in prepared_sql and client.last_query.progress.written_rows > 0:
+            if (
+                "INSERT INTO" in prepared_sql
+                and hasattr(client, "last_query")
+                and client.last_query.progress.written_rows > 0
+            ):
                 result = client.last_query.progress.written_rows
     except Exception as e:
         exception_type = clickhouse_error_type(e)

--- a/posthog/clickhouse/client/test/test_connection.py
+++ b/posthog/clickhouse/client/test/test_connection.py
@@ -1,6 +1,27 @@
 import pytest
 
-from posthog.clickhouse.client.connection import Workload, get_pool, make_ch_pool, set_default_clickhouse_workload_type
+from posthog.clickhouse.client.connection import (
+    Workload,
+    get_http_client,
+    get_pool,
+    make_ch_pool,
+    set_default_clickhouse_workload_type,
+)
+from posthog.clickhouse.client.execute import sync_execute
+
+
+def test_insert_with_http_client():
+    sync_execute("DROP TABLE IF EXISTS _test_http_insert")
+    sync_execute("CREATE TABLE _test_http_insert (id UInt64) ENGINE = Memory")
+    try:
+        with get_http_client() as client:
+            result = sync_execute(
+                "INSERT INTO _test_http_insert SELECT number FROM numbers(3)",
+                sync_client=client,
+            )
+            assert result == 3
+    finally:
+        sync_execute("DROP TABLE IF EXISTS _test_http_insert")
 
 
 def test_connection_pool_creation_without_offline_cluster(settings):


### PR DESCRIPTION
## Problem

The http client throws an error when you try to insert with it

## Changes
Fix this, it already returns the row count, so the existing logic was not needed

## How did you test this code?

Added a test that asserts that we can get the inserted row count
👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
