### PR TITLE
fix: postHog AI usage message

### DIFF
--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -438,6 +438,10 @@ describe('getUsageLimitConsequence', () => {
         expect(getUsageLimitConsequence('Feature flags & Experiments')).toEqual('feature flags will not evaluate')
     })
 
+    it('should return specific message for PostHog AI', () => {
+        expect(getUsageLimitConsequence('PostHog AI')).toEqual('to continue using PostHog AI')
+    })
+
     it('should return generic message for other products', () => {
         expect(getUsageLimitConsequence('Session replay')).toEqual('data loss may occur')
         expect(getUsageLimitConsequence('Product analytics')).toEqual('data loss may occur')
@@ -471,6 +475,14 @@ describe('buildUsageLimitExceededMessage', () => {
         expect(result.title).toEqual('Usage limits exceeded')
         expect(result.message).toEqual(
             'You have exceeded the usage limit for Session replay and Feature flags & Experiments. Please increase your billing limit or data loss may occur and feature flags will not evaluate.'
+        )
+    })
+
+    it('should build message for PostHog AI with specific consequence', () => {
+        const result = buildUsageLimitExceededMessage([{ name: 'PostHog AI', subscribed: true }])
+        expect(result.title).toEqual('Usage limit exceeded')
+        expect(result.message).toEqual(
+            'You have exceeded the usage limit for PostHog AI. Please increase your billing to continue using PostHog AI.'
         )
     })
 

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -438,11 +438,14 @@ describe('getUsageLimitConsequence', () => {
         expect(getUsageLimitConsequence('Feature flags & Experiments')).toEqual('feature flags will not evaluate')
     })
 
+    it('should return specific message for PostHog AI', () => {
+        expect(getUsageLimitConsequence('PostHog AI')).toEqual('PostHog AI will be unavailable')
+    })
+
     it('should return generic message for other products', () => {
         expect(getUsageLimitConsequence('Session replay')).toEqual('data loss may occur')
         expect(getUsageLimitConsequence('Product analytics')).toEqual('data loss may occur')
         expect(getUsageLimitConsequence('Surveys')).toEqual('data loss may occur')
-        expect(getUsageLimitConsequence('PostHog AI')).toEqual('data loss may occur')
     })
 })
 
@@ -480,6 +483,17 @@ describe('buildUsageLimitExceededMessage', () => {
         expect(result.title).toEqual('Usage limit exceeded')
         expect(result.message).toEqual(
             'You have exceeded the usage limit for PostHog AI. Please increase your billing to continue using PostHog AI.'
+        )
+    })
+
+    it('should build message for PostHog AI with other products', () => {
+        const result = buildUsageLimitExceededMessage([
+            { name: 'PostHog AI', subscribed: true },
+            { name: 'Session replay', subscribed: true },
+        ])
+        expect(result.title).toEqual('Usage limits exceeded')
+        expect(result.message).toEqual(
+            'You have exceeded the usage limit for PostHog AI and Session replay. Please increase your billing limit or PostHog AI will be unavailable and data loss may occur.'
         )
     })
 

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -478,6 +478,14 @@ describe('buildUsageLimitExceededMessage', () => {
         )
     })
 
+    it('should build message for PostHog AI with specific consequence', () => {
+        const result = buildUsageLimitExceededMessage([{ name: 'PostHog AI', subscribed: true }])
+        expect(result.title).toEqual('Usage limit exceeded')
+        expect(result.message).toEqual(
+            'You have exceeded the usage limit for PostHog AI. Please increase your billing limit or PostHog AI will be unavailable.'
+        )
+    })
+
     it('should deduplicate consequences for products with same consequence', () => {
         const result = buildUsageLimitExceededMessage([
             { name: 'Session replay', subscribed: true },

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -478,25 +478,6 @@ describe('buildUsageLimitExceededMessage', () => {
         )
     })
 
-    it('should build message for PostHog AI with specific consequence', () => {
-        const result = buildUsageLimitExceededMessage([{ name: 'PostHog AI', subscribed: true }])
-        expect(result.title).toEqual('Usage limit exceeded')
-        expect(result.message).toEqual(
-            'You have exceeded the usage limit for PostHog AI. Please increase your billing limit or PostHog AI will be unavailable.'
-        )
-    })
-
-    it('should build message for PostHog AI with other products', () => {
-        const result = buildUsageLimitExceededMessage([
-            { name: 'PostHog AI', subscribed: true },
-            { name: 'Session replay', subscribed: true },
-        ])
-        expect(result.title).toEqual('Usage limits exceeded')
-        expect(result.message).toEqual(
-            'You have exceeded the usage limit for PostHog AI and Session replay. Please increase your billing limit or PostHog AI will be unavailable and data loss may occur.'
-        )
-    })
-
     it('should deduplicate consequences for products with same consequence', () => {
         const result = buildUsageLimitExceededMessage([
             { name: 'Session replay', subscribed: true },

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -486,6 +486,17 @@ describe('buildUsageLimitExceededMessage', () => {
         )
     })
 
+    it('should build message for PostHog AI with other products', () => {
+        const result = buildUsageLimitExceededMessage([
+            { name: 'PostHog AI', subscribed: true },
+            { name: 'Session replay', subscribed: true },
+        ])
+        expect(result.title).toEqual('Usage limits exceeded')
+        expect(result.message).toEqual(
+            'You have exceeded the usage limit for PostHog AI and Session replay. Please increase your billing limit or PostHog AI will be unavailable and data loss may occur.'
+        )
+    })
+
     it('should deduplicate consequences for products with same consequence', () => {
         const result = buildUsageLimitExceededMessage([
             { name: 'Session replay', subscribed: true },

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -482,7 +482,7 @@ describe('buildUsageLimitExceededMessage', () => {
         const result = buildUsageLimitExceededMessage([{ name: 'PostHog AI', subscribed: true }])
         expect(result.title).toEqual('Usage limit exceeded')
         expect(result.message).toEqual(
-            'You have exceeded the usage limit for PostHog AI. Please increase your billing to continue using PostHog AI.'
+            'You have exceeded the usage limit for PostHog AI. Please increase your billing limit or PostHog AI will be unavailable.'
         )
     })
 

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -438,14 +438,11 @@ describe('getUsageLimitConsequence', () => {
         expect(getUsageLimitConsequence('Feature flags & Experiments')).toEqual('feature flags will not evaluate')
     })
 
-    it('should return specific message for PostHog AI', () => {
-        expect(getUsageLimitConsequence('PostHog AI')).toEqual('to continue using PostHog AI')
-    })
-
     it('should return generic message for other products', () => {
         expect(getUsageLimitConsequence('Session replay')).toEqual('data loss may occur')
         expect(getUsageLimitConsequence('Product analytics')).toEqual('data loss may occur')
         expect(getUsageLimitConsequence('Surveys')).toEqual('data loss may occur')
+        expect(getUsageLimitConsequence('PostHog AI')).toEqual('data loss may occur')
     })
 })
 

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -624,6 +624,9 @@ export function getUsageLimitConsequence(productName: string): string {
     if (productName === 'Feature flags & Experiments') {
         return 'feature flags will not evaluate'
     }
+    if (productName === 'PostHog AI') {
+        return 'PostHog AI will be unavailable'
+    }
     return 'data loss may occur'
 }
 

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -624,9 +624,6 @@ export function getUsageLimitConsequence(productName: string): string {
     if (productName === 'Feature flags & Experiments') {
         return 'feature flags will not evaluate'
     }
-    if (productName === 'PostHog AI') {
-        return 'to continue using PostHog AI'
-    }
     return 'data loss may occur'
 }
 

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -624,6 +624,9 @@ export function getUsageLimitConsequence(productName: string): string {
     if (productName === 'Feature flags & Experiments') {
         return 'feature flags will not evaluate'
     }
+    if (productName === 'PostHog AI') {
+        return 'to continue using PostHog AI'
+    }
     return 'data loss may occur'
 }
 
@@ -640,6 +643,15 @@ export function buildUsageLimitExceededMessage(products: Array<{ name: string; s
 
     const productNames = products.map((p) => p.name)
     const allSubscribed = products.every((p) => p.subscribed === true)
+
+    // Special case for single PostHog AI product
+    if (products.length === 1 && products[0].name === 'PostHog AI') {
+        return {
+            title: 'Usage limit exceeded',
+            message:
+                'You have exceeded the usage limit for PostHog AI. Please increase your billing to continue using PostHog AI.',
+        }
+    }
 
     // Build consequence message, deduplicating common consequences
     const consequences = [...new Set(products.map((p) => getUsageLimitConsequence(p.name)))]

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -644,15 +644,6 @@ export function buildUsageLimitExceededMessage(products: Array<{ name: string; s
     const productNames = products.map((p) => p.name)
     const allSubscribed = products.every((p) => p.subscribed === true)
 
-    // Special case for single PostHog AI product
-    if (products.length === 1 && products[0].name === 'PostHog AI') {
-        return {
-            title: 'Usage limit exceeded',
-            message:
-                'You have exceeded the usage limit for PostHog AI. Please increase your billing to continue using PostHog AI.',
-        }
-    }
-
     // Build consequence message, deduplicating common consequences
     const consequences = [...new Set(products.map((p) => getUsageLimitConsequence(p.name)))]
 


### PR DESCRIPTION
## Problem

PostHog AI usage limit messages incorrectly warned of "data loss," which is not applicable to the service. This caused confusion and unnecessary concern for users.

## Changes

- Updated `getUsageLimitConsequence` to return a specific message for PostHog AI.
- Modified `buildUsageLimitExceededMessage` to construct the correct usage limit message for PostHog AI: "You have exceeded the usage limit for PostHog AI. Please increase your billing to continue using PostHog AI."

## How did you test this code?

- Added new unit tests for `getUsageLimitConsequence` and `buildUsageLimitExceededMessage` to cover the PostHog AI specific message.
- Verified existing tests still pass.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1770937256721549?thread_ts=1770937256.721549&cid=D0ACMC57HDE)

<p><a href="https://cursor.com/background-agent?bcId=bc-3c18f775-e773-553c-bde0-5b156e405149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c18f775-e773-553c-bde0-5b156e405149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

