### PR TITLE
fix(llma): round floating point percentages in evaluations table

### DIFF
--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
@@ -117,7 +117,7 @@ function LLMAnalyticsEvaluationsContent(): JSX.Element {
                 <div className="flex flex-wrap gap-1">
                     {evaluation.conditions.map((condition) => (
                         <LemonTag key={condition.id} type="option">
-                            {condition.rollout_percentage}%
+                            {parseFloat(condition.rollout_percentage.toFixed(2))}%
                             {condition.properties.length > 0 &&
                                 ` when ${condition.properties.length} condition${condition.properties.length !== 1 ? 's' : ''}`}
                         </LemonTag>
@@ -147,7 +147,7 @@ function LLMAnalyticsEvaluationsContent(): JSX.Element {
                         <div className="text-sm">
                             {stats.runs_count} run{stats.runs_count !== 1 ? 's' : ''}
                         </div>
-                        <div className={`font-semibold ${passRateColor}`}>{stats.pass_rate}%</div>
+                        <div className={`font-semibold ${passRateColor}`}>{parseFloat(stats.pass_rate.toFixed(2))}%</div>
                     </div>
                 )
             },

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
@@ -147,7 +147,9 @@ function LLMAnalyticsEvaluationsContent(): JSX.Element {
                         <div className="text-sm">
                             {stats.runs_count} run{stats.runs_count !== 1 ? 's' : ''}
                         </div>
-                        <div className={`font-semibold ${passRateColor}`}>{parseFloat(stats.pass_rate.toFixed(2))}%</div>
+                        <div className={`font-semibold ${passRateColor}`}>
+                            {parseFloat(stats.pass_rate.toFixed(2))}%
+                        </div>
                     </div>
                 )
             },


### PR DESCRIPTION
## Summary

- Fix floating point precision errors in the evaluations table (e.g. `50.400000000000006%` → `50.4%`)
- Apply `parseFloat(value.toFixed(2))` to `rollout_percentage` in the Triggers column and `pass_rate` in the Runs column

## Test plan

- [ ] Open the Evaluations table with evaluations that have non-round rollout percentages
- [ ] Verify trigger badges show clean numbers (e.g. `50.4%` not `50.400000000000006%`)
- [ ] Verify pass rate in the Runs column also displays cleanly