### PR TITLE
feat(llma): Eval results table filter

### DIFF
--- a/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationRunsTable.tsx
@@ -12,7 +12,7 @@ import { EvaluationRun } from '../types'
 import { EvaluationSummaryControls, EvaluationSummaryPanel } from './EvaluationSummaryPanel'
 
 export function EvaluationRunsTable(): JSX.Element {
-    const { evaluationRuns, evaluationRunsLoading, runsLookup } = useValues(llmEvaluationLogic)
+    const { filteredEvaluationRuns, evaluationRunsLoading, runsLookup } = useValues(llmEvaluationLogic)
     const { refreshEvaluationRuns } = useActions(llmEvaluationLogic)
 
     const columns: LemonTableColumns<EvaluationRun> = [
@@ -126,7 +126,7 @@ export function EvaluationRunsTable(): JSX.Element {
 
             <LemonTable
                 columns={columns}
-                dataSource={evaluationRuns}
+                dataSource={filteredEvaluationRuns}
                 loading={evaluationRunsLoading}
                 rowKey="id"
                 pagination={{

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
@@ -524,6 +524,66 @@ describe('llmEvaluationLogic', () => {
             })
         })
 
+        describe('filteredEvaluationRuns', () => {
+            it('returns all runs when filter is all', async () => {
+                logic.actions.loadEvaluationRunsSuccess(mockRuns)
+
+                await expectLogic(logic).toMatchValues({
+                    filteredEvaluationRuns: mockRuns,
+                })
+            })
+
+            it('returns only passing runs when filter is pass', async () => {
+                logic.actions.loadEvaluationRunsSuccess(mockRuns)
+                logic.actions.setEvaluationSummaryFilter('pass', 'all')
+
+                await expectLogic(logic).toMatchValues({
+                    filteredEvaluationRuns: [expect.objectContaining({ id: 'run-1', result: true })],
+                })
+            })
+
+            it('returns only failing runs when filter is fail', async () => {
+                logic.actions.loadEvaluationRunsSuccess(mockRuns)
+                logic.actions.setEvaluationSummaryFilter('fail', 'all')
+
+                await expectLogic(logic).toMatchValues({
+                    filteredEvaluationRuns: [expect.objectContaining({ id: 'run-2', result: false })],
+                })
+            })
+
+            it('returns only N/A runs when filter is na', async () => {
+                logic.actions.loadEvaluationRunsSuccess(mockRuns)
+                logic.actions.setEvaluationSummaryFilter('na', 'all')
+
+                await expectLogic(logic).toMatchValues({
+                    filteredEvaluationRuns: [expect.objectContaining({ id: 'run-3', result: null })],
+                })
+            })
+
+            it('excludes non-completed runs when filter is not all', async () => {
+                const runsWithFailed: EvaluationRun[] = [
+                    ...mockRuns,
+                    {
+                        id: 'run-4',
+                        evaluation_id: 'eval-123',
+                        evaluation_name: 'Test Evaluation',
+                        generation_id: 'gen-4',
+                        trace_id: 'trace-4',
+                        timestamp: '2024-01-01T15:00:00Z',
+                        result: true,
+                        reasoning: 'Good',
+                        status: 'failed',
+                    },
+                ]
+                logic.actions.loadEvaluationRunsSuccess(runsWithFailed)
+                logic.actions.setEvaluationSummaryFilter('pass', 'all')
+
+                await expectLogic(logic).toMatchValues({
+                    filteredEvaluationRuns: [expect.objectContaining({ id: 'run-1' })],
+                })
+            })
+        })
+
         describe('runsLookup', () => {
             it('creates lookup by generation_id', async () => {
                 logic.actions.loadEvaluationRunsSuccess(mockRuns)

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -574,30 +574,26 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 if (filter === 'all') {
                     return runs
                 }
+                // Only consider completed runs for filtering
+                const completedRuns = runs.filter((r) => r.status === 'completed')
                 if (filter === 'pass') {
-                    return runs.filter((r) => r.status === 'completed' && r.result === true)
+                    return completedRuns.filter((r) => r.result === true)
                 }
                 if (filter === 'fail') {
-                    return runs.filter((r) => r.status === 'completed' && r.result === false)
+                    return completedRuns.filter((r) => r.result === false)
                 }
                 // na
-                return runs.filter((r) => r.status === 'completed' && r.result === null)
+                return completedRuns.filter((r) => r.result === null)
             },
         ],
 
         runsToSummarizeCount: [
-            (s) => [s.evaluationRuns, s.evaluationSummaryFilter],
-            (runs, filter) => {
-                // This is for UI display only - actual filtering happens server-side
-                let filteredRuns = runs.filter((r) => r.status === 'completed')
-                if (filter === 'pass') {
-                    filteredRuns = filteredRuns.filter((r) => r.result === true)
-                } else if (filter === 'fail') {
-                    filteredRuns = filteredRuns.filter((r) => r.result === false)
-                } else if (filter === 'na') {
-                    filteredRuns = filteredRuns.filter((r) => r.result === null)
-                }
-                return Math.min(filteredRuns.length, EVALUATION_SUMMARY_MAX_RUNS)
+            (s) => [s.filteredEvaluationRuns, s.evaluationSummaryFilter],
+            (filteredRuns: EvaluationRun[], filter: EvaluationSummaryFilter): number => {
+                // When 'all', filteredEvaluationRuns includes non-completed runs, but summarization only uses completed
+                const count =
+                    filter === 'all' ? filteredRuns.filter((r) => r.status === 'completed').length : filteredRuns.length
+                return Math.min(count, EVALUATION_SUMMARY_MAX_RUNS)
             },
         ],
 

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -568,6 +568,23 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
             },
         ],
 
+        filteredEvaluationRuns: [
+            (s) => [s.evaluationRuns, s.evaluationSummaryFilter],
+            (runs: EvaluationRun[], filter: EvaluationSummaryFilter): EvaluationRun[] => {
+                if (filter === 'all') {
+                    return runs
+                }
+                if (filter === 'pass') {
+                    return runs.filter((r) => r.status === 'completed' && r.result === true)
+                }
+                if (filter === 'fail') {
+                    return runs.filter((r) => r.status === 'completed' && r.result === false)
+                }
+                // na
+                return runs.filter((r) => r.status === 'completed' && r.result === null)
+            },
+        ],
+
         runsToSummarizeCount: [
             (s) => [s.evaluationRuns, s.evaluationSummaryFilter],
             (runs, filter) => {


### PR DESCRIPTION
## Problem

Previously, the Pass/Fail/N/A filter on the LLM evaluation results page only affected the summarization scope. Users expect this filter to also apply to the evaluation runs table displayed below.

## Changes

-   Introduced a `filteredEvaluationRuns` selector in `llmEvaluationLogic.ts` to filter evaluation runs based on the `evaluationSummaryFilter` state (All, Pass, Fail, N/A).
-   Updated `EvaluationRunsTable.tsx` to use this new `filteredEvaluationRuns` selector as its data source, ensuring the table reflects the selected filter.

## How did you test this code?

Added 5 new tests for the `filteredEvaluationRuns` selector in `llmEvaluationLogic.test.ts`, covering all filter states and ensuring non-completed runs are correctly handled. All 40 existing and new tests pass.

## Publish to changelog?

No

---
<p><a href="https://cursor.com/background-agent?bcId=bc-22ffa531-1154-48b6-88fa-ecb4adac41fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22ffa531-1154-48b6-88fa-ecb4adac41fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

