### PR TITLE
refactor(cli): simplify SourceFile save API

### DIFF
--- a/cli/src/experimental/schema.rs
+++ b/cli/src/experimental/schema.rs
@@ -15,6 +15,7 @@ enum Language {
     TypeScript,
     Golang,
     Python,
+    Json,
 }
 
 impl Language {
@@ -24,6 +25,7 @@ impl Language {
             Language::TypeScript => "typescript",
             Language::Golang => "golang",
             Language::Python => "python",
+            Language::Json => "json",
         }
     }
 
@@ -33,6 +35,7 @@ impl Language {
             Language::TypeScript => "TypeScript",
             Language::Golang => "Go",
             Language::Python => "Python",
+            Language::Json => "JSON",
         }
     }
 
@@ -43,6 +46,7 @@ impl Language {
             Language::Golang => "posthog-typed.go",
             // Python uses underscore because hyphens aren't valid in Python module names
             Language::Python => "posthog_typed.py",
+            Language::Json => "posthog_schema.json",
         }
     }
 
@@ -100,12 +104,28 @@ You can add optional properties through the option functions:
    client.shutdown()
 "#
             ),
+            Language::Json => format!(
+                r#"
+1. You now have a raw JSON export of your PostHog event schema:
+   {output_path}
+
+2. You can use this file to:
+   - Generate code for languages not yet supported by the CLI
+   - Validate events in your CI/CD pipeline
+   - Build custom integrations
+"#
+            ),
         }
     }
 
     /// Get all available languages
     fn all() -> Vec<Language> {
-        vec![Language::TypeScript, Language::Golang, Language::Python]
+        vec![
+            Language::TypeScript,
+            Language::Golang,
+            Language::Python,
+            Language::Json,
+        ]
     }
 
     /// Parse a language from a string identifier
@@ -114,6 +134,7 @@ You can add optional properties through the option functions:
             "typescript" => Some(Language::TypeScript),
             "golang" => Some(Language::Golang),
             "python" => Some(Language::Python),
+            "json" => Some(Language::Json),
             _ => None,
         }
     }

--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -40,7 +40,7 @@ impl SourceMapFile {
     }
 
     pub fn save(&self) -> Result<()> {
-        self.inner.save(None)
+        self.inner.save()
     }
 
     pub fn get_chunk_id(&self) -> Option<String> {
@@ -124,7 +124,7 @@ impl MinifiedSourceFile {
     }
 
     pub fn save(&self) -> Result<()> {
-        self.inner.save(None)
+        self.inner.save()
     }
 
     pub fn get_chunk_id(&self) -> Option<String> {

--- a/cli/src/utils/files/content.rs
+++ b/cli/src/utils/files/content.rs
@@ -20,10 +20,13 @@ impl<T: SourceContent> SourceFile<T> {
         Ok(SourceFile::new(path.clone(), T::parse(content)?))
     }
 
-    // TODO - I'm fairly sure the `dest` is redundant if it's None
-    pub fn save(&self, dest: Option<PathBuf>) -> Result<()> {
-        let final_path = dest.unwrap_or(self.path.clone());
-        std::fs::write(&final_path, &self.content.serialize()?)?;
+    pub fn save(&self) -> Result<()> {
+        std::fs::write(&self.path, &self.content.serialize()?)?;
+        Ok(())
+    }
+
+    pub fn save_to(&self, dest: PathBuf) -> Result<()> {
+        std::fs::write(&dest, &self.content.serialize()?)?;
         Ok(())
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ catalogs:
     lint-staged:
       specifier: ~15.4.3
       version: 15.4.3
+    posthog-js:
+      specifier: 1.345.2
+      version: 1.345.2
     prettier:
       specifier: ^3.6.2
       version: 3.6.2
@@ -7422,6 +7425,9 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@posthog/core@1.21.0':
+    resolution: {integrity: sha512-0a2JUIX1vhduP2El/6/J8s5AeYAurIoufQGFgMiGnJE5ajd63o9LFocu2vFYYBnIOmy75y4ADNeW8zSl1keEQQ==}
+
   '@posthog/core@1.22.0':
     resolution: {integrity: sha512-WkmOnq95aAOu6yk6r5LWr5cfXsQdpVbWDCwOxQwxSne8YV6GuZET1ziO5toSQXgrgbdcjrSz2/GopAfiL6iiAA==}
 
@@ -7478,6 +7484,9 @@ packages:
 
   '@posthog/siphash@1.1.1':
     resolution: {integrity: sha512-JUFk57H89fOnHpF62FDyFGw4uXeHAX20OPfkLL8/iqg/xrVp5Q21LvJUDijmS5wt0avgUwXF2bxYgaZ5iWRmAg==}
+
+  '@posthog/types@1.345.2':
+    resolution: {integrity: sha512-VZ1I+bp1YbYG4pSN84YAYCfvUyG5PmKIHx0ucZ6HO23sRgMZw381LLzfBAtmsA4tQ9+uMLigCTIZ4sDMl4ADFw==}
 
   '@posthog/types@1.345.5':
     resolution: {integrity: sha512-nPQQ5QfVMmsKquXQkXfA8g1/2IrHO7npw8ezcC0v3xJaTpAKoqBqknqugP+RwTlIfkhCbHSGd6x00yRSwTGaBQ==}
@@ -17514,6 +17523,9 @@ packages:
   posthog-js-lite@4.2.2:
     resolution: {integrity: sha512-fFCoGtMICWwoW0tsEdyFS7OFFgwe7bTTha/SKEtUdyJ56UyJ8wi6VghxyPkO2GVWpco5Za/edT1z1ovGYPCyLQ==}
 
+  posthog-js@1.345.2:
+    resolution: {integrity: sha512-5J0RfI6U11Sy76cL7QR5f+a/IqbQvcsF6XSItT6i+VPp0oX+XQE3eRnqkx1Ne8/PLegpn1xP3h6KSBMshwq0SQ==}
+
   posthog-js@1.345.5:
     resolution: {integrity: sha512-Hplt/aRD3DQLTQl3NxmS7V0jZPF18nnKJ4rST0qinz/6tXNCMemYqOVb4C/HYAXXWrtVVzGSJeNCNKvECFHHoQ==}
 
@@ -20074,8 +20086,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.369.0:
-    resolution: {integrity: sha512-KFL5s+AJTDxxKfG2WGsmZTOwCeVz8EA6/dAFJ6uljwTwLu7r6/SYSM724nE8HRVcKiYRT77UK6vAcZLsZiNCsA==}
+  unlayer-types@1.372.0:
+    resolution: {integrity: sha512-VkxM4XkjZAqRXywuY0ZI8feONHEKv/IfuQOWBqho7qpv4/+y4PlzsFAaGklx3D4aZoxa/xCKgJV3FSx69FMQug==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -20945,7 +20957,7 @@ snapshots:
       '@emotion/hash': 0.8.0
       '@emotion/unitless': 0.7.5
       classnames: 2.5.1
-      csstype: 3.1.3
+      csstype: 3.2.3
       rc-util: 5.44.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -27758,6 +27770,10 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@posthog/core@1.21.0':
+    dependencies:
+      cross-spawn: 7.0.6
+
   '@posthog/core@1.22.0':
     dependencies:
       cross-spawn: 7.0.6
@@ -27819,6 +27835,8 @@ snapshots:
       mitt: 3.0.0
 
   '@posthog/siphash@1.1.1': {}
+
+  '@posthog/types@1.345.2': {}
 
   '@posthog/types@1.345.5': {}
 
@@ -30412,7 +30430,7 @@ snapshots:
       commander: 9.4.1
       expect-playwright: 0.8.0
       glob: 10.4.5
-      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
+      jest: 29.7.0
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -36849,6 +36867,25 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0:
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@25.0.10)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.10)(typescript@5.4.5))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@25.0.10)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@25.0.10)(typescript@5.4.5))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
@@ -37221,7 +37258,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
+      jest: 29.7.0
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -37501,7 +37538,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.6.2
-      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
+      jest: 29.7.0
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -37550,6 +37587,18 @@ snapshots:
       jest-util: 30.0.5
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jest@29.7.0:
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.4.5)):
     dependencies:
@@ -40502,6 +40551,22 @@ snapshots:
     dependencies:
       '@posthog/core': 1.7.1
 
+  posthog-js@1.345.2:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
+      '@posthog/core': 1.21.0
+      '@posthog/types': 1.345.2
+      core-js: 3.40.0
+      dompurify: 3.3.1
+      fflate: 0.4.8
+      preact: 10.28.3
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.1.0
+
   posthog-js@1.345.5:
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -41384,7 +41449,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.369.0
+      unlayer-types: 1.372.0
 
   react-error-overlay@6.0.9: {}
 
@@ -43552,7 +43617,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.369.0: {}
+  unlayer-types@1.372.0: {}
 
   unpipe@1.0.0: {}
 

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -11,6 +11,7 @@ from rest_framework import mixins, request, response, serializers, status, views
 
 from posthog.api.event_definition_generators.base import EventDefinitionGenerator
 from posthog.api.event_definition_generators.golang import GolangGenerator
+from posthog.api.event_definition_generators.json import JsonGenerator
 from posthog.api.event_definition_generators.python import PythonGenerator
 from posthog.api.event_definition_generators.typescript import TypeScriptGenerator
 from posthog.api.routing import TeamAndOrgViewSetMixin
@@ -390,6 +391,10 @@ class EventDefinitionViewSet(
     @action(detail=False, methods=["GET"], url_path="python", required_scopes=["event_definition:read"])
     def python_definitions(self, *args, **kwargs):
         return self._generate_definitions(PythonGenerator())
+
+    @action(detail=False, methods=["GET"], url_path="json", required_scopes=["event_definition:read"])
+    def json_definitions(self, *args, **kwargs):
+        return self._generate_definitions(JsonGenerator())
 
     def _generate_definitions(self, generator: EventDefinitionGenerator) -> response.Response:
         event_definitions, schema_map = generator.fetch_event_definitions_and_schemas(self.project_id)

--- a/posthog/api/event_definition_generators/json.py
+++ b/posthog/api/event_definition_generators/json.py
@@ -1,0 +1,51 @@
+from django.db.models import QuerySet
+
+import orjson
+
+from posthog.api.event_definition_generators.base import EventDefinitionGenerator
+from posthog.models import EventDefinition, SchemaPropertyGroupProperty
+
+
+class JsonGenerator(EventDefinitionGenerator):
+    def generator_version(self) -> str:
+        return "0.0.1"
+
+    def language_name(self) -> str:
+        return "JSON"
+
+    def generate(
+        self,
+        event_definitions: QuerySet[EventDefinition],
+        schema_map: dict[str, list[SchemaPropertyGroupProperty]],
+    ) -> str:
+        """
+        Generate a JSON representation of the event definitions and their schemas.
+        """
+        output_data = []
+
+        for event_def in event_definitions:
+            event_data = {
+                "name": event_def.name,
+                "description": getattr(event_def, "description", None),
+                "properties": [],
+            }
+
+            # Get properties for this event
+            properties = schema_map.get(str(event_def.id), [])
+
+            # Sort properties by name for deterministic output
+            sorted_properties = sorted(properties, key=lambda p: p.name)
+
+            for prop in sorted_properties:
+                event_data["properties"].append(
+                    {
+                        "name": prop.name,
+                        "type": prop.property_type,
+                        "required": prop.is_required,
+                    }
+                )
+
+            output_data.append(event_data)
+
+        # Return pretty-printed JSON
+        return orjson.dumps(output_data, option=orjson.OPT_INDENT_2).decode("utf-8")

--- a/posthog/api/test/test_event_definition_json.py
+++ b/posthog/api/test/test_event_definition_json.py
@@ -1,0 +1,127 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+import orjson
+from rest_framework import status
+
+from posthog.api.event_definition_generators.json import JsonGenerator
+from posthog.models import EventDefinition, EventSchema, SchemaPropertyGroup, SchemaPropertyGroupProperty
+
+
+class TestJsonGenerator(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.generator = JsonGenerator()
+
+    def test_generator_metadata(self):
+        self.assertEqual(self.generator.language_name(), "JSON")
+        self.assertEqual(self.generator.generator_version(), "0.0.1")
+
+    def test_generate_simple_event(self):
+        event = MagicMock()
+        event.id = "1"
+        event.name = "simple_event"
+        event.description = "A simple test event"
+
+        # Mock properties
+        prop1 = self._create_mock_property("user_id", "String", required=True)
+        prop2 = self._create_mock_property("is_active", "Boolean", required=False)
+
+        schema_map = {"1": [prop1, prop2]}
+
+        json_output = self.generator.generate([event], schema_map)  # type: ignore
+        data = orjson.loads(json_output)
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["name"], "simple_event")
+        self.assertEqual(data[0]["description"], "A simple test event")
+
+        properties = data[0]["properties"]
+        self.assertEqual(len(properties), 2)
+
+        # Check properties (sorted by name)
+        self.assertEqual(properties[0]["name"], "is_active")
+        self.assertEqual(properties[0]["type"], "Boolean")
+        self.assertEqual(properties[0]["required"], False)
+
+        self.assertEqual(properties[1]["name"], "user_id")
+        self.assertEqual(properties[1]["type"], "String")
+        self.assertEqual(properties[1]["required"], True)
+
+    def test_generate_empty(self):
+        json_output = self.generator.generate([], {})  # type: ignore
+        data = orjson.loads(json_output)
+        self.assertEqual(data, [])
+
+    def _create_mock_property(self, name: str, property_type: str, required: bool = False) -> MagicMock:
+        prop = MagicMock()
+        prop.name = name
+        prop.property_type = property_type
+        prop.is_required = required
+        return prop
+
+
+class TestJsonGeneratorAPI(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        # Create test data
+        self.event_def_1 = EventDefinition.objects.create(team=self.team, project=self.project, name="file_downloaded")
+        self.prop_group_1 = SchemaPropertyGroup.objects.create(
+            team=self.team, project=self.project, name="File Properties"
+        )
+        SchemaPropertyGroupProperty.objects.create(
+            property_group=self.prop_group_1,
+            name="file_name",
+            property_type="String",
+            is_required=True,
+        )
+        EventSchema.objects.create(event_definition=self.event_def_1, property_group=self.prop_group_1)
+
+    @patch("posthog.api.event_definition_generators.base.report_user_action")
+    def test_json_endpoint_success(self, mock_report):
+        response = self.client.get(f"/api/projects/{self.project.id}/event_definitions/json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+
+        self.assertIn("content", data)
+        self.assertIn("event_count", data)
+        self.assertIn("schema_hash", data)
+        self.assertEqual(data["generator_version"], "0.0.1")
+
+        # Verify content is valid JSON and contains our event
+        content = orjson.loads(data["content"])
+        self.assertEqual(len(content), 1)
+        self.assertEqual(content[0]["name"], "file_downloaded")
+        self.assertEqual(content[0]["properties"][0]["name"], "file_name")
+
+        self._test_telemetry_called(mock_report)
+
+    def test_json_endpoint_excludes_system_events(self):
+        EventDefinition.objects.create(team=self.team, project=self.project, name="$autocapture")
+        EventDefinition.objects.create(team=self.team, project=self.project, name="$pageview")
+
+        response = self.client.get(f"/api/projects/{self.project.id}/event_definitions/json")
+        content = orjson.loads(response.json()["content"])
+
+        event_names = [e["name"] for e in content]
+        self.assertNotIn("$autocapture", event_names)
+        self.assertIn("$pageview", event_names)
+
+    def test_json_schema_hash_is_deterministic(self):
+        response1 = self.client.get(f"/api/projects/{self.project.id}/event_definitions/json")
+        hash1 = response1.json()["schema_hash"]
+
+        response2 = self.client.get(f"/api/projects/{self.project.id}/event_definitions/json")
+        hash2 = response2.json()["schema_hash"]
+
+        self.assertEqual(hash1, hash2, "Schema hash should be deterministic")
+
+    def _test_telemetry_called(self, mock_report) -> None:
+        self.assertEqual(mock_report.call_count, 1)
+        call_args = mock_report.call_args
+        self.assertEqual(call_args[0][0], self.user)
+        self.assertEqual(call_args[0][1], "event definitions generated")
+        telemetry_props = call_args[0][2]
+        self.assertEqual(telemetry_props["language"], "JSON")
+        self.assertEqual(telemetry_props["team_id"], self.team.id)


### PR DESCRIPTION
## Summary
- simplify SourceFile::save() to always write to its path
- add SourceFile::save_to() for explicit destinations
- update sourcemap wrappers to use new API

## Testing
- not run (not requested)
