### PR TITLE
feat: add react native error boundary docs

### DIFF
--- a/docs/onboarding/error-tracking/react-native.tsx
+++ b/docs/onboarding/error-tracking/react-native.tsx
@@ -59,6 +59,68 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
         ),
     }
 
+    const errorBoundaryStep: StepDefinition = {
+        title: 'Set up error boundaries',
+        badge: 'optional',
+        content: (
+            <>
+                <Markdown>
+                    {dedent`
+                        You can use the \`PostHogErrorBoundary\` component to capture rendering errors thrown by components:
+                    `}
+                </Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'jsx',
+                            file: 'React Native',
+                            code: dedent`
+                                import { PostHogProvider, PostHogErrorBoundary } from 'posthog-react-native'
+                                import { View, Text } from 'react-native'
+
+                                const App = () => {
+                                  return (
+                                    <PostHogProvider apiKey="<ph_project_api_key>">
+                                      <PostHogErrorBoundary
+                                        fallback={YourFallbackComponent}
+                                        additionalProperties={{ screen: "home" }}
+                                      >
+                                        <YourApp />
+                                      </PostHogErrorBoundary>
+                                    </PostHogProvider>
+                                  )
+                                }
+
+                                const YourFallbackComponent = ({ error, componentStack }) => {
+                                  return (
+                                    <View>
+                                      <Text>Something went wrong!</Text>
+                                      <Text>{error instanceof Error ? error.message : String(error)}</Text>
+                                    </View>
+                                  )
+                                }
+                            `,
+                        },
+                    ]}
+                />
+                <CalloutBox type="caution" title="Duplicate errors with console capture">
+                    <Markdown>
+                        {dedent`
+                            If you have both \`PostHogErrorBoundary\` and \`console\` capture enabled in your \`errorTracking\` config, render errors will be captured twice. This is because React logs all errors to the console by default. To avoid this, set \`console: []\` in your error tracking autocapture config when using \`PostHogErrorBoundary\`.
+                        `}
+                    </Markdown>
+                </CalloutBox>
+                <CalloutBox type="fyi" title="Dev mode behavior">
+                    <Markdown>
+                        {dedent`
+                            In development mode, React propagates all errors to the global error handler even when they are caught by an error boundary. This means you may see errors reported twice in dev builds. This is expected React behavior and does not occur in production builds.
+                        `}
+                    </Markdown>
+                </CalloutBox>
+            </>
+        ),
+    }
+
     const manualCaptureStep: StepDefinition = {
         title: 'Manually capture exceptions',
         badge: 'optional',
@@ -129,6 +191,7 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
     return [
         ...installSteps,
         exceptionAutocaptureStep,
+        errorBoundaryStep,
         manualCaptureStep,
         verifyStep,
         futureFeaturesStep,

--- a/docs/onboarding/error-tracking/react-native.tsx
+++ b/docs/onboarding/error-tracking/react-native.tsx
@@ -106,7 +106,7 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                 <CalloutBox type="caution" title="Duplicate errors with console capture">
                     <Markdown>
                         {dedent`
-                            If you have both \`PostHogErrorBoundary\` and \`console\` capture enabled in your \`errorTracking\` config, render errors will be captured twice. This is because React logs all errors to the console by default. To avoid this, set \`console: []\` in your error tracking autocapture config when using \`PostHogErrorBoundary\`.
+                            If you have both \`PostHogErrorBoundary\` and \`console\` capture enabled in your \`errorTracking\` config, render errors will be captured twice. This is because React logs all errors to the console by default. To avoid this, set \`console: []\` on \`errorTracking.autocapture\` (for example, \`errorTracking: { autocapture: { console: [] } }\`) when using \`PostHogErrorBoundary\`.
                         `}
                     </Markdown>
                 </CalloutBox>


### PR DESCRIPTION
Add react native error boundary docs. These docs live in a similar place to where plain react error boundary docs live.

I think we should also mention this in general capture guide in docs so here is the follow up PR https://github.com/PostHog/posthog.com/pull/15007

<img width="724" height="665" alt="image" src="https://github.com/user-attachments/assets/722ca08e-d53e-4d06-882e-9329902500d5" />
