### PR TITLE
feat(workflows): raise variable size limit to 5KB and error on overflow

### DIFF
--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -563,7 +563,7 @@ export class HogFlowExecutorService {
             }
         }
 
-        // Check that total variables are below 1kb
+        // Check that total variables are below 5KB
         const resultSize = Buffer.byteLength(JSON.stringify(result.invocation.state.variables), 'utf8')
         if (resultSize > 5120) {
             const keyNames = allStoredKeys.join(', ')

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -565,12 +565,12 @@ export class HogFlowExecutorService {
 
         // Check that total variables are below 1kb
         const resultSize = Buffer.byteLength(JSON.stringify(result.invocation.state.variables), 'utf8')
-        if (resultSize > 1024) {
+        if (resultSize > 5120) {
             const keyNames = allStoredKeys.join(', ')
             this.log(
                 result,
-                'warn',
-                `Total variable size after updating '${keyNames}' is larger than 1KB, these results will not be stored and won't be available in subsequent actions.`
+                'error',
+                `Total variable size after updating '${keyNames}' exceeds 5KB limit. Use result_path to store only the fields you need.`
             )
             // Clean up all variables we just set
             for (const outputVar of outputVars) {
@@ -587,7 +587,9 @@ export class HogFlowExecutorService {
                     delete result.invocation.state.variables[outputVar.key]
                 }
             }
-            return
+            throw new Error(
+                `Total variable size after updating '${keyNames}' exceeds 5KB limit. Use result_path to store only the fields you need.`
+            )
         }
 
         const details = allStoredKeys


### PR DESCRIPTION
depends on https://github.com/PostHog/posthog/pull/47715 

## Problem

1. 1KB as size limit was very limited in its usefulness e.g. showing problems making the conversations product support sending support messages. Let's raise it to give folks more flexibility.
2. whenever output variables were not present due to the 1KB size limit we just logged a warning and continued. thats bad UX as most people when the set the variables need them down the line.

## Changes

Raised the variable size limit from 1KB to 5KB. Exceeding it now throws an error instead  of silently dropping the values, so workflows with on_error: abort will exit and on_error: continue will skip to the next step.

## How did you test this code?

- adjusted tests