### PR TITLE
Temporal worker triggers tests

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -260,7 +260,7 @@ jobs:
             - name: Check for changes that affect video export temporal worker
               id: check_changes_video_export_temporal_worker
               run: |
-                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/exports_video|^posthog/tasks/exports/video_exporter.py|^nodejs/src/scripts/record-replay|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/exports_video|^posthog/tasks/exports/video_exporter.py|^nodejs/src/scripts/record-replay|^posthog/temporal/ai/session_summary|^posthog/temporal/ai/video_segment_clustering|^ee/hogai/session_summaries|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
 
             - name: Check for changes that affect session replay temporal worker
               id: check_changes_session_replay_temporal_worker

--- a/posthog/management/commands/execute_temporal_workflow.py
+++ b/posthog/management/commands/execute_temporal_workflow.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
-from posthog.temporal.ai import WORKFLOWS as AI_WORKFLOWS
+from posthog.temporal.ai import AI_WORKFLOWS as AI_WORKFLOWS
 from posthog.temporal.common.client import connect
 from posthog.temporal.data_imports.settings import WORKFLOWS as DATA_IMPORT_WORKFLOWS
 from posthog.temporal.data_modeling import WORKFLOWS as DATA_MODELING_WORKFLOWS

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -18,10 +18,7 @@ with workflow.unsafe.imports_passed_through():
     from django.core.management.base import BaseCommand
 
 from posthog.clickhouse.query_tagging import tag_queries
-from posthog.temporal.ai import (
-    ACTIVITIES as AI_ACTIVITIES,
-    WORKFLOWS as AI_WORKFLOWS,
-)
+from posthog.temporal.ai import AI_ACTIVITIES, AI_WORKFLOWS, SIGNALS_ACTIVITIES, SIGNALS_WORKFLOWS
 from posthog.temporal.cleanup_property_definitions import (
     ACTIVITIES as CLEANUP_PROPDEFS_ACTIVITIES,
     WORKFLOWS as CLEANUP_PROPDEFS_WORKFLOWS,
@@ -220,8 +217,8 @@ _task_queue_specs = [
     ),
     (
         settings.VIDEO_EXPORT_TASK_QUEUE,
-        VIDEO_EXPORT_WORKFLOWS,
-        VIDEO_EXPORT_ACTIVITIES,
+        VIDEO_EXPORT_WORKFLOWS + SIGNALS_WORKFLOWS,
+        VIDEO_EXPORT_ACTIVITIES + SIGNALS_ACTIVITIES,
     ),
     (
         settings.SESSION_REPLAY_TASK_QUEUE,

--- a/posthog/management/commands/start_temporal_workflow.py
+++ b/posthog/management/commands/start_temporal_workflow.py
@@ -7,7 +7,7 @@ from django.core.management.base import BaseCommand
 
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
-from posthog.temporal.ai import WORKFLOWS as AI_WORKFLOWS
+from posthog.temporal.ai import AI_WORKFLOWS as AI_WORKFLOWS
 from posthog.temporal.common.client import connect
 from posthog.temporal.data_imports.settings import WORKFLOWS as DATA_IMPORT_WORKFLOWS
 from posthog.temporal.delete_persons import WORKFLOWS as DELETE_PERSONS_WORKFLOWS

--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -69,25 +69,35 @@ from .video_segment_clustering.coordinator_workflow import (
     get_proactive_tasks_enabled_team_ids_activity,
 )
 
-WORKFLOWS = [
+AI_WORKFLOWS = [
     SyncVectorsWorkflow,
-    SummarizeSingleSessionStreamWorkflow,
-    SummarizeSingleSessionWorkflow,
-    SummarizeSessionGroupWorkflow,
     AssistantConversationRunnerWorkflow,
     ChatAgentWorkflow,
     ResearchAgentWorkflow,
     SummarizeLLMTracesWorkflow,
     SlackConversationRunnerWorkflow,
-    # Video segment clustering workflows
+]
+
+AI_ACTIVITIES = [
+    get_approximate_actions_count,
+    batch_summarize_actions,
+    batch_embed_and_sync_actions,
+    process_conversation_activity,
+    process_chat_agent_activity,
+    process_research_agent_activity,
+    summarize_llm_traces_activity,
+    process_slack_conversation_activity,
+]
+
+SIGNALS_WORKFLOWS = [
+    SummarizeSingleSessionStreamWorkflow,
+    SummarizeSingleSessionWorkflow,
+    SummarizeSessionGroupWorkflow,
     VideoSegmentClusteringWorkflow,
     VideoSegmentClusteringCoordinatorWorkflow,
 ]
 
-ACTIVITIES = [
-    get_approximate_actions_count,
-    batch_summarize_actions,
-    batch_embed_and_sync_actions,
+SIGNALS_ACTIVITIES = [
     stream_llm_single_session_summary_activity,
     get_llm_single_session_summary_activity,
     fetch_session_batch_events_activity,
@@ -96,13 +106,7 @@ ACTIVITIES = [
     fetch_session_data_activity,
     combine_patterns_from_chunks_activity,
     split_session_summaries_into_chunks_for_patterns_extraction_activity,
-    process_conversation_activity,
-    process_chat_agent_activity,
-    process_research_agent_activity,
     validate_llm_single_session_summary_with_videos_activity,
-    summarize_llm_traces_activity,
-    process_slack_conversation_activity,
-    # Video analysis activities
     prep_session_video_asset_activity,
     upload_video_to_gemini_activity,
     analyze_video_segment_activity,
@@ -110,7 +114,6 @@ ACTIVITIES = [
     store_video_session_summary_activity,
     consolidate_video_segments_activity,
     capture_timing_activity,
-    # Video segment clustering activities
     get_sessions_to_prime_activity,
     fetch_segments_activity,
     cluster_segments_activity,

--- a/posthog/temporal/ai/session_summary/summarize_session.py
+++ b/posthog/temporal/ai/session_summary/summarize_session.py
@@ -735,7 +735,7 @@ async def _execute_single_session_summary_workflow(inputs: SingleSessionSummaryI
         inputs,
         id=workflow_id,
         id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
-        task_queue=settings.MAX_AI_TASK_QUEUE,
+        task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
         retry_policy=retry_policy,
     )
 
@@ -751,7 +751,7 @@ async def _start_single_session_summary_workflow_stream(
         inputs,
         id=workflow_id,
         id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
-        task_queue=settings.MAX_AI_TASK_QUEUE,
+        task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
         retry_policy=retry_policy,
     )
     return handle

--- a/posthog/temporal/ai/session_summary/summarize_session_group.py
+++ b/posthog/temporal/ai/session_summary/summarize_session_group.py
@@ -674,7 +674,7 @@ async def _start_session_group_summary_workflow(
         inputs,
         id=workflow_id,
         id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
-        task_queue=settings.MAX_AI_TASK_QUEUE,
+        task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
         retry_policy=retry_policy,
     )
 

--- a/posthog/temporal/ai/video_segment_clustering/schedule.py
+++ b/posthog/temporal/ai/video_segment_clustering/schedule.py
@@ -33,7 +33,7 @@ async def create_video_segment_clustering_coordinator_schedule(client: Client):
                 lookback_hours=int(DEFAULT_LOOKBACK_WINDOW.total_seconds() / 3600),
             ),
             id="video-segment-clustering-coordinator-schedule",
-            task_queue=settings.MAX_AI_TASK_QUEUE,
+            task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=PROACTIVE_TASKS_SCHEDULE_INTERVAL)]),
         policy=SchedulePolicy(

--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -17,7 +17,7 @@ class TestAITemporalModuleIntegrity:
             "VideoSegmentClusteringWorkflow",
             "VideoSegmentClusteringCoordinatorWorkflow",
         ]
-        actual_workflow_names = [workflow.__name__ for workflow in ai.WORKFLOWS]
+        actual_workflow_names = [workflow.__name__ for workflow in ai.AI_WORKFLOWS]
         assert len(actual_workflow_names) == len(expected_workflows), (
             f"Workflow count mismatch. Expected {len(expected_workflows)}, got {len(actual_workflow_names)}. "
             "If you're adding/removing workflows, update this test accordingly."
@@ -67,7 +67,7 @@ class TestAITemporalModuleIntegrity:
             "persist_reports_activity",
             "get_proactive_tasks_enabled_team_ids_activity",
         ]
-        actual_activity_names = [activity.__name__ for activity in ai.ACTIVITIES]
+        actual_activity_names = [activity.__name__ for activity in ai.AI_ACTIVITIES]
         assert len(actual_activity_names) == len(expected_activities), (
             f"Activity count mismatch. Expected {len(expected_activities)}, got {len(actual_activity_names)}. "
             "If you're adding/removing activities, update this test accordingly."

--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -17,7 +17,7 @@ class TestAITemporalModuleIntegrity:
             "VideoSegmentClusteringWorkflow",
             "VideoSegmentClusteringCoordinatorWorkflow",
         ]
-        actual_workflow_names = [workflow.__name__ for workflow in ai.AI_WORKFLOWS]
+        actual_workflow_names = [workflow.__name__ for workflow in ai.AI_WORKFLOWS + ai.SIGNALS_WORKFLOWS]
         assert len(actual_workflow_names) == len(expected_workflows), (
             f"Workflow count mismatch. Expected {len(expected_workflows)}, got {len(actual_workflow_names)}. "
             "If you're adding/removing workflows, update this test accordingly."
@@ -67,7 +67,7 @@ class TestAITemporalModuleIntegrity:
             "persist_reports_activity",
             "get_proactive_tasks_enabled_team_ids_activity",
         ]
-        actual_activity_names = [activity.__name__ for activity in ai.AI_ACTIVITIES]
+        actual_activity_names = [activity.__name__ for activity in ai.AI_ACTIVITIES + ai.SIGNALS_ACTIVITIES]
         assert len(actual_activity_names) == len(expected_activities), (
             f"Activity count mismatch. Expected {len(expected_activities)}, got {len(actual_activity_names)}. "
             "If you're adding/removing activities, update this test accordingly."

--- a/posthog/temporal/tests/ai/test_summarize_session.py
+++ b/posthog/temporal/tests/ai/test_summarize_session.py
@@ -22,7 +22,7 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 from posthog.models import Team
 from posthog.models.user import User
 from posthog.sync import database_sync_to_async
-from posthog.temporal.ai import WORKFLOWS
+from posthog.temporal.ai import AI_WORKFLOWS
 from posthog.temporal.ai.session_summary.state import (
     StateActivitiesEnum,
     _compress_redis_data,
@@ -297,8 +297,8 @@ class TestSummarizeSingleSessionStreamWorkflow:
         try:
             async with Worker(
                 activity_environment.client,
-                task_queue=settings.MAX_AI_TASK_QUEUE,
-                workflows=WORKFLOWS,
+                task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
+                workflows=AI_WORKFLOWS,
                 activities=[stream_llm_single_session_summary_activity, fetch_session_data_activity],
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ) as worker:

--- a/posthog/temporal/tests/ai/test_summarize_session.py
+++ b/posthog/temporal/tests/ai/test_summarize_session.py
@@ -22,7 +22,7 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 from posthog.models import Team
 from posthog.models.user import User
 from posthog.sync import database_sync_to_async
-from posthog.temporal.ai import AI_WORKFLOWS
+from posthog.temporal.ai import AI_WORKFLOWS, SIGNALS_WORKFLOWS
 from posthog.temporal.ai.session_summary.state import (
     StateActivitiesEnum,
     _compress_redis_data,
@@ -298,7 +298,7 @@ class TestSummarizeSingleSessionStreamWorkflow:
             async with Worker(
                 activity_environment.client,
                 task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
-                workflows=AI_WORKFLOWS,
+                workflows=AI_WORKFLOWS + SIGNALS_WORKFLOWS,
                 activities=[stream_llm_single_session_summary_activity, fetch_session_data_activity],
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ) as worker:

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -24,7 +24,7 @@ from posthog.models import Team
 from posthog.models.user import User
 from posthog.redis import get_async_client
 from posthog.sync import database_sync_to_async
-from posthog.temporal.ai import WORKFLOWS
+from posthog.temporal.ai import AI_WORKFLOWS
 from posthog.temporal.ai.session_summary.activities.capture_timing import capture_timing_activity
 from posthog.temporal.ai.session_summary.activities.patterns import (
     assign_events_to_patterns_activity,
@@ -1027,7 +1027,7 @@ class TestSummarizeSessionGroupWorkflow:
                 async with Worker(
                     activity_environment.client,
                     task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
-                    workflows=WORKFLOWS,
+                    workflows=AI_WORKFLOWS,
                     activities=[
                         get_llm_single_session_summary_activity,
                         extract_session_group_patterns_activity,

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -24,7 +24,7 @@ from posthog.models import Team
 from posthog.models.user import User
 from posthog.redis import get_async_client
 from posthog.sync import database_sync_to_async
-from posthog.temporal.ai import AI_WORKFLOWS
+from posthog.temporal.ai import AI_WORKFLOWS, SIGNALS_WORKFLOWS
 from posthog.temporal.ai.session_summary.activities.capture_timing import capture_timing_activity
 from posthog.temporal.ai.session_summary.activities.patterns import (
     assign_events_to_patterns_activity,
@@ -1027,7 +1027,7 @@ class TestSummarizeSessionGroupWorkflow:
                 async with Worker(
                     activity_environment.client,
                     task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
-                    workflows=AI_WORKFLOWS,
+                    workflows=AI_WORKFLOWS + SIGNALS_WORKFLOWS,
                     activities=[
                         get_llm_single_session_summary_activity,
                         extract_session_group_patterns_activity,


### PR DESCRIPTION
## Problem

The video-export Temporal worker deployment trigger was not correctly configured to monitor changes to `session_summary` and `video_segment_clustering` related files, preventing necessary deployments. Additionally, several AI Temporal tests were failing due to incomplete workflow/activity registration after the split into `AI_WORKFLOWS` and `SIGNALS_WORKFLOWS`.

## Changes

-   **CI Trigger:** Expanded the `check_changes_video_export_temporal_worker` pattern in `container-images-cd.yml` to include paths for `session_summary`, `video_segment_clustering`, and `ee/hogai/session_summaries`.
-   **Test Fixes:** Updated `test_module_integrity.py`, `test_summarize_session.py`, and `test_summarize_session_group.py` to correctly reference both `AI_WORKFLOWS` and `SIGNALS_WORKFLOWS` (and their activities) for comprehensive testing and worker registration.

## How did you test this code?

-   Verified all automated tests now pass.
-   Manually confirmed the CI trigger logic by simulating changes to the newly added paths.

## Publish to changelog?

no

---
<p><a href="https://cursor.com/background-agent?bcId=bc-6d6183f0-f2df-4e62-a229-893147393832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d6183f0-f2df-4e62-a229-893147393832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

