### PR TITLE
fix: show correct tooltip when no recording exists for a person

### DIFF
--- a/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
+++ b/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
@@ -154,7 +154,9 @@ export const recordingDisabledReason = (
     recordingStatus: string | undefined,
     hasRecording?: boolean
 ): JSX.Element | string | null => {
-    if (!sessionId) {
+    if (!sessionId && hasRecording === false) {
+        return 'No recording for this event'
+    } else if (!sessionId) {
         return (
             <>
                 No session ID associated with this event.{' '}


### PR DESCRIPTION
## Problem

When no session recording exists for a user, the PersonsModal shows the misleading tooltip "No session ID associated with this event" instead of "No recording for this event," because the ViewRecordingButton receives sessionId from matchedRecordings rather than from event properties.

https://posthoghelp.zendesk.com/agent/tickets/49206 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/52481) 

## Changes

Added another check in recordingDisabledReason so that when `!sessionId && hasRecording === false`, show "No recording for this event" instead of the incorrect "No session ID" message.

## How did you test this code?

typescript passes 

## Publish to changelog?
no 