### PR TITLE
fix: Provide logicKey for LogsViewer for source sync logs

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -115,6 +115,7 @@ export const Syncs = ({ id }: SyncsProps): JSX.Element => {
                               expandedRowRender: (job) => (
                                   <div className="p-4">
                                       <LogsViewer
+                                          logicKey={`external_data_jobs:${job.id}`}
                                           sourceType="external_data_jobs"
                                           sourceId={job.schema.id}
                                           groupByInstanceId={false}


### PR DESCRIPTION
## Problem

I noticed that when you expand more than one `LogsViewer`, you were getting the same logs.

## Changes

Use the `job.id` as a `logicKey`.

## How did you test this code?

Verified locally this works - a new `/query` network request is made each time a `LogsViewer` is expanded.