### PR TITLE
fix: Keep ImpersonationNotice draggable position within window bounds

### DIFF
--- a/frontend/src/lib/components/DraggableWithSnapZones/DraggableWithSnapZones.tsx
+++ b/frontend/src/lib/components/DraggableWithSnapZones/DraggableWithSnapZones.tsx
@@ -307,7 +307,10 @@ export const DraggableWithSnapZones = forwardRef<DraggableWithSnapZonesRef, Drag
             const height = elementSize?.height ?? 0
 
             if (freePosition) {
-                return freePosition
+                return {
+                    x: Math.max(padding, Math.min(freePosition.x, windowSize.width - width - padding)),
+                    y: Math.max(padding, Math.min(freePosition.y, windowSize.height - height - padding)),
+                }
             }
 
             if (snapPosition) {


### PR DESCRIPTION
## Problem

Noticed a small bug - if you resize the window while position for the impersonation notice is not snapped/free, it can move off screen which is not ideal for a notice that should always be visible!

## Changes

Make sure the position is always kept to the window bounds. Has the added advantage of not allowing you to drag the notice off screen.

## How did you test this code?

Tested locally.