### PR TITLE
feat(hobby): persons migrations on hobby deploys via django

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -313,6 +313,8 @@ COPY --from=node-scripts-build --chown=posthog:posthog /code/common/plugin_trans
 
 # Add in custom bin files and Django deps.
 COPY --chown=posthog:posthog ./bin ./bin/
+# Persons SQL migration files (read by apply_persons_migrations management command for hobby deploys)
+COPY --chown=posthog:posthog ./rust/persons_migrations ./rust/persons_migrations/
 COPY --chown=posthog:posthog manage.py manage.py
 COPY --chown=posthog:posthog posthog posthog/
 COPY --chown=posthog:posthog ee ee/

--- a/bin/migrate
+++ b/bin/migrate
@@ -23,8 +23,18 @@ else
     timestamp() { echo "$(date +%s).000000000"; }
 fi
 
+# Hobby deploys: run persons migrations via Django (no sqlx binary needed)
+if [ "${DEPLOYMENT:-}" = "hobby" ] && run_scope "persons"; then
+    echo "Running persons migrations via Django management command..."
+    python manage.py apply_persons_migrations
+    if [ $? -ne 0 ]; then
+        echo "Error in apply_persons_migrations, exiting."
+        exit 1
+    fi
+fi
+
 # NOTE when running in docker, rust might not exist so we need to check for it
-if [ -d "$SCRIPT_DIR/../rust/bin" ]; then
+if [ -d "$SCRIPT_DIR/../rust/bin" ] && [ "${DEPLOYMENT:-}" != "hobby" ]; then
     if run_scope "cyclotron"; then
         bash $SCRIPT_DIR/../rust/bin/migrate-cyclotron
         if [ $? -ne 0 ]; then

--- a/bin/migrate
+++ b/bin/migrate
@@ -151,13 +151,14 @@ fi
 
 # Persons migrations via Django management command.
 # Hobby: runs against default DB, skipping partitioning migrations.
-# Non-hobby (local dev / production): runs against persons_db_writer, creating
-# the database if needed and applying all migrations including partitioning.
+# Local dev (DEBUG=1): runs against persons_db_writer, creating the database
+# if needed and applying all migrations including partitioning.
+# Production: skipped — persons migrations are handled by the sqlx-migrate K8s job.
 if run_scope "persons"; then
     if [ "${DEPLOYMENT:-}" = "hobby" ]; then
         echo "Running persons migrations via Django management command (hobby)..."
         python manage.py apply_persons_migrations --hobby
-    else
+    elif [ "${DEBUG:-0}" = "1" ]; then
         echo "Running persons migrations via Django management command..."
         python manage.py apply_persons_migrations --database=persons_db_writer --ensure-database
     fi

--- a/bin/migrate
+++ b/bin/migrate
@@ -40,16 +40,8 @@ if [ -d "$SCRIPT_DIR/../rust/bin" ] && [ "${DEPLOYMENT:-}" != "hobby" ]; then
             exit 1
         fi
     fi
-    
-    if run_scope "persons"; then
-        echo "Running persons migrations via external non-django migrator..."
-        bash $SCRIPT_DIR/../rust/bin/migrate-persons
-        if [ $? -ne 0 ]; then
-            echo "Error in rust/bin/migrate-persons, exiting."
-            exit 1
-        fi
-    fi
-    
+
+
     if run_scope "behavioral-cohorts"; then
         echo "Running behavioral cohorts migrations via external non-django migrator..."
         bash $SCRIPT_DIR/../rust/bin/migrate-behavioral-cohorts
@@ -157,12 +149,18 @@ if [ "$RUN_POSTGRES" = "1" ]; then
     
 fi
 
-# Hobby deploys: run persons migrations via Django (no sqlx binary needed).
-# Must run AFTER Django postgres migrations so that historical migrations
-# (0001-0872) create the person tables first via CreateModel.
-if [ "${DEPLOYMENT:-}" = "hobby" ] && run_scope "persons"; then
-    echo "Running persons migrations via Django management command..."
-    python manage.py apply_persons_migrations
+# Persons migrations via Django management command.
+# Hobby: runs against default DB, skipping partitioning migrations.
+# Non-hobby (local dev / production): runs against persons_db_writer, creating
+# the database if needed and applying all migrations including partitioning.
+if run_scope "persons"; then
+    if [ "${DEPLOYMENT:-}" = "hobby" ]; then
+        echo "Running persons migrations via Django management command (hobby)..."
+        python manage.py apply_persons_migrations --hobby
+    else
+        echo "Running persons migrations via Django management command..."
+        python manage.py apply_persons_migrations --database=persons_db_writer --ensure-database
+    fi
     if [ $? -ne 0 ]; then
         echo "Error in apply_persons_migrations, exiting."
         exit 1

--- a/bin/migrate
+++ b/bin/migrate
@@ -158,13 +158,17 @@ if run_scope "persons"; then
     if [ "${DEPLOYMENT:-}" = "hobby" ]; then
         echo "Running persons migrations via Django management command (hobby)..."
         python manage.py apply_persons_migrations --hobby
+        if [ $? -ne 0 ]; then
+            echo "Error in apply_persons_migrations, exiting."
+            exit 1
+        fi
     elif [ "${DEBUG:-0}" = "1" ]; then
         echo "Running persons migrations via Django management command..."
         python manage.py apply_persons_migrations --database=persons_db_writer --ensure-database
-    fi
-    if [ $? -ne 0 ]; then
-        echo "Error in apply_persons_migrations, exiting."
-        exit 1
+        if [ $? -ne 0 ]; then
+            echo "Error in apply_persons_migrations, exiting."
+            exit 1
+        fi
     fi
 fi
 

--- a/bin/migrate
+++ b/bin/migrate
@@ -23,16 +23,6 @@ else
     timestamp() { echo "$(date +%s).000000000"; }
 fi
 
-# Hobby deploys: run persons migrations via Django (no sqlx binary needed)
-if [ "${DEPLOYMENT:-}" = "hobby" ] && run_scope "persons"; then
-    echo "Running persons migrations via Django management command..."
-    python manage.py apply_persons_migrations
-    if [ $? -ne 0 ]; then
-        echo "Error in apply_persons_migrations, exiting."
-        exit 1
-    fi
-fi
-
 # NOTE when running in docker, rust might not exist so we need to check for it
 if [ -d "$SCRIPT_DIR/../rust/bin" ] && [ "${DEPLOYMENT:-}" != "hobby" ]; then
     if run_scope "cyclotron"; then
@@ -165,6 +155,18 @@ if [ "$RUN_POSTGRES" = "1" ]; then
         exit 1
     fi
     
+fi
+
+# Hobby deploys: run persons migrations via Django (no sqlx binary needed).
+# Must run AFTER Django postgres migrations so that historical migrations
+# (0001-0872) create the person tables first via CreateModel.
+if [ "${DEPLOYMENT:-}" = "hobby" ] && run_scope "persons"; then
+    echo "Running persons migrations via Django management command..."
+    python manage.py apply_persons_migrations
+    if [ $? -ne 0 ]; then
+        echo "Error in apply_persons_migrations, exiting."
+        exit 1
+    fi
 fi
 
 if run_scope "async"; then

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -121,6 +121,7 @@ services:
             USE_GRANIAN: 'true'
             GRANIAN_WORKERS: '2'
             OPT_OUT_CAPTURE: ${OPT_OUT_CAPTURE:-false}
+            DEPLOYMENT: 'hobby'
         depends_on:
             - db
             - redis7

--- a/posthog/management/commands/apply_persons_migrations.py
+++ b/posthog/management/commands/apply_persons_migrations.py
@@ -1,0 +1,119 @@
+"""Apply persons SQL migrations for hobby deploys.
+
+Reads SQL migration files from rust/persons_migrations/ and executes them
+against the default database, skipping partitioning migrations that are only
+needed in production.
+
+Tracks applied migrations in a _persons_migrations_applied table so each
+migration is only executed once, regardless of whether the SQL is idempotent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection
+
+# Migrations that must be skipped on hobby deploys.
+# These partition the posthog_person table, which is only needed in production
+# where the table is large enough to benefit from hash partitioning.
+SKIP_MIGRATIONS = {
+    "20251113000001_add_partitioned_person_table.sql",
+    "20251115000001_add_partition_indexes_and_foreign_keys.sql",
+    "20251117000001_rename_person_tables.sql",
+}
+
+TRACKING_TABLE = "_persons_migrations_applied"
+
+
+def _ensure_tracking_table(cursor) -> None:
+    cursor.execute(f"""
+        CREATE TABLE IF NOT EXISTS {TRACKING_TABLE} (
+            filename TEXT PRIMARY KEY,
+            applied_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+        )
+    """)
+
+
+def _get_applied_migrations(cursor) -> set[str]:
+    cursor.execute(f"SELECT filename FROM {TRACKING_TABLE}")
+    return {row[0] for row in cursor.fetchall()}
+
+
+def _record_migration(cursor, filename: str) -> None:
+    cursor.execute(f"INSERT INTO {TRACKING_TABLE} (filename) VALUES (%s)", [filename])
+
+
+class Command(BaseCommand):
+    help = "Apply persons SQL migrations for hobby deploys (reads from rust/persons_migrations/)"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--migrations-dir",
+            type=str,
+            default=None,
+            help="Path to the persons migrations directory. Defaults to rust/persons_migrations/ relative to BASE_DIR.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print which migrations would be applied without executing them.",
+        )
+
+    def handle(self, *args, **options):
+        migrations_path = self._resolve_migrations_dir(options["migrations_dir"])
+        sql_files = sorted(f for f in migrations_path.iterdir() if f.suffix == ".sql")
+        if not sql_files:
+            self.stdout.write("No SQL migration files found.")
+            return
+
+        dry_run = options["dry_run"]
+        applied_count = 0
+        skipped_count = 0
+        already_applied_count = 0
+
+        with connection.cursor() as cursor:
+            if not dry_run:
+                _ensure_tracking_table(cursor)
+            already_applied = _get_applied_migrations(cursor) if not dry_run else set()
+
+            for sql_file in sql_files:
+                if sql_file.name in SKIP_MIGRATIONS:
+                    self.stdout.write(f"  Skipping {sql_file.name} (partitioning)")
+                    skipped_count += 1
+                    continue
+
+                if sql_file.name in already_applied:
+                    already_applied_count += 1
+                    continue
+
+                if dry_run:
+                    self.stdout.write(f"  Would apply: {sql_file.name}")
+                    applied_count += 1
+                    continue
+
+                sql = sql_file.read_text()
+                self.stdout.write(f"  Applying {sql_file.name}...")
+                cursor.execute(sql)
+                _record_migration(cursor, sql_file.name)
+                applied_count += 1
+
+        action = "Would apply" if dry_run else "Applied"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{action} {applied_count} migration(s), skipped {skipped_count}, "
+                f"already applied {already_applied_count}."
+            )
+        )
+
+    def _resolve_migrations_dir(self, override: str | None) -> Path:
+        if override:
+            path = Path(override)
+        else:
+            path = Path(settings.BASE_DIR) / "rust" / "persons_migrations"
+
+        if not path.is_dir():
+            raise CommandError(f"Migrations directory not found: {path}")
+        return path

--- a/posthog/management/commands/apply_persons_migrations.py
+++ b/posthog/management/commands/apply_persons_migrations.py
@@ -81,17 +81,15 @@ def _ensure_database_exists(db_alias: str) -> None:
     db_settings = settings.DATABASES[db_alias]
     target_db = db_settings["NAME"]
 
-    conn_kwargs = {
-        "dbname": "postgres",
-        "host": db_settings.get("HOST") or "localhost",
-        "port": int(db_settings.get("PORT") or 5432),
-        "user": db_settings.get("USER") or "posthog",
-        "password": db_settings.get("PASSWORD") or "posthog",
-        "autocommit": True,
-    }
-
     try:
-        with psycopg.connect(**conn_kwargs) as conn:
+        with psycopg.connect(
+            dbname="postgres",
+            host=db_settings.get("HOST") or "localhost",
+            port=int(db_settings.get("PORT") or 5432),
+            user=db_settings.get("USER") or "posthog",
+            password=db_settings.get("PASSWORD") or "posthog",
+            autocommit=True,
+        ) as conn:
             with conn.cursor() as cur:
                 cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (target_db,))
                 if cur.fetchone():

--- a/posthog/management/commands/apply_persons_migrations.py
+++ b/posthog/management/commands/apply_persons_migrations.py
@@ -149,7 +149,7 @@ class Command(BaseCommand):
         hobby = options["hobby"]
         dry_run = options["dry_run"]
 
-        if options["ensure_database"]:
+        if options["ensure_database"] and not dry_run:
             _ensure_database_exists(db_alias)
 
         migrations_path = self._resolve_migrations_dir(options["migrations_dir"])


### PR DESCRIPTION
## Problem

Hobby deploy uses a single PostgreSQL database (posthog) for everything, but new person schema changes (last_seen_at) are only defined in rust/persons_migrations/ and applied via sqlx in production against the separate posthog_persons database. These migrations never run in hobby because the main Dockerfile doesn't include rust/bin/ or sqlx, so the guard in bin/migrate (`[ -d "$SCRIPT_DIR/../rust/bin" ]`) skips all Rust migrations. Additionally, 3 of the 6 persons migrations perform 64-partition hash partitioning of the posthog_person table, which is unnecessary and harmful for hobby's single-database setup.

For local dev, persons migrations required having sqlx installed via the Rust toolchain. This replaces that dependency with the same Django management command, making the dev setup simpler.

## Changes

### `posthog/management/commands/apply_persons_migrations.py`

Management command that:
- Creates a `_persons_migrations_applied` tracking table on first run
- Reads all `.sql` files from `rust/persons_migrations/`, sorted by name
- Only executes migrations not already in the tracking table
- Records each applied migration so it never re-runs
- Supports `--dry-run` and `--migrations-dir` flags
- `--hobby` flag: skips the 3 partitioning migrations (hobby deploys only)
- `--database` flag: target a specific Django database alias (default: `default`)
- `--ensure-database` flag: creates the target database if it doesn't exist (for local dev bootstrap)
- sqlx bridge: detects migrations already applied by sqlx (via `_sqlx_migrations` version column) and records them in the tracking table without re-executing

### `bin/migrate`

Unified persons migration path for hobby and local dev:
- Removed persons from the `rust/bin` block (no longer requires sqlx)
- Added unified block after Django postgres migrations:
  - Hobby (`DEPLOYMENT=hobby`): `apply_persons_migrations --hobby`
  - Local dev (`DEBUG=1`): `apply_persons_migrations --database=persons_db_writer --ensure-database`
  - Production (neither): skipped — persons migrations handled by sqlx-migrate K8s job

### `bin/mprocs.yaml`

Changed `migrate-persons-db` to check `posthog` instead of `posthog_persons` since `--ensure-database` handles DB creation.

### `Dockerfile`

Copies `rust/persons_migrations/` SQL files into the image (2 lines, no sqlx binary needed).

### `docker-compose.hobby.yml`

Adds `DEPLOYMENT: 'hobby'` env var.

## How it works

- **Hobby**: runs against default DB, skips partitioning, applies 3 of 6 migrations
- **Local dev**: runs against `persons_db_writer` (separate `posthog_persons` DB), applies all 6 migrations including partitioning
- **sqlx transition**: detects existing `_sqlx_migrations` table, bridges already-applied migrations into the tracking table without re-executing SQL
- **Production**: unaffected — persons migrations are handled by a separate `sqlx-migrate` K8s job (`rust/Dockerfile.sqlx-migrate`), not by `bin/migrate`
- Migration authors do NOT need to write idempotent SQL — the tracking table ensures each file runs exactly once
- Single source of truth: SQL files in `rust/persons_migrations/` are used by sqlx (production), this command (hobby + local dev)

## How did you test this code?

### Hobby deploy — fresh install
Built the hobby project locally. Applied 3 migrations, skipped 3 partitioning. Verified: `_persons_migrations_applied` has 3 rows, `posthog_person` is regular table (not partitioned), no `posthog_person_new`, `last_seen_at` column present.

### Hobby deploy — idempotent re-run
Restarted the web container. Output: `Applied 0, skipped 3, already applied 3`. No errors.

### Local dev — sqlx-to-django transition
Ran against existing `posthog_persons` DB with 5 sqlx-applied migrations. Bridged all 5 from `_sqlx_migrations`, applied 1 new migration (`last_seen_at`). Verified: `_persons_migrations_applied` has 6 rows, `last_seen_at` column present.

### Local dev — idempotent re-run
Re-ran after transition. Output: `Applied 0, skipped 0, already applied 6`. No errors.

### Local dev — fresh install (DB dropped)
Dropped `posthog_persons`, ran `bin/migrate --scope=persons`. `--ensure-database` created the DB, all 6 migrations applied including partitioning.

### Local dev — full reset
Wiped all Docker volumes (`hogli docker:services:remove`), brought services back up, ran `bin/migrate`. All migrations (postgres, clickhouse, persons, async) completed successfully from scratch.

### Production safety
The Django persons migration command does not run in production. The persons block in `bin/migrate` is gated on `DEPLOYMENT=hobby` or `DEBUG=1`. Production has neither. Production persons migrations continue to be handled by the separate `sqlx-migrate` K8s job (`rust/Dockerfile.sqlx-migrate`).