### PR TITLE
chore: Remove git itself from Flox manifest

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -34,8 +34,7 @@ go = { pkg-path = "go", version = "1.24", pkg-group = "go" }
 golangci-lint = { pkg-path = "golangci-lint", pkg-group = "go" }
 air = { pkg-path = "air" }
 # CLI tools
-git = { pkg-path = "git" }
-git-lfs = { pkg-path = "git" }
+git-lfs = { pkg-path = "git-lfs" }
 mprocs = { pkg-path = "mprocs" }
 util-linux = { pkg-path = "util-linux" } # flock
 cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }


### PR DESCRIPTION
## Problem

So in #47748 we added git-lfs to Flox, as we now use LFS, and for consistency I added git there too. This is problematic in practice – suddenly I can't commit in GitHub Desktop as the app seems confused which git to use, and in the CLI I had to provide my sudo password for some reason. 

## Changes

No git in Flox, just git-lfs.