### PR TITLE
chore: Tune distinct_id_usage job

### DIFF
--- a/posthog/dags/distinct_id_usage.py
+++ b/posthog/dags/distinct_id_usage.py
@@ -28,12 +28,16 @@ class DistinctIdUsageMonitoringConfig(dagster.Config):
         default=10_000,
         description="Minimum total team events required before high usage percentage alerts apply (filters out low-volume test accounts)",
     )
+    high_usage_distinct_id_min_events: int = pydantic.Field(
+        default=100_000,
+        description="Minimum events from a distinct_id to trigger high usage alerts (reduces noise from low-volume distinct_ids)",
+    )
     high_cardinality_threshold: int = pydantic.Field(
         default=1_000_000,
         description="Number of unique distinct_ids per team that triggers a high cardinality alert",
     )
     burst_threshold: int = pydantic.Field(
-        default=10_000,
+        default=100_000,
         description="Events per minute from a single (team, distinct_id) that triggers a burst alert",
     )
     default_lookback_hours: int = pydantic.Field(
@@ -138,7 +142,8 @@ def query_distinct_id_usage(
         FROM distinct_id_totals d
         JOIN team_totals t ON d.team_id = t.team_id
         WHERE d.event_count * 100.0 / t.total_events >= %(threshold)s
-        ORDER BY percentage DESC
+          AND d.event_count >= %(distinct_id_min_events)s
+        ORDER BY d.event_count DESC
         LIMIT 100
         """
 
@@ -148,6 +153,7 @@ def query_distinct_id_usage(
                 "lookback_start": lookback_start,
                 "threshold": config.high_usage_percentage_threshold,
                 "min_events_threshold": config.high_usage_min_events_threshold,
+                "distinct_id_min_events": config.high_usage_distinct_id_min_events,
             },
             settings=query_settings,
         )


### PR DESCRIPTION
## Problem

The `distinct_id_usage` dagster job was producing too many noisy alerts for relatively small distinct_id usage patterns and minor burst events. This made it difficult to identify truly problematic patterns that could impact ingestion performance.


## Changes

Raised thresholds to focus on high-impact issues:

- Added `high_usage_distinct_id_min_events = 100,000` to only alert on distinct_ids with substantial volume (previously any distinct_id above percentage threshold triggered alerts)
- Burst threshold Increased from 10,000 to 100,000 events/minute to catch only significant spikes
- Changed high usage results to sort by event volume instead of percentage, prioritizing highest-impact distinct_ids first



## How did you test this code?

Updated integration tests and added verification that empty results don't trigger Slack notifications.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
