### PR TITLE
fix(hogql): limit macro expansion depth

### DIFF
--- a/posthog/hogql/functions/clickhouse/datetime.py
+++ b/posthog/hogql/functions/clickhouse/datetime.py
@@ -319,7 +319,7 @@ INTERVAL_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
 POSTGRESQL_DATETIME_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     # PostgreSQL-style date/time functions
     "date_part": HogQLFunctionMeta(
-        "if({0} = 'year', toYear({1}), if({0} = 'month', toMonth({1}), if({0} = 'day', toDayOfMonth({1}), if({0} = 'hour', toHour({1}), if({0} = 'minute', toMinute({1}), if({0} = 'second', toSecond({1}), if({0} = 'dow', toDayOfWeek({1}), if({0} = 'doy', toDayOfYear({1}), if({0} = 'quarter', toQuarter({1}), null)))))))))",
+        "arrayElement(arrayMap((part, dt) -> multiIf(part = 'year', toYear(dt), part = 'month', toMonth(dt), part = 'day', toDayOfMonth(dt), part = 'hour', toHour(dt), part = 'minute', toMinute(dt), part = 'second', toSecond(dt), part = 'dow', toDayOfWeek(dt), part = 'doy', toDayOfYear(dt), part = 'quarter', toQuarter(dt), null), [{0}], [{1}]), 1)",
         # Maps to same implementation as extract
         2,
         2,

--- a/posthog/hogql/functions/clickhouse/strings.py
+++ b/posthog/hogql/functions/clickhouse/strings.py
@@ -163,7 +163,7 @@ POSTGRESQL_STRING_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     ),
     "split_part": HogQLFunctionMeta(
         # We need to repeat each argument in the format string since we use each one multiple times
-        "if(empty(splitByString({1}, {0})), '', if(length(splitByString({1}, {0})) >= {2}, arrayElement(splitByString({1}, {0}), {2}), ''))",
+        "arrayElement(arrayMap((parts, idx) -> if(empty(parts), '', if(length(parts) >= idx, arrayElement(parts, idx), '')), [splitByString({1}, {0})], [{2}]), 1)",
         3,
         3,
         signatures=[((StringType(), StringType(), IntegerType()), StringType())],

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -57,7 +57,6 @@ from posthog.models.team.team import WeekStartDay
 from posthog.models.utils import UUIDT
 
 MAX_PLACEHOLDER_MACRO_EXPANSION_DEPTH = 8
-MAX_PLACEHOLDER_MACRO_OUTPUT_LENGTH = 100_000
 
 
 def get_channel_definition_dict():
@@ -93,7 +92,6 @@ class HogQLPrinter(Visitor[str]):
         self.tab_size = 4
         self._table_top_level_settings: dict[str, Any] = {}
         self._placeholder_macro_expansion_depth = 0
-        self._placeholder_macro_output_chars = 0
 
     def indent(self, extra: int = 0):
         return " " * self.tab_size * (self._indent + extra)
@@ -856,12 +854,6 @@ class HogQLPrinter(Visitor[str]):
                         f"Function '{node.name}' requires exactly {placeholder_count} argument{'s' if placeholder_count != 1 else ''}"
                     )
                 rendered = clickhouse_name.format(*[self.visit(arg) for arg in node.args])
-
-            self._placeholder_macro_output_chars += len(rendered)
-            if self._placeholder_macro_output_chars > MAX_PLACEHOLDER_MACRO_OUTPUT_LENGTH:
-                raise QueryError(
-                    f"Function '{node.name}' exceeded maximum placeholder macro output size of {MAX_PLACEHOLDER_MACRO_OUTPUT_LENGTH} characters."
-                )
 
             return rendered
         finally:

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -558,7 +558,8 @@ class HogQLPrinter(Visitor[str]):
                     )
 
             # Handle format strings in function names before checking function type
-            if func_meta.using_placeholder_arguments:
+            # For HogQL, don't expand the macro, just display it in its original shape.
+            if func_meta.using_placeholder_arguments and self.dialect != "hogql":
                 return self._render_placeholder_macro(
                     node=node,
                     clickhouse_name=func_meta.clickhouse_name,

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -56,6 +56,9 @@ from posthog.models.property import PropertyName, TableColumn
 from posthog.models.team.team import WeekStartDay
 from posthog.models.utils import UUIDT
 
+MAX_PLACEHOLDER_MACRO_EXPANSION_DEPTH = 8
+MAX_PLACEHOLDER_MACRO_OUTPUT_LENGTH = 100_000
+
 
 def get_channel_definition_dict():
     """Get the channel definition dictionary name with the correct database.
@@ -89,6 +92,8 @@ class HogQLPrinter(Visitor[str]):
         self._indent = -1
         self.tab_size = 4
         self._table_top_level_settings: dict[str, Any] = {}
+        self._placeholder_macro_expansion_depth = 0
+        self._placeholder_macro_output_chars = 0
 
     def indent(self, extra: int = 0):
         return " " * self.tab_size * (self._indent + extra)
@@ -554,22 +559,11 @@ class HogQLPrinter(Visitor[str]):
 
             # Handle format strings in function names before checking function type
             if func_meta.using_placeholder_arguments:
-                # Check if using positional arguments (e.g. {0}, {1})
-                if func_meta.using_positional_arguments:
-                    # For positional arguments, pass the args as a dictionary
-                    arg_arr = [self.visit(arg) for arg in node.args]
-                    try:
-                        return func_meta.clickhouse_name.format(*arg_arr)
-                    except (KeyError, IndexError) as e:
-                        raise QueryError(f"Invalid argument reference in function '{node.name}': {str(e)}")
-                else:
-                    # Original sequential placeholder behavior
-                    placeholder_count = func_meta.clickhouse_name.count("{}")
-                    if len(node.args) != placeholder_count:
-                        raise QueryError(
-                            f"Function '{node.name}' requires exactly {placeholder_count} argument{'s' if placeholder_count != 1 else ''}"
-                        )
-                    return func_meta.clickhouse_name.format(*[self.visit(arg) for arg in node.args])
+                return self._render_placeholder_macro(
+                    node=node,
+                    clickhouse_name=func_meta.clickhouse_name,
+                    using_positional_arguments=func_meta.using_positional_arguments,
+                )
 
         if node.name in HOGQL_COMPARISON_MAPPING:
             op = HOGQL_COMPARISON_MAPPING[node.name]
@@ -839,6 +833,38 @@ class HogQLPrinter(Visitor[str]):
         if node.field is None:
             raise QueryError("You can not use placeholders here")
         raise QueryError(f"Unresolved placeholder: {{{node.field}}}")
+
+    def _render_placeholder_macro(self, node: ast.Call, clickhouse_name: str, using_positional_arguments: bool) -> str:
+        self._placeholder_macro_expansion_depth += 1
+        try:
+            if self._placeholder_macro_expansion_depth > MAX_PLACEHOLDER_MACRO_EXPANSION_DEPTH:
+                raise QueryError(
+                    f"Function '{node.name}' exceeded maximum placeholder macro depth of {MAX_PLACEHOLDER_MACRO_EXPANSION_DEPTH}."
+                )
+
+            if using_positional_arguments:
+                arg_arr = [self.visit(arg) for arg in node.args]
+                try:
+                    rendered = clickhouse_name.format(*arg_arr)
+                except (KeyError, IndexError) as e:
+                    raise QueryError(f"Invalid argument reference in function '{node.name}': {str(e)}")
+            else:
+                placeholder_count = clickhouse_name.count("{}")
+                if len(node.args) != placeholder_count:
+                    raise QueryError(
+                        f"Function '{node.name}' requires exactly {placeholder_count} argument{'s' if placeholder_count != 1 else ''}"
+                    )
+                rendered = clickhouse_name.format(*[self.visit(arg) for arg in node.args])
+
+            self._placeholder_macro_output_chars += len(rendered)
+            if self._placeholder_macro_output_chars > MAX_PLACEHOLDER_MACRO_OUTPUT_LENGTH:
+                raise QueryError(
+                    f"Function '{node.name}' exceeded maximum placeholder macro output size of {MAX_PLACEHOLDER_MACRO_OUTPUT_LENGTH} characters."
+                )
+
+            return rendered
+        finally:
+            self._placeholder_macro_expansion_depth -= 1
 
     def visit_alias(self, node: ast.Alias):
         # Skip hidden aliases completely.

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -3020,6 +3020,13 @@ class TestPrinter(BaseTest):
                 dialect="clickhouse",
             )
 
+    def test_date_part_macro_does_not_expand_exponentially(self):
+        sql = self._select("SELECT date_part('year', date_part('year', date_part('year', now())))")
+
+        assert "arrayMap((part, dt) -> multiIf" in sql
+        assert sql.count("now()") == 1
+        assert len(sql) < 3_000
+
     def test_fails_on_placeholder_macro_output_size_limit(self):
         large_string = "a" * 40_000
         query = parse_select(f"SELECT split_part('{large_string}', '.', 1)")

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -3007,6 +3007,27 @@ class TestPrinter(BaseTest):
                 dialect="clickhouse",
             )
 
+    def test_fails_on_placeholder_macro_expansion_depth_limit(self):
+        query = parse_select(
+            "SELECT date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', now()))))))))))"
+        )
+        with pytest.raises(QueryError, match="exceeded maximum placeholder macro depth"):
+            prepare_and_print_ast(
+                query,
+                HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+                dialect="clickhouse",
+            )
+
+    def test_fails_on_placeholder_macro_output_size_limit(self):
+        large_string = "a" * 40_000
+        query = parse_select(f"SELECT split_part('{large_string}', '.', 1)")
+        with pytest.raises(QueryError, match="exceeded maximum placeholder macro output size"):
+            prepare_and_print_ast(
+                query,
+                HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+                dialect="clickhouse",
+            )
+
     def test_team_id_guarding_events(self):
         sql = self._select(
             "SELECT event FROM events",

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -3027,16 +3027,6 @@ class TestPrinter(BaseTest):
         assert sql.count("now()") == 1
         assert len(sql) < 3_000
 
-    def test_fails_on_placeholder_macro_output_size_limit(self):
-        large_string = "a" * 40_000
-        query = parse_select(f"SELECT split_part('{large_string}', '.', 1)")
-        with pytest.raises(QueryError, match="exceeded maximum placeholder macro output size"):
-            prepare_and_print_ast(
-                query,
-                HogQLContext(team_id=self.team.pk, enable_select_queries=True),
-                dialect="clickhouse",
-            )
-
     def test_team_id_guarding_events(self):
         sql = self._select(
             "SELECT event FROM events",

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -3009,7 +3009,9 @@ class TestPrinter(BaseTest):
 
     def test_fails_on_placeholder_macro_expansion_depth_limit(self):
         query = parse_select(
-            "SELECT date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', now()))))))))))"
+            """
+            SELECT date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', date_part('year', now())))))))))
+            """
         )
         with pytest.raises(QueryError, match="exceeded maximum placeholder macro depth"):
             prepare_and_print_ast(

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -1833,6 +1833,56 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.10
   '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."queryable_folder",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."description",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.11
+  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -1851,7 +1901,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.11
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.12
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -1880,24 +1930,13 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.12
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.13
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
   WHERE ("posthog_sessionrecordingviewed"."team_id" = 99999
          AND "posthog_sessionrecordingviewed"."user_id" = 99999
          AND "posthog_sessionrecordingviewed"."session_id" IN ('session_many_ids'))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.13
-  '''
-  SELECT "posthog_sessionrecordingviewed"."session_id",
-         "posthog_user"."email"
-  FROM "posthog_sessionrecordingviewed"
-  INNER JOIN "posthog_user" ON ("posthog_sessionrecordingviewed"."user_id" = "posthog_user"."id")
-  WHERE ("posthog_sessionrecordingviewed"."session_id" IN ('session_many_ids')
-         AND "posthog_sessionrecordingviewed"."team_id" = 99999
-         AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.14
@@ -2256,6 +2295,19 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.8
   '''
+  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
+         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
+         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
+         "posthog_teamrevenueanalyticsconfig"."events",
+         "posthog_teamrevenueanalyticsconfig"."goals",
+         "posthog_teamrevenueanalyticsconfig"."base_currency"
+  FROM "posthog_teamrevenueanalyticsconfig"
+  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.9
+  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -2283,56 +2335,6 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.9
-  '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."queryable_folder",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."description",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_


### PR DESCRIPTION
## Problem

A query using `date_part` could fail if the expression was written in a nested/recursive way.

https://posthog.slack.com/archives/C0AE259HCVB/p1770858377724319

## Changes

- Fix the `date_part` and `split_part` functions to only use its inputs once (with the help of lambdas and array functions)
- Add max macro expansion depth limit.
- Quick fix: we expanded macros when printing out HogQL. There's no need for that.

## How did you test this code?

The query would've always failed, but where before it would timeout/stall, now it returns a proper error:

<img width="1140" height="770" alt="Screenshot 2026-02-12 at 15 13 38" src="https://github.com/user-attachments/assets/1fe192d1-a647-4cda-a9c3-758639b0a8d1" />


## Publish to changelog?

no