### PR TITLE
chore(admin): Add integration models to Django admin

### DIFF
--- a/posthog/admin/__init__.py
+++ b/posthog/admin/__init__.py
@@ -23,10 +23,12 @@ def register_all_admin():
         HogFunctionAdmin,
         InsightAdmin,
         InstanceSettingAdmin,
+        IntegrationAdmin,
         LinkAdmin,
         OAuthApplicationAdmin,
         OrganizationAdmin,
         OrganizationDomainAdmin,
+        OrganizationIntegrationAdmin,
         PersonalAPIKeyAdmin,
         PersonDistinctIdAdmin,
         PluginAdmin,
@@ -59,9 +61,11 @@ def register_all_admin():
         HogFunction,
         Insight,
         InstanceSetting,
+        Integration,
         Link,
         Organization,
         OrganizationDomain,
+        OrganizationIntegration,
         PersonalAPIKey,
         PersonDistinctId,
         Plugin,
@@ -84,6 +88,7 @@ def register_all_admin():
 
     admin.site.register(Organization, OrganizationAdmin)
     admin.site.register(OrganizationDomain, OrganizationDomainAdmin)
+    admin.site.register(OrganizationIntegration, OrganizationIntegrationAdmin)
     admin.site.register(Project, ProjectAdmin)
     admin.site.register(Team, TeamAdmin)
     admin.site.register(User, UserAdmin)
@@ -101,6 +106,7 @@ def register_all_admin():
 
     admin.site.register(AsyncDeletion, AsyncDeletionAdmin)
     admin.site.register(InstanceSetting, InstanceSettingAdmin)
+    admin.site.register(Integration, IntegrationAdmin)
     admin.site.register(PluginConfig, PluginConfigAdmin)
     admin.site.register(Plugin, PluginAdmin)
     admin.site.register(Text, TextAdmin)

--- a/posthog/admin/admins/__init__.py
+++ b/posthog/admin/admins/__init__.py
@@ -17,6 +17,7 @@ from .group_type_mapping_admin import GroupTypeMappingAdmin
 from .hog_function_admin import HogFunctionAdmin
 from .insight_admin import InsightAdmin
 from .instance_setting_admin import InstanceSettingAdmin
+from .integration_admin import IntegrationAdmin, OrganizationIntegrationAdmin
 from .oauth_admin import OAuthApplicationAdmin
 from .organization_admin import OrganizationAdmin
 from .organization_domain_admin import OrganizationDomainAdmin
@@ -50,6 +51,8 @@ __all__ = [
     "HogFunctionAdmin",
     "InsightAdmin",
     "InstanceSettingAdmin",
+    "IntegrationAdmin",
+    "OrganizationIntegrationAdmin",
     "LinkAdmin",
     "OAuthApplicationAdmin",
     "OrganizationAdmin",

--- a/posthog/admin/admins/integration_admin.py
+++ b/posthog/admin/admins/integration_admin.py
@@ -64,7 +64,6 @@ class OrganizationIntegrationAdmin(admin.ModelAdmin):
         ),
     ]
 
+    @admin.display(description="Organization")
     def organization_link(self, obj: OrganizationIntegration) -> str:
         return format_html("{} ({})", obj.organization.name, obj.organization_id)
-
-    organization_link.short_description = "Organization"  # type: ignore

--- a/posthog/admin/admins/integration_admin.py
+++ b/posthog/admin/admins/integration_admin.py
@@ -1,0 +1,71 @@
+from django.contrib import admin
+from django.utils.html import format_html
+
+from posthog.models.integration import Integration
+from posthog.models.organization_integration import OrganizationIntegration
+
+
+class IntegrationAdmin(admin.ModelAdmin):
+    list_select_related = ("team", "created_by")
+    list_display = ("id", "kind", "integration_id", "team_link", "created_by", "created_at")
+    list_display_links = ("id",)
+    list_filter = (
+        "kind",
+        ("created_at", admin.DateFieldListFilter),
+    )
+    search_fields = ("integration_id", "team__name", "team__organization__name", "config")
+    ordering = ("-created_at",)
+    readonly_fields = ("id", "team", "created_by", "created_at")
+
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": ["id", "team", "kind", "integration_id", "created_by", "created_at"],
+            },
+        ),
+        (
+            "Config",
+            {
+                "fields": ["config", "sensitive_config", "errors"],
+            },
+        ),
+    ]
+
+    def team_link(self, obj: Integration) -> str:
+        return format_html("{} ({})", obj.team.name, obj.team_id)
+
+    team_link.short_description = "Team"  # type: ignore
+
+
+class OrganizationIntegrationAdmin(admin.ModelAdmin):
+    list_select_related = ("organization", "created_by")
+    list_display = ("id", "kind", "integration_id", "organization_link", "created_by", "created_at")
+    list_display_links = ("id",)
+    list_filter = (
+        "kind",
+        ("created_at", admin.DateFieldListFilter),
+    )
+    search_fields = ("integration_id", "organization__name", "config")
+    ordering = ("-created_at",)
+    readonly_fields = ("id", "organization", "created_by", "created_at", "updated_at")
+
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": ["id", "organization", "kind", "integration_id", "created_by", "created_at", "updated_at"],
+            },
+        ),
+        (
+            "Config",
+            {
+                "fields": ["config", "sensitive_config"],
+            },
+        ),
+    ]
+
+    def organization_link(self, obj: OrganizationIntegration) -> str:
+        return format_html("{} ({})", obj.organization.name, obj.organization_id)
+
+    organization_link.short_description = "Organization"  # type: ignore

--- a/posthog/admin/admins/integration_admin.py
+++ b/posthog/admin/admins/integration_admin.py
@@ -27,7 +27,7 @@ class IntegrationAdmin(admin.ModelAdmin):
         (
             "Config",
             {
-                "fields": ["config", "sensitive_config", "errors"],
+                "fields": ["config", "errors"],
             },
         ),
     ]
@@ -59,7 +59,7 @@ class OrganizationIntegrationAdmin(admin.ModelAdmin):
         (
             "Config",
             {
-                "fields": ["config", "sensitive_config"],
+                "fields": ["config"],
             },
         ),
     ]

--- a/posthog/admin/admins/integration_admin.py
+++ b/posthog/admin/admins/integration_admin.py
@@ -32,10 +32,9 @@ class IntegrationAdmin(admin.ModelAdmin):
         ),
     ]
 
+    @admin.display(description="Team")
     def team_link(self, obj: Integration) -> str:
         return format_html("{} ({})", obj.team.name, obj.team_id)
-
-    team_link.short_description = "Team"  # type: ignore
 
 
 class OrganizationIntegrationAdmin(admin.ModelAdmin):


### PR DESCRIPTION
## Problem

Gotta debug an issue with the state of a Slack Integration instance in app.dev.posthog.dev – but I don't want to connect to that Postgres directly. Great use case for Django admin. 

## Changes

Adds `Integration` (team-level, e.g. Slack/Salesforce/HubSpot) and `OrganizationIntegration` (org-level, e.g. Vercel) to Django admin. Searchable by integration ID, team/org name, config.