### PR TITLE
fix: minimize re-renders on sql editor

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
@@ -18,7 +18,6 @@ export interface VariablesLogicProps {
     /** Dashboard ID for the current dashboard if we're viewing one */
     dashboardId?: DashboardType['id']
 
-    queryInput?: string
     sourceQuery?: DataVisualizationNode
     setQuery?: (query: DataVisualizationNode) => void
     onUpdate?: (query: DataVisualizationNode) => void
@@ -63,11 +62,7 @@ export const variablesLogic = kea<variablesLogicType>([
         setSearchTerm: (search: string) => ({ search }),
         clickVariable: (variable: Variable & { selected: boolean }) => ({ variable }),
     })),
-    propsChanged(({ props, actions, values }, oldProps) => {
-        if (oldProps.queryInput !== props.queryInput) {
-            actions.setEditorQuery(props.queryInput ?? '')
-        }
-
+    propsChanged(({ props, actions, values }) => {
         if (props.sourceQuery) {
             const variables = Object.values(props.sourceQuery?.source.variables ?? {})
 

--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
@@ -3,7 +3,7 @@ import './EditorScene.scss'
 import { Monaco } from '@monaco-editor/react'
 import { BindLogic, useActions, useValues } from 'kea'
 import type { editor as importedEditor } from 'monaco-editor'
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
@@ -89,7 +89,7 @@ export function EditorScene({ tabId }: { tabId?: string }): JSX.Element {
         editor,
     })
 
-    const { queryInput, sourceQuery, dataLogicKey } = useValues(logic)
+    const { sourceQuery, dataLogicKey } = useValues(logic)
     const { setSourceQuery } = useActions(logic)
 
     const dataVisualizationLogicProps: DataVisualizationLogicProps = {
@@ -132,7 +132,6 @@ export function EditorScene({ tabId }: { tabId?: string }): JSX.Element {
     const variablesLogicProps: VariablesLogicProps = {
         key: dataVisualizationLogicProps.key,
         readOnly: false,
-        queryInput: queryInput ?? '',
         sourceQuery,
         setQuery: setSourceQuery,
         onUpdate: (query) => {
@@ -149,6 +148,7 @@ export function EditorScene({ tabId }: { tabId?: string }): JSX.Element {
                             <BindLogic logic={variableModalLogic} props={{ key: dataVisualizationLogicProps.key }}>
                                 <BindLogic logic={outputPaneLogic} props={{ tabId }}>
                                     <BindLogic logic={multitabEditorLogic} props={{ tabId, monaco, editor }}>
+                                        <VariablesQuerySync />
                                         <div className="flex grow h-full">
                                             <DatabaseTree databaseTreeRef={databaseTreeRef} />
                                             <div
@@ -174,4 +174,16 @@ export function EditorScene({ tabId }: { tabId?: string }): JSX.Element {
             </BindLogic>
         </BindLogic>
     )
+}
+
+/** Syncs queryInput from multitabEditorLogic to variablesLogic without causing EditorScene re-renders */
+function VariablesQuerySync(): null {
+    const { queryInput } = useValues(multitabEditorLogic)
+    const { setEditorQuery } = useActions(variablesLogic)
+
+    useEffect(() => {
+        setEditorQuery(queryInput ?? '')
+    }, [queryInput])
+
+    return null
 }

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -292,7 +292,7 @@ export function OutputPane({ tabId }: { tabId: string }): JSX.Element {
     const { setActiveTab } = useActions(outputPaneLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const { sourceQuery, exportContext, editingInsight, updateInsightButtonEnabled, showLegacyFilters, queryInput } =
+    const { sourceQuery, exportContext, editingInsight, updateInsightButtonEnabled, showLegacyFilters, hasQueryInput } =
         useValues(multitabEditorLogic)
     const { saveAsInsight, updateInsight, setSourceQuery, runQuery, shareTab } = useActions(multitabEditorLogic)
     const { isDarkModeOn } = useValues(themeLogic)
@@ -630,7 +630,7 @@ export function OutputPane({ tabId }: { tabId: string }): JSX.Element {
                         <Tooltip title="Share your current query">
                             <LemonButton
                                 id="sql-editor-share"
-                                disabledReason={!queryInput && 'No query to share'}
+                                disabledReason={!hasQueryInput && 'No query to share'}
                                 type="secondary"
                                 icon={<IconShare />}
                                 onClick={() => shareTab()}

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -1,7 +1,7 @@
 import { Monaco } from '@monaco-editor/react'
 import { useActions, useValues } from 'kea'
 import type { editor as importedEditor } from 'monaco-editor'
-import { useMemo } from 'react'
+import { memo, useMemo } from 'react'
 
 import { IconBook, IconDownload, IconInfo, IconPlayFilled } from '@posthog/icons'
 import { LemonDivider, Spinner } from '@posthog/lemon-ui'
@@ -355,7 +355,7 @@ function RunButton(): JSX.Element {
     )
 }
 
-function InternalQueryWindow({ tabId }: { tabId: string }): JSX.Element | null {
+const InternalQueryWindow = memo(function InternalQueryWindow({ tabId }: { tabId: string }): JSX.Element | null {
     const { finishedLoading } = useValues(multitabEditorLogic)
 
     // NOTE: hacky way to avoid flicker loading
@@ -364,4 +364,4 @@ function InternalQueryWindow({ tabId }: { tabId: string }): JSX.Element | null {
     }
 
     return <OutputPane tabId={tabId} />
-}
+})

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -1082,6 +1082,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                 return queryInput && (queryInput.indexOf('{filters}') !== -1 || queryInput.indexOf('{filters.') !== -1)
             },
         ],
+        hasQueryInput: [(s) => [s.queryInput], (queryInput) => !!queryInput],
         dataLogicKey: [(_, p) => [p.tabId], (tabId) => `data-warehouse-editor-data-node-${tabId}`],
         isDraft: [(s) => [s.activeTab], (activeTab) => (activeTab ? !!activeTab.draft?.id : false)],
         currentDraft: [(s) => [s.activeTab], (activeTab) => (activeTab ? activeTab.draft : null)],

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -63,7 +63,6 @@ export const QueryDatabase = (): JSX.Element => {
     const { deleteJoin } = useActions(dataWarehouseSettingsLogic)
     const { deleteDraft } = useActions(draftsLogic)
     const { setQueryInput } = useActions(multitabEditorLogic)
-    const { selectedQueryColumns } = useValues(multitabEditorLogic)
     const builtTabLogic = useMountedLogic(multitabEditorLogic)
     const formatTraversalChain = (chain?: (string | number)[]): string | null => {
         if (!chain || chain.length === 0) {
@@ -231,7 +230,6 @@ export const QueryDatabase = (): JSX.Element => {
                 const hasMatches = matches && matches.length > 0
                 const isColumn = item.record?.type === 'column'
                 const columnType = isColumn ? item.record?.field?.type : null
-                const columnKey = isColumn && item.record ? `${item.record.table}.${item.record.columnName}` : null
                 const tableKindLabel = !isColumn && item.children?.length ? getTableKindLabel(item) : null
 
                 return (
@@ -256,9 +254,6 @@ export const QueryDatabase = (): JSX.Element => {
                                                 'endpoints',
                                             ].includes(item.record?.type) && 'font-semibold',
                                             isColumn && 'font-mono text-xs',
-                                            columnKey &&
-                                                selectedQueryColumns[columnKey] &&
-                                                'underline underline-offset-2',
                                             'truncate shrink-0'
                                         )}
                                     >


### PR DESCRIPTION
## Problem

in the sql editor, every keystroke causes _lots_ of re-renders across the entire page:

[sql-renders-before.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/7ac88491-bb2d-46d8-9323-8c96b78b5fdc.mp4" />](https://app.graphite.com/user-attachments/video/7ac88491-bb2d-46d8-9323-8c96b78b5fdc.mp4)

in that test, according to react-scan, my fps dropped to 5 while typing the table name; i think at least partially caused by the sidebar re-renders

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- `EditorScene` subscribed to `queryInput` only to pass it to `variablesLogicProps`, causing 8 nested `BindLogic`s to re-render. removed from the editor scene, added a smaller component that syncs `queryInput` -> `variablesLogic` without causing re-renders
- `OutputPane` renders on every keystroke because it also subscribed to `queryInput`, but only used it for a button's disabled state; replaced with a `hasQueryInput` selector, and wrapped `InternalQueryWindow` with memo
- sidebar re-renders on every keystroke; it subscribed to `selectedQueryColumns` to apply an underline to selected columns, but personally i've never seen that in prod, could not even get it to work locally, and it's not worth the renders either way; removed it

[sql-render-after.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2dfdce4e-ef83-4a03-875a-3091a251419d.mp4" />](https://app.graphite.com/user-attachments/video/2dfdce4e-ef83-4a03-875a-3091a251419d.mp4)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
