### PR TITLE
fix(ux/growth): reduce the onboarding target button for smaller devices, and straight…

### DIFF
--- a/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
+++ b/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
@@ -152,14 +152,15 @@ const ExpandedButton = forwardRef<HTMLButtonElement, ExpandedButtonProps>(functi
                         <span className="relative">
                             <IconTarget />
                             {showBadge && remainingCount > 0 && (
-                                <LemonBadge.Number count={remainingCount} status="warning" size="small" position="top-right" />
-                            )}
-                        </span>
-                    }
+            <div className="block @4xl/main-content:hidden">
+                <LemonButton
+                    ref={ref}
+                    icon={<IconTarget />}
                     size="small"
                     type="secondary"
                     onClick={onClick}
                     active={isActive}
+                    tooltip="Quick start"
                 />
             </div>
         </>

--- a/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
+++ b/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
@@ -57,23 +57,29 @@ export function ProductSetupButton(): JSX.Element | null {
     }
 
     return (
-        <ProductSetupPopover
-            visible={isGlobalModalOpen}
-            onClickOutside={closeGlobalSetup}
-            selectedProduct={selectedProduct}
-            onSelectProduct={setSelectedProduct}
-        >
-            {isDismissed && !isGlobalModalOpen ? (
-                <MinimizedButton remainingCount={remainingCount} isActive={isGlobalModalOpen} onClick={handleToggle} />
-            ) : (
-                <ExpandedButton
-                    remainingCount={remainingCount}
-                    showBadge={shouldShowSetup}
-                    isActive={isGlobalModalOpen}
-                    onClick={handleToggle}
-                />
-            )}
-        </ProductSetupPopover>
+        <div className="hidden @2xl/main-content:block">
+            <ProductSetupPopover
+                visible={isGlobalModalOpen}
+                onClickOutside={closeGlobalSetup}
+                selectedProduct={selectedProduct}
+                onSelectProduct={setSelectedProduct}
+            >
+                {isDismissed && !isGlobalModalOpen ? (
+                    <MinimizedButton
+                        remainingCount={remainingCount}
+                        isActive={isGlobalModalOpen}
+                        onClick={handleToggle}
+                    />
+                ) : (
+                    <ExpandedButton
+                        remainingCount={remainingCount}
+                        showBadge={shouldShowSetup}
+                        isActive={isGlobalModalOpen}
+                        onClick={handleToggle}
+                    />
+                )}
+            </ProductSetupPopover>
+        </div>
     )
 }
 
@@ -94,7 +100,7 @@ const MinimizedButton = forwardRef<HTMLButtonElement, MinimizedButtonProps>(func
                 <span className="relative">
                     <IconTarget />
                     {remainingCount > 0 && (
-                        <LemonBadge.Number count={remainingCount} status="warning" size="medium" position="top-right" />
+                        <LemonBadge.Number count={remainingCount} status="warning" size="small" position="top-right" />
                     )}
                 </span>
             }
@@ -120,21 +126,35 @@ const ExpandedButton = forwardRef<HTMLButtonElement, ExpandedButtonProps>(functi
     ref
 ) {
     return (
-        <LemonButton
-            ref={ref}
-            icon={<IconTarget />}
-            size="small"
-            type="secondary"
-            onClick={onClick}
-            active={isActive}
-            data-attr="global-product-setup-button"
-            sideIcon={
-                showBadge && remainingCount > 0 ? (
-                    <LemonBadge.Number count={remainingCount} status="warning" size="medium" />
-                ) : undefined
-            }
-        >
-            Quick start
-        </LemonButton>
+        <>
+            <div className="hidden @4xl/main-content:block">
+                <LemonButton
+                    ref={ref}
+                    icon={<IconTarget />}
+                    size="small"
+                    type="secondary"
+                    onClick={onClick}
+                    active={isActive}
+                    data-attr="global-product-setup-button"
+                    sideIcon={
+                        showBadge && remainingCount > 0 ? (
+                            <LemonBadge.Number count={remainingCount} status="warning" size="medium" />
+                        ) : undefined
+                    }
+                >
+                    <span className="hidden @4xl/main-content:block">Quick start</span>
+                </LemonButton>
+            </div>
+            <div className="block @4xl/main-content:hidden">
+                <LemonButton
+                    ref={ref}
+                    icon={<IconTarget />}
+                    size="small"
+                    type="secondary"
+                    onClick={onClick}
+                    active={isActive}
+                />
+            </div>
+        </>
     )
 })

--- a/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
+++ b/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
@@ -148,7 +148,14 @@ const ExpandedButton = forwardRef<HTMLButtonElement, ExpandedButtonProps>(functi
             <div className="block @4xl/main-content:hidden">
                 <LemonButton
                     ref={ref}
-                    icon={<IconTarget />}
+                    icon={
+                        <span className="relative">
+                            <IconTarget />
+                            {showBadge && remainingCount > 0 && (
+                                <LemonBadge.Number count={remainingCount} status="warning" size="small" position="top-right" />
+                            )}
+                        </span>
+                    }
                     size="small"
                     type="secondary"
                     onClick={onClick}

--- a/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
+++ b/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
@@ -153,6 +153,7 @@ const ExpandedButton = forwardRef<HTMLButtonElement, ExpandedButtonProps>(functi
                             <IconTarget />
                             {showBadge && remainingCount > 0 && (
             <div className="block @4xl/main-content:hidden">
+            <div className="block @4xl/main-content:hidden">
                 <LemonButton
                     ref={ref}
                     icon={<IconTarget />}
@@ -160,7 +161,7 @@ const ExpandedButton = forwardRef<HTMLButtonElement, ExpandedButtonProps>(functi
                     type="secondary"
                     onClick={onClick}
                     active={isActive}
-                    tooltip="Quick start"
+                    data-attr="global-product-setup-button-compact"
                 />
             </div>
         </>


### PR DESCRIPTION

## Problem
The onboarding button is large! and on smaller screens it takes up too much space.

<img width="511" height="85" alt="image" src="https://github.com/user-attachments/assets/a165893a-6492-429c-ae7e-4ae9377ba5e1" />


## Changes

- For smaller screens just show target icon in button
- For mobile, hide the button altogether
<img width="1025" height="191" alt="image" src="https://github.com/user-attachments/assets/08fcb42a-d92c-44cf-94fe-b38e9cb930c0" />
<img width="842" height="195" alt="image" src="https://github.com/user-attachments/assets/b19a0b1c-0871-45b0-b83d-b24746f11b61" />
<img width="658" height="182" alt="image" src="https://github.com/user-attachments/assets/0d1a85cd-d1cd-4ffe-909e-5a5daff67be9" />


## How did you test this code?
Locally... maybe there's edge cases where this pops open and it won't now?

## Publish to changelog?
No
