### PR TITLE
chore(flags): add internal docs for holdout groups and super groups

### DIFF
--- a/docs/internal/feature-flags/holdout-groups.md
+++ b/docs/internal/feature-flags/holdout-groups.md
@@ -7,9 +7,9 @@ Holdout groups are stable sets of users intentionally excluded from experiment v
 Key characteristics:
 
 - **Stable across experiments**: The same users are consistently excluded, enabling cross-experiment analysis
-- **Hash-based assignment**: Uses consistent hashing on `distinct_id` so assignment is deterministic
+- **Hash-based assignment**: Uses consistent hashing on the bucketing identifier (distinct_id or group key) so assignment is deterministic
 - **Pre-condition evaluation**: Evaluated _before_ regular feature flag conditions, acting as a gate
-- **Immutable after launch**: Cannot be modified once an experiment starts
+- **Immutable experiment linkage**: Once an experiment starts, its associated holdout cannot be changed (the holdout definition itself may still be edited)
 
 ## What they're used for
 
@@ -44,16 +44,14 @@ When an experiment has a holdout, the holdout configuration is copied into the e
 
 ```json
 {
-  "filters": {
-    "groups": [...],
-    "holdout_groups": [
-      {
-        "variant": "holdout-42",
-        "properties": [],
-        "rollout_percentage": 10
-      }
-    ]
-  }
+  "groups": [...],
+  "holdout_groups": [
+    {
+      "variant": "holdout-42",
+      "properties": [],
+      "rollout_percentage": 10
+    }
+  ]
 }
 ```
 

--- a/docs/internal/feature-flags/holdout-groups.md
+++ b/docs/internal/feature-flags/holdout-groups.md
@@ -1,0 +1,128 @@
+# Holdout groups
+
+## What they are
+
+Holdout groups are stable sets of users intentionally excluded from experiment variations to serve as a baseline control group. When a user falls into a holdout group, they are excluded from the experiment entirely—they don't see any experiment variation, including the control. This allows direct comparison between users who experience the experiment and those who experience the product completely unchanged.
+
+Key characteristics:
+
+- **Stable across experiments**: The same users are consistently excluded, enabling cross-experiment analysis
+- **Hash-based assignment**: Uses consistent hashing on `distinct_id` so assignment is deterministic
+- **Pre-condition evaluation**: Evaluated _before_ regular feature flag conditions, acting as a gate
+- **Immutable after launch**: Cannot be modified once an experiment starts
+
+## What they're used for
+
+Holdout groups solve the problem of measuring the cumulative impact of running many experiments. Individual A/B tests measure incremental changes, but holdout groups let you answer: "What's the overall impact of all our experiments compared to users who saw none of them?"
+
+Example use case: An e-commerce site runs dozens of checkout optimization experiments. A 5% holdout group never sees any of these experiments, allowing the team to measure whether the combined effect of all optimizations actually improves conversion compared to the original experience.
+
+## How they are stored
+
+### Database model
+
+The `ExperimentHoldout` model stores the holdout definition:
+
+```python
+class ExperimentHoldout(models.Model):
+    name = models.CharField(max_length=400)
+    description = models.CharField(max_length=400, null=True, blank=True)
+    team = models.ForeignKey("Team", on_delete=models.CASCADE)
+    filters = models.JSONField(default=list)  # List of filter groups
+    created_by = models.ForeignKey("User", on_delete=models.SET_NULL, null=True)
+```
+
+The `Experiment` model links to a holdout via foreign key:
+
+```python
+holdout = models.ForeignKey("ExperimentHoldout", on_delete=models.SET_NULL, null=True)
+```
+
+### Feature flag integration
+
+When an experiment has a holdout, the holdout configuration is copied into the experiment's feature flag `filters` as `holdout_groups`:
+
+```json
+{
+  "filters": {
+    "groups": [...],
+    "holdout_groups": [
+      {
+        "variant": "holdout-42",
+        "properties": [],
+        "rollout_percentage": 10
+      }
+    ]
+  }
+}
+```
+
+### Data type used
+
+Holdout groups use `FlagPropertyGroup` (in Rust) / `FeatureFlagGroupType` (in TypeScript):
+
+```rust
+pub struct FlagPropertyGroup {
+    pub properties: Option<Vec<PropertyFilter>>,
+    pub rollout_percentage: Option<f64>,
+    pub variant: Option<String>,
+}
+```
+
+## Why this causes confusion
+
+### The type doesn't match the data
+
+The `FlagPropertyGroup` type was designed for regular feature flag conditions where you might target users based on properties (e.g., "country = US") with a rollout percentage. Holdout groups reuse this type but only use two of its fields:
+
+| Field                | Regular conditions  | Holdout groups               |
+| -------------------- | ------------------- | ---------------------------- |
+| `properties`         | Array of filters    | Always empty (not supported) |
+| `rollout_percentage` | % of matching users | % of all users to exclude    |
+| `variant`            | Not used            | Set to `holdout-{id}`        |
+
+This creates several problems:
+
+1. **The `properties` field is misleading**: The type suggests you could filter holdouts by user properties, but the evaluation code explicitly ignores properties:
+
+   ```rust
+   // From flag_matching.rs
+   if condition.properties.as_ref().is_some_and(|p| !p.is_empty()) {
+       return Ok((false, None, FeatureFlagMatchReason::NoConditionMatch));
+   }
+   ```
+
+2. **The `variant` field has different semantics**: In regular conditions, variants relate to multivariate flags. In holdout groups, variant is just an identifier (`holdout-{holdout_id}`) used to mark which holdout matched.
+
+3. **`rollout_percentage` means the opposite**: In regular conditions, it's "what percentage should get this flag." In holdout groups, it's "what percentage should be _excluded_ from the experiment."
+
+### Why it was done this way
+
+Holdout groups were added later, and reusing `FlagPropertyGroup` avoided:
+
+- Creating new database columns
+- Modifying the feature flag evaluation pipeline significantly
+- Adding new types to the Rust/Python/TypeScript codebases
+
+The trade-off was clarity for expediency.
+
+### A clearer alternative would be
+
+A dedicated type that reflects what holdout groups actually support:
+
+```typescript
+interface HoldoutCondition {
+  holdoutId: number
+  exclusionPercentage: number // 0-100, what % to exclude
+}
+```
+
+## Key files
+
+| Component         | Path                                            |
+| ----------------- | ----------------------------------------------- |
+| Model             | `posthog/models/experiment.py`                  |
+| Serializer        | `ee/clickhouse/views/experiment_holdouts.py`    |
+| Rust evaluation   | `rust/feature-flags/src/flags/flag_matching.rs` |
+| Python evaluation | `posthog/models/feature_flag/flag_matching.py`  |
+| Frontend types    | `frontend/src/types.ts`                         |

--- a/docs/internal/feature-flags/super-groups.md
+++ b/docs/internal/feature-flags/super-groups.md
@@ -1,0 +1,150 @@
+# Super groups
+
+## What they are
+
+Super groups are a feature flag evaluation mechanism that controls enrollment in early access features. Despite the name suggesting "groups of users," they're actually a single person-level property check that determines whether someone has opted into an early access feature.
+
+When a super group condition matches, it takes precedence over all regular feature flag conditions—hence "super." The evaluation returns immediately without checking other conditions.
+
+## What they're used for
+
+Super groups power the early access feature (EAF) system. When users opt into an early access feature through the UI, PostHog sets a person property like `$feature_enrollment/my-feature = true`. The super group condition checks for this property.
+
+Example flow:
+
+1. Product team creates an early access feature "New Dashboard" linked to feature flag `new-dashboard`
+2. PostHog automatically adds a super group to the flag checking `$feature_enrollment/new-dashboard`
+3. User opts in via the early access features UI
+4. PostHog sets `$feature_enrollment/new-dashboard = true` on their person
+5. On next flag evaluation, super group matches → user sees the feature
+6. Regular rollout conditions are never checked for this user
+
+This allows opted-in users to see features regardless of percentage rollouts, geography targeting, or other conditions on the flag.
+
+## How they are stored
+
+Super groups are stored in the feature flag's `filters` JSON field alongside regular conditions:
+
+```json
+{
+  "filters": {
+    "groups": [
+      {
+        "properties": [...],
+        "rollout_percentage": 50
+      }
+    ],
+    "super_groups": [
+      {
+        "properties": [
+          {
+            "key": "$feature_enrollment/new-dashboard",
+            "type": "person",
+            "operator": "exact",
+            "value": ["true"]
+          }
+        ],
+        "rollout_percentage": 100
+      }
+    ]
+  }
+}
+```
+
+### Data type used
+
+Super groups use the same `FeatureFlagGroupType` as regular conditions:
+
+```typescript
+interface FeatureFlagGroupType {
+  properties: AnyPropertyFilter[]
+  rollout_percentage: number | null
+  variant: string | null
+}
+```
+
+## Why this causes confusion
+
+### The name doesn't match the purpose
+
+"Super groups" suggests:
+
+- A group-based targeting concept (like "premium users" or "beta testers")
+- Something related to PostHog's group analytics feature
+- A collection of users
+
+What it actually is:
+
+- A single person property check
+- Specifically for `$feature_enrollment/{flag_key}` properties
+- An enrollment gate, not a targeting mechanism
+
+A clearer name would be `enrollment_condition` or `early_access_gate`.
+
+### The type allows more than is supported
+
+Using `FeatureFlagGroupType` implies you can:
+
+- Add multiple properties (you can't—only the first is evaluated)
+- Use any property key (only `$feature_enrollment/*` makes sense)
+- Use different operators (only `exact` with `["true"]` is meaningful)
+- Set different rollout percentages (it's always 100% for enrolled users)
+
+The evaluation code only checks the first property:
+
+```python
+# From flag_matching.py
+prop_key = (condition.get("properties") or [{}])[0].get("key")
+```
+
+### It's not group-based at all
+
+This is the most confusing aspect. PostHog has a separate "groups" feature for company-level / account-level analytics. Super groups have nothing to do with that:
+
+| Concept             | What it means                                    |
+| ------------------- | ------------------------------------------------ |
+| PostHog groups      | Company/account-level entities for B2B analytics |
+| Feature flag groups | Release condition sets (targeting rules)         |
+| Super groups        | Early access enrollment checks                   |
+
+Three unrelated uses of "group" in feature flags.
+
+### Constraints not enforced by the type
+
+The serializer and API enforce constraints that the type doesn't express:
+
+- Early access features can't attach to group-based flags
+- Early access features can't have multivariate variants
+- Super groups only support person properties
+
+These constraints live in validation code, not the type system, making the valid configurations unclear from the schema alone.
+
+### A clearer alternative would be
+
+A dedicated type that reflects what super groups actually do:
+
+```typescript
+interface EarlyAccessEnrollment {
+  featureFlagKey: string // The key checked in $feature_enrollment/{key}
+  enabled: boolean // Always true when present
+}
+```
+
+Or even simpler, a boolean flag on the feature flag model:
+
+```python
+class FeatureFlag(models.Model):
+    has_early_access_enrollment = models.BooleanField(default=False)
+```
+
+The enrollment property key can be derived from the flag key, eliminating the need for a separate structure.
+
+## Key files
+
+| Component         | Path                                                                     |
+| ----------------- | ------------------------------------------------------------------------ |
+| Python evaluation | `posthog/models/feature_flag/flag_matching.py`                           |
+| Rust evaluation   | `rust/feature-flags/src/flags/flag_matching.rs`                          |
+| Early access API  | `products/early_access_features/backend/api.py`                          |
+| Frontend types    | `frontend/src/types.ts`                                                  |
+| Frontend logic    | `frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts` |

--- a/docs/internal/feature-flags/super-groups.md
+++ b/docs/internal/feature-flags/super-groups.md
@@ -8,16 +8,18 @@ When a super group condition matches, it takes precedence over all regular featu
 
 ## What they're used for
 
-Super groups power the early access feature (EAF) system. When users opt into an early access feature through the UI, PostHog sets a person property like `$feature_enrollment/my-feature = true`. The super group condition checks for this property.
+Super groups power the early access feature (EAF) system. When users opt into an early access feature through the UI, PostHog sets a person property like `$feature_enrollment/my-feature` with the value `"true"` (stored as a string, not a boolean). The super group condition checks for this property.
 
 Example flow:
 
 1. Product team creates an early access feature "New Dashboard" linked to feature flag `new-dashboard`
 2. PostHog automatically adds a super group to the flag checking `$feature_enrollment/new-dashboard`
 3. User opts in via the early access features UI
-4. PostHog sets `$feature_enrollment/new-dashboard = true` on their person
+4. PostHog sets `$feature_enrollment/new-dashboard` to `"true"` on their person
 5. On next flag evaluation, super group matches → user sees the feature
 6. Regular rollout conditions are never checked for this user
+
+Note: The condition uses `["true"]` (an array) because property filters in PostHog always expect array values for the `exact` operator, even for single values.
 
 This allows opted-in users to see features regardless of percentage rollouts, geography targeting, or other conditions on the flag.
 


### PR DESCRIPTION
## Summary

- Add internal documentation explaining holdout groups and super groups in feature flags
- Document the confusing data structures: why the types don't match the actual data constraints
- Explain why "super groups" is a misnomer (they're enrollment gates, not group-based targeting)

## Context

These data structures reuse `FlagPropertyGroup`/`FeatureFlagGroupType` for expedience, but this causes confusion because:

- **Holdout groups**: The `properties` field suggests filtering support that doesn't exist, and `rollout_percentage` semantically means the opposite of regular conditions
- **Super groups**: The name implies group-based targeting, but it's actually a single person property check for early access enrollment

## Test plan

- [ ] Documentation only - no code changes