### PR TITLE
fix(signals): Check for summaries to exist before summarizing again

### DIFF
--- a/posthog/temporal/ai/session_summary/activities/a1_prep_session_video_asset.py
+++ b/posthog/temporal/ai/session_summary/activities/a1_prep_session_video_asset.py
@@ -43,12 +43,14 @@ async def prep_session_video_asset_activity(
     success = False
     try:
         # Check if a video-based summary already exists for this session
-        summary_exists = await database_sync_to_async(SingleSessionSummary.objects.summaries_exist)(
+        existing_summary = await database_sync_to_async(
+            SingleSessionSummary.objects.get_summary, thread_sensitive=False
+        )(
             team_id=inputs.team_id,
-            session_ids=[inputs.session_id],
+            session_id=inputs.session_id,
             extra_summary_context=inputs.extra_summary_context,
         )
-        if summary_exists.get(inputs.session_id):
+        if existing_summary is not None:
             logger.debug(
                 f"Summary already exists for session {inputs.session_id}, skipping video processing",
                 session_id=inputs.session_id,

--- a/posthog/temporal/ai/session_summary/activities/a6_store_video_session_summary.py
+++ b/posthog/temporal/ai/session_summary/activities/a6_store_video_session_summary.py
@@ -53,16 +53,15 @@ async def store_video_session_summary_activity(
         from ee.hogai.session_summaries.session.output_data import SessionSummarySerializer
         from ee.models.session_summaries import SessionSummaryRunMeta, SingleSessionSummary
 
-        # Check if summary already exists
+        # Check against duplicate writes (summary already exists). Should not happen, as we should avoid starting the workflow in the first place.
         summary_exists = await database_sync_to_async(SingleSessionSummary.objects.summaries_exist)(
             team_id=inputs.team_id,
             session_ids=[inputs.session_id],
             extra_summary_context=inputs.extra_summary_context,
         )
-
         if summary_exists.get(inputs.session_id):
-            logger.debug(
-                f"Video-based summary already exists for session {inputs.session_id}, skipping storage",
+            logger.exception(
+                f"Video-based summary already exists for session {inputs.session_id}, duplicate write detected, skipping storage",
                 session_id=inputs.session_id,
                 signals_type="session-summaries",
             )


### PR DESCRIPTION
## Problem
- We don't check if the session is already summarized before running the Temporal workflow

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Now we do, safe check in multiple places

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
