### PR TITLE
feat(analytics-platform): Give session backfill its own async concurrency tags

### DIFF
--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -386,12 +386,16 @@ ORDER BY event_time DESC;
 
 # Create a copy of the sessions backfill job to be used for backfilling experimental setups
 
+EXPERIMENTAL_CONCURRENCY_TAG = {
+    "sessions_backfill_concurrency": "experimental_sessions_v3",
+}
+
 
 @asset(
     partitions_def=daily_partitions,
     name="experimental_sessions_v3_backfill",
     backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=MAX_PARTITIONS_PER_RUN),
-    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **CONCURRENCY_TAG},
+    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **EXPERIMENTAL_CONCURRENCY_TAG},
 )
 def experimental_sessions_v3_backfill(
     context: AssetExecutionContext, config: ExperimentalSessionsBackfillConfig
@@ -405,7 +409,7 @@ experimental_sessions_backfill_job = define_asset_job(
     name="experimental_sessions_v3_backfill_job",
     selection=["experimental_sessions_v3_backfill"],
     config=sessions_backfill_partitioned_config,
-    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **CONCURRENCY_TAG},
+    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value, **EXPERIMENTAL_CONCURRENCY_TAG},
 )
 
 

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -387,7 +387,7 @@ ORDER BY event_time DESC;
 # Create a copy of the sessions backfill job to be used for backfilling experimental setups
 
 EXPERIMENTAL_CONCURRENCY_TAG = {
-    "sessions_backfill_concurrency": "experimental_sessions_v3",
+    "experimental_sessions_backfill_concurrency": "experimental_sessions_v3",
 }
 
 


### PR DESCRIPTION
## Problem

We can increase the concurrency of this backfill, this works based on tags in dagster. We don't want to increase the regular sessions backfill concurrency, so let's put this on its own tag

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
