### PR TITLE
fix(dev): Add git-lfs to Flox manifest

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -34,6 +34,8 @@ go = { pkg-path = "go", version = "1.24", pkg-group = "go" }
 golangci-lint = { pkg-path = "golangci-lint", pkg-group = "go" }
 air = { pkg-path = "air" }
 # CLI tools
+git = { pkg-path = "git" }
+git-lfs = { pkg-path = "git" }
 mprocs = { pkg-path = "mprocs" }
 util-linux = { pkg-path = "util-linux" } # flock
 cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }


### PR DESCRIPTION
## Problem

We not use git-lfs for a large test dataset in this repo. But it turns out git-lfs doesn't come installed with git.

## Changes

Adding git-lfs to Flox manifest.