### PR TITLE
chore(endpoints): add soft-delete schema fields

### DIFF
--- a/products/endpoints/backend/migrations/0014_endpoint_soft_delete.py
+++ b/products/endpoints/backend/migrations/0014_endpoint_soft_delete.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("endpoints", "0013_add_endpointversion_is_active"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="endpoint",
+            name="unique_team_endpoint_name",
+        ),
+        migrations.AddField(
+            model_name="endpoint",
+            name="deleted",
+            field=models.BooleanField(blank=True, default=False, null=True),
+        ),
+        migrations.AddField(
+            model_name="endpoint",
+            name="deleted_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/products/endpoints/backend/migrations/0015_endpoint_soft_delete_constraint.py
+++ b/products/endpoints/backend/migrations/0015_endpoint_soft_delete_constraint.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("endpoints", "0014_endpoint_soft_delete"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddConstraint(
+                    model_name="endpoint",
+                    constraint=models.UniqueConstraint(
+                        condition=Q(deleted=False) | Q(deleted__isnull=True),
+                        fields=["team", "name"],
+                        name="unique_team_endpoint_name_active",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql='CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "unique_team_endpoint_name_active" ON "endpoints_endpoint" ("team_id", "name") WHERE (NOT "deleted" OR "deleted" IS NULL)',
+                    reverse_sql='DROP INDEX CONCURRENTLY IF EXISTS "unique_team_endpoint_name_active"',
+                ),
+                migrations.RunSQL(
+                    sql='ALTER TABLE "endpoints_endpoint" ADD CONSTRAINT "unique_team_endpoint_name_active" UNIQUE USING INDEX "unique_team_endpoint_name_active"',
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+    ]

--- a/products/endpoints/backend/migrations/max_migration.txt
+++ b/products/endpoints/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0013_add_endpointversion_is_active
+0015_endpoint_soft_delete_constraint

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -5,10 +5,11 @@ from typing import Any
 
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models import Q
 
 from posthog.models.team import Team
 from posthog.models.user import User
-from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDTModel
+from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UpdatedMetaFields, UUIDTModel
 
 
 def validate_endpoint_name(value: str) -> None:
@@ -135,7 +136,7 @@ class EndpointVersion(models.Model):
         return True, ""
 
 
-class Endpoint(CreatedMetaFields, UpdatedMetaFields, UUIDTModel):
+class Endpoint(CreatedMetaFields, UpdatedMetaFields, DeletedMetaFields, UUIDTModel):
     """Model for storing endpoints that can be accessed via API endpoints.
 
     Endpoints allow creating reusable query endpoints like:
@@ -176,7 +177,8 @@ class Endpoint(CreatedMetaFields, UpdatedMetaFields, UUIDTModel):
         constraints = [
             models.UniqueConstraint(
                 fields=["team", "name"],
-                name="unique_team_endpoint_name",
+                condition=Q(deleted=False) | Q(deleted__isnull=True),
+                name="unique_team_endpoint_name_active",
             )
         ]
         indexes = [


### PR DESCRIPTION
**\## Problem**

Not really a problem - just a nice to have



**\## Changes**

- add the fields for soft deletes

**Schema-only change. No behavior changes** — hard deletes still work, queries return all endpoints. This is PR 1 of a 2-PR stack.

**Stack:**

1. This PR — schema migration
2. #48036 — enable soft-delete behavior



**\## How did you test this code?**

- ran locally



👉 __Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review.__



**\## Publish to changelog?**

no