### PR TITLE
refactor(logs): rename tabId to id for consistency across logics and components

### DIFF
--- a/products/logs/frontend/AttributeBreakdowns.tsx
+++ b/products/logs/frontend/AttributeBreakdowns.tsx
@@ -11,14 +11,14 @@ export const AttributeBreakdowns = ({
     attribute,
     type,
     addFilter,
-    tabId,
+    id,
 }: {
     attribute: string
     type: PropertyFilterType
     addFilter: (key: string, value: string, operator?: PropertyOperator, type?: PropertyFilterType) => void
-    tabId: string
+    id: string
 }): JSX.Element => {
-    const logic = attributeBreakdownLogic({ attribute, type, tabId })
+    const logic = attributeBreakdownLogic({ attribute, type, id })
     const { attributeValues, logCount, breakdowns } = useValues(logic)
 
     const dataSource = Object.entries(breakdowns)

--- a/products/logs/frontend/attributeBreakdownLogic.tsx
+++ b/products/logs/frontend/attributeBreakdownLogic.tsx
@@ -8,16 +8,16 @@ import { logsViewerDataLogic } from './components/LogsViewer/data/logsViewerData
 export interface AttributeBreakdownLogicProps {
     attribute: string
     type: PropertyFilterType
-    tabId: string
+    id: string
 }
 
 export const attributeBreakdownLogic = kea<attributeBreakdownLogicType>([
     props({} as AttributeBreakdownLogicProps),
-    key((props) => `${props.tabId}-${props.type}-${props.attribute}`),
+    key((props) => `${props.id}-${props.type}-${props.attribute}`),
     path((key) => ['products', 'logs', 'frontend', 'logsAttributeBreakdownsLogic', key]),
 
     connect((props: AttributeBreakdownLogicProps) => ({
-        values: [logsViewerDataLogic({ id: props.tabId }), ['parsedLogs as logs']],
+        values: [logsViewerDataLogic({ id: props.id }), ['parsedLogs as logs']],
     })),
 
     selectors(({ props }) => ({

--- a/products/logs/frontend/components/LogsViewer/Filters/FilterGroup.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/FilterGroup.tsx
@@ -31,7 +31,7 @@ export const taxonomicGroupTypes = [
 ]
 
 export const LogsFilterGroup = (): JSX.Element => {
-    const { filters, tabId, utcDateRange } = useValues(logsViewerFiltersLogic)
+    const { filters, id, utcDateRange } = useValues(logsViewerFiltersLogic)
     const { filterGroup, serviceNames } = filters
     const { setFilterGroup } = useActions(logsViewerFiltersLogic)
 
@@ -43,7 +43,7 @@ export const LogsFilterGroup = (): JSX.Element => {
 
     return (
         <UniversalFilters
-            rootKey={`${taxonomicFilterLogicKey}-${tabId}`}
+            rootKey={`${taxonomicFilterLogicKey}-${id}`}
             group={filterGroup.values[0] as UniversalFiltersGroup}
             taxonomicGroupTypes={taxonomicGroupTypes}
             endpointFilters={endpointFilters}

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -124,7 +124,7 @@ export const LogsFilterBar = (): JSX.Element => {
 }
 
 const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Element => {
-    const { filters, tabId, utcDateRange } = useValues(logsViewerFiltersLogic)
+    const { filters, id, utcDateRange } = useValues(logsViewerFiltersLogic)
     const { filterGroup, serviceNames } = filters
     const { setFilterGroup } = useActions(logsViewerFiltersLogic)
 
@@ -136,7 +136,7 @@ const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Eleme
 
     return (
         <UniversalFilters
-            rootKey={`${taxonomicFilterLogicKey}-${tabId}`}
+            rootKey={`${taxonomicFilterLogicKey}-${id}`}
             group={filterGroup.values[0] as UniversalFiltersGroup}
             taxonomicGroupTypes={taxonomicGroupTypes}
             endpointFilters={endpointFilters}

--- a/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
@@ -109,7 +109,7 @@ export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
     }),
 
     selectors({
-        tabId: [(_, p) => [p.id], (id: string) => id],
+        id: [(_, p) => [p.id], (id: string) => id],
         filters: [
             (s) => [s.dateRange, s.searchTerm, s.severityLevels, s.serviceNames, s.filterGroup],
             (

--- a/products/logs/frontend/components/LogsViewer/LogAttributes.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogAttributes.tsx
@@ -26,7 +26,7 @@ export interface LogAttributesProps {
 }
 
 export function LogAttributes({ attributes, type, logUuid, title }: LogAttributesProps): JSX.Element {
-    const { expandedAttributeBreakdowns, tabId, isAttributeColumn } = useValues(logsViewerLogic)
+    const { expandedAttributeBreakdowns, id, isAttributeColumn } = useValues(logsViewerLogic)
     const { addFilter, toggleAttributeColumn, toggleAttributeBreakdown } = useActions(logsViewerLogic)
 
     const expandedBreakdownsForThisLog = expandedAttributeBreakdowns[logUuid] || []
@@ -157,12 +157,7 @@ export function LogAttributes({ attributes, type, logUuid, title }: LogAttribute
                     showRowExpansionToggle: false,
                     isRowExpanded: (record) => expandedBreakdownsForThisLog.includes(record.key),
                     expandedRowRender: (record) => (
-                        <AttributeBreakdowns
-                            attribute={record.key}
-                            addFilter={addFilter}
-                            tabId={tabId}
-                            type={record.type}
-                        />
+                        <AttributeBreakdowns attribute={record.key} addFilter={addFilter} id={id} type={record.type} />
                     ),
                 }}
             />

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
@@ -10,13 +10,13 @@ import type { logDetailsModalLogicType } from './logDetailsModalLogicType'
 export type LogDetailsTab = 'details' | 'raw' | 'explore-ai' | 'comments' | 'related-errors'
 
 export interface LogDetailsModalProps {
-    tabId: string
+    id: string
 }
 
 export const logDetailsModalLogic = kea<logDetailsModalLogicType>([
     path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'LogDetailsModal', 'logDetailsModalLogic']),
     props({} as LogDetailsModalProps),
-    key((props) => props.tabId),
+    key((props) => props.id),
 
     actions({
         openLogDetails: (log: ParsedLogMessage) => ({ log }),

--- a/products/logs/frontend/components/LogsViewer/LogRowFAB/LogRowFAB.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogRowFAB/LogRowFAB.tsx
@@ -39,10 +39,10 @@ export function LogRowFAB({
     onTogglePrettify,
     showScrollButtons = false,
 }: LogRowFABProps): JSX.Element {
-    const { tabId } = useValues(logsViewerLogic)
+    const { id } = useValues(logsViewerLogic)
     const { copyLinkToLog } = useActions(logsViewerLogic)
     const { openLogDetails } = useActions(logDetailsModalLogic)
-    const { startScrolling, stopScrolling } = useCellScrollControls({ tabId, cellKey: 'message' })
+    const { startScrolling, stopScrolling } = useCellScrollControls({ id, cellKey: 'message' })
 
     return (
         <div

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -32,9 +32,9 @@ export function LogsViewer({ id }: LogsViewerProps): JSX.Element {
         <BindLogic logic={logsViewerFiltersLogic} props={{ id }}>
             <BindLogic logic={logsViewerConfigLogic} props={{ id }}>
                 <BindLogic logic={logsViewerDataLogic} props={{ id }}>
-                    <BindLogic logic={logDetailsModalLogic} props={{ tabId: id }}>
-                        <BindLogic logic={logsViewerLogic} props={{ tabId: id }}>
-                            <BindLogic logic={logsExportLogic} props={{ tabId: id }}>
+                    <BindLogic logic={logDetailsModalLogic} props={{ id }}>
+                        <BindLogic logic={logsViewerLogic} props={{ id }}>
+                            <BindLogic logic={logsExportLogic} props={{ id }}>
                                 <LogsViewerContent />
                             </BindLogic>
                         </BindLogic>
@@ -47,7 +47,7 @@ export function LogsViewer({ id }: LogsViewerProps): JSX.Element {
 
 function LogsViewerContent(): JSX.Element {
     const {
-        tabId,
+        id,
         wrapBody,
         prettifyJson,
         pinnedLogsArray,
@@ -75,8 +75,8 @@ function LogsViewerContent(): JSX.Element {
         useValues(logsViewerDataLogic)
     const { runQuery, fetchNextLogsPage } = useActions(logsViewerDataLogic)
     const { setDateRange, zoomDateRange } = useActions(logsViewerFiltersLogic)
-    const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ tabId }))
-    const { setCellScrollLeft } = useActions(virtualizedLogsListLogic({ tabId }))
+    const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ id }))
+    const { setCellScrollLeft } = useActions(virtualizedLogsListLogic({ id }))
     const messageScrollLeft = cellScrollLefts['message'] ?? 0
     const scrollLeftRef = useRef(messageScrollLeft)
     scrollLeftRef.current = messageScrollLeft

--- a/products/logs/frontend/components/LogsViewer/logsExportLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsExportLogic.test.ts
@@ -44,10 +44,10 @@ describe('logsExportLogic', () => {
             initKeaTests()
             jest.clearAllMocks()
 
-            viewerLogic = logsViewerLogic({ tabId: 'test-tab' })
+            viewerLogic = logsViewerLogic({ id: 'test-tab' })
             viewerLogic.mount()
 
-            exportLogic = logsExportLogic({ tabId: 'test-tab' })
+            exportLogic = logsExportLogic({ id: 'test-tab' })
             exportLogic.mount()
         })
 

--- a/products/logs/frontend/components/LogsViewer/logsExportLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsExportLogic.ts
@@ -42,22 +42,22 @@ export function getExportColumns(attributeColumns: string[]): string[] {
 }
 
 export interface LogsExportLogicProps {
-    tabId: string
+    id: string
 }
 
 export const logsExportLogic = kea<logsExportLogicType>([
-    path((tabId) => ['products', 'logs', 'frontend', 'components', 'LogsViewer', 'logsExportLogic', tabId]),
+    path((id) => ['products', 'logs', 'frontend', 'components', 'LogsViewer', 'logsExportLogic', id]),
     props({} as LogsExportLogicProps),
-    key((props) => props.tabId),
-    connect(({ tabId }: LogsExportLogicProps) => ({
+    key((props) => props.id),
+    connect(({ id }: LogsExportLogicProps) => ({
         values: [
-            logsViewerLogic({ tabId }),
+            logsViewerLogic({ id }),
             ['selectedLogsArray', 'attributeColumns'],
-            logsViewerFiltersLogic({ id: tabId }),
+            logsViewerFiltersLogic({ id }),
             ['filters', 'utcDateRange'],
-            logsViewerDataLogic({ id: tabId }),
+            logsViewerDataLogic({ id }),
             ['maxExportableLogs'],
-            logsViewerConfigLogic({ id: tabId }),
+            logsViewerConfigLogic({ id }),
             ['orderBy'],
         ],
         actions: [sidePanelStateLogic, ['openSidePanel']],

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -55,7 +55,7 @@ function mountWithLogs(rawLogs: LogMessage[] = mockRawLogs): {
     if (rawLogs.length > 0) {
         dataLogic.actions.setLogs(rawLogs)
     }
-    const logic = logsViewerLogic({ tabId: TEST_ID })
+    const logic = logsViewerLogic({ id: TEST_ID })
     logic.mount()
     return { logic, dataLogic }
 }

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -30,32 +30,32 @@ export interface VisibleLogsTimeRange {
 export type LogCursor = number | null
 
 export interface LogsViewerLogicProps {
-    tabId: string
+    id: string
 }
 
 export const logsViewerLogic = kea<logsViewerLogicType>([
-    path((tabId) => ['products', 'logs', 'frontend', 'components', 'LogsViewer', 'logsViewerLogic', tabId]),
+    path((id) => ['products', 'logs', 'frontend', 'components', 'LogsViewer', 'logsViewerLogic', id]),
     props({} as LogsViewerLogicProps),
-    key((props) => props.tabId),
-    connect(({ tabId }: LogsViewerLogicProps) => ({
+    key((props) => props.id),
+    connect(({ id }: LogsViewerLogicProps) => ({
         values: [
             logsViewerSettingsLogic,
             ['timezone', 'wrapBody', 'prettifyJson'],
-            logDetailsModalLogic({ tabId }),
+            logDetailsModalLogic({ id }),
             ['isLogDetailsOpen'],
-            logsViewerDataLogic({ id: tabId }),
+            logsViewerDataLogic({ id }),
             ['parsedLogs as logs'],
-            logsViewerConfigLogic({ id: tabId }),
+            logsViewerConfigLogic({ id }),
             ['orderBy'],
         ],
         actions: [
             logsViewerSettingsLogic,
             ['setTimezone', 'setWrapBody', 'setPrettifyJson'],
-            logDetailsModalLogic({ tabId }),
+            logDetailsModalLogic({ id }),
             ['openLogDetails', 'closeLogDetails'],
-            logsViewerFiltersLogic({ id: tabId }),
+            logsViewerFiltersLogic({ id }),
             ['addFilter'],
-            logsViewerDataLogic({ id: tabId }),
+            logsViewerDataLogic({ id }),
             ['setLogs', 'clearLogs'],
         ],
     })),
@@ -284,7 +284,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
     })),
 
     selectors({
-        tabId: [(_, p) => [p.tabId], (tabId: string): string => tabId],
+        id: [(_, p) => [p.id], (id: string): string => id],
 
         pinnedLogsArray: [(s) => [s.pinnedLogs], (pinnedLogs): ParsedLogMessage[] => Object.values(pinnedLogs)],
 

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -155,7 +155,7 @@ export function VirtualizedLogsList({
     onChangeOrderBy,
 }: VirtualizedLogsListProps): JSX.Element {
     const {
-        tabId,
+        id,
         pinnedLogs,
         expandedLogIds,
         cursorIndex,
@@ -187,8 +187,8 @@ export function VirtualizedLogsList({
 
     const containerRef = useRef<HTMLDivElement>(null)
 
-    const { shouldLoadMore } = useValues(virtualizedLogsListLogic({ tabId }))
-    const { setContainerWidth } = useActions(virtualizedLogsListLogic({ tabId }))
+    const { shouldLoadMore } = useValues(virtualizedLogsListLogic({ id }))
+    const { setContainerWidth } = useActions(virtualizedLogsListLogic({ id }))
     const listRef = useListRef(null)
     const autosizerWidthRef = useRef<number>(0)
 

--- a/products/logs/frontend/components/VirtualizedLogsList/cells/AttributeCell.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/cells/AttributeCell.tsx
@@ -24,11 +24,11 @@ export const AttributeCell = memo(function AttributeCell({
     value,
     width,
 }: AttributeCellProps): JSX.Element {
-    const { tabId, isAttributeColumn } = useValues(logsViewerLogic)
+    const { id, isAttributeColumn } = useValues(logsViewerLogic)
     const { addFilter, toggleAttributeColumn } = useActions(logsViewerLogic)
 
     const { scrollRef, handleScroll, startScrolling, stopScrolling } = useCellScroll({
-        tabId,
+        id,
         cellKey: `attr:${attributeKey}`,
     })
 

--- a/products/logs/frontend/components/VirtualizedLogsList/cells/MessageCell.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/cells/MessageCell.tsx
@@ -17,8 +17,8 @@ export interface MessageCellProps {
 }
 
 export function MessageCell({ message, wrapBody, prettifyJson, parsedBody, style }: MessageCellProps): JSX.Element {
-    const { tabId } = useValues(logsViewerLogic)
-    const { scrollRef, handleScroll } = useCellScrollRef({ tabId, cellKey: 'message', enabled: !wrapBody })
+    const { id } = useValues(logsViewerLogic)
+    const { scrollRef, handleScroll } = useCellScrollRef({ id, cellKey: 'message', enabled: !wrapBody })
 
     const displayValue = prettifyJson && parsedBody ? JSON.stringify(parsedBody, null, 2) : message
 

--- a/products/logs/frontend/components/VirtualizedLogsList/useCellScroll.ts
+++ b/products/logs/frontend/components/VirtualizedLogsList/useCellScroll.ts
@@ -8,7 +8,7 @@ const SCROLL_AMOUNT_PX = 8
 
 // Hook for the component that owns the scrollable element (e.g., MessageCell)
 export interface UseCellScrollRefOptions {
-    tabId: string
+    id: string
     cellKey: string
     enabled?: boolean
 }
@@ -18,9 +18,9 @@ export interface UseCellScrollRefResult {
     handleScroll: (e: React.UIEvent<HTMLDivElement>) => void
 }
 
-export function useCellScrollRef({ tabId, cellKey, enabled = true }: UseCellScrollRefOptions): UseCellScrollRefResult {
-    const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ tabId }))
-    const { setCellScrollLeft } = useActions(virtualizedLogsListLogic({ tabId }))
+export function useCellScrollRef({ id, cellKey, enabled = true }: UseCellScrollRefOptions): UseCellScrollRefResult {
+    const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ id }))
+    const { setCellScrollLeft } = useActions(virtualizedLogsListLogic({ id }))
 
     const scrollRef = useRef<HTMLDivElement>(null)
     const isProgrammaticScrollRef = useRef(false)
@@ -60,7 +60,7 @@ export function useCellScrollRef({ tabId, cellKey, enabled = true }: UseCellScro
 
 // Hook for the component that controls scrolling (e.g., LogRowFAB)
 export interface UseCellScrollControlsOptions {
-    tabId: string
+    id: string
     cellKey: string
 }
 
@@ -69,9 +69,9 @@ export interface UseCellScrollControlsResult {
     stopScrolling: () => void
 }
 
-export function useCellScrollControls({ tabId, cellKey }: UseCellScrollControlsOptions): UseCellScrollControlsResult {
-    const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ tabId }))
-    const { setCellScrollLeft } = useActions(virtualizedLogsListLogic({ tabId }))
+export function useCellScrollControls({ id, cellKey }: UseCellScrollControlsOptions): UseCellScrollControlsResult {
+    const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ id }))
+    const { setCellScrollLeft } = useActions(virtualizedLogsListLogic({ id }))
 
     const scrollIntervalRef = useRef<number | null>(null)
     const scrollRef = useRef<((direction: 'left' | 'right') => void) | null>(null)
@@ -123,7 +123,7 @@ export function useCellScrollControls({ tabId, cellKey }: UseCellScrollControlsO
 
 // Combined hook for backward compatibility (used when one component needs both)
 export interface UseCellScrollOptions {
-    tabId: string
+    id: string
     cellKey: string
     enabled?: boolean
 }
@@ -136,9 +136,9 @@ export interface UseCellScrollResult {
 }
 
 /** @deprecated Use useCellScrollRef and useCellScrollControls instead */
-export function useCellScroll({ tabId, cellKey, enabled = true }: UseCellScrollOptions): UseCellScrollResult {
-    const { scrollRef, handleScroll } = useCellScrollRef({ tabId, cellKey, enabled })
-    const { startScrolling, stopScrolling } = useCellScrollControls({ tabId, cellKey })
+export function useCellScroll({ id, cellKey, enabled = true }: UseCellScrollOptions): UseCellScrollResult {
+    const { scrollRef, handleScroll } = useCellScrollRef({ id, cellKey, enabled })
+    const { startScrolling, stopScrolling } = useCellScrollControls({ id, cellKey })
 
     return {
         scrollRef,

--- a/products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic.test.ts
+++ b/products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic.test.ts
@@ -19,7 +19,7 @@ describe('virtualizedLogsListLogic', () => {
         ])(
             'stopIndex=%i, dataLength=%i, hasMore=%s, isLoading=%s → %s (%s)',
             (stopIndex, dataLength, hasMore, isLoading, expected) => {
-                const logic = virtualizedLogsListLogic({ tabId: 'test-tab' })
+                const logic = virtualizedLogsListLogic({ id: 'test-tab' })
                 logic.mount()
 
                 expect(logic.values.shouldLoadMore(stopIndex, dataLength, hasMore, isLoading)).toBe(expected)
@@ -27,7 +27,7 @@ describe('virtualizedLogsListLogic', () => {
         )
 
         it('respects custom scrollThreshold', () => {
-            const logic = virtualizedLogsListLogic({ tabId: 'test-tab', scrollThreshold: 50 })
+            const logic = virtualizedLogsListLogic({ id: 'test-tab', scrollThreshold: 50 })
             logic.mount()
 
             // With threshold 50: dataLength 200 - 50 = 150, so stopIndex 149 should NOT load

--- a/products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic.ts
+++ b/products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic.ts
@@ -3,7 +3,7 @@ import { actions, kea, key, path, props, reducers, selectors } from 'kea'
 import type { virtualizedLogsListLogicType } from './virtualizedLogsListLogicType'
 
 export interface VirtualizedLogsListLogicProps {
-    tabId: string
+    id: string
     scrollThreshold?: number
 }
 
@@ -11,16 +11,8 @@ const DEFAULT_SCROLL_THRESHOLD = 100
 
 export const virtualizedLogsListLogic = kea<virtualizedLogsListLogicType>([
     props({ scrollThreshold: DEFAULT_SCROLL_THRESHOLD } as VirtualizedLogsListLogicProps),
-    key((props) => props.tabId),
-    path((tabId) => [
-        'products',
-        'logs',
-        'frontend',
-        'components',
-        'VirtualizedLogsList',
-        'virtualizedLogsListLogic',
-        tabId,
-    ]),
+    key((props) => props.id),
+    path((id) => ['products', 'logs', 'frontend', 'components', 'VirtualizedLogsList', 'virtualizedLogsListLogic', id]),
 
     actions({
         setContainerWidth: (width: number) => ({ width }),


### PR DESCRIPTION
## Problem

Viewer-level logics use tabId as their prop name, coupling them to the scene's tab concept and preventing LogsViewer from being reused in non-tab contexts.

## Changes

Simple but high-touch renaming refactor

- Renamed `tabId` to `id` in all component props and logic interfaces
- Updated all references to `tabId` in component logic and JSX
- Maintained consistent naming across all logs viewer components
- Updated path functions and key selectors to use the new property name

## How did you test this code?

- Verified existing functionality works as intended
- Unit tests pass

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No