### PR TITLE
fix: expose amplitude migration options for s3

### DIFF
--- a/products/managed_migrations/frontend/ManagedMigration.tsx
+++ b/products/managed_migrations/frontend/ManagedMigration.tsx
@@ -21,7 +21,7 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
-import { managedMigrationLogic } from './managedMigrationLogic'
+import { type ManagedMigrationForm, managedMigrationLogic } from './managedMigrationLogic'
 import { type ManagedMigration } from './types'
 
 const STATUS_COLORS = {
@@ -38,6 +38,42 @@ const STATUS_LABELS: Record<string, string> = {
 function StatusTag({ status }: { status: string }): JSX.Element {
     const label = STATUS_LABELS[status] ?? status.charAt(0).toUpperCase() + status.slice(1)
     return <LemonTag type={STATUS_COLORS[status as keyof typeof STATUS_COLORS] || 'default'}>{label}</LemonTag>
+}
+
+function AmplitudeImportOptions({
+    managedMigration,
+    setManagedMigrationValue,
+}: {
+    managedMigration: ManagedMigrationForm
+    setManagedMigrationValue: (key: string, value: any) => void
+}): JSX.Element {
+    return (
+        <FlaggedFeature flag={FEATURE_FLAGS.AMPLITUDE_BATCH_IMPORT_OPTIONS}>
+            <LemonField name="import_events">
+                <LemonCheckbox
+                    checked={managedMigration.import_events !== false}
+                    onChange={(checked) => setManagedMigrationValue('import_events', checked)}
+                    label="Import events from Amplitude"
+                />
+            </LemonField>
+
+            <LemonField name="generate_identify_events">
+                <LemonCheckbox
+                    checked={managedMigration.generate_identify_events !== false}
+                    onChange={(checked) => setManagedMigrationValue('generate_identify_events', checked)}
+                    label="Generate identify events to link user IDs with device IDs"
+                />
+            </LemonField>
+
+            <LemonField name="generate_group_identify_events">
+                <LemonCheckbox
+                    checked={managedMigration.generate_group_identify_events === true}
+                    onChange={(checked) => setManagedMigrationValue('generate_group_identify_events', checked)}
+                    label="Generate group identify events from group property changes"
+                />
+            </LemonField>
+        </FlaggedFeature>
+    )
 }
 
 export function ManagedMigration(): JSX.Element {
@@ -171,38 +207,21 @@ export function ManagedMigration(): JSX.Element {
                         </LemonField>
 
                         {managedMigration.source_type === 'amplitude' && (
-                            <FlaggedFeature flag={FEATURE_FLAGS.AMPLITUDE_BATCH_IMPORT_OPTIONS}>
-                                <LemonField name="import_events">
-                                    <LemonCheckbox
-                                        checked={managedMigration.import_events !== false}
-                                        onChange={(checked) => setManagedMigrationValue('import_events', checked)}
-                                        label="Import events from Amplitude"
-                                    />
-                                </LemonField>
-
-                                <LemonField name="generate_identify_events">
-                                    <LemonCheckbox
-                                        checked={managedMigration.generate_identify_events !== false}
-                                        onChange={(checked) =>
-                                            setManagedMigrationValue('generate_identify_events', checked)
-                                        }
-                                        label="Generate identify events to link user IDs with device IDs"
-                                    />
-                                </LemonField>
-
-                                <LemonField name="generate_group_identify_events">
-                                    <LemonCheckbox
-                                        checked={managedMigration.generate_group_identify_events === true}
-                                        onChange={(checked) =>
-                                            setManagedMigrationValue('generate_group_identify_events', checked)
-                                        }
-                                        label="Generate group identify events from group property changes"
-                                    />
-                                </LemonField>
-                            </FlaggedFeature>
+                            <AmplitudeImportOptions
+                                managedMigration={managedMigration}
+                                setManagedMigrationValue={setManagedMigrationValue}
+                            />
                         )}
                     </>
                 )}
+
+                {(managedMigration.source_type === 's3' || managedMigration.source_type === 's3_gzip') &&
+                    managedMigration.content_type === 'amplitude' && (
+                        <AmplitudeImportOptions
+                            managedMigration={managedMigration}
+                            setManagedMigrationValue={setManagedMigrationValue}
+                        />
+                    )}
 
                 <div className="flex gap-4">
                     <LemonField name="access_key" label="Access Key ID" className="flex-1">

--- a/products/managed_migrations/frontend/managedMigrationLogic.ts
+++ b/products/managed_migrations/frontend/managedMigrationLogic.ts
@@ -83,6 +83,7 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
             defaults: NEW_MANAGED_MIGRATION,
             errors: ({
                 source_type,
+                content_type,
                 access_key,
                 secret_key,
                 s3_region,
@@ -101,6 +102,13 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
                 if (source_type === 's3' || source_type === 's3_gzip') {
                     errors.s3_region = !s3_region ? 'S3 region is required' : null
                     errors.s3_bucket = !s3_bucket ? 'S3 bucket is required' : null
+
+                    if (content_type === 'amplitude') {
+                        if (!import_events && !generate_identify_events && !generate_group_identify_events) {
+                            errors.import_events =
+                                'At least one of "Import events", "Generate identify events", or "Generate group identify events" must be enabled'
+                        }
+                    }
                 } else if (source_type === 'mixpanel' || source_type === 'amplitude') {
                     errors.start_date = !start_date ? 'Start date is required' : null
                     errors.end_date = !end_date ? 'End date is required' : null
@@ -141,6 +149,12 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
                         s3_region: values.s3_region,
                         s3_bucket: values.s3_bucket,
                         s3_prefix: values.s3_prefix,
+                    }
+
+                    if (values.content_type === 'amplitude') {
+                        payload.import_events = values.import_events
+                        payload.generate_identify_events = values.generate_identify_events
+                        payload.generate_group_identify_events = values.generate_group_identify_events
                     }
                 } else if (values.source_type === 'mixpanel' || values.source_type === 'amplitude') {
                     payload = {


### PR DESCRIPTION
## Problem

We have a bunch of managed migration settings for Amplitude, but we only expose them for the Amplitude source, not S3 with Amplitude content type.

## Changes

Exposes Amplitude options for S3 imports with Amplitude content type.

## How did you test this code?

- Manually
- Existing regression tests