### PR TITLE
fix(insights): align compare data point counts across DST 

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -4758,7 +4758,7 @@
 # ---
 # name: TestTrends.test_trends_compare_day_interval_relative_range.1
   '''
-  SELECT arrayMap(number -> plus(toStartOfInterval(assumeNotNull(toDateTime('2019-12-21 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfInterval(assumeNotNull(toDateTime('2019-12-21 00:00:00', 'UTC')), toIntervalDay(1)), toStartOfInterval(assumeNotNull(toDateTime('2019-12-28 23:59:59', 'UTC')), toIntervalDay(1)))), 1))) AS date,
+  SELECT arrayMap(number -> plus(toStartOfInterval(assumeNotNull(toDateTime('2019-12-21 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(number)), range(0, 8)) AS date,
          arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
                                                                                                                                                                                                    and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total
   FROM

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -153,6 +153,10 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
                     query_date_range = self.query_date_range
                 else:
                     query_date_range = self.query_previous_date_range
+                    # Align the previous period's interval count with the current period
+                    # so both produce the same number of data points. DST transitions can
+                    # cause dateDiff to return different counts for the same wall-clock duration.
+                    query_date_range._num_intervals_override = self.query_date_range.num_intervals()
 
                 query_date_range._earliest_timestamp_fallback = earliest_timestamp
 


### PR DESCRIPTION
## Problem

The `chartjs-plugin-stacked100` crashes with `TypeError: Cannot read properties of undefined (reading 'Symbol()')` when using compare mode on trends insights across DST transitions.

The root cause: ClickHouse's `dateDiff('hour', from, to)` counts UTC-based intervals, so a day spanning DST fall-back (e.g. Nov 3 in US/Eastern) produces 25 hours, while the corresponding previous period (a non-DST day) produces only 24. The stacked100 plugin assumes all datasets have equal-length data arrays and crashes when they don't.

## Changes

- Adds `num_intervals()` to `QueryDateRange` that computes interval counts matching ClickHouse's `dateDiff` using UTC timestamps
- In compare mode, passes the current period's interval count to the previous period's query builder so it generates the same number of date buckets
- The previous period query uses a fixed `range(0, N)` instead of `dateDiff` to generate its date array

### Design decision: padding the shorter period

This fix **pads the shorter (previous) period with extra zero-value data points** to match the current period's count. This means the previous period may include data points for time slots outside its natural range (e.g. a 24-hour day gets a 25th bucket to match a 25-hour DST day). Zeros are the correct event count for those slots, so this is invisible in practice — but it is a data presentation choice.

**Alternatives considered:**
- **Trim the longer period** — rejected because it hides real data
- **Fix in the frontend** — `chartjs-plugin-stacked100` is a third-party plugin, and the mismatch also affects data exports and other chart types
- **Wall-clock interval counting in ClickHouse** — more "correct" but significantly more complex and would change query behavior broadly

If you disagree with this approach, please comment!

### Technical note

`num_intervals()` uses `.timestamp()` difference instead of `(end - start).total_seconds()` because Python's datetime subtraction with the same `ZoneInfo` does a naive calculation that ignores DST offset changes.

## How did you test this code?

- Added parameterized integration tests: hourly across DST fall-back (the original bug), multi-day across DST, monthly relative, and `compare_to` mode
- Added parameterized unit tests for `num_intervals()`: fall-back 25h, spring-forward 23h, normal 24h, two-day span 49h, day intervals, and UTC
- All 194 existing trends + date range tests pass
- I haven't tested replicating this bug locally yet, thought it would be good to get feedback on the approach / PR first. 

## Publish to changelog?

No