### PR TITLE
chore: Remove hardoced service label

### DIFF
--- a/rust/kafka-deduplicator/src/metrics.rs
+++ b/rust/kafka-deduplicator/src/metrics.rs
@@ -149,15 +149,9 @@ mod tests {
 
     #[test]
     fn test_metrics_helper_with_additional_label() {
-        let helper = MetricsHelper::with_partition("test_topic", 0)
-            .with_label("service", "kafka-deduplicator")
-            .with_label("version", "1.0.0");
+        let helper = MetricsHelper::with_partition("test_topic", 0).with_label("version", "1.0.0");
 
-        assert_eq!(helper.baseline_labels.len(), 2);
-        assert_eq!(
-            helper.baseline_labels.get("service"),
-            Some(&"kafka-deduplicator".to_string())
-        );
+        assert_eq!(helper.baseline_labels.len(), 1);
         assert_eq!(
             helper.baseline_labels.get("version"),
             Some(&"1.0.0".to_string())

--- a/rust/kafka-deduplicator/src/pipelines/ingestion_events/processor.rs
+++ b/rust/kafka-deduplicator/src/pipelines/ingestion_events/processor.rs
@@ -84,8 +84,7 @@ impl DuplicateEventProducerWrapper {
             )
             .await;
 
-        let metrics = MetricsHelper::with_partition(&partition_topic, partition_number)
-            .with_label("service", "kafka-deduplicator");
+        let metrics = MetricsHelper::with_partition(&partition_topic, partition_number);
 
         match delivery_result {
             Ok(_) => {
@@ -290,8 +289,7 @@ impl IngestionEventsBatchProcessor {
 
         // Create metrics helper for similarity metrics
         let metrics =
-            MetricsHelper::with_partition(partition.topic(), partition.partition_number())
-                .with_label("service", "kafka-deduplicator");
+            MetricsHelper::with_partition(partition.topic(), partition.partition_number());
 
         // Process results: emit metrics and collect publish futures
         // We batch all Kafka sends and execute them concurrently for better throughput

--- a/rust/kafka-deduplicator/src/pipelines/processor.rs
+++ b/rust/kafka-deduplicator/src/pipelines/processor.rs
@@ -144,7 +144,6 @@ pub fn emit_deduplication_result_metrics(
     labels: DeduplicationResultLabels,
 ) {
     let mut counter = MetricsHelper::with_partition(topic, partition)
-        .with_label("service", "kafka-deduplicator")
         .with_label("pipeline", pipeline)
         .counter(DEDUPLICATION_RESULT_COUNTER)
         .with_label("result_type", labels.result_type);

--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -39,8 +39,7 @@ impl DeduplicationStore {
 
     pub fn new(config: DeduplicationStoreConfig, topic: String, partition: i32) -> Result<Self> {
         // Create metrics helper for the RocksDB store
-        let metrics = MetricsHelper::with_partition(&topic, partition)
-            .with_label("service", "kafka-deduplicator");
+        let metrics = MetricsHelper::with_partition(&topic, partition);
 
         let cf_descriptors = Self::get_cf_descriptors();
         let store = RocksDbStore::new(&config.path, cf_descriptors, metrics)?;

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -144,7 +144,7 @@ impl StoreManager {
         store_config: DeduplicationStoreConfig,
         rebalance_tracker: Arc<RebalanceTracker>,
     ) -> Self {
-        let metrics = MetricsHelper::new().with_label("service", "kafka-deduplicator");
+        let metrics = MetricsHelper::new();
 
         Self {
             stores: DashMap::new(),


### PR DESCRIPTION
## Problem

Service labels are enriched by the OTEL collector, there's no point in hardcoding values

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
