### PR TITLE
feat: Allow bypass person processing in batch import worker

### DIFF
--- a/rust/batch-import-worker/src/config.rs
+++ b/rust/batch-import-worker/src/config.rs
@@ -74,6 +74,10 @@ pub struct Config {
     pub group_memory_cache_capacity: u64,
     #[envconfig(from = "GROUP_MEMORY_CACHE_TTL_SECONDS", default = "3600")]
     pub group_memory_cache_ttl_seconds: u64,
+
+    // Force disable person processing for specific token:distinct_id pairs
+    #[envconfig(from = "FORCE_DISABLE_PERSON_PROCESSING", default = "")]
+    pub force_disable_person_processing: String,
 }
 
 impl Config {

--- a/rust/batch-import-worker/src/context.rs
+++ b/rust/batch-import-worker/src/context.rs
@@ -8,6 +8,7 @@ use tracing::info;
 
 use crate::cache::{GroupCache, IdentifyCache, MemoryGroupCache, MemoryIdentifyCache};
 use crate::config::Config;
+use crate::person_processing_filter::PersonProcessingFilter;
 
 pub struct AppContext {
     pub config: Config,
@@ -18,6 +19,7 @@ pub struct AppContext {
     pub worker_liveness: Arc<HealthHandle>,
     pub identify_cache: Arc<dyn IdentifyCache>,
     pub group_cache: Arc<dyn GroupCache>,
+    pub person_processing_filter: PersonProcessingFilter,
 }
 
 impl AppContext {
@@ -53,6 +55,9 @@ impl AppContext {
             Duration::from_secs(config.group_memory_cache_ttl_seconds),
         ));
 
+        let person_processing_filter =
+            PersonProcessingFilter::new(&config.force_disable_person_processing);
+
         let ctx = Self {
             config: config.clone(),
             db,
@@ -66,6 +71,7 @@ impl AppContext {
             worker_liveness: liveness,
             identify_cache,
             group_cache,
+            person_processing_filter,
         };
 
         Ok(ctx)

--- a/rust/batch-import-worker/src/emit/kafka.rs
+++ b/rust/batch-import-worker/src/emit/kafka.rs
@@ -16,7 +16,10 @@ use common_types::InternallyCapturedEvent;
 use rdkafka::types::RDKafkaErrorCode;
 use tracing::{error, info};
 
-use crate::{context::AppContext, job::config::KafkaEmitterConfig};
+use crate::{
+    context::AppContext, job::config::KafkaEmitterConfig,
+    person_processing_filter::PersonProcessingFilter,
+};
 
 use super::{Emitter, Transaction};
 
@@ -24,6 +27,7 @@ pub struct KafkaEmitter {
     producer: TransactionalProducer,
     topic: String,
     send_rate: u64, // Messages sent per second
+    person_processing_filter: PersonProcessingFilter,
 }
 
 pub struct KafkaEmitterTransaction<'a> {
@@ -32,6 +36,7 @@ pub struct KafkaEmitterTransaction<'a> {
     send_rate: u64,
     start: Instant,
     count: AtomicUsize,
+    person_processing_filter: &'a PersonProcessingFilter,
 }
 
 impl KafkaEmitter {
@@ -50,6 +55,7 @@ impl KafkaEmitter {
             producer,
             topic: emitter_config.topic,
             send_rate: emitter_config.send_rate,
+            person_processing_filter: context.person_processing_filter.clone(),
         })
     }
 }
@@ -64,6 +70,7 @@ impl Emitter for KafkaEmitter {
             topic: &self.topic,
             send_rate: self.send_rate,
             count: AtomicUsize::new(0),
+            person_processing_filter: &self.person_processing_filter,
         }))
     }
 }
@@ -75,8 +82,28 @@ impl<'a> Transaction<'a> for KafkaEmitterTransaction<'a> {
             .inner
             .send_keyed_iter_to_kafka_with_headers(
                 self.topic,
-                |e| Some(e.inner.key()),
-                |e| Some(e.inner.to_headers().into()),
+                |e| {
+                    // If person processing should be disabled, send without a key
+                    if self
+                        .person_processing_filter
+                        .should_disable_person_processing(&e.inner.token, &e.inner.distinct_id)
+                    {
+                        None
+                    } else {
+                        Some(e.inner.key())
+                    }
+                },
+                |e| {
+                    let mut headers = e.inner.to_headers();
+                    // Set force_disable_person_processing header if needed
+                    if self
+                        .person_processing_filter
+                        .should_disable_person_processing(&e.inner.token, &e.inner.distinct_id)
+                    {
+                        headers.set_force_disable_person_processing(true);
+                    }
+                    Some(headers.into())
+                },
                 data.iter(),
             )
             .await

--- a/rust/batch-import-worker/src/emit/kafka.rs
+++ b/rust/batch-import-worker/src/emit/kafka.rs
@@ -78,9 +78,7 @@ impl Emitter for KafkaEmitter {
 #[async_trait]
 impl<'a> Transaction<'a> for KafkaEmitterTransaction<'a> {
     async fn emit(&self, data: &[InternallyCapturedEvent]) -> Result<(), Error> {
-        let iter = data
-            .iter()
-            .map(|e| (e, self.disable_person_processing(e)));
+        let iter = data.iter().map(|e| (e, self.disable_person_processing(e)));
 
         for (idx, result) in self
             .inner

--- a/rust/batch-import-worker/src/lib.rs
+++ b/rust/batch-import-worker/src/lib.rs
@@ -17,6 +17,7 @@ pub mod extractor;
 pub mod job;
 pub mod metrics;
 pub mod parse;
+pub mod person_processing_filter;
 pub mod source;
 
 // During job init, we can hang for a long time initialising sinks or sources, so we kick off a task to

--- a/rust/batch-import-worker/src/person_processing_filter.rs
+++ b/rust/batch-import-worker/src/person_processing_filter.rs
@@ -1,0 +1,87 @@
+use std::collections::HashSet;
+
+/// Handles logic for determining if person processing should be disabled for specific token:distinct_id pairs
+#[derive(Debug, Clone)]
+pub struct PersonProcessingFilter {
+    // Set of "token:distinct_id" pairs that should have person processing disabled
+    disabled_pairs: HashSet<String>,
+}
+
+impl PersonProcessingFilter {
+    /// Create a new filter from a comma-separated string of "token:distinct_id" pairs
+    pub fn new(config_string: &str) -> Self {
+        let disabled_pairs = config_string
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+
+        Self { disabled_pairs }
+    }
+
+    /// Check if person processing should be disabled for the given token and distinct_id
+    pub fn should_disable_person_processing(&self, token: &str, distinct_id: &str) -> bool {
+        let pair = format!("{}:{}", token, distinct_id);
+        self.disabled_pairs.contains(&pair)
+    }
+
+    /// Returns true if the filter is empty (no pairs configured)
+    pub fn is_empty(&self) -> bool {
+        self.disabled_pairs.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_config() {
+        let filter = PersonProcessingFilter::new("");
+        assert!(filter.is_empty());
+        assert!(!filter.should_disable_person_processing("token1", "user1"));
+    }
+
+    #[test]
+    fn test_single_pair() {
+        let filter = PersonProcessingFilter::new("token1:user1");
+        assert!(!filter.is_empty());
+        assert!(filter.should_disable_person_processing("token1", "user1"));
+        assert!(!filter.should_disable_person_processing("token1", "user2"));
+        assert!(!filter.should_disable_person_processing("token2", "user1"));
+    }
+
+    #[test]
+    fn test_multiple_pairs() {
+        let filter = PersonProcessingFilter::new("token1:user1,token2:user2,token3:user3");
+        assert!(filter.should_disable_person_processing("token1", "user1"));
+        assert!(filter.should_disable_person_processing("token2", "user2"));
+        assert!(filter.should_disable_person_processing("token3", "user3"));
+        assert!(!filter.should_disable_person_processing("token1", "user2"));
+        assert!(!filter.should_disable_person_processing("token4", "user4"));
+    }
+
+    #[test]
+    fn test_whitespace_handling() {
+        let filter = PersonProcessingFilter::new("token1:user1 , token2:user2 , token3:user3");
+        assert!(filter.should_disable_person_processing("token1", "user1"));
+        assert!(filter.should_disable_person_processing("token2", "user2"));
+        assert!(filter.should_disable_person_processing("token3", "user3"));
+    }
+
+    #[test]
+    fn test_empty_elements() {
+        let filter = PersonProcessingFilter::new("token1:user1,,,token2:user2");
+        assert!(filter.should_disable_person_processing("token1", "user1"));
+        assert!(filter.should_disable_person_processing("token2", "user2"));
+        assert!(!filter.should_disable_person_processing("", ""));
+    }
+
+    #[test]
+    fn test_distinct_id_with_special_characters() {
+        let filter = PersonProcessingFilter::new("token1:user@example.com");
+        assert!(filter.should_disable_person_processing("token1", "user@example.com"));
+        assert!(!filter.should_disable_person_processing("token1", "user"));
+    }
+}

--- a/rust/batch-import-worker/tests/person_processing_kafka_integration_test.rs
+++ b/rust/batch-import-worker/tests/person_processing_kafka_integration_test.rs
@@ -1,0 +1,296 @@
+//! Integration test for person processing filter with Kafka emission
+//!
+//! Tests that when FORCE_DISABLE_PERSON_PROCESSING env var is set,
+//! events matching token:distinct_id pairs are sent to Kafka without a key
+//! and with force_disable_person_processing header set to true.
+//!
+//! Requires Kafka running at localhost:9092. Skips if Kafka is unreachable.
+
+use anyhow::Result;
+use batch_import_worker::{
+    config::Config,
+    context::AppContext,
+    emit::{kafka::KafkaEmitter, Emitter},
+    job::config::KafkaEmitterConfig,
+};
+use common_types::{CapturedEvent, CapturedEventHeaders, InternallyCapturedEvent};
+use envconfig::Envconfig;
+use rdkafka::{
+    admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
+    config::ClientConfig,
+    consumer::{Consumer, StreamConsumer},
+    message::Message,
+};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use tokio::sync::Mutex as TokioMutex;
+use uuid::Uuid;
+
+const KAFKA_BROKERS: &str = "localhost:9092";
+
+// Global mutex to serialize Kafka integration tests
+static KAFKA_TEST_MUTEX: OnceLock<TokioMutex<()>> = OnceLock::new();
+
+/// Helper to create Kafka topics before tests
+async fn create_kafka_topic(topic: &str) -> Result<()> {
+    let admin_client: AdminClient<_> = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .create()?;
+
+    let new_topic = NewTopic::new(topic, 1, TopicReplication::Fixed(1));
+    let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(10)));
+
+    match admin_client.create_topics(&[new_topic], &opts).await {
+        Ok(results) => {
+            for result in results {
+                match result {
+                    Ok(topic) => println!("Created topic: {topic}"),
+                    Err((topic, error)) => {
+                        println!("Topic {topic} result: {error:?}");
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            println!("Failed to create topic: {e:?}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Create test events
+fn create_test_events() -> Vec<InternallyCapturedEvent> {
+    vec![
+        InternallyCapturedEvent {
+            inner: CapturedEvent {
+                uuid: Uuid::new_v4(),
+                distinct_id: "user1".to_string(),
+                session_id: None,
+                ip: "127.0.0.1".to_string(),
+                data: r#"{"event":"test_event","properties":{}}"#.to_string(),
+                now: "2024-01-01T00:00:00Z".to_string(),
+                sent_at: None,
+                token: "token1".to_string(),
+                event: "test_event".to_string(),
+                timestamp: chrono::Utc::now(),
+                is_cookieless_mode: false,
+                historical_migration: false,
+            },
+            team_id: 1,
+        },
+        InternallyCapturedEvent {
+            inner: CapturedEvent {
+                uuid: Uuid::new_v4(),
+                distinct_id: "user2".to_string(),
+                session_id: None,
+                ip: "127.0.0.1".to_string(),
+                data: r#"{"event":"test_event","properties":{}}"#.to_string(),
+                now: "2024-01-01T00:00:00Z".to_string(),
+                sent_at: None,
+                token: "token1".to_string(),
+                event: "test_event".to_string(),
+                timestamp: chrono::Utc::now(),
+                is_cookieless_mode: false,
+                historical_migration: false,
+            },
+            team_id: 1,
+        },
+        InternallyCapturedEvent {
+            inner: CapturedEvent {
+                uuid: Uuid::new_v4(),
+                distinct_id: "user3".to_string(),
+                session_id: None,
+                ip: "127.0.0.1".to_string(),
+                data: r#"{"event":"test_event","properties":{}}"#.to_string(),
+                now: "2024-01-01T00:00:00Z".to_string(),
+                sent_at: None,
+                token: "token2".to_string(),
+                event: "test_event".to_string(),
+                timestamp: chrono::Utc::now(),
+                is_cookieless_mode: false,
+                historical_migration: false,
+            },
+            team_id: 1,
+        },
+    ]
+}
+
+/// Consume messages from Kafka topic and return them with their keys and headers
+async fn consume_messages_with_metadata(
+    topic: &str,
+    expected_count: usize,
+    timeout: Duration,
+) -> Result<Vec<(Option<String>, CapturedEventHeaders)>> {
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .set("group.id", format!("test-{}", Uuid::new_v4()))
+        .set("auto.offset.reset", "earliest")
+        .set("enable.auto.commit", "false")
+        .create()?;
+
+    consumer.subscribe(&[topic])?;
+
+    let mut messages = Vec::new();
+    let start = std::time::Instant::now();
+
+    while start.elapsed() < timeout && messages.len() < expected_count {
+        match tokio::time::timeout(Duration::from_millis(100), consumer.recv()).await {
+            Ok(Ok(msg)) => {
+                let key = msg.key().map(|k| String::from_utf8_lossy(k).to_string());
+                let headers = msg
+                    .headers()
+                    .map(|h| CapturedEventHeaders::from(h.detach()));
+
+                if let Some(headers) = headers {
+                    messages.push((key, headers));
+                }
+            }
+            Ok(Err(e)) => {
+                if !matches!(e, rdkafka::error::KafkaError::NoMessageReceived) {
+                    println!("Error consuming message: {e:?}");
+                }
+            }
+            Err(_) => {}
+        }
+    }
+
+    Ok(messages)
+}
+
+#[tokio::test]
+async fn test_person_processing_filter_with_kafka() -> Result<()> {
+    let _guard = KAFKA_TEST_MUTEX
+        .get_or_init(|| TokioMutex::new(()))
+        .lock()
+        .await;
+
+    let topic = format!("test-person-processing-{}", Uuid::new_v4());
+    create_kafka_topic(&topic).await?;
+
+    // Create a mock config with the person processing filter
+    std::env::set_var(
+        "FORCE_DISABLE_PERSON_PROCESSING",
+        "token1:user1,token2:user3",
+    );
+    std::env::set_var("KAFKA_HOSTS", KAFKA_BROKERS);
+    std::env::set_var(
+        "DATABASE_URL",
+        "postgres://posthog:posthog@localhost:5432/posthog",
+    );
+
+    let config = Config::init_from_env()?;
+    let context = Arc::new(AppContext::new(&config).await?);
+
+    // Create KafkaEmitter
+    let emitter_config = KafkaEmitterConfig {
+        topic: topic.clone(),
+        send_rate: 1000,
+        transaction_timeout_seconds: 60,
+    };
+
+    let mut emitter = KafkaEmitter::new(emitter_config, "test-txn-id", context).await?;
+
+    // Emit test events
+    let events = create_test_events();
+    let txn = emitter.begin_write().await?;
+    txn.emit(&events).await?;
+    txn.commit_write().await?;
+
+    // Consume messages and verify
+    let messages = consume_messages_with_metadata(&topic, 3, Duration::from_secs(10)).await?;
+
+    assert_eq!(messages.len(), 3, "Should have received 3 messages");
+
+    // Event 1: token1:user1 should have no key and force_disable_person_processing=true
+    let (key1, headers1) = &messages[0];
+    assert!(key1.is_none(), "First event should have no key");
+    assert_eq!(
+        headers1.force_disable_person_processing,
+        Some(true),
+        "First event should have force_disable_person_processing=true"
+    );
+    assert_eq!(headers1.token, Some("token1".to_string()));
+    assert_eq!(headers1.distinct_id, Some("user1".to_string()));
+
+    // Event 2: token1:user2 should have a key and no force_disable_person_processing
+    let (key2, headers2) = &messages[1];
+    assert!(
+        key2.is_some(),
+        "Second event should have a key (not in filter)"
+    );
+    assert_eq!(
+        headers2.force_disable_person_processing, None,
+        "Second event should not have force_disable_person_processing header"
+    );
+    assert_eq!(headers2.token, Some("token1".to_string()));
+    assert_eq!(headers2.distinct_id, Some("user2".to_string()));
+
+    // Event 3: token2:user3 should have no key and force_disable_person_processing=true
+    let (key3, headers3) = &messages[2];
+    assert!(key3.is_none(), "Third event should have no key");
+    assert_eq!(
+        headers3.force_disable_person_processing,
+        Some(true),
+        "Third event should have force_disable_person_processing=true"
+    );
+    assert_eq!(headers3.token, Some("token2".to_string()));
+    assert_eq!(headers3.distinct_id, Some("user3".to_string()));
+
+    // Clean up env vars
+    std::env::remove_var("FORCE_DISABLE_PERSON_PROCESSING");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_empty_person_processing_filter() -> Result<()> {
+    let _guard = KAFKA_TEST_MUTEX
+        .get_or_init(|| TokioMutex::new(()))
+        .lock()
+        .await;
+
+    let topic = format!("test-person-processing-empty-{}", Uuid::new_v4());
+    create_kafka_topic(&topic).await?;
+
+    // Empty filter - all events should have keys
+    std::env::set_var("FORCE_DISABLE_PERSON_PROCESSING", "");
+    std::env::set_var("KAFKA_HOSTS", KAFKA_BROKERS);
+    std::env::set_var(
+        "DATABASE_URL",
+        "postgres://posthog:posthog@localhost:5432/posthog",
+    );
+
+    let config = Config::init_from_env()?;
+    let context = Arc::new(AppContext::new(&config).await?);
+
+    let emitter_config = KafkaEmitterConfig {
+        topic: topic.clone(),
+        send_rate: 1000,
+        transaction_timeout_seconds: 60,
+    };
+
+    let mut emitter = KafkaEmitter::new(emitter_config, "test-txn-id-2", context).await?;
+
+    let events = create_test_events();
+    let txn = emitter.begin_write().await?;
+    txn.emit(&events).await?;
+    txn.commit_write().await?;
+
+    let messages = consume_messages_with_metadata(&topic, 3, Duration::from_secs(10)).await?;
+
+    assert_eq!(messages.len(), 3, "Should have received 3 messages");
+
+    // All events should have keys and no force_disable_person_processing header
+    for (key, headers) in messages {
+        assert!(key.is_some(), "All events should have keys");
+        assert_eq!(
+            headers.force_disable_person_processing, None,
+            "No events should have force_disable_person_processing header"
+        );
+    }
+
+    std::env::remove_var("FORCE_DISABLE_PERSON_PROCESSING");
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

We currently have a migration where users want to disable person processing for a user, this PR adds an environment variable that we can set to basically force messages to have the force disable person processing header set to `true` and randomly route messages to kafka

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
