### PR TITLE
fix(marketing-analytics): apply currency conversion to reported conversion values

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/adapters/google_ads.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/google_ads.py
@@ -101,15 +101,40 @@ class GoogleAdsAdapter(MarketingSourceAdapter[GoogleAdsConfig]):
 
     def _get_reported_conversion_value_field(self) -> ast.Expr:
         stats_table_name = self.config.stats_table.name
-        field_as_float = ast.Call(
+        base_currency = self.context.base_currency
+
+        conversion_value_field = ast.Field(chain=[stats_table_name, "metrics_conversions_value"])
+        conversion_value_float = ast.Call(
             name="ifNull",
-            args=[
-                ast.Call(name="toFloat", args=[ast.Field(chain=[stats_table_name, "metrics_conversions_value"])]),
-                ast.Constant(value=0),
-            ],
+            args=[ast.Call(name="toFloat", args=[conversion_value_field]), ast.Constant(value=0)],
         )
-        sum = ast.Call(name="SUM", args=[field_as_float])
-        return ast.Call(name="toFloat", args=[sum])
+
+        # Check if currency column exists in stats table
+        try:
+            columns = getattr(self.config.stats_table, "columns", None)
+            if columns and hasattr(columns, "__contains__") and "customer_currency_code" in columns:
+                # Convert each row's conversion value, then sum
+                # Use coalesce to handle NULL currency values - fallback to base_currency
+                currency_field = ast.Field(chain=[stats_table_name, "customer_currency_code"])
+                currency_with_fallback = ast.Call(
+                    name="coalesce", args=[currency_field, ast.Constant(value=base_currency)]
+                )
+                convert_currency = ast.Call(
+                    name="convertCurrency",
+                    args=[currency_with_fallback, ast.Constant(value=base_currency), conversion_value_float],
+                )
+                convert_to_float = ast.Call(name="toFloat", args=[convert_currency])
+                return ast.Call(name="SUM", args=[convert_to_float])
+        except (TypeError, AttributeError, KeyError):
+            pass
+
+        # Currency column doesn't exist, treat as USD because it's google default and convert into base currency
+        sum_conversion_value = ast.Call(name="SUM", args=[conversion_value_float])
+        convert_from_usd = ast.Call(
+            name="convertCurrency",
+            args=[ast.Constant(value="USD"), ast.Constant(value=base_currency), sum_conversion_value],
+        )
+        return ast.Call(name="toFloat", args=[convert_from_usd])
 
     def _get_cost_field(self) -> ast.Expr:
         stats_table_name = self.config.stats_table.name


### PR DESCRIPTION
Fixes #47315

## Problem
ROAS (Return on Ad Spend) was calculated incorrectly when ad platform currency differed from team base currency. Conversion values were not being converted to the base currency while costs were, resulting in mismatched currency calculations.

Example issue:
- Google Ads currency: SEK, Team currency: USD
- Cost: 1000 SEK → ~95 USD ✓ (correctly converted)
- Conversion Value: 5000 SEK → 5000 (not converted) ✗
- ROAS shown: 5000/95 = 52.6 (incorrect, should be 5.0)

## Solution
Applied the same currency conversion logic used in `_get_cost_field()` to `_get_reported_conversion_value_field()` in all three marketing source adapters:

1. **Google Ads adapter** - Convert from `customer_currency_code` or default to USD
2. **Meta Ads adapter** - Convert from `account_currency` when available
3. **LinkedIn Ads adapter** - Convert from USD to base currency

Now both costs and conversion values are converted to the base currency, ensuring ROAS calculations use matching currencies.

## Test plan
- [ ] Existing marketing analytics adapter tests pass
- [ ] Manual testing with multi-currency ad campaigns
- [ ] Verify ROAS calculations match expected values

## Changes
- Modified `_get_reported_conversion_value_field()` in:
  - `products/marketing_analytics/backend/hogql_queries/adapters/google_ads.py`
  - `products/marketing_analytics/backend/hogql_queries/adapters/meta_ads.py`
  - `products/marketing_analytics/backend/hogql_queries/adapters/linkedin_ads.py`