### PR TITLE
feat(product tours): rework AI generation for tour content

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -162,6 +162,8 @@ import {
     PluginConfigWithPluginInfoNew,
     PluginLogEntry,
     ProductTour,
+    ProductTourAIGenerationResponse,
+    ProductTourStep,
     ProjectType,
     PropertyDefinition,
     PropertyDefinitionType,
@@ -4427,6 +4429,15 @@ const api = {
         },
         async delete(tourId: ProductTour['id']): Promise<void> {
             await new ApiRequest().productTour(tourId).delete()
+        },
+        async generateContent(
+            tourId: ProductTour['id'],
+            title: ProductTour['name'],
+            steps: ProductTourStep[],
+            goal: string
+        ): Promise<ProductTourAIGenerationResponse> {
+            const apiRequest = new ApiRequest().productTour(tourId).withAction('generate')
+            return await apiRequest.create({ data: { title, steps, goal } })
         },
     },
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3492,6 +3492,16 @@ export type ProductTourType = 'tour' | 'announcement'
 
 export type ProductTourDisplayFrequency = 'show_once' | 'until_interacted' | 'always'
 
+export interface ProductTourGeneratedStepContent {
+    step_id: string
+    title: string
+    description: string
+}
+
+export interface ProductTourAIGenerationResponse {
+    steps: ProductTourGeneratedStepContent[]
+}
+
 export interface ProductTourContent {
     type?: ProductTourType
     steps: ProductTourStep[]

--- a/products/product_tours/backend/api/product_tour.py
+++ b/products/product_tours/backend/api/product_tour.py
@@ -8,11 +8,10 @@ from django.http import HttpResponse, JsonResponse
 from django.utils.text import slugify
 from django.views.decorators.csrf import csrf_exempt
 
-from langchain_core.messages import HumanMessage, SystemMessage
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from loginas.utils import is_impersonated_session
 from nanoid import generate
-from pydantic import BaseModel, Field
-from rest_framework import filters, serializers, status, viewsets
+from rest_framework import exceptions, filters, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -22,6 +21,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import get_token
 from posthog.auth import TemporaryTokenAuthentication
+from posthog.cloud_utils import is_cloud
 from posthog.constants import PRODUCT_TOUR_TARGETING_FLAG_PREFIX
 from posthog.event_usage import report_user_action
 from posthog.exceptions import generate_exception_response
@@ -33,10 +33,8 @@ from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.utils_cors import cors_response
 
 from products.product_tours.backend.constants import ProductTourEventName
+from products.product_tours.backend.generate_tour_content import ContentGenerationResult, generate_with_gemini
 from products.product_tours.backend.models import ProductTour
-from products.product_tours.backend.prompts import TOUR_GENERATION_SYSTEM_PROMPT, TOUR_GENERATION_USER_PROMPT
-
-from ee.hogai.llm import MaxChatAnthropic
 
 logger = logging.getLogger(__name__)
 
@@ -84,36 +82,6 @@ def _validate_step_targeting(step: dict, idx: int):
 
     if targeting == "auto" and not step.get("inferenceData"):
         raise serializers.ValidationError(f"Step {idx + 1} requires an element to be selected")
-
-
-class TourStepContent(BaseModel):
-    """A single step in the generated tour."""
-
-    selector: str = Field(description="The CSS selector for this step's target element")
-    title: str = Field(description="Short, catchy title for this step (2-5 words)")
-    description: str = Field(description="Helpful description explaining what to do and why (1-2 sentences)")
-
-
-class TourGenerationResponse(BaseModel):
-    """Structured response from the tour generation LLM."""
-
-    name: str = Field(description="A short, descriptive name for this tour (3-6 words)")
-    steps: list[TourStepContent] = Field(description="List of tour steps with content for each element")
-
-
-class SuggestedElement(BaseModel):
-    """An element suggested for highlighting in the tour."""
-
-    selector: str = Field(description="The CSS selector for this element")
-    reason: str = Field(description="Why this element is important for the tour (1 sentence)")
-
-
-class TourSuggestionResponse(BaseModel):
-    """Structured response from the tour suggestion LLM."""
-
-    name: str = Field(description="Suggested tour name (3-6 words)")
-    goal: str = Field(description="What users will learn from this tour (1 sentence)")
-    elements: list[SuggestedElement] = Field(description="3-5 elements to highlight, in order")
 
 
 class ProductTourSerializer(serializers.ModelSerializer):
@@ -701,6 +669,22 @@ class ProductTourSerializerCreateUpdateOnly(serializers.ModelSerializer):
         return content_changed
 
 
+class GenerateRequestSerializer(serializers.Serializer):
+    title = serializers.CharField(required=False, default="", allow_blank=True)
+    goal = serializers.CharField(required=False, default="", allow_blank=True)
+    steps = serializers.ListField(child=serializers.DictField(), required=False, default=list)
+
+
+class GenerateStepResponseSerializer(serializers.Serializer):
+    step_id = serializers.CharField()
+    title = serializers.CharField()
+    description = serializers.CharField()
+
+
+class GenerateResponseSerializer(serializers.Serializer):
+    steps = GenerateStepResponseSerializer(many=True)
+
+
 class ProductTourViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.ModelViewSet):
     scope_object = "product_tour"
     queryset = ProductTour.all_objects.select_related("internal_targeting_flag", "linked_flag", "created_by").all()
@@ -766,96 +750,63 @@ class ProductTourViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, view
         self.perform_destroy(instance)
         return Response(status=204)
 
-    @action(detail=False, methods=["POST"])
+    @extend_schema(
+        request=GenerateRequestSerializer,
+        responses={
+            200: OpenApiResponse(response=GenerateResponseSerializer),
+        },
+    )
+    @action(detail=True, methods=["POST"])
     def generate(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Generate tour step content using AI."""
-        screenshot = request.data.get("screenshot")
-        elements = request.data.get("elements", [])
+
+        environment_is_allowed = settings.DEBUG or is_cloud()
+        has_gemini_api_key = bool(settings.GEMINI_API_KEY)
+        if not environment_is_allowed or not has_gemini_api_key:
+            raise exceptions.ValidationError("Product Tour AI generation is only supported in PostHog Cloud.")
+
+        if not self.team.organization.is_ai_data_processing_approved:
+            return Response(
+                {"error": "AI data processing must be approved for Product Tour AI generation."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        tour_id = kwargs["pk"]
+        tour = ProductTour.objects.filter(id=tour_id, team__project_id=self.project_id).first()
+        if not tour:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        user = cast(User, self.request.user)
+
+        title = request.data.get("title", "")
+        existing_steps = request.data.get("steps", [])
         goal = request.data.get("goal", "")
 
-        if not elements:
-            return Response(
-                {"error": "No elements provided"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        # Goal is optional - AI will infer from context if not provided
-
-        if not getattr(settings, "ANTHROPIC_API_KEY", None):
-            return Response(
-                {"error": "ANTHROPIC_API_KEY not configured"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
-
-        # Format elements for the prompt
-        elements_text = "\n".join(
-            f"{i + 1}. Selector: `{el.get('selector', 'unknown')}`\n"
-            f"   Tag: {el.get('tag', 'unknown')}\n"
-            f"   Text: {el.get('text', '')[:100] if el.get('text') else 'N/A'}\n"
-            f"   Attributes: {el.get('attributes', {})}"
-            for i, el in enumerate(elements)
-        )
-
-        user_prompt = TOUR_GENERATION_USER_PROMPT.format(
-            goal=goal,
-            elements=elements_text,
-            element_count=len(elements),
-        )
-
         try:
-            llm = MaxChatAnthropic(
-                model=TOUR_GENERATION_MODEL,
-                user=cast(User, request.user),
-                team=self.team,
-                inject_context=False,
-                billable=False,
-                # TODO: add the API manually here in case it doesn't work
-                # api_key="add-api-key-here",
+            result: ContentGenerationResult = generate_with_gemini(
+                tour_id, title, goal, existing_steps, self.team_id, distinct_id=str(user.distinct_id)
             )
 
-            # Use structured output for reliable JSON parsing
-            structured_llm = llm.with_structured_output(TourGenerationResponse)
+            report_user_action(
+                cast(User, self.request.user),
+                ProductTourEventName.AI_CONTENT_GENERATED,
+                tour.get_analytics_metadata(),
+                self.team,
+            )
 
-            # Build message content
-            message_content: list[str | dict[str, Any]] = [{"type": "text", "text": user_prompt}]
-
-            if screenshot:
-                message_content.insert(
-                    0,
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:image/jpeg;base64,{screenshot}"},
-                    },
-                )
-
-            messages = [
-                SystemMessage(content=TOUR_GENERATION_SYSTEM_PROMPT),
-                HumanMessage(content=message_content),
-            ]
-
-            result = cast(TourGenerationResponse, structured_llm.invoke(messages))
-
-            # Convert to TipTap format
-            steps = []
-            for step in result.steps:
-                tiptap_content = {
-                    "type": "doc",
-                    "content": [
-                        {
-                            "type": "heading",
-                            "attrs": {"level": 1},
-                            "content": [{"type": "text", "text": step.title}],
-                        },
-                        {
-                            "type": "paragraph",
-                            "content": [{"type": "text", "text": step.description}],
-                        },
-                    ],
+            id_map = result.index_to_step_id
+            return Response(
+                {
+                    "steps": [
+                        {**step.model_dump(), "step_id": id_map[step.step_id]}
+                        for step in result.tour_content.steps
+                        if step.step_id in id_map
+                    ]
                 }
-                steps.append({"selector": step.selector, "content": tiptap_content})
+            )
 
-            return Response({"name": result.name, "steps": steps})
-
+        except exceptions.ValidationError:
+            raise
         except Exception:
             logger.exception("Error generating tour content")
             return Response(

--- a/products/product_tours/backend/constants.py
+++ b/products/product_tours/backend/constants.py
@@ -7,6 +7,7 @@ class ProductTourEventName(StrEnum):
     LAUNCHED = "product tour launched"
     STOPPED = "product tour stopped"
     DELETED = "product tour deleted"
+    AI_CONTENT_GENERATED = "product tour ai generated"
 
 
 class ProductTourEventProperties(StrEnum):

--- a/products/product_tours/backend/generate_tour_content/__init__.py
+++ b/products/product_tours/backend/generate_tour_content/__init__.py
@@ -1,0 +1,6 @@
+from .generate import ContentGenerationResult, generate_with_gemini
+
+__all__ = [
+    "ContentGenerationResult",
+    "generate_with_gemini",
+]

--- a/products/product_tours/backend/generate_tour_content/constants.py
+++ b/products/product_tours/backend/generate_tour_content/constants.py
@@ -1,0 +1,4 @@
+from .models import GeminiModel
+
+DEFAULT_MODEL = GeminiModel.GEMINI_3_FLASH_PREVIEW
+CONTENT_GENERATION_TIMEOUT_SECONDS = 60

--- a/products/product_tours/backend/generate_tour_content/generate.py
+++ b/products/product_tours/backend/generate_tour_content/generate.py
@@ -1,0 +1,146 @@
+import json
+from dataclasses import dataclass
+
+import structlog
+from bs4 import BeautifulSoup
+from google.genai.types import Blob, Content, Part
+from rest_framework import exceptions
+
+from posthog.models.uploaded_media import UploadedMedia
+from posthog.storage import object_storage
+
+from ..llm import generate_structured_output
+from ..prompts import TOUR_GENERATION_SYSTEM_PROMPT, TOUR_GENERATION_USER_PROMPT
+from .constants import DEFAULT_MODEL
+from .schema import TourGenerationResponse
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class ContentGenerationResult:
+    tour_content: TourGenerationResponse
+    trace_id: str
+    index_to_step_id: dict[int, str]
+
+
+def _get_element_context(step: dict) -> dict:
+    if step.get("elementTargeting") == "auto":
+        return {"inferred_text": step.get("inferenceData", {}).get("text")}
+    elif step.get("elementTargeting") == "manual" and step.get("selector"):
+        return {"selector": step.get("selector")}
+
+    return {}
+
+
+def _extract_content_text(step: dict) -> str | None:
+    html = step.get("contentHtml", "")
+    if not html:
+        return None
+    text = BeautifulSoup(html, "html.parser").get_text().strip()
+    return text or None
+
+
+def _effective_step_type(step: dict) -> str:
+    if step.get("elementTargeting"):
+        return "Element tooltip"
+    return "Pop-up"
+
+
+def _fetch_screenshot(media_id: str, team_id: int) -> tuple[bytes, str] | None:
+    try:
+        media = UploadedMedia.objects.get(id=media_id, team_id=team_id)
+    except UploadedMedia.DoesNotExist:
+        logger.warning("Screenshot media not found", media_id=media_id)
+        return None
+
+    if not media.media_location:
+        return None
+
+    image_bytes = object_storage.read_bytes(media.media_location, missing_ok=True)
+    if not image_bytes:
+        logger.warning("Screenshot bytes not found in storage", media_id=media_id)
+        return None
+
+    return image_bytes, media.content_type or "image/png"
+
+
+def _fetch_step_screenshot(step: dict, step_index: int, team_id: int) -> list[Part]:
+    media_id = step.get("screenshotMediaId")
+    if not media_id:
+        return []
+
+    result = _fetch_screenshot(media_id, team_id)
+    if not result:
+        return []
+
+    image_bytes, content_type = result
+    return [
+        Part(text=f"Screenshot for step {step_index}:"),
+        Part(inline_data=Blob(data=image_bytes, mime_type=content_type)),
+    ]
+
+
+def generate_with_gemini(
+    tour_id: str,
+    title: str,
+    goal: str,
+    existing_steps: list[dict],
+    team_id: int,
+    distinct_id: str | None = None,
+) -> ContentGenerationResult:
+    if not existing_steps:
+        raise exceptions.ValidationError("Elements cannot be empty")
+
+    # build a index->ID mapping so we don't have to trust the LLM
+    # not to hallucinate UUIDs
+    index_to_step_id: dict[int, str] = {}
+
+    clean_steps: list[dict] = []
+    screenshot_parts: list[Part] = []
+
+    def _is_valid_step(step: dict):
+        return step.get("type") in ("element", "modal") and not step.get("survey")
+
+    for idx, step in enumerate(step for step in existing_steps if _is_valid_step(step)):
+        index_to_step_id[idx] = step["id"]
+        clean_steps.append(
+            {
+                "step_id": idx,
+                "type": _effective_step_type(step),
+                "progression": step.get("progressionTrigger"),
+                "existing_content": _extract_content_text(step),
+                **_get_element_context(step),
+            }
+        )
+        screenshot_parts.extend(_fetch_step_screenshot(step, idx, team_id))
+
+    if not clean_steps:
+        raise exceptions.ValidationError("No valid steps found to generate content for")
+
+    user_prompt = TOUR_GENERATION_USER_PROMPT.format(
+        title=title,
+        goal=goal,
+        steps=json.dumps(clean_steps, indent=2),
+        step_count=len(clean_steps),
+    )
+    contents = Content(parts=[Part(text=user_prompt), *screenshot_parts])
+
+    tour_content, trace_id = generate_structured_output(
+        model=DEFAULT_MODEL,
+        system_prompt=TOUR_GENERATION_SYSTEM_PROMPT,
+        contents=contents,
+        response_schema=TourGenerationResponse,
+        posthog_properties={
+            "tour_id": tour_id,
+            "ai_product": "tour_content_generation",
+        },
+        team_id=team_id,
+        distinct_id=distinct_id,
+    )
+
+    return ContentGenerationResult(
+        tour_content=tour_content,
+        trace_id=trace_id,
+        index_to_step_id=index_to_step_id,
+    )

--- a/products/product_tours/backend/generate_tour_content/models.py
+++ b/products/product_tours/backend/generate_tour_content/models.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class GeminiModel(StrEnum):
+    GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview"
+    GEMINI_2_5_FLASH = "gemini-2.5-flash"
+    GEMINI_2_0_FLASH = "gemini-2.0-flash"

--- a/products/product_tours/backend/generate_tour_content/schema.py
+++ b/products/product_tours/backend/generate_tour_content/schema.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+
+
+class TourStepContent(BaseModel):
+    """A single step in the generated tour."""
+
+    step_id: int = Field(description="The step ID, matching exactly what was provided.")
+    title: str = Field(description="Short step title, 2-5 words. No markdown formatting.")
+    description: str = Field(description="Brief step description, 1-2 sentences. No markdown formatting.")
+
+
+class TourGenerationResponse(BaseModel):
+    """Structured response from the tour generation LLM."""
+
+    steps: list[TourStepContent] = Field(description="List of tour steps with content for each element")

--- a/products/product_tours/backend/llm/__init__.py
+++ b/products/product_tours/backend/llm/__init__.py
@@ -1,0 +1,3 @@
+from .client import create_gemini_client, generate_structured_output
+
+__all__ = ["create_gemini_client", "generate_structured_output"]

--- a/products/product_tours/backend/llm/client.py
+++ b/products/product_tours/backend/llm/client.py
@@ -1,0 +1,75 @@
+import uuid
+from typing import TypeVar
+
+from django.conf import settings
+
+import structlog
+import posthoganalytics
+from google.genai.types import ContentListUnion, GenerateContentConfig
+from posthoganalytics.ai.gemini import genai
+from pydantic import BaseModel
+from rest_framework import exceptions
+
+logger = structlog.get_logger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def create_gemini_client():
+    if settings.DEBUG and posthoganalytics.disabled:
+        posthoganalytics.disabled = False
+        if not posthoganalytics.host:
+            posthoganalytics.host = settings.SITE_URL
+
+    posthog_client = posthoganalytics.default_client
+    if not posthog_client:
+        logger.warning("PostHog default_client not available, LLM analytics will not be tracked")
+
+    return genai.Client(
+        api_key=settings.GEMINI_API_KEY,
+        posthog_client=posthog_client,
+    )
+
+
+def generate_structured_output(
+    *,
+    model: str,
+    system_prompt: str,
+    contents: ContentListUnion,
+    response_schema: type[T],
+    posthog_properties: dict | None = None,
+    team_id: int | None = None,
+    distinct_id: str | None = None,
+) -> tuple[T, str]:
+    client = create_gemini_client()
+
+    config = GenerateContentConfig(
+        system_instruction=system_prompt,
+        response_mime_type="application/json",
+        response_json_schema=response_schema.model_json_schema(),
+    )
+
+    trace_id = str(uuid.uuid4())
+    properties = posthog_properties or {}
+
+    try:
+        response = client.models.generate_content(
+            model=model,
+            contents=contents,
+            config=config,
+            posthog_distinct_id=distinct_id or "",
+            posthog_trace_id=trace_id,
+            posthog_properties=properties,
+            posthog_groups={"project": str(team_id)} if team_id else {},
+        )
+
+        if not response.text:
+            raise exceptions.ValidationError("Gemini returned empty response")
+
+        return response_schema.model_validate_json(response.text), trace_id
+
+    except exceptions.ValidationError:
+        raise
+    except Exception:
+        logger.exception("Gemini API call failed", model=model, properties=properties)
+        raise exceptions.APIException("Failed to generate response")

--- a/products/product_tours/backend/prompts.py
+++ b/products/product_tours/backend/prompts.py
@@ -9,19 +9,23 @@ Guidelines:
 - Use friendly, encouraging tone
 - Each title should be 2-5 words
 - Each description should be 1-2 sentences
-- Reference what's visible in the screenshot when helpful
 - Make the tour feel like a helpful guide, not a manual
-- If no goal is provided, infer the purpose from the selected elements"""
+- If no goal is provided, infer the purpose from the selected elements
+- If screenshots are provided for steps, use them to understand the UI context and write more specific, relevant content
+
+Constraints:
+- Title should be plain text, 2-5 words, no markdown formatting
+- Description should be plain text, 1-2 sentences, no markdown formatting
+"""
 
 TOUR_GENERATION_USER_PROMPT = """I'm creating a product tour for my web application.
 
+**Tour Title:** {title}
 **Tour Goal:** {goal}
 
-**Selected Elements (in order they should appear):**
-{elements}
+**Existing tour steps** (in the order they will appear; some steps are intentionally omitted):
+{steps}
 
-Generate:
-1. A short, descriptive name for this tour (3-6 words)
-2. Engaging content for each of the {element_count} selected elements
+Generate engaging content for each of the {step_count} selected elements.
 
-Maintain the order of elements as listed above. If no goal is provided, infer the purpose from the elements."""
+If no goal is provided, infer the purpose from the existing step data."""

--- a/products/product_tours/frontend/generated/api.schemas.ts
+++ b/products/product_tours/frontend/generated/api.schemas.ts
@@ -239,6 +239,24 @@ export interface PatchedProductTourSerializerCreateUpdateOnlyApi {
     creation_context?: ProductTourSerializerCreateUpdateOnlyCreationContextEnumApi
 }
 
+export type GenerateRequestApiStepsItem = { [key: string]: unknown }
+
+export interface GenerateRequestApi {
+    title?: string
+    goal?: string
+    steps?: GenerateRequestApiStepsItem[]
+}
+
+export interface GenerateStepResponseApi {
+    step_id: string
+    title: string
+    description: string
+}
+
+export interface GenerateResponseApi {
+    steps: GenerateStepResponseApi[]
+}
+
 export type ProductToursListParams = {
     /**
      * Number of results to return per page.

--- a/products/product_tours/frontend/generated/api.ts
+++ b/products/product_tours/frontend/generated/api.ts
@@ -9,6 +9,8 @@
  */
 import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
 import type {
+    GenerateRequestApi,
+    GenerateResponseApi,
     PaginatedProductTourListApi,
     PatchedProductTourSerializerCreateUpdateOnlyApi,
     ProductTourApi,
@@ -142,19 +144,20 @@ export const productToursDestroy = async (projectId: string, id: string, options
 /**
  * Generate tour step content using AI.
  */
-export const getProductToursGenerateCreateUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/product_tours/generate/`
+export const getProductToursGenerateCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/product_tours/${id}/generate/`
 }
 
 export const productToursGenerateCreate = async (
     projectId: string,
-    productTourSerializerCreateUpdateOnlyApi: NonReadonly<ProductTourSerializerCreateUpdateOnlyApi>,
+    id: string,
+    generateRequestApi: GenerateRequestApi,
     options?: RequestInit
-): Promise<ProductTourSerializerCreateUpdateOnlyApi> => {
-    return apiMutator<ProductTourSerializerCreateUpdateOnlyApi>(getProductToursGenerateCreateUrl(projectId), {
+): Promise<GenerateResponseApi> => {
+    return apiMutator<GenerateResponseApi>(getProductToursGenerateCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(productTourSerializerCreateUpdateOnlyApi),
+        body: JSON.stringify(generateRequestApi),
     })
 }


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/48349

since the tour building experience has changed a bit, i'm reworking the AI generation, and aligning it with surveys re: structured output + llma

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

new ai generation flow:

- entire tour object passed to server
- mapping built for uuid->int so we don't have to trust an llm with uuids
- valuable info extracted from each step, then passed to llm
- step data returned as step uuid, title, desc

on the frontend we'll build this into tiptap content

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing - frontned PR to follow

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->