### PR TITLE
chore: reload tickets on update / send

### DIFF
--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, beforeUnmount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, beforeUnmount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { lemonToast } from '@posthog/lemon-ui'
@@ -13,6 +13,7 @@ import { PropertyFilterType, PropertyOperator } from '~/types'
 import type { TicketAssignee } from '../../components/Assignee'
 import { supportTicketCounterLogic } from '../../supportTicketCounterLogic'
 import type { ChatMessage, Ticket, TicketPriority, TicketStatus } from '../../types'
+import { supportTicketsSceneLogic } from '../tickets/supportTicketsSceneLogic'
 import type { supportTicketSceneLogicType } from './supportTicketSceneLogicType'
 
 const MESSAGE_POLL_INTERVAL = 5000 // 5 seconds
@@ -87,6 +88,9 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
     path(['products', 'conversations', 'frontend', 'scenes', 'ticket', 'supportTicketSceneLogic']),
     props({ id: 'new' as string | number }),
     key((props) => props.id),
+    connect(() => ({
+        actions: [supportTicketsSceneLogic, ['loadTickets']],
+    })),
     actions({
         loadTicket: true,
         setTicket: (ticket: Ticket | null) => ({ ticket }),
@@ -396,6 +400,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 const ticket = await api.conversationsTickets.update(props.id.toString(), data)
                 actions.setTicket(ticket)
                 lemonToast.success('Ticket updated')
+                actions.loadTickets()
             } catch {
                 lemonToast.error('Failed to update ticket')
             }
@@ -469,6 +474,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 setTimeout(() => {
                     actions.loadMessages()
                 }, 300)
+                actions.loadTickets()
             } catch {
                 lemonToast.error('Failed to send message')
                 actions.setMessageSending(false)


### PR DESCRIPTION
Fix the issue where, after sending a new message or updating a ticket, returning to the tickets list still shows the previous state.