### PR TITLE
fix(llma): dismiss trial evals banner after adding an API key

### DIFF
--- a/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
@@ -129,7 +129,7 @@ function KeyValidationStatus({
 }
 
 function AddKeyModal(): JSX.Element {
-    const { newKeyModalOpen, providerKeysLoading, preValidationResult, preValidationResultLoading } =
+    const { newKeyModalOpen, providerKeysLoading, preValidationResult, preValidationResultLoading, evaluationConfig } =
         useValues(llmProviderKeysLogic)
     const { setNewKeyModalOpen, createProviderKey, preValidateKey, clearPreValidation } =
         useActions(llmProviderKeysLogic)
@@ -162,6 +162,7 @@ function AddKeyModal(): JSX.Element {
                         provider,
                         name,
                         api_key: apiKey,
+                        set_as_active: !evaluationConfig?.active_provider_key,
                     },
                 })
             }
@@ -180,6 +181,7 @@ function AddKeyModal(): JSX.Element {
                     provider,
                     name,
                     api_key: apiKey,
+                    set_as_active: !evaluationConfig?.active_provider_key,
                 },
             })
         } else if (apiKey.length > 0) {

--- a/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
@@ -49,6 +49,7 @@ export interface CreateLLMProviderKeyPayload {
     provider: LLMProvider
     name: string
     api_key: string
+    set_as_active?: boolean
 }
 
 export interface UpdateLLMProviderKeyPayload {
@@ -207,6 +208,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                         payload
                     )
                     actions.setNewKeyModalOpen(false)
+                    actions.loadEvaluationConfig()
                     return [...values.providerKeys, response]
                 },
                 updateProviderKey: async ({


### PR DESCRIPTION
## Summary

- Reload evaluation config after creating a provider key so the trial banner reflects the new state
- Pass `set_as_active: true` when creating a key and no active key exists, so the new key is automatically activated
- This mirrors the existing pattern used when deleting a provider key

## Test plan

- [ ] Start with no provider keys configured
- [ ] Verify the "Trial evaluations exhausted" banner is visible
- [ ] Add a new OpenAI API key
- [ ] Verify the banner disappears after the key is created