### PR TITLE
feat(cli): Add JSON schema export option

### DIFF
--- a/cli/src/experimental/schema.rs
+++ b/cli/src/experimental/schema.rs
@@ -15,6 +15,7 @@ enum Language {
     TypeScript,
     Golang,
     Python,
+    Json,
 }
 
 impl Language {
@@ -24,6 +25,7 @@ impl Language {
             Language::TypeScript => "typescript",
             Language::Golang => "golang",
             Language::Python => "python",
+            Language::Json => "json",
         }
     }
 
@@ -33,6 +35,7 @@ impl Language {
             Language::TypeScript => "TypeScript",
             Language::Golang => "Go",
             Language::Python => "Python",
+            Language::Json => "JSON",
         }
     }
 
@@ -43,6 +46,7 @@ impl Language {
             Language::Golang => "posthog-typed.go",
             // Python uses underscore because hyphens aren't valid in Python module names
             Language::Python => "posthog_typed.py",
+            Language::Json => "posthog_schema.json",
         }
     }
 
@@ -100,12 +104,28 @@ You can add optional properties through the option functions:
    client.shutdown()
 "#
             ),
+            Language::Json => format!(
+                r#"
+1. You now have a raw JSON export of your PostHog event schema:
+   {output_path}
+
+2. You can use this file to:
+   - Generate code for languages not yet supported by the CLI
+   - Validate events in your CI/CD pipeline
+   - Build custom integrations
+"#
+            ),
         }
     }
 
     /// Get all available languages
     fn all() -> Vec<Language> {
-        vec![Language::TypeScript, Language::Golang, Language::Python]
+        vec![
+            Language::TypeScript,
+            Language::Golang,
+            Language::Python,
+            Language::Json,
+        ]
     }
 
     /// Parse a language from a string identifier
@@ -114,6 +134,7 @@ You can add optional properties through the option functions:
             "typescript" => Some(Language::TypeScript),
             "golang" => Some(Language::Golang),
             "python" => Some(Language::Python),
+            "json" => Some(Language::Json),
             _ => None,
         }
     }

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -11,6 +11,7 @@ from rest_framework import mixins, request, response, serializers, status, views
 
 from posthog.api.event_definition_generators.base import EventDefinitionGenerator
 from posthog.api.event_definition_generators.golang import GolangGenerator
+from posthog.api.event_definition_generators.json import JsonGenerator
 from posthog.api.event_definition_generators.python import PythonGenerator
 from posthog.api.event_definition_generators.typescript import TypeScriptGenerator
 from posthog.api.routing import TeamAndOrgViewSetMixin
@@ -390,6 +391,10 @@ class EventDefinitionViewSet(
     @action(detail=False, methods=["GET"], url_path="python", required_scopes=["event_definition:read"])
     def python_definitions(self, *args, **kwargs):
         return self._generate_definitions(PythonGenerator())
+
+    @action(detail=False, methods=["GET"], url_path="json", required_scopes=["event_definition:read"])
+    def json_definitions(self, *args, **kwargs):
+        return self._generate_definitions(JsonGenerator())
 
     def _generate_definitions(self, generator: EventDefinitionGenerator) -> response.Response:
         event_definitions, schema_map = generator.fetch_event_definitions_and_schemas(self.project_id)

--- a/posthog/api/event_definition_generators/json.py
+++ b/posthog/api/event_definition_generators/json.py
@@ -1,0 +1,51 @@
+from django.db.models import QuerySet
+
+import orjson
+
+from posthog.api.event_definition_generators.base import EventDefinitionGenerator
+from posthog.models import EventDefinition, SchemaPropertyGroupProperty
+
+
+class JsonGenerator(EventDefinitionGenerator):
+    def generator_version(self) -> str:
+        return "0.0.1"
+
+    def language_name(self) -> str:
+        return "JSON"
+
+    def generate(
+        self,
+        event_definitions: QuerySet[EventDefinition],
+        schema_map: dict[str, list[SchemaPropertyGroupProperty]],
+    ) -> str:
+        """
+        Generate a JSON representation of the event definitions and their schemas.
+        """
+        output_data = []
+
+        for event_def in event_definitions:
+            event_data = {
+                "name": event_def.name,
+                "description": getattr(event_def, "description", None),
+                "properties": [],
+            }
+
+            # Get properties for this event
+            properties = schema_map.get(str(event_def.id), [])
+
+            # Sort properties by name for deterministic output
+            sorted_properties = sorted(properties, key=lambda p: p.name)
+
+            for prop in sorted_properties:
+                event_data["properties"].append(
+                    {
+                        "name": prop.name,
+                        "type": prop.property_type,
+                        "required": prop.is_required,
+                    }
+                )
+
+            output_data.append(event_data)
+
+        # Return pretty-printed JSON
+        return orjson.dumps(output_data, option=orjson.OPT_INDENT_2).decode("utf-8")


### PR DESCRIPTION
## Summary
Resolves #47768

This PR adds a raw JSON export option to the `posthog-cli schema pull` command. This allows developers using languages not yet supported by the CLI (like Lua/Love2D) to generate their own type definitions or use the raw schema for validation.

## Changes
- **Backend:** Added `JsonGenerator` to `posthog/api/event_definition_generators/json.py`.
- **API:** Exposed a new `/json` endpoint in `EventDefinitionViewSet` within `posthog/api/event_definition.py`.
- **CLI:** Added `json` as a supported language option in `posthog-cli` (`cli/src/experimental/schema.rs`).

## How to test
1. Run the backend server.
2. Run the CLI command:
   ```bash
   posthog-cli exp schema pull --language json