### PR TITLE
feat: created_by to ResourceTransfer

### DIFF
--- a/posthog/api/resource_transfer.py
+++ b/posthog/api/resource_transfer.py
@@ -151,7 +151,7 @@ class ResourceTransferViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         ]
 
         try:
-            duplicated = duplicate_resource_to_new_team(resource, destination_team, substitution_pairs)
+            duplicated = duplicate_resource_to_new_team(resource, destination_team, substitution_pairs, created_by=user)
         except (ValueError, TypeError) as e:
             raise exceptions.ValidationError(str(e))
         mutable_results = [r for r in duplicated if r is not None and not _is_immutable(r)]

--- a/posthog/migrations/1007_resourcetransfer_created_by.py
+++ b/posthog/migrations/1007_resourcetransfer_created_by.py
@@ -1,0 +1,38 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1006_resource_transfer_duplicated_resource_id"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="resourcetransfer",
+                    name="created_by",
+                    field=models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    """
+                    ALTER TABLE "posthog_resourcetransfer" ADD COLUMN "created_by_id" integer NULL CONSTRAINT "posthog_resourcetran_created_by_id_cfdd93a0_fk_posthog_u" REFERENCES "posthog_user"("id") DEFERRABLE INITIALLY DEFERRED;  -- existing-table-constraint-ignore
+                    SET CONSTRAINTS "posthog_resourcetran_created_by_id_cfdd93a0_fk_posthog_u" IMMEDIATE;  -- existing-table-constraint-ignore
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE "posthog_resourcetransfer" DROP COLUMN IF EXISTS "created_by_id";
+                    """,
+                ),
+            ],
+        ),
+    ]

--- a/posthog/migrations/1008_resourcetransfer_created_by_index.py
+++ b/posthog/migrations/1008_resourcetransfer_created_by_index.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False  # Required for CREATE INDEX CONCURRENTLY
+
+    dependencies = [
+        ("posthog", "1007_resourcetransfer_created_by"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS "posthog_resourcetransfer_created_by_id_cfdd93a0" ON "posthog_resourcetransfer" ("created_by_id");
+            """,
+            reverse_sql="""
+                DROP INDEX IF EXISTS "posthog_resourcetransfer_created_by_id_cfdd93a0";
+            """,
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1006_resource_transfer_duplicated_resource_id
+1008_resourcetransfer_created_by_index

--- a/posthog/models/resource_transfer/resource_transfer.py
+++ b/posthog/models/resource_transfer/resource_transfer.py
@@ -6,6 +6,7 @@ from posthog.models.utils import UUIDModel
 class ResourceTransfer(UUIDModel):
     source_team = models.ForeignKey("Team", on_delete=models.CASCADE, related_name="outbound_resource_transfers")
     destination_team = models.ForeignKey("Team", on_delete=models.CASCADE, related_name="inbound_resource_transfers")
+    created_by = models.ForeignKey("User", on_delete=models.SET_NULL, null=True, blank=True)
 
     resource_kind = models.CharField(max_length=100)
     resource_id = models.CharField(max_length=100)  # from the source team


### PR DESCRIPTION
## Problem

When transferring resources between projects, we need to track who initiated the transfer for audit and accountability purposes.

## Changes

Added a `created_by` field to the `ResourceTransfer` model to track the user who initiated the transfer

## How did you test this code?

Tests

## Publish to changelog?

No