### PR TITLE
fix(llma): add trace_filters to summarization sampling

### DIFF
--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -2995,6 +2995,56 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.10
   '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."queryable_folder",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."description",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.11
+  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -3013,7 +3063,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.11
+# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.12
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -3043,7 +3093,7 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.12
+# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.13
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
@@ -3051,18 +3101,6 @@
          AND "posthog_sessionrecordingviewed"."user_id" = 99999
          AND "posthog_sessionrecordingviewed"."session_id" IN ('at_base_time_plus_20',
                                                                'at_base_time'))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.13
-  '''
-  SELECT "posthog_sessionrecordingviewed"."session_id",
-         "posthog_user"."email"
-  FROM "posthog_sessionrecordingviewed"
-  INNER JOIN "posthog_user" ON ("posthog_sessionrecordingviewed"."user_id" = "posthog_user"."id")
-  WHERE ("posthog_sessionrecordingviewed"."session_id" IN ('at_base_time_plus_20',
-                                                           'at_base_time')
-         AND "posthog_sessionrecordingviewed"."team_id" = 99999
-         AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.14
@@ -3422,6 +3460,19 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.8
   '''
+  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
+         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
+         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
+         "posthog_teamrevenueanalyticsconfig"."events",
+         "posthog_teamrevenueanalyticsconfig"."goals",
+         "posthog_teamrevenueanalyticsconfig"."base_currency"
+  FROM "posthog_teamrevenueanalyticsconfig"
+  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.9
+  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -3449,56 +3500,6 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.9
-  '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."queryable_folder",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."description",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -13,6 +13,7 @@ start_child_workflow + await pattern for controlled concurrency.
 
 import dataclasses
 from datetime import timedelta
+from typing import Any
 
 import structlog
 import temporalio
@@ -53,6 +54,14 @@ with temporalio.workflow.unsafe.imports_passed_through():
     )
 
 logger = structlog.get_logger(__name__)
+
+# Per-team trace filters to scope which traces are included in summarization sampling.
+# team_id=2 (PostHog internal): only summarize posthog_ai traces, excluding
+# summarization LLM calls, playground, and other internal noise.
+# TODO: generalize via FF payload config so any team can define filters without code changes.
+PER_TEAM_TRACE_FILTERS: dict[int, list[dict[str, Any]]] = {
+    2: [{"key": "ai_product", "value": "posthog_ai", "operator": "exact", "type": "event"}],
+}
 
 
 @dataclasses.dataclass
@@ -138,6 +147,7 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
                 tuple[int, ChildWorkflowHandle[BatchTraceSummarizationWorkflow, BatchSummarizationResult]]
             ] = []
             for team_id in batch:
+                trace_filters = PER_TEAM_TRACE_FILTERS.get(team_id, [])
                 handle = await temporalio.workflow.start_child_workflow(
                     BatchTraceSummarizationWorkflow.run,
                     BatchSummarizationInputs(
@@ -148,6 +158,7 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
                         mode=inputs.mode,
                         window_minutes=inputs.window_minutes,
                         model=inputs.model,
+                        trace_filters=trace_filters,
                     ),
                     id=f"{child_id_prefix}-{team_id}-{temporalio.workflow.now().isoformat()}",
                     execution_timeout=timedelta(minutes=WORKFLOW_EXECUTION_TIMEOUT_MINUTES),

--- a/posthog/temporal/llm_analytics/trace_summarization/models.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/models.py
@@ -1,6 +1,6 @@
 """Data models for batch trace summarization."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from pydantic import BaseModel
@@ -47,6 +47,9 @@ class BatchSummarizationInputs:
     # Optional explicit window (if not provided, uses window_minutes from now)
     window_start: str | None = None  # RFC3339 format
     window_end: str | None = None  # RFC3339 format
+    # Optional property filters to scope which traces/generations are sampled.
+    # Uses PostHog's standard property filter format (same as clustering trace_filters).
+    trace_filters: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass

--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -5,12 +5,15 @@ The full trace data is fetched later by the summarization activity using
 TraceQueryRunner per-item, so sampling only needs IDs and timestamps.
 """
 
+from typing import Any
+
 import structlog
 import temporalio
 
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.parser import parse_select
+from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.models.team import Team
@@ -45,7 +48,12 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
         raise ValueError("window_start and window_end must be provided by the workflow")
 
     def _sample_items(
-        team_id: int, window_start: str, window_end: str, max_items: int, analysis_level: str
+        team_id: int,
+        window_start: str,
+        window_end: str,
+        max_items: int,
+        analysis_level: str,
+        trace_filters: list[dict[str, Any]] | None = None,
     ) -> list[SampledItem]:
         try:
             team = Team.objects.get(id=team_id)
@@ -55,6 +63,12 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
 
         start_dt_str = format_datetime_for_clickhouse(window_start)
         end_dt_str = format_datetime_for_clickhouse(window_end)
+
+        # Build optional trace filter expression from property filters
+        trace_filter_expr: ast.Expr | None = None
+        if trace_filters:
+            filter_exprs = [property_to_expr(f, team) for f in trace_filters]
+            trace_filter_expr = ast.And(exprs=filter_exprs) if len(filter_exprs) > 1 else filter_exprs[0]
 
         if analysis_level == "generation":
             # Sample generations directly: get the last generation per trace
@@ -80,6 +94,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 HAVING last_generation_id IS NOT NULL
                     AND event_count <= {max_events}
                     AND total_properties_size <= {max_properties_size}
+                    AND countIf({trace_filter}) > 0
                 ORDER BY trace_first_timestamp DESC
                 LIMIT {limit}
                 """
@@ -94,6 +109,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                     "limit": ast.Constant(value=max_items),
                     "max_events": ast.Constant(value=MAX_TRACE_EVENTS_LIMIT),
                     "max_properties_size": ast.Constant(value=MAX_TRACE_PROPERTIES_SIZE),
+                    "trace_filter": trace_filter_expr or ast.Constant(value=True),
                 },
                 team=team,
                 limit_context=LimitContext.QUERY_ASYNC,
@@ -144,6 +160,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 GROUP BY trace_id
                 HAVING event_count <= {max_events}
                     AND total_properties_size <= {max_properties_size}
+                    AND countIf({trace_filter}) > 0
                 ORDER BY first_timestamp DESC
                 LIMIT {limit}
                 """
@@ -158,6 +175,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                     "limit": ast.Constant(value=max_items),
                     "max_events": ast.Constant(value=MAX_TRACE_EVENTS_LIMIT),
                     "max_properties_size": ast.Constant(value=MAX_TRACE_PROPERTIES_SIZE),
+                    "trace_filter": trace_filter_expr or ast.Constant(value=True),
                 },
                 team=team,
                 limit_context=LimitContext.QUERY_ASYNC,
@@ -190,6 +208,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
             inputs.window_end,
             inputs.max_items,
             inputs.analysis_level,
+            trace_filters=inputs.trace_filters if inputs.trace_filters else None,
         )
 
     logger.debug(

--- a/posthog/temporal/llm_analytics/trace_summarization/workflow.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/workflow.py
@@ -199,6 +199,7 @@ class BatchTraceSummarizationWorkflow(PostHogWorkflow):
             model=inputs.model,
             window_start=window_start,
             window_end=window_end,
+            trace_filters=inputs.trace_filters,
         )
 
         semaphore = asyncio.Semaphore(inputs.batch_size)


### PR DESCRIPTION
## Problem

The summarization sampler picks up all AI traces for a team, including internal noise like summarization LLM calls, playground usage, and other non-user traces. This wastes LLM calls and embedding quota on traces that aren't useful.

Related: #47641 (same approach for clustering)

## Changes

Adds general-purpose `trace_filters` support to summarization sampling, using PostHog's standard property filter format (same as clustering `trace_filters`):

- **models.py**: Added `trace_filters: list[dict]` field to `BatchSummarizationInputs`
- **sampling.py**: Converts filters to HogQL via `property_to_expr`, adds as WHERE clause to both trace and generation sampling queries. No-op (`true`) when no filters provided.
- **workflow.py**: Forwards `trace_filters` when rebuilding inputs with computed window
- **coordinator.py**: Passes per-team filters via `PER_TEAM_TRACE_FILTERS` dict. Currently team_id=2 includes only `ai_product="posthog_ai"` traces.

Any team can be added to `PER_TEAM_TRACE_FILTERS` without changing query logic. TODO to generalize via FF payload config.

## How did you test this code?

- All 46 summarization tests pass (excluding pre-existing profiling test failure unrelated to this change)
- `pytest posthog/temporal/llm_analytics/trace_summarization/ -x -q --ignore=.../profiling`

## Publish to changelog?

No