### PR TITLE
feat(devex): Add Slack notifications for priority review PRs

### DIFF
--- a/.github/workflows/pr-fast-approval.yml
+++ b/.github/workflows/pr-fast-approval.yml
@@ -1,0 +1,149 @@
+name: Fast Approval Slack Notifications
+
+on:
+    pull_request_target:
+        types: [labeled]
+    pull_request_review:
+        types: [submitted]
+
+env:
+    SLACK_CHANNEL: 'C0AEM55RJ77' # #dev-stamp-exchange
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    # When a PR is labeled "fast-approval", post to #dev-stamp-exchange
+    notify-fast-approval:
+        runs-on: ubuntu-latest
+        if: >-
+            github.event.action == 'labeled'
+            && github.event.label.name == 'fast-approval'
+        steps:
+            - name: Escape PR title for YAML
+              id: pr
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              with:
+                  script: |
+                      const title = context.payload.pull_request.title;
+                      const escaped = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+                      core.setOutput('title', escaped);
+
+            - name: Post to Slack
+              id: slack
+              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  errors: true
+                  payload: |
+                      channel: "${{ env.SLACK_CHANNEL }}"
+                      text: "Fast approval requested: ${{ steps.pr.outputs.title }}"
+                      unfurl_links: false
+                      blocks:
+                        - type: "section"
+                          text:
+                            type: "mrkdwn"
+                            text: ":rocket: *Fast approval requested*"
+                        - type: "section"
+                          fields:
+                            - type: "mrkdwn"
+                              text: "*PR*\n<${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }}> ${{ steps.pr.outputs.title }}"
+                            - type: "mrkdwn"
+                              text: "*Author*\n${{ github.event.pull_request.user.login }}"
+                        - type: "actions"
+                          elements:
+                            - type: "button"
+                              text:
+                                type: "plain_text"
+                                text: "Review PR"
+                              url: "${{ github.event.pull_request.html_url }}"
+                              style: "primary"
+
+            - name: Save Slack message info
+              run: |
+                  echo '{}' | jq \
+                    --arg channel "${{ steps.slack.outputs.channel_id }}" \
+                    --arg ts "${{ steps.slack.outputs.ts }}" \
+                    '{channel: $channel, ts: $ts}' > .fast-approval-slack
+
+            - name: Cache Slack message info
+              uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+              with:
+                  path: .fast-approval-slack
+                  key: fast-approval-slack-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+
+    # When a fast-approval PR is approved, react and thread-reply on the Slack message
+    notify-approval:
+        runs-on: ubuntu-latest
+        if: >-
+            github.event.action == 'submitted'
+            && github.event.review.state == 'approved'
+            && contains(github.event.pull_request.labels.*.name, 'fast-approval')
+        steps:
+            - name: Restore Slack message info
+              uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+              with:
+                  path: .fast-approval-slack
+                  key: fast-approval-slack-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+                  restore-keys: fast-approval-slack-pr-${{ github.event.pull_request.number }}-
+
+            - name: Read Slack message info
+              id: slack_msg
+              run: |
+                  if [ -f .fast-approval-slack ]; then
+                    echo "found=true" >> $GITHUB_OUTPUT
+                    echo "channel=$(jq -r '.channel' .fast-approval-slack)" >> $GITHUB_OUTPUT
+                    echo "ts=$(jq -r '.ts' .fast-approval-slack)" >> $GITHUB_OUTPUT
+                  else
+                    echo "found=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Add checkmark reaction
+              if: steps.slack_msg.outputs.found == 'true'
+              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              with:
+                  method: reactions.add
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  errors: true
+                  payload: |
+                      channel: "${{ steps.slack_msg.outputs.channel }}"
+                      timestamp: "${{ steps.slack_msg.outputs.ts }}"
+                      name: "white_check_mark"
+
+            - name: Build approval message
+              if: steps.slack_msg.outputs.found == 'true'
+              id: review
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              with:
+                  script: |
+                      const reviewer = context.payload.review.user.login;
+                      const body = (context.payload.review.body || '').trim();
+                      let text = `:white_check_mark: Approved by *${reviewer}*`;
+                      if (body) {
+                        const truncated = body.length > 500
+                          ? body.substring(0, 500) + '...'
+                          : body;
+                        const quoted = truncated.split('\n').map(l => `> ${l}`).join('\n');
+                        text += '\n\n' + quoted;
+                      }
+                      // Escape for embedding in a YAML double-quoted string
+                      const escaped = text
+                        .replace(/\\/g, '\\\\')
+                        .replace(/"/g, '\\"')
+                        .replace(/\n/g, '\\n');
+                      core.setOutput('text', escaped);
+
+            - name: Thread reply with approval
+              if: steps.slack_msg.outputs.found == 'true'
+              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  errors: true
+                  payload: |
+                      channel: "${{ steps.slack_msg.outputs.channel }}"
+                      thread_ts: "${{ steps.slack_msg.outputs.ts }}"
+                      text: "${{ steps.review.outputs.text }}"
+                      unfurl_links: false

--- a/.github/workflows/pr-priority-review.yml
+++ b/.github/workflows/pr-priority-review.yml
@@ -1,4 +1,4 @@
-name: Fast Approval Slack Notifications
+name: Priority Review Slack Notifications
 
 on:
     pull_request_target:
@@ -14,12 +14,12 @@ permissions:
     pull-requests: read
 
 jobs:
-    # When a PR is labeled "fast-approval", post to #dev-stamp-exchange
-    notify-fast-approval:
+    # When a PR is labeled "priority-review", post to #dev-stamp-exchange
+    notify-priority-review:
         runs-on: ubuntu-latest
         if: >-
             github.event.action == 'labeled'
-            && github.event.label.name == 'fast-approval'
+            && github.event.label.name == 'priority-review'
         steps:
             - name: Escape PR title for YAML
               id: pr
@@ -39,13 +39,13 @@ jobs:
                   errors: true
                   payload: |
                       channel: "${{ env.SLACK_CHANNEL }}"
-                      text: "Fast approval requested: ${{ steps.pr.outputs.title }}"
+                      text: "Priority review requested: ${{ steps.pr.outputs.title }}"
                       unfurl_links: false
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":rocket: *Fast approval requested*"
+                            text: ":eyes: *Priority review requested*"
                         - type: "section"
                           fields:
                             - type: "mrkdwn"
@@ -66,36 +66,36 @@ jobs:
                   echo '{}' | jq \
                     --arg channel "${{ steps.slack.outputs.channel_id }}" \
                     --arg ts "${{ steps.slack.outputs.ts }}" \
-                    '{channel: $channel, ts: $ts}' > .fast-approval-slack
+                    '{channel: $channel, ts: $ts}' > .priority-review-slack
 
             - name: Cache Slack message info
               uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
               with:
-                  path: .fast-approval-slack
-                  key: fast-approval-slack-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+                  path: .priority-review-slack
+                  key: priority-review-slack-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
 
-    # When a fast-approval PR is approved, react and thread-reply on the Slack message
-    notify-approval:
+    # When a priority-review PR is approved, react and thread-reply on the Slack message
+    notify-reviewed:
         runs-on: ubuntu-latest
         if: >-
             github.event.action == 'submitted'
             && github.event.review.state == 'approved'
-            && contains(github.event.pull_request.labels.*.name, 'fast-approval')
+            && contains(github.event.pull_request.labels.*.name, 'priority-review')
         steps:
             - name: Restore Slack message info
               uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
               with:
-                  path: .fast-approval-slack
-                  key: fast-approval-slack-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
-                  restore-keys: fast-approval-slack-pr-${{ github.event.pull_request.number }}-
+                  path: .priority-review-slack
+                  key: priority-review-slack-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+                  restore-keys: priority-review-slack-pr-${{ github.event.pull_request.number }}-
 
             - name: Read Slack message info
               id: slack_msg
               run: |
-                  if [ -f .fast-approval-slack ]; then
+                  if [ -f .priority-review-slack ]; then
                     echo "found=true" >> $GITHUB_OUTPUT
-                    echo "channel=$(jq -r '.channel' .fast-approval-slack)" >> $GITHUB_OUTPUT
-                    echo "ts=$(jq -r '.ts' .fast-approval-slack)" >> $GITHUB_OUTPUT
+                    echo "channel=$(jq -r '.channel' .priority-review-slack)" >> $GITHUB_OUTPUT
+                    echo "ts=$(jq -r '.ts' .priority-review-slack)" >> $GITHUB_OUTPUT
                   else
                     echo "found=false" >> $GITHUB_OUTPUT
                   fi
@@ -120,7 +120,7 @@ jobs:
                   script: |
                       const reviewer = context.payload.review.user.login;
                       const body = (context.payload.review.body || '').trim();
-                      let text = `:white_check_mark: Approved by *${reviewer}*`;
+                      let text = `:white_check_mark: Reviewed and approved by *${reviewer}*`;
                       if (body) {
                         const truncated = body.length > 500
                           ? body.substring(0, 500) + '...'

--- a/.github/workflows/pr-priority-review.yml
+++ b/.github/workflows/pr-priority-review.yml
@@ -101,6 +101,7 @@ jobs:
 
             - name: Add checkmark reaction
               if: steps.slack_msg.outputs.found == 'true'
+              continue-on-error: true # already_reacted is expected on multi-approval PRs
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: reactions.add

--- a/.github/workflows/pr-priority-review.yml
+++ b/.github/workflows/pr-priority-review.yml
@@ -72,7 +72,7 @@ jobs:
               uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
               with:
                   path: .priority-review-slack
-                  key: priority-review-slack-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+                  key: priority-review-slack-pr-${{ github.event.pull_request.number }}
 
     # When a priority-review PR is approved, react and thread-reply on the Slack message
     notify-reviewed:
@@ -86,8 +86,7 @@ jobs:
               uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
               with:
                   path: .priority-review-slack
-                  key: priority-review-slack-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
-                  restore-keys: priority-review-slack-pr-${{ github.event.pull_request.number }}-
+                  key: priority-review-slack-pr-${{ github.event.pull_request.number }}
 
             - name: Read Slack message info
               id: slack_msg


### PR DESCRIPTION
## Problem

We need a way to notify the team in Slack when a PR is marked for priority approval and when it receives approvals, to streamline the review process and increase visibility of urgent PRs.

## Changes

Added a new GitHub Actions workflow (`.github/workflows/pr-fast-approval.yml`) that:

1. **Notifies on fast-approval label**: When a PR is labeled with "priority-review", posts a formatted message to the #dev-stamp-exchange Slack channel with:
   - PR title and link
   - Author information
   - Direct "Review PR" button for quick access

2. **Notifies on approval**: When a fast-approval PR receives an approval review:
   - Adds a checkmark reaction to the original Slack message
   - Posts a thread reply with the reviewer's name and any review comments (truncated to 500 chars if needed)

The workflow uses GitHub Actions caching to persist the Slack message coordinates (channel ID and timestamp) between the labeling and approval events, enabling proper threading of notifications.

## How did you test this code?

This is a GitHub Actions workflow configuration. Testing will be performed by:
1. Creating a test PR and labeling it with "priority-review"
2. Verifying the Slack notification appears in #dev-stamp-exchange with correct formatting
3. Approving the PR and verifying the checkmark reaction and thread reply appear correctly

## Publish to changelog?

No

https://claude.ai/code/session_01JM3L5CiNF3UW67i8ME3EZi