### PR TITLE
Endpoint creation panel state

### DIFF
--- a/products/endpoints/frontend/endpointLogic.tsx
+++ b/products/endpoints/frontend/endpointLogic.tsx
@@ -198,14 +198,16 @@ export const endpointLogic = kea<endpointLogicType>([
                 actions.setEndpointName('')
                 actions.setEndpointDescription('')
                 actions.loadEndpoints()
+                
+                // Close the scene panel (info & actions panel) if endpoint was created from insight
+                if (response.derived_from_insight) {
+                    actions.setScenePanelOpen(false)
+                }
+                
                 lemonToast.success(<>Endpoint created</>, {
                     button: {
                         label: 'View',
                         action: () => {
-                            // Close the scene panel (info & actions panel) if endpoint was created from insight
-                            if (response.derived_from_insight) {
-                                actions.setScenePanelOpen(false)
-                            }
                             router.actions.push(urls.endpoint(response.name))
                         },
                     },


### PR DESCRIPTION
## Problem

When a user successfully creates an endpoint from an insight, the side panel for actions was only closing when the user clicked the "View" button in the success toast. This leads to a less immediate and intuitive user experience.

This change ensures the side panel closes immediately upon successful endpoint creation, providing better UI cleanup.

## Changes

Moved the `setScenePanelOpen(false)` call from inside the "View" button's action callback to execute immediately within the `createEndpointSuccess` listener in `endpointLogic.tsx`, specifically when `derived_from_insight` is present.

## How did you test this code?

Manually tested by creating an endpoint from an insight and observing that the side panel closes immediately after the endpoint is successfully created, before interacting with the toast.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/D09F4NR6W1L/p1770814305853549?thread_ts=1770814305.853549&cid=D09F4NR6W1L)

<p><a href="https://cursor.com/background-agent?bcId=bc-c6743aa8-1daf-54f7-a41d-52927666f53f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c6743aa8-1daf-54f7-a41d-52927666f53f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

