### PR TITLE
fix(surveys): improve empty state UI and template handling

### DIFF
--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -1,5 +1,5 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
-import { router } from 'kea-router'
+import { router, urlToAction } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -335,6 +335,20 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
             actions.loadSurveys()
             actions.reportSurveyEdited(survey)
             router.actions.push(urls.survey(survey.id))
+        },
+    })),
+
+    urlToAction(({ actions, props }) => ({
+        [urls.surveyWizard(props.id)]: (_, searchParams) => {
+            const templateParam = searchParams.template
+            if (templateParam && props.id === 'new') {
+                const matchingTemplate = defaultSurveyTemplates.find(
+                    (t) => t.templateType === templateParam || t.templateType === decodeURIComponent(templateParam)
+                )
+                if (matchingTemplate) {
+                    actions.selectTemplate(matchingTemplate)
+                }
+            }
         },
     })),
 


### PR DESCRIPTION
- Remove MaxTool wrapper from "Create with AI" button to prevent redundant AI overlay
- Navigate template clicks to guided wizard with template preselection when guided editor flag is enabled
- Update "See all other templates" button to launch guided wizard when flag is enabled
- Add URL param handling in wizard to auto-select template from ?template= param

https://claude.ai/code/session_019RBGd8KD1a3y1fKx7za83N

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
