### PR TITLE
fix(toolbar): filter out invalid URLs from authorized URL suggestions

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.test.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.test.ts
@@ -218,5 +218,18 @@ describe('the authorized urls list logic', () => {
                 { url: 'https://not.valid.io', count: 1 },
             ])
         })
+
+        it('filters out invalid URLs like paths without domains', () => {
+            const urlsWithInvalidPaths: SuggestedDomain[] = [
+                { url: '/', count: 10 },
+                { url: '/billing', count: 5 },
+                { url: '/settings/project', count: 3 },
+                { url: 'https://valid.example.com', count: 2 },
+                { url: 'not-a-url', count: 1 },
+            ]
+            expect(filterNotAuthorizedUrls(urlsWithInvalidPaths, [])).toEqual([
+                { url: 'https://valid.example.com', count: 2 },
+            ])
+        })
     })
 })

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -209,7 +209,8 @@ export const filterNotAuthorizedUrls = (
             const parsedUrl = sanitizePossibleWildCardedURL(url)
             urlWithoutPath = parsedUrl.protocol + '//' + parsedUrl.host
         } catch {
-            urlWithoutPath = url
+            // Skip invalid URLs (e.g., "/" or "/billing" paths without a domain)
+            return
         }
         // Have we already added this domain?
         if (suggestedDomains.some((sd) => sd.url === urlWithoutPath)) {


### PR DESCRIPTION
Invalid URLs like "/" or "/billing" (paths without domains) were being shown as toolbar authorized URL suggestions. This happened because when sanitizePossibleWildCardedURL threw an error for invalid URLs, the catch block would fall back to using the invalid URL as-is. Now we skip these invalid URLs instead of including them in suggestions.

https://claude.ai/code/session_01NPZ8d85NFvka5b8WqyiLkQ

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
