### PR TITLE
feat(signals): Track video generation

### DIFF
--- a/ee/hogai/videos/utils.py
+++ b/ee/hogai/videos/utils.py
@@ -7,9 +7,7 @@ from pymediainfo import MediaInfo
 logger = structlog.get_logger(__name__)
 
 
-def get_video_duration_s(video_bytes: bytes) -> int:
-    """Extract duration in seconds from video bytes to understand when the export UI finished rendering"""
-    media_info = MediaInfo.parse(BytesIO(video_bytes))
+def _extract_duration_s(media_info: MediaInfo) -> int:
     for track in media_info.tracks:
         if track.track_type == "General":
             if track.duration is None:
@@ -17,3 +15,13 @@ def get_video_duration_s(video_bytes: bytes) -> int:
             # Convert ms to seconds, ceil to avoid grey "not-rendered" frames at the start
             return int(math.ceil(track.duration / 1000.0))
     raise ValueError("No General track found in video to extract duration from")
+
+
+def get_video_duration_s(video_bytes: bytes) -> int:
+    """Extract duration in seconds from video bytes."""
+    return _extract_duration_s(MediaInfo.parse(BytesIO(video_bytes)))
+
+
+def get_video_duration_from_path_s(path: str) -> int:
+    """Extract duration in seconds from a video file on disk."""
+    return _extract_duration_s(MediaInfo.parse(path))

--- a/posthog/temporal/exports_video/activities.py
+++ b/posthog/temporal/exports_video/activities.py
@@ -7,10 +7,12 @@ from typing import Any
 from django.db import close_old_connections
 
 import structlog
+import posthoganalytics
 from temporalio import activity
 
 from posthog.schema import ReplayInactivityPeriod
 
+from posthog.event_usage import groups
 from posthog.models.exported_asset import ExportedAsset, get_public_access_token, save_content_from_file
 from posthog.tasks.exports.video_exporter import RecordReplayToFileOptions
 from posthog.utils import absolute_uri
@@ -107,6 +109,55 @@ def build_export_context_activity(exported_asset_id: int) -> dict[str, Any]:
     }
 
 
+def _track_video_export_started(asset: ExportedAsset, build: dict[str, Any]) -> None:
+    try:
+        posthoganalytics.capture(
+            distinct_id=asset.created_by.distinct_id if asset.created_by else str(asset.team.uuid),
+            event="video export started",
+            properties={
+                **asset.get_analytics_metadata(),
+                "recording_duration_s": build["duration"],
+                "playback_speed": build.get("playback_speed", 1),
+                # Crucial to separate summaries from regular exports
+                "use_puppeteer": build.get("use_puppeteer", False),
+            },
+            groups=groups(asset.team.organization, asset.team),
+        )
+    except Exception:
+        logger.exception("Failed to capture video export started event")
+        # Not failing, as failed tracking should not block the export
+
+
+def _track_video_export_completed(asset: ExportedAsset, build: dict[str, Any], video_path: str, file_size: int) -> None:
+    try:
+        from ee.hogai.videos.utils import get_video_duration_from_path_s
+
+        video_duration_s = get_video_duration_from_path_s(video_path)
+        recording_duration_s = build["duration"]
+        # How much of the session was skipped in the video as inactivity
+        inactivity_skip_ratio = (
+            round(1 - (video_duration_s / recording_duration_s), 2) if recording_duration_s > 0 else 0
+        )
+        posthoganalytics.capture(
+            distinct_id=asset.created_by.distinct_id if asset.created_by else str(asset.team.uuid),
+            event="video export completed",
+            properties={
+                **asset.get_analytics_metadata(),
+                "recording_duration_s": recording_duration_s,
+                "video_duration_s": video_duration_s,
+                "inactivity_skip_ratio": inactivity_skip_ratio,
+                "playback_speed": build.get("playback_speed", 1),
+                "file_size_bytes": file_size,
+                # Crucial to separate summaries from regular exports
+                "use_puppeteer": build.get("use_puppeteer", False),
+            },
+            groups=groups(asset.team.organization, asset.team),
+        )
+    except Exception:
+        logger.exception("Failed to capture video export completed event")
+        # Not failing, as failed tracking should not block the export
+
+
 @activity.defn
 def record_and_persist_video_activity(build: dict[str, Any]) -> None:
     """Record replay to file and persist in a single activity. Must run on same worker
@@ -115,8 +166,10 @@ def record_and_persist_video_activity(build: dict[str, Any]) -> None:
     from posthog.tasks.exports.video_exporter import record_replay_to_file
 
     close_old_connections()
-    asset = ExportedAsset.objects.select_related("team").get(pk=build["exported_asset_id"])
-
+    asset = ExportedAsset.objects.select_related("team", "team__organization", "created_by").get(
+        pk=build["exported_asset_id"]
+    )
+    _track_video_export_started(asset, build)
     with tempfile.TemporaryDirectory(prefix="ph-video-export-") as tmp_dir:
         tmp_path = os.path.join(tmp_dir, f"{uuid.uuid4()}.{build['tmp_ext']}")
         inactivity_periods = record_replay_to_file(
@@ -149,4 +202,5 @@ def record_and_persist_video_activity(build: dict[str, Any]) -> None:
             raise RuntimeError(
                 f"Video file too large: {file_size / (1024 * 1024):.1f}MB exceeds {MAX_FILE_SIZE // (1024 * 1024)}MB limit"
             )
+        _track_video_export_completed(asset, build, tmp_path, file_size)
         save_content_from_file(asset, tmp_path)


### PR DESCRIPTION
## Problem
- We don't track video exports properly

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Now we can analyze:
- How many videos do we export
- The average duration
- Success rate
- % of inactivity
- and so on

<img width="1276" height="374" alt="CleanShot 2026-02-13 at 16 46 29" src="https://github.com/user-attachments/assets/7347b166-1989-40e2-a130-7660fe1852aa" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
