### PR TITLE
fix: move the placeholder

### DIFF
--- a/products/conversations/frontend/components/Editor/SupportEditor.scss
+++ b/products/conversations/frontend/components/Editor/SupportEditor.scss
@@ -11,6 +11,16 @@
                 margin-bottom: 0;
             }
         }
+
+        .ProseMirror {
+            > .is-empty:first-child::before {
+                float: left;
+                height: 0;
+                color: var(--color-text-tertiary);
+                pointer-events: none;
+                content: attr(data-placeholder);
+            }
+        }
     }
 
     &__image {

--- a/products/conversations/frontend/components/SidePanel/NewTicket.tsx
+++ b/products/conversations/frontend/components/SidePanel/NewTicket.tsx
@@ -22,14 +22,10 @@ export function NewTicket(): JSX.Element {
                 <span className="font-semibold">New ticket</span>
             </div>
 
-            <p className="text-sm text-muted-alt m-0">
-                Describe what you need help with and our team will get back to you.
-            </p>
-
             <MessageInput
                 onSendMessage={(content, _richContent, _isPrivate, onSuccess) => sendMessage(content, onSuccess)}
                 messageSending={messageSending}
-                placeholder="What can we help you with?"
+                placeholder="Describe what you need help with and our team will get back to you."
                 buttonText="Submit ticket"
                 minRows={4}
             />


### PR DESCRIPTION
## Problem

I kept clicking the placeholder text thinking it was the input. The placeholder wasn't visible, and the descriptive text appeared as a separate paragraph, making the input area unclear.

## Changes

- Updated placeholder text to "Describe what you need help with and our team will get back to you."
- Removed redundant paragraph text
- Added CSS styling to make the TipTap editor placeholder visible

## How did you test this code?

- Verified placeholder appears when editor is empty and disappears when typing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

Do not publish to changelog