### PR TITLE
fix: dlq on kafka parse message errors

### DIFF
--- a/nodejs/src/ingestion/event-preprocessing/parse-kafka-message.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/parse-kafka-message.test.ts
@@ -1,7 +1,7 @@
 import { Message } from 'node-rdkafka'
 
 import { logger } from '../../utils/logger'
-import { drop, ok } from '../pipelines/results'
+import { dlq, ok } from '../pipelines/results'
 import { createParseKafkaMessageStep } from './parse-kafka-message'
 
 // Mock dependencies
@@ -218,7 +218,7 @@ describe('createParseKafkaMessageStep', () => {
             const input = { message: mockMessage }
             const result = await step(input)
 
-            expect(result).toEqual(drop('failed_parse_message'))
+            expect(result).toEqual(dlq('failed_parse_message', expect.any(Error)))
             expect(mockLogger.warn).toHaveBeenCalledWith('Failed to parse Kafka message', {
                 error: expect.any(Error),
             })
@@ -232,7 +232,7 @@ describe('createParseKafkaMessageStep', () => {
             const input = { message: mockMessage }
             const result = await step(input)
 
-            expect(result).toEqual(drop('failed_parse_message'))
+            expect(result).toEqual(dlq('failed_parse_message', expect.any(Error)))
             expect(mockLogger.warn).toHaveBeenCalledWith('Failed to parse Kafka message', {
                 error: expect.any(Error),
             })
@@ -246,7 +246,7 @@ describe('createParseKafkaMessageStep', () => {
             const input = { message: mockMessage }
             const result = await step(input)
 
-            expect(result).toEqual(drop('failed_parse_message'))
+            expect(result).toEqual(dlq('failed_parse_message', expect.any(Error)))
             expect(mockLogger.warn).toHaveBeenCalledWith('Failed to parse Kafka message', {
                 error: expect.any(Error),
             })
@@ -265,7 +265,7 @@ describe('createParseKafkaMessageStep', () => {
             const input = { message: mockMessage }
             const result = await step(input)
 
-            expect(result).toEqual(drop('failed_parse_message'))
+            expect(result).toEqual(dlq('failed_parse_message', expect.any(Error)))
             expect(mockLogger.warn).toHaveBeenCalledWith('Failed to parse Kafka message', {
                 error: expect.any(Error),
             })
@@ -286,7 +286,7 @@ describe('createParseKafkaMessageStep', () => {
             const input = { message: mockMessage }
             const result = await step(input)
 
-            expect(result).toEqual(drop('failed_parse_message'))
+            expect(result).toEqual(dlq('failed_parse_message', expect.any(Error)))
             expect(mockLogger.warn).toHaveBeenCalledWith('Failed to parse Kafka message', {
                 error: expect.any(Error),
             })
@@ -305,7 +305,7 @@ describe('createParseKafkaMessageStep', () => {
             const input = { message: mockMessage }
             const result = await step(input)
 
-            expect(result).toEqual(drop('failed_parse_message'))
+            expect(result).toEqual(dlq('failed_parse_message', expect.any(Error)))
             expect(mockLogger.warn).toHaveBeenCalledWith('Failed to parse Kafka message', {
                 error: expect.any(Error),
             })


### PR DESCRIPTION
## Problem

When we have misformatted Kafka messages we drop them, making it harder to troubleshoot the issues and replay the lost messages.

## Changes

Changes the parse kafka message step to DLQ instead of dropping the message.

## How did you test this code?

Updated tests for the step.