### PR TITLE
fix(experiments): replace sanitization with validation errors.

### DIFF
--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -286,30 +286,23 @@ class TestWebExperiment(APIBaseTest):
         # New variant should not have transforms (not in original experiment)
         assert "transforms" not in variants["new_variant"]
 
-    @patch("posthog.api.feature_flag.report_user_action")
-    def test_sanitizes_xss_in_transforms(self, mock_capture):
-        """Test that XSS attacks in text and html fields are sanitized"""
+    def test_rejects_xss_in_text_field(self):
+        """Test that XSS attacks in text field are rejected"""
         response = self.client.post(
             f"/api/projects/{self.team.id}/web_experiments/",
             data={
-                "name": "XSS Test Experiment",
+                "name": "XSS Text Test",
                 "variants": {
                     "control": {
-                        "transforms": [
-                            {
-                                "html": "",
-                                "text": "Safe text",
-                                "selector": "#page > #body > .header h1",
-                            }
-                        ],
+                        "transforms": [{"html": "", "text": "Safe text", "selector": "#test"}],
                         "rollout_percentage": 50,
                     },
                     "test": {
                         "transforms": [
                             {
-                                "html": "<img src=x onerror=\"alert('XSS')\">",
+                                "html": "",
                                 "text": '<script>alert("XSS")</script>Hello',
-                                "selector": "#page > #body > .header h1",
+                                "selector": "#test",
                             }
                         ],
                         "rollout_percentage": 50,
@@ -318,23 +311,140 @@ class TestWebExperiment(APIBaseTest):
             },
             format="json",
         )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
-        assert response.status_code == status.HTTP_201_CREATED, response_data
+        assert "script" in str(response_data).lower()
 
-        # Verify the experiment was created and XSS was sanitized
+    def test_rejects_xss_event_handlers_in_html(self):
+        """Test that event handlers in html field are rejected"""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/web_experiments/",
+            data={
+                "name": "XSS Event Handler Test",
+                "variants": {
+                    "control": {
+                        "transforms": [{"html": "", "text": "Safe", "selector": "#test"}],
+                        "rollout_percentage": 50,
+                    },
+                    "test": {
+                        "transforms": [
+                            {
+                                "html": "<img src=x onerror=\"alert('XSS')\">",
+                                "text": "Test",
+                                "selector": "#test",
+                            }
+                        ],
+                        "rollout_percentage": 50,
+                    },
+                },
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert "event handler" in str(response_data).lower()
+
+    def test_rejects_javascript_protocol(self):
+        """Test that javascript: protocol is rejected"""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/web_experiments/",
+            data={
+                "name": "XSS JavaScript Protocol Test",
+                "variants": {
+                    "control": {
+                        "transforms": [{"html": "", "text": "Safe", "selector": "#test"}],
+                        "rollout_percentage": 50,
+                    },
+                    "test": {
+                        "transforms": [
+                            {
+                                "html": '<a href="javascript:alert(1)">Click</a>',
+                                "text": "Test",
+                                "selector": "#test",
+                            }
+                        ],
+                        "rollout_percentage": 50,
+                    },
+                },
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert "javascript:" in str(response_data).lower()
+
+    def test_rejects_iframe_tags(self):
+        """Test that iframe tags are rejected"""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/web_experiments/",
+            data={
+                "name": "XSS Iframe Test",
+                "variants": {
+                    "control": {
+                        "transforms": [{"html": "", "text": "Safe", "selector": "#test"}],
+                        "rollout_percentage": 50,
+                    },
+                    "test": {
+                        "transforms": [
+                            {
+                                "html": '<iframe src="https://evil.com"></iframe>',
+                                "text": "Test",
+                                "selector": "#test",
+                            }
+                        ],
+                        "rollout_percentage": 50,
+                    },
+                },
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert "iframe" in str(response_data).lower()
+
+    def test_accepts_safe_html_with_formatting(self):
+        """Test that safe HTML with complex formatting is accepted and preserved"""
+        complex_html = """<div class="flex h-4 items-center justify-center lg:h-12">
+  <div class="hidden lg:block" data-testid="nav-container">
+    <div class="flex h-full w-full">
+      <a href="https://example.com" class="nav-link">Link</a>
+      <span>Text content</span>
+    </div>
+  </div>
+</div>"""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/web_experiments/",
+            data={
+                "name": "Safe HTML Test",
+                "variants": {
+                    "control": {
+                        "transforms": [{"html": "", "text": "Safe", "selector": "#test"}],
+                        "rollout_percentage": 50,
+                    },
+                    "test": {
+                        "transforms": [
+                            {
+                                "html": complex_html,
+                                "text": "Safe <b>formatted</b> text",
+                                "selector": "#test",
+                            }
+                        ],
+                        "rollout_percentage": 50,
+                    },
+                },
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        response_data = response.json()
+
+        # Verify the HTML is preserved exactly as submitted
         experiment_id = response_data["id"]
         web_experiment = WebExperiment.objects.get(id=experiment_id)
-
-        # Check that the script tags and event handlers were removed
         assert web_experiment.variants is not None
         test_variant = web_experiment.variants["test"]
         transforms = test_variant["transforms"][0]
 
-        # Script tags should be removed but safe text should remain
-        assert "<script>" not in transforms["text"]
-        assert "alert" not in transforms["text"]
-        assert "Hello" in transforms["text"]
-
-        # Event handlers should be removed but img tag may remain
-        assert "onerror" not in transforms["html"]
-        assert "alert" not in transforms["html"]
+        # HTML should be preserved with original formatting
+        assert transforms["html"] == complex_html
+        assert transforms["text"] == "Safe <b>formatted</b> text"

--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 from django.http import HttpResponse, JsonResponse
@@ -12,12 +13,46 @@ from rest_framework.request import Request
 
 from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.api.survey import nh3_clean_with_allow_list
 from posthog.api.utils import get_token
 from posthog.auth import TemporaryTokenAuthentication
 from posthog.exceptions import generate_exception_response
 from posthog.models import Team, WebExperiment
 from posthog.utils_cors import cors_response
+
+
+def validate_no_xss(content: str, field_name: str) -> None:
+    """
+    Validates that content doesn't contain XSS vectors.
+    Raises ValidationError if dangerous content is found.
+
+    This validation-only approach preserves the original formatting while preventing XSS attacks.
+    """
+    # Check for script tags (opening and closing)
+    if re.search(r"<script[^>]*>", content, re.IGNORECASE):
+        raise ValidationError(f"{field_name} contains disallowed <script> tags")
+
+    if re.search(r"</script>", content, re.IGNORECASE):
+        raise ValidationError(f"{field_name} contains disallowed </script> tags")
+
+    # Check for event handlers (onclick, onerror, onload, onmouseover, etc.)
+    if re.search(r"\son\w+\s*=", content, re.IGNORECASE):
+        raise ValidationError(f"{field_name} contains disallowed event handlers (onclick, onerror, etc.)")
+
+    # Check for javascript: protocol in attributes
+    if re.search(r"javascript\s*:", content, re.IGNORECASE):
+        raise ValidationError(f"{field_name} contains disallowed javascript: protocol")
+
+    # Check for data: protocol with HTML/script content
+    if re.search(r"data\s*:\s*text/html", content, re.IGNORECASE):
+        raise ValidationError(f"{field_name} contains disallowed data:text/html")
+
+    # Check for iframe tags (commonly used for XSS)
+    if re.search(r"<iframe[^>]*>", content, re.IGNORECASE):
+        raise ValidationError(f"{field_name} contains disallowed <iframe> tags")
+
+    # Check for object and embed tags
+    if re.search(r"<(object|embed)[^>]*>", content, re.IGNORECASE):
+        raise ValidationError(f"{field_name} contains disallowed <object> or <embed> tags")
 
 
 class WebExperimentsAPISerializer(serializers.ModelSerializer):
@@ -132,11 +167,11 @@ class WebExperimentsAPISerializer(serializers.ModelSerializer):
                             f"Experiment transform [${idx}] variant '{name}' does not have a valid selector"
                         )
 
-                    # Sanitize text and html fields to prevent XSS attacks
+                    # Validate text and html fields to prevent XSS attacks
                     if "text" in transform and isinstance(transform["text"], str):
-                        transform["text"] = nh3_clean_with_allow_list(transform["text"])
+                        validate_no_xss(transform["text"], f"Transform text in variant '{name}'")
                     if "html" in transform and isinstance(transform["html"], str):
-                        transform["html"] = nh3_clean_with_allow_list(transform["html"])
+                        validate_no_xss(transform["html"], f"Transform html in variant '{name}'")
 
         return attrs
 


### PR DESCRIPTION
## Problem

PR #47418 added sanitization for web experiments `transform` and `html` to prevent malicious use. This was not the right approach because it modifies the input, which in web experiments could produce unexpected results.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We replace the sanitization function with a validation. Now, disallowed tags will throw a validation error instead of cleaning the input and saving it anyway.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
hogli test:python posthog/api/test/test_web_experiment.py
```

![cat-type](https://github.com/user-attachments/assets/186026c8-2577-490b-be7f-5ba8480c857b)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
