### PR TITLE
fix(signals): Skip idle sessions & analyze more active ones

### DIFF
--- a/ee/hogai/session_summaries/constants.py
+++ b/ee/hogai/session_summaries/constants.py
@@ -22,7 +22,7 @@ SESSION_EVENTS_REPLAY_CUTOFF_MS = 5000
 MIN_SESSION_DURATION_FOR_SUMMARY_MS = 2 * SESSION_EVENTS_REPLAY_CUTOFF_MS + 1
 # Minimum session duration for video-based summarization, where we don't need (or want) to cut off anything
 MIN_SESSION_DURATION_FOR_VIDEO_SUMMARY_S = 15
-MIN_ACTIVE_SECONDS_FOR_VIDEO_SUMMARY_S = 5  # Session below this activity threshold don't show much
+MIN_ACTIVE_SECONDS_FOR_VIDEO_SUMMARY_S = 5  # Sessions below this activity threshold don't show much
 
 # Temporal
 SESSION_SUMMARIES_DB_DATA_REDIS_TTL = 60 * 60 * 24  # How long to store the DB data in Redis within Temporal jobs

--- a/ee/hogai/session_summaries/constants.py
+++ b/ee/hogai/session_summaries/constants.py
@@ -22,6 +22,7 @@ SESSION_EVENTS_REPLAY_CUTOFF_MS = 5000
 MIN_SESSION_DURATION_FOR_SUMMARY_MS = 2 * SESSION_EVENTS_REPLAY_CUTOFF_MS + 1
 # Minimum session duration for video-based summarization, where we don't need (or want) to cut off anything
 MIN_SESSION_DURATION_FOR_VIDEO_SUMMARY_S = 15
+MIN_ACTIVE_SECONDS_FOR_VIDEO_SUMMARY_S = 5  # Session below this activity threshold don't show much
 
 # Temporal
 SESSION_SUMMARIES_DB_DATA_REDIS_TTL = 60 * 60 * 24  # How long to store the DB data in Redis within Temporal jobs


### PR DESCRIPTION
## Changes

Follow-up to #47749: in proactive analysis of sessions, let's skip sessions that don't have at least a few seconds of activity. At the same time, let's set an explicit limit of sessions analyzed, higher than RecordingsQuery's default of 50. Proposing 250, which we'll mostly hit on the first run. Then, the hourly runs will be just the most recent sessions.
