### PR TITLE
fix: Dont do approvals endpoint calls when the feature missing

### DIFF
--- a/frontend/src/scenes/approvals/approvalsLogic.tsx
+++ b/frontend/src/scenes/approvals/approvalsLogic.tsx
@@ -61,7 +61,7 @@ export const approvalsLogic = kea<approvalsLogicType>([
             {
                 loadChangeRequests: async ({ url }, breakpoint) => {
                     if (!values.currentTeamId || !values.hasAvailableFeature(AvailableFeature.APPROVALS)) {
-                        return values.changeRequestsData
+                        return { changeRequests: [], changeRequestsCount: 0 }
                     }
 
                     await breakpoint(300)

--- a/frontend/src/scenes/approvals/approvalsLogic.tsx
+++ b/frontend/src/scenes/approvals/approvalsLogic.tsx
@@ -5,8 +5,9 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api, { CountedPaginatedResponse } from 'lib/api'
 import { teamLogic } from 'scenes/teamLogic'
+import { userLogic } from 'scenes/userLogic'
 
-import { ChangeRequest, ChangeRequestState } from '~/types'
+import { AvailableFeature, ChangeRequest, ChangeRequestState } from '~/types'
 
 import type { approvalsLogicType } from './approvalsLogicType'
 
@@ -45,7 +46,7 @@ function mergeChangeRequestsData(
 export const approvalsLogic = kea<approvalsLogicType>([
     path(['scenes', 'approvals', 'approvalsLogic']),
     connect(() => ({
-        values: [teamLogic, ['currentTeamId']],
+        values: [teamLogic, ['currentTeamId'], userLogic, ['hasAvailableFeature']],
     })),
     actions({
         setFilters: (filters: Partial<ApprovalsFilters>) => ({ filters }),
@@ -59,7 +60,7 @@ export const approvalsLogic = kea<approvalsLogicType>([
             { changeRequests: [], changeRequestsCount: 0 } as ApprovalDataState,
             {
                 loadChangeRequests: async ({ url }, breakpoint) => {
-                    if (!values.currentTeamId) {
+                    if (!values.currentTeamId || !values.hasAvailableFeature(AvailableFeature.APPROVALS)) {
                         return values.changeRequestsData
                     }
 

--- a/frontend/src/scenes/approvals/changeRequestsLogic.ts
+++ b/frontend/src/scenes/approvals/changeRequestsLogic.ts
@@ -5,8 +5,9 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { teamLogic } from 'scenes/teamLogic'
+import { userLogic } from 'scenes/userLogic'
 
-import { ChangeRequest, ChangeRequestState } from '~/types'
+import { AvailableFeature, ChangeRequest, ChangeRequestState } from '~/types'
 
 import type { changeRequestsLogicType } from './changeRequestsLogicType'
 
@@ -42,7 +43,7 @@ export const changeRequestsLogic = kea<changeRequestsLogicType>([
     key((props) => `${props.resourceType}-${props.resourceId}`),
 
     connect(() => ({
-        values: [teamLogic, ['currentTeamId']],
+        values: [teamLogic, ['currentTeamId'], userLogic, ['hasAvailableFeature']],
     })),
 
     actions({
@@ -57,7 +58,7 @@ export const changeRequestsLogic = kea<changeRequestsLogicType>([
             [] as ChangeRequest[],
             {
                 loadChangeRequests: async () => {
-                    if (!values.currentTeamId) {
+                    if (!values.currentTeamId || !values.hasAvailableFeature(AvailableFeature.APPROVALS)) {
                         return []
                     }
 


### PR DESCRIPTION

## Problem

- Users see request errors because the FE is trying to call approvals endpoint without the org having the needed feature entitlement.
<img width="856" height="284" alt="image" src="https://github.com/user-attachments/assets/7b4b17e7-e035-42d7-9591-3e5750d53ad8" />

## Changes

- Don't make the calls if the feature is not available for the org.

## How did you test this code?

- Manually

## Publish to changelog?

No