### PR TITLE
fix: dont fail on non-existent variables being passed to endpoint/run

### DIFF
--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -852,7 +852,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         if query_kind == "HogQLQuery":
             # HogQL: allowed variables are code_names from query["variables"]
             variables = query.get("variables", {})
-            return {v.get("code_name") for v in variables.values() if v.get("code_name")}
+            return {v.get("code_name") for v in variables.values() if v.get("code_name")} if variables else set()
 
         # Insight queries
         allowed: set[str] = set()


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
if the endpoint has been (wrongfully) created without a variable defined (we have a PR in review for not allowing this) - executing it will always fail with 500

## Changes
- don't fail with 500 but let it fail as it should

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- executed an endpoint locally that uses a variable but didn't send it in the create request

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no