### PR TITLE
chore(feature-flags): Add delete button to new feature flag overview

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -53,7 +53,7 @@ import { BulkDeleteResultsModal } from './BulkDeleteResultsModal'
 import { FeatureFlagEvaluationTags } from './FeatureFlagEvaluationTags'
 import { FeatureFlagFiltersSection } from './FeatureFlagFilters'
 import { OverlayForNewFeatureFlagMenu } from './NewFeatureFlagMenu'
-import { featureFlagLogic } from './featureFlagLogic'
+import { featureFlagDeleteDisabledReason, featureFlagLogic } from './featureFlagLogic'
 import { FLAGS_PER_PAGE, FeatureFlagsTab, featureFlagsLogic } from './featureFlagsLogic'
 import { flagSelectionLogic } from './flagSelectionLogic'
 
@@ -255,13 +255,7 @@ function FeatureFlagRowActions({ featureFlag }: { featureFlag: FeatureFlagType }
                                     disabledReason={
                                         !featureFlag.can_edit
                                             ? "You have only 'View' access for this feature flag. To make changes, please contact the flag's creator."
-                                            : (featureFlag.features?.length || 0) > 0
-                                              ? 'This feature flag is in use with an early access feature. Delete the early access feature to delete this flag'
-                                              : (featureFlag.experiment_set?.length || 0) > 0
-                                                ? 'This feature flag is linked to an experiment. Delete the experiment to delete this flag.'
-                                                : (featureFlag.surveys?.length || 0) > 0
-                                                  ? 'This feature flag is linked to a survey. Delete the survey to delete this flag.'
-                                                  : null
+                                            : featureFlagDeleteDisabledReason(featureFlag)
                                     }
                                     fullWidth
                                 >

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -240,6 +240,19 @@ export const indexToVariantKeyFeatureFlagPayloads = (flag: Partial<FeatureFlagTy
     return flag
 }
 
+export function featureFlagDeleteDisabledReason(featureFlag: Partial<FeatureFlagType>): string | undefined {
+    if ((featureFlag.features?.length || 0) > 0) {
+        return 'This feature flag is in use with an early access feature. Delete the early access feature to delete this flag'
+    }
+    if ((featureFlag.experiment_set?.length || 0) > 0) {
+        return 'This feature flag is linked to an experiment. Delete the experiment to delete this flag'
+    }
+    if ((featureFlag.surveys?.length || 0) > 0) {
+        return 'This feature flag is linked to a survey. Delete the survey to delete this flag'
+    }
+    return undefined
+}
+
 export const getRecordingFilterForFlagVariant = (
     flagKey: string,
     variantKey: string | null,


### PR DESCRIPTION
## Problem
I can never find the delete button

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add the delete button to advanced settings
Make the back button go back to the flag overview instead of list

https://github.com/user-attachments/assets/95f84711-3027-4334-9fd7-e176a23b1973


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
