### PR TITLE
fix(prop-defs): type matching for utm prop defs doesnt capture initial

### DIFF
--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -354,11 +354,13 @@ pub fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueTyp
     let key = key.to_lowercase();
 
     // There are a whole set of special cases here, taken from the TS
-    if key.starts_with("utm_") {
+    if key.starts_with("utm_") || key.starts_with("$initial_utm_") {
         // utm_ prefixed properties should always be detected as strings.
         // Sometimes the first value sent looks like a number, event though
         // subsequent values are not. See
         // https://github.com/PostHog/posthog/issues/12529 for more context.
+        // $initial_utm_* properties are the "initial" variants set by the SDK
+        // and must follow the same rule.
         return Some(PropertyValueType::String);
     }
     if key.starts_with("$feature/") {

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -372,7 +372,10 @@ fn test_initial_utm_properties_always_string() {
     // See https://github.com/PostHog/posthog/issues/12529
     let cases: Vec<(&str, Value)> = vec![
         // datetime-looking values that would otherwise be classified as DateTime
-        ("$initial_utm_campaign", Value::from("2025-03-11T09:48:12.863948+00:00")),
+        (
+            "$initial_utm_campaign",
+            Value::from("2025-03-11T09:48:12.863948+00:00"),
+        ),
         ("$initial_utm_source", Value::from("2023-12-13")),
         ("$initial_utm_medium", Value::from("2023-12-13T15:45:30Z")),
         // numeric values
@@ -403,7 +406,10 @@ fn test_initial_utm_properties_always_string() {
 fn test_bare_utm_properties_still_string() {
     // bare utm_* properties must still be classified as String
     let cases: Vec<(&str, Value)> = vec![
-        ("utm_source", Value::from("2025-03-11T09:48:12.863948+00:00")),
+        (
+            "utm_source",
+            Value::from("2025-03-11T09:48:12.863948+00:00"),
+        ),
         ("utm_campaign", Value::Number(Number::from(12345))),
         ("utm_medium", Value::from("true")),
         ("utm_content", Value::from("google")),


### PR DESCRIPTION
## Problem

Bug: Properties like `$initial_utm_campaign` bypassed the `utm_`string-type guard in detect_property_type because the function checks `key.starts_with("utm_")`, but these properties start with `$initial_utm_`. A datetime-looking value (e.g. "2025-03-11T09:48:12") would then cause the property to be misclassified as DateTime.  

## Changes

Fix (src/types.rs:357): Added || key.starts_with("$initial_utm_") to the existing utm_ prefix check, so the $initial_ variants of utm properties are also always classified as String.

## How did you test this code?

  Tests (tests/types.rs):
  - test_initial_utm_properties_always_string — 11 cases verifying $initial_utm_* properties are
  always String regardless of value (datetime strings, numbers, booleans, normal strings)
  - test_bare_utm_properties_still_string — 4 cases confirming the existing utm_* behavior is
  unchanged