### PR TITLE
feat(llm): auto-increment prompt version on content update

### DIFF
--- a/posthog/models/test/test_llm_prompt.py
+++ b/posthog/models/test/test_llm_prompt.py
@@ -1,0 +1,27 @@
+from posthog.test.base import PostHogTestCase
+
+from posthog.models.llm_prompt import LLMPrompt
+
+
+class TestLLMPrompt(PostHogTestCase):
+    def test_versioning_logic(self):
+        # 1. Initial creation starts at version 1
+        prompt = LLMPrompt.objects.create(team=self.team, name="test_p", prompt={"text": "v1"}, created_by=self.user)
+        self.assertEqual(prompt.version, 1)
+
+        # 2. Prompt content change increments version
+        prompt.prompt = {"text": "v2"}
+        prompt.save()
+        prompt.refresh_from_db()
+        self.assertEqual(prompt.version, 2)
+
+        # 3. Metadata-only update doesn't increment version
+        prompt.name = "new_name"
+        prompt.save()
+        prompt.refresh_from_db()
+        self.assertEqual(prompt.version, 2)
+
+        # 4. Saving without changes doesn't increment version
+        prompt.save()
+        prompt.refresh_from_db()
+        self.assertEqual(prompt.version, 2)


### PR DESCRIPTION
This PR addresses the TODO in posthog/models/llm_prompt.py regarding the implementation of auto-incrementing versions for the Prompt Registry. As PostHog expands its LLM observability and prompt management features, tracking changes to prompt content is essential for reproducibility and analytics.

Changes
Model Logic: Overrode the save() method in LLMPrompt to handle versioning.

Smart Incrementing: The version field now increments only if the prompt JSON content has changed.

Integrity: Updating metadata (like the prompt name) or saving without changes will no longer trigger a version bump, preventing unnecessary version bloat in the database.

API Safety: Verified that the LLMPromptSerializer treats version as a read-only field, ensuring the backend remains the sole source of truth for version control.

Testing & Verification
Due to local environment constraints (8GB RAM), the logic was verified using a standalone mock execution script to isolate the Model's domain logic:

[x] Initial Creation: Verified version starts at 1.

[x] Metadata Update: Verified renaming a prompt keeps version at 1.

[x] Content Update: Verified changing the prompt JSON increments version to 2.

[x] No-op Save: Verified saving the same content does not increment the version.