### PR TITLE
fix: fix clickhouse events enum for kafka-dedup

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -9,13 +9,13 @@ use envconfig::Envconfig;
 ///
 /// Each pipeline type handles a different event format:
 /// - `IngestionEvents`: Events from capture (CapturedEvent/RawEvent format)
-/// - `ClickHouseEvents`: Events from ingestion pipeline (ClickHouseEvent format)
+/// - `ClickhouseEvents`: Events from ingestion pipeline (ClickhouseEvent format)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, strum_macros::EnumString)]
 #[strum(serialize_all = "snake_case")]
 pub enum PipelineType {
     #[default]
     IngestionEvents,
-    ClickHouseEvents,
+    ClickhouseEvents,
 }
 
 #[derive(Envconfig, Clone, Debug)]

--- a/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
+++ b/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
@@ -119,7 +119,7 @@ impl PipelineBuilder {
             PipelineType::IngestionEvents => {
                 self.build_ingestion_events(rebalance_tracker, offset_tracker, shutdown_rx)
             }
-            PipelineType::ClickHouseEvents => {
+            PipelineType::ClickhouseEvents => {
                 self.build_clickhouse_events(rebalance_tracker, offset_tracker, shutdown_rx)
             }
         }


### PR DESCRIPTION
## Problem

ClickHouseEvents would convert to `click_house_events`, this PR fixes it, so that the string representation of PIPELINE_TYPE is `clickhouse_events`

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
