### PR TITLE
fix: audio mute plugin error

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/audio/audio-mute-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/audio/audio-mute-plugin.ts
@@ -75,7 +75,7 @@ export const AudioMuteReplayerPlugin = (isMuted: boolean): ReplayPlugin => {
             // Handle DOM mutations that might add new media elements
             if (e.type === EventType.IncrementalSnapshot && e.data.source === IncrementalSource.Mutation) {
                 // Apply mute state to any newly added nodes
-                if (e.data.adds) {
+                if (Array.isArray(e.data.adds)) {
                     e.data.adds.forEach((addedNode: any) => {
                         if (addedNode.node && addedNode.node.type === 1) {
                             // Element node


### PR DESCRIPTION
## Problem

This PR fixes a `TypeError: n.data.adds.forEach is not a function` that occurred in the session recording player. The error happened when `e.data.adds` was present but not an array, leading to a runtime error when `forEach` was called on it.

error tracking link: **https://us.posthog.com/project/2/error_tracking/0199ebde-ad42-7d31-969f-6038f31939c9?timestamp=2026-02-12T06%3A34%3A59.978000-08%3A00&searchQuery=n.data.adds.forEach%20is%20not%20a%20function**

## Changes

Added an `Array.isArray()` check before iterating over `e.data.adds` in `audio-mute-plugin.ts`. This ensures that `forEach` is only called when `e.data.adds` is confirmed to be an array.

## How did you test this code?

The fix was identified by inspecting the code path and recognizing that `e.data.adds` was not guaranteed to be an array, despite being checked for existence. The `Array.isArray()` pattern is consistent with other parts of the codebase handling similar data structures.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1770935436307789?thread_ts=1770935436.307789&cid=D0ACMC57HDE)

<p><a href="https://cursor.com/background-agent?bcId=bc-482176b7-bdbb-5d53-b7b2-1278b9b13824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-482176b7-bdbb-5d53-b7b2-1278b9b13824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

