### PR TITLE
fix(cohorts): Reduce replication lag issue for cohorts

### DIFF
--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -241,20 +241,22 @@ def increment_version_and_enqueue_calculate_cohort(cohort: Cohort, *, initiating
             _enqueue_single_cohort_calculation(cohort, initiating_user)
             return
 
-        # Create a chain of tasks to ensure sequential execution
+        # Create a chain of tasks to ensure sequential execution.
+        # Non-first tasks get a 2s countdown to mitigate ClickHouse replica lag:
+        # the preceding cohort's new rows may not have replicated yet. See #47618.
         task_chain: list = []
         for cohort_id in sorted_cohort_ids:
             current_cohort = seen_cohorts_cache.get(cohort_id)
             if current_cohort and not current_cohort.is_static:
                 _prepare_cohort_for_calculation(current_cohort)
-                task_chain.append(
-                    calculate_cohort_ch.si(
-                        current_cohort.id,
-                        current_cohort.pending_version,
-                        initiating_user.id if initiating_user else None,
-                        len(task_chain) > 0,
-                    )
+                task = calculate_cohort_ch.si(
+                    current_cohort.id,
+                    current_cohort.pending_version,
+                    initiating_user.id if initiating_user else None,
                 )
+                if len(task_chain) > 0:
+                    task = task.set(countdown=2)
+                task_chain.append(task)
 
         if task_chain:
             chain(*task_chain).apply_async()
@@ -284,15 +286,7 @@ def _enqueue_single_cohort_calculation(cohort: Cohort, initiating_user: Optional
 
 
 @shared_task(ignore_result=True, max_retries=2, queue=CeleryQueue.LONG_RUNNING.value)
-def calculate_cohort_ch(
-    cohort_id: int, pending_version: int, initiating_user_id: Optional[int] = None, is_chained: bool = False
-) -> None:
-    # Temporary mitigation for ClickHouse replica lag when calculating chained cohorts.
-    # When cohort A depends on cohort B and both are in a Celery chain, B's new rows may
-    # not have replicated to the CH replica by the time A starts. See #47618.
-    if is_chained:
-        time.sleep(2)
-
+def calculate_cohort_ch(cohort_id: int, pending_version: int, initiating_user_id: Optional[int] = None) -> None:
     with posthoganalytics.new_context():
         posthoganalytics.tag("feature", Feature.COHORT.value)
         posthoganalytics.tag("cohort_id", cohort_id)

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -242,7 +242,7 @@ def increment_version_and_enqueue_calculate_cohort(cohort: Cohort, *, initiating
             return
 
         # Create a chain of tasks to ensure sequential execution
-        task_chain = []
+        task_chain: list = []
         for cohort_id in sorted_cohort_ids:
             current_cohort = seen_cohorts_cache.get(cohort_id)
             if current_cohort and not current_cohort.is_static:

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -581,17 +581,18 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             self.assertLess(b_index, c_index, "Cohort B must be processed before C (dependency)")
             self.assertLess(c_index, d_index, "Cohort C must be processed before D (dependency)")
 
-            # Verify is_chained: first task in chain should be False, all subsequent True
-            is_chained_values = [call[0][3] for call in actual_calls]
-            self.assertFalse(is_chained_values[0], "First task in chain should not have is_chained=True")
-            for i in range(1, len(is_chained_values)):
-                self.assertTrue(is_chained_values[i], f"Task at index {i} should have is_chained=True")
+            # Verify countdown: first task has no countdown, all subsequent have countdown=2
+            # mock_calculate_cohort_ch_si returns mock_task, and .set() is called on it for non-first tasks
+            set_calls = mock_task.set.call_args_list
+            self.assertEqual(len(set_calls), 3, "3 of 4 tasks should have .set(countdown=2) called")
+            for call in set_calls:
+                self.assertEqual(call, ((), {"countdown": 2}))
 
-            mock_chain.assert_called_once_with(mock_task, mock_task, mock_task, mock_task)
+            mock_chain.assert_called_once()
             mock_chain_instance.apply_async.assert_called_once()
 
         @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay")
-        def test_increment_version_and_enqueue_single_cohort_does_not_pass_is_chained(
+        def test_increment_version_and_enqueue_single_cohort_has_no_countdown(
             self, mock_calculate_cohort_ch_delay: MagicMock
         ) -> None:
             cohort = Cohort.objects.create(
@@ -610,9 +611,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
 
             mock_calculate_cohort_ch_delay.assert_called_once()
             call_args = mock_calculate_cohort_ch_delay.call_args[0]
-            self.assertEqual(
-                len(call_args), 3, "Single cohort path should pass exactly 3 positional args (no is_chained)"
-            )
+            self.assertEqual(len(call_args), 3, "Single cohort path should use .delay() with no countdown")
 
         @patch("posthog.tasks.calculate_cohort.chain")
         @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.si")


### PR DESCRIPTION
## Problem

When calculating cohorts that depend on other cohorts, we're experiencing race conditions due to ClickHouse replica lag. When cohort A depends on cohort B and both are in a Celery chain, B's new rows may not have replicated to the ClickHouse replica by the time A starts calculating. The result is that cohort A will be incorrect which can lead to several issues. See: https://github.com/PostHog/posthog/issues/47618 for more context.

More details here: https://posthog.slack.com/archives/C076R4753Q8/p1770830017956439

## Changes

Effectively we now have a 2-second delay for chained cohort calculations, giving the read replicas time to catch up in order to reduce the frequency of this happening. This delay is done with the help of the `countdown` feature from Celery to avoid blocking workers / throughput and ensure that we limit the impact of the delay. 

This is a "stopgap" solution with the idea that a more permanent solution will come in the future.

## How did you test this code?

✅ New tests are passing in the CI

👀 Impact assessment:

- [EU Grafana Dashboard](https://grafana.prod-eu.posthog.dev/d/feo1v3xyi6sjkb/cohorts?orgId=1&from=now-6h&to=now&timezone=utc)
- [US Grafana Dashboard](https://grafana.prod-us.posthog.dev/d/feo1v3xyi6sjkb/cohorts?orgId=1&from=now-6h&to=now&timezone=utc)

| Region | % chained | P99 | Avg response time |
| ------ | --------- | --- | ----------------- | 
| EU     | [8,4%](https://metabase.prod-eu.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6MzQsIm5hdGl2ZSI6eyJxdWVyeSI6IiAgU0VMRUNUXG4gICAgICBjb3VudCgqKSBGSUxURVIgKFdIRVJFIGZpbHRlcnM6OnRleHQgTElLRSAnJVwidHlwZVwiOiBcImNvaG9ydFwiJScpIEFTIGNoYWluZWQsXG4gICAgICBjb3VudCgqKSBGSUxURVIgKFdIRVJFIGZpbHRlcnM6OnRleHQgTk9UIExJS0UgJyVcInR5cGVcIjogXCJjb2hvcnRcIiUnKSBBUyBzdGFuZGFsb25lLFxuICAgICAgcm91bmQoMTAwLjAgKiBjb3VudCgqKSBGSUxURVIgKFdIRVJFIGZpbHRlcnM6OnRleHQgTElLRSAnJVwidHlwZVwiOiBcImNvaG9ydFwiJScpIC8gY291bnQoKiksIDEpIEFTIGNoYWluZWRfcGN0XG4gIEZST00gcG9zdGhvZ19jb2hvcnRcbiAgV0hFUkUgZGVsZXRlZCA9IGZhbHNlIEFORCBpc19zdGF0aWMgPSBmYWxzZTsiLCJ0ZW1wbGF0ZS10YWdzIjp7fX19LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319) | [23,59s](https://metabase.prod-eu.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiIgIFNFTEVDVFxuICAgICAgcGVyY2VudGlsZV9jb250KDAuNTApIFdJVEhJTiBHUk9VUCAoT1JERVIgQlkgRVhUUkFDVChFUE9DSCBGUk9NIChmaW5pc2hlZF9hdCAtIHN0YXJ0ZWRfYXQpKSkgQVMgcDUwLFxuICAgICAgcGVyY2VudGlsZV9jb250KDAuOTApIFdJVEhJTiBHUk9VUCAoT1JERVIgQlkgRVhUUkFDVChFUE9DSCBGUk9NIChmaW5pc2hlZF9hdCAtIHN0YXJ0ZWRfYXQpKSkgQVMgcDkwLFxuICAgICAgcGVyY2VudGlsZV9jb250KDAuOTkpIFdJVEhJTiBHUk9VUCAoT1JERVIgQlkgRVhUUkFDVChFUE9DSCBGUk9NIChmaW5pc2hlZF9hdCAtIHN0YXJ0ZWRfYXQpKSkgQVMgcDk5LFxuICAgICAgYXZnKEVYVFJBQ1QoRVBPQ0ggRlJPTSAoZmluaXNoZWRfYXQgLSBzdGFydGVkX2F0KSkpIEFTIGF2Z19zZWNvbmRzXG4gIEZST00gcG9zdGhvZ19jb2hvcnRjYWxjdWxhdGlvbmhpc3RvcnlcbiAgV0hFUkUgZmluaXNoZWRfYXQgSVMgTk9UIE5VTExcbiAgICBBTkQgZXJyb3IgSVMgTlVMTFxuICAgIEFORCBzdGFydGVkX2F0ID4gbm93KCkgLSBpbnRlcnZhbCAnNyBkYXlzJzsiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjozNH0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=) | 2,18s |
| US     | [5,7%](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6MzQsIm5hdGl2ZSI6eyJxdWVyeSI6IiAgU0VMRUNUXG4gICAgICBjb3VudCgqKSBGSUxURVIgKFdIRVJFIGZpbHRlcnM6OnRleHQgTElLRSAnJVwidHlwZVwiOiBcImNvaG9ydFwiJScpIEFTIGNoYWluZWQsXG4gICAgICBjb3VudCgqKSBGSUxURVIgKFdIRVJFIGZpbHRlcnM6OnRleHQgTk9UIExJS0UgJyVcInR5cGVcIjogXCJjb2hvcnRcIiUnKSBBUyBzdGFuZGFsb25lLFxuICAgICAgcm91bmQoMTAwLjAgKiBjb3VudCgqKSBGSUxURVIgKFdIRVJFIGZpbHRlcnM6OnRleHQgTElLRSAnJVwidHlwZVwiOiBcImNvaG9ydFwiJScpIC8gY291bnQoKiksIDEpIEFTXG4gIGNoYWluZWRfcGN0XG4gIEZST00gcG9zdGhvZ19jb2hvcnRcbiAgV0hFUkUgZGVsZXRlZCA9IGZhbHNlIEFORCBpc19zdGF0aWMgPSBmYWxzZTsiLCJ0ZW1wbGF0ZS10YWdzIjp7fX19LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319) | [26,51s](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiIgIFNFTEVDVFxuICAgICAgcGVyY2VudGlsZV9jb250KDAuNTApIFdJVEhJTiBHUk9VUCAoT1JERVIgQlkgRVhUUkFDVChFUE9DSCBGUk9NIChmaW5pc2hlZF9hdCAtIHN0YXJ0ZWRfYXQpKSkgQVMgcDUwLFxuICAgICAgcGVyY2VudGlsZV9jb250KDAuOTApIFdJVEhJTiBHUk9VUCAoT1JERVIgQlkgRVhUUkFDVChFUE9DSCBGUk9NIChmaW5pc2hlZF9hdCAtIHN0YXJ0ZWRfYXQpKSkgQVMgcDkwLFxuICAgICAgcGVyY2VudGlsZV9jb250KDAuOTkpIFdJVEhJTiBHUk9VUCAoT1JERVIgQlkgRVhUUkFDVChFUE9DSCBGUk9NIChmaW5pc2hlZF9hdCAtIHN0YXJ0ZWRfYXQpKSkgQVMgcDk5LFxuICAgICAgYXZnKEVYVFJBQ1QoRVBPQ0ggRlJPTSAoZmluaXNoZWRfYXQgLSBzdGFydGVkX2F0KSkpIEFTIGF2Z19zZWNvbmRzXG4gIEZST00gcG9zdGhvZ19jb2hvcnRjYWxjdWxhdGlvbmhpc3RvcnlcbiAgV0hFUkUgZmluaXNoZWRfYXQgSVMgTk9UIE5VTExcbiAgICBBTkQgZXJyb3IgSVMgTlVMTFxuICAgIEFORCBzdGFydGVkX2F0ID4gbm93KCkgLSBpbnRlcnZhbCAnNyBkYXlzJzsiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjozNH0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=) | 1,89s | 

After merging we can monitor these queries to observe the improvements:

- [US](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6MzQsIm5hdGl2ZSI6eyJxdWVyeSI6Ii0tIFplcm8tY291bnQgcmF0ZSBmb3IgY2hhaW5lZCBjb2hvcnRzIChleGNsdWRpbmcgcGVybWFuZW50bHkgYnJva2VuIG9uZXMpXG4gIC0tIFJ1biBiZWZvcmUgYW5kIGFmdGVyIHRoZSBmaXggdG8gbWVhc3VyZSBpbXBhY3RcbiAgU0VMRUNUXG4gICAgICBkYXRlX3RydW5jKCdkYXknLCBoLnN0YXJ0ZWRfYXQpIEFTIGRheSxcbiAgICAgIGNvdW50KCopIEFTIGNoYWluZWRfY2FsY3VsYXRpb25zLFxuICAgICAgY291bnQoKikgRklMVEVSIChXSEVSRSBoLmNvdW50ID0gMCkgQVMgemVyb19jb3VudCxcbiAgICAgIGNvdW50KCopIEZJTFRFUiAoV0hFUkUgaC5jb3VudCA-IDApIEFTIG5vbnplcm9fY291bnQsXG4gICAgICByb3VuZCgoMTAwLjAgKiBjb3VudCgqKSBGSUxURVIgKFdIRVJFIGguY291bnQgPSAwKSAvIGNvdW50KCopKTo6bnVtZXJpYywgMSkgQVMgemVyb19jb3VudF9wY3RcbiAgRlJPTSBwb3N0aG9nX2NvaG9ydGNhbGN1bGF0aW9uaGlzdG9yeSBoXG4gIEpPSU4gcG9zdGhvZ19jb2hvcnQgYyBPTiBjLmlkID0gaC5jb2hvcnRfaWRcbiAgV0hFUkUgYy5kZWxldGVkID0gZmFsc2VcbiAgICBBTkQgYy5pc19zdGF0aWMgPSBmYWxzZVxuICAgIEFORCBjLmZpbHRlcnM6OnRleHQgfiAnXCJ0eXBlXCI6XFxzKlwiY29ob3J0XCInXG4gICAgQU5EIGguZXJyb3IgSVMgTlVMTFxuICAgIEFORCBoLnN0YXJ0ZWRfYXQgPiBub3coKSAtIGludGVydmFsICcxNCBkYXlzJ1xuICAgIC0tIEV4Y2x1ZGUgY29ob3J0cyB0aGF0IEFMV0FZUyByZXR1cm4gMCAobGlrZWx5IGVtcHR5IGJ5IGRlc2lnbiBvciBicm9rZW4gY29uZmlnKVxuICAgIEFORCBjLmlkIE5PVCBJTiAoXG4gICAgICAgIFNFTEVDVCBoMi5jb2hvcnRfaWRcbiAgICAgICAgRlJPTSBwb3N0aG9nX2NvaG9ydGNhbGN1bGF0aW9uaGlzdG9yeSBoMlxuICAgICAgICBXSEVSRSBoMi5zdGFydGVkX2F0ID4gbm93KCkgLSBpbnRlcnZhbCAnMTQgZGF5cydcbiAgICAgICAgICBBTkQgaDIuZXJyb3IgSVMgTlVMTFxuICAgICAgICBHUk9VUCBCWSBoMi5jb2hvcnRfaWRcbiAgICAgICAgSEFWSU5HIG1heChoMi5jb3VudCkgPSAwXG4gICAgKVxuICBHUk9VUCBCWSBkYXlcbiAgT1JERVIgQlkgZGF5OyIsInRlbXBsYXRlLXRhZ3MiOnt9fX0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=)
- [EU](https://metabase.prod-eu.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6MzQsIm5hdGl2ZSI6eyJxdWVyeSI6Ii0tIFplcm8tY291bnQgcmF0ZSBmb3IgY2hhaW5lZCBjb2hvcnRzIChleGNsdWRpbmcgcGVybWFuZW50bHkgYnJva2VuIG9uZXMpXG4gIC0tIFJ1biBiZWZvcmUgYW5kIGFmdGVyIHRoZSBmaXggdG8gbWVhc3VyZSBpbXBhY3RcbiAgU0VMRUNUXG4gICAgICBkYXRlX3RydW5jKCdkYXknLCBoLnN0YXJ0ZWRfYXQpIEFTIGRheSxcbiAgICAgIGNvdW50KCopIEFTIGNoYWluZWRfY2FsY3VsYXRpb25zLFxuICAgICAgY291bnQoKikgRklMVEVSIChXSEVSRSBoLmNvdW50ID0gMCkgQVMgemVyb19jb3VudCxcbiAgICAgIGNvdW50KCopIEZJTFRFUiAoV0hFUkUgaC5jb3VudCA-IDApIEFTIG5vbnplcm9fY291bnQsXG4gICAgICByb3VuZCgoMTAwLjAgKiBjb3VudCgqKSBGSUxURVIgKFdIRVJFIGguY291bnQgPSAwKSAvIGNvdW50KCopKTo6bnVtZXJpYywgMSkgQVMgemVyb19jb3VudF9wY3RcbiAgRlJPTSBwb3N0aG9nX2NvaG9ydGNhbGN1bGF0aW9uaGlzdG9yeSBoXG4gIEpPSU4gcG9zdGhvZ19jb2hvcnQgYyBPTiBjLmlkID0gaC5jb2hvcnRfaWRcbiAgV0hFUkUgYy5kZWxldGVkID0gZmFsc2VcbiAgICBBTkQgYy5pc19zdGF0aWMgPSBmYWxzZVxuICAgIEFORCBjLmZpbHRlcnM6OnRleHQgfiAnXCJ0eXBlXCI6XFxzKlwiY29ob3J0XCInXG4gICAgQU5EIGguZXJyb3IgSVMgTlVMTFxuICAgIEFORCBoLnN0YXJ0ZWRfYXQgPiBub3coKSAtIGludGVydmFsICcxNCBkYXlzJ1xuICAgIC0tIEV4Y2x1ZGUgY29ob3J0cyB0aGF0IEFMV0FZUyByZXR1cm4gMCAobGlrZWx5IGVtcHR5IGJ5IGRlc2lnbiBvciBicm9rZW4gY29uZmlnKVxuICAgIEFORCBjLmlkIE5PVCBJTiAoXG4gICAgICAgIFNFTEVDVCBoMi5jb2hvcnRfaWRcbiAgICAgICAgRlJPTSBwb3N0aG9nX2NvaG9ydGNhbGN1bGF0aW9uaGlzdG9yeSBoMlxuICAgICAgICBXSEVSRSBoMi5zdGFydGVkX2F0ID4gbm93KCkgLSBpbnRlcnZhbCAnMTQgZGF5cydcbiAgICAgICAgICBBTkQgaDIuZXJyb3IgSVMgTlVMTFxuICAgICAgICBHUk9VUCBCWSBoMi5jb2hvcnRfaWRcbiAgICAgICAgSEFWSU5HIG1heChoMi5jb3VudCkgPSAwXG4gICAgKVxuICBHUk9VUCBCWSBkYXlcbiAgT1JERVIgQlkgZGF5OyIsInRlbXBsYXRlLXRhZ3MiOnt9fX0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=)

## Publish to changelog?

Yes; in the sense that this will improve stability of our cohorts.