### PR TITLE
feat(surveys): add type filter to surevys table

### DIFF
--- a/frontend/src/scenes/surveys/components/SurveysTable.tsx
+++ b/frontend/src/scenes/surveys/components/SurveysTable.tsx
@@ -27,7 +27,7 @@ import { isSurveyRunning } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
 
 import { ProductIntentContext } from '~/queries/schema/schema-general'
-import { AccessControlLevel, AccessControlResourceType, Survey } from '~/types'
+import { AccessControlLevel, AccessControlResourceType, Survey, SurveyType } from '~/types'
 
 export function SurveysTable(): JSX.Element {
     const {
@@ -87,6 +87,24 @@ export function SurveysTable(): JSX.Element {
                         {tab === SurveysTabs.Active && (
                             <>
                                 <span>
+                                    <b>Type</b>
+                                </span>
+                                <LemonSelect
+                                    dropdownMatchSelectWidth={false}
+                                    onChange={(type) => {
+                                        setSurveysFilters({ type })
+                                    }}
+                                    size="small"
+                                    options={[
+                                        { label: 'Any', value: 'any' },
+                                        { label: 'Popover', value: SurveyType.Popover },
+                                        { label: 'Widget', value: SurveyType.Widget },
+                                        { label: 'Hosted', value: SurveyType.ExternalSurvey },
+                                        { label: 'API', value: SurveyType.API },
+                                    ]}
+                                    value={filters.type}
+                                />
+                                <span className="ml-1">
                                     <b>Status</b>
                                 </span>
                                 <LemonSelect

--- a/frontend/src/scenes/surveys/surveysLogic.tsx
+++ b/frontend/src/scenes/surveys/surveysLogic.tsx
@@ -21,7 +21,7 @@ import { userLogic } from 'scenes/userLogic'
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { deleteFromTree } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
-import { ActivityScope, AvailableFeature, Breadcrumb, ProgressStatus, Survey } from '~/types'
+import { ActivityScope, AvailableFeature, Breadcrumb, ProgressStatus, Survey, SurveyType } from '~/types'
 
 import type { surveysLogicType } from './surveysLogicType'
 import { surveysSdkLogic } from './surveysSdkLogic'
@@ -50,6 +50,7 @@ function hasMorePages(surveys: any[], count: number): boolean {
 
 export interface SurveysFilters {
     status: string
+    type: SurveyType | 'any'
     created_by: null | number
     archived: boolean
 }
@@ -316,6 +317,7 @@ export const surveysLogic = kea<surveysLogicType>([
         filters: [
             {
                 archived: false,
+                type: 'any',
                 status: 'any',
                 created_by: null,
             } as Partial<SurveysFilters>,
@@ -421,9 +423,12 @@ export const surveysLogic = kea<surveysLogicType>([
                     }
                 }
 
-                const { status, created_by, archived } = filters
+                const { status, type, created_by, archived } = filters
                 if (status !== 'any') {
                     searchedSurveys = searchedSurveys.filter((survey: Survey) => getSurveyStatus(survey) === status)
+                }
+                if (type !== 'any') {
+                    searchedSurveys = searchedSurveys.filter((survey: Survey) => survey.type === type)
                 }
                 if (created_by) {
                     searchedSurveys = searchedSurveys.filter((survey: Survey) => survey.created_by?.id === created_by)


### PR DESCRIPTION
## Problem

i want to filter for all active popover surveys without using metabase 😛

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds 'type' filter to surveys table

risking getting cluttered here but i think this is still ok - if we add more, we can reconsider the filter button layout here

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->