### PR TITLE
chore: Make primary key approach more consistent across sources

### DIFF
--- a/posthog/temporal/data_imports/sources/common/utils.py
+++ b/posthog/temporal/data_imports/sources/common/utils.py
@@ -1,4 +1,5 @@
 from dlt.sources import DltSource
+from structlog.types import FilteringBoundLogger
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.pipelines.pipeline.utils import _get_column_hints, _get_primary_keys
@@ -16,3 +17,30 @@ def dlt_source_to_source_response(source: DltSource) -> SourceResponse:
         column_hints=_get_column_hints(resource),
         partition_count=None,
     )
+
+
+def resolve_primary_keys(
+    keys: list[str] | None,
+    table_name: str,
+    logger: FilteringBoundLogger,
+    existing_fields: set[str] | None = None,
+) -> tuple[list[str] | None, bool]:
+    """Resolve primary keys for a data import source, with fallback to 'id' column.
+
+    Returns a tuple of (primary_keys, is_id_fallback) where is_id_fallback is True
+    only when no real primary keys were found and we fell back to the 'id' column.
+    """
+    if keys:
+        logger.info(f"Found primary keys: {keys}")
+        return keys, False
+
+    if existing_fields and "id" in existing_fields:
+        logger.info("Found primary keys: ['id'] (fallback)")
+        return ["id"], True
+
+    logger.warning(
+        f"No primary keys found for {table_name}. If the table is not a view, "
+        "(a) does the table have a primary key set? "
+        "(b) does the service account have permission to read primary key metadata?"
+    )
+    return None, False

--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -27,6 +27,7 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     table_from_iterator,
 )
 from posthog.temporal.data_imports.sources.common.sql import Column, Table
+from posthog.temporal.data_imports.sources.common.utils import resolve_primary_keys
 
 from products.data_warehouse.backend.types import IncrementalFieldType, PartitionSettings
 
@@ -226,8 +227,12 @@ def _explain_query(cursor: psycopg.Cursor, query: sql.Composed, logger: Filterin
 
 
 def _get_primary_keys(
-    cursor: psycopg.Cursor, schema: str, table_name: str, logger: FilteringBoundLogger
-) -> list[str] | None:
+    cursor: psycopg.Cursor,
+    schema: str,
+    table_name: str,
+    logger: FilteringBoundLogger,
+    existing_fields: set[str] | None = None,
+) -> tuple[list[str] | None, bool]:
     query = sql.SQL("""
         SELECT
             kcu.column_name
@@ -246,14 +251,8 @@ def _get_primary_keys(
     logger.debug(f"Running query: {query.as_string()}")
     cursor.execute(query)
     rows = cursor.fetchall()
-    if len(rows) > 0:
-        return [row[0] for row in rows]
-
-    logger.warning(
-        f"No primary keys found for {table_name}. If the table is not a view, (a) does the table have a primary key set? (b) is the primary key returned from querying information_schema?"
-    )
-
-    return None
+    keys = [row[0] for row in rows] or None
+    return resolve_primary_keys(keys, table_name, logger, existing_fields=existing_fields)
 
 
 def _has_duplicate_primary_keys(
@@ -578,9 +577,9 @@ def redshift_source(
                 )
                 try:
                     logger.debug("Getting primary keys...")
-                    primary_keys = _get_primary_keys(cursor, schema, table_name, logger)
-                    if primary_keys:
-                        logger.debug(f"Found primary keys: {primary_keys}")
+                    primary_keys, _ = _get_primary_keys(
+                        cursor, schema, table_name, logger, existing_fields={col.name for col in table.columns}
+                    )
                     logger.debug("Getting table chunk size...")
                     if chunk_size_override is not None:
                         chunk_size = chunk_size_override
@@ -595,16 +594,12 @@ def redshift_source(
                         if should_use_incremental_field
                         else None
                     )
-                    has_duplicate_primary_keys = False
 
-                    # Fallback on checking for an `id` field on the table
-                    if primary_keys is None and "id" in table:
-                        logger.debug("Falling back to ['id'] for primary keys...")
-                        primary_keys = ["id"]
-                        logger.debug("Checking duplicate primary keys...")
-                        has_duplicate_primary_keys = _has_duplicate_primary_keys(
-                            cursor, schema, table_name, primary_keys, logger
-                        )
+                    # Redshift doesn't enforce PK uniqueness, so always check
+                    # the PK(s) for uniqueness
+                    has_duplicate_primary_keys = _has_duplicate_primary_keys(
+                        cursor, schema, table_name, primary_keys, logger
+                    )
                 except psycopg.errors.QueryCanceled:
                     if should_use_incremental_field:
                         raise QueryTimeoutException(


### PR DESCRIPTION
## Problem

I've worked on a couple of tickets recently where customers have had trouble with incremental syncs, and they've ended up being related to primary keys and `id` fallbacks. I was looking at the logging in code, which led me down a bit of a rabbit hole understanding what the difference is in how we do incremental syncs between different sources.

I am very likely missing some context on why some of these differences exist in the first place!

https://posthog.slack.com/archives/C0A6L24BU0P/p1770995891536829

## Changes

Generally make primary key management for incremental syncs more consistent in terms of:
- logging
- fallback to `id` in the absence of primary keys - and make it clearer that we are doing so
- achieved via a common `get_primary_keys` utility function to share the logging/logic for this across sources

Source specific changes:
- Ensure that we check primary key uniqueness for BigQuery, Redshift, and Snowflake, where uniqueness isn't enforced by the  database
- Added duplicate primary key check for MSSQL, MySQL and Snowflake, but only on `id`, and only when being used as a fallback)
- Added `id` column fallback to Snowflake, which was missing

I'll also update our docs to make this behavior clearer if this change looks good/like something we'd want

## How did you test this code?

Setup BigQuery and Snowflake sources for testing locally - might need to verify it for other sources too? I think there's also a risk this breaks some syncs given we're adding checks - but those would be for sources using incremental syncs that _could_ result in duplicates in PostHog.