### PR TITLE
feat(deduplicator): new consumer for output topic rewind on rebalance/app startup

### DIFF
--- a/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
@@ -83,11 +83,6 @@ where
 
         let consumer_ctx = BatchConsumerContext::new(rebalance_handler, consumer_command_tx);
 
-        // TODO: when we transition off stateful consumer, we must ensure we update the
-        // incoming production-env ClientConfig to set:
-        // - auto-store of offsets to DISABLED (we handle this directly after each batch in code)
-        // - auto-commit ENABLED or DISABLED (if enabled, we can remove the manual commit
-        //                                    operation in the batch consumer loop!)
         let consumer: StreamConsumer<BatchConsumerContext> = config
             .create_with_context(consumer_ctx)
             .context("Failed to create Kafka consumer")?;

--- a/rust/kafka-deduplicator/src/kafka/error_handling.rs
+++ b/rust/kafka-deduplicator/src/kafka/error_handling.rs
@@ -1,0 +1,117 @@
+use std::time::Duration;
+
+use rdkafka::error::{KafkaError, RDKafkaErrorCode};
+use tokio::time::sleep;
+use tracing::{error, info, warn};
+
+/// Handles Kafka consumer errors: retries with backoff for retriable errors,
+/// returns Some(e) for fatal/canceled errors so the caller can stop.
+/// `metric_name` is the counter used for error metrics (e.g. BATCH_CONSUMER_KAFKA_ERROR).
+pub(crate) async fn handle_kafka_error(
+    e: KafkaError,
+    current_count: u64,
+    metric_name: &'static str,
+) -> Option<KafkaError> {
+    match &e {
+        KafkaError::MessageConsumption(code) => {
+            match code {
+                RDKafkaErrorCode::PartitionEOF => {
+                    metrics::counter!(
+                        metric_name,
+                        &[("level", "info"), ("error", "partition_eof"),]
+                    )
+                    .increment(1);
+                }
+                RDKafkaErrorCode::OperationTimedOut => {
+                    metrics::counter!(
+                        metric_name,
+                        &[("level", "info"), ("error", "op_timed_out"),]
+                    )
+                    .increment(1);
+                }
+                RDKafkaErrorCode::OffsetOutOfRange => {
+                    warn!("Offset out of range - seeking to configured offset reset policy",);
+                    metrics::counter!(
+                        metric_name,
+                        &[("level", "info"), ("error", "offset_out_of_range"),]
+                    )
+                    .increment(1);
+                    sleep(Duration::from_millis(500)).await;
+                }
+                _ => {
+                    warn!("Kafka consumer error: {code:?}");
+                    metrics::counter!(metric_name, &[("level", "warn"), ("error", "consumer"),])
+                        .increment(1);
+                    sleep(Duration::from_millis(100 * current_count.min(10))).await;
+                }
+            }
+
+            None
+        }
+
+        KafkaError::MessageConsumptionFatal(code) => {
+            error!("Fatal Kafka consumer error: {code:?}");
+            metrics::counter!(metric_name, &[("level", "fatal"), ("error", "consumer"),])
+                .increment(1);
+
+            Some(e)
+        }
+
+        KafkaError::Global(code) => {
+            match code {
+                RDKafkaErrorCode::AllBrokersDown => {
+                    warn!("All brokers down: {code:?} - waiting for reconnect");
+                    metrics::counter!(
+                        metric_name,
+                        &[("level", "warn"), ("error", "all_brokers_down"),]
+                    )
+                    .increment(1);
+                    sleep(Duration::from_secs(current_count.min(5))).await;
+                }
+                RDKafkaErrorCode::BrokerTransportFailure => {
+                    warn!("Broker transport failure: {code:?} - waiting for reconnect");
+                    metrics::counter!(
+                        metric_name,
+                        &[("level", "warn"), ("error", "broker_transport"),]
+                    )
+                    .increment(1);
+                    sleep(Duration::from_secs(current_count.min(3))).await;
+                }
+                RDKafkaErrorCode::Authentication => {
+                    error!("Authentication failed: {code:?}");
+                    metrics::counter!(
+                        metric_name,
+                        &[("level", "fatal"), ("error", "authentication"),]
+                    )
+                    .increment(1);
+                    return Some(e);
+                }
+                _ => {
+                    warn!("Global Kafka error: {code:?}");
+                    metrics::counter!(metric_name, &[("level", "warn"), ("error", "global"),])
+                        .increment(1);
+                    sleep(Duration::from_millis(500 * current_count.min(6))).await;
+                }
+            }
+
+            None
+        }
+
+        KafkaError::Canceled => {
+            info!("Consumer canceled - shutting down");
+            metrics::counter!(metric_name, &[("level", "info"), ("error", "canceled"),])
+                .increment(1);
+
+            Some(e)
+        }
+
+        _ => {
+            error!("Unexpected error: {e:#}");
+            metrics::counter!(metric_name, &[("level", "fatal"), ("error", "unexpected"),])
+                .increment(1);
+            sleep(Duration::from_millis(100 * current_count.min(10))).await;
+
+            None
+        }
+    }
+}

--- a/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
+++ b/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
@@ -76,6 +76,9 @@ pub const WATERMARK_CONSUMER_PARTITIONS_COMPLETED: &str =
     "kafka_watermark_consumer_partitions_completed_total";
 /// rdkafka consumption errors received by the watermark consumer
 pub const WATERMARK_CONSUMER_KAFKA_ERROR: &str = "kafka_watermark_consumer_kafka_error";
+/// Messages received from partitions not in the original assignment
+pub const WATERMARK_CONSUMER_UNEXPECTED_PARTITION: &str =
+    "kafka_watermark_consumer_unexpected_partition_total";
 
 // ==== Partition Worker metrics ====
 /// Counter for partition worker channel backpressure events

--- a/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
+++ b/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
@@ -68,6 +68,15 @@ pub const BATCH_CONSUMER_BATCH_COLLECTION_DURATION_MS: &str =
 pub const BATCH_CONSUMER_SEEK_ERROR: &str = "kafka_batch_consumer_seek_error";
 pub const BATCH_CONSUMER_SEEK_DURATION_MS: &str = "kafka_batch_consumer_seek_duration_ms";
 
+// ==== Watermark Consumer metrics ====
+/// Counter for messages received by the watermark consumer, tagged by deserialization status
+pub const WATERMARK_CONSUMER_MESSAGES_RECEIVED: &str = "kafka_watermark_consumer_messages_received";
+/// Counter for partitions that have reached high-watermark
+pub const WATERMARK_CONSUMER_PARTITIONS_COMPLETED: &str =
+    "kafka_watermark_consumer_partitions_completed_total";
+/// rdkafka consumption errors received by the watermark consumer
+pub const WATERMARK_CONSUMER_KAFKA_ERROR: &str = "kafka_watermark_consumer_kafka_error";
+
 // ==== Partition Worker metrics ====
 /// Counter for partition worker channel backpressure events
 /// Incremented when route_batch has to wait because the worker channel is full

--- a/rust/kafka-deduplicator/src/kafka/mod.rs
+++ b/rust/kafka-deduplicator/src/kafka/mod.rs
@@ -1,4 +1,4 @@
-// Kafka module - batch consumption with rebalance handling
+// Kafka module - batch consumption with rebalance handling, and watermark (assign-only) consumption
 pub mod batch_consumer;
 pub mod batch_context;
 pub mod batch_message;

--- a/rust/kafka-deduplicator/src/kafka/mod.rs
+++ b/rust/kafka-deduplicator/src/kafka/mod.rs
@@ -3,6 +3,7 @@ pub mod batch_consumer;
 pub mod batch_context;
 pub mod batch_message;
 pub mod config;
+pub mod error_handling;
 pub mod metrics_consts;
 pub mod offset_tracker;
 pub mod partition_router;
@@ -10,6 +11,7 @@ pub mod partition_worker;
 pub mod rebalance_handler;
 pub mod routing_processor;
 pub mod types;
+pub mod watermark_consumer;
 
 // Used in "mod tests" and tests/ directory (integration tests)
 pub mod test_utils;
@@ -21,3 +23,4 @@ pub use partition_router::{PartitionRouter, PartitionRouterConfig};
 pub use partition_worker::{PartitionBatch, PartitionWorker, PartitionWorkerConfig};
 pub use rebalance_handler::RebalanceHandler;
 pub use routing_processor::RoutingProcessor;
+pub use watermark_consumer::WatermarkConsumer;

--- a/rust/kafka-deduplicator/src/kafka/types.rs
+++ b/rust/kafka-deduplicator/src/kafka/types.rs
@@ -57,6 +57,10 @@ impl PartitionOffset {
         self.partition.partition_number()
     }
 
+    pub fn partition(&self) -> &Partition {
+        &self.partition
+    }
+
     pub fn offset(&self) -> i64 {
         self.offset
     }

--- a/rust/kafka-deduplicator/src/kafka/watermark_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/watermark_consumer.rs
@@ -22,7 +22,10 @@ use tracing::{info, warn};
 
 /// Low-level consumer that reads from assigned (topic, partition, offset) tuples
 /// until each partition reaches its high-watermark, then shuts down.
-/// No consumer group; outputs batches via a channel.
+/// No consumer group coordination; outputs batches via a channel.
+///
+/// Use `ConsumerConfigBuilder::for_watermark_consumer()` (or `Config::build_watermark_consumer_config()`)
+/// to create an appropriate `ClientConfig` for this consumer.
 pub struct WatermarkConsumer<T> {
     consumer: StreamConsumer,
     batch_size: usize,

--- a/rust/kafka-deduplicator/src/kafka/watermark_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/watermark_consumer.rs
@@ -1,0 +1,242 @@
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use crate::kafka::batch_message::{Batch, BatchError, KafkaMessage};
+use crate::kafka::error_handling;
+use crate::kafka::metrics_consts::{
+    WATERMARK_CONSUMER_KAFKA_ERROR, WATERMARK_CONSUMER_MESSAGES_RECEIVED,
+    WATERMARK_CONSUMER_PARTITIONS_COMPLETED,
+};
+use crate::kafka::types::{Partition, PartitionOffset};
+
+use anyhow::{Context, Result};
+use futures_util::StreamExt;
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::message::Message;
+use rdkafka::{Offset, TopicPartitionList};
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot::Receiver;
+use tracing::{info, warn};
+
+/// Low-level consumer that reads from assigned (topic, partition, offset) tuples
+/// until each partition reaches its high-watermark, then shuts down.
+/// No consumer group; outputs batches via a channel.
+pub struct WatermarkConsumer<T> {
+    consumer: StreamConsumer,
+    batch_size: usize,
+    batch_timeout: Duration,
+    batch_tx: mpsc::Sender<Batch<T>>,
+    shutdown_rx: Receiver<()>,
+    partition_targets: HashMap<Partition, i64>,
+    completed_partitions: HashSet<Partition>,
+}
+
+impl<T> WatermarkConsumer<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    /// Creates a watermark consumer and returns (consumer, batch_receiver).
+    /// Caller runs `consumer.consume().await` to drive consumption; batches are received on the returned receiver.
+    /// When all partitions reach high-watermark (or shutdown is signaled), the sender is dropped and the receiver sees channel close.
+    pub fn new(
+        config: &ClientConfig,
+        assignments: Vec<PartitionOffset>,
+        batch_size: usize,
+        batch_timeout: Duration,
+        fetch_watermarks_timeout: Duration,
+        shutdown_rx: Receiver<()>,
+    ) -> Result<(Self, mpsc::Receiver<Batch<T>>)> {
+        if assignments.is_empty() {
+            anyhow::bail!("assignments must not be empty");
+        }
+
+        let consumer: StreamConsumer =
+            config.create().context("Failed to create Kafka consumer")?;
+
+        let mut tpl = TopicPartitionList::new();
+        for a in &assignments {
+            tpl.add_partition_offset(a.topic(), a.partition_number(), Offset::Offset(a.offset()))
+                .context("add_partition_offset")?;
+        }
+        consumer
+            .assign(&tpl)
+            .context("Failed to assign partitions")?;
+
+        let mut partition_targets = HashMap::new();
+        let mut completed_partitions = HashSet::new();
+
+        for a in &assignments {
+            let (_low, high) = consumer.fetch_watermarks(
+                a.topic(),
+                a.partition_number(),
+                fetch_watermarks_timeout,
+            )?;
+            let partition = a.partition().clone();
+            partition_targets.insert(partition.clone(), high);
+            if high <= a.offset() {
+                completed_partitions.insert(partition);
+            }
+        }
+
+        let (batch_tx, batch_rx) = mpsc::channel(4);
+
+        Ok((
+            Self {
+                consumer,
+                batch_size,
+                batch_timeout,
+                batch_tx,
+                shutdown_rx,
+                partition_targets,
+                completed_partitions,
+            },
+            batch_rx,
+        ))
+    }
+
+    /// Drives consumption until all partitions reach high-watermark or shutdown.
+    /// Drops the batch sender when done so the receiver sees channel close.
+    pub async fn consume(mut self) -> Result<()> {
+        info!(
+            "Watermark consumer starting ({} partitions, {} already at watermark)",
+            self.partition_targets.len(),
+            self.completed_partitions.len()
+        );
+
+        let mut stream = self.consumer.stream();
+        let batch_size = self.batch_size;
+        let batch_timeout = self.batch_timeout;
+        let mut kafka_error_count = 0u64;
+        let mut stream_ended = false;
+
+        loop {
+            if self.completed_partitions.len() >= self.partition_targets.len() {
+                info!("All partitions reached high-watermark, shutting down");
+                break;
+            }
+            if stream_ended {
+                break;
+            }
+
+            let mut batch = Batch::new_with_size_hint(batch_size);
+            let batch_deadline = tokio::time::Instant::now() + batch_timeout;
+
+            while batch.message_count() < batch_size {
+                let now = tokio::time::Instant::now();
+                if now >= batch_deadline {
+                    break;
+                }
+                let remaining = batch_deadline.saturating_duration_since(now);
+
+                tokio::select! {
+                    _ = &mut self.shutdown_rx => {
+                        info!("Shutdown signal received");
+                        drop(self.batch_tx);
+                        return Ok(());
+                    }
+
+                    next_msg = tokio::time::timeout(remaining, stream.next()) => {
+                        match next_msg {
+                            Ok(Some(Ok(borrowed_message))) => {
+                                let partition = Partition::new(
+                                    borrowed_message.topic().to_owned(),
+                                    borrowed_message.partition(),
+                                );
+                                match KafkaMessage::<T>::from_borrowed_message(&borrowed_message) {
+                                    Ok(kafka_message) => {
+                                        batch.push_message(kafka_message);
+                                        kafka_error_count = 0;
+                                        let offset = borrowed_message.offset();
+                                        let target = self.partition_targets.get(&partition).copied().unwrap_or(0);
+                                        if target > 0 && offset >= target - 1 {
+                                            self.completed_partitions.insert(partition);
+                                            metrics::counter!(WATERMARK_CONSUMER_PARTITIONS_COMPLETED)
+                                                .increment(1);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        let wrapped_err = e.context("Error deserializing message");
+                                        batch.push_error(BatchError::new(
+                                            wrapped_err,
+                                            Some(partition),
+                                            Some(borrowed_message.offset()),
+                                        ));
+                                    }
+                                }
+                            }
+                            Ok(Some(Err(e))) => {
+                                kafka_error_count += 1;
+                                if let Some(ke) =
+                                    error_handling::handle_kafka_error(e, kafka_error_count, WATERMARK_CONSUMER_KAFKA_ERROR).await
+                                {
+                                    drop(self.batch_tx);
+                                    return Err(ke.into());
+                                }
+                            }
+                            Ok(None) => {
+                                stream_ended = true;
+                                break;
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                }
+            }
+
+            if !batch.is_empty() {
+                let message_count = batch.message_count();
+                metrics::counter!(WATERMARK_CONSUMER_MESSAGES_RECEIVED, "status" => "success")
+                    .increment(message_count as u64);
+                metrics::counter!(WATERMARK_CONSUMER_MESSAGES_RECEIVED, "status" => "error")
+                    .increment(batch.error_count() as u64);
+                if self.batch_tx.send(batch).await.is_err() {
+                    warn!("Batch receiver dropped, stopping consumer");
+                    return Ok(());
+                }
+            }
+        }
+
+        drop(self.batch_tx);
+        Ok(())
+    }
+}
+
+/// Returns true when a partition has no messages to read (high watermark at or before start offset).
+#[cfg(test)]
+pub(crate) fn partition_already_at_watermark(start_offset: i64, high_watermark: i64) -> bool {
+    high_watermark <= start_offset
+}
+
+/// Returns true when the last message for this partition has been consumed (offset is at or past high - 1).
+#[cfg(test)]
+pub(crate) fn partition_done_after_message(offset: i64, high_watermark: i64) -> bool {
+    high_watermark > 0 && offset >= high_watermark - 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_partition_already_at_watermark() {
+        assert!(partition_already_at_watermark(0, 0));
+        assert!(partition_already_at_watermark(5, 5));
+        assert!(partition_already_at_watermark(10, 5));
+        assert!(!partition_already_at_watermark(0, 1));
+        assert!(!partition_already_at_watermark(4, 5));
+    }
+
+    #[test]
+    fn test_partition_done_after_message() {
+        assert!(!partition_done_after_message(0, 0));
+        assert!(partition_done_after_message(0, 1));
+        assert!(partition_done_after_message(0, 1));
+        assert!(!partition_done_after_message(0, 2));
+        assert!(partition_done_after_message(1, 2));
+        assert!(partition_done_after_message(2, 2));
+        assert!(partition_done_after_message(99, 100));
+        assert!(!partition_done_after_message(98, 100));
+    }
+}

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     checkpoint_manager::CheckpointManager,
     config::Config,
-    kafka::{ConsumerConfigBuilder, PartitionRouterConfig, PartitionWorkerConfig},
+    kafka::{PartitionRouterConfig, PartitionWorkerConfig},
     rebalance_tracker::RebalanceTracker,
     store::DeduplicationStoreConfig,
     store_manager::{CleanupTaskHandle, StoreManager},
@@ -215,33 +215,7 @@ impl KafkaDeduplicatorService {
             return Err(anyhow::anyhow!("Service already initialized"));
         }
 
-        // Create consumer config using the kafka module's builder
-        let consumer_config =
-            ConsumerConfigBuilder::new(&self.config.kafka_hosts, &self.config.kafka_consumer_group)
-                .with_tls(self.config.kafka_tls)
-                .with_max_partition_fetch_bytes(
-                    self.config.kafka_consumer_max_partition_fetch_bytes,
-                )
-                .with_topic_metadata_refresh_interval_ms(
-                    self.config.kafka_topic_metadata_refresh_interval_ms,
-                )
-                .with_metadata_max_age_ms(self.config.kafka_metadata_max_age_ms)
-                .with_sticky_partition_assignment(self.config.pod_hostname.as_deref())
-                .with_offset_reset(&self.config.kafka_consumer_offset_reset)
-                // Fetch settings for throughput optimization
-                .with_fetch_min_bytes(self.config.kafka_consumer_fetch_min_bytes)
-                .with_fetch_max_bytes(self.config.kafka_consumer_fetch_max_bytes)
-                .with_fetch_wait_max_ms(self.config.kafka_consumer_fetch_wait_max_ms)
-                // Prefetch settings for batching efficiency
-                .with_queued_min_messages(self.config.kafka_consumer_queued_min_messages)
-                .with_queued_max_messages_kbytes(
-                    self.config.kafka_consumer_queued_max_messages_kbytes,
-                )
-                // Consumer group membership settings
-                .with_max_poll_interval_ms(self.config.kafka_max_poll_interval_ms)
-                .with_session_timeout_ms(self.config.kafka_session_timeout_ms)
-                .with_heartbeat_interval_ms(self.config.kafka_heartbeat_interval_ms)
-                .build();
+        let consumer_config = self.config.build_batch_consumer_config();
 
         // Create partition router for parallel processing across partitions
         let router_config = PartitionRouterConfig {

--- a/rust/kafka-deduplicator/tests/watermark_consumer_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/watermark_consumer_integration_tests.rs
@@ -1,0 +1,181 @@
+use std::time::Duration;
+
+use kafka_deduplicator::kafka::{
+    types::{Partition, PartitionOffset},
+    watermark_consumer::WatermarkConsumer,
+};
+
+use common_types::CapturedEvent;
+
+use anyhow::Result;
+use rdkafka::{
+    admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
+    config::ClientConfig,
+    producer::{FutureProducer, FutureRecord},
+    util::Timeout,
+};
+use time::OffsetDateTime;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+const KAFKA_BROKERS: &str = "localhost:9092";
+const TEST_TOPIC_BASE: &str = "kdedup-watermark-consumer-integration-test";
+
+async fn create_topic_with_partitions(topic: &str, num_partitions: i32) -> Result<()> {
+    use rdkafka::client::DefaultClientContext;
+
+    let admin_client: AdminClient<DefaultClientContext> = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .create()?;
+
+    let new_topic = NewTopic::new(topic, num_partitions, TopicReplication::Fixed(1));
+    let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(5)));
+
+    let results = admin_client.create_topics(&[new_topic], &opts).await?;
+
+    for result in results {
+        match result {
+            Ok(_) => {}
+            Err((_, rdkafka::types::RDKafkaErrorCode::TopicAlreadyExists)) => {}
+            Err((topic_name, err)) => {
+                return Err(anyhow::anyhow!(
+                    "Failed to create topic {topic_name}: {err:?}"
+                ));
+            }
+        }
+    }
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(())
+}
+
+async fn send_test_messages_to_partition(
+    topic: &str,
+    partition: i32,
+    messages: Vec<(String, String)>,
+) -> Result<()> {
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .set("message.timeout.ms", "5000")
+        .create()?;
+
+    for (key, value) in messages {
+        let record = FutureRecord::to(topic)
+            .key(&key)
+            .payload(&value)
+            .partition(partition);
+
+        producer
+            .send(record, Timeout::After(Duration::from_secs(5)))
+            .await
+            .map_err(|(e, _)| anyhow::anyhow!("Failed to send message: {e}"))?;
+    }
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    Ok(())
+}
+
+fn create_captured_event() -> CapturedEvent {
+    let now = std::time::SystemTime::now();
+    let now_offset_datetime = OffsetDateTime::from(now);
+    let now_rfc3339 = chrono::DateTime::<chrono::Utc>::from(now).to_rfc3339();
+    let distinct_id = Uuid::now_v7().to_string();
+    let token = Uuid::now_v7().to_string();
+    let event_name = "$pageview";
+    let event_uuid = Uuid::now_v7();
+    let data = format!(
+        r#"{{"uuid": "{event_uuid}", "event": "{event_name}", "distinct_id": "{distinct_id}", "token": "{token}", "properties": {{}}}}"#,
+    );
+
+    CapturedEvent {
+        uuid: event_uuid,
+        distinct_id: distinct_id.to_string(),
+        session_id: None,
+        ip: "127.0.0.1".to_string(),
+        now: now_rfc3339.clone(),
+        token: token.to_string(),
+        data: data.to_string(),
+        sent_at: Some(now_offset_datetime),
+        event: event_name.to_string(),
+        timestamp: chrono::Utc::now(),
+        is_cookieless_mode: false,
+        historical_migration: false,
+    }
+}
+
+fn generate_test_messages(count: usize) -> Vec<(String, String)> {
+    (0..count)
+        .map(|i| {
+            let payload = create_captured_event();
+            let serialized = serde_json::to_string(&payload).unwrap();
+            (format!("key_{i}"), serialized)
+        })
+        .collect()
+}
+
+/// Watermark consumer reads from assigned (topic, partition, offset) until each partition
+/// reaches high-watermark, then closes the batch channel. Verifies we receive exactly
+/// the expected messages and then the channel closes.
+#[tokio::test]
+async fn test_watermark_consumer_reads_to_high_watermark_then_closes() -> Result<()> {
+    let test_topic = format!("{}-{}", TEST_TOPIC_BASE, Uuid::now_v7());
+    let messages_per_partition = 20;
+    let partitions_to_use = vec![0, 1, 2];
+    let total_messages = messages_per_partition * partitions_to_use.len();
+
+    create_topic_with_partitions(&test_topic, partitions_to_use.len() as i32).await?;
+
+    for partition in &partitions_to_use {
+        let messages = generate_test_messages(messages_per_partition);
+        send_test_messages_to_partition(&test_topic, *partition, messages).await?;
+    }
+
+    let group_id = format!("watermark-consumer-{}", Uuid::now_v7());
+    let mut config = ClientConfig::new();
+    config
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .set("group.id", &group_id)
+        .set("socket.timeout.ms", "10000");
+
+    let assignments: Vec<PartitionOffset> = partitions_to_use
+        .iter()
+        .map(|&p| PartitionOffset::new(Partition::new(test_topic.clone(), p), 0))
+        .collect();
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let (consumer, mut batch_rx) = WatermarkConsumer::<CapturedEvent>::new(
+        &config,
+        assignments,
+        50,
+        Duration::from_millis(200),
+        Duration::from_secs(5),
+        shutdown_rx,
+    )?;
+
+    let consumer_handle = tokio::spawn(async move { consumer.consume().await });
+
+    let mut total_received = 0usize;
+    while let Some(batch) = batch_rx.recv().await {
+        let (msgs, errs) = batch.unpack();
+        if !errs.is_empty() {
+            panic!("Errors in batch: {errs:?}");
+        }
+        total_received += msgs.len();
+    }
+
+    assert_eq!(
+        total_received, total_messages,
+        "Expected {} messages, got {}",
+        total_messages, total_received
+    );
+
+    let consume_result = tokio::time::timeout(Duration::from_secs(10), consumer_handle).await;
+    assert!(consume_result.is_ok(), "Consumer task should complete");
+    let join_result = consume_result.unwrap();
+    assert!(join_result.is_ok(), "Consumer should not panic");
+    join_result.unwrap()?;
+
+    drop(shutdown_tx);
+    Ok(())
+}

--- a/rust/kafka-deduplicator/tests/watermark_consumer_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/watermark_consumer_integration_tests.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use kafka_deduplicator::kafka::{
+    config::ConsumerConfigBuilder,
     types::{Partition, PartitionOffset},
     watermark_consumer::WatermarkConsumer,
 };
@@ -131,11 +132,7 @@ async fn test_watermark_consumer_reads_to_high_watermark_then_closes() -> Result
     }
 
     let group_id = format!("watermark-consumer-{}", Uuid::now_v7());
-    let mut config = ClientConfig::new();
-    config
-        .set("bootstrap.servers", KAFKA_BROKERS)
-        .set("group.id", &group_id)
-        .set("socket.timeout.ms", "10000");
+    let config = ConsumerConfigBuilder::for_watermark_consumer(KAFKA_BROKERS, &group_id).build();
 
     let assignments: Vec<PartitionOffset> = partitions_to_use
         .iter()


### PR DESCRIPTION
## Problem
We need an ephemeral, non-group consumer to pull batches of messages from our output topic from a set of fixed partitions and offsets until high watermarks are reached, then shut down. This will help power exactly-once synchronization of local stores during rebalancing and pod startup.

This PR lands the basic functionality but doesn't wire it up in the rebalancing finalizer yet. We can assemble all the components there once they are all landed.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement "watermark consumer" for rewinding output topic as described above (better name welcome!)
* Refactor consumer config builder to be more ergonomic for both consumer types
* Related test and docs/comment updates
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
