### PR TITLE
fix(settings): deduplicate web vitals settings in environment view

### DIFF
--- a/frontend/src/scenes/settings/settingsLogic.ts
+++ b/frontend/src/scenes/settings/settingsLogic.ts
@@ -273,9 +273,18 @@ export const settingsLogic = kea<settingsLogicType>([
                 if (selectedSectionId) {
                     settings = sections.find((x) => x.id === selectedSectionId)?.settings || []
                 } else {
+                    const seen = new Set<string>()
                     settings = sections
                         .filter((section) => section.level === selectedLevel)
-                        .reduce((acc, section) => acc.concat(section.settings), [] as Setting[])
+                        .reduce((acc, section) => {
+                            for (const setting of section.settings) {
+                                if (!seen.has(setting.id)) {
+                                    seen.add(setting.id)
+                                    acc.push(setting)
+                                }
+                            }
+                            return acc
+                        }, [] as Setting[])
                 }
 
                 return settings.filter((x) => {


### PR DESCRIPTION
## Problem

We are seeing multiple web vitals settings.

<img width="1822" height="1722" alt="image" src="https://github.com/user-attachments/assets/ae69bbee-1026-4758-b75c-bbd017fab59b" />


## Changes

Deduplicate settings by `id` in `settingsLogic.ts` when concatenating settings from multiple sections. The first occurrence is kept, subsequent duplicates are skipped using a `Set`.

This preserves the intended behavior from #47507 (web vitals accessible from each section individually) while fixing the triplication in the combined view.

## How did you test this code?

Manual testing — navigated to Environment settings and verified web vitals only appears once.
<img width="1314" height="701" alt="Screenshot 2026-02-12 at 12 14 50 PM" src="https://github.com/user-attachments/assets/fe24921a-2846-44d1-bbe4-f012d86c71df" />
<img width="1312" height="602" alt="Screenshot 2026-02-12 at 12 14 58 PM" src="https://github.com/user-attachments/assets/f2c137f9-af51-486a-856a-89e341ea12a3" />
<img width="1309" height="627" alt="Screenshot 2026-02-12 at 12 15 09 PM" src="https://github.com/user-attachments/assets/e843c11f-2394-48ba-8ecc-a1c762891d7b" />


## Publish to changelog?

No