### PR TITLE
feat(rust-builds): adds personhog-router to rust CI

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -133,6 +133,7 @@ jobs:
                     - kafka-deduplicator
                     - limiters
                     - personhog-replica
+                    - personhog-router
                     - posthog-symbol-data
                     - property-defs-rs
                     - serve-metrics

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -60,6 +60,9 @@ jobs:
                     - image: personhog-replica
                       dockerfile: ./rust/Dockerfile
                       project: vq4lxdfdv2
+                    - image: personhog-router
+                      dockerfile: ./rust/Dockerfile
+                      project: wqvvpmzgbk
         runs-on: depot-ubuntu-22.04
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
@@ -82,6 +85,7 @@ jobs:
             capture-logs_digest: ${{ steps.digest.outputs.capture-logs_digest }}
             kafka-deduplicator_digest: ${{ steps.digest.outputs.kafka-deduplicator_digest }}
             personhog-replica_digest: ${{ steps.digest.outputs.personhog-replica_digest }}
+            personhog-router_digest: ${{ steps.digest.outputs.personhog-router_digest }}
         defaults:
             run:
                 working-directory: rust
@@ -242,6 +246,10 @@ jobs:
                       values:
                           image:
                               sha: '${{ needs.build.outputs.personhog-replica_digest }}'
+                    - release: personhog-router
+                      values:
+                          image:
+                              sha: '${{ needs.build.outputs.personhog-router_digest }}'
         steps:
             - name: get deployer token
               id: deployer


### PR DESCRIPTION
## Problem

Personhog-router needs to be added to the Rust CI to start building and deploying the service

## Changes

- adds personhog-router service to the rust build and deploy matrix
- adds personhog-router to the rust test CI

## How did you test this code?

Manually triggered the rust build workflow against this feature branch to ensure the personhog-router service builds:
https://github.com/PostHog/posthog/actions/runs/21932646251/job/63339836270
