### PR TITLE
fix(llma): refresh list data after creating prompts, datasets, and evaluations

### DIFF
--- a/products/llm_analytics/frontend/datasets/llmAnalyticsDatasetLogic.ts
+++ b/products/llm_analytics/frontend/datasets/llmAnalyticsDatasetLogic.ts
@@ -200,6 +200,7 @@ export const llmAnalyticsDatasetLogic = kea<llmAnalyticsDatasetLogicType>([
                             description: formValues.description,
                             metadata: coerceJsonToObject(formValues.metadata),
                         })
+                        llmAnalyticsDatasetsLogic.findMounted()?.actions.loadDatasets(false)
 
                         lemonToast.success('Dataset created successfully')
                         router.actions.replace(urls.llmAnalyticsDataset(savedDataset.id))

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -13,6 +13,7 @@ import { LLMProvider, LLMProviderKey, llmProviderKeysLogic } from '../settings/l
 import { queryEvaluationRuns } from '../utils'
 import { EVALUATION_SUMMARY_MAX_RUNS } from './constants'
 import type { llmEvaluationLogicType } from './llmEvaluationLogicType'
+import { llmEvaluationsLogic } from './llmEvaluationsLogic'
 import { EvaluationTemplateKey, defaultEvaluationTemplates } from './templates'
 import {
     EvaluationConditionSet,
@@ -425,6 +426,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 if (props.evaluationId === 'new') {
                     const response = await api.create(`/api/environments/${teamId}/evaluations/`, values.evaluation!)
                     actions.saveEvaluationSuccess(response)
+                    llmEvaluationsLogic.findMounted()?.actions.loadEvaluations()
                 } else {
                     const response = await api.update(
                         `/api/environments/${teamId}/evaluations/${props.evaluationId}/`,

--- a/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
+++ b/products/llm_analytics/frontend/prompts/llmPromptLogic.ts
@@ -114,6 +114,7 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                             name: formValues.name,
                             prompt: formValues.prompt,
                         })
+                        llmPromptsLogic.findMounted()?.actions.loadPrompts(false)
                         lemonToast.success('Prompt created successfully')
                         router.actions.replace(urls.llmAnalyticsPrompt(savedPrompt.name))
 


### PR DESCRIPTION
## Summary

- When creating a new prompt, dataset, or evaluation, the corresponding list view wasn't refreshing because the scene logics persist across internal navigation
- After a successful create, call `findMounted()?.actions.load*()` on the list logic to trigger a data refresh

## Test plan

- [ ] Create a new prompt, navigate back to prompts list — new prompt appears without manual refresh
- [ ] Create a new dataset, navigate back to datasets list — new dataset appears without manual refresh
- [ ] Create a new evaluation, navigate back to evaluations list — new evaluation appears without manual refresh