### PR TITLE
fix(product tours): do not break selection mode when dom changes

### DIFF
--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -682,20 +682,20 @@ export const productToursLogic = kea<productToursLogicType>([
             toolbarLogic.actions.toggleMinimized(false)
         },
         updateRects: () => {
-            // if in selecting mode: try to find + highlight element
+            // If in selecting mode with a previously selected element that got
+            // detached, try to re-find it via selector. We guard on
+            // selectedElement being non-null so we don't auto-select when the
+            // user hasn't clicked yet (selectedElement is cleared to null on
+            // entering selecting mode).
             const { editorState, selectedElement, tourForm } = values
-            if (editorState.mode === 'selecting') {
-                const selectedElementValid = selectedElement && document.body.contains(selectedElement)
-
-                if (!selectedElementValid) {
-                    // Element missing or detached - try to find it via selector
+            if (editorState.mode === 'selecting' && selectedElement) {
+                if (!selectedElement.isConnected) {
                     const step = tourForm?.steps?.[editorState.stepIndex]
                     if (step?.selector) {
                         const element = document.querySelector(step.selector) as HTMLElement | null
                         if (element) {
                             actions.selectElement(element)
-                        } else if (selectedElement) {
-                            // Had an element but it's gone - clear it
+                        } else {
                             actions.clearSelectedElement()
                         }
                     }


### PR DESCRIPTION
## Problem

`updateRects` fires on a mutation observer so we can re-highlight elements if the dom changes during tour building

however, if a user:
- attached a step element
- clicked "change element"
- hovered around looking for an element and triggered a dom change (like a tooltip opening)

...then selection mode completely broke, because `updateRects` -> finds existing element -> exits selection mode

saw this in posthog with some tooltips, and in some session replays where it looked like a hover on the target element or maybe a click(?) was firing and updating rects before we could attach the element

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

ensures we don't exit selection mode during `updateRects` by guarding on `selectedElement` being non-null

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
