### PR TITLE
chore(admin): make state of batch import editable in admin

### DIFF
--- a/posthog/admin/admins/batch_imports.py
+++ b/posthog/admin/admins/batch_imports.py
@@ -44,7 +44,7 @@ class BatchImportAdmin(admin.ModelAdmin):
     list_display = ("id", "team", "status", "created_by_id", "created_at", "get_send_rate")
     list_filter = ("status", "created_at")
     search_fields = ("id", "status_message", "team__name")
-    readonly_fields = ("id", "created_at", "updated_at", "state", "import_config")
+    readonly_fields = ("id", "created_at", "updated_at", "import_config")
     autocomplete_fields = ("team",)
     fieldsets = (
         (None, {"fields": ("team", "created_by_id", "status", "status_message")}),


### PR DESCRIPTION
## Problem

To rewind the state of a batch import job we want to be able to edit the state parts in django admin

## Changes

Remove state as a readonly field from the admin model

## How did you test this code?

Just a one line admin change, will have to test it out when shipped