### PR TITLE
fix: Restore all references to posthog-js to point to catalog

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -211,7 +211,7 @@
         "openai": "^4.81.0",
         "papaparse": "^5.4.1",
         "pmtiles": "^2.11.0",
-        "posthog-js": "1.345.5",
+        "posthog-js": "catalog:",
         "posthog-js-lite": "4.2.2",
         "prettier": "catalog:",
         "prop-types": "^15.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -955,8 +955,8 @@ importers:
         specifier: ^2.11.0
         version: 2.11.0
       posthog-js:
-        specifier: 1.345.5
-        version: 1.345.5
+        specifier: 'catalog:'
+        version: 1.347.0
       posthog-js-lite:
         specifier: 4.2.2
         version: 4.2.2
@@ -1816,8 +1816,8 @@ importers:
         specifier: 'catalog:'
         version: 3.0.1(kea@3.1.7(react@18.3.1))
       posthog-js:
-        specifier: 1.345.5
-        version: 1.345.5
+        specifier: 'catalog:'
+        version: 1.347.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2016,8 +2016,8 @@ importers:
         specifier: 'catalog:'
         version: 3.0.1(kea@3.1.7(react@18.3.1))
       posthog-js:
-        specifier: 1.345.5
-        version: 1.345.5
+        specifier: 'catalog:'
+        version: 1.347.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2257,8 +2257,8 @@ importers:
         specifier: 'catalog:'
         version: 3.0.1(kea@3.1.7(react@18.3.1))
       posthog-js:
-        specifier: 1.345.5
-        version: 1.345.5
+        specifier: 'catalog:'
+        version: 1.347.0
       prettier:
         specifier: '*'
         version: 3.6.2
@@ -2339,8 +2339,8 @@ importers:
         specifier: '*'
         version: 5.4.1
       posthog-js:
-        specifier: 1.345.5
-        version: 1.345.5
+        specifier: 'catalog:'
+        version: 1.347.0
       prettier:
         specifier: '*'
         version: 3.4.2
@@ -2660,8 +2660,8 @@ importers:
         specifier: 'catalog:'
         version: 3.4.1(kea@3.1.7(react@18.3.1))
       posthog-js:
-        specifier: 1.345.5
-        version: 1.345.5
+        specifier: 'catalog:'
+        version: 1.347.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2732,8 +2732,8 @@ importers:
         specifier: 'catalog:'
         version: 3.0.1(kea@3.1.7(react@18.3.1))
       posthog-js:
-        specifier: 1.345.5
-        version: 1.345.5
+        specifier: 'catalog:'
+        version: 1.347.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -7481,9 +7481,6 @@ packages:
 
   '@posthog/siphash@1.1.1':
     resolution: {integrity: sha512-JUFk57H89fOnHpF62FDyFGw4uXeHAX20OPfkLL8/iqg/xrVp5Q21LvJUDijmS5wt0avgUwXF2bxYgaZ5iWRmAg==}
-
-  '@posthog/types@1.345.5':
-    resolution: {integrity: sha512-nPQQ5QfVMmsKquXQkXfA8g1/2IrHO7npw8ezcC0v3xJaTpAKoqBqknqugP+RwTlIfkhCbHSGd6x00yRSwTGaBQ==}
 
   '@posthog/types@1.347.0':
     resolution: {integrity: sha512-wnz/9DBO4b/C7mzhXgUacKyqt/DNN+yg7CutJXflAm7cbrSygULhndHlGhDtbZPL7XgCkoNq9tEjVr7tUVm8aA==}
@@ -17519,9 +17516,6 @@ packages:
 
   posthog-js-lite@4.2.2:
     resolution: {integrity: sha512-fFCoGtMICWwoW0tsEdyFS7OFFgwe7bTTha/SKEtUdyJ56UyJ8wi6VghxyPkO2GVWpco5Za/edT1z1ovGYPCyLQ==}
-
-  posthog-js@1.345.5:
-    resolution: {integrity: sha512-Hplt/aRD3DQLTQl3NxmS7V0jZPF18nnKJ4rST0qinz/6tXNCMemYqOVb4C/HYAXXWrtVVzGSJeNCNKvECFHHoQ==}
 
   posthog-js@1.347.0:
     resolution: {integrity: sha512-AEbSkr1EAg4v8PvijuuaQ0z/Ki9yRT1MrkRRkQpt+gN/ZuQNsjVZgKZYrLd0kPzAI0vLLK0ToCpt4BCytwULqQ==}
@@ -27825,8 +27819,6 @@ snapshots:
       mitt: 3.0.0
 
   '@posthog/siphash@1.1.1': {}
-
-  '@posthog/types@1.345.5': {}
 
   '@posthog/types@1.347.0': {}
 
@@ -40540,22 +40532,6 @@ snapshots:
   posthog-js-lite@4.2.2:
     dependencies:
       '@posthog/core': 1.7.1
-
-  posthog-js@1.345.5:
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.5.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
-      '@posthog/core': 1.22.0
-      '@posthog/types': 1.345.5
-      core-js: 3.40.0
-      dompurify: 3.3.1
-      fflate: 0.4.8
-      preact: 10.28.3
-      query-selector-shadow-dom: 1.0.1
-      web-vitals: 5.1.0
 
   posthog-js@1.347.0:
     dependencies:

--- a/products/conversations/package.json
+++ b/products/conversations/package.json
@@ -5,7 +5,7 @@
         "kea-loaders": "catalog:",
         "kea-router": "catalog:",
         "kea-subscriptions": "catalog:",
-        "posthog-js": "1.345.5",
+        "posthog-js": "catalog:",
         "ts-pattern": "catalog:"
     },
     "peerDependencies": {

--- a/products/error_tracking/package.json
+++ b/products/error_tracking/package.json
@@ -7,7 +7,7 @@
         "kea-loaders": "catalog:",
         "kea-router": "catalog:",
         "kea-subscriptions": "catalog:",
-        "posthog-js": "1.345.5"
+        "posthog-js": "catalog:"
     },
     "peerDependencies": {
         "@dnd-kit/core": "*",

--- a/products/llm_analytics/package.json
+++ b/products/llm_analytics/package.json
@@ -7,7 +7,7 @@
         "kea-loaders": "catalog:",
         "kea-router": "catalog:",
         "kea-subscriptions": "catalog:",
-        "posthog-js": "1.345.5"
+        "posthog-js": "catalog:"
     },
     "devDependencies": {
         "kea-test-utils": "catalog:"

--- a/products/logs/package.json
+++ b/products/logs/package.json
@@ -6,7 +6,7 @@
         "kea-loaders": "catalog:",
         "kea-router": "catalog:",
         "kea-subscriptions": "catalog:",
-        "posthog-js": "1.345.5"
+        "posthog-js": "catalog:"
     },
     "peerDependencies": {
         "@posthog/icons": "*",

--- a/products/user_interviews/package.json
+++ b/products/user_interviews/package.json
@@ -4,7 +4,7 @@
         "kea": "catalog:",
         "kea-loaders": "catalog:",
         "kea-router": "catalog:",
-        "posthog-js": "1.345.5"
+        "posthog-js": "catalog:"
     },
     "peerDependencies": {
         "@posthog/icons": "*",

--- a/products/workflows/package.json
+++ b/products/workflows/package.json
@@ -6,7 +6,7 @@
         "kea-loaders": "catalog:",
         "kea-router": "catalog:",
         "kea-subscriptions": "catalog:",
-        "posthog-js": "1.345.5",
+        "posthog-js": "catalog:",
         "use-debounce": "catalog:"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem
Update bot [went mad](https://github.com/PostHog/posthog/pull/47772) and updated posthog-js everyhere
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
