### PR TITLE
feat(llma): gate clusters tab on early-adopters flag

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -477,7 +477,8 @@ export function LLMAnalyticsScene(): JSX.Element {
 
     const availableItemsInSidebar = useMemo(() => {
         return [
-            featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB] ? (
+            featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB] ||
+            featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS] ? (
                 <Link to={urls.llmAnalyticsClusters()} onClick={() => toggleProduct('Clusters', true)}>
                     clusters
                 </Link>

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -794,7 +794,9 @@ const EventContent = React.memo(
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SUMMARIZATION] ||
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
 
-        const showClustersTab = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB]
+        const showClustersTab =
+            !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERS_TAB] ||
+            !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
 
         const showFeedbackTab = true
 


### PR DESCRIPTION
## Problem

The clusters tab is currently gated only by `llm-analytics-clusters-tab`. For the open beta rollout, we want to first give access to all early adopters via `llm-analytics-early-adopters` before rolling `llm-analytics-clusters-tab` to 100%.

## Changes

Add `llm-analytics-early-adopters` as an OR condition for showing the clusters tab in two places:

- **LLMAnalyticsScene.tsx** - sidebar "clusters" link
- **LLMAnalyticsTraceScene.tsx** - clusters tab in trace view

This follows the same pattern already used for sessions, discussions, summary, and text view.

The manifest `flag` field (controls apps menu/search visibility) remains on `llm-analytics-clusters-tab` only, matching how other early-adopter features work.

## How did you test this code?

Verified the pattern matches existing early-adopter gating for sessions, discussions, summary tab, and text view.

## Publish to changelog?

No