### PR TITLE
fix: make distinct_id_usage job write to proper slack channel

### DIFF
--- a/posthog/dags/distinct_id_usage.py
+++ b/posthog/dags/distinct_id_usage.py
@@ -348,7 +348,7 @@ def send_alerts(
 
     try:
         slack_client = slack.get_client()
-        channel = settings.DAGSTER_DEFAULT_SLACK_ALERTS_CHANNEL
+        channel = "#alerts-ingestion"
 
         # Post the summary message
         slack_client.chat_postMessage(channel=channel, blocks=blocks)


### PR DESCRIPTION
## Problem

We were sending alerts to the default channel instead of #alerts-ingestion

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
