### PR TITLE
fix(experiments): Disable row limit in pre-aggregation

### DIFF
--- a/products/analytics_platform/backend/lazy_preaggregation/lazy_preaggregation_executor.py
+++ b/products/analytics_platform/backend/lazy_preaggregation/lazy_preaggregation_executor.py
@@ -392,7 +392,7 @@ def build_preaggregation_insert_sql(
         query.where = date_range_filter
 
     # Print the SELECT query to ClickHouse SQL
-    context = HogQLContext(team_id=team.id, team=team, enable_select_queries=True)
+    context = HogQLContext(team_id=team.id, team=team, enable_select_queries=True, limit_top_select=False)
     select_sql, _ = prepare_and_print_ast(
         query,
         context=context,
@@ -907,7 +907,7 @@ def _build_manual_insert_sql(
     query.select.insert(1, job_id_expr)
 
     # Print to SQL
-    context = HogQLContext(team_id=team.id, team=team, enable_select_queries=True)
+    context = HogQLContext(team_id=team.id, team=team, enable_select_queries=True, limit_top_select=False)
     select_sql, _ = prepare_and_print_ast(
         query,
         context=context,


### PR DESCRIPTION
## Problem
After running preaggregation on the first production experiment, the number of rows in the preaggregation table is exactly 50,000.

## Changes
The HogQL printer injects a default `LIMIT 50000` on every top-level SELECT (`MAX_SELECT_RETURNED_ROWS` in `posthog/hogql/constants.py`), which silently capped preaggregation inserts. This disables it, matching the pattern used by batch exports, cohort calculations, and other internal write paths.