### PR TITLE
chore(admin): rms editable state field from batch import

### DIFF
--- a/posthog/admin/admins/batch_imports.py
+++ b/posthog/admin/admins/batch_imports.py
@@ -44,7 +44,7 @@ class BatchImportAdmin(admin.ModelAdmin):
     list_display = ("id", "team", "status", "created_by_id", "created_at", "get_send_rate")
     list_filter = ("status", "created_at")
     search_fields = ("id", "status_message", "team__name")
-    readonly_fields = ("id", "created_at", "updated_at", "import_config")
+    readonly_fields = ("id", "created_at", "updated_at", "state", "import_config")
     autocomplete_fields = ("team",)
     fieldsets = (
         (None, {"fields": ("team", "created_by_id", "status", "status_message")}),


### PR DESCRIPTION
## Problem

Editable state field is very hard to read. We only temporarily needed this, so moving it back.

## Changes

Add state field to the readonly field list on batch import model.

## How did you test this code?

It was like this earlier today and worked well. One line change.
