### PR TITLE
fix(settings): reverting previous fix and using unique key per setting

### DIFF
--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -286,8 +286,8 @@ function SettingsRenderer(props: SettingsLogicProps & { handleLocally: boolean }
     return (
         <div className="flex flex-col gap-y-8 pb-[80vh]">
             {settings.length ? (
-                settings.map((x) => (
-                    <div key={x.id} className="relative last:mb-4">
+                settings.map((x, index) => (
+                    <div key={`${x.id}-${index}`} className="relative last:mb-4">
                         {!settingsInSidebar && x.title && (
                             <h2 id={x.id} className="flex gap-2 items-center">
                                 {x.title}

--- a/frontend/src/scenes/settings/settingsLogic.ts
+++ b/frontend/src/scenes/settings/settingsLogic.ts
@@ -273,18 +273,9 @@ export const settingsLogic = kea<settingsLogicType>([
                 if (selectedSectionId) {
                     settings = sections.find((x) => x.id === selectedSectionId)?.settings || []
                 } else {
-                    const seen = new Set<string>()
                     settings = sections
                         .filter((section) => section.level === selectedLevel)
-                        .reduce((acc, section) => {
-                            for (const setting of section.settings) {
-                                if (!seen.has(setting.id)) {
-                                    seen.add(setting.id)
-                                    acc.push(setting)
-                                }
-                            }
-                            return acc
-                        }, [] as Setting[])
+                        .reduce((acc, section) => acc.concat(section.settings), [] as Setting[])
                 }
 
                 return settings.filter((x) => {


### PR DESCRIPTION
## Problem

Reverts the deduplication fix from #47737 and applies a better approach.

Settings like `web-vitals-autocapture` intentionally appear in multiple sections (autocapture, web-analytics, replay). When viewing "all settings" for a level, the old `concat` produced duplicate entries. The previous fix (#47737) deduplicated them, but the team agreed we may want to show them multiple times since they belong to multiple sections.

The real bug was that duplicate setting IDs were used as React `key` props (`key={x.id}`). When multiple elements share the same key, React's internal reconciliation map can only store one reference per key — the others become orphaned DOM nodes that React can't clean up. This caused settings to visually "accumulate" across navigations.

## Changes

- **`Settings.tsx`**: Use `key={`${x.id}-${index}`}` instead of `key={x.id}` so React can properly track each element even when the same setting appears multiple times
- **`settingsLogic.ts`**: Revert the `uniqueSettingsForLevel` deduplication — settings now show in all their section contexts

## How did you test this code?

- Navigated between individual sections and "all settings" view repeatedly — no ghost/orphaned elements
- Verified `web-vitals-autocapture` renders in all its section contexts without accumulation

## Publish to changelog?

no