### PR TITLE
fix(surveys): set Exit and Announcement survey templates to 'once' ca…

### DIFF
--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -200,7 +200,12 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
                         reason: 'Transactional surveys can be more frequent',
                     }
                 }
-                if (templateType?.includes('Onboarding') || templateType?.includes('Attribution')) {
+                if (
+                    templateType?.includes('Onboarding') ||
+                    templateType?.includes('Attribution') ||
+                    templateType?.includes('Exit') ||
+                    templateType?.includes('Announcement')
+                ) {
                     return { value: 'once', label: 'Once ever', reason: 'One-time feedback collection' }
                 }
                 return { value: 'monthly', label: 'Every month', reason: 'General feedback cadence' }


### PR DESCRIPTION
…dence

Exit surveys should only be shown once since they're triggered when a user cancels/churns. Announcement surveys are also one-time communications to users.

Previously, these templates fell through to the default 'monthly' cadence which was incorrect for their intended use cases.

Slack thread: https://posthog.slack.com/archives/C07QD3LT8U9/p1770937332380719

https://claude.ai/code/session_01Q24yseA6JHPaHto2C1tcsH

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
