### PR TITLE
refactor(logs): decouple data fetching and other state from logs scene to enable log viewer portability

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 
 import { IconGear } from '@posthog/icons'
 import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
@@ -32,21 +32,8 @@ export function LogsScene(): JSX.Element {
 }
 
 const LogsSceneContent = (): JSX.Element => {
-    const {
-        tabId,
-        parsedLogs,
-        logsLoading,
-        totalLogsMatchingFilters,
-        sparklineLoading,
-        hasMoreLogsToLoad,
-        orderBy,
-        sparklineData,
-        sparklineBreakdownBy,
-        maxExportableLogs,
-    } = useValues(logsSceneLogic)
+    const { tabId } = useValues(logsSceneLogic)
     const { hasLogs, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
-    const { runQuery, fetchNextLogsPage, setOrderBy, addFilter, setDateRange, setSparklineBreakdownBy, zoomDateRange } =
-        useActions(logsSceneLogic)
     const openLogsSettings = useOpenLogsSettingsPanel()
 
     return (
@@ -85,25 +72,7 @@ const LogsSceneContent = (): JSX.Element => {
             )}
             <LogsSetupPrompt>
                 <div className="flex flex-col gap-2 py-2 h-[calc(100vh_-_var(--breadcrumbs-height-compact,_0px)_-_var(--scene-title-section-height,_0px)_-_5px_+_10rem)]">
-                    <LogsViewer
-                        tabId={tabId}
-                        logs={parsedLogs}
-                        loading={logsLoading}
-                        totalLogsCount={sparklineLoading ? undefined : totalLogsMatchingFilters}
-                        hasMoreLogsToLoad={hasMoreLogsToLoad}
-                        orderBy={orderBy}
-                        onChangeOrderBy={setOrderBy}
-                        onRefresh={runQuery}
-                        onLoadMore={fetchNextLogsPage}
-                        onAddFilter={addFilter}
-                        sparklineData={sparklineData}
-                        sparklineLoading={sparklineLoading}
-                        onDateRangeChange={setDateRange}
-                        sparklineBreakdownBy={sparklineBreakdownBy}
-                        onSparklineBreakdownByChange={setSparklineBreakdownBy}
-                        onExpandTimeRange={() => zoomDateRange(2)}
-                        maxExportableLogs={maxExportableLogs}
-                    />
+                    <LogsViewer id={tabId} />
                 </div>
             </LogsSetupPrompt>
         </>

--- a/products/logs/frontend/attributeBreakdownLogic.tsx
+++ b/products/logs/frontend/attributeBreakdownLogic.tsx
@@ -3,7 +3,7 @@ import { connect, kea, key, path, props, selectors } from 'kea'
 import { PropertyFilterType } from '~/types'
 
 import type { attributeBreakdownLogicType } from './attributeBreakdownLogicType'
-import { logsSceneLogic } from './logsSceneLogic'
+import { logsViewerDataLogic } from './components/LogsViewer/data/logsViewerDataLogic'
 
 export interface AttributeBreakdownLogicProps {
     attribute: string
@@ -17,7 +17,7 @@ export const attributeBreakdownLogic = kea<attributeBreakdownLogicType>([
     path((key) => ['products', 'logs', 'frontend', 'logsAttributeBreakdownsLogic', key]),
 
     connect((props: AttributeBreakdownLogicProps) => ({
-        values: [logsSceneLogic({ tabId: props.tabId }), ['logs']],
+        values: [logsViewerDataLogic({ id: props.tabId }), ['parsedLogs as logs']],
     })),
 
     selectors(({ props }) => ({

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -30,8 +30,8 @@ import {
 } from '~/types'
 
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 
-import { logsSceneLogic } from '../../../../logsSceneLogic'
 import { DateRangeFilter } from '../DateRangeFilter'
 import { FilterHistoryDropdown } from '../FilterHistoryDropdown'
 import { LogsDateRangePicker } from '../LogsDateRangePicker/LogsDateRangePicker'
@@ -47,8 +47,9 @@ const taxonomicGroupTypes = [
 
 export const LogsFilterBar = (): JSX.Element => {
     const newLogsDateRangePicker = useFeatureFlag('NEW_LOGS_DATE_RANGE_PICKER')
-    const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsSceneLogic)
-    const { runQuery, zoomDateRange, setLiveTailRunning } = useActions(logsSceneLogic)
+    const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsViewerDataLogic)
+    const { runQuery, setLiveTailRunning } = useActions(logsViewerDataLogic)
+    const { zoomDateRange } = useActions(logsViewerFiltersLogic)
     const { filters } = useValues(logsViewerFiltersLogic)
     const { setDateRange } = useActions(logsViewerFiltersLogic)
     const { dateRange } = filters

--- a/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
@@ -1,11 +1,13 @@
-import { actions, kea, key, path, props, reducers, selectors } from 'kea'
+import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import posthog from 'posthog-js'
 
 import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { dayjs } from 'lib/dayjs'
 
 import { DateRange, LogSeverityLevel, LogsQuery } from '~/queries/schema/schema-general'
-import { UniversalFiltersGroup } from '~/types'
+import { PropertyFilterType, PropertyOperator, UniversalFiltersGroup, UniversalFiltersGroupValue } from '~/types'
 
+import { zoomDateRange } from 'products/logs/frontend/components/LogsViewer/Filters/zoom-utils'
 import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
 
 import type { logsViewerFiltersLogicType } from './logsViewerFiltersLogicType'
@@ -43,6 +45,20 @@ export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
         setFilters: (filters: Partial<LogsViewerFilters>, pushToHistory: boolean = true) => ({
             filters,
             pushToHistory,
+        }),
+
+        zoomDateRange: (multiplier: number) => ({ multiplier }),
+
+        addFilter: (
+            key: string,
+            value: string,
+            operator: PropertyOperator = PropertyOperator.Exact,
+            propertyType: PropertyFilterType = PropertyFilterType.LogAttribute
+        ) => ({
+            key,
+            value,
+            operator,
+            propertyType,
         }),
     }),
 
@@ -117,4 +133,33 @@ export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
             }),
         ],
     }),
+
+    listeners(({ actions, values }) => ({
+        zoomDateRange: ({ multiplier }) => {
+            posthog.capture('logs date range zoomed', {
+                direction: multiplier > 1 ? 'out' : 'in',
+                multiplier,
+            })
+            const newDateRange = zoomDateRange(values.filters.dateRange, multiplier)
+            actions.setDateRange(newDateRange)
+        },
+        addFilter: ({ key, value, operator, propertyType }) => {
+            const currentGroup = values.filters.filterGroup.values[0] as UniversalFiltersGroup
+
+            const newGroup: UniversalFiltersGroup = {
+                ...currentGroup,
+                values: [
+                    ...currentGroup.values,
+                    {
+                        key,
+                        value: [value],
+                        operator,
+                        type: propertyType,
+                    } as UniversalFiltersGroupValue,
+                ],
+            }
+
+            actions.setFilterGroup({ ...values.filters.filterGroup, values: [newGroup] }, false)
+        },
+    })),
 ])

--- a/products/logs/frontend/components/LogsViewer/LogsExportMenu.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsExportMenu.tsx
@@ -5,19 +5,17 @@ import { LemonButton, LemonMenu } from '@posthog/lemon-ui'
 
 import { humanFriendlyNumber } from 'lib/utils'
 
-import { LogsOrderBy } from '../../types'
 import { logsExportLogic } from './logsExportLogic'
 import { logsViewerLogic } from './logsViewerLogic'
 
 interface LogsExportMenuProps {
     totalLogsCount?: number
-    orderBy: LogsOrderBy
-    maxExportableLogs: number
 }
 
-export const LogsExportMenu = ({ totalLogsCount, orderBy, maxExportableLogs }: LogsExportMenuProps): JSX.Element => {
-    const { selectedCount, tabId } = useValues(logsViewerLogic)
-    const { exportServerSide, exportSelectedAsCsv, copySelectedLogs } = useActions(logsExportLogic({ tabId, orderBy }))
+export const LogsExportMenu = ({ totalLogsCount }: LogsExportMenuProps): JSX.Element => {
+    const { selectedCount } = useValues(logsViewerLogic)
+    const { exportServerSide, exportSelectedAsCsv, copySelectedLogs } = useActions(logsExportLogic)
+    const { maxExportableLogs } = useValues(logsExportLogic)
 
     return (
         <LemonMenu

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -5,19 +5,18 @@ import { TZLabelProps } from 'lib/components/TZLabel'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
-import { DateRange, LogsSparklineBreakdownBy } from '~/queries/schema/schema-general'
-import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { LogsFilterBar } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
+import { logsExportLogic } from 'products/logs/frontend/components/LogsViewer/logsExportLogic'
 import { VirtualizedLogsList } from 'products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList'
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
-import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
 
 import { LogDetailsModal } from './LogDetailsModal'
 import { logDetailsModalLogic } from './LogDetailsModal/logDetailsModalLogic'
-import { LogsSparkline, LogsSparklineData } from './LogsViewerSparkline'
+import { LogsSparkline } from './LogsViewerSparkline'
 import { LogsViewerToolbar } from './LogsViewerToolbar'
 import { logsViewerLogic } from './logsViewerLogic'
 
@@ -25,65 +24,20 @@ const SCROLL_INTERVAL_MS = 16 // ~60fps
 const SCROLL_AMOUNT_PX = 8
 
 export interface LogsViewerProps {
-    tabId: string
-    logs: ParsedLogMessage[]
-    loading: boolean
-    totalLogsCount?: number
-    hasMoreLogsToLoad?: boolean
-    orderBy: LogsOrderBy
-    onChangeOrderBy: (orderBy: LogsOrderBy, source: 'header' | 'toolbar') => void
-    onRefresh?: () => void
-    onLoadMore?: () => void
-    onAddFilter?: (key: string, value: string, operator?: PropertyOperator, type?: PropertyFilterType) => void
-    sparklineData: LogsSparklineData
-    sparklineLoading: boolean
-    onDateRangeChange: (dateRange: DateRange) => void
-    sparklineBreakdownBy: LogsSparklineBreakdownBy
-    onSparklineBreakdownByChange: (breakdownBy: LogsSparklineBreakdownBy) => void
-    onExpandTimeRange?: () => void
-    maxExportableLogs: number
+    id: string
 }
 
-export function LogsViewer({
-    tabId,
-    logs,
-    loading,
-    totalLogsCount,
-    hasMoreLogsToLoad,
-    orderBy,
-    onChangeOrderBy,
-    onRefresh,
-    onLoadMore,
-    onAddFilter,
-    sparklineData,
-    sparklineLoading,
-    onDateRangeChange,
-    sparklineBreakdownBy,
-    onSparklineBreakdownByChange,
-    onExpandTimeRange,
-    maxExportableLogs,
-}: LogsViewerProps): JSX.Element {
+export function LogsViewer({ id }: LogsViewerProps): JSX.Element {
     return (
-        <BindLogic logic={logsViewerFiltersLogic} props={{ id: tabId }}>
-            <BindLogic logic={logsViewerConfigLogic} props={{ id: tabId }}>
-                <BindLogic logic={logDetailsModalLogic} props={{ tabId }}>
-                    <BindLogic logic={logsViewerLogic} props={{ tabId, logs, orderBy, onAddFilter }}>
-                        <LogsViewerContent
-                            loading={loading}
-                            totalLogsCount={totalLogsCount}
-                            hasMoreLogsToLoad={hasMoreLogsToLoad}
-                            orderBy={orderBy}
-                            onChangeOrderBy={onChangeOrderBy}
-                            onRefresh={onRefresh}
-                            onLoadMore={onLoadMore}
-                            sparklineData={sparklineData}
-                            sparklineLoading={sparklineLoading}
-                            onDateRangeChange={onDateRangeChange}
-                            sparklineBreakdownBy={sparklineBreakdownBy}
-                            onSparklineBreakdownByChange={onSparklineBreakdownByChange}
-                            onExpandTimeRange={onExpandTimeRange}
-                            maxExportableLogs={maxExportableLogs}
-                        />
+        <BindLogic logic={logsViewerFiltersLogic} props={{ id }}>
+            <BindLogic logic={logsViewerConfigLogic} props={{ id }}>
+                <BindLogic logic={logsViewerDataLogic} props={{ id }}>
+                    <BindLogic logic={logDetailsModalLogic} props={{ tabId: id }}>
+                        <BindLogic logic={logsViewerLogic} props={{ tabId: id }}>
+                            <BindLogic logic={logsExportLogic} props={{ tabId: id }}>
+                                <LogsViewerContent />
+                            </BindLogic>
+                        </BindLogic>
                     </BindLogic>
                 </BindLogic>
             </BindLogic>
@@ -91,39 +45,7 @@ export function LogsViewer({
     )
 }
 
-interface LogsViewerContentProps {
-    loading: boolean
-    totalLogsCount?: number
-    hasMoreLogsToLoad?: boolean
-    orderBy: LogsOrderBy
-    onChangeOrderBy: (orderBy: LogsOrderBy, source: 'header' | 'toolbar') => void
-    onRefresh?: () => void
-    onLoadMore?: () => void
-    sparklineData: LogsSparklineData
-    sparklineLoading: boolean
-    onDateRangeChange: (dateRange: DateRange) => void
-    sparklineBreakdownBy: LogsSparklineBreakdownBy
-    onSparklineBreakdownByChange: (breakdownBy: LogsSparklineBreakdownBy) => void
-    onExpandTimeRange?: () => void
-    maxExportableLogs: number
-}
-
-function LogsViewerContent({
-    loading,
-    totalLogsCount,
-    hasMoreLogsToLoad,
-    orderBy,
-    onChangeOrderBy,
-    onRefresh,
-    onLoadMore,
-    sparklineData,
-    sparklineLoading,
-    onDateRangeChange,
-    sparklineBreakdownBy,
-    onSparklineBreakdownByChange,
-    onExpandTimeRange,
-    maxExportableLogs,
-}: LogsViewerContentProps): JSX.Element {
+function LogsViewerContent(): JSX.Element {
     const {
         tabId,
         wrapBody,
@@ -132,7 +54,6 @@ function LogsViewerContent({
         isFocused,
         cursorIndex,
         cursorLogId,
-        logs,
         timezone,
         isSelectionActive,
         keyboardNavEnabled,
@@ -148,6 +69,12 @@ function LogsViewerContent({
         clearSelection,
         togglePrettifyLog,
     } = useActions(logsViewerLogic)
+    const { orderBy, sparklineBreakdownBy } = useValues(logsViewerConfigLogic)
+    const { setOrderBy, setSparklineBreakdownBy } = useActions(logsViewerConfigLogic)
+    const { logsLoading, parsedLogs, sparklineData, sparklineLoading, hasMoreLogsToLoad, totalLogsMatchingFilters } =
+        useValues(logsViewerDataLogic)
+    const { runQuery, fetchNextLogsPage } = useActions(logsViewerDataLogic)
+    const { setDateRange, zoomDateRange } = useActions(logsViewerFiltersLogic)
     const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ tabId }))
     const { setCellScrollLeft } = useActions(virtualizedLogsListLogic({ tabId }))
     const messageScrollLeft = cellScrollLefts['message'] ?? 0
@@ -252,17 +179,17 @@ function LogsViewerContent({
             // arrowleft, arrowright, h, l handled by native keydown/keyup for smooth 60fps scrolling
             enter: {
                 action: () => {
-                    if (cursorIndex !== null && logs[cursorIndex]) {
-                        openLogDetails(logs[cursorIndex])
+                    if (cursorIndex !== null && parsedLogs[cursorIndex]) {
+                        openLogDetails(parsedLogs[cursorIndex])
                     }
                 },
                 disabled: !keyboardNavEnabled,
             },
             r: {
                 action: () => {
-                    if (onRefresh && !loading) {
+                    if (!logsLoading) {
                         resetCursor()
-                        onRefresh()
+                        runQuery()
                     }
                 },
                 disabled: !isFocused,
@@ -300,11 +227,11 @@ function LogsViewerContent({
             keyboardNavEnabled,
             isLogDetailsOpen,
             cursorIndex,
-            logs,
+            parsedLogs,
             openLogDetails,
             closeLogDetails,
-            onRefresh,
-            loading,
+            runQuery,
+            logsLoading,
             resetCursor,
             moveCursorDown,
             moveCursorUp,
@@ -321,17 +248,16 @@ function LogsViewerContent({
             <LogsSparkline
                 sparklineData={sparklineData}
                 sparklineLoading={sparklineLoading}
-                onDateRangeChange={onDateRangeChange}
+                onDateRangeChange={setDateRange}
                 displayTimezone={timezone}
                 breakdownBy={sparklineBreakdownBy}
-                onBreakdownByChange={onSparklineBreakdownByChange}
+                onBreakdownByChange={setSparklineBreakdownBy}
             />
             <SceneDivider />
             <LogsViewerToolbar
-                totalLogsCount={totalLogsCount}
+                totalLogsCount={sparklineLoading ? undefined : totalLogsMatchingFilters}
                 orderBy={orderBy}
-                onChangeOrderBy={(newOrderBy) => onChangeOrderBy(newOrderBy, 'toolbar')}
-                maxExportableLogs={maxExportableLogs}
+                onChangeOrderBy={(newOrderBy) => setOrderBy(newOrderBy, 'toolbar')}
             />
             {pinnedLogsArray.length > 0 && (
                 <VirtualizedLogsList
@@ -344,22 +270,22 @@ function LogsViewerContent({
                     disableInfiniteScroll
                     disableCursor
                     orderBy={orderBy}
-                    onChangeOrderBy={(newOrderBy) => onChangeOrderBy(newOrderBy, 'header')}
+                    onChangeOrderBy={(newOrderBy) => setOrderBy(newOrderBy, 'header')}
                 />
             )}
 
             <VirtualizedLogsList
-                dataSource={logs}
-                loading={loading}
+                dataSource={parsedLogs}
+                loading={logsLoading}
                 wrapBody={wrapBody}
                 prettifyJson={prettifyJson}
                 tzLabelFormat={tzLabelFormat}
                 showPinnedWithOpacity
                 hasMoreLogsToLoad={hasMoreLogsToLoad}
-                onLoadMore={onLoadMore}
-                onExpandTimeRange={onExpandTimeRange}
+                onLoadMore={fetchNextLogsPage}
+                onExpandTimeRange={() => zoomDateRange(2)}
                 orderBy={orderBy}
-                onChangeOrderBy={(newOrderBy) => onChangeOrderBy(newOrderBy, 'header')}
+                onChangeOrderBy={(newOrderBy) => setOrderBy(newOrderBy, 'header')}
             />
 
             <LogDetailsModal timezone={timezone} />

--- a/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
@@ -16,14 +16,12 @@ export interface LogsViewerToolbarProps {
     totalLogsCount?: number
     orderBy: LogsOrderBy
     onChangeOrderBy: (orderBy: LogsOrderBy) => void
-    maxExportableLogs: number
 }
 
 export const LogsViewerToolbar = ({
     totalLogsCount,
     orderBy,
     onChangeOrderBy,
-    maxExportableLogs,
 }: LogsViewerToolbarProps): JSX.Element => {
     const { wrapBody, prettifyJson, timezone } = useValues(logsViewerLogic)
     const { setWrapBody, setPrettifyJson, setTimezone } = useActions(logsViewerLogic)
@@ -55,11 +53,7 @@ export const LogsViewerToolbar = ({
                     size="small"
                 />
                 <TimezoneSelect value={timezone} onChange={setTimezone} size="small" />
-                <LogsExportMenu
-                    totalLogsCount={totalLogsCount}
-                    orderBy={orderBy}
-                    maxExportableLogs={maxExportableLogs}
-                />
+                <LogsExportMenu totalLogsCount={totalLogsCount} />
             </div>
             <div className="flex items-center gap-4 flex-wrap">
                 {totalLogsCount !== undefined && totalLogsCount > 0 && (

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
@@ -1,8 +1,10 @@
 import { actions, kea, key, path, props, reducers, selectors } from 'kea'
 
+import { LogsSparklineBreakdownBy } from '~/queries/schema/schema-general'
 import { FilterLogicalOperator } from '~/types'
 
 import { LogsViewerConfig, LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
+import { LogsOrderBy } from 'products/logs/frontend/types'
 
 import type { logsViewerConfigLogicType } from './logsViewerConfigLogicType'
 
@@ -15,6 +17,10 @@ export const DEFAULT_LOGS_VIEWER_CONFIG: LogsViewerConfig = {
         filterGroup: { type: FilterLogicalOperator.And, values: [] },
     },
 }
+
+export const DEFAULT_SPARKLINE_BREAKDOWN_BY: LogsSparklineBreakdownBy = 'severity'
+
+export const DEFAULT_ORDER_BY: LogsOrderBy = 'latest'
 
 export interface LogsViewerConfigProps {
     id: string
@@ -31,6 +37,8 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
             filter,
             value,
         }),
+        setSparklineBreakdownBy: (sparklineBreakdownBy: LogsSparklineBreakdownBy) => ({ sparklineBreakdownBy }),
+        setOrderBy: (orderBy: LogsOrderBy, source: 'header' | 'toolbar' = 'toolbar') => ({ orderBy, source }),
     }),
 
     reducers({
@@ -42,6 +50,19 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
                     ...state,
                     [filter]: value,
                 }),
+            },
+        ],
+        sparklineBreakdownBy: [
+            DEFAULT_SPARKLINE_BREAKDOWN_BY as LogsSparklineBreakdownBy,
+            { persist: true },
+            {
+                setSparklineBreakdownBy: (_, { sparklineBreakdownBy }) => sparklineBreakdownBy,
+            },
+        ],
+        orderBy: [
+            DEFAULT_ORDER_BY as LogsOrderBy,
+            {
+                setOrderBy: (_, { orderBy }) => orderBy,
             },
         ],
     }),

--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
@@ -1,0 +1,83 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { logsViewerDataLogic } from './logsViewerDataLogic'
+
+jest.mock('@posthog/lemon-ui', () => ({
+    ...jest.requireActual('@posthog/lemon-ui'),
+    lemonToast: {
+        error: jest.fn(),
+    },
+}))
+
+describe('logsViewerDataLogic', () => {
+    let logic: ReturnType<typeof logsViewerDataLogic.build>
+
+    beforeEach(async () => {
+        useMocks({
+            post: {
+                '/api/environments/:team_id/logs/query/': () => [200, { results: [], maxExportableLogs: 5000 }],
+                '/api/environments/:team_id/logs/sparkline/': () => [200, []],
+            },
+        })
+        initKeaTests()
+        logic = logsViewerDataLogic({ id: 'test-tab' })
+        logic.mount()
+
+        await expectLogic(logic).toFinishAllListeners()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    describe('error handling', () => {
+        beforeEach(() => {
+            jest.clearAllMocks()
+        })
+
+        it.each([
+            ['new query started', 'exact match for NEW_QUERY_STARTED_ERROR_MESSAGE'],
+            ['Fetch is aborted', 'Safari abort message'],
+            ['The operation was aborted', 'alternative abort message'],
+            ['ABORTED', 'uppercase abort'],
+            ['Request aborted by user', 'abort substring'],
+        ])('suppresses fetchLogs error "%s" (%s)', async (error) => {
+            logic.actions.fetchLogsFailure(error)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(lemonToast.error).not.toHaveBeenCalled()
+        })
+
+        it.each([['Network error'], ['Server returned 500'], ['Timeout exceeded']])(
+            'shows toast for legitimate fetchLogs error "%s"',
+            async (error) => {
+                logic.actions.fetchLogsFailure(error)
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(lemonToast.error).toHaveBeenCalledWith(`Failed to load logs: ${error}`)
+            }
+        )
+
+        it.each([
+            ['Fetch is aborted', 'Safari abort message'],
+            ['new query started', 'exact match for NEW_QUERY_STARTED_ERROR_MESSAGE'],
+        ])('suppresses fetchNextLogsPage error "%s" (%s)', async (error) => {
+            logic.actions.fetchNextLogsPageFailure(error)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(lemonToast.error).not.toHaveBeenCalled()
+        })
+
+        it('shows toast for legitimate fetchNextLogsPage error', async () => {
+            logic.actions.fetchNextLogsPageFailure('Network error')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith('Failed to load more logs: Network error')
+        })
+    })
+})

--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -1,0 +1,632 @@
+import colors from 'ansi-colors'
+import { actions, afterMount, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { dataColorVars } from 'lib/colors'
+import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
+import { dayjs } from 'lib/dayjs'
+import { humanFriendlyDetailedTime } from 'lib/utils'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { LogMessage, LogsQuery, LogsSparklineBreakdownBy } from '~/queries/schema/schema-general'
+import { integer } from '~/queries/schema/type-utils'
+import { JsonType, PropertyGroupFilter } from '~/types'
+
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
+
+// TODO: Move to ./types.ts
+import { ParsedLogMessage } from '../../../types'
+import type { logsViewerDataLogicType } from './logsViewerDataLogicType'
+
+const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS = 1000
+const DEFAULT_LOGS_PAGE_SIZE: number = 250
+export const DEFAULT_INITIAL_LOGS_LIMIT = null as number | null
+const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
+const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MAX_MS = 5000
+
+const stringifyLogAttributes = (attributes: Record<string, any>): Record<string, string> => {
+    const result: Record<string, string> = {}
+    for (const attributeKey of Object.keys(attributes)) {
+        const value = attributes[attributeKey]
+        result[attributeKey] = typeof value === 'string' ? value : JSON.stringify(value)
+    }
+    return result
+}
+
+export interface LogsViewerDataLogicProps {
+    id: string
+    autoLoad?: boolean
+}
+
+export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
+    props({ id: 'default', autoLoad: true } as LogsViewerDataLogicProps),
+    path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'data', 'logsViewerDataLogic']),
+    key((props) => props.id),
+    connect(({ id }: LogsViewerDataLogicProps) => ({
+        actions: [
+            teamLogic,
+            ['addProductIntent'],
+            logsViewerFiltersLogic({ id }),
+            ['setDateRange', 'setFilterGroup', 'setFilters', 'setSearchTerm', 'setSeverityLevels', 'setServiceNames'],
+            logsViewerConfigLogic({ id }),
+            ['setSparklineBreakdownBy'],
+        ],
+        values: [
+            logsViewerFiltersLogic({ id }),
+            ['filters', 'utcDateRange'],
+            logsViewerConfigLogic({ id }),
+            ['sparklineBreakdownBy', 'orderBy'],
+        ],
+    })),
+
+    actions({
+        runQuery: (debounce?: integer) => ({ debounce }),
+        fetchNextLogsPage: (limit?: number) => ({ limit }),
+        truncateLogs: (limit: number) => ({ limit }),
+        clearLogs: true,
+        cancelInProgressLogs: (logsAbortController: AbortController | null) => ({ logsAbortController }),
+        cancelInProgressSparkline: (sparklineAbortController: AbortController | null) => ({ sparklineAbortController }),
+        cancelInProgressLiveTail: (liveTailAbortController: AbortController | null) => ({ liveTailAbortController }),
+        setLogsAbortController: (logsAbortController: AbortController | null) => ({ logsAbortController }),
+        setSparklineAbortController: (sparklineAbortController: AbortController | null) => ({
+            sparklineAbortController,
+        }),
+        setLiveTailAbortController: (liveTailAbortController: AbortController | null) => ({
+            liveTailAbortController,
+        }),
+        setLiveLogsCheckpoint: (liveLogsCheckpoint: string | null) => ({ liveLogsCheckpoint }),
+        setHasMoreLogsToLoad: (hasMoreLogsToLoad: boolean) => ({ hasMoreLogsToLoad }),
+        setLiveTailRunning: (enabled: boolean) => ({ enabled }),
+        setLiveTailInterval: (interval: number) => ({ interval }),
+        setLogs: (logs: LogMessage[]) => ({ logs }),
+        setSparkline: (sparkline: any[]) => ({ sparkline }),
+        setNextCursor: (nextCursor: string | null) => ({ nextCursor }),
+        expireLiveTail: () => true,
+        setLiveTailExpired: (liveTailExpired: boolean) => ({ liveTailExpired }),
+        addLogsToSparkline: (logs: LogMessage[]) => logs,
+        setInitialLogsLimit: (initialLogsLimit: number | null) => ({ initialLogsLimit }),
+        pollForNewLogs: true,
+        setMaxExportableLogs: (maxExportableLogs: number) => ({ maxExportableLogs }),
+    }),
+
+    reducers({
+        initialLogsLimit: [
+            DEFAULT_INITIAL_LOGS_LIMIT as number | null,
+            {
+                setInitialLogsLimit: (_, { initialLogsLimit }) => initialLogsLimit,
+                fetchLogsSuccess: () => null,
+            },
+        ],
+        liveLogsCheckpoint: [
+            null as string | null,
+            { persist: false },
+            {
+                setLiveLogsCheckpoint: (_, { liveLogsCheckpoint }) => liveLogsCheckpoint,
+            },
+        ],
+        liveTailExpired: [
+            true as boolean,
+            { persist: false },
+            {
+                setLiveTailExpired: (_, { liveTailExpired }) => liveTailExpired,
+                fetchLogsSuccess: () => false,
+            },
+        ],
+        logsAbortController: [
+            null as AbortController | null,
+            {
+                setLogsAbortController: (_, { logsAbortController }) => logsAbortController,
+            },
+        ],
+        sparklineAbortController: [
+            null as AbortController | null,
+            {
+                setSparklineAbortController: (_, { sparklineAbortController }) => sparklineAbortController,
+            },
+        ],
+        liveTailAbortController: [
+            null as AbortController | null,
+            {
+                setLiveTailAbortController: (_, { liveTailAbortController }) => liveTailAbortController,
+            },
+        ],
+        hasRunQuery: [
+            false as boolean,
+            {
+                fetchLogsSuccess: () => true,
+                fetchLogsFailure: () => true,
+            },
+        ],
+        logsLoading: [
+            false as boolean,
+            {
+                fetchLogs: () => true,
+                fetchLogsSuccess: () => false,
+                fetchLogsFailure: () => true,
+                fetchNextLogsPage: () => true,
+                fetchNextLogsPageSuccess: () => false,
+                fetchNextLogsPageFailure: () => true,
+            },
+        ],
+        sparklineLoading: [
+            false as boolean,
+            {
+                fetchSparkline: () => true,
+                fetchSparklineSuccess: () => false,
+                fetchSparklineFailure: () => true,
+            },
+        ],
+        liveTailRunning: [
+            false as boolean,
+            {
+                setLiveTailRunning: (_, { enabled }) => enabled,
+                runQuery: () => false,
+            },
+        ],
+        liveTailPollInterval: [
+            DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS as number,
+            {
+                setLiveTailInterval: (_, { interval }) => interval,
+            },
+        ],
+        hasMoreLogsToLoad: [
+            true as boolean,
+            {
+                setHasMoreLogsToLoad: (_, { hasMoreLogsToLoad }) => hasMoreLogsToLoad,
+                clearLogs: () => true,
+            },
+        ],
+        nextCursor: [
+            null as string | null,
+            {
+                setNextCursor: (_, { nextCursor }) => nextCursor,
+                clearLogs: () => null,
+            },
+        ],
+        maxExportableLogs: [
+            10_000 as number,
+            {
+                setMaxExportableLogs: (_, { maxExportableLogs }) => maxExportableLogs,
+            },
+        ],
+    }),
+
+    loaders(({ values, actions }) => ({
+        logs: [
+            [] as LogMessage[],
+            {
+                clearLogs: () => [],
+                truncateLogs: ({ limit }) => values.logs.slice(0, limit),
+                fetchLogs: async () => {
+                    const logsController = new AbortController()
+                    const signal = logsController.signal
+                    actions.cancelInProgressLogs(logsController)
+
+                    const response = await api.logs.query({
+                        query: {
+                            limit: values.initialLogsLimit ?? DEFAULT_LOGS_PAGE_SIZE,
+                            orderBy: values.orderBy,
+                            dateRange: values.utcDateRange,
+                            searchTerm: values.filters.searchTerm,
+                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            severityLevels: values.filters.severityLevels,
+                            serviceNames: values.filters.serviceNames,
+                        },
+                        signal,
+                    })
+                    actions.setLogsAbortController(null)
+                    actions.setHasMoreLogsToLoad(!!response.hasMore)
+                    actions.setNextCursor(response.nextCursor ?? null)
+                    actions.setMaxExportableLogs(response.maxExportableLogs)
+                    return response.results
+                },
+                fetchNextLogsPage: async ({ limit }, breakpoint) => {
+                    const logsController = new AbortController()
+                    const signal = logsController.signal
+                    actions.cancelInProgressLogs(logsController)
+
+                    if (!values.nextCursor) {
+                        return values.logs
+                    }
+
+                    await breakpoint(300)
+                    const response = await api.logs.query({
+                        query: {
+                            limit: limit ?? DEFAULT_LOGS_PAGE_SIZE,
+                            orderBy: values.orderBy,
+                            dateRange: values.utcDateRange,
+                            searchTerm: values.filters.searchTerm,
+                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            severityLevels: values.filters.severityLevels,
+                            serviceNames: values.filters.serviceNames,
+                            after: values.nextCursor,
+                        },
+                        signal,
+                    })
+                    actions.setLogsAbortController(null)
+                    actions.setHasMoreLogsToLoad(!!response.hasMore)
+                    actions.setNextCursor(response.nextCursor ?? null)
+                    return [...values.logs, ...response.results]
+                },
+                setLogs: ({ logs }) => logs,
+            },
+        ],
+        sparkline: [
+            [] as any[],
+            {
+                fetchSparkline: async () => {
+                    const sparklineController = new AbortController()
+                    const signal = sparklineController.signal
+                    actions.cancelInProgressSparkline(sparklineController)
+
+                    const response = await api.logs.sparkline({
+                        query: {
+                            orderBy: values.orderBy,
+                            dateRange: values.utcDateRange,
+                            searchTerm: values.filters.searchTerm,
+                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            severityLevels: values.filters.severityLevels,
+                            serviceNames: values.filters.serviceNames,
+                            sparklineBreakdownBy: values.sparklineBreakdownBy,
+                        },
+                        signal,
+                    })
+                    actions.setSparklineAbortController(null)
+                    return response
+                },
+                setSparkline: ({ sparkline }) => sparkline,
+            },
+        ],
+    })),
+
+    selectors({
+        liveTailDisabledReason: [
+            (s) => [s.orderBy, s.filters, s.logsLoading, s.liveTailExpired],
+            (
+                orderBy: LogsQuery['orderBy'],
+                filters: LogsViewerFilters,
+                logsLoading: boolean,
+                liveTailExpired: boolean
+            ): string | undefined => {
+                if (orderBy !== 'latest') {
+                    return 'Live tail only works with "Latest" ordering'
+                }
+
+                if (filters.dateRange.date_to) {
+                    return 'Live tail requires an open-ended time range'
+                }
+
+                if (logsLoading) {
+                    return 'Wait for query to finish'
+                }
+
+                if (liveTailExpired) {
+                    return 'Live tail has expired, run search again to live tail'
+                }
+
+                return undefined
+            },
+        ],
+        parsedLogs: [
+            (s) => [s.logs],
+            (logs: LogMessage[]): ParsedLogMessage[] => {
+                const seen = new Set<string>()
+                const result: ParsedLogMessage[] = []
+
+                for (const log of logs) {
+                    if (seen.has(log.uuid)) {
+                        continue
+                    }
+                    seen.add(log.uuid)
+                    const cleanBody = colors.unstyle(log.body)
+                    let parsedBody: JsonType | null = null
+                    try {
+                        parsedBody = JSON.parse(cleanBody)
+                    } catch {
+                        // Not JSON, that's fine
+                    }
+                    result.push({
+                        ...log,
+                        attributes: stringifyLogAttributes(log.attributes),
+                        cleanBody,
+                        parsedBody,
+                        originalLog: log,
+                    })
+                }
+
+                return result
+            },
+        ],
+        sparklineData: [
+            (s) => [s.sparkline, s.sparklineBreakdownBy],
+            (sparkline: any[], sparklineBreakdownBy: LogsSparklineBreakdownBy) => {
+                const breakdownKey = sparklineBreakdownBy
+
+                let lastTime = ''
+                let i = -1
+                const labels: string[] = []
+                const dates: string[] = []
+                const accumulated = sparkline.reduce(
+                    (accumulator, currentItem) => {
+                        if (currentItem.time !== lastTime) {
+                            labels.push(
+                                humanFriendlyDetailedTime(currentItem.time, 'YYYY-MM-DD', 'HH:mm:ss', {
+                                    timestampStyle: 'absolute',
+                                })
+                            )
+                            dates.push(currentItem.time)
+                            lastTime = currentItem.time
+                            i++
+                        }
+                        const key = currentItem[breakdownKey]
+                        if (!key) {
+                            return accumulator
+                        }
+                        if (!accumulator[key]) {
+                            accumulator[key] = []
+                        }
+                        while (accumulator[key].length <= i) {
+                            accumulator[key].push(0)
+                        }
+                        accumulator[key][i] += currentItem.count
+                        return accumulator
+                    },
+                    {} as Record<string, number[]>
+                )
+
+                const data = Object.entries(accumulated)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .map(([name, values], index) => ({
+                        name,
+                        values: values as number[],
+                        color:
+                            sparklineBreakdownBy === 'service'
+                                ? dataColorVars[index % dataColorVars.length]
+                                : {
+                                      fatal: 'danger-dark',
+                                      error: 'danger',
+                                      warn: 'warning',
+                                      info: 'brand-blue',
+                                      debug: 'muted',
+                                      trace: 'muted-alt',
+                                  }[name],
+                    }))
+                    .filter((series) => series.values.reduce((a, b) => a + b) > 0)
+
+                return { data, labels, dates }
+            },
+        ],
+        totalLogsMatchingFilters: [
+            (s) => [s.sparkline],
+            (sparkline): number => sparkline.reduce((sum, item) => sum + item.count, 0),
+        ],
+        logsRemainingToLoad: [
+            (s) => [s.totalLogsMatchingFilters, s.logs],
+            (totalLogsMatchingFilters, logs): number => totalLogsMatchingFilters - logs.length,
+        ],
+    }),
+
+    listeners(({ actions, values, cache }) => ({
+        setSparklineBreakdownBy: () => {
+            actions.fetchSparkline()
+        },
+        fetchLogsFailure: ({ error }) => {
+            const errorStr = String(error).toLowerCase()
+            if (error !== NEW_QUERY_STARTED_ERROR_MESSAGE && !errorStr.includes('abort')) {
+                lemonToast.error(`Failed to load logs: ${error}`)
+            }
+        },
+        fetchNextLogsPageFailure: ({ error }) => {
+            const errorStr = String(error).toLowerCase()
+            if (error !== NEW_QUERY_STARTED_ERROR_MESSAGE && !errorStr.includes('abort')) {
+                lemonToast.error(`Failed to load more logs: ${error}`)
+            }
+        },
+        fetchLogsSuccess: ({ logs }) => {
+            if (logs.length === 0) {
+                posthog.capture('logs no results returned')
+            } else {
+                posthog.capture('logs results returned', { count: logs.length })
+                globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.ViewFirstLogs)
+            }
+        },
+        fetchNextLogsPage: () => {
+            posthog.capture('logs load more requested')
+        },
+        setLiveTailRunning: async ({ enabled }) => {
+            if (enabled) {
+                posthog.capture('logs live tail started')
+                actions.pollForNewLogs()
+            } else {
+                actions.cancelInProgressLiveTail(null)
+                actions.expireLiveTail()
+            }
+        },
+        runQuery: async ({ debounce }, breakpoint) => {
+            if (debounce) {
+                await breakpoint(debounce)
+            }
+            // Track query execution (skip initial page load)
+            if (values.hasRunQuery) {
+                posthog.capture('logs query executed', {
+                    has_search_term: !!values.filters.searchTerm,
+                    has_filters: values.filters.filterGroup.values.length > 0,
+                    severity_count: values.filters.severityLevels?.length ?? 0,
+                    service_count: values.filters.serviceNames?.length ?? 0,
+                })
+            }
+            actions.clearLogs()
+            actions.fetchLogs()
+            actions.fetchSparkline()
+            actions.cancelInProgressLiveTail(null)
+        },
+        cancelInProgressLogs: ({ logsAbortController }) => {
+            if (values.logsAbortController !== null) {
+                values.logsAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+            }
+            actions.setLogsAbortController(logsAbortController)
+        },
+        cancelInProgressSparkline: ({ sparklineAbortController }) => {
+            if (values.sparklineAbortController !== null) {
+                values.sparklineAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+            }
+            actions.setSparklineAbortController(sparklineAbortController)
+        },
+        cancelInProgressLiveTail: ({ liveTailAbortController }) => {
+            if (values.liveTailAbortController !== null) {
+                values.liveTailAbortController.abort('live tail request cancelled')
+            }
+            actions.setLiveTailAbortController(liveTailAbortController)
+            cache.disposables.dispose('liveTailTimer')
+        },
+        expireLiveTail: async ({}, breakpoint) => {
+            await breakpoint(30000)
+            if (values.liveTailRunning) {
+                return
+            }
+            actions.setLiveTailExpired(true)
+        },
+        pollForNewLogs: async () => {
+            if (!values.liveTailRunning || values.orderBy !== 'latest' || document.hidden) {
+                return
+            }
+
+            const liveTailController = new AbortController()
+            const signal = liveTailController.signal
+            actions.cancelInProgressLiveTail(liveTailController)
+            let duration = 0
+
+            try {
+                const start = Date.now()
+                const response = await api.logs.query({
+                    query: {
+                        limit: DEFAULT_LOGS_PAGE_SIZE,
+                        orderBy: values.orderBy,
+                        dateRange: values.utcDateRange,
+                        searchTerm: values.filters.searchTerm,
+                        filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                        severityLevels: values.filters.severityLevels,
+                        serviceNames: values.filters.serviceNames,
+                        liveLogsCheckpoint: values.liveLogsCheckpoint ?? undefined,
+                    },
+                    signal,
+                })
+                duration = Date.now() - start
+
+                if (response.results.length > 0) {
+                    // the live_logs_checkpoint is the latest known timestamp for which we know we have all logs up to that point
+                    // it's returned from clickhouse as a value on every log row - but the value is fixed per query
+                    actions.setLiveLogsCheckpoint(response.results[0].live_logs_checkpoint ?? null)
+                }
+
+                const existingUuids = new Set(values.logs.map((log) => log.uuid))
+                const newLogs = response.results.filter((log) => !existingUuids.has(log.uuid))
+
+                if (newLogs.length > 0) {
+                    actions.setLiveTailInterval(DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS)
+                    actions.setLogs(
+                        [
+                            ...newLogs.map((log) => ({ ...log, new: true })),
+                            ...values.logs.map((log) => ({ ...log, new: false })),
+                        ]
+                            .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+                            .slice(0, DEFAULT_LOGS_PAGE_SIZE)
+                    )
+                    actions.addLogsToSparkline(newLogs)
+                } else {
+                    const newInterval = Math.min(
+                        values.liveTailPollInterval * 1.5,
+                        DEFAULT_LIVE_TAIL_POLL_INTERVAL_MAX_MS
+                    )
+                    actions.setLiveTailInterval(newInterval)
+                }
+            } catch (error) {
+                if (signal.aborted) {
+                    return
+                }
+                console.error('Live tail polling error:', error)
+                actions.setLiveTailRunning(false)
+            } finally {
+                actions.setLiveTailAbortController(null)
+                if (values.liveTailRunning) {
+                    cache.disposables.add(() => {
+                        const timerId = setTimeout(
+                            () => {
+                                actions.pollForNewLogs()
+                            },
+                            Math.max(duration, values.liveTailPollInterval)
+                        )
+                        return () => clearTimeout(timerId)
+                    }, 'liveTailTimer')
+                }
+            }
+        },
+        // insert logs into the sparkline data (only works for severity breakdown)
+        addLogsToSparkline: (logs: LogMessage[]) => {
+            // Only update incrementally for severity breakdown - service would need service_name from logs
+            if (values.sparklineBreakdownBy !== 'severity') {
+                return
+            }
+            // if the sparkline hasn't loaded do nothing.
+            if (!values.sparkline || values.sparkline.length < 2) {
+                return
+            }
+
+            const first_bucket = values.sparklineData.dates[0]
+            const last_bucket = values.sparklineData.dates[values.sparklineData.dates.length - 1]
+            const sparklineTimeWindow = dayjs(last_bucket).diff(first_bucket, 'seconds')
+            const interval = dayjs(values.sparklineData.dates[1]).diff(first_bucket, 'seconds')
+            let latest_time_bucket = dayjs(last_bucket)
+
+            const sparklineMap: Map<string, { time: string; severity: string; count: number }> = new Map()
+
+            for (const bucket of values.sparkline) {
+                const key = `${dayjs(bucket.time).toISOString()}_${bucket.severity}`
+                sparklineMap.set(key, { ...bucket })
+            }
+
+            for (const log of logs) {
+                const time_bucket = dayjs.unix(Math.floor(dayjs(log.timestamp).unix() / interval) * interval)
+                if (time_bucket.isAfter(latest_time_bucket)) {
+                    latest_time_bucket = time_bucket
+                }
+                const key = `${time_bucket.toISOString()}_${log.level}`
+                if (sparklineMap.has(key)) {
+                    sparklineMap.get(key)!.count += 1
+                } else {
+                    sparklineMap.set(key, { time: time_bucket.toISOString(), severity: log.level, count: 1 })
+                }
+            }
+            actions.setSparkline(
+                Array.from(sparklineMap.values())
+                    .sort((a, b) => dayjs(a.time).diff(dayjs(b.time)) || a.severity.localeCompare(b.severity))
+                    .filter((item) => latest_time_bucket.diff(dayjs(item.time), 'seconds') <= sparklineTimeWindow)
+            )
+        },
+    })),
+
+    events(({ values, actions }) => ({
+        beforeUnmount: () => {
+            actions.setLiveTailRunning(false)
+            actions.cancelInProgressLiveTail(null)
+            if (values.logsAbortController) {
+                values.logsAbortController.abort('unmounting component')
+            }
+            if (values.sparklineAbortController) {
+                values.sparklineAbortController.abort('unmounting component')
+            }
+        },
+    })),
+
+    afterMount(({ values, actions, props }) => {
+        if (props.autoLoad && values.parsedLogs.length === 0) {
+            actions.runQuery()
+        }
+    }),
+])

--- a/products/logs/frontend/components/LogsViewer/logsExportLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsExportLogic.test.ts
@@ -5,43 +5,11 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import { initKeaTests } from '~/test/init'
 
-import { ParsedLogMessage } from 'products/logs/frontend/types'
-
 import { getExportColumns, logsExportLogic } from './logsExportLogic'
 import { logsViewerLogic } from './logsViewerLogic'
 
 jest.mock('lib/api')
 jest.mock('lib/utils/copyToClipboard')
-
-const createMockParsedLog = (uuid: string, body: string = `Log ${uuid}`): ParsedLogMessage => {
-    const baseLog = {
-        uuid,
-        trace_id: 'trace-1',
-        span_id: 'span-1',
-        body,
-        attributes: { 'service.name': 'test-service', custom: 'value' },
-        timestamp: '2024-01-01T00:00:00Z',
-        observed_timestamp: '2024-01-01T00:00:00Z',
-        severity_text: 'info' as const,
-        severity_number: 9,
-        level: 'info' as const,
-        resource_attributes: { 'host.name': 'localhost' },
-        instrumentation_scope: 'test',
-        event_name: 'log',
-    }
-    return {
-        ...baseLog,
-        cleanBody: body,
-        parsedBody: null,
-        originalLog: baseLog,
-    }
-}
-
-const mockLogs = [
-    createMockParsedLog('log-1', 'First log message'),
-    createMockParsedLog('log-2', 'Second log message'),
-    createMockParsedLog('log-3', 'Third log message'),
-]
 
 describe('logsExportLogic', () => {
     describe('getExportColumns', () => {
@@ -76,10 +44,10 @@ describe('logsExportLogic', () => {
             initKeaTests()
             jest.clearAllMocks()
 
-            viewerLogic = logsViewerLogic({ tabId: 'test-tab', logs: mockLogs, orderBy: 'latest' })
+            viewerLogic = logsViewerLogic({ tabId: 'test-tab' })
             viewerLogic.mount()
 
-            exportLogic = logsExportLogic({ tabId: 'test-tab', orderBy: 'latest' })
+            exportLogic = logsExportLogic({ tabId: 'test-tab' })
             exportLogic.mount()
         })
 

--- a/products/logs/frontend/components/LogsViewer/logsExportLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsExportLogic.ts
@@ -9,10 +9,13 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { PropertyGroupFilter, SidePanelTab } from '~/types'
 
-import { LogsOrderBy, ParsedLogMessage } from '../../types'
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+
+import { ParsedLogMessage } from '../../types'
 import { logsViewerFiltersLogic } from './Filters/logsViewerFiltersLogic'
+import { logsViewerDataLogic } from './data/logsViewerDataLogic'
 import type { logsExportLogicType } from './logsExportLogicType'
-import { LogsViewerLogicProps, logsViewerLogic } from './logsViewerLogic'
+import { logsViewerLogic } from './logsViewerLogic'
 
 function triggerBlobDownload(blob: Blob, filename: string): void {
     const url = URL.createObjectURL(blob)
@@ -40,19 +43,22 @@ export function getExportColumns(attributeColumns: string[]): string[] {
 
 export interface LogsExportLogicProps {
     tabId: string
-    orderBy: LogsOrderBy
 }
 
 export const logsExportLogic = kea<logsExportLogicType>([
     path((tabId) => ['products', 'logs', 'frontend', 'components', 'LogsViewer', 'logsExportLogic', tabId]),
     props({} as LogsExportLogicProps),
     key((props) => props.tabId),
-    connect((props: LogsExportLogicProps) => ({
+    connect(({ tabId }: LogsExportLogicProps) => ({
         values: [
-            logsViewerLogic({ tabId: props.tabId } as LogsViewerLogicProps),
+            logsViewerLogic({ tabId }),
             ['selectedLogsArray', 'attributeColumns'],
-            logsViewerFiltersLogic({ id: props.tabId }),
+            logsViewerFiltersLogic({ id: tabId }),
             ['filters', 'utcDateRange'],
+            logsViewerDataLogic({ id: tabId }),
+            ['maxExportableLogs'],
+            logsViewerConfigLogic({ id: tabId }),
+            ['orderBy'],
         ],
         actions: [sidePanelStateLogic, ['openSidePanel']],
     })),
@@ -63,7 +69,7 @@ export const logsExportLogic = kea<logsExportLogicType>([
         exportServerSide: (totalLogsCount?: number) => ({ totalLogsCount }),
     }),
 
-    listeners(({ actions, values, props }) => ({
+    listeners(({ actions, values }) => ({
         copySelectedLogs: () => {
             const selectedLogs = values.selectedLogsArray
             posthog.capture('logs bulk copy', { count: selectedLogs.length })
@@ -98,7 +104,7 @@ export const logsExportLogic = kea<logsExportLogicType>([
                 filterGroup: values.filters.filterGroup as PropertyGroupFilter,
                 severityLevels: values.filters.severityLevels,
                 serviceNames: values.filters.serviceNames,
-                orderBy: props.orderBy,
+                orderBy: values.orderBy,
             }
             posthog.capture('logs exported', { format: 'csv', source: 'server', totalLogsCount })
             try {

--- a/products/logs/frontend/logsSceneLogic.test.ts
+++ b/products/logs/frontend/logsSceneLogic.test.ts
@@ -1,8 +1,6 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
-import { lemonToast } from '@posthog/lemon-ui'
-
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { FilterLogicalOperator } from '~/types'
@@ -10,13 +8,6 @@ import { FilterLogicalOperator } from '~/types'
 import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
 
 import { logsSceneLogic } from './logsSceneLogic'
-
-jest.mock('@posthog/lemon-ui', () => ({
-    ...jest.requireActual('@posthog/lemon-ui'),
-    lemonToast: {
-        error: jest.fn(),
-    },
-}))
 
 describe('logsSceneLogic', () => {
     let logic: ReturnType<typeof logsSceneLogic.build>
@@ -37,93 +28,6 @@ describe('logsSceneLogic', () => {
 
     afterEach(() => {
         logic.unmount()
-    })
-
-    describe('toggleExpandLog', () => {
-        it('expands a log when not expanded', async () => {
-            await expectLogic(logic, () => {
-                logic.actions.toggleExpandLog('log-1')
-            }).toDispatchActions(['toggleExpandLog'])
-
-            expect(logic.values.expandedLogIds.has('log-1')).toBe(true)
-        })
-
-        it('collapses a log when already expanded', async () => {
-            logic.actions.toggleExpandLog('log-1')
-            await expectLogic(logic).toFinishAllListeners()
-
-            expect(logic.values.expandedLogIds.has('log-1')).toBe(true)
-
-            await expectLogic(logic, () => {
-                logic.actions.toggleExpandLog('log-1')
-            }).toDispatchActions(['toggleExpandLog'])
-
-            expect(logic.values.expandedLogIds.has('log-1')).toBe(false)
-        })
-
-        it('supports multiple expanded logs', async () => {
-            logic.actions.toggleExpandLog('log-1')
-            logic.actions.toggleExpandLog('log-2')
-            logic.actions.toggleExpandLog('log-3')
-            await expectLogic(logic).toFinishAllListeners()
-
-            expect(logic.values.expandedLogIds.has('log-1')).toBe(true)
-            expect(logic.values.expandedLogIds.has('log-2')).toBe(true)
-            expect(logic.values.expandedLogIds.has('log-3')).toBe(true)
-
-            logic.actions.toggleExpandLog('log-2')
-            await expectLogic(logic).toFinishAllListeners()
-
-            expect(logic.values.expandedLogIds.has('log-1')).toBe(true)
-            expect(logic.values.expandedLogIds.has('log-2')).toBe(false)
-            expect(logic.values.expandedLogIds.has('log-3')).toBe(true)
-        })
-    })
-
-    describe('error handling', () => {
-        beforeEach(() => {
-            jest.clearAllMocks()
-        })
-
-        it.each([
-            ['new query started', 'exact match for NEW_QUERY_STARTED_ERROR_MESSAGE'],
-            ['Fetch is aborted', 'Safari abort message'],
-            ['The operation was aborted', 'alternative abort message'],
-            ['ABORTED', 'uppercase abort'],
-            ['Request aborted by user', 'abort substring'],
-        ])('suppresses error "%s" (%s)', async (error) => {
-            logic.actions.fetchLogsFailure(error)
-            await expectLogic(logic).toFinishAllListeners()
-
-            expect(lemonToast.error).not.toHaveBeenCalled()
-        })
-
-        it.each([['Network error'], ['Server returned 500'], ['Timeout exceeded']])(
-            'shows toast for legitimate error "%s"',
-            async (error) => {
-                logic.actions.fetchLogsFailure(error)
-                await expectLogic(logic).toFinishAllListeners()
-
-                expect(lemonToast.error).toHaveBeenCalledWith(`Failed to load logs: ${error}`)
-            }
-        )
-
-        it.each([
-            ['Fetch is aborted', 'Safari abort message'],
-            ['new query started', 'exact match for NEW_QUERY_STARTED_ERROR_MESSAGE'],
-        ])('suppresses fetchNextLogsPage error "%s" (%s)', async (error) => {
-            logic.actions.fetchNextLogsPageFailure(error)
-            await expectLogic(logic).toFinishAllListeners()
-
-            expect(lemonToast.error).not.toHaveBeenCalled()
-        })
-
-        it('shows toast for legitimate fetchNextLogsPage error', async () => {
-            logic.actions.fetchNextLogsPageFailure('Network error')
-            await expectLogic(logic).toFinishAllListeners()
-
-            expect(lemonToast.error).toHaveBeenCalledWith('Failed to load more logs: Network error')
-        })
     })
 
     describe('URL parameter parsing', () => {

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -1,41 +1,20 @@
-import colors from 'ansi-colors'
 import equal from 'fast-deep-equal'
-import { actions, afterMount, connect, events, kea, listeners, path, props, reducers, selectors } from 'kea'
-import { loaders } from 'kea-loaders'
+import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
-import { lemonToast } from '@posthog/lemon-ui'
 import { syncSearchParams, updateSearchParams } from '@posthog/products-error-tracking/frontend/utils'
 
-import api from 'lib/api'
-import { dataColorVars } from 'lib/colors'
-import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
-import { dayjs } from 'lib/dayjs'
 import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
-import { humanFriendlyDetailedTime, parseTagsFilter } from 'lib/utils'
+import { parseTagsFilter } from 'lib/utils'
 import { Params } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 
-import {
-    LogMessage,
-    LogsQuery,
-    LogsSparklineBreakdownBy,
-    ProductIntentContext,
-    ProductKey,
-} from '~/queries/schema/schema-general'
-import { integer } from '~/queries/schema/type-utils'
-import {
-    JsonType,
-    PropertyFilterType,
-    PropertyGroupFilter,
-    PropertyOperator,
-    UniversalFiltersGroup,
-    UniversalFiltersGroupValue,
-} from '~/types'
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
+import { UniversalFiltersGroup, UniversalFiltersGroupValue } from '~/types'
 
 import {
     DEFAULT_DATE_RANGE,
@@ -44,29 +23,18 @@ import {
     isValidSeverityLevel,
     logsViewerFiltersLogic,
 } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+import {
+    DEFAULT_ORDER_BY,
+    logsViewerConfigLogic,
+} from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
+import {
+    DEFAULT_INITIAL_LOGS_LIMIT,
+    logsViewerDataLogic,
+} from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 
-import { zoomDateRange } from './components/LogsViewer/Filters/zoom-utils'
 import type { logsSceneLogicType } from './logsSceneLogicType'
-import { LogsFiltersHistoryEntry, LogsOrderBy, ParsedLogMessage } from './types'
-
-const DEFAULT_ORDER_BY = 'latest' as LogsQuery['orderBy']
-const DEFAULT_LOGS_PAGE_SIZE: number = 250
-const DEFAULT_INITIAL_LOGS_LIMIT = null as number | null
-const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
-const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS = 1000
-const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MAX_MS = 5000
-
-const DEFAULT_SPARKLINE_BREAKDOWN_BY: LogsSparklineBreakdownBy = 'severity'
-
-const stringifyLogAttributes = (attributes: Record<string, any>): Record<string, string> => {
-    const result: Record<string, string> = {}
-    for (const key of Object.keys(attributes)) {
-        const value = attributes[key]
-        result[key] = typeof value === 'string' ? value : JSON.stringify(value)
-    }
-    return result
-}
+import { LogsFiltersHistoryEntry } from './types'
 
 export interface LogsLogicProps {
     tabId: string
@@ -82,8 +50,19 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             ['addProductIntent'],
             logsViewerFiltersLogic({ id: props.tabId }),
             ['setDateRange', 'setFilterGroup', 'setFilters', 'setSearchTerm', 'setSeverityLevels', 'setServiceNames'],
+            logsViewerConfigLogic({ id: props.tabId }),
+            ['setOrderBy'],
+            logsViewerDataLogic({ id: props.tabId }),
+            ['setInitialLogsLimit', 'runQuery', 'clearLogs', 'fetchLogsSuccess'],
         ],
-        values: [logsViewerFiltersLogic({ id: props.tabId }), ['filters', 'utcDateRange']],
+        values: [
+            logsViewerFiltersLogic({ id: props.tabId }),
+            ['filters', 'utcDateRange'],
+            logsViewerConfigLogic({ id: props.tabId }),
+            ['orderBy'],
+            logsViewerDataLogic({ id: props.tabId }),
+            ['initialLogsLimit', 'hasRunQuery'],
+        ],
     })),
     tabAwareUrlToAction(({ actions, values }) => {
         const urlToAction = (_: any, params: Params): void => {
@@ -197,6 +176,9 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
         }
 
         return {
+            // initialLogsLimit is a one-shot override from "copy link to log" URLs.
+            // It ensures the first fetch loads enough logs to include the linked log,
+            // then resets to null so subsequent queries use the default page size.
             fetchLogsSuccess: () => clearInitialLogsLimit(),
             syncUrlAndRunQuery: () => buildUrlAndRunQuery(),
         }
@@ -204,54 +186,11 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
 
     actions({
         syncUrlAndRunQuery: true,
-        runQuery: (debounce?: integer) => ({ debounce }),
-        fetchNextLogsPage: (limit?: number) => ({ limit }),
-        truncateLogs: (limit: number) => ({ limit }),
-        clearLogs: true,
-        cancelInProgressLogs: (logsAbortController: AbortController | null) => ({ logsAbortController }),
-        cancelInProgressSparkline: (sparklineAbortController: AbortController | null) => ({ sparklineAbortController }),
-        cancelInProgressLiveTail: (liveTailAbortController: AbortController | null) => ({ liveTailAbortController }),
-        setLogsAbortController: (logsAbortController: AbortController | null) => ({ logsAbortController }),
-        setSparklineAbortController: (sparklineAbortController: AbortController | null) => ({
-            sparklineAbortController,
-        }),
-        setLiveTailAbortController: (liveTailAbortController: AbortController | null) => ({
-            liveTailAbortController,
-        }),
-        setOrderBy: (orderBy: LogsOrderBy, source: 'header' | 'toolbar' = 'toolbar') => ({ orderBy, source }),
         pushToFilterHistory: (filters: LogsViewerFilters) => ({ filters }),
         restoreFiltersFromHistory: (index: number) => ({ index }),
         clearFilterHistory: true,
-        setLiveLogsCheckpoint: (liveLogsCheckpoint: string | null) => ({ liveLogsCheckpoint }),
-
         toggleAttributeBreakdown: (key: string) => ({ key }),
         setExpandedAttributeBreaksdowns: (expandedAttributeBreaksdowns: string[]) => ({ expandedAttributeBreaksdowns }),
-        zoomDateRange: (multiplier: number) => ({ multiplier }),
-        addFilter: (
-            key: string,
-            value: string,
-            operator: PropertyOperator = PropertyOperator.Exact,
-            propertyType: PropertyFilterType = PropertyFilterType.LogAttribute
-        ) => ({
-            key,
-            value,
-            operator,
-            propertyType,
-        }),
-        setHasMoreLogsToLoad: (hasMoreLogsToLoad: boolean) => ({ hasMoreLogsToLoad }),
-        setInitialLogsLimit: (initialLogsLimit: number | null) => ({ initialLogsLimit }),
-        toggleExpandLog: (logId: string) => ({ logId }),
-        setLiveTailRunning: (enabled: boolean) => ({ enabled }),
-        setLiveTailInterval: (interval: number) => ({ interval }),
-        pollForNewLogs: true,
-        setLogs: (logs: LogMessage[]) => ({ logs }),
-        setSparkline: (sparkline: any[]) => ({ sparkline }),
-        setNextCursor: (nextCursor: string | null) => ({ nextCursor }),
-        expireLiveTail: () => true,
-        setLiveTailExpired: (liveTailExpired: boolean) => ({ liveTailExpired }),
-        addLogsToSparkline: (logs: LogMessage[]) => logs,
-        setSparklineBreakdownBy: (sparklineBreakdownBy: LogsSparklineBreakdownBy) => ({ sparklineBreakdownBy }),
-        setMaxExportableLogs: (maxExportableLogs: number) => ({ maxExportableLogs }),
     }),
 
     reducers({
@@ -269,229 +208,13 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                 clearFilterHistory: () => [],
             },
         ],
-        initialLogsLimit: [
-            DEFAULT_INITIAL_LOGS_LIMIT as number | null,
-            {
-                setInitialLogsLimit: (_, { initialLogsLimit }) => initialLogsLimit,
-                fetchLogsSuccess: () => null,
-            },
-        ],
-        orderBy: [
-            DEFAULT_ORDER_BY,
-            {
-                setOrderBy: (_, { orderBy }) => orderBy,
-            },
-        ],
-        liveLogsCheckpoint: [
-            null as string | null,
-            { persist: false },
-            {
-                setLiveLogsCheckpoint: (_, { liveLogsCheckpoint }) => liveLogsCheckpoint,
-            },
-        ],
-        liveTailExpired: [
-            true as boolean,
-            { persist: false },
-            {
-                setLiveTailExpired: (_, { liveTailExpired }) => liveTailExpired,
-                fetchLogsSuccess: () => false,
-            },
-        ],
-        logsAbortController: [
-            null as AbortController | null,
-            {
-                setLogsAbortController: (_, { logsAbortController }) => logsAbortController,
-            },
-        ],
-        sparklineAbortController: [
-            null as AbortController | null,
-            {
-                setSparklineAbortController: (_, { sparklineAbortController }) => sparklineAbortController,
-            },
-        ],
-        liveTailAbortController: [
-            null as AbortController | null,
-            {
-                setLiveTailAbortController: (_, { liveTailAbortController }) => liveTailAbortController,
-            },
-        ],
-        hasRunQuery: [
-            false as boolean,
-            {
-                fetchLogsSuccess: () => true,
-                fetchLogsFailure: () => true,
-            },
-        ],
-        logsLoading: [
-            false as boolean,
-            {
-                fetchLogs: () => true,
-                fetchLogsSuccess: () => false,
-                fetchLogsFailure: () => true,
-                fetchNextLogsPage: () => true,
-                fetchNextLogsPageSuccess: () => false,
-                fetchNextLogsPageFailure: () => true,
-            },
-        ],
-
-        sparklineLoading: [
-            false as boolean,
-            {
-                fetchSparkline: () => true,
-                fetchSparklineSuccess: () => false,
-                fetchSparklineFailure: () => true,
-            },
-        ],
         expandedAttributeBreaksdowns: [
             [] as string[],
             {
                 setExpandedAttributeBreaksdowns: (_, { expandedAttributeBreaksdowns }) => expandedAttributeBreaksdowns,
             },
         ],
-        liveTailRunning: [
-            false as boolean,
-            {
-                setLiveTailRunning: (_, { enabled }) => enabled,
-                runQuery: () => false,
-            },
-        ],
-        liveTailPollInterval: [
-            DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS as number,
-            {
-                setLiveTailInterval: (_, { interval }) => interval,
-            },
-        ],
-        hasMoreLogsToLoad: [
-            true as boolean,
-            {
-                setHasMoreLogsToLoad: (_, { hasMoreLogsToLoad }) => hasMoreLogsToLoad,
-                clearLogs: () => true,
-            },
-        ],
-        nextCursor: [
-            null as string | null,
-            {
-                setNextCursor: (_, { nextCursor }) => nextCursor,
-                clearLogs: () => null,
-            },
-        ],
-        expandedLogIds: [
-            new Set<string>(),
-            {
-                toggleExpandLog: (state, { logId }) => {
-                    const newSet = new Set(state)
-                    if (newSet.has(logId)) {
-                        newSet.delete(logId)
-                    } else {
-                        newSet.add(logId)
-                    }
-                    return newSet
-                },
-                clearLogs: () => new Set<string>(),
-            },
-        ],
-        sparklineBreakdownBy: [
-            DEFAULT_SPARKLINE_BREAKDOWN_BY as LogsSparklineBreakdownBy,
-            { persist: true },
-            {
-                setSparklineBreakdownBy: (_, { sparklineBreakdownBy }) => sparklineBreakdownBy,
-            },
-        ],
-        maxExportableLogs: [
-            10_000 as number,
-            {
-                setMaxExportableLogs: (_, { maxExportableLogs }) => maxExportableLogs,
-            },
-        ],
     }),
-
-    loaders(({ values, actions }) => ({
-        logs: [
-            [] as LogMessage[],
-            {
-                clearLogs: () => [],
-                truncateLogs: ({ limit }) => values.logs.slice(0, limit),
-                fetchLogs: async () => {
-                    const logsController = new AbortController()
-                    const signal = logsController.signal
-                    actions.cancelInProgressLogs(logsController)
-
-                    const response = await api.logs.query({
-                        query: {
-                            limit: values.initialLogsLimit ?? DEFAULT_LOGS_PAGE_SIZE,
-                            orderBy: values.orderBy,
-                            dateRange: values.utcDateRange,
-                            searchTerm: values.filters.searchTerm,
-                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
-                            severityLevels: values.filters.severityLevels,
-                            serviceNames: values.filters.serviceNames,
-                        },
-                        signal,
-                    })
-                    actions.setLogsAbortController(null)
-                    actions.setHasMoreLogsToLoad(!!response.hasMore)
-                    actions.setNextCursor(response.nextCursor ?? null)
-                    actions.setMaxExportableLogs(response.maxExportableLogs)
-                    return response.results
-                },
-                fetchNextLogsPage: async ({ limit }, breakpoint) => {
-                    const logsController = new AbortController()
-                    const signal = logsController.signal
-                    actions.cancelInProgressLogs(logsController)
-
-                    if (!values.nextCursor) {
-                        return values.logs
-                    }
-
-                    await breakpoint(300)
-                    const response = await api.logs.query({
-                        query: {
-                            limit: limit ?? DEFAULT_LOGS_PAGE_SIZE,
-                            orderBy: values.orderBy,
-                            dateRange: values.utcDateRange,
-                            searchTerm: values.filters.searchTerm,
-                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
-                            severityLevels: values.filters.severityLevels,
-                            serviceNames: values.filters.serviceNames,
-                            after: values.nextCursor,
-                        },
-                        signal,
-                    })
-                    actions.setLogsAbortController(null)
-                    actions.setHasMoreLogsToLoad(!!response.hasMore)
-                    actions.setNextCursor(response.nextCursor ?? null)
-                    return [...values.logs, ...response.results]
-                },
-                setLogs: ({ logs }) => logs,
-            },
-        ],
-        sparkline: [
-            [] as any[],
-            {
-                fetchSparkline: async () => {
-                    const sparklineController = new AbortController()
-                    const signal = sparklineController.signal
-                    actions.cancelInProgressSparkline(sparklineController)
-
-                    const response = await api.logs.sparkline({
-                        query: {
-                            orderBy: values.orderBy,
-                            dateRange: values.utcDateRange,
-                            searchTerm: values.filters.searchTerm,
-                            filterGroup: values.filters.filterGroup as PropertyGroupFilter,
-                            severityLevels: values.filters.severityLevels,
-                            serviceNames: values.filters.serviceNames,
-                            sparklineBreakdownBy: values.sparklineBreakdownBy,
-                        },
-                        signal,
-                    })
-                    actions.setSparklineAbortController(null)
-                    return response
-                },
-                setSparkline: ({ sparkline }) => sparkline,
-            },
-        ],
-    })),
 
     selectors({
         tabId: [(_, p) => [p.tabId], (tabId: string) => tabId],
@@ -499,182 +222,9 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             (s) => [s.filterHistory],
             (filterHistory: LogsFiltersHistoryEntry[]) => filterHistory.length > 0,
         ],
-        liveTailDisabledReason: [
-            (s) => [s.orderBy, s.filters, s.logsLoading, s.liveTailExpired],
-            (
-                orderBy: LogsQuery['orderBy'],
-                filters: LogsViewerFilters,
-                logsLoading: boolean,
-                liveTailExpired: boolean
-            ): string | undefined => {
-                if (orderBy !== 'latest') {
-                    return 'Live tail only works with "Latest" ordering'
-                }
-
-                if (filters.dateRange.date_to) {
-                    return 'Live tail requires an open-ended time range'
-                }
-
-                if (logsLoading) {
-                    return 'Wait for query to finish'
-                }
-
-                if (liveTailExpired) {
-                    return 'Live tail has expired, run search again to live tail'
-                }
-
-                return undefined
-            },
-        ],
-        parsedLogs: [
-            (s) => [s.logs],
-            (logs: LogMessage[]): ParsedLogMessage[] => {
-                const seen = new Set<string>()
-                const result: ParsedLogMessage[] = []
-
-                for (const log of logs) {
-                    if (seen.has(log.uuid)) {
-                        continue
-                    }
-                    seen.add(log.uuid)
-                    const cleanBody = colors.unstyle(log.body)
-                    let parsedBody: JsonType | null = null
-                    try {
-                        parsedBody = JSON.parse(cleanBody)
-                    } catch {
-                        // Not JSON, that's fine
-                    }
-                    result.push({
-                        ...log,
-                        attributes: stringifyLogAttributes(log.attributes),
-                        cleanBody,
-                        parsedBody,
-                        originalLog: log,
-                    })
-                }
-
-                return result
-            },
-        ],
-        visibleLogsTimeRange: [
-            (s) => [s.parsedLogs, s.orderBy],
-            (
-                parsedLogs: ParsedLogMessage[],
-                orderBy: LogsQuery['orderBy']
-            ): { date_from: string; date_to: string } | null => {
-                if (parsedLogs.length === 0) {
-                    return null
-                }
-                const firstTimestamp = parsedLogs[0].timestamp
-                const lastTimestamp = parsedLogs[parsedLogs.length - 1].timestamp
-
-                // When orderBy is 'latest', first log is newest, last log is oldest
-                // When orderBy is 'earliest', first log is oldest, last log is newest
-                if (orderBy === 'latest') {
-                    return {
-                        date_from: dayjs(lastTimestamp).toISOString(),
-                        date_to: dayjs(firstTimestamp).toISOString(),
-                    }
-                }
-                return {
-                    date_from: dayjs(firstTimestamp).toISOString(),
-                    date_to: dayjs(lastTimestamp).toISOString(),
-                }
-            },
-        ],
-        sparklineData: [
-            (s) => [s.sparkline, s.sparklineBreakdownBy],
-            (sparkline: any[], sparklineBreakdownBy: LogsSparklineBreakdownBy) => {
-                const breakdownKey = sparklineBreakdownBy
-
-                let lastTime = ''
-                let i = -1
-                const labels: string[] = []
-                const dates: string[] = []
-                const accumulated = sparkline.reduce(
-                    (accumulator, currentItem) => {
-                        if (currentItem.time !== lastTime) {
-                            labels.push(
-                                humanFriendlyDetailedTime(currentItem.time, 'YYYY-MM-DD', 'HH:mm:ss', {
-                                    timestampStyle: 'absolute',
-                                })
-                            )
-                            dates.push(currentItem.time)
-                            lastTime = currentItem.time
-                            i++
-                        }
-                        const key = currentItem[breakdownKey]
-                        if (!key) {
-                            return accumulator
-                        }
-                        if (!accumulator[key]) {
-                            accumulator[key] = []
-                        }
-                        while (accumulator[key].length <= i) {
-                            accumulator[key].push(0)
-                        }
-                        accumulator[key][i] += currentItem.count
-                        return accumulator
-                    },
-                    {} as Record<string, number[]>
-                )
-
-                const data = Object.entries(accumulated)
-                    .sort(([a], [b]) => a.localeCompare(b))
-                    .map(([name, values], index) => ({
-                        name,
-                        values: values as number[],
-                        color:
-                            sparklineBreakdownBy === 'service'
-                                ? dataColorVars[index % dataColorVars.length]
-                                : {
-                                      fatal: 'danger-dark',
-                                      error: 'danger',
-                                      warn: 'warning',
-                                      info: 'brand-blue',
-                                      debug: 'muted',
-                                      trace: 'muted-alt',
-                                  }[name],
-                    }))
-                    .filter((series) => series.values.reduce((a, b) => a + b) > 0)
-
-                return { data, labels, dates }
-            },
-        ],
-        totalLogsMatchingFilters: [
-            (s) => [s.sparkline],
-            (sparkline): number => sparkline.reduce((sum, item) => sum + item.count, 0),
-        ],
-        logsRemainingToLoad: [
-            (s) => [s.totalLogsMatchingFilters, s.logs],
-            (totalLogsMatchingFilters, logs): number => totalLogsMatchingFilters - logs.length,
-        ],
     }),
 
-    listeners(({ values, actions, cache }) => ({
-        fetchLogsFailure: ({ error }) => {
-            const errorStr = String(error).toLowerCase()
-            if (error !== NEW_QUERY_STARTED_ERROR_MESSAGE && !errorStr.includes('abort')) {
-                lemonToast.error(`Failed to load logs: ${error}`)
-            }
-        },
-        fetchNextLogsPageFailure: ({ error }) => {
-            const errorStr = String(error).toLowerCase()
-            if (error !== NEW_QUERY_STARTED_ERROR_MESSAGE && !errorStr.includes('abort')) {
-                lemonToast.error(`Failed to load more logs: ${error}`)
-            }
-        },
-        fetchLogsSuccess: ({ logs }) => {
-            if (logs.length === 0) {
-                posthog.capture('logs no results returned')
-            } else {
-                posthog.capture('logs results returned', { count: logs.length })
-                globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.ViewFirstLogs)
-            }
-        },
-        fetchNextLogsPage: () => {
-            posthog.capture('logs load more requested')
-        },
+    listeners(({ values, actions }) => ({
         setSearchTerm: ({ searchTerm }) => {
             if (values.hasRunQuery) {
                 posthog.capture('logs filter changed', {
@@ -790,33 +340,6 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             posthog.capture('logs setting changed', { setting: 'order_by', value: orderBy, source })
             actions.syncUrlAndRunQuery()
         },
-        setLiveTailRunning: async ({ enabled }) => {
-            if (enabled) {
-                posthog.capture('logs live tail started')
-                actions.pollForNewLogs()
-            } else {
-                actions.cancelInProgressLiveTail(null)
-                actions.expireLiveTail()
-            }
-        },
-        runQuery: async ({ debounce }, breakpoint) => {
-            if (debounce) {
-                await breakpoint(debounce)
-            }
-            // Track query execution (skip initial page load)
-            if (values.hasRunQuery) {
-                posthog.capture('logs query executed', {
-                    has_search_term: !!values.filters.searchTerm,
-                    has_filters: values.filters.filterGroup.values.length > 0,
-                    severity_count: values.filters.severityLevels?.length ?? 0,
-                    service_count: values.filters.serviceNames?.length ?? 0,
-                })
-            }
-            actions.clearLogs()
-            actions.fetchLogs()
-            actions.fetchSparkline()
-            actions.cancelInProgressLiveTail(null)
-        },
         restoreFiltersFromHistory: ({ index }) => {
             const entry = values.filterHistory[index]
             if (entry) {
@@ -832,212 +355,12 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                 history_size: values.filterHistory.length,
             })
         },
-        cancelInProgressLogs: ({ logsAbortController }) => {
-            if (values.logsAbortController !== null) {
-                values.logsAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
-            }
-            actions.setLogsAbortController(logsAbortController)
-        },
-        cancelInProgressSparkline: ({ sparklineAbortController }) => {
-            if (values.sparklineAbortController !== null) {
-                values.sparklineAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
-            }
-            actions.setSparklineAbortController(sparklineAbortController)
-        },
-        setSparklineBreakdownBy: () => {
-            actions.fetchSparkline()
-        },
-        cancelInProgressLiveTail: ({ liveTailAbortController }) => {
-            if (values.liveTailAbortController !== null) {
-                values.liveTailAbortController.abort('live tail request cancelled')
-            }
-            actions.setLiveTailAbortController(liveTailAbortController)
-            cache.disposables.dispose('liveTailTimer')
-        },
+
         toggleAttributeBreakdown: ({ key }) => {
             const breakdowns = [...values.expandedAttributeBreaksdowns]
             const index = breakdowns.indexOf(key)
             index >= 0 ? breakdowns.splice(index, 1) : breakdowns.push(key)
             actions.setExpandedAttributeBreaksdowns(breakdowns)
         },
-        zoomDateRange: ({ multiplier }) => {
-            posthog.capture('logs date range zoomed', {
-                direction: multiplier > 1 ? 'out' : 'in',
-                multiplier,
-            })
-            const newDateRange = zoomDateRange(values.filters.dateRange, multiplier)
-            actions.setDateRange(newDateRange)
-        },
-        expireLiveTail: async ({}, breakpoint) => {
-            await breakpoint(30000)
-            if (values.liveTailRunning) {
-                return
-            }
-            actions.setLiveTailExpired(true)
-        },
-        addFilter: ({
-            key,
-            value,
-            operator,
-            propertyType,
-        }: {
-            key: string
-            value: string
-            operator: string
-            propertyType: PropertyFilterType
-        }) => {
-            const currentGroup = values.filters.filterGroup.values[0] as UniversalFiltersGroup
-
-            const newGroup: UniversalFiltersGroup = {
-                ...currentGroup,
-                values: [
-                    ...currentGroup.values,
-                    {
-                        key,
-                        value: [value],
-                        operator,
-                        type: propertyType,
-                    } as UniversalFiltersGroupValue,
-                ],
-            }
-
-            actions.setFilterGroup({ ...values.filters.filterGroup, values: [newGroup] }, false)
-        },
-        pollForNewLogs: async () => {
-            if (!values.liveTailRunning || values.orderBy !== 'latest' || document.hidden) {
-                return
-            }
-
-            const liveTailController = new AbortController()
-            const signal = liveTailController.signal
-            actions.cancelInProgressLiveTail(liveTailController)
-            let duration = 0
-
-            try {
-                const start = Date.now()
-                const response = await api.logs.query({
-                    query: {
-                        limit: DEFAULT_LOGS_PAGE_SIZE,
-                        orderBy: values.orderBy,
-                        dateRange: values.utcDateRange,
-                        searchTerm: values.filters.searchTerm,
-                        filterGroup: values.filters.filterGroup as PropertyGroupFilter,
-                        severityLevels: values.filters.severityLevels,
-                        serviceNames: values.filters.serviceNames,
-                        liveLogsCheckpoint: values.liveLogsCheckpoint ?? undefined,
-                    },
-                    signal,
-                })
-                duration = Date.now() - start
-
-                if (response.results.length > 0) {
-                    // the live_logs_checkpoint is the latest known timestamp for which we know we have all logs up to that point
-                    // it's returned from clickhouse as a value on every log row - but the value is fixed per query
-                    actions.setLiveLogsCheckpoint(response.results[0].live_logs_checkpoint ?? null)
-                }
-
-                const existingUuids = new Set(values.logs.map((log) => log.uuid))
-                const newLogs = response.results.filter((log) => !existingUuids.has(log.uuid))
-
-                if (newLogs.length > 0) {
-                    actions.setLiveTailInterval(DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS)
-                    actions.setLogs(
-                        [
-                            ...newLogs.map((log) => ({ ...log, new: true })),
-                            ...values.logs.map((log) => ({ ...log, new: false })),
-                        ]
-                            .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
-                            .slice(0, DEFAULT_LOGS_PAGE_SIZE)
-                    )
-                    actions.addLogsToSparkline(newLogs)
-                } else {
-                    const newInterval = Math.min(
-                        values.liveTailPollInterval * 1.5,
-                        DEFAULT_LIVE_TAIL_POLL_INTERVAL_MAX_MS
-                    )
-                    actions.setLiveTailInterval(newInterval)
-                }
-            } catch (error) {
-                if (signal.aborted) {
-                    return
-                }
-                console.error('Live tail polling error:', error)
-                actions.setLiveTailRunning(false)
-            } finally {
-                actions.setLiveTailAbortController(null)
-                if (values.liveTailRunning) {
-                    cache.disposables.add(() => {
-                        const timerId = setTimeout(
-                            () => {
-                                actions.pollForNewLogs()
-                            },
-                            Math.max(duration, values.liveTailPollInterval)
-                        )
-                        return () => clearTimeout(timerId)
-                    }, 'liveTailTimer')
-                }
-            }
-        },
-        // insert logs into the sparkline data (only works for severity breakdown)
-        addLogsToSparkline: (logs: LogMessage[]) => {
-            // Only update incrementally for severity breakdown - service would need service_name from logs
-            if (values.sparklineBreakdownBy !== 'severity') {
-                return
-            }
-            // if the sparkline hasn't loaded do nothing.
-            if (!values.sparkline || values.sparkline.length < 2) {
-                return
-            }
-
-            const first_bucket = values.sparklineData.dates[0]
-            const last_bucket = values.sparklineData.dates[values.sparklineData.dates.length - 1]
-            const sparklineTimeWindow = dayjs(last_bucket).diff(first_bucket, 'seconds')
-            const interval = dayjs(values.sparklineData.dates[1]).diff(first_bucket, 'seconds')
-            let latest_time_bucket = dayjs(last_bucket)
-
-            const sparklineMap: Map<string, { time: string; severity: string; count: number }> = new Map()
-
-            for (const bucket of values.sparkline) {
-                const key = `${dayjs(bucket.time).toISOString()}_${bucket.severity}`
-                sparklineMap.set(key, { ...bucket })
-            }
-
-            for (const log of logs) {
-                const time_bucket = dayjs.unix(Math.floor(dayjs(log.timestamp).unix() / interval) * interval)
-                if (time_bucket.isAfter(latest_time_bucket)) {
-                    latest_time_bucket = time_bucket
-                }
-                const key = `${time_bucket.toISOString()}_${log.level}`
-                if (sparklineMap.has(key)) {
-                    sparklineMap.get(key)!.count += 1
-                } else {
-                    sparklineMap.set(key, { time: time_bucket.toISOString(), severity: log.level, count: 1 })
-                }
-            }
-            actions.setSparkline(
-                Array.from(sparklineMap.values())
-                    .sort((a, b) => dayjs(a.time).diff(dayjs(b.time)) || a.severity.localeCompare(b.severity))
-                    .filter((item) => latest_time_bucket.diff(dayjs(item.time), 'seconds') <= sparklineTimeWindow)
-            )
-        },
     })),
-
-    events(({ values, actions }) => ({
-        beforeUnmount: () => {
-            actions.setLiveTailRunning(false)
-            actions.cancelInProgressLiveTail(null)
-            if (values.logsAbortController) {
-                values.logsAbortController.abort('unmounting component')
-            }
-            if (values.sparklineAbortController) {
-                values.sparklineAbortController.abort('unmounting component')
-            }
-        },
-    })),
-
-    afterMount(({ values, actions }) => {
-        if (values.parsedLogs.length === 0) {
-            actions.runQuery()
-        }
-    }),
 ])


### PR DESCRIPTION
## Problem

We want the logs viewer to be portable, however much of its logic and state is tied to the scene.

## Changes

> [!NOTE]
> This PR is large by line count but most changes are code moving from `logsSceneLogic` into dedicated logics - the net change is -123 lines.

This PR is the start of a refactor aimed at making the sceneLogic concern itself only with the URL / scene state.

1. Created a dedicated `logsViewerDataLogic` to handle data fetching, live tail functionality, and sparkline data processing
2. Moving configuration settings to `logsViewerConfigLogic` (order by, sparkline breakdown)
3. Simplifying the `LogsViewer` component to use these logics instead of receiving numerous props
4. Removing redundant code from `logsSceneLogic` that has been moved to the appropriate logic files

This change improves maintainability by better separating concerns and reducing prop drilling.

## How did you test this code?

- Verified all logs viewer functionality works as before
- Confirmed logs can be loaded, filtered, and displayed correctly
- Tested live tail functionality
- Ensured error handling works properly with unit tests for the new logic
- Checked that all UI interactions (filtering, sorting, exporting) function correctly
- Ran all unit tests

## Publish to changelog?

No