### PR TITLE
chore(session-recording): make result handling producer optional

### DIFF
--- a/nodejs/src/ingestion/session_replay/session-replay-pipeline.ts
+++ b/nodejs/src/ingestion/session_replay/session-replay-pipeline.ts
@@ -20,7 +20,7 @@ export interface SessionReplayPipelineOutput {
 }
 
 export interface SessionReplayPipelineConfig {
-    kafkaProducer: KafkaProducerWrapper
+    kafkaProducer?: KafkaProducerWrapper
     eventIngestionRestrictionManager: EventIngestionRestrictionManager
     overflowEnabled: boolean
     overflowTopic: string

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -167,18 +167,8 @@ export class PluginServer {
                     const actualHub = hub ?? (await createHub(this.config))
                     const postgres = actualHub.postgres
                     const kafkaMetadataProducer = actualHub.kafkaProducer
-                    const kafkaMessageProducer = await KafkaProducerWrapper.create(
-                        actualHub.KAFKA_CLIENT_RACK,
-                        'WARPSTREAM_PRODUCER'
-                    )
 
-                    const ingester = new SessionRecordingIngester(
-                        actualHub,
-                        true,
-                        postgres,
-                        kafkaMetadataProducer,
-                        kafkaMessageProducer
-                    )
+                    const ingester = new SessionRecordingIngester(actualHub, true, postgres, kafkaMetadataProducer)
                     await ingester.start()
                     return ingester.service
                 })

--- a/nodejs/src/session-recording/consumer.ts
+++ b/nodejs/src/session-recording/consumer.ts
@@ -95,7 +95,7 @@ export class SessionRecordingIngester {
         { message: Message }
     >
     private readonly kafkaMetadataProducer: KafkaProducerWrapper
-    private readonly kafkaMessageProducer: KafkaProducerWrapper
+    private readonly kafkaMessageProducer?: KafkaProducerWrapper
     private readonly ingestionWarningProducer?: KafkaProducerWrapper
     private readonly overflowTopic: string
     private readonly topTracker: TopTracker
@@ -106,7 +106,7 @@ export class SessionRecordingIngester {
         private consumeOverflow: boolean,
         postgres: PostgresRouter,
         kafkaMetadataProducer: KafkaProducerWrapper,
-        kafkaMessageProducer: KafkaProducerWrapper,
+        kafkaMessageProducer?: KafkaProducerWrapper,
         ingestionWarningProducer?: KafkaProducerWrapper
     ) {
         this.topic = consumeOverflow
@@ -447,7 +447,9 @@ export class SessionRecordingIngester {
         // Clean up resources owned by this ingester
         // Note: kafkaMetadataProducer may be shared (e.g., hub.kafkaProducer in production),
         // so callers are responsible for disconnecting it if they created it
-        await this.kafkaMessageProducer.disconnect()
+        if (this.kafkaMessageProducer) {
+            await this.kafkaMessageProducer.disconnect()
+        }
         if (this.ingestionWarningProducer) {
             await this.ingestionWarningProducer.disconnect()
         }


### PR DESCRIPTION
## Problem

the pipeline response handler code requires a kafka producer - this will break ingestion overflow pipelines (i.e. session recording) that have no rerouting. currently the session recording overflow deployment is broken, as it is attempting to create a producer it's not configured to have.

## Changes

- make the response handler producer optional
- only make the session recording producer when non overflow

## How did you test this code?

unit tests

## Publish to changelog?

no