### PR TITLE
feat: conversation assignee quick assign

### DIFF
--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -11,6 +11,7 @@ import { newInternalTab } from 'lib/utils/newInternalTab'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
@@ -54,6 +55,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
         hasUnsavedChanges,
     } = useValues(logic)
     const { setStatus, setPriority, setAssignee, sendMessage, updateTicket, loadOlderMessages } = useActions(logic)
+    const { user } = useValues(userLogic)
 
     const chatPanelRef = useRef<HTMLDivElement>(null)
 
@@ -233,21 +235,32 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                             </div>
                             <div className="flex justify-between items-center">
                                 <span className="text-muted-alt">Assignee</span>
-                                <AssigneeSelect assignee={assignee} onChange={setAssignee}>
-                                    {(resolvedAssignee, isOpen) => (
+                                <div className="flex items-center gap-2">
+                                    {user && assignee?.id !== user.id && (
                                         <LemonButton
-                                            size="small"
-                                            type="secondary"
-                                            active={isOpen}
-                                            sideIcon={<IconChevronDown />}
+                                            type="tertiary"
+                                            size="xsmall"
+                                            onClick={() => setAssignee({ type: 'user', id: user.id })}
                                         >
-                                            <span className="flex items-center gap-1">
-                                                <AssigneeIconDisplay assignee={resolvedAssignee} size="small" />
-                                                <AssigneeLabelDisplay assignee={resolvedAssignee} size="small" />
-                                            </span>
+                                            Take it
                                         </LemonButton>
                                     )}
-                                </AssigneeSelect>
+                                    <AssigneeSelect assignee={assignee} onChange={setAssignee}>
+                                        {(resolvedAssignee, isOpen) => (
+                                            <LemonButton
+                                                size="small"
+                                                type="secondary"
+                                                active={isOpen}
+                                                sideIcon={<IconChevronDown />}
+                                            >
+                                                <span className="flex items-center gap-1">
+                                                    <AssigneeIconDisplay assignee={resolvedAssignee} size="small" />
+                                                    <AssigneeLabelDisplay assignee={resolvedAssignee} size="small" />
+                                                </span>
+                                            </LemonButton>
+                                        )}
+                                    </AssigneeSelect>
+                                </div>
                             </div>
                         </div>
                         <div className="mt-3 pt-3 border-t flex justify-end">


### PR DESCRIPTION
## Problem

Users need a quicker way to assign an unassigned conversation ticket to themselves. Currently, they have to open the assignee dropdown and select their name.

## Changes

Adds a "Take it" button to the left of the assignee field on the conversations ticket view.
- The button is visible only when the ticket is unassigned or assigned to a different user.
- Clicking the button instantly assigns the ticket to the current logged-in user.
- The button uses `type="tertiary"` and `size="xsmall"` for a subtle appearance.

## How did you test this code?

1. Navigate to a conversation ticket (`/conversations/ticket/:id`).
2. Observe the assignee field:
    - If the ticket is unassigned, a "Take it" button should appear.
    - If the ticket is assigned to another user, a "Take it" button should appear.
    - If the ticket is assigned to the current user, the "Take it" button should **not** appear.
3. Click the "Take it" button when visible.
4. Verify that the ticket's assignee is updated to the current user.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1770947603275959?thread_ts=1770947603.275959&cid=D0ACMC57HDE)

<p><a href="https://cursor.com/background-agent?bcId=bc-f1de8e00-f1b7-55c3-b56d-564e9e5067e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f1de8e00-f1b7-55c3-b56d-564e9e5067e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

