### PR TITLE
feat(llma): configurable clustering trace filters

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -58,6 +58,7 @@ from products.llm_analytics.backend.api import (
     EvaluationRunViewSet,
     EvaluationViewSet,
     LLMAnalyticsClusteringRunViewSet,
+    LLMAnalyticsClusteringSettingsViewSet,
     LLMAnalyticsSummarizationViewSet,
     LLMAnalyticsTextReprViewSet,
     LLMAnalyticsTranslateViewSet,
@@ -1194,6 +1195,13 @@ environments_router.register(
     r"llm_analytics/clustering_runs",
     LLMAnalyticsClusteringRunViewSet,
     "environment_llm_analytics_clustering_runs",
+    ["team_id"],
+)
+
+environments_router.register(
+    r"llm_analytics/clustering_settings",
+    LLMAnalyticsClusteringSettingsViewSet,
+    "environment_llm_analytics_clustering_settings",
     ["team_id"],
 )
 

--- a/posthog/temporal/llm_analytics/__init__.py
+++ b/posthog/temporal/llm_analytics/__init__.py
@@ -17,6 +17,7 @@ from posthog.temporal.llm_analytics.trace_clustering import (
     generate_cluster_labels_activity,
     perform_clustering_compute_activity,
 )
+from posthog.temporal.llm_analytics.trace_filters import get_team_trace_filters
 from posthog.temporal.llm_analytics.trace_summarization import (
     BatchTraceSummarizationCoordinatorWorkflow,
     BatchTraceSummarizationWorkflow,
@@ -51,6 +52,8 @@ WORKFLOWS = [
 ACTIVITIES = [
     # Team discovery
     get_team_ids_for_llm_analytics,
+    # Trace filters
+    get_team_trace_filters,
     # Summarization activities
     sample_items_in_window_activity,
     fetch_and_format_activity,

--- a/posthog/temporal/llm_analytics/trace_filters.py
+++ b/posthog/temporal/llm_analytics/trace_filters.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+
+import structlog
+import temporalio.activity
+from temporalio.common import RetryPolicy
+
+from products.llm_analytics.backend.trace_filters import get_team_trace_filters_bulk
+
+logger = structlog.get_logger(__name__)
+
+TRACE_FILTERS_ACTIVITY_TIMEOUT = timedelta(seconds=30)
+TRACE_FILTERS_ACTIVITY_RETRY_POLICY = RetryPolicy(maximum_attempts=2)
+
+
+@temporalio.activity.defn
+async def get_team_trace_filters(team_ids: list[int]) -> dict[str, list[dict]]:
+    if not team_ids:
+        return {}
+
+    try:
+        return await asyncio.to_thread(get_team_trace_filters_bulk, team_ids)
+    except Exception:
+        logger.exception("Failed to fetch LLMA trace filters", team_ids=team_ids)
+        raise

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -13,7 +13,6 @@ start_child_workflow + await pattern for controlled concurrency.
 
 import dataclasses
 from datetime import timedelta
-from typing import Any
 
 import structlog
 import temporalio
@@ -52,16 +51,15 @@ with temporalio.workflow.unsafe.imports_passed_through():
         TeamDiscoveryInput,
         get_team_ids_for_llm_analytics,
     )
+    from posthog.temporal.llm_analytics.trace_filters import (
+        TRACE_FILTERS_ACTIVITY_RETRY_POLICY,
+        TRACE_FILTERS_ACTIVITY_TIMEOUT,
+        get_team_trace_filters,
+    )
 
 logger = structlog.get_logger(__name__)
 
-# Per-team trace filters to scope which traces are included in summarization sampling.
-# team_id=2 (PostHog internal): only summarize posthog_ai traces, excluding
-# summarization LLM calls, playground, and other internal noise.
-# TODO: generalize via FF payload config so any team can define filters without code changes.
-PER_TEAM_TRACE_FILTERS: dict[int, list[dict[str, Any]]] = {
-    2: [{"key": "ai_product", "value": "posthog_ai", "operator": "exact", "type": "event"}],
-}
+# Per-team trace filters are resolved from team settings via a Temporal activity.
 
 
 @dataclasses.dataclass
@@ -126,6 +124,18 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
 
         logger.info("Processing discovered teams", team_count=len(team_ids), team_ids=team_ids)
 
+        # Fetch per-team trace filters from settings via activity.
+        try:
+            trace_filters_by_team = await temporalio.workflow.execute_activity(
+                get_team_trace_filters,
+                team_ids,
+                start_to_close_timeout=TRACE_FILTERS_ACTIVITY_TIMEOUT,
+                retry_policy=TRACE_FILTERS_ACTIVITY_RETRY_POLICY,
+            )
+        except Exception:
+            logger.warning("Trace filter lookup failed, defaulting to empty filters", exc_info=True)
+            trace_filters_by_team = {}
+
         # Spawn child workflows for each team with concurrency limit.
         # Uses start_child_workflow + await pattern: start all workflows in a
         # batch first, then await results. This runs teams in parallel within
@@ -147,7 +157,7 @@ class BatchTraceSummarizationCoordinatorWorkflow(PostHogWorkflow):
                 tuple[int, ChildWorkflowHandle[BatchTraceSummarizationWorkflow, BatchSummarizationResult]]
             ] = []
             for team_id in batch:
-                trace_filters = PER_TEAM_TRACE_FILTERS.get(team_id, [])
+                trace_filters = trace_filters_by_team.get(str(team_id), [])
                 handle = await temporalio.workflow.start_child_workflow(
                     BatchTraceSummarizationWorkflow.run,
                     BatchSummarizationInputs(

--- a/products/llm_analytics/backend/api/__init__.py
+++ b/products/llm_analytics/backend/api/__init__.py
@@ -1,4 +1,5 @@
 from .clustering import LLMAnalyticsClusteringRunViewSet
+from .clustering_settings import LLMAnalyticsClusteringSettingsViewSet
 from .datasets import DatasetItemViewSet, DatasetViewSet
 from .evaluation_config import EvaluationConfigViewSet
 from .evaluation_runs import EvaluationRunViewSet
@@ -13,6 +14,7 @@ from .translate import LLMAnalyticsTranslateViewSet
 
 __all__ = [
     "LLMAnalyticsClusteringRunViewSet",
+    "LLMAnalyticsClusteringSettingsViewSet",
     "LLMModelsViewSet",
     "LLMProxyViewSet",
     "LLMAnalyticsTextReprViewSet",

--- a/products/llm_analytics/backend/api/clustering_settings.py
+++ b/products/llm_analytics/backend/api/clustering_settings.py
@@ -1,0 +1,55 @@
+"""API endpoint for managing per-team clustering trace filters."""
+
+from typing import cast
+
+from rest_framework import serializers, status, viewsets
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.monitoring import monitor
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.event_usage import report_user_action
+from posthog.models import User
+from posthog.permissions import AccessControlPermission
+
+from products.llm_analytics.backend.trace_filters import get_team_trace_filters, set_team_trace_filters
+
+
+class ClusteringSettingsSerializer(serializers.Serializer):
+    trace_filters = serializers.ListField(
+        child=serializers.DictField(),
+        required=False,
+        default=list,
+        help_text="Property filters to scope which traces are included in clustering (PostHog standard format)",
+    )
+
+
+class LLMAnalyticsClusteringSettingsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
+    """ViewSet for managing per-team clustering settings."""
+
+    scope_object = "llm_analytics"
+    permission_classes = [IsAuthenticated, AccessControlPermission]
+
+    @monitor(feature=None, endpoint="llma_clustering_settings_list", method="GET")
+    def list(self, request: Request, **kwargs) -> Response:
+        trace_filters = get_team_trace_filters(self.team)
+        serializer = ClusteringSettingsSerializer({"trace_filters": trace_filters})
+        return Response(serializer.data)
+
+    @monitor(feature=None, endpoint="llma_clustering_settings_update", method="POST")
+    def create(self, request: Request, **kwargs) -> Response:
+        serializer = ClusteringSettingsSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        trace_filters = serializer.validated_data["trace_filters"]
+        set_team_trace_filters(self.team, trace_filters)
+
+        report_user_action(
+            cast(User, request.user),
+            "llma clustering settings updated",
+            {"trace_filters_count": len(trace_filters)},
+            self.team,
+        )
+
+        return Response({"trace_filters": trace_filters}, status=status.HTTP_200_OK)

--- a/products/llm_analytics/backend/api/test/test_clustering_settings.py
+++ b/products/llm_analytics/backend/api/test/test_clustering_settings.py
@@ -1,0 +1,33 @@
+from posthog.test.base import APIBaseTest
+
+
+class TestClusteringSettings(APIBaseTest):
+    def test_clustering_settings_default(self):
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_analytics/clustering_settings/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"trace_filters": []})
+
+    def test_clustering_settings_update(self):
+        payload = {
+            "trace_filters": [
+                {
+                    "key": "ai_product",
+                    "value": "posthog_ai",
+                    "operator": "exact",
+                    "type": "event",
+                }
+            ]
+        }
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/llm_analytics/clustering_settings/",
+            payload,
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), payload)
+
+        self.team.refresh_from_db()
+        self.assertEqual(self.team.extra_settings.get("llm_analytics_trace_filters"), payload["trace_filters"])

--- a/products/llm_analytics/backend/api/test/test_llm_analytics_access_control.py
+++ b/products/llm_analytics/backend/api/test/test_llm_analytics_access_control.py
@@ -81,6 +81,7 @@ class TestLLMAnalyticsAccessControl(APIBaseTest):
             ("evaluations", "evaluation"),
             ("datasets", "dataset"),
             ("llm_analytics/provider_keys", "provider_key"),
+            ("llm_analytics/clustering_settings", "clustering_settings"),
         ]
     )
     def test_viewer_can_list(self, endpoint, _attr):
@@ -95,6 +96,7 @@ class TestLLMAnalyticsAccessControl(APIBaseTest):
             ("evaluations", "evaluation"),
             ("datasets", "dataset"),
             ("llm_analytics/provider_keys", "provider_key"),
+            ("llm_analytics/clustering_settings", "clustering_settings"),
         ]
     )
     def test_viewer_can_retrieve(self, endpoint, attr):
@@ -205,6 +207,28 @@ class TestLLMAnalyticsAccessControl(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
+    def test_viewer_cannot_update_clustering_settings(self):
+        self._set_access_level(self.viewer_user, access_level="viewer")
+        self.client.force_login(self.viewer_user)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/llm_analytics/clustering_settings/",
+            {"trace_filters": []},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_editor_can_update_clustering_settings(self):
+        self._set_access_level(self.editor_user, access_level="editor")
+        self.client.force_login(self.editor_user)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/llm_analytics/clustering_settings/",
+            {"trace_filters": []},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     # -- None access blocks everything --
 
     @parameterized.expand(
@@ -212,6 +236,7 @@ class TestLLMAnalyticsAccessControl(APIBaseTest):
             ("evaluations",),
             ("datasets",),
             ("llm_analytics/provider_keys",),
+            ("llm_analytics/clustering_settings",),
         ]
     )
     def test_none_access_blocks_list(self, endpoint):
@@ -228,6 +253,7 @@ class TestLLMAnalyticsAccessControl(APIBaseTest):
             ("evaluations", "evaluation"),
             ("datasets", "dataset"),
             ("llm_analytics/provider_keys", "provider_key"),
+            ("llm_analytics/clustering_settings", "clustering_settings"),
         ]
     )
     def test_llm_analytics_viewer_can_list_child_resources(self, endpoint, _attr):

--- a/products/llm_analytics/backend/trace_filters.py
+++ b/products/llm_analytics/backend/trace_filters.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from posthog.models import Team
+
+TRACE_FILTERS_SETTING_KEY = "llm_analytics_trace_filters"
+
+
+def sanitize_trace_filters(raw_filters: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_filters, list):
+        return []
+    return [filter_item for filter_item in raw_filters if isinstance(filter_item, dict)]
+
+
+def get_trace_filters_from_extra_settings(extra_settings: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not extra_settings:
+        return []
+    return sanitize_trace_filters(extra_settings.get(TRACE_FILTERS_SETTING_KEY))
+
+
+def get_team_trace_filters(team: Team) -> list[dict[str, Any]]:
+    return get_trace_filters_from_extra_settings(team.extra_settings)
+
+
+def get_team_trace_filters_bulk(team_ids: Iterable[int]) -> dict[str, list[dict[str, Any]]]:
+    team_ids_list = list(team_ids)
+    if not team_ids_list:
+        return {}
+
+    filters_by_team: dict[str, list[dict[str, Any]]] = {}
+    for team_id, extra_settings in Team.objects.filter(id__in=team_ids_list).values_list("id", "extra_settings"):
+        filters_by_team[str(team_id)] = get_trace_filters_from_extra_settings(extra_settings)
+
+    return filters_by_team
+
+
+def set_team_trace_filters(team: Team, trace_filters: list[dict[str, Any]]) -> None:
+    extra_settings = team.extra_settings or {}
+    extra_settings[TRACE_FILTERS_SETTING_KEY] = trace_filters
+    team.extra_settings = extra_settings
+    team.save(update_fields=["extra_settings"])

--- a/products/llm_analytics/backend/trace_filters.py
+++ b/products/llm_analytics/backend/trace_filters.py
@@ -38,6 +38,6 @@ def get_team_trace_filters_bulk(team_ids: Iterable[int]) -> dict[str, list[dict[
 
 def set_team_trace_filters(team: Team, trace_filters: list[dict[str, Any]]) -> None:
     extra_settings = team.extra_settings or {}
-    extra_settings[TRACE_FILTERS_SETTING_KEY] = trace_filters
+    extra_settings[TRACE_FILTERS_SETTING_KEY] = sanitize_trace_filters(trace_filters)
     team.extra_settings = extra_settings
     team.save(update_fields=["extra_settings"])

--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -4,6 +4,8 @@ import { IconChevronDown, IconChevronRight, IconGear, IconInfo } from '@posthog/
 import { LemonButton, LemonSegmentedButton, LemonSelect, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -16,6 +18,7 @@ import { ClusterScatterPlot } from './ClusterScatterPlot'
 import { ClusteringAdminModal } from './ClusteringAdminModal'
 import { clustersAdminLogic } from './clustersAdminLogic'
 import { clustersLogic } from './clustersLogic'
+import { clustersSettingsLogic } from './clustersSettingsLogic'
 import { NOISE_CLUSTER_ID } from './constants'
 import { Cluster, ClusteringLevel, ClusteringParams } from './types'
 
@@ -88,23 +91,107 @@ export function ClustersView(): JSX.Element {
         useActions(clustersLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { openModal } = useActions(clustersAdminLogic)
+    const {
+        traceFilters,
+        hasChanges,
+        isLoading: settingsLoading,
+        isSaving: settingsSaving,
+    } = useValues(clustersSettingsLogic)
+    const { setTraceFilters, saveClusteringSettings, resetTraceFilters } = useActions(clustersSettingsLogic)
 
     const showAdminPanel = featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_CLUSTERING_ADMIN]
 
-    if (clusteringRunsLoading) {
-        return (
-            <div className="flex items-center justify-center p-8">
-                <Spinner className="text-2xl" />
+    const filtersPanel = (
+        <div className="border rounded-lg bg-surface-primary p-4 space-y-3">
+            <div className="flex items-start justify-between gap-4">
+                <div>
+                    <div className="font-semibold">Clustering filters</div>
+                    <div className="text-xs text-muted mt-1">
+                        These filters apply to scheduled clustering runs and summarization sampling. Manual runs can
+                        override them.
+                    </div>
+                </div>
+                <div className="flex items-center gap-2">
+                    {hasChanges && <span className="text-xs text-warning">Unsaved changes</span>}
+                    <AccessControlAction
+                        resourceType={AccessControlResourceType.LlmAnalytics}
+                        minAccessLevel={AccessControlLevel.Editor}
+                    >
+                        {({ disabled, disabledReason }) => (
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                onClick={resetTraceFilters}
+                                disabled={disabled || !hasChanges || settingsLoading || settingsSaving}
+                                disabledReason={disabledReason || (!hasChanges ? 'No changes to reset' : undefined)}
+                            >
+                                Reset
+                            </LemonButton>
+                        )}
+                    </AccessControlAction>
+                    <AccessControlAction
+                        resourceType={AccessControlResourceType.LlmAnalytics}
+                        minAccessLevel={AccessControlLevel.Editor}
+                    >
+                        {({ disabled, disabledReason }) => (
+                            <LemonButton
+                                type="primary"
+                                size="small"
+                                onClick={saveClusteringSettings}
+                                loading={settingsSaving}
+                                disabled={disabled || !hasChanges || settingsLoading}
+                                disabledReason={disabledReason || (!hasChanges ? 'No changes to save' : undefined)}
+                            >
+                                Save filters
+                            </LemonButton>
+                        )}
+                    </AccessControlAction>
+                </div>
             </div>
-        )
-    }
+            {settingsLoading ? (
+                <div className="flex items-center gap-2 text-muted text-sm">
+                    <Spinner className="text-base" /> Loading filters...
+                </div>
+            ) : (
+                <AccessControlAction
+                    resourceType={AccessControlResourceType.LlmAnalytics}
+                    minAccessLevel={AccessControlLevel.Editor}
+                >
+                    {({ disabled, disabledReason }) => (
+                        <PropertyFilters
+                            propertyFilters={traceFilters}
+                            onChange={setTraceFilters}
+                            pageKey="llm-analytics-clusters-trace-filters"
+                            taxonomicGroupTypes={[
+                                TaxonomicFilterGroupType.EventProperties,
+                                TaxonomicFilterGroupType.EventMetadata,
+                            ]}
+                            addText="Add filter"
+                            hasRowOperator={false}
+                            sendAllKeyUpdates
+                            allowRelativeDateOptions={false}
+                            editable={!disabled}
+                            disabledReason={disabledReason || undefined}
+                        />
+                    )}
+                </AccessControlAction>
+            )}
+        </div>
+    )
 
     // Show empty state only after checking both trace and generation levels
     // Always show the level toggle so users can switch between levels
     const showEmptyState = clusteringRuns.length === 0
 
-    if (showEmptyState) {
-        return (
+    let content: JSX.Element
+    if (clusteringRunsLoading) {
+        content = (
+            <div className="flex items-center justify-center p-8">
+                <Spinner className="text-2xl" />
+            </div>
+        )
+    } else if (showEmptyState) {
+        content = (
             <div className="space-y-4">
                 {/* Level toggle is always visible so users can switch */}
                 <div className="flex items-center gap-3">
@@ -139,171 +226,178 @@ export function ClustersView(): JSX.Element {
                 </div>
             </div>
         )
+    } else {
+        content = (
+            <>
+                {/* Run Selector Header */}
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                        <Tooltip
+                            title="Traces cluster entire conversations, while generations cluster individual LLM calls"
+                            placement="bottom"
+                        >
+                            <span>
+                                <LemonSegmentedButton
+                                    value={clusteringLevel}
+                                    onChange={(value) => setClusteringLevel(value as ClusteringLevel)}
+                                    options={[
+                                        { value: 'trace', label: 'Traces' },
+                                        { value: 'generation', label: 'Generations' },
+                                    ]}
+                                    size="small"
+                                    data-attr="clusters-level-toggle"
+                                />
+                            </span>
+                        </Tooltip>
+                        <span className="text-muted">|</span>
+                        <Tooltip title="Clustering run">
+                            <span>
+                                <LemonSelect
+                                    value={effectiveRunId || undefined}
+                                    onChange={(value) => setSelectedRunId(value || null)}
+                                    options={clusteringRuns.map((run: { runId: string; label: string }) => ({
+                                        value: run.runId,
+                                        label: run.label,
+                                    }))}
+                                    placeholder="Select a run"
+                                    data-attr="clusters-run-select"
+                                />
+                            </span>
+                        </Tooltip>
+                    </div>
+
+                    <div className="flex items-center gap-4">
+                        {currentRun && (
+                            <div className="flex items-center gap-2 text-muted text-sm whitespace-nowrap">
+                                <span>
+                                    {currentRun.totalItemsAnalyzed}{' '}
+                                    {clusteringLevel === 'generation' ? 'generations' : 'traces'} analyzed
+                                </span>
+                                <span>|</span>
+                                <span>
+                                    {(() => {
+                                        const outlierCluster = sortedClusters.find(
+                                            (c: Cluster) => c.cluster_id === NOISE_CLUSTER_ID
+                                        )
+                                        const regularClusterCount = sortedClusters.filter(
+                                            (c: Cluster) => c.cluster_id !== NOISE_CLUSTER_ID
+                                        ).length
+                                        const outlierCount = outlierCluster?.size || 0
+
+                                        if (outlierCount > 0) {
+                                            return `${regularClusterCount} clusters, ${outlierCount} outliers`
+                                        }
+                                        return `${regularClusterCount} clusters`
+                                    })()}
+                                </span>
+                                <span>|</span>
+                                <span>
+                                    {dayjs(currentRun.windowStart).format('MMM D')} -{' '}
+                                    {dayjs(currentRun.windowEnd).format('MMM D, YYYY')}
+                                </span>
+                                {currentRun.clusteringParams && (
+                                    <Tooltip
+                                        title={<ClusteringParamsTooltip params={currentRun.clusteringParams} />}
+                                        placement="bottom"
+                                    >
+                                        <IconInfo className="text-muted-alt cursor-help" />
+                                    </Tooltip>
+                                )}
+                            </div>
+                        )}
+
+                        {showAdminPanel && (
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.LlmAnalytics}
+                                minAccessLevel={AccessControlLevel.Editor}
+                            >
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    icon={<IconGear />}
+                                    onClick={openModal}
+                                    tooltip="Run clustering with custom parameters"
+                                    data-attr="clusters-run-clustering-button"
+                                >
+                                    Run clustering
+                                </LemonButton>
+                            </AccessControlAction>
+                        )}
+                    </div>
+                </div>
+
+                {/* Loading State */}
+                {currentRunLoading && (
+                    <div className="flex items-center justify-center p-8">
+                        <Spinner className="text-2xl" />
+                    </div>
+                )}
+
+                {/* Scatter Plot Visualization */}
+                {!currentRunLoading && !traceSummariesLoading && sortedClusters.length > 0 && (
+                    <div className="border rounded-lg bg-surface-primary overflow-hidden transition-all">
+                        <div
+                            className="p-4 cursor-pointer hover:bg-surface-secondary transition-colors"
+                            onClick={toggleScatterPlotExpanded}
+                            data-attr="clusters-scatter-plot-toggle"
+                        >
+                            <div className="flex items-center gap-4">
+                                <ClusterDistributionBar clusters={sortedClusters} runId={effectiveRunId || ''} />
+                                <LemonButton
+                                    size="small"
+                                    noPadding
+                                    icon={isScatterPlotExpanded ? <IconChevronDown /> : <IconChevronRight />}
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        toggleScatterPlotExpanded()
+                                    }}
+                                />
+                            </div>
+                        </div>
+                        {isScatterPlotExpanded && (
+                            <div className="border-t p-4">
+                                <ClusterScatterPlot traceSummaries={traceSummaries} />
+                            </div>
+                        )}
+                    </div>
+                )}
+
+                {/* Cluster Cards */}
+                {!currentRunLoading && sortedClusters.length > 0 && (
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                        {sortedClusters.map((cluster: Cluster) => (
+                            <ClusterCard
+                                key={cluster.cluster_id}
+                                cluster={cluster}
+                                totalTraces={currentRun?.totalItemsAnalyzed || 0}
+                                isExpanded={expandedClusterIds.has(cluster.cluster_id)}
+                                onToggleExpand={() => toggleClusterExpanded(cluster.cluster_id)}
+                                traceSummaries={traceSummaries}
+                                loadingTraces={traceSummariesLoading}
+                                runId={effectiveRunId || ''}
+                                clusteringLevel={clusteringLevel}
+                                metrics={clusterMetrics[cluster.cluster_id]}
+                                metricsLoading={clusterMetricsLoading}
+                            />
+                        ))}
+                    </div>
+                )}
+
+                {/* Empty State */}
+                {!currentRunLoading && sortedClusters.length === 0 && currentRun && (
+                    <div className="text-center p-8 text-muted">No clusters found in this run.</div>
+                )}
+
+                {/* Admin Modal */}
+                {showAdminPanel && <ClusteringAdminModal />}
+            </>
+        )
     }
 
     return (
         <div className="space-y-4">
-            {/* Run Selector Header */}
-            <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                    <Tooltip
-                        title="Traces cluster entire conversations, while generations cluster individual LLM calls"
-                        placement="bottom"
-                    >
-                        <span>
-                            <LemonSegmentedButton
-                                value={clusteringLevel}
-                                onChange={(value) => setClusteringLevel(value as ClusteringLevel)}
-                                options={[
-                                    { value: 'trace', label: 'Traces' },
-                                    { value: 'generation', label: 'Generations' },
-                                ]}
-                                size="small"
-                                data-attr="clusters-level-toggle"
-                            />
-                        </span>
-                    </Tooltip>
-                    <span className="text-muted">|</span>
-                    <Tooltip title="Clustering run">
-                        <span>
-                            <LemonSelect
-                                value={effectiveRunId || undefined}
-                                onChange={(value) => setSelectedRunId(value || null)}
-                                options={clusteringRuns.map((run: { runId: string; label: string }) => ({
-                                    value: run.runId,
-                                    label: run.label,
-                                }))}
-                                placeholder="Select a run"
-                                data-attr="clusters-run-select"
-                            />
-                        </span>
-                    </Tooltip>
-                </div>
-
-                <div className="flex items-center gap-4">
-                    {currentRun && (
-                        <div className="flex items-center gap-2 text-muted text-sm whitespace-nowrap">
-                            <span>
-                                {currentRun.totalItemsAnalyzed}{' '}
-                                {clusteringLevel === 'generation' ? 'generations' : 'traces'} analyzed
-                            </span>
-                            <span>|</span>
-                            <span>
-                                {(() => {
-                                    const outlierCluster = sortedClusters.find(
-                                        (c: Cluster) => c.cluster_id === NOISE_CLUSTER_ID
-                                    )
-                                    const regularClusterCount = sortedClusters.filter(
-                                        (c: Cluster) => c.cluster_id !== NOISE_CLUSTER_ID
-                                    ).length
-                                    const outlierCount = outlierCluster?.size || 0
-
-                                    if (outlierCount > 0) {
-                                        return `${regularClusterCount} clusters, ${outlierCount} outliers`
-                                    }
-                                    return `${regularClusterCount} clusters`
-                                })()}
-                            </span>
-                            <span>|</span>
-                            <span>
-                                {dayjs(currentRun.windowStart).format('MMM D')} -{' '}
-                                {dayjs(currentRun.windowEnd).format('MMM D, YYYY')}
-                            </span>
-                            {currentRun.clusteringParams && (
-                                <Tooltip
-                                    title={<ClusteringParamsTooltip params={currentRun.clusteringParams} />}
-                                    placement="bottom"
-                                >
-                                    <IconInfo className="text-muted-alt cursor-help" />
-                                </Tooltip>
-                            )}
-                        </div>
-                    )}
-
-                    {showAdminPanel && (
-                        <AccessControlAction
-                            resourceType={AccessControlResourceType.LlmAnalytics}
-                            minAccessLevel={AccessControlLevel.Editor}
-                        >
-                            <LemonButton
-                                type="secondary"
-                                size="small"
-                                icon={<IconGear />}
-                                onClick={openModal}
-                                tooltip="Run clustering with custom parameters"
-                                data-attr="clusters-run-clustering-button"
-                            >
-                                Run clustering
-                            </LemonButton>
-                        </AccessControlAction>
-                    )}
-                </div>
-            </div>
-
-            {/* Loading State */}
-            {currentRunLoading && (
-                <div className="flex items-center justify-center p-8">
-                    <Spinner className="text-2xl" />
-                </div>
-            )}
-
-            {/* Scatter Plot Visualization */}
-            {!currentRunLoading && !traceSummariesLoading && sortedClusters.length > 0 && (
-                <div className="border rounded-lg bg-surface-primary overflow-hidden transition-all">
-                    <div
-                        className="p-4 cursor-pointer hover:bg-surface-secondary transition-colors"
-                        onClick={toggleScatterPlotExpanded}
-                        data-attr="clusters-scatter-plot-toggle"
-                    >
-                        <div className="flex items-center gap-4">
-                            <ClusterDistributionBar clusters={sortedClusters} runId={effectiveRunId || ''} />
-                            <LemonButton
-                                size="small"
-                                noPadding
-                                icon={isScatterPlotExpanded ? <IconChevronDown /> : <IconChevronRight />}
-                                onClick={(e) => {
-                                    e.stopPropagation()
-                                    toggleScatterPlotExpanded()
-                                }}
-                            />
-                        </div>
-                    </div>
-                    {isScatterPlotExpanded && (
-                        <div className="border-t p-4">
-                            <ClusterScatterPlot traceSummaries={traceSummaries} />
-                        </div>
-                    )}
-                </div>
-            )}
-
-            {/* Cluster Cards */}
-            {!currentRunLoading && sortedClusters.length > 0 && (
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                    {sortedClusters.map((cluster: Cluster) => (
-                        <ClusterCard
-                            key={cluster.cluster_id}
-                            cluster={cluster}
-                            totalTraces={currentRun?.totalItemsAnalyzed || 0}
-                            isExpanded={expandedClusterIds.has(cluster.cluster_id)}
-                            onToggleExpand={() => toggleClusterExpanded(cluster.cluster_id)}
-                            traceSummaries={traceSummaries}
-                            loadingTraces={traceSummariesLoading}
-                            runId={effectiveRunId || ''}
-                            clusteringLevel={clusteringLevel}
-                            metrics={clusterMetrics[cluster.cluster_id]}
-                            metricsLoading={clusterMetricsLoading}
-                        />
-                    ))}
-                </div>
-            )}
-
-            {/* Empty State */}
-            {!currentRunLoading && sortedClusters.length === 0 && currentRun && (
-                <div className="text-center p-8 text-muted">No clusters found in this run.</div>
-            )}
-
-            {/* Admin Modal */}
-            {showAdminPanel && <ClusteringAdminModal />}
+            {filtersPanel}
+            {content}
         </div>
     )
 }

--- a/products/llm_analytics/frontend/clusters/clustersSettingsLogic.ts
+++ b/products/llm_analytics/frontend/clusters/clustersSettingsLogic.ts
@@ -1,0 +1,89 @@
+import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { objectsEqual } from 'lib/utils'
+
+import type { AnyPropertyFilter } from '~/types'
+
+import type { clustersSettingsLogicType } from './clustersSettingsLogicType'
+
+export interface ClusteringSettings {
+    trace_filters: AnyPropertyFilter[]
+}
+
+export const clustersSettingsLogic = kea<clustersSettingsLogicType>([
+    path(['products', 'llm_analytics', 'frontend', 'clusters', 'clustersSettingsLogic']),
+
+    actions({
+        setTraceFilters: (traceFilters: AnyPropertyFilter[]) => ({ traceFilters }),
+        resetTraceFilters: true,
+    }),
+
+    loaders(({ values }) => ({
+        clusteringSettings: [
+            null as ClusteringSettings | null,
+            {
+                loadClusteringSettings: async () => {
+                    return (await api.get(
+                        'api/environments/@current/llm_analytics/clustering_settings'
+                    )) as ClusteringSettings
+                },
+                saveClusteringSettings: async (_, breakpoint) => {
+                    await breakpoint(100)
+                    const response = await api.create('api/environments/@current/llm_analytics/clustering_settings', {
+                        trace_filters: values.traceFilters,
+                    })
+                    return response as ClusteringSettings
+                },
+            },
+        ],
+    })),
+
+    reducers({
+        traceFilters: [
+            [] as AnyPropertyFilter[],
+            {
+                setTraceFilters: (_, { traceFilters }) => traceFilters,
+                loadClusteringSettingsSuccess: (_, { clusteringSettings }) => clusteringSettings?.trace_filters || [],
+                saveClusteringSettingsSuccess: (_, { clusteringSettings }) => clusteringSettings?.trace_filters || [],
+            },
+        ],
+        savedTraceFilters: [
+            [] as AnyPropertyFilter[],
+            {
+                loadClusteringSettingsSuccess: (_, { clusteringSettings }) => clusteringSettings?.trace_filters || [],
+                saveClusteringSettingsSuccess: (_, { clusteringSettings }) => clusteringSettings?.trace_filters || [],
+            },
+        ],
+    }),
+
+    selectors({
+        hasChanges: [
+            (s) => [s.traceFilters, s.savedTraceFilters],
+            (traceFilters, savedTraceFilters) => !objectsEqual(traceFilters, savedTraceFilters),
+        ],
+        isLoading: [(s) => [s.clusteringSettingsLoading], (loading) => loading],
+        isSaving: [(s) => [s.saveClusteringSettingsLoading], (loading) => loading],
+    }),
+
+    listeners(({ actions, values }) => ({
+        saveClusteringSettingsSuccess: () => {
+            lemonToast.success('Clustering filters saved')
+        },
+        saveClusteringSettingsFailure: () => {
+            lemonToast.error('Failed to save clustering filters')
+        },
+        loadClusteringSettingsFailure: () => {
+            lemonToast.error('Failed to load clustering filters')
+        },
+        resetTraceFilters: () => {
+            actions.setTraceFilters(values.savedTraceFilters)
+        },
+    })),
+
+    afterMount(({ actions }) => {
+        actions.loadClusteringSettings()
+    }),
+])


### PR DESCRIPTION
## Summary
- add per-team clustering trace filters stored in team extra_settings
- expose clustering_settings API to read/write filters
- apply saved filters to scheduled clustering and summarization workflows
- add clusters UI settings panel with save/reset controls
- add backend tests and access control coverage for the new endpoint

## Testing
- not run 

