### PR TITLE
fix(llma): change tool result role to render as assistant message

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -565,7 +565,7 @@ export const LLMMessageDisplay = React.memo(
                         ? 'bg-[var(--color-bg-fill-success-tertiary)] not-last:mb-2'
                         : role === 'user'
                           ? 'bg-[var(--color-bg-fill-tertiary)]'
-                          : role === 'assistant'
+                          : role.startsWith('assistant')
                             ? 'bg-[var(--color-bg-fill-info-tertiary)]'
                             : null
                 )}

--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -275,7 +275,7 @@ describe('LLM Analytics utils', () => {
 
         expect(normalizeMessage(message, 'user')).toEqual([
             {
-                role: 'user',
+                role: 'assistant (tool result)',
                 content: 'foo',
                 tool_call_id: '1',
             },
@@ -298,7 +298,7 @@ describe('LLM Analytics utils', () => {
         }
         expect(normalizeMessage(message, 'user')).toEqual([
             {
-                role: 'user',
+                role: 'assistant (tool result)',
                 content: 'foo',
                 tool_call_id: '1',
             },
@@ -435,7 +435,7 @@ describe('LLM Analytics utils', () => {
             expect(result[0].content).toBe('{"type":"output_text","text":"Some text"}')
         })
 
-        it('handles Anthropic tool result with nested content and preserves role', () => {
+        it('handles Anthropic tool result with nested content and overrides role to assistant (tool result)', () => {
             const toolResultMessage = {
                 type: 'tool_result',
                 tool_use_id: 'tool_123',
@@ -450,7 +450,7 @@ describe('LLM Analytics utils', () => {
             const result = normalizeMessage(toolResultMessage, 'tool')
 
             expect(result).toHaveLength(1)
-            expect(result[0].role).toBe('tool')
+            expect(result[0].role).toBe('assistant (tool result)')
             expect(result[0].content).toBe('Weather is sunny')
             expect(result[0].tool_call_id).toBe('tool_123')
         })

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -648,9 +648,10 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
     }
     // Tool result completion
     if (isAnthropicToolResultMessage(rawMessage)) {
+        const toolResultRole = normalizeRole('assistant (tool result)', roleToUse)
         if (Array.isArray(rawMessage.content)) {
             return rawMessage.content
-                .map((content) => normalizeMessage(content, roleToUse))
+                .map((content) => normalizeMessage(content, toolResultRole))
                 .flat()
                 .map((msg) => ({
                     ...msg,
@@ -659,7 +660,7 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
         }
         return [
             {
-                role: normalizeRole('assistant (tool result)', roleToUse),
+                role: toolResultRole,
                 content: rawMessage.content,
                 tool_call_id: rawMessage.tool_use_id,
             },

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -659,7 +659,7 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
         }
         return [
             {
-                role: roleToUse,
+                role: normalizeRole('assistant (tool result)', roleToUse),
                 content: rawMessage.content,
                 tool_call_id: rawMessage.tool_use_id,
             },


### PR DESCRIPTION
## Problem

Tool call results are being shown to users as `user` messages.

The PostHog AI recently shipped a [PR](https://github.com/PostHog/posthog/pull/46282) that started showing tool call results to the user, so that may have caused the issue. Not 100% sure. Either way, we adopt the same format as Claude where the result of a tool execution is sent back with the role `user` with content type as `tool_result`.

## Changes

Override role to be "assistant (tool result)" in line with how the role is overridden for assistant thinking.

## How did you test this code?

Tested in local environment

## Publish to changelog?

no