### PR TITLE
feat(product tours): clean up new tour UX

### DIFF
--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -67,6 +67,7 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                     }
                 />
 
+                <div data-attr="product-tours-tour-editor-banner" />
                 <ProductTourStepsEditor tourId={id} />
             </SceneContent>
         </Form>

--- a/frontend/src/scenes/product-tours/ProductTours.tsx
+++ b/frontend/src/scenes/product-tours/ProductTours.tsx
@@ -25,8 +25,11 @@ export const scene: SceneExport = {
 }
 
 function NewTourButton(): JSX.Element {
-    const { createAnnouncement, createBanner } = useActions(productToursLogic)
+    const { productTours } = useValues(productToursLogic)
+    const { createAnnouncement, createBanner, createTour } = useActions(productToursLogic)
     const [isModalOpen, setIsModalOpen] = useState(false)
+
+    const existingTourNames = new Set(productTours.map((tour) => tour.name).filter(Boolean))
 
     return (
         <>
@@ -38,6 +41,8 @@ function NewTourButton(): JSX.Element {
                 onClose={() => setIsModalOpen(false)}
                 onCreateAnnouncement={createAnnouncement}
                 onCreateBanner={createBanner}
+                onCreateTour={createTour}
+                existingTourNames={existingTourNames}
             />
         </>
     )

--- a/frontend/src/scenes/product-tours/components/AutoShowModal.tsx
+++ b/frontend/src/scenes/product-tours/components/AutoShowModal.tsx
@@ -37,7 +37,7 @@ export function AutoShowModal({ tourId, isOpen, onClose }: AutoShowModalProps): 
             <div className="space-y-6">
                 {/* Who to show */}
                 <div>
-                    <h4 className="font-semibold mb-3">Who to show</h4>
+                    <h5 className="font-semibold mb-2">Who to show</h5>
                     <LemonSegmentedButton
                         size="small"
                         fullWidth
@@ -51,7 +51,7 @@ export function AutoShowModal({ tourId, isOpen, onClose }: AutoShowModalProps): 
                         }}
                         options={[
                             { value: 'everyone', label: 'All users' },
-                            { value: 'conditions', label: 'Matching conditions' },
+                            { value: 'conditions', label: 'Users matching conditions' },
                         ]}
                     />
                     {showUserTargeting && (

--- a/frontend/src/scenes/product-tours/components/AutoShowSection.tsx
+++ b/frontend/src/scenes/product-tours/components/AutoShowSection.tsx
@@ -329,7 +329,9 @@ export function AutoShowSection({ id }: { id: string }): JSX.Element | null {
             <div>
                 <h5 className="font-semibold mb-2">
                     When to show&nbsp;
-                    <Tooltip title={`Choose when to show the ${entityKeyword} to matching users.`}>
+                    <Tooltip
+                        title={`By default, ${entityKeyword}s will show on page load when a user matches your conditions. Alternatively, you can wait to show this tour until the user performs an event or action.`}
+                    >
                         <IconInfo />
                     </Tooltip>
                 </h5>

--- a/frontend/src/scenes/product-tours/components/LinkedFlagField.tsx
+++ b/frontend/src/scenes/product-tours/components/LinkedFlagField.tsx
@@ -15,7 +15,7 @@ import { productTourLogic } from '../productTourLogic'
 type FlagType = FeatureFlagBasicType | FeatureFlagType
 
 export function LinkedFlagField({ id }: { id: string }): JSX.Element {
-    const { productTourForm, entityKeyword } = useValues(productTourLogic({ id }))
+    const { productTourForm, entityKeyword, hasCustomTargeting } = useValues(productTourLogic({ id }))
     const { setProductTourFormValue } = useActions(productTourLogic({ id }))
 
     const conditions = productTourForm.content?.conditions || {}
@@ -109,6 +109,19 @@ export function LinkedFlagField({ id }: { id: string }): JSX.Element {
                         onChange={handleVariantSelect}
                     />
                 </div>
+            )}
+
+            {flagId && (
+                <p className="text-muted mt-2">
+                    {hasCustomTargeting ? (
+                        <>
+                            This {entityKeyword} will be shown to users who have this flag enabled <strong>and</strong>{' '}
+                            match the conditions specified above.
+                        </>
+                    ) : (
+                        <>This {entityKeyword} will be shown only to users who have this flag enabled.</>
+                    )}
+                </p>
             )}
         </div>
     )

--- a/frontend/src/scenes/product-tours/components/StepSettings.tsx
+++ b/frontend/src/scenes/product-tours/components/StepSettings.tsx
@@ -89,59 +89,6 @@ function ElementSettings({ tourId }: StepSettingsPanelProps): JSX.Element | null
                                 ]}
                             />
                         </div>
-
-                        {step.elementTargeting === 'manual' && (
-                            <div className="flex flex-col gap-1 flex-1 min-w-0">
-                                <label className="text-[0.6875rem] font-medium text-muted uppercase tracking-wide">
-                                    CSS Selector
-                                </label>
-                                <LemonInput
-                                    value={step.selector || ''}
-                                    onChange={(value) => updateSelectedStep({ selector: value })}
-                                    placeholder="#my-element"
-                                    size="small"
-                                    className="font-mono max-w-md"
-                                    autoFocus={!hasTarget}
-                                />
-                            </div>
-                        )}
-
-                        {step.elementTargeting === 'auto' && (
-                            <div className="flex flex-col gap-1">
-                                <label className="text-[0.6875rem] font-medium text-muted uppercase tracking-wide">
-                                    Element
-                                </label>
-                                <div className="flex gap-2">
-                                    <LemonButton
-                                        size="small"
-                                        type="secondary"
-                                        icon={<IconCursorClick />}
-                                        onClick={() => submitAndOpenToolbar('edit')}
-                                    >
-                                        {step.inferenceData ? 'Change' : 'Select element in Toolbar'}
-                                    </LemonButton>
-                                    {step.inferenceData && (
-                                        <LemonButton
-                                            size="small"
-                                            type="secondary"
-                                            status="danger"
-                                            icon={<IconTrash />}
-                                            onClick={() =>
-                                                updateSelectedStep({
-                                                    selector: undefined,
-                                                    inferenceData: undefined,
-                                                    screenshotMediaId: undefined,
-                                                    useManualSelector: undefined,
-                                                    elementTargeting: undefined,
-                                                })
-                                            }
-                                        >
-                                            Remove
-                                        </LemonButton>
-                                    )}
-                                </div>
-                            </div>
-                        )}
                     </div>
 
                     {step.elementTargeting === 'auto' && step.inferenceData && (
@@ -215,6 +162,57 @@ function ElementSettings({ tourId }: StepSettingsPanelProps): JSX.Element | null
                     </div>
                 )}
             </div>
+
+            {step.elementTargeting === 'manual' && (
+                <div className="flex flex-col gap-1 flex-1 min-w-0">
+                    <label className="text-[0.6875rem] font-medium text-muted uppercase tracking-wide">
+                        CSS Selector
+                    </label>
+                    <LemonInput
+                        value={step.selector || ''}
+                        onChange={(value) => updateSelectedStep({ selector: value })}
+                        placeholder="#my-element"
+                        size="small"
+                        className="font-mono max-w-md"
+                        autoFocus={!hasTarget}
+                    />
+                </div>
+            )}
+
+            {step.elementTargeting === 'auto' && (
+                <div className="flex flex-col gap-1">
+                    <label className="text-[0.6875rem] font-medium text-muted uppercase tracking-wide">Element</label>
+                    <div className="flex gap-2">
+                        <LemonButton
+                            size="small"
+                            type="secondary"
+                            icon={<IconCursorClick />}
+                            onClick={() => submitAndOpenToolbar('edit')}
+                        >
+                            {step.inferenceData ? 'Change' : 'Select element in Toolbar'}
+                        </LemonButton>
+                        {step.inferenceData && (
+                            <LemonButton
+                                size="small"
+                                type="secondary"
+                                status="danger"
+                                icon={<IconTrash />}
+                                onClick={() =>
+                                    updateSelectedStep({
+                                        selector: undefined,
+                                        inferenceData: undefined,
+                                        screenshotMediaId: undefined,
+                                        useManualSelector: undefined,
+                                        elementTargeting: undefined,
+                                    })
+                                }
+                            >
+                                Remove
+                            </LemonButton>
+                        )}
+                    </div>
+                </div>
+            )}
 
             {step.elementTargeting && hasIncompleteTargeting(step) && (
                 <div className="flex flex-col items-start gap-2">

--- a/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
@@ -105,7 +105,7 @@ export function ProductTourStepsEditor({ tourId }: ProductTourStepsEditorProps):
     const cardHeaderClasses = 'flex items-center justify-between px-3 py-2 bg-surface-primary border-b font-semibold'
 
     return (
-        <div className="flex gap-4 items-start p-4 overflow-auto">
+        <div className="flex gap-4 items-start overflow-auto">
             {/* Sidebar - hidden for announcements */}
             {!isAnnouncementMode && (
                 <div className={`flex flex-col w-[220px] min-w-[220px] ${cardClasses}`}>

--- a/frontend/src/scenes/product-tours/editor/TourSettingsPanel.tsx
+++ b/frontend/src/scenes/product-tours/editor/TourSettingsPanel.tsx
@@ -57,19 +57,30 @@ export function TourSettingsPanel({ tourId }: TourSettingsPanelProps): JSX.Eleme
 
     const displayContent = (
         <div className="space-y-4">
-            <div className="flex items-center justify-between">
-                <span className="text-sm">Auto-show this {entityKeyword}</span>
-                <LemonSwitch
-                    checked={productTourForm.auto_launch}
-                    onChange={(checked) => setProductTourFormValue('auto_launch', checked)}
-                />
+            <div>
+                <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium">Auto-show this {entityKeyword}</span>
+                    <LemonSwitch
+                        checked={productTourForm.auto_launch}
+                        onChange={(checked) => setProductTourFormValue('auto_launch', checked)}
+                    />
+                </div>
+                {productTourForm.auto_launch && (
+                    <>
+                        <p className="text-xs text-secondary mt-2 mb-2">
+                            Show automatically when some conditions are met
+                        </p>
+                        <LemonButton
+                            type="secondary"
+                            icon={<IconGear />}
+                            onClick={() => setShowAutoShowModal(true)}
+                            fullWidth
+                        >
+                            Configure targeting
+                        </LemonButton>
+                    </>
+                )}
             </div>
-
-            {productTourForm.auto_launch && (
-                <LemonButton type="secondary" icon={<IconGear />} onClick={() => setShowAutoShowModal(true)} fullWidth>
-                    Configure targeting
-                </LemonButton>
-            )}
 
             <div className="pt-4 border-t">
                 <div className="flex items-center justify-between">

--- a/frontend/src/scenes/product-tours/stepUtils.tsx
+++ b/frontend/src/scenes/product-tours/stepUtils.tsx
@@ -48,6 +48,79 @@ export function getDefaultStepContent(): JSONContent {
     }
 }
 
+export function getExplainerStepContent(): JSONContent {
+    return {
+        type: 'doc',
+        content: [
+            {
+                type: 'heading',
+                attrs: { level: 2 },
+                content: [{ type: 'text', text: 'Welcome to Product Tours!' }],
+            },
+            {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'Here are some tips to get you going 🦔' }],
+            },
+            {
+                type: 'bulletList',
+                content: [
+                    {
+                        type: 'listItem',
+                        content: [
+                            {
+                                type: 'paragraph',
+                                content: [
+                                    {
+                                        type: 'text',
+                                        text: 'Add an element to display this step as a tooltip',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        type: 'listItem',
+                        content: [
+                            {
+                                type: 'paragraph',
+                                content: [
+                                    {
+                                        type: 'text',
+                                        text: 'Configure when & where to show the tour',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        type: 'listItem',
+                        content: [
+                            {
+                                type: 'paragraph',
+                                content: [
+                                    {
+                                        type: 'text',
+                                        text: "Customize your tour's theme",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        type: 'listItem',
+                        content: [
+                            {
+                                type: 'paragraph',
+                                content: [{ type: 'text', text: 'Add custom buttons' }],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+}
+
 export function getDefaultSurveyContent(type: ProductTourSurveyQuestionType): ProductTourSurveyQuestion {
     if (type === 'rating') {
         return {

--- a/frontend/src/toolbar/product-tours/StepCard.tsx
+++ b/frontend/src/toolbar/product-tours/StepCard.tsx
@@ -183,6 +183,26 @@ export function StepCard({
                                 </div>
                             )}
 
+                            <LemonButton
+                                size="xsmall"
+                                type="primary"
+                                status="danger"
+                                onClick={() =>
+                                    updateStep(index, {
+                                        type: 'modal',
+                                        selector: undefined,
+                                        inferenceData: undefined,
+                                        screenshotMediaId: undefined,
+                                        useManualSelector: undefined,
+                                        element: undefined,
+                                        elementTargeting: undefined,
+                                    })
+                                }
+                                icon={<IconTrash />}
+                            >
+                                Remove element
+                            </LemonButton>
+
                             <div>
                                 <label className="block text-[11px] font-medium text-muted-3000 mb-1.5">
                                     Targeting
@@ -215,6 +235,18 @@ export function StepCard({
                                 </div>
                             ) : (
                                 <>
+                                    {!step.inferenceData && (
+                                        <LemonButton
+                                            size="small"
+                                            type="secondary"
+                                            fullWidth
+                                            icon={<IconCursorClick />}
+                                            onClick={handleReselectElement}
+                                            disabledReason={isSelecting ? 'Click your element' : undefined}
+                                        >
+                                            {isSelecting ? 'Click your element' : 'Select element'}
+                                        </LemonButton>
+                                    )}
                                     <div>
                                         <Tooltip title="How strictly we should identify the target element">
                                             <label className="flex text-[11px] font-medium text-muted-3000 mb-1 gap-1">
@@ -272,37 +304,6 @@ export function StepCard({
                                         { value: 'click', label: 'Element click' },
                                     ]}
                                 />
-                            </div>
-
-                            <div className="flex gap-2">
-                                <LemonButton
-                                    size="small"
-                                    type="secondary"
-                                    fullWidth
-                                    icon={<IconCursorClick />}
-                                    onClick={handleReselectElement}
-                                >
-                                    Change
-                                </LemonButton>
-                                {step.type === 'modal' && (
-                                    <LemonButton
-                                        size="small"
-                                        type="tertiary"
-                                        status="danger"
-                                        onClick={() =>
-                                            updateStep(index, {
-                                                type: 'modal',
-                                                selector: undefined,
-                                                inferenceData: undefined,
-                                                screenshotMediaId: undefined,
-                                                useManualSelector: undefined,
-                                                element: undefined,
-                                                elementTargeting: undefined,
-                                            })
-                                        }
-                                        icon={<IconTrash />}
-                                    />
-                                )}
                             </div>
                         </>
                     ) : (


### PR DESCRIPTION
## Problem

i think it's confusing and maybe frustrating to _start_ the tour building experience in the toolbar. this PR shuffles things around so we start directly in-app.

i may come back and set up an experiement on this later, but the user base is v small right now :)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

new tour building flow:

- click new
- click tour, enter name
- go directly to tour editor with some nice content
- if it's your first time, you'll see a banner that launches a product tour of product tours

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

manually

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->