### PR TITLE
fix(replay): fix memory leak bugs

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -366,6 +366,21 @@ const handleMutationError = (error: unknown): void => {
 }
 
 const objectUrlsById = new Map<number, Set<string>>()
+const controllerById = new Map<number, AbortController>()
+
+export const cleanupCanvasPlugin = (): void => {
+    for (const [, urlSet] of objectUrlsById.entries()) {
+        for (const url of urlSet) {
+            URL.revokeObjectURL(url)
+        }
+    }
+    objectUrlsById.clear()
+
+    for (const [, controller] of controllerById.entries()) {
+        controller.abort()
+    }
+    controllerById.clear()
+}
 
 const trackUrl = (id: number, url: string): void => {
     let set = objectUrlsById.get(id)
@@ -404,8 +419,6 @@ const finalizeUrl = (id: number, url: string): void => {
         }
     }
 }
-
-const controllerById = new Map<number, AbortController>()
 
 const storeController = (id: number, controller: AbortController): void => {
     controllerById.set(id, controller)

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
@@ -483,7 +483,8 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
             }),
         ],
     })),
-    beforeUnmount(({ cache }) => {
+    beforeUnmount(({ cache, actions }) => {
+        actions.setProcessedSnapshots([])
         cache.windowIdForTimestamp = undefined
         cache.processingCache = undefined
     }),

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -245,6 +245,7 @@ function PlayerWrapper({
                 </div>
             ) : showContent && activeSessionRecording ? (
                 <AttachedPlayer
+                    key={activeSessionRecording.id}
                     playlistProps={props}
                     activeSessionRecording={activeSessionRecording}
                     matchingEventsMatchType={matchingEventsMatchType}


### PR DESCRIPTION
## Problem

customer reported 7.4GB memory after watching 40+ recordings, resulting in page crashing

I could repro by spoofing/clicking around, JS heap seemed to stay ok but tab memory still exploded, the robot says this points to possible Canvas issues but other possibilities too

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

kitchen sink

1. Canvas cleanup
2. add key to the player to force/ensure component destroyed when changing recordings
2. add cleanup to processed snapshots array
4. added another fallback to iframe cleanup to release reference from hypothetical parent

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

couldnt repro locally......


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
