### PR TITLE
chore: add original kafka message dlq headers

### DIFF
--- a/nodejs/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
+++ b/nodejs/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
@@ -5,9 +5,9 @@ exports[`IngestionConsumer error handling should handle explicitly non retriable
   {
     "headers": {
       "distinct_id": "user-1",
-      "dlq-reason": "test",
-      "dlq-step": "prefetchHogFunctionsStep",
-      "dlq-timestamp": "2025-01-01T00:00:00.000Z",
+      "dlq_reason": "test",
+      "dlq_step": "prefetchHogFunctionsStep",
+      "dlq_timestamp": "2025-01-01T00:00:00.000Z",
       "event": "$pageview",
       "now": "2025-01-01T00:00:00.000Z",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
@@ -22,79 +22,6 @@ exports[`IngestionConsumer error handling should handle explicitly non retriable
       "now": "2025-01-01T00:00:00.000Z",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
       "uuid": "<REPLACED-UUID-0>",
-    },
-  },
-]
-`;
-
-exports[`IngestionConsumer general overflow force overflow should force events with matching token:distinct_id to overflow: force overflow messages 1`] = `
-[
-  {
-    "headers": {
-      "distinct_id": "team1-user",
-      "event": "$pageview",
-      "now": "2025-01-01T00:00:00.000Z",
-      "redirect-step": "applyEventRestrictionsStep",
-      "redirect-timestamp": "2025-01-01T00:00:00.000Z",
-      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
-      "uuid": "<REPLACED-UUID-0>",
-    },
-    "key": "THIS IS NOT A TOKEN FOR TEAM 2:team1-user",
-    "topic": "events_plugin_ingestion_overflow_test",
-    "value": {
-      "data": "{"distinct_id":"team1-user","uuid":"<REPLACED-UUID-0>","token":"THIS IS NOT A TOKEN FOR TEAM 2","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
-      "distinct_id": "team1-user",
-      "ip": "127.0.0.1",
-      "now": "2025-01-01T00:00:00.000Z",
-      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
-      "uuid": "<REPLACED-UUID-0>",
-    },
-  },
-]
-`;
-
-exports[`IngestionConsumer general overflow force overflow should handle multiple token:distinct_id pairs in force overflow setting: force overflow messages multiple pairs 1`] = `
-[
-  {
-    "headers": {
-      "distinct_id": "user1",
-      "event": "$pageview",
-      "now": "2025-01-01T00:00:00.000Z",
-      "redirect-step": "applyEventRestrictionsStep",
-      "redirect-timestamp": "2025-01-01T00:00:00.000Z",
-      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
-      "uuid": "<REPLACED-UUID-0>",
-    },
-    "key": "THIS IS NOT A TOKEN FOR TEAM 2:user1",
-    "topic": "events_plugin_ingestion_overflow_test",
-    "value": {
-      "data": "{"distinct_id":"user1","uuid":"<REPLACED-UUID-0>","token":"THIS IS NOT A TOKEN FOR TEAM 2","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
-      "distinct_id": "user1",
-      "ip": "127.0.0.1",
-      "now": "2025-01-01T00:00:00.000Z",
-      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
-      "uuid": "<REPLACED-UUID-0>",
-    },
-  },
-  {
-    "headers": {
-      "distinct_id": "user2",
-      "event": "$pageview",
-      "now": "2025-01-01T00:00:00.000Z",
-      "redirect-step": "applyEventRestrictionsStep",
-      "redirect-timestamp": "2025-01-01T00:00:00.000Z",
-      "token": "<REPLACED-UUID-1>",
-      "uuid": "<REPLACED-UUID-2>",
-    },
-    "key": "<REPLACED-UUID-1>:user2",
-    "topic": "events_plugin_ingestion_overflow_test",
-    "value": {
-      "data": "{"distinct_id":"user2","uuid":"<REPLACED-UUID-2>","token":"<REPLACED-UUID-1>","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
-      "distinct_id": "user2",
-      "ip": "127.0.0.1",
-      "now": "2025-01-01T00:00:00.000Z",
-      "token": "<REPLACED-UUID-1>",
-      "uuid": "<REPLACED-UUID-2>",
     },
   },
 ]

--- a/nodejs/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
+++ b/nodejs/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
@@ -5,9 +5,12 @@ exports[`IngestionConsumer error handling should handle explicitly non retriable
   {
     "headers": {
       "distinct_id": "user-1",
+      "dlq_offset": "0",
+      "dlq_partition": "1",
       "dlq_reason": "test",
       "dlq_step": "prefetchHogFunctionsStep",
       "dlq_timestamp": "2025-01-01T00:00:00.000Z",
+      "dlq_topic": "test",
       "event": "$pageview",
       "now": "2025-01-01T00:00:00.000Z",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
@@ -22,6 +25,79 @@ exports[`IngestionConsumer error handling should handle explicitly non retriable
       "now": "2025-01-01T00:00:00.000Z",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
       "uuid": "<REPLACED-UUID-0>",
+    },
+  },
+]
+`;
+
+exports[`IngestionConsumer general overflow force overflow should force events with matching token:distinct_id to overflow: force overflow messages 1`] = `
+[
+  {
+    "headers": {
+      "distinct_id": "team1-user",
+      "event": "$pageview",
+      "now": "2025-01-01T00:00:00.000Z",
+      "redirect-step": "applyEventRestrictionsStep",
+      "redirect-timestamp": "2025-01-01T00:00:00.000Z",
+      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
+      "uuid": "<REPLACED-UUID-0>",
+    },
+    "key": "THIS IS NOT A TOKEN FOR TEAM 2:team1-user",
+    "topic": "events_plugin_ingestion_overflow_test",
+    "value": {
+      "data": "{"distinct_id":"team1-user","uuid":"<REPLACED-UUID-0>","token":"THIS IS NOT A TOKEN FOR TEAM 2","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
+      "distinct_id": "team1-user",
+      "ip": "127.0.0.1",
+      "now": "2025-01-01T00:00:00.000Z",
+      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
+      "uuid": "<REPLACED-UUID-0>",
+    },
+  },
+]
+`;
+
+exports[`IngestionConsumer general overflow force overflow should handle multiple token:distinct_id pairs in force overflow setting: force overflow messages multiple pairs 1`] = `
+[
+  {
+    "headers": {
+      "distinct_id": "user1",
+      "event": "$pageview",
+      "now": "2025-01-01T00:00:00.000Z",
+      "redirect-step": "applyEventRestrictionsStep",
+      "redirect-timestamp": "2025-01-01T00:00:00.000Z",
+      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
+      "uuid": "<REPLACED-UUID-0>",
+    },
+    "key": "THIS IS NOT A TOKEN FOR TEAM 2:user1",
+    "topic": "events_plugin_ingestion_overflow_test",
+    "value": {
+      "data": "{"distinct_id":"user1","uuid":"<REPLACED-UUID-0>","token":"THIS IS NOT A TOKEN FOR TEAM 2","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
+      "distinct_id": "user1",
+      "ip": "127.0.0.1",
+      "now": "2025-01-01T00:00:00.000Z",
+      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
+      "uuid": "<REPLACED-UUID-0>",
+    },
+  },
+  {
+    "headers": {
+      "distinct_id": "user2",
+      "event": "$pageview",
+      "now": "2025-01-01T00:00:00.000Z",
+      "redirect-step": "applyEventRestrictionsStep",
+      "redirect-timestamp": "2025-01-01T00:00:00.000Z",
+      "token": "THIS IS NOT A TOKEN FOR TEAM 3",
+      "uuid": "<REPLACED-UUID-1>",
+    },
+    "key": "THIS IS NOT A TOKEN FOR TEAM 3:user2",
+    "topic": "events_plugin_ingestion_overflow_test",
+    "value": {
+      "data": "{"distinct_id":"user2","uuid":"<REPLACED-UUID-1>","token":"THIS IS NOT A TOKEN FOR TEAM 3","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
+      "distinct_id": "user2",
+      "ip": "127.0.0.1",
+      "now": "2025-01-01T00:00:00.000Z",
+      "token": "THIS IS NOT A TOKEN FOR TEAM 3",
+      "uuid": "<REPLACED-UUID-1>",
     },
   },
 ]

--- a/nodejs/src/ingestion/ingestion-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.test.ts
@@ -161,7 +161,7 @@ describe('IngestionConsumer', () => {
 
         // hub.kafkaProducer = mockProducer
         team = await getFirstTeam(hub)
-        const team2Id = await createTeam(hub.postgres, team.organization_id)
+        const team2Id = await createTeam(hub.postgres, team.organization_id, 'THIS IS NOT A TOKEN FOR TEAM 3')
         team2 = (await getTeam(hub, team2Id))!
 
         jest.mocked(createEventPipelineRunnerV1Step).mockImplementation((...args) => {

--- a/nodejs/src/ingestion/ingestion-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.test.ts
@@ -933,7 +933,7 @@ describe('IngestionConsumer', () => {
             )
             expect(dlqMessages).toHaveLength(1)
             expect(dlqMessages[0].value).toEqual(parseJSON(messages[0].value!.toString()))
-            expect(dlqMessages[0].headers!['dlq-reason']).toEqual(error.message)
+            expect(dlqMessages[0].headers!['dlq_reason']).toEqual(error.message)
         })
     })
 

--- a/nodejs/src/ingestion/pipelines/docs/07-result-handling.test.ts
+++ b/nodejs/src/ingestion/pipelines/docs/07-result-handling.test.ts
@@ -126,10 +126,10 @@ describe('Result Handling', () => {
         expect(dlqMessage.value).toEqual(message.value)
         expect(dlqMessage.key).toEqual(message.key)
         expect(dlqMessage.headers).toMatchObject({
-            'dlq-reason': 'Invalid data format',
-            'dlq-step': 'validationStep',
+            dlq_reason: 'Invalid data format',
+            dlq_step: 'validationStep',
         })
-        expect(dlqMessage.headers['dlq-timestamp']).toBeDefined()
+        expect(dlqMessage.headers['dlq_timestamp']).toBeDefined()
     })
 
     /**

--- a/nodejs/src/worker/ingestion/pipeline-helpers.test.ts
+++ b/nodejs/src/worker/ingestion/pipeline-helpers.test.ts
@@ -431,12 +431,12 @@ describe('sendMessageToDLQ', () => {
                 team_id: '42',
                 distinct_id: 'test-user',
                 event: 'pageview',
-                'dlq-reason': 'Test error',
-                'dlq-step': stepName,
-                'dlq-timestamp': expect.any(String),
-                'dlq-topic': 'test-topic',
-                'dlq-partition': '0',
-                'dlq-offset': '123',
+                dlq_reason: 'Test error',
+                dlq_step: stepName,
+                dlq_timestamp: expect.any(String),
+                dlq_topic: 'test-topic',
+                dlq_partition: '0',
+                dlq_offset: '123',
             }),
         })
     })
@@ -502,7 +502,7 @@ describe('sendMessageToDLQ', () => {
         expect(mockKafkaProducer.produce).toHaveBeenCalledWith(
             expect.objectContaining({
                 headers: expect.objectContaining({
-                    'dlq-reason': 'String error',
+                    dlq_reason: 'String error',
                 }),
             })
         )

--- a/nodejs/src/worker/ingestion/pipeline-helpers.test.ts
+++ b/nodejs/src/worker/ingestion/pipeline-helpers.test.ts
@@ -434,6 +434,9 @@ describe('sendMessageToDLQ', () => {
                 'dlq-reason': 'Test error',
                 'dlq-step': stepName,
                 'dlq-timestamp': expect.any(String),
+                'dlq-topic': 'test-topic',
+                'dlq-partition': '0',
+                'dlq-offset': '123',
             }),
         })
     })

--- a/nodejs/src/worker/ingestion/pipeline-helpers.ts
+++ b/nodejs/src/worker/ingestion/pipeline-helpers.ts
@@ -238,12 +238,12 @@ export async function sendMessageToDLQ(
             value: originalMessage.value,
             key: originalMessage.key ?? null,
             headers: copyAndExtendHeaders(originalMessage, {
-                'dlq-reason': error instanceof Error ? error.message : String(error),
-                'dlq-step': step,
-                'dlq-timestamp': new Date().toISOString(),
-                'dlq-topic': originalMessage.topic,
-                'dlq-partition': String(originalMessage.partition),
-                'dlq-offset': String(originalMessage.offset),
+                dlq_reason: error instanceof Error ? error.message : String(error),
+                dlq_step: step,
+                dlq_timestamp: new Date().toISOString(),
+                dlq_topic: originalMessage.topic,
+                dlq_partition: String(originalMessage.partition),
+                dlq_offset: String(originalMessage.offset),
             }),
         })
     } catch (dlqError) {

--- a/nodejs/src/worker/ingestion/pipeline-helpers.ts
+++ b/nodejs/src/worker/ingestion/pipeline-helpers.ts
@@ -241,6 +241,9 @@ export async function sendMessageToDLQ(
                 'dlq-reason': error instanceof Error ? error.message : String(error),
                 'dlq-step': step,
                 'dlq-timestamp': new Date().toISOString(),
+                'dlq-topic': originalMessage.topic,
+                'dlq-partition': String(originalMessage.partition),
+                'dlq-offset': String(originalMessage.offset),
             }),
         })
     } catch (dlqError) {


### PR DESCRIPTION
## Problem

It's hard to trace the source messages from DLQ.

## Changes

- Adds new headers with topic name, partition and offset for DLQ'd messages.
- Changes the header names to use underscores for consistency

## How did you test this code?

Updated the tests