### PR TITLE
fix(Insights): Fixes funnel tooltips not showing

### DIFF
--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -42,7 +42,7 @@ export function ensureTooltip(id: string): [Root, HTMLElement] {
                 inst.isMouseOver = false
                 inst.hideTimeout = setTimeout(() => {
                     if (!inst.isMouseOver) {
-                        inst.element.classList.add('opacity-0', 'invisible')
+                        inst.element.style.opacity = '0'
                     }
                 }, 100)
             }
@@ -91,7 +91,7 @@ export function hideTooltip(id?: string): void {
 
     instance.hideTimeout = setTimeout(() => {
         if (!instance.isMouseOver) {
-            instance.element.classList.add('opacity-0', 'invisible')
+            instance.element.style.opacity = '0'
         }
     }, 100)
 }


### PR DESCRIPTION
## Problem
https://posthog.slack.com/archives/C045L1VEG87/p1770940253484159

Funnel tooltips not showing when using breakdown

## Changes
Don't use tailwind classes. 
Some tooltips use this opacity override to show the tooltip, they wern't setting this visible property also, so just stop doing that.

<img width="845" height="582" alt="Screenshot 2026-02-13 at 07 08 02" src="https://github.com/user-attachments/assets/013626d4-7b19-4ec9-82ee-00132e0244b2" />

## How did you test this code?
Made a breakdown, saw a tooltip!
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
