### PR TITLE
chore(customer-analytics): Make config warning banner square

### DIFF
--- a/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
+++ b/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
@@ -82,7 +82,7 @@ export function CustomerAnalyticsQueryCard({ insight, tabId }: CustomerAnalytics
                     content={<InsightMetaContent title={insight.name} description={insight.description} />}
                 />
 
-                <LemonBanner type="warning">
+                <LemonBanner type="warning" square>
                     <div className="flex flex-row items-center gap-2">This insight requires configuration</div>
                     <div className="flex flex-col items-start gap-2 mt-2 max-w-160">
                         {eventsToConfigure.map((event) => (


### PR DESCRIPTION
## Problem
The round corners of the banners stand out against the parent border
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
### Before
<img width="878" height="970" alt="image" src="https://github.com/user-attachments/assets/923eb5b9-5088-4d8e-94f0-a9f322f86a4d" />

### After
<img width="426" height="418" alt="image" src="https://github.com/user-attachments/assets/acd8f729-935a-40cd-809e-c8a744582a09" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
