### PR TITLE
chore(batch-exports): remove temporary keyless S3 auth setting after rollout

### DIFF
--- a/posthog/settings/batch_exports.py
+++ b/posthog/settings/batch_exports.py
@@ -92,6 +92,3 @@ BATCH_EXPORTS_ENABLE_BILLING_CHECK: bool = get_from_env(
 BATCH_EXPORTS_PERSONS_LIMITED_EXPORT_TEAM_IDS: list[str] = get_list(
     os.getenv("BATCH_EXPORTS_PERSONS_LIMITED_EXPORT_TEAM_IDS", "")
 )
-# Temporary setting to rollout keyless S3 authentication for batch exports.
-# TODO: Remove after testing.
-BATCH_EXPORT_USE_KEYLESS_S3_AUTH: bool = get_from_env("BATCH_EXPORT_USE_KEYLESS_S3_AUTH", False, type_cast=str_to_bool)

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -85,10 +85,8 @@ def _get_s3_credentials() -> tuple[str | None, str | None]:
 
     If keyless S3 auth is enabled, we use no credentials as the IAM role will be used to authenticate.
     Otherwise, we use the credentials from the object storage settings.
-
-    TODO: Remove BATCH_EXPORT_USE_KEYLESS_S3_AUTH after rollout.
     """
-    use_keyless_s3_auth = not _is_local_or_test() and settings.BATCH_EXPORT_USE_KEYLESS_S3_AUTH
+    use_keyless_s3_auth = not _is_local_or_test()
     if use_keyless_s3_auth:
         aws_access_key_id = None
         aws_secret_access_key = None


### PR DESCRIPTION
## Problem

In PR https://github.com/PostHog/posthog/pull/46953 we implemented keyless S3 auth in our production environments. We used an env var to control the rollout. Since it went successfully we can now clean this up. 

## Changes

Remove `BATCH_EXPORT_USE_KEYLESS_S3_AUTH` since it is true in all envs now.