### PR TITLE
fix(product tours): fix tour analytics and default button actions

### DIFF
--- a/frontend/src/scenes/product-tours/ProductTourView.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourView.tsx
@@ -299,15 +299,10 @@ function StepsFunnel({ tour, dateRange }: { tour: ProductTour; dateRange: DateRa
         value: tour.id,
     }
 
-    // Build funnel: tour shown → step 1 shown → step 2 shown → ... → tour completed
+    // Build funnel: step 1 shown → step 2 shown → ... → tour completed
     // Filter by step ID (stable across reorders) rather than step order (positional)
+    // "product tour shown" === "step 1 shown", so we do not include it here
     const series = [
-        {
-            kind: NodeKind.EventsNode,
-            event: 'product tour shown',
-            custom_name: 'Tour started',
-            properties: [tourIdFilter],
-        },
         ...steps.map((step, index) => ({
             kind: NodeKind.EventsNode,
             event: 'product tour step shown',

--- a/frontend/src/scenes/product-tours/editor/StepButtonsEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/StepButtonsEditor.tsx
@@ -29,11 +29,9 @@ function ButtonEditor({
     totalSteps = 1,
 }: ButtonEditorProps): JSX.Element {
     const actionOptions = isTourContext ? TOUR_BUTTON_ACTION_OPTIONS : BUTTON_ACTION_OPTIONS
+    const isLastStep = stepIndex === totalSteps - 1
 
     const actionDisabledReason = (action: ProductTourButtonAction): string | undefined => {
-        if (action === 'next_step' && stepIndex === totalSteps - 1) {
-            return 'No further tour steps'
-        }
         if (action === 'previous_step' && stepIndex === 0) {
             return 'No previous tour steps'
         }
@@ -65,6 +63,7 @@ function ButtonEditor({
                     }}
                     options={actionOptions.map((opt) => ({
                         ...opt,
+                        label: opt.value === 'next_step' && isLastStep ? 'Complete tour' : opt.label,
                         disabledReason: actionDisabledReason(opt.value),
                     }))}
                     size="small"

--- a/frontend/src/scenes/product-tours/productToursLogic.ts
+++ b/frontend/src/scenes/product-tours/productToursLogic.ts
@@ -105,7 +105,7 @@ export function getDefaultTourStepButtons(stepIndex: number, totalSteps: number)
     return {
         primary: {
             text: isLastStep ? 'Done' : 'Next',
-            action: isLastStep ? 'dismiss' : 'next_step',
+            action: 'next_step',
         },
         ...(isFirstStep
             ? {}


### PR DESCRIPTION
## Problem

product tour analytics are a bit broken 

the default funnel view is wonky. it shows tour shown -> step 1 shown -> step n shown -> step completed. however, "tour shown" should === "step 1 shown"

in fact, the sdk does not emit "tour shown" events until _after_ the first step is shown, so it's actually a useless funnel sequence.

see https://us.posthog.com/project/2/product_tours/d6c4719e-697d-4752-9487-10e7bf3c1e98 for an example of a broken funnel

furthermore, the default button actions for the last step of a tour are wonky:
- the default primary button action on the last step of a tour is "dismiss"
- in the editor, you can't actually set "next step" as a button action for the last step; you must use dismiss
- the sdk never emits a "product tour completed" event when a tour is "dismissed" (only when "next step" is triggered on the last step)

so if you have a custom button on the last step (even just to change the text, for example, like the tour linked above), you'll never have accurate conversion metrics

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- replaces "tour shown" with "step 1 shown" as the first funnel step
- updates default primary custom button action to _always_ be "next step"
- renames "next step" -> "complete tour" in the button action dropdown for the last step of a tour

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no