### PR TITLE
chore(endpoints): add insight picker modal for creating endpoints from insights

### DIFF
--- a/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModal.tsx
+++ b/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModal.tsx
@@ -29,7 +29,7 @@ export function AddInsightToDashboardModal(): JSX.Element {
     const { dashboard } = useValues(dashboardLogic)
 
     const handleClose = (): void => {
-        posthog.capture('insight dashboard modal closed')
+        posthog.capture('insight dashboard modal - closed')
         hideAddInsightToDashboardModal()
     }
 

--- a/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModal.tsx
+++ b/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModal.tsx
@@ -29,7 +29,7 @@ export function AddInsightToDashboardModal(): JSX.Element {
     const { dashboard } = useValues(dashboardLogic)
 
     const handleClose = (): void => {
-        posthog.capture('insight dashboard modal - closed')
+        posthog.capture('insight dashboard modal closed')
         hideAddInsightToDashboardModal()
     }
 

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -149,7 +149,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         typeof lastBreadcrumb?.name === 'string' ? lastBreadcrumb.name : insight.name || insight.derived_name
 
     const [addToDashboardModalOpen, setAddToDashboardModalOpenModal] = useState<boolean>(false)
-    const [endpointModalOpen, setEndpointModalOpen] = useState<boolean>(false)
     const [tablePreviewModalOpen, setTablePreviewModalOpen] = useState<boolean>(false)
     const [terraformModalOpen, setTerraformModalOpen] = useState<boolean>(false)
     const [selectedPreviewColumn, setSelectedPreviewColumn] = useState<string | null>('event_person_id')
@@ -261,8 +260,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                     )}
                     <NewDashboardModal />
                     <EndpointFromInsightModal
-                        isOpen={endpointModalOpen}
-                        closeModal={() => setEndpointModalOpen(false)}
                         tabId={insightProps.tabId || ''}
                         insightQuery={insightQuery as HogQLQuery | InsightQueryNode}
                         insightShortId={insight.short_id}
@@ -448,7 +445,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             <ButtonPrimitive
                                 onClick={() => {
                                     openCreateFromInsightModal()
-                                    setEndpointModalOpen(true)
                                 }}
                                 menuItem
                             >

--- a/products/endpoints/frontend/Endpoints.tsx
+++ b/products/endpoints/frontend/Endpoints.tsx
@@ -236,8 +236,6 @@ export const EndpointsTable = ({ tabId }: EndpointsTableProps): JSX.Element => {
             />
             {duplicateEndpoint && (
                 <EndpointFromInsightModal
-                    isOpen={!!duplicateEndpoint}
-                    closeModal={() => setDuplicateEndpoint(null)}
                     tabId={tabId}
                     insightQuery={duplicateEndpoint.query}
                     insightShortId={duplicateEndpoint.derived_from_insight ?? undefined}

--- a/products/endpoints/frontend/EndpointsScene.tsx
+++ b/products/endpoints/frontend/EndpointsScene.tsx
@@ -21,6 +21,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 
 import { Endpoints } from './Endpoints'
 import { EndpointsUsage } from './EndpointsUsage'
+import { InsightPickerEndpointModal } from './InsightPickerEndpointModal'
 import { endpointsLogic } from './endpointsLogic'
 import { endpointsUsageLogic } from './endpointsUsageLogic'
 import { OverlayForNewEndpointMenu } from './newEndpointMenu'
@@ -132,6 +133,7 @@ export function EndpointsScene({ tabId }: { tabId?: string }): JSX.Element {
                             action={() => router.actions.push(urls.sqlEditor({ outputTab: OutputTab.Endpoint }))}
                         />
                         <LemonTabs activeKey={activeTab} data-attr="endpoints-tabs" tabs={tabs} sceneInset />
+                        <InsightPickerEndpointModal tabId={tabId || ''} />
                     </SceneContent>
                 </BindLogic>
             </BindLogic>

--- a/products/endpoints/frontend/InsightPickerEndpointModal.tsx
+++ b/products/endpoints/frontend/InsightPickerEndpointModal.tsx
@@ -1,0 +1,139 @@
+import { useActions, useValues } from 'kea'
+import { BindLogic } from 'kea'
+
+import { IconCode2, IconFunnels, IconPlus, IconRetention, IconTrends } from '@posthog/icons'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { Popover } from 'lib/lemon-ui/Popover'
+import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
+import { SavedInsightsTable } from 'scenes/saved-insights/SavedInsightsTable'
+import { addSavedInsightsModalLogic } from 'scenes/saved-insights/addSavedInsightsModalLogic'
+import { urls } from 'scenes/urls'
+
+import { HogQLQuery, InsightQueryNode } from '~/queries/schema/schema-general'
+import { isNodeWithSource } from '~/queries/utils'
+import { InsightType, QueryBasedInsightModel } from '~/types'
+
+import { EndpointFromInsightModal } from './EndpointFromInsightModal'
+import { endpointLogic } from './endpointLogic'
+import { insightPickerEndpointModalLogic } from './insightPickerEndpointModalLogic'
+
+const QUICK_CREATE_TYPES = [
+    { type: InsightType.TRENDS, icon: IconTrends, label: 'Trend' },
+    { type: InsightType.FUNNELS, icon: IconFunnels, label: 'Funnel' },
+    { type: InsightType.RETENTION, icon: IconRetention, label: 'Retention' },
+]
+
+interface InsightPickerEndpointModalProps {
+    tabId: string
+}
+
+export function InsightPickerEndpointModal({ tabId }: InsightPickerEndpointModalProps): JSX.Element {
+    const { isOpen, selectedInsight, showMoreInsightTypes } = useValues(insightPickerEndpointModalLogic)
+    const { closeModal, selectInsight, toggleShowMoreInsightTypes } = useActions(insightPickerEndpointModalLogic)
+    const { openCreateFromInsightModal } = useActions(endpointLogic({ tabId }))
+
+    const insightQuery: HogQLQuery | InsightQueryNode | null = selectedInsight?.query
+        ? isNodeWithSource(selectedInsight.query)
+            ? (selectedInsight.query.source as HogQLQuery | InsightQueryNode)
+            : (selectedInsight.query as HogQLQuery | InsightQueryNode)
+        : null
+
+    const additionalTypes = Object.entries(INSIGHT_TYPES_METADATA).filter(
+        ([type, meta]) =>
+            meta.inMenu &&
+            type !== InsightType.JSON &&
+            type !== InsightType.HOG &&
+            !QUICK_CREATE_TYPES.some((qt) => qt.type === type)
+    )
+
+    return (
+        <>
+            <BindLogic logic={addSavedInsightsModalLogic} props={{}}>
+                <LemonModal
+                    title="New insight-based endpoint"
+                    onClose={closeModal}
+                    isOpen={isOpen}
+                    width="min(80vw, 64rem)"
+                >
+                    <div className="space-y-4">
+                        <div className="flex flex-wrap items-center gap-3 p-4 bg-surface-secondary rounded-lg">
+                            <IconPlus className="text-2xl text-secondary shrink-0" />
+                            <div className="flex-1 min-w-[200px]">
+                                <div className="font-semibold text-base">Create an endpoint from a new insight</div>
+                                <div className="text-sm text-secondary">
+                                    <>
+                                        Once the insight is saved, open the right side panel and click
+                                        <br /> <IconCode2 /> <code>Create endpoint</code>.
+                                    </>
+                                </div>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-2">
+                                {QUICK_CREATE_TYPES.map(({ type, icon: Icon, label }) => (
+                                    <LemonButton
+                                        key={type}
+                                        type="primary"
+                                        icon={<Icon />}
+                                        to={urls.insightNew({ type })}
+                                        tooltip={INSIGHT_TYPES_METADATA[type]?.description}
+                                        data-attr={`endpoint-quick-create-${type.toLowerCase()}`}
+                                    >
+                                        {label}
+                                    </LemonButton>
+                                ))}
+                                <Popover
+                                    visible={showMoreInsightTypes}
+                                    onClickOutside={() => toggleShowMoreInsightTypes()}
+                                    overlay={
+                                        <div className="p-2 space-y-1 min-w-48">
+                                            {additionalTypes.map(([type, metadata]) => {
+                                                const Icon = metadata.icon
+                                                return (
+                                                    <LemonButton
+                                                        key={type}
+                                                        type="tertiary"
+                                                        fullWidth
+                                                        icon={Icon ? <Icon /> : undefined}
+                                                        to={urls.insightNew({ type: type as InsightType })}
+                                                        data-attr={`endpoint-create-${type.toLowerCase()}`}
+                                                    >
+                                                        {metadata.name}
+                                                    </LemonButton>
+                                                )
+                                            })}
+                                        </div>
+                                    }
+                                >
+                                    <LemonButton type="secondary" onClick={() => toggleShowMoreInsightTypes()}>
+                                        More
+                                    </LemonButton>
+                                </Popover>
+                            </div>
+                        </div>
+
+                        <div>
+                            <div className="font-semibold text-base mb-2">
+                                Create an endpoint from an existing insight
+                            </div>
+                            <SavedInsightsTable
+                                onToggle={(insight: QueryBasedInsightModel) => {
+                                    selectInsight(insight)
+                                    openCreateFromInsightModal()
+                                }}
+                            />
+                        </div>
+                    </div>
+                </LemonModal>
+            </BindLogic>
+
+            {insightQuery && (
+                <EndpointFromInsightModal
+                    tabId={tabId}
+                    insightQuery={insightQuery}
+                    insightShortId={selectedInsight?.short_id}
+                />
+            )}
+        </>
+    )
+}

--- a/products/endpoints/frontend/endpointLogic.tsx
+++ b/products/endpoints/frontend/endpointLogic.tsx
@@ -17,6 +17,7 @@ import { EndpointType, EndpointVersionType } from '~/types'
 
 import type { endpointLogicType } from './endpointLogicType'
 import { endpointsLogic } from './endpointsLogic'
+import { insightPickerEndpointModalLogic } from './insightPickerEndpointModalLogic'
 
 export type CodeExampleTab = 'terminal' | 'python' | 'nodejs'
 
@@ -46,6 +47,7 @@ export const endpointLogic = kea<endpointLogicType>([
         setIsUpdateMode: (isUpdateMode: boolean) => ({ isUpdateMode }),
         setSelectedEndpointName: (selectedEndpointName: string | null) => ({ selectedEndpointName }),
         openCreateFromInsightModal: true,
+        closeCreateFromInsightModal: true,
         setDuplicateEndpoint: (endpoint: EndpointType | null) => ({ endpoint }),
         createEndpoint: (request: EndpointRequest) => ({ request }),
         createEndpointSuccess: (response: any) => ({ response }),
@@ -98,10 +100,20 @@ export const endpointLogic = kea<endpointLogicType>([
                 setSelectedEndpointName: (_, { selectedEndpointName }) => selectedEndpointName,
             },
         ],
+        createFromInsightModalOpen: [
+            false,
+            {
+                openCreateFromInsightModal: () => true,
+                setDuplicateEndpoint: (_, { endpoint }) => !!endpoint,
+                closeCreateFromInsightModal: () => false,
+                createEndpointSuccess: () => false,
+            },
+        ],
         duplicateEndpoint: [
             null as EndpointType | null,
             {
                 setDuplicateEndpoint: (_, { endpoint }) => endpoint,
+                createEndpointSuccess: () => null,
             },
         ],
         // Extend the loader reducer to clear on action
@@ -181,6 +193,10 @@ export const endpointLogic = kea<endpointLogicType>([
             openCreateFromInsightModal: () => {
                 actions.loadEndpoints()
             },
+            closeCreateFromInsightModal: () => {
+                actions.setDuplicateEndpoint(null)
+                insightPickerEndpointModalLogic.findMounted()?.actions.clearSelectedInsight()
+            },
             createEndpoint: async ({ request }) => {
                 try {
                     if (request.name) {
@@ -198,6 +214,7 @@ export const endpointLogic = kea<endpointLogicType>([
                 actions.setEndpointName('')
                 actions.setEndpointDescription('')
                 actions.loadEndpoints()
+                insightPickerEndpointModalLogic.findMounted()?.actions.closeModal()
                 lemonToast.success(<>Endpoint created</>, {
                     button: {
                         label: 'View',

--- a/products/endpoints/frontend/insightPickerEndpointModalLogic.ts
+++ b/products/endpoints/frontend/insightPickerEndpointModalLogic.ts
@@ -1,0 +1,62 @@
+import { actions, kea, listeners, path, reducers } from 'kea'
+import { actionToUrl, urlToAction } from 'kea-router'
+
+import { addSavedInsightsModalLogic } from 'scenes/saved-insights/addSavedInsightsModalLogic'
+import { urls } from 'scenes/urls'
+
+import { QueryBasedInsightModel } from '~/types'
+
+import type { insightPickerEndpointModalLogicType } from './insightPickerEndpointModalLogicType'
+
+export const insightPickerEndpointModalLogic = kea<insightPickerEndpointModalLogicType>([
+    path(['products', 'endpoints', 'frontend', 'insightPickerEndpointModalLogic']),
+    actions({
+        openModal: true,
+        closeModal: true,
+        selectInsight: (insight: QueryBasedInsightModel) => ({ insight }),
+        clearSelectedInsight: true,
+        toggleShowMoreInsightTypes: true,
+    }),
+    reducers({
+        isOpen: [
+            false,
+            {
+                openModal: () => true,
+                closeModal: () => false,
+            },
+        ],
+        selectedInsight: [
+            null as QueryBasedInsightModel | null,
+            {
+                selectInsight: (_, { insight }) => insight,
+                clearSelectedInsight: () => null,
+                closeModal: () => null,
+            },
+        ],
+        showMoreInsightTypes: [
+            false,
+            {
+                toggleShowMoreInsightTypes: (state) => !state,
+                closeModal: () => false,
+            },
+        ],
+    }),
+    listeners(() => ({
+        closeModal: () => {
+            addSavedInsightsModalLogic.findMounted()?.actions.setModalFilters({}, false)
+        },
+    })),
+    actionToUrl(() => ({
+        openModal: () => [urls.endpoints(), { new: 'insight' }],
+        closeModal: () => [urls.endpoints(), {}],
+    })),
+    urlToAction(({ actions, values }) => ({
+        [urls.endpoints()]: (_, searchParams) => {
+            if (searchParams.new === 'insight' && !values.isOpen) {
+                actions.openModal()
+            } else if (searchParams.new !== 'insight' && values.isOpen) {
+                actions.closeModal()
+            }
+        },
+    })),
+])

--- a/products/endpoints/frontend/newEndpointMenu.tsx
+++ b/products/endpoints/frontend/newEndpointMenu.tsx
@@ -1,3 +1,4 @@
+import { useActions } from 'kea'
 import { router } from 'kea-router'
 
 import { IconGraph, IconServer } from '@posthog/icons'
@@ -6,41 +7,43 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { OutputTab } from 'scenes/data-warehouse/editor/outputPaneLogic'
 import { urls } from 'scenes/urls'
 
+import { insightPickerEndpointModalLogic } from './insightPickerEndpointModalLogic'
+
 interface EndpointTypeOption {
     icon: React.ComponentType
     name: string
     description: string
-    url: string
+    onClick: () => void
     dataAttr: string
 }
 
-const ENDPOINT_TYPE_OPTIONS: EndpointTypeOption[] = [
-    {
-        icon: IconServer,
-        name: 'HogQL endpoint',
-        description: 'Create an endpoint from a HogQL query in the SQL editor.',
-        url: urls.sqlEditor({ outputTab: OutputTab.Endpoint }),
-        dataAttr: 'new-endpoint-overlay-hogql',
-    },
-    {
-        icon: IconGraph,
-        name: 'Insight endpoint',
-        description: 'Create an endpoint from a new insight.',
-        url: urls.insightNew(),
-        dataAttr: 'new-endpoint-overlay-insight',
-    },
-]
-
 export function OverlayForNewEndpointMenu(): JSX.Element {
+    const { openModal } = useActions(insightPickerEndpointModalLogic)
+
+    const options: EndpointTypeOption[] = [
+        {
+            icon: IconServer,
+            name: 'SQL-based endpoint',
+            description: 'Create an endpoint from a query in the SQL editor.',
+            onClick: () => router.actions.push(urls.sqlEditor({ outputTab: OutputTab.Endpoint })),
+            dataAttr: 'new-endpoint-overlay-hogql',
+        },
+        {
+            icon: IconGraph,
+            name: 'Insight-based endpoint',
+            description: 'Create an endpoint from a new or existing insight.',
+            onClick: openModal,
+            dataAttr: 'new-endpoint-overlay-insight',
+        },
+    ]
+
     return (
         <>
-            {ENDPOINT_TYPE_OPTIONS.map((option) => (
+            {options.map((option) => (
                 <LemonButton
                     key={option.name}
                     icon={<option.icon />}
-                    onClick={() => {
-                        router.actions.push(option.url)
-                    }}
+                    onClick={option.onClick}
                     data-attr={option.dataAttr}
                     data-attr-endpoint-type={option.name}
                     fullWidth


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

not a nice xp creating a new endpoint based on an insight - you're pretty much on your own.

## Changes

- add a modal to select an existing insight to create an endpoint from, or create a new insight
- remove option to update an endpoint from the `Create new endpoint from insight` modal - no business here. if you want to use a different insight for your endpoint either edit the insight on the endpoint page, create a new endpoint or i might add an action like 'use different insight for this endpoint'
- url to add /endpoints?new=insight

https://github.com/user-attachments/assets/4b9148ff-533f-4c56-8f47-ceabe9b70e25


<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- click around locally

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

noo

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->