### PR TITLE
feat(permissions): Add project ID to feature flag evaluation

### DIFF
--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -673,6 +673,7 @@ class PostHogFeatureFlagPermission(BasePermission):
     def has_permission(self, request, view) -> bool:
         user = cast(User, request.user)
         organization = get_organization_from_view(view)
+        team_id = view.team_id  # type: ignore
         flag = getattr(view, "posthog_feature_flag", None)
 
         config = {}
@@ -694,8 +695,8 @@ class PostHogFeatureFlagPermission(BasePermission):
                 enabled = posthoganalytics.feature_enabled(
                     required_flag,
                     user.distinct_id,
-                    groups={"organization": org_id},
-                    group_properties={"organization": {"id": org_id}},
+                    groups={"organization": org_id, "project": str(team_id)},
+                    group_properties={"organization": {"id": org_id}, "project": {"id": str(team_id)}},
                     only_evaluate_locally=False,
                     send_feature_flag_events=False,
                 )

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -71,7 +71,7 @@ class SignalReportViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewSet)
     serializer_class = SignalReportSerializer
     authentication_classes = [SessionAuthentication, PersonalAPIKeyAuthentication, OAuthAccessTokenAuthentication]
     permission_classes = [IsAuthenticated, APIScopePermission, PostHogFeatureFlagPermission]
-    scope_object = "task"  # Using task scope as signal_report doesn't have its own scope yet
+    scope_object = "INTERNAL"
     queryset = SignalReport.objects.all()
     posthog_feature_flag = {
         "product-autonomy": [


### PR DESCRIPTION
## Problem

We need to allow project-level targeting in `PostHogFeatureFlagPermission`, as currently only org-level is supported. Rolling out a [flag that needs this](https://us.posthog.com/project/2/feature_flags/534010).

## Changes

Updated `PostHogFeatureFlagPermission` in `posthog/permissions.py` to include project (team) information when evaluating feature flags.

Flyby fix: Changed the scope object for `SignalReportViewSet` from "task" to "INTERNAL" to avoid confusion.