### PR TITLE
fix(llma): cast generation UUIDs to strings for embedding lookup

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/data.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/data.py
@@ -153,7 +153,7 @@ def fetch_generation_ids_for_traces(
         )
 
     rows = result.results or []
-    return [row[0] for row in rows if row[0]]
+    return [str(row[0]) for row in rows if row[0]]
 
 
 def fetch_item_embeddings_for_clustering(


### PR DESCRIPTION
## Problem

Generation-level clustering silently returns 0 items when `trace_filters` are applied. The `fetch_generation_ids_for_traces` function returns UUID objects from HogQL's `events.uuid` column, but the `document_embeddings` table stores `document_id` as strings. The type mismatch causes the `IN` clause to match nothing.

## Changes

Cast UUID objects to strings in `fetch_generation_ids_for_traces` return value so they match the string `document_id` in the embeddings table.

One-line fix in `posthog/temporal/llm_analytics/trace_clustering/data.py`.

## How did you test this code?

Tested locally end-to-end: sent generation events, ran summarization coordinator to create embeddings, then ran clustering coordinator with `$ai_provider = openai` filter. Before fix: 0 items. After fix: 30 items analyzed, 2 clusters generated.

## Publish to changelog?

No