### PR TITLE
fix: apply skip person processing forcefully

### DIFF
--- a/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.test.ts
@@ -27,6 +27,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
 
         expect(result).toEqual(ok(input))
         expect(input.event.properties).toEqual({ defaultProp: 'defaultValue' })
+        expect(input.headers.force_disable_person_processing).toBe(false)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'valid-token-abc',
             expect.objectContaining({
@@ -35,7 +36,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
         )
     })
 
-    it('should set $process_person_profile to false if there is a restriction', async () => {
+    it('should set $process_person_profile to false and force_disable_person_processing to true if there is a restriction', async () => {
         const event = createTestPipelineEvent()
         const team = createTestTeam({ person_processing_opt_out: false })
         const headers = createTestEventHeaders({ token: 'restricted-token-def', distinct_id: 'restricted-user-456' })
@@ -48,6 +49,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
 
         expect(result).toEqual(ok(input))
         expect(input.event.properties?.$process_person_profile).toBe(false)
+        expect(input.headers.force_disable_person_processing).toBe(true)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'restricted-token-def',
             expect.objectContaining({
@@ -56,7 +58,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
         )
     })
 
-    it('should set $process_person_profile to false if team opted out of person processing', async () => {
+    it('should set $process_person_profile to false and force_disable_person_processing to true if team opted out of person processing', async () => {
         const event = createTestPipelineEvent()
         const team = createTestTeam({ person_processing_opt_out: true })
         const headers = createTestEventHeaders({ token: 'opt-out-token-ghi', distinct_id: 'opt-out-user-789' })
@@ -66,6 +68,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
 
         expect(result).toEqual(ok(input))
         expect(input.event.properties?.$process_person_profile).toBe(false)
+        expect(input.headers.force_disable_person_processing).toBe(true)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'opt-out-token-ghi',
             expect.objectContaining({
@@ -93,6 +96,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
             $set: { a: 1, b: 2 },
             $process_person_profile: false,
         })
+        expect(input.headers.force_disable_person_processing).toBe(true)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'preserve-token-jkl',
             expect.objectContaining({
@@ -121,7 +125,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
         )
     })
 
-    it('should set $process_person_profile to false when token is undefined and restriction is applied', async () => {
+    it('should set $process_person_profile to false and force_disable_person_processing to true when token is undefined and restriction is applied', async () => {
         const event = createTestPipelineEvent({
             properties: { customProp: 'customValue' },
         })
@@ -139,6 +143,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
             customProp: 'customValue',
             $process_person_profile: false,
         })
+        expect(input.headers.force_disable_person_processing).toBe(true)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             undefined,
             expect.objectContaining({
@@ -230,6 +235,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
 
         expect(result).toEqual(ok(input))
         expect(input.event.properties?.$process_person_profile).toBe(false)
+        expect(input.headers.force_disable_person_processing).toBe(true)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'valid-token-abc',
             expect.objectContaining({
@@ -256,6 +262,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
 
         expect(result).toEqual(ok(input))
         expect(input.event.properties?.$process_person_profile).toBe(false)
+        expect(input.headers.force_disable_person_processing).toBe(true)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'valid-token-abc',
             expect.objectContaining({
@@ -282,6 +289,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
 
         expect(result).toEqual(ok(input))
         expect(input.event.properties?.$process_person_profile).toBe(false)
+        expect(input.headers.force_disable_person_processing).toBe(true)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'valid-token-abc',
             expect.objectContaining({

--- a/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.test.ts
@@ -58,7 +58,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
         )
     })
 
-    it('should set $process_person_profile to false and force_disable_person_processing to true if team opted out of person processing', async () => {
+    it('should set $process_person_profile to false but not force_disable_person_processing if team opted out of person processing', async () => {
         const event = createTestPipelineEvent()
         const team = createTestTeam({ person_processing_opt_out: true })
         const headers = createTestEventHeaders({ token: 'opt-out-token-ghi', distinct_id: 'opt-out-user-789' })
@@ -68,7 +68,7 @@ describe('createApplyPersonProcessingRestrictionsStep', () => {
 
         expect(result).toEqual(ok(input))
         expect(input.event.properties?.$process_person_profile).toBe(false)
-        expect(input.headers.force_disable_person_processing).toBe(true)
+        expect(input.headers.force_disable_person_processing).toBe(false)
         expect(eventIngestionRestrictionManager.getAppliedRestrictions).toHaveBeenCalledWith(
             'opt-out-token-ghi',
             expect.objectContaining({

--- a/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.ts
+++ b/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.ts
@@ -5,12 +5,14 @@ import { ProcessingStep } from '../pipelines/steps'
 
 function applyPersonProcessingRestrictions(
     event: PipelineEvent,
+    headers: EventHeaders,
     restrictions: ReadonlySet<RestrictionType>,
     team_person_processing_opt_out: boolean
 ): void {
     const shouldSkipPerson = restrictions.has(RestrictionType.SKIP_PERSON_PROCESSING) || team_person_processing_opt_out
 
     if (shouldSkipPerson) {
+        headers.force_disable_person_processing = true
         if (event.properties) {
             event.properties.$process_person_profile = false
         } else {
@@ -26,7 +28,7 @@ export function createApplyPersonProcessingRestrictionsStep<
         const { event, team, headers } = input
 
         const restrictions = eventIngestionRestrictionManager.getAppliedRestrictions(headers.token, headers)
-        applyPersonProcessingRestrictions(event, restrictions, team.person_processing_opt_out ?? false)
+        applyPersonProcessingRestrictions(event, headers, restrictions, team.person_processing_opt_out ?? false)
         return Promise.resolve(ok(input))
     }
 }

--- a/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.ts
+++ b/nodejs/src/ingestion/event-preprocessing/apply-person-processing-restrictions.ts
@@ -9,15 +9,19 @@ function applyPersonProcessingRestrictions(
     restrictions: ReadonlySet<RestrictionType>,
     team_person_processing_opt_out: boolean
 ): void {
-    const shouldSkipPerson = restrictions.has(RestrictionType.SKIP_PERSON_PROCESSING) || team_person_processing_opt_out
+    const hasSkipRestriction = restrictions.has(RestrictionType.SKIP_PERSON_PROCESSING)
+    const shouldSkipPerson = hasSkipRestriction || team_person_processing_opt_out
 
     if (shouldSkipPerson) {
-        headers.force_disable_person_processing = true
         if (event.properties) {
             event.properties.$process_person_profile = false
         } else {
             event.properties = { $process_person_profile: false }
         }
+    }
+
+    if (hasSkipRestriction) {
+        headers.force_disable_person_processing = true
     }
 }
 


### PR DESCRIPTION
## Problem

We don't fully enforce skip person processing restrictions in ingestion, allowing the pipeline to force person upgrade.

## Changes

Skips the person processing on restrictions by setting the force `force_disable_person_processing` header.

## How did you test this code?

- Updated the tests
- Regression tests