### PR TITLE
fix(hogql): parse comparison value for date operators

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -398,10 +398,26 @@ def _expr_to_compare_op(
             left=expr,
             right=ast.Constant(value=_handle_bool_values(value, expr, property, team)),
         )
-    elif operator == PropertyOperator.LT or operator == PropertyOperator.IS_DATE_BEFORE:
+    elif operator == PropertyOperator.LT:
         return ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=expr, right=ast.Constant(value=value))
-    elif operator == PropertyOperator.GT or operator == PropertyOperator.IS_DATE_AFTER:
+    elif operator == PropertyOperator.GT:
         return ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=expr, right=ast.Constant(value=value))
+    elif operator == PropertyOperator.IS_DATE_BEFORE:
+        # Only parse the value - the PropertySwapper handles typed DateTime properties.
+        # For untyped string properties, ClickHouse will do implicit conversion.
+        return ast.CompareOperation(
+            op=ast.CompareOperationOp.Lt,
+            left=expr,
+            right=ast.Call(name="toDateTime", args=[ast.Constant(value=value)]),
+        )
+    elif operator == PropertyOperator.IS_DATE_AFTER:
+        # Only parse the value - the PropertySwapper handles typed DateTime properties.
+        # For untyped string properties, ClickHouse will do implicit conversion.
+        return ast.CompareOperation(
+            op=ast.CompareOperationOp.Gt,
+            left=expr,
+            right=ast.Call(name="toDateTime", args=[ast.Constant(value=value)]),
+        )
     elif operator == PropertyOperator.LTE or operator == PropertyOperator.MAX:
         return ast.CompareOperation(op=ast.CompareOperationOp.LtEq, left=expr, right=ast.Constant(value=value))
     elif operator == PropertyOperator.GTE or operator == PropertyOperator.MIN:


### PR DESCRIPTION
## Summary

Fixes the `is_date_after` and `is_date_before` HogQL operators to correctly handle ISO 8601 datetime strings like `"2026-02-10T14:15:00Z"`.

**Problem**: Cohort queries with date property filters were failing with:
```
Cannot convert string '2026-02-10T14:15:00Z' to type DateTime64(6, 'UTC')
```

**Solution**: Parse the comparison value with `toDateTime()`. The property expression is left unchanged because:
- The `PropertySwapper` already handles typed DateTime properties
- For untyped string properties, ClickHouse does implicit conversion

## Changes

- `posthog/hogql/property.py` - Added `toDateTime()` wrapper for the comparison value in `IS_DATE_BEFORE` and `IS_DATE_AFTER` operators
- `posthog/hogql/test/test_property.py` - Added regression test

## Test plan

- [x] Unit tests pass (53 property tests)
- [x] Manually verified cohort recalculation works with ISO 8601 datetime strings

Fixes Zendesk #50438