### PR TITLE
fix(batch-import-worker): person processing filter fix

### DIFF
--- a/rust/batch-import-worker/tests/person_processing_kafka_integration_test.rs
+++ b/rust/batch-import-worker/tests/person_processing_kafka_integration_test.rs
@@ -214,9 +214,10 @@ async fn test_person_processing_filter_with_kafka() -> Result<()> {
             parsed.is_object(),
             "Message {i} payload should be a JSON object, got: {payload}"
         );
-        let deserialized: InternallyCapturedEvent = serde_json::from_str(payload).unwrap_or_else(
-            |e| panic!("Message {i} payload should deserialize as InternallyCapturedEvent: {e}"),
-        );
+        let deserialized: InternallyCapturedEvent =
+            serde_json::from_str(payload).unwrap_or_else(|e| {
+                panic!("Message {i} payload should deserialize as InternallyCapturedEvent: {e}")
+            });
         assert_eq!(deserialized.inner.token, events[i].inner.token);
         assert_eq!(deserialized.inner.distinct_id, events[i].inner.distinct_id);
     }


### PR DESCRIPTION
## Problem


The person processing filter introduced a bug in the batch-import-worker's Kafka emission path. In emit(), events were wrapped into (event, disable_person_processing) tuples before being passed to send_keyed_iter_to_kafka_with_headers. The key and header extractors correctly destructured the tuple to use only the parts they needed, but the payload serializer (serde_json::to_string(&item)) serialized the entire tuple. Since serde serializes a Rust tuple as a JSON array, Kafka messages were being produced as [{...event...}, true] instead of {...event...}.

The integration tests didn't catch this because consume_messages_with_metadata only validated keys and headers — it never read the message payload.

## Changes

  - Fix payload serialization (rust/batch-import-worker/src/emit/kafka.rs): Pass data.iter() directly
   instead of wrapping events in tuples. The disable_person_processing flag is now computed inline
  within each extractor closure. This means the payload type D is &InternallyCapturedEvent rather
  than (&InternallyCapturedEvent, bool), so the serializer produces a plain JSON object.
  - Add payload assertions to integration tests
  (rust/batch-import-worker/tests/person_processing_kafka_integration_test.rs): The
  consume_messages_with_metadata helper now captures the raw payload from each Kafka message. Both
  integration tests now verify that:
    - The payload is a JSON object (not an array)
    - The payload deserializes as a valid InternallyCapturedEvent with matching fields

## How did you test this code?

  - cargo check -p batch-import-worker --tests passes
  - The new payload assertions in test_person_processing_filter_with_kafka and
  test_empty_person_processing_filter would have caught the original bug — a serialized tuple
  produces a JSON array, which fails the parsed.is_object() assertion and the
  serde_json::from_str::<InternallyCapturedEvent>() deserialization

