### PR TITLE
feat(deduplicator): ensure root cause is displayed in error logs

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/export.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/export.rs
@@ -97,8 +97,7 @@ impl CheckpointExporter {
                     error!(
                         remote_path = plan.info.get_metadata_key(),
                         elapsed_seconds = upload_duration.as_secs_f64(),
-                        "Export failed: uploading checkpoint: {}",
-                        e
+                        "Export failed: uploading checkpoint: {e:#}"
                     );
                 }
                 Err(e)

--- a/rust/kafka-deduplicator/src/checkpoint/import.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/import.rs
@@ -56,7 +56,7 @@ impl Drop for ImportCleanupGuard {
                         topic = %self.topic,
                         partition = self.partition,
                         path = %self.path.display(),
-                        error = %e,
+                        error = ?e,
                         "Import cleanup guard: failed to remove directory, orphan cleaner will handle it"
                     );
                 }
@@ -287,7 +287,7 @@ impl CheckpointImporter {
                         checkpoint = attempt_tag,
                         local_attempt_path = local_path_tag,
                         attempt_duration_secs = attempt_duration,
-                        error = e.to_string(),
+                        error = ?e,
                         "Failed to import checkpoint files"
                     );
                     continue;
@@ -323,11 +323,11 @@ impl CheckpointImporter {
                         fetched_metadata_files.push(metadata);
                     }
                     Err(e) => {
-                        error!("Failed to parse metadata from file bytes: {remote_key}: {e}");
+                        error!("Failed to parse metadata from file bytes: {remote_key}: {e:#}");
                     }
                 },
                 Err(e) => {
-                    error!("Failed to download metadata file: {remote_key}: {e}");
+                    error!("Failed to download metadata file: {remote_key}: {e:#}");
                 }
             }
         }
@@ -379,7 +379,7 @@ impl CheckpointImporter {
                 Ok(())
             }
             Err(e) => {
-                error!("Failed to download checkpoint files to: {local_attempt_path:?}: {e}");
+                error!("Failed to download checkpoint files to: {local_attempt_path:?}: {e:#}");
                 Err(e)
             }
         }

--- a/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
@@ -354,7 +354,7 @@ impl CheckpointDownloader for S3Downloader {
                     keys_found.push(meta.location.to_string());
                 }
                 Err(e) => {
-                    error!("Error listing S3 objects: {e}");
+                    error!("Error listing S3 objects: {e:#}");
                 }
             }
         }

--- a/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
@@ -88,6 +88,18 @@ fn format_checkpoint_list_start_after(partition_prefix: &str, cutoff: DateTime<U
     )
 }
 
+/// Classify an object_store error into a short, searchable label for structured logging.
+fn s3_error_kind(e: &object_store::Error) -> &'static str {
+    match e {
+        object_store::Error::NotFound { .. } => "not_found",
+        object_store::Error::PermissionDenied { .. } => "permission_denied",
+        object_store::Error::Unauthenticated { .. } => "unauthenticated",
+        object_store::Error::Precondition { .. } => "precondition",
+        object_store::Error::Generic { .. } => "generic",
+        _ => "other",
+    }
+}
+
 /// S3Downloader using `object_store` crate with `LimitStore` for bounded concurrency.
 /// The LimitStore wraps the S3 client with a semaphore that limits concurrent requests.
 /// Each download holds a permit for the entire stream duration, ensuring memory is bounded.
@@ -131,6 +143,14 @@ impl CheckpointDownloader for S3Downloader {
                 result
             }
             Err(e) => {
+                let error_kind = s3_error_kind(&e);
+                error!(
+                    remote_key,
+                    bucket = %self.s3_bucket,
+                    error_kind,
+                    error = %e,
+                    "S3 object download failed"
+                );
                 metrics::counter!(CHECKPOINT_FILE_DOWNLOADS_COUNTER, "status" => "error")
                     .increment(1);
                 return Err(anyhow::anyhow!(e)).with_context(|| {
@@ -181,6 +201,14 @@ impl CheckpointDownloader for S3Downloader {
         let result = match self.store.get(&path).await {
             Ok(result) => result,
             Err(e) => {
+                let error_kind = s3_error_kind(&e);
+                error!(
+                    remote_key,
+                    bucket = %self.s3_bucket,
+                    error_kind,
+                    error = %e,
+                    "S3 object download failed"
+                );
                 metrics::counter!(CHECKPOINT_FILE_DOWNLOADS_COUNTER, "status" => "error")
                     .increment(1);
                 return Err(anyhow::anyhow!(e)).with_context(|| {

--- a/rust/kafka-deduplicator/src/checkpoint/worker.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/worker.rs
@@ -199,9 +199,8 @@ impl CheckpointWorker {
                 "Checkpoint worker: failed to create local directory: {e:#}"
             );
 
-            return Err(Err::<(), _>(e)
-                .with_context(|| "Checkpoint worker: failed to create local directory")
-                .unwrap_err());
+            return Err(anyhow::Error::from(e)
+                .context("Checkpoint worker: failed to create local directory"));
         }
 
         Ok(())

--- a/rust/kafka-deduplicator/src/checkpoint/worker.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/worker.rs
@@ -156,8 +156,7 @@ impl CheckpointWorker {
                 self.worker_id,
                 partition = self.partition.to_string(),
                 attempt_timestamp = self.attempt_timestamp.to_string(),
-                "Checkpoint worker: failed store metrics update after local checkpoint: {}",
-                e
+                "Checkpoint worker: failed store metrics update after local checkpoint: {e:#}"
             );
         }
 
@@ -176,8 +175,7 @@ impl CheckpointWorker {
             error!(
                 self.worker_id,
                 local_attempt_path = self.get_local_attempt_path().to_string_lossy().to_string(),
-                "Checkpoint worker: failed to clean up local attempt directory: {}",
-                e
+                "Checkpoint worker: failed to clean up local attempt directory: {e:#}"
             );
         }
     }
@@ -198,11 +196,12 @@ impl CheckpointWorker {
             error!(
                 self.worker_id,
                 local_base_path = base_path.to_string_lossy().to_string(),
-                "Checkpoint worker: failed to create local directory: {}",
-                e
+                "Checkpoint worker: failed to create local directory: {e:#}"
             );
 
-            return Err(anyhow::anyhow!(e));
+            return Err(Err::<(), _>(e)
+                .with_context(|| "Checkpoint worker: failed to create local directory")
+                .unwrap_err());
         }
 
         Ok(())
@@ -240,24 +239,15 @@ impl CheckpointWorker {
             }
 
             Err(e) => {
-                // Build the complete error chain
-                let mut error_chain = vec![format!("{:?}", e)];
-                let mut source = e.source();
-                while let Some(err) = source {
-                    error_chain.push(format!("Caused by: {err:?}"));
-                    source = err.source();
-                }
-
                 let tags = [("result", "error"), ("cause", "local_checkpoint")];
                 metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
                 error!(
                     self.worker_id,
                     local_attempt_path = local_attempt_path.to_string_lossy().to_string(),
-                    "Checkpoint worker: local attempt failed: {}",
-                    error_chain.join(" -> ")
+                    "Checkpoint worker: local attempt failed: {e:#}"
                 );
 
-                Err(anyhow::anyhow!(error_chain.join(" -> ")))
+                Err(e.context("local checkpoint attempt failed"))
             }
         }
     }
@@ -353,8 +343,7 @@ impl CheckpointWorker {
                                 self.worker_id,
                                 local_attempt_path = local_attempt_path_tag,
                                 attempt_type,
-                                "Checkpoint worker: export failed: {}",
-                                e
+                                "Checkpoint worker: export failed: {e:#}"
                             );
                         }
 

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -371,7 +371,7 @@ impl CheckpointManager {
                                         if e.downcast_ref::<UploadCancelledError>().is_some() {
                                             "cancelled"
                                         } else {
-                                            error!(partition = partition_tag, "Checkpoint worker thread: attempt failed: {}", e);
+                                            error!(partition = partition_tag, "Checkpoint worker thread: attempt failed: {e:#}");
                                             "error"
                                         }
                                     },

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -303,38 +303,29 @@ impl Config {
 
     /// Validate configuration settings
     pub fn validate(&self) -> Result<()> {
-        // Check store path is writable
-        if let Err(e) = fs::create_dir_all(&self.store_path) {
-            return Err(anyhow::anyhow!(
-                "Cannot create RocksDB store directory '{}' for consumer group '{}': {}",
-                self.store_path,
-                self.kafka_consumer_group,
-                e
-            ));
-        }
+        fs::create_dir_all(&self.store_path).with_context(|| {
+            format!(
+                "Cannot create RocksDB store directory '{}' for consumer group '{}'",
+                self.store_path, self.kafka_consumer_group
+            )
+        })?;
 
-        // Check if we can write to the directory
         let test_file = self.store_path_buf().join(".write_test");
-        if let Err(e) = fs::write(&test_file, b"test") {
-            return Err(anyhow::anyhow!(
-                "RocksDB store path '{}' is not writable for consumer group '{}': {}",
-                self.store_path,
-                self.kafka_consumer_group,
-                e
-            ));
-        }
+        fs::write(&test_file, b"test").with_context(|| {
+            format!(
+                "RocksDB store path '{}' is not writable for consumer group '{}'",
+                self.store_path, self.kafka_consumer_group
+            )
+        })?;
         fs::remove_file(test_file).ok();
 
-        // Validate checkpoint path if S3 is configured
         if let Some(ref bucket) = self.s3_bucket {
-            if let Err(e) = fs::create_dir_all(&self.local_checkpoint_dir) {
-                return Err(anyhow::anyhow!(
-                    "Cannot create local checkpoint directory '{}' for S3 bucket '{}': {}",
-                    self.local_checkpoint_dir,
-                    bucket,
-                    e
-                ));
-            }
+            fs::create_dir_all(&self.local_checkpoint_dir).with_context(|| {
+                format!(
+                    "Cannot create local checkpoint directory '{}' for S3 bucket '{}'",
+                    self.local_checkpoint_dir, bucket
+                )
+            })?;
         }
 
         Ok(())

--- a/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
@@ -414,9 +414,7 @@ where
                                     kafka_error_count = 0;
                                 }
                                 Err(e) => {
-                                    let wrapped_err = Err::<(), _>(e)
-                                        .with_context(|| "Error deserializing message")
-                                        .unwrap_err();
+                                    let wrapped_err = e.context("Error deserializing message");
                                     batch.push_error(BatchError::new(
                                         wrapped_err,
                                         Some(Partition::new(

--- a/rust/kafka-deduplicator/src/kafka/batch_context.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_context.rs
@@ -89,7 +89,7 @@ impl BatchConsumerContext {
                     // Note: setup_revoked_partitions was already called synchronously
                     // Note: File deletion happens in finalize_rebalance_cycle at end of cycle
                     if let Err(e) = handler.cleanup_revoked_partitions(&tpl).await {
-                        error!("Partition revocation cleanup failed: {}", e);
+                        error!("Partition revocation cleanup failed: {e:#}");
                     }
                 }
                 RebalanceEvent::Assign => {
@@ -107,7 +107,7 @@ impl BatchConsumerContext {
                     {
                         // This error only occurs if the consumer command channel is broken.
                         // Resume is handled by async_setup_assigned_partitions when appropriate.
-                        error!("Partition assignment async setup failed: {}", e);
+                        error!("Partition assignment async setup failed: {e:#}");
                     }
                 }
             }
@@ -127,7 +127,7 @@ impl ConsumerContext for BatchConsumerContext {
         let handler = self.rebalance_handler.clone();
         self.rt_handle.spawn(async move {
             if let Err(e) = handler.on_pre_rebalance().await {
-                error!("Pre-rebalance handler failed: {}", e);
+                error!("Pre-rebalance handler failed: {e:#}");
             }
         });
 
@@ -160,7 +160,7 @@ impl ConsumerContext for BatchConsumerContext {
                     .collect();
 
                 if let Err(e) = self.rebalance_tx.send(RebalanceEvent::Revoke(partitions)) {
-                    error!("Failed to send revoke event to rebalance worker: {}", e);
+                    error!("Failed to send revoke event to rebalance worker: {e:#}");
                 }
             }
             Rebalance::Assign(partitions) => {
@@ -170,7 +170,7 @@ impl ConsumerContext for BatchConsumerContext {
                 );
             }
             Rebalance::Error(e) => {
-                error!("Rebalance error: {}", e);
+                error!("Rebalance error: {e:#}");
             }
         }
     }
@@ -200,9 +200,8 @@ impl ConsumerContext for BatchConsumerContext {
                 // completes via a ConsumerCommand::Resume.
                 if let Err(e) = base_consumer.pause(partitions) {
                     error!(
-                        "Failed to pause {} newly assigned partitions: {}",
-                        partitions.count(),
-                        e
+                        "Failed to pause {} newly assigned partitions: {e:#}",
+                        partitions.count()
                     );
                 } else {
                     info!(
@@ -224,14 +223,14 @@ impl ConsumerContext for BatchConsumerContext {
                 // (downloading checkpoints, creating stores, then RESUME)
                 // Handler uses rebalance_tracker.get_owned_partitions() for definitive list
                 if let Err(e) = self.rebalance_tx.send(RebalanceEvent::Assign) {
-                    error!("Failed to send assign event to rebalance worker: {}", e);
+                    error!("Failed to send assign event to rebalance worker: {e:#}");
                 }
             }
             Rebalance::Revoke(_) => {
                 info!("Post-rebalance revoke event");
             }
             Rebalance::Error(e) => {
-                error!("Post-rebalance error: {}", e);
+                error!("Post-rebalance error: {e:#}");
             }
         }
 
@@ -239,7 +238,7 @@ impl ConsumerContext for BatchConsumerContext {
         let handler = self.rebalance_handler.clone();
         self.rt_handle.spawn(async move {
             if let Err(e) = handler.on_post_rebalance().await {
-                error!("Post-rebalance handler failed: {}", e);
+                error!("Post-rebalance handler failed: {e:#}");
             }
         });
     }
@@ -257,7 +256,7 @@ impl ConsumerContext for BatchConsumerContext {
                 );
             }
             Err(e) => {
-                warn!("Failed to commit offsets: {}", e);
+                warn!("Failed to commit offsets: {e:#}");
             }
         }
     }

--- a/rust/kafka-deduplicator/src/kafka/partition_worker.rs
+++ b/rust/kafka-deduplicator/src/kafka/partition_worker.rs
@@ -147,10 +147,9 @@ impl<T: Send + 'static> PartitionWorker<T> {
                 }
                 Err(e) => {
                     warn!(
-                        "Partition worker for {}:{} panicked during shutdown: {}",
+                        "Partition worker for {}:{} panicked during shutdown: {e:#}",
                         self.partition.topic(),
-                        self.partition.partition_number(),
-                        e
+                        self.partition.partition_number()
                     );
                 }
             }
@@ -223,8 +222,7 @@ impl<T: Send + 'static> PartitionWorker<T> {
                         batch_id = batch_id,
                         first_offset = ?first_offset,
                         last_offset = ?last_offset,
-                        error = %e,
-                        error_chain = ?e,
+                        error = ?e,
                         "Error processing batch - offset not advanced"
                     );
 

--- a/rust/kafka-deduplicator/src/kafka/routing_processor.rs
+++ b/rust/kafka-deduplicator/src/kafka/routing_processor.rs
@@ -101,10 +101,9 @@ where
         for (partition, result) in results {
             if let Err(e) = result {
                 warn!(
-                    "Failed to route batch to partition {}:{}: {}",
+                    "Failed to route batch to partition {}:{}: {e:#}",
                     partition.topic(),
-                    partition.partition_number(),
-                    e
+                    partition.partition_number()
                 );
             }
         }

--- a/rust/kafka-deduplicator/src/lib.rs
+++ b/rust/kafka-deduplicator/src/lib.rs
@@ -1,3 +1,18 @@
+//! Kafka deduplicator service.
+//!
+//! ## Error logging (anyhow)
+//!
+//! When logging `anyhow::Error` or other error types that implement `std::error::Error` with
+//! a cause chain, use formats that include the full chain so root causes are visible in logs:
+//!
+//! - **Inline format:** `{e:#}` — full chain on one line (`outer: middle: root cause`).
+//! - **Structured field:** `error = ?e` — full chain with `Caused by:` sections (Debug).
+//!
+//! Avoid `{}` / `%e` (Display) for errors — they only show the top-level message and hide the chain.
+//!
+//! When constructing errors, use `.context()` / `.with_context()` so the original error remains
+//! the source. Avoid `anyhow!("...{e}")` — that formats the error into a string and drops the chain.
+
 pub mod checkpoint;
 pub mod checkpoint_manager;
 pub mod config;

--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -230,7 +230,7 @@ async fn main() -> Result<()> {
     let _profiling_agent = match config.continuous_profiling.start_agent() {
         Ok(agent) => agent,
         Err(e) => {
-            tracing::warn!("Failed to start continuous profiling agent: {e}");
+            tracing::warn!("Failed to start continuous profiling agent: {e:#}");
             None
         }
     };

--- a/rust/kafka-deduplicator/src/pipelines/clickhouse_events/processor.rs
+++ b/rust/kafka-deduplicator/src/pipelines/clickhouse_events/processor.rs
@@ -98,7 +98,7 @@ impl ClickHouseEventsBatchProcessor {
                 if let Ok(event) = result {
                     Some(event)
                 } else if let Err(e) = &parsed_events[idx] {
-                    error!("Failed to parse ClickHouseEvent: {}", e);
+                    error!("Failed to parse ClickHouseEvent: {e:#}");
                     None
                 } else {
                     None

--- a/rust/kafka-deduplicator/src/pipelines/ingestion_events/processor.rs
+++ b/rust/kafka-deduplicator/src/pipelines/ingestion_events/processor.rs
@@ -272,7 +272,7 @@ impl IngestionEventsBatchProcessor {
                     .to_string();
                 keys.push(key);
             } else if let Err(e) = &parsed_events[idx] {
-                error!("Failed to parse event: {}", e);
+                error!("Failed to parse event: {e:#}");
             }
         }
 
@@ -361,7 +361,7 @@ impl IngestionEventsBatchProcessor {
                             Some(max_producer_offset.map_or(offset, |current| current.max(offset)));
                     }
                     Err(e) => {
-                        error!("Failed to publish non-duplicate event: {}", e);
+                        error!("Failed to publish non-duplicate event: {e:#}");
                         return Err(e);
                     }
                 }
@@ -434,12 +434,17 @@ impl IngestionEventsBatchProcessor {
             }
             Err((e, _)) => {
                 error!(
-                    "Failed to publish event with key {} to {}: {}",
-                    key, output_topic, e
+                    "Failed to publish event with key {} to {}: {e:#}",
+                    key, output_topic
                 );
-                Err(anyhow::anyhow!(
-                    "Failed to publish event with key '{key}' to topic '{output_topic}': {e}"
-                ))
+                Err(Err::<(), _>(e)
+                    .with_context(|| {
+                        format!(
+                            "Failed to publish event with key '{}' to topic '{}'",
+                            key, output_topic
+                        )
+                    })
+                    .unwrap_err())
             }
         }
     }

--- a/rust/kafka-deduplicator/src/pipelines/ingestion_events/processor.rs
+++ b/rust/kafka-deduplicator/src/pipelines/ingestion_events/processor.rs
@@ -437,14 +437,10 @@ impl IngestionEventsBatchProcessor {
                     "Failed to publish event with key {} to {}: {e:#}",
                     key, output_topic
                 );
-                Err(Err::<(), _>(e)
-                    .with_context(|| {
-                        format!(
-                            "Failed to publish event with key '{}' to topic '{}'",
-                            key, output_topic
-                        )
-                    })
-                    .unwrap_err())
+                Err(anyhow::Error::from(e).context(format!(
+                    "Failed to publish event with key '{}' to topic '{}'",
+                    key, output_topic
+                )))
             }
         }
     }

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
@@ -312,7 +312,7 @@ where
                                             topic = partition.topic(),
                                             partition = partition.partition_number(),
                                             path = %path.display(),
-                                            error = %e,
+                                            error = ?e,
                                             "Failed to clean up checkpoint import, orphan cleaner will handle it"
                                         );
                                     }
@@ -350,7 +350,7 @@ where
                                 error!(
                                     topic = partition.topic(),
                                     partition = partition.partition_number(),
-                                    error = %e,
+                                    error = ?e,
                                     "Failed to restore checkpoint"
                                 );
                                 fallback_reasons.insert(partition.clone(), "import_failed");
@@ -369,7 +369,7 @@ where
                             warn!(
                                 topic = partition.topic(),
                                 partition = partition.partition_number(),
-                                error = %e,
+                                error = ?e,
                                 "Failed to import checkpoint"
                             );
                             fallback_reasons.insert(partition.clone(), "import_failed");
@@ -463,7 +463,7 @@ where
                         error!(
                             topic = partition.topic(),
                             partition = partition.partition_number(),
-                            error = %e,
+                            error = ?e,
                             "Failed to create fallback store - processor will retry on first message"
                         );
                     }
@@ -478,7 +478,7 @@ where
             .await
         {
             warn!(
-                error = %e,
+                error = ?e,
                 "Partition directory cleanup failed - orphan cleaner will handle it"
             );
         }
@@ -497,8 +497,10 @@ where
                 "Resuming all owned partitions (rebalance cycle complete)"
             );
             if let Err(e) = consumer_command_tx.send(ConsumerCommand::Resume(resume_tpl)) {
-                error!("Failed to send resume command after store setup: {}", e);
-                return Err(anyhow::anyhow!("Failed to send resume command: {}", e));
+                error!("Failed to send resume command after store setup: {e:#}");
+                return Err(Err::<(), _>(e)
+                    .with_context(|| "Failed to send resume command")
+                    .unwrap_err());
             }
         }
 

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
@@ -498,9 +498,7 @@ where
             );
             if let Err(e) = consumer_command_tx.send(ConsumerCommand::Resume(resume_tpl)) {
                 error!("Failed to send resume command after store setup: {e:#}");
-                return Err(Err::<(), _>(e)
-                    .with_context(|| "Failed to send resume command")
-                    .unwrap_err());
+                return Err(anyhow::Error::from(e).context("Failed to send resume command"));
             }
         }
 

--- a/rust/kafka-deduplicator/src/rocksdb/store.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/store.rs
@@ -314,14 +314,10 @@ impl RocksDbStore {
                 rocksdb_error = ?e,
                 "RocksDB write_opt failed"
             );
-            Err::<(), _>(e)
-                .with_context(|| {
-                    format!(
-                        "Failed to put batch ({} entries, {} bytes)",
-                        entry_count, batch_size_bytes
-                    )
-                })
-                .unwrap_err()
+            anyhow::Error::from(e).context(format!(
+                "Failed to put batch ({} entries, {} bytes)",
+                entry_count, batch_size_bytes
+            ))
         })
     }
 
@@ -427,9 +423,7 @@ impl RocksDbStore {
             Ok(_) => Ok(()),
             Err(e) => {
                 self.metrics.counter(ROCKSDB_ERRORS_COUNTER).increment(1);
-                Err(Err::<(), _>(e)
-                    .with_context(|| "Failed to flush")
-                    .unwrap_err())
+                Err(anyhow::Error::from(e).context("Failed to flush"))
             }
         }
     }

--- a/rust/kafka-deduplicator/src/rocksdb/store.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/store.rs
@@ -311,12 +311,17 @@ impl RocksDbStore {
                 entry_count = entry_count,
                 batch_size_bytes = batch_size_bytes,
                 db_path = %self.path_location.display(),
-                rocksdb_error = %e,
+                rocksdb_error = ?e,
                 "RocksDB write_opt failed"
             );
-            anyhow::anyhow!(
-                "Failed to put batch ({entry_count} entries, {batch_size_bytes} bytes): {e}"
-            )
+            Err::<(), _>(e)
+                .with_context(|| {
+                    format!(
+                        "Failed to put batch ({} entries, {} bytes)",
+                        entry_count, batch_size_bytes
+                    )
+                })
+                .unwrap_err()
         })
     }
 
@@ -422,7 +427,9 @@ impl RocksDbStore {
             Ok(_) => Ok(()),
             Err(e) => {
                 self.metrics.counter(ROCKSDB_ERRORS_COUNTER).increment(1);
-                Err(anyhow::anyhow!("Failed to flush: {e}"))
+                Err(Err::<(), _>(e)
+                    .with_context(|| "Failed to flush")
+                    .unwrap_err())
             }
         }
     }
@@ -441,7 +448,7 @@ impl RocksDbStore {
     pub fn flush_wal(&self, sync: bool) -> Result<()> {
         self.db
             .flush_wal(sync)
-            .map_err(|e| anyhow::anyhow!("Failed to flush WAL (sync={sync}): {e}"))
+            .with_context(|| format!("Failed to flush WAL (sync={sync})"))
     }
 
     /// Get the latest sequence number from the database

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -327,19 +327,11 @@ impl StoreManager {
                     // Real failure - no one succeeded in creating the store
                     metrics::counter!(STORE_CREATION_EVENTS, "outcome" => "failure").increment(1);
 
-                    // Build the complete error chain
-                    let mut error_chain = vec![format!("{:?}", e)];
-                    let mut source = e.source();
-                    while let Some(err) = source {
-                        error_chain.push(format!("Caused by: {err:?}"));
-                        source = err.source();
-                    }
-
                     error!(
                         topic = topic,
                         partition = partition,
                         duration_ms = creation_duration.as_millis(),
-                        error = error_chain.join(" -> "),
+                        error = ?e,
                         "Failed to create deduplication store"
                     );
 
@@ -502,7 +494,7 @@ impl StoreManager {
             Err(e) => {
                 warn!(
                     path = %base_path.display(),
-                    error = %e,
+                    error = ?e,
                     "Failed to read store base directory for cleanup"
                 );
                 return Ok(());
@@ -515,7 +507,7 @@ impl StoreManager {
                     .map_err(|e| {
                         warn!(
                             path = %base_path.display(),
-                            error = %e,
+                            error = ?e,
                             "Error reading directory entry during cleanup"
                         );
                     })
@@ -566,7 +558,7 @@ impl StoreManager {
                         Ok(())
                     }
                     Err(e) => {
-                        warn!(path = %path_str, error = %e, "Failed to delete partition directory");
+                        warn!(path = %path_str, error = ?e, "Failed to delete partition directory");
                         Err(e)
                     }
                 }
@@ -849,7 +841,7 @@ impl StoreManager {
                                 info!("Cleaned up {} bytes of orphaned directories", bytes_freed);
                             }
                             Err(e) => {
-                                warn!("Failed to clean up orphaned directories: {}", e);
+                                warn!("Failed to clean up orphaned directories: {e:#}");
                             }
                         }
 
@@ -863,7 +855,7 @@ impl StoreManager {
                                     info!("Periodic cleanup freed {} bytes", bytes_freed);
                                 }
                                 Err(e) => {
-                                    error!("Periodic cleanup failed: {}", e);
+                                    error!("Periodic cleanup failed: {e:#}");
                                 }
                             }
                         } else {
@@ -1316,7 +1308,7 @@ impl CleanupTaskHandle {
 
         match tokio::time::timeout(Duration::from_secs(5), self.handle).await {
             Ok(Ok(())) => info!("Cleanup task shut down successfully"),
-            Ok(Err(e)) => warn!("Cleanup task failed: {}", e),
+            Ok(Err(e)) => warn!("Cleanup task failed: {e:#}"),
             Err(_) => warn!("Cleanup task shutdown timed out"),
         }
     }


### PR DESCRIPTION
## Problem
In `kafka-deduplicator` we're not logging wrapped errors in full detail so the root cause is often obscured. This has been making debugging difficult
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Stop holding it wrong 😆 when using `anyhow` crate with structured logging
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
