### PR TITLE
chore(cli): rename env variables

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 0.5.29
 
-- chore: introduce env variable `POSTHOG_CLI_API_KEY` and `POSTHOG_PROJECT_ID` (backwards compatible)
+- chore: introduce env variable `POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_PROJECT_ID` (backwards compatible)
 
 # 0.5.28
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.5.29
+
+- chore: introduce env variable `POSTHOG_CLI_API_KEY` and `POSTHOG_PROJECT_ID` (backwards compatible)
+
 # 0.5.28
 
 - chore: introduce `--release-name` and `--release-version` options (backwards compatible)

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1566,7 +1566,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.28"
+version = "0.5.29"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.28"
+version = "0.5.29"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/README.md
+++ b/cli/README.md
@@ -7,7 +7,7 @@ The command line interface for PostHog 🦔
 Usage: posthog-cli [OPTIONS] <COMMAND>
 
 Commands:
-  login      Interactively authenticate with PostHog, storing a personal API token locally. You can also use the environment variables `POSTHOG_CLI_TOKEN`, `POSTHOG_CLI_ENV_ID` and `POSTHOG_CLI_HOST`
+  login      Interactively authenticate with PostHog, storing a personal API token locally. You can also use the environment variables `POSTHOG_CLI_API_KEY`, `POSTHOG_CLI_PROJECT_ID` and `POSTHOG_CLI_HOST`
   query      Run a SQL query against any data you have in posthog. This is mostly for fun, and subject to change
   sourcemap  Upload a directory of bundled chunks to PostHog
   exp        Contains a set of experimental commands
@@ -24,8 +24,8 @@ Options:
 You can authenticate with PostHog interactively for using the CLI locally, but if you'd like to use it in a CI/CD pipeline, we recommend using these environment variables:
 
 - `POSTHOG_CLI_HOST`: The PostHog host to connect to [default: https://us.posthog.com]
-- `POSTHOG_CLI_TOKEN`: [A posthog personal API key.](https://posthog.com/docs/api#private-endpoint-authentication)
-- `POSTHOG_CLI_ENV_ID`: The ID number of the project/environment to connect to. E.g. the "2" in `https://us.posthog.com/project/2`
+- `POSTHOG_CLI_API_KEY`: [A posthog personal API key.](https://posthog.com/docs/api#private-endpoint-authentication) (also accepts `POSTHOG_CLI_TOKEN` for backward compatibility)
+- `POSTHOG_CLI_PROJECT_ID`: The ID number of the project/environment to connect to. E.g. the "2" in `https://us.posthog.com/project/2` (also accepts `POSTHOG_CLI_ENV_ID` for backward compatibility)
 
 ### Personal API key scopes
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -34,7 +34,7 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Commands {
     /// Interactively authenticate with PostHog, storing a personal API token locally. You can also use the
-    /// environment variables `POSTHOG_CLI_TOKEN` and `POSTHOG_CLI_ENV_ID`
+    /// environment variables `POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_PROJECT_ID`
     Login,
 
     /// Experimental commands, not quite ready for prime time

--- a/cli/src/login.rs
+++ b/cli/src/login.rs
@@ -37,7 +37,7 @@ struct PollResponse {
 
 pub fn login(host_override: Option<String>) -> Result<()> {
     if !io::stdout().is_terminal() {
-        bail!("Failed to login. If you are running on a CI, skip this step and use POSTHOG_CLI_HOST, POSTHOG_CLI_ENV_ID, POSTHOG_CLI_TOKEN env variables when running commands")
+        bail!("Failed to login. If you are running on a CI, skip this step and use POSTHOG_CLI_HOST, POSTHOG_CLI_PROJECT_ID, POSTHOG_CLI_API_KEY env variables when running commands")
     }
     login_with_use_cases(host_override, vec!["schema", "error_tracking", "endpoints"])
 }

--- a/cli/src/utils/auth.rs
+++ b/cli/src/utils/auth.rs
@@ -59,14 +59,20 @@ impl CredentialProvider for HomeDirProvider {
     }
 }
 
-/// Tries to read the token from the env var `POSTHOG_CLI_TOKEN`
+/// Tries to read the token from the env var `POSTHOG_CLI_API_KEY`
 pub struct EnvVarProvider;
 
 impl CredentialProvider for EnvVarProvider {
     fn get_credentials(&self) -> Result<Token, Error> {
         let host = std::env::var("POSTHOG_CLI_HOST").ok();
-        let token = std::env::var("POSTHOG_CLI_TOKEN").context("While trying to read env var")?;
-        let env_id = std::env::var("POSTHOG_CLI_ENV_ID").context("While trying to read env var")?;
+        // Try POSTHOG_CLI_API_KEY first, fall back to POSTHOG_CLI_TOKEN for backward compatibility
+        let token = std::env::var("POSTHOG_CLI_API_KEY")
+            .or_else(|_| std::env::var("POSTHOG_CLI_TOKEN"))
+            .context("While trying to read env var POSTHOG_CLI_API_KEY")?;
+        // Try POSTHOG_CLI_PROJECT_ID first, fall back to POSTHOG_CLI_ENV_ID for backward compatibility
+        let env_id = std::env::var("POSTHOG_CLI_PROJECT_ID")
+            .or_else(|_| std::env::var("POSTHOG_CLI_ENV_ID"))
+            .context("While trying to read env var POSTHOG_CLI_PROJECT_ID")?;
         Ok(Token {
             host,
             token,


### PR DESCRIPTION
## Problem

- POSTHOG_CLI_ENV_ID -> POSTHOG_CLI_PROJECT_ID 
- POSTHOG_CLI_TOKEN -> POSTHOG_CLI_API_KEY