### PR TITLE
fix(replay): remove tab awareness

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -6,13 +6,11 @@ import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { useWindowSize } from 'lib/hooks/useWindowSize'
-import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { Playlist } from 'scenes/session-recordings/playlist/Playlist'
 
 import { RecordingsUniversalFiltersEmbed } from '../filters/RecordingsUniversalFiltersEmbed'
 import { SessionRecordingPlayer } from '../player/SessionRecordingPlayer'
 import { playerSettingsLogic } from '../player/playerSettingsLogic'
-import { sessionRecordingPlayerLogic } from '../player/sessionRecordingPlayerLogic'
 import { playlistFiltersLogic } from './playlistFiltersLogic'
 import { SessionRecordingPlaylistLogicProps, sessionRecordingsPlaylistLogic } from './sessionRecordingsPlaylistLogic'
 
@@ -138,59 +136,6 @@ function VerticalLayout({
     )
 }
 
-function AttachedPlayer({
-    playlistProps,
-    activeSessionRecording,
-    matchingEventsMatchType,
-    pinnedRecordings,
-    onPlayNextRecording,
-}: {
-    playlistProps: SessionRecordingPlaylistLogicProps
-    activeSessionRecording: any
-    matchingEventsMatchType: any
-    pinnedRecordings: any[]
-    onPlayNextRecording: () => void
-}): JSX.Element {
-    const playerKey = playlistProps.logicKey ?? 'playlist'
-
-    // Attach player logic to playlist logic so it persists across tab switches
-    // Pass autoPlay from playlistProps to match what the component will use
-    useAttachedLogic(
-        sessionRecordingPlayerLogic({
-            playerKey,
-            sessionRecordingId: activeSessionRecording.id,
-            matchingEventsMatchType,
-            autoPlay: playlistProps.autoPlay,
-        }),
-        sessionRecordingsPlaylistLogic(playlistProps)
-    )
-
-    return (
-        <SessionRecordingPlayer
-            playerKey={playerKey}
-            sessionRecordingId={activeSessionRecording.id}
-            matchingEventsMatchType={matchingEventsMatchType}
-            autoPlay={playlistProps.autoPlay}
-            onRecordingDeleted={() => {
-                sessionRecordingsPlaylistLogic.actions.loadAllRecordings()
-                sessionRecordingsPlaylistLogic.actions.setSelectedRecordingId(null)
-            }}
-            pinned={!!pinnedRecordings.find((x) => x.id === activeSessionRecording.id)}
-            setPinned={
-                playlistProps.onPinnedChange
-                    ? (pinned) => {
-                          if (!activeSessionRecording.id) {
-                              return
-                          }
-                          playlistProps.onPinnedChange?.(activeSessionRecording, pinned)
-                      }
-                    : undefined
-            }
-            playNextRecording={onPlayNextRecording}
-        />
-    )
-}
-
 function PlayerWrapper({
     showContent = true,
     containerRef,
@@ -245,12 +190,27 @@ function PlayerWrapper({
                     />
                 </div>
             ) : showContent && activeSessionRecording ? (
-                <AttachedPlayer
-                    playlistProps={props}
-                    activeSessionRecording={activeSessionRecording}
+                <SessionRecordingPlayer
+                    playerKey={props.logicKey ?? 'playlist'}
+                    sessionRecordingId={activeSessionRecording.id}
                     matchingEventsMatchType={matchingEventsMatchType}
-                    pinnedRecordings={pinnedRecordings}
-                    onPlayNextRecording={onPlayNextRecording}
+                    autoPlay={props.autoPlay}
+                    onRecordingDeleted={() => {
+                        sessionRecordingsPlaylistLogic.actions.loadAllRecordings()
+                        sessionRecordingsPlaylistLogic.actions.setSelectedRecordingId(null)
+                    }}
+                    pinned={!!pinnedRecordings.find((x) => x.id === activeSessionRecording.id)}
+                    setPinned={
+                        props.onPinnedChange
+                            ? (pinned) => {
+                                  if (!activeSessionRecording.id) {
+                                      return
+                                  }
+                                  props.onPinnedChange?.(activeSessionRecording, pinned)
+                              }
+                            : undefined
+                    }
+                    playNextRecording={onPlayNextRecording}
                 />
             ) : (
                 <div className="mt-20">


### PR DESCRIPTION
## Problem

saw when messing with memory in dev tools that we were keeping extra Replayers around, will re-implement this when i can assure thats not happening anymore but in the meantime we're chipping away at memory leaks

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

remove tab awareness, this is basically a clean revert of me adding it 6 weeks ago
#44455
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Clicked around

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
