### PR TITLE
fix(insights): Stop long breakdown name overflowing

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.scss
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.scss
@@ -2,6 +2,7 @@
     display: inline-flex;
     gap: 0.125rem;
     align-items: center;
+    max-width: 100%;
     height: 2.25rem;
     padding: 0.5rem 0.75rem;
     font-size: 0.875rem;

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -59,7 +59,7 @@ export function EditableBreakdownTag({
                 taxonomicType={taxonomicBreakdownType}
             >
                 {!isMultipleBreakdownsEnabled || isHistogramable || isNormalizeable ? (
-                    <div>
+                    <div className="max-w-full">
                         {/* :TRICKY: we don't want the close button to be active when the edit popover is open.
                          * Therefore we're wrapping the lemon tag a context provider to override the parent context. */}
                         <PopoverReferenceContext.Provider value={null}>
@@ -83,7 +83,7 @@ export function EditableBreakdownTag({
                         </PopoverReferenceContext.Provider>
                     </div>
                 ) : (
-                    <div>
+                    <div className="max-w-full">
                         {/* If multiple breakdowns are enabled and it's not a numeric or URL property, enable the delete button */}
                         <BreakdownTag
                             breakdown={breakdown}
@@ -151,6 +151,7 @@ export function BreakdownTag({
                 'BreakdownTag--clickable': clickable,
             })}
             type={ButtonComponent === 'button' ? 'button' : undefined}
+            title={String(propertyName)}
             onClick={onClick}
         >
             {breakdownType === 'hogql' ? (


### PR DESCRIPTION
## Problem

Breakdown overflows with a long name
<img width="679" height="164" alt="Screenshot 2026-02-12 at 16 08 02" src="https://github.com/user-attachments/assets/85e60339-778f-4ed9-8825-479f39577000" />

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Dont overflow container:
<img width="522" height="257" alt="Screenshot 2026-02-12 at 16 01 57" src="https://github.com/user-attachments/assets/21050e64-bebd-44e1-b871-d0cccb899338" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Hard coded a long flag name in, saw it was fixed!
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
