### PR TITLE
chore(ci): bucket Rust test shards to reduce setup overhead

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -257,23 +257,7 @@ jobs:
                   UV_PROJECT_ENVIRONMENT=.venv-master uv sync --frozen --dev
 
             - name: Wait for Docker services
-              run: |
-                  # Can't use bin/wait-for-docker here — working tree is on master
-                  # which doesn't have the script yet.
-                  SECONDS=0
-                  for svc in db redis7 kafka clickhouse; do
-                    while true; do
-                      if [ "$SECONDS" -ge 300 ]; then
-                        echo "Timed out after 300s waiting for $svc"
-                        exit 1
-                      fi
-                      cid=$(docker compose -f docker-compose.dev.yml ps -q "$svc" 2>/dev/null || true)
-                      [ -n "$cid" ] && status=$(docker inspect --format='{{.State.Health.Status}}' "$cid" 2>/dev/null || echo starting) && [ "$status" = "healthy" ] && break
-                      echo "Waiting for $svc... (${SECONDS}s)"
-                      sleep 1
-                    done
-                  done
-                  echo "All services healthy in ${SECONDS}s."
+              run: bin/wait-for-docker
 
             - name: Run migrations up to master
               run: |

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -295,8 +295,8 @@ jobs:
               env:
                   RUST_BACKTRACE: 1
                   # Set up dual database environment for feature-flags service
-                  PERSONS_READ_DATABASE_URL: ${{ contains(matrix.packages, 'feature-flags') && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}
-                  PERSONS_WRITE_DATABASE_URL: ${{ contains(matrix.packages, 'feature-flags') && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}
+                  PERSONS_READ_DATABASE_URL: ${{ contains(format(' {0} ', matrix.packages), ' feature-flags ') && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}
+                  PERSONS_WRITE_DATABASE_URL: ${{ contains(format(' {0} ', matrix.packages), ' feature-flags ') && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}
               run: |
                   for pkg in ${{ matrix.packages }}; do
                       echo "::group::Testing $pkg"

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -24,6 +24,7 @@ jobs:
         # Set job outputs to values from filter step
         outputs:
             rust: ${{ steps.filter.outputs.rust || 'true' }}
+            matrix: ${{ steps.shards.outputs.matrix }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -46,6 +47,77 @@ jobs:
                         - 'posthog/migrations/**'
                         - 'ee/migrations/**'
                         - 'docker-compose.dev.yml'
+
+            # Bin-pack packages into balanced test shards.
+            # Weights are approximate test durations in seconds — update periodically.
+            - name: Compute test shards
+              id: shards
+              if: steps.filter.outputs.rust != 'false'
+              shell: python3 {0}
+              run: |
+                  import json, os
+
+                  packages = {
+                      "batch-import-worker": 137,
+                      "capture": 198,
+                      "capture-logs": 130,
+                      "common-alloc": 37,
+                      "common-compression": 14,
+                      "common-cookieless": 72,
+                      "common-database": 10,
+                      "common-dns": 8,
+                      "common-geoip": 4,
+                      "common-hypercache": 93,
+                      "common-kafka": 68,
+                      "common-metrics": 7,
+                      "common-profiler": 49,
+                      "common-s3": 29,
+                      "cyclotron-core": 25,
+                      "cyclotron-janitor": 107,
+                      "cyclotron-node": 22,
+                      "cymbal": 173,
+                      "embedding-worker": 98,
+                      "feature-flags": 241,
+                      "health": 8,
+                      "hogvm": 5,
+                      "hook-api": 88,
+                      "hook-common": 73,
+                      "hook-janitor": 94,
+                      "hook-worker": 100,
+                      "kafka-deduplicator": 239,
+                      "limiters": 23,
+                      "personhog-replica": 49,
+                      "personhog-router": 10,
+                      "posthog-symbol-data": 4,
+                      "property-defs-rs": 93,
+                      "serve-metrics": 8,
+                  }
+
+                  TARGET_SHARDS = 8
+
+                  # Greedy bin-packing: largest first into lightest bucket
+                  buckets = [[] for _ in range(TARGET_SHARDS)]
+                  times = [0] * TARGET_SHARDS
+
+                  for pkg, t in sorted(packages.items(), key=lambda x: -x[1]):
+                      lightest = min(range(TARGET_SHARDS), key=lambda i: times[i])
+                      buckets[lightest].append(pkg)
+                      times[lightest] += t
+
+                  matrix = {
+                      "include": [
+                          {"packages": " ".join(sorted(b))}
+                          for b in buckets
+                          if b
+                      ]
+                  }
+
+                  for i, b in enumerate(buckets):
+                      if b:
+                          print(f"Shard {i + 1} ({times[i]}s): {', '.join(sorted(b))}")
+
+                  with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                      f.write(f"matrix={json.dumps(matrix)}\n")
 
     build:
         name: Build Rust services
@@ -100,43 +172,9 @@ jobs:
               run: cargo build --all --locked --release && find target/release/ -maxdepth 1 -executable -type f | xargs strip
 
     test:
-        name: Test Rust services
+        name: Test Rust (${{ matrix.packages }})
         strategy:
-            matrix:
-                package:
-                    - batch-import-worker
-                    - capture
-                    - capture-logs
-                    - common-alloc
-                    - common-cookieless
-                    - common-compression
-                    - common-database
-                    - common-dns
-                    - common-geoip
-                    - common-hypercache
-                    - common-metrics
-                    - common-kafka
-                    - common-profiler
-                    - common-s3
-                    - cyclotron-core
-                    - cyclotron-node
-                    - cyclotron-janitor
-                    - cymbal
-                    - embedding-worker
-                    - feature-flags
-                    - health
-                    - hogvm
-                    - hook-api
-                    - hook-common
-                    - hook-janitor
-                    - hook-worker
-                    - kafka-deduplicator
-                    - limiters
-                    - personhog-replica
-                    - personhog-router
-                    - posthog-symbol-data
-                    - property-defs-rs
-                    - serve-metrics
+            matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
         needs: changes
         if: needs.changes.outputs.rust == 'true'
         runs-on: depot-ubuntu-24.04-4
@@ -257,12 +295,14 @@ jobs:
               env:
                   RUST_BACKTRACE: 1
                   # Set up dual database environment for feature-flags service
-                  PERSONS_READ_DATABASE_URL: ${{ matrix.package == 'feature-flags' && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}
-                  PERSONS_WRITE_DATABASE_URL: ${{ matrix.package == 'feature-flags' && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}
+                  PERSONS_READ_DATABASE_URL: ${{ contains(matrix.packages, 'feature-flags') && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}
+                  PERSONS_WRITE_DATABASE_URL: ${{ contains(matrix.packages, 'feature-flags') && 'postgres://posthog:posthog@localhost:5432/posthog_persons' || '' }}
               run: |
-                  echo "Starting cargo test"
-                  cargo test -p ${{matrix.package}}
-                  echo "Cargo test completed"
+                  for pkg in ${{ matrix.packages }}; do
+                      echo "::group::Testing $pkg"
+                      cargo test -p "$pkg"
+                      echo "::endgroup::"
+                  done
 
     linting:
         name: Lint Rust services


### PR DESCRIPTION
**Stacked on #47687**

Each of the 32 Rust test matrix shards pays ~320s of setup overhead (docker pull, python deps, DB migrations) for test runs that are often <30s. That's ~2.8h of wasted compute per run — 82% overhead ratio.

**Approach**
A cheap pre-matrix job (`ubuntu-latest`, <5s) bin-packs packages into 8 balanced shards using greedy largest-first allocation. Package weights (approximate test durations in seconds) live as a sorted map in the workflow file — same place the package list lived before, just annotated with sizes. Adding a new crate is still just adding one line.

**Expected savings**
~2h compute per run (24 fewer shards x ~320s overhead). Wall clock stays similar or improves slightly since the critical path was already setup-dominated.

**Before/after timings** (from recent master run)
| Metric | Before (32 shards) | After (8 shards) |
|---|---|---|
| Total compute | ~3.5h | ~1.3h |
| Overhead ratio | 82% | ~53% |
| Critical path | ~13 min | ~11 min |