### PR TITLE
chore(product tours): fix archive/delete, add duplicate

### DIFF
--- a/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
@@ -1,7 +1,17 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconCursorClick, IconMegaphone } from '@posthog/icons'
+import {
+    IconArchive,
+    IconCopy,
+    IconCursorClick,
+    IconEye,
+    IconMegaphone,
+    IconRefresh,
+    IconRocket,
+    IconStopFilled,
+    IconTrash,
+} from '@posthog/icons'
 import { LemonButton, LemonDialog, LemonDivider, LemonInput, LemonTable, LemonTag } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
@@ -41,7 +51,7 @@ export function ProductTourStatusTag({ tour }: { tour: ProductTour }): JSX.Eleme
 
 export function ProductToursTable(): JSX.Element {
     const { filteredProductTours, productToursLoading, searchTerm, tab } = useValues(productToursLogic)
-    const { deleteProductTour, updateProductTour, setSearchTerm } = useActions(productToursLogic)
+    const { deleteProductTour, updateProductTour, duplicateProductTour, setSearchTerm } = useActions(productToursLogic)
 
     return (
         <>
@@ -119,13 +129,27 @@ export function ProductToursTable(): JSX.Element {
                                         <>
                                             <LemonButton
                                                 fullWidth
+                                                icon={<IconEye className="w-4" />}
                                                 onClick={() => router.actions.push(urls.productTour(tour.id))}
                                             >
                                                 View
                                             </LemonButton>
+                                            <LemonButton
+                                                fullWidth
+                                                icon={<IconCopy className="w-4" />}
+                                                onClick={() => duplicateProductTour(tour)}
+                                            >
+                                                Duplicate
+                                            </LemonButton>
                                             {!tour.start_date && (
                                                 <LemonButton
                                                     fullWidth
+                                                    icon={<IconRocket className="w-4" />}
+                                                    disabledReason={
+                                                        tour.archived
+                                                            ? 'Restore your tour before launching.'
+                                                            : undefined
+                                                    }
                                                     onClick={() => {
                                                         LemonDialog.open({
                                                             title: 'Launch this product tour?',
@@ -162,6 +186,7 @@ export function ProductToursTable(): JSX.Element {
                                             {isProductTourRunning(tour) && (
                                                 <LemonButton
                                                     fullWidth
+                                                    icon={<IconStopFilled className="w-4" />}
                                                     onClick={() => {
                                                         LemonDialog.open({
                                                             title: 'Stop this product tour?',
@@ -197,6 +222,7 @@ export function ProductToursTable(): JSX.Element {
                                             {tour.end_date && !tour.archived && (
                                                 <LemonButton
                                                     fullWidth
+                                                    icon={<IconRefresh className="w-4" />}
                                                     onClick={() => {
                                                         LemonDialog.open({
                                                             title: 'Resume this product tour?',
@@ -231,9 +257,10 @@ export function ProductToursTable(): JSX.Element {
                                                 </LemonButton>
                                             )}
                                             <LemonDivider />
-                                            {tour.end_date && tour.archived && (
+                                            {tour.archived && (
                                                 <LemonButton
                                                     fullWidth
+                                                    icon={<IconArchive className="w-4" />}
                                                     onClick={() => {
                                                         updateProductTour({
                                                             id: tour.id,
@@ -241,15 +268,21 @@ export function ProductToursTable(): JSX.Element {
                                                         })
                                                     }}
                                                 >
-                                                    Unarchive
+                                                    Restore
                                                 </LemonButton>
                                             )}
-                                            {tour.end_date && !tour.archived && (
+                                            {!tour.archived && (
                                                 <LemonButton
                                                     fullWidth
+                                                    icon={<IconArchive className="w-4" />}
+                                                    disabledReason={
+                                                        isProductTourRunning(tour)
+                                                            ? 'Stop your tour before archiving.'
+                                                            : undefined
+                                                    }
                                                     onClick={() => {
                                                         LemonDialog.open({
-                                                            title: 'Archive this product tour?',
+                                                            title: `Archive tour ${tour.name}?`,
                                                             content: (
                                                                 <div className="text-sm text-secondary">
                                                                     This action will remove the tour from your active
@@ -282,9 +315,15 @@ export function ProductToursTable(): JSX.Element {
                                             )}
                                             <LemonButton
                                                 status="danger"
+                                                icon={<IconTrash className="w-4" />}
+                                                disabledReason={
+                                                    isProductTourRunning(tour)
+                                                        ? 'Stop your tour before deleting.'
+                                                        : undefined
+                                                }
                                                 onClick={() => {
                                                     LemonDialog.open({
-                                                        title: 'Delete this product tour?',
+                                                        title: `Delete tour ${tour.name}?`,
                                                         content: (
                                                             <div className="text-sm text-secondary">
                                                                 This action cannot be undone. All tour data will be

--- a/products/product_tours/backend/api/test/test_product_tour.py
+++ b/products/product_tours/backend/api/test/test_product_tour.py
@@ -91,10 +91,10 @@ class TestProductTour(APIBaseTest):
         assert call_args[0][2]["tour_name"] == "Updated name"
 
     @patch("products.product_tours.backend.api.product_tour.report_user_action")
-    def test_delete_archives_tour(self, mock_report):
+    def test_delete_hard_deletes_tour(self, mock_report):
         tour = ProductTour.objects.create(
             team=self.team,
-            name="To be archived",
+            name="To be deleted",
             content={"steps": []},
             created_by=self.user,
         )
@@ -103,12 +103,7 @@ class TestProductTour(APIBaseTest):
         response = self.client.delete(f"/api/projects/{self.team.id}/product_tours/{tour.id}/")
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
-        # Tour should be archived, not deleted
-        tour = ProductTour.all_objects.get(id=tour_id)
-        assert tour.archived
-
-        # Should not appear in normal list
-        assert not ProductTour.objects.filter(id=tour_id).exists()
+        assert not ProductTour.all_objects.filter(id=tour_id).exists()
 
         mock_report.assert_called_once()
         call_args = mock_report.call_args


### PR DESCRIPTION
## Problem

we made a mess; "delete" actually archives a tour, "archive" works but then archived responses are never returned from the api

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- makes delete a real hard-delete
- archived responses are now returned from api
- added some disables on buttons (e.g. cannot delete a running tour)
- implemented "duplicate tour"

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no