### PR TITLE
feat: add link to access control in the roles table

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.ts
@@ -1,6 +1,6 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
-import { router } from 'kea-router'
+import { urlToAction } from 'kea-router'
 
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { fullName, toSentenceCase } from 'lib/utils'
@@ -554,14 +554,15 @@ export const accessControlsLogic = kea<accessControlsLogicType>([
         },
     })),
 
-    afterMount(({ actions }) => {
-        const { searchParams } = router.values
-        const tab = searchParams.access_tab
-        if (tab === 'roles' || tab === 'members' || tab === 'defaults') {
-            actions.setActiveTab(tab)
-        }
-        if (tab === 'roles' && searchParams.access_role_id) {
-            actions.setFilters({ roleIds: [searchParams.access_role_id] })
-        }
-    }),
+    urlToAction(({ actions }) => ({
+        '/settings/:section': (_, searchParams) => {
+            const tab = searchParams.access_tab
+            if (tab === 'roles' || tab === 'members' || tab === 'defaults') {
+                actions.setActiveTab(tab)
+            }
+            if (tab === 'roles' && searchParams.access_role_id) {
+                actions.setFilters({ roleIds: [searchParams.access_role_id] })
+            }
+        },
+    })),
 ])

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.ts
@@ -1,5 +1,6 @@
-import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
+import { router } from 'kea-router'
 
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { fullName, toSentenceCase } from 'lib/utils'
@@ -552,4 +553,15 @@ export const accessControlsLogic = kea<accessControlsLogicType>([
             actions.closeRuleModal()
         },
     })),
+
+    afterMount(({ actions }) => {
+        const { searchParams } = router.values
+        const tab = searchParams.access_tab
+        if (tab === 'roles' || tab === 'members' || tab === 'defaults') {
+            actions.setActiveTab(tab)
+        }
+        if (tab === 'roles' && searchParams.access_role_id) {
+            actions.setFilters({ roleIds: [searchParams.access_role_id] })
+        }
+    }),
 ])

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
-import { combineUrl } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import { useMemo, useState } from 'react'
 
 import { IconInfo, IconPlus } from '@posthog/icons'
@@ -104,15 +104,19 @@ export function RolesAccessControls(): JSX.Element {
                 if (!role) {
                     return null
                 }
+                const manageAccessUrl = combineUrl(urls.settings('environment-access-control'), {
+                    access_tab: 'roles',
+                    access_role_id: role.id,
+                }).url
                 return (
                     <LemonButton
                         type="tertiary"
                         size="small"
-                        to={
-                            combineUrl(urls.settings('environment-access-control'), {
-                                access_tab: 'roles',
-                                access_role_id: role.id,
-                            }).url
+                        className="whitespace-nowrap"
+                        onClick={() =>
+                            guardAvailableFeature(AvailableFeature.ROLE_BASED_ACCESS, () => {
+                                router.actions.push(manageAccessUrl)
+                            })
                         }
                     >
                         Manage access

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls.tsx
@@ -1,5 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
+import { combineUrl } from 'kea-router'
 import { useMemo, useState } from 'react'
 
 import { IconInfo, IconPlus } from '@posthog/icons'
@@ -27,6 +28,7 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { fullName } from 'lib/utils'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature, RoleType } from '~/types'
@@ -92,6 +94,29 @@ export function RolesAccessControls(): JSX.Element {
                     )
                 ) : (
                     'All members'
+                )
+            },
+        },
+        {
+            key: 'manage_access',
+            width: 0,
+            render: (_, role) => {
+                if (!role) {
+                    return null
+                }
+                return (
+                    <LemonButton
+                        type="tertiary"
+                        size="small"
+                        to={
+                            combineUrl(urls.settings('environment-access-control'), {
+                                access_tab: 'roles',
+                                access_role_id: role.id,
+                            }).url
+                        }
+                    >
+                        Manage access
+                    </LemonButton>
                 )
             },
         },


### PR DESCRIPTION
## Problem

A user on the Roles page (/settings/organization-roles) couldn't easily discover where to configure project-level permissions for roles — that configuration lives on a separate Access Control page.

Ticket: https://posthoghelp.zendesk.com/agent/tickets/47783 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/54168)

## Changes
- Added "Manage access" button to each role row that navigates to /settings/environment-access-control with the Roles tab pre-selected and filtered to that specific role
- Uses URL params (access_tab=roles&access_role_id=<id>) to restore tab/filter state on navigation
- Shows upgrade modal for users without the feature

## How did you test this code?

*   Manually verified that the "Manage access" button appears in the roles table.
*   Manually verified that clicking the button navigates to the Access Control page, opens the "Roles" tab, and filters by the correct role.

![2026-02-11 13 21 52](https://github.com/user-attachments/assets/612b38b1-9240-4ab8-b9cf-64ded1c8177c)

![2026-02-11 13 21 03](https://github.com/user-attachments/assets/6e4e9a70-d159-4b8d-b8db-6477c4c510e1)


## Publish to changelog?
no