### PR TITLE
fix: Revenue analytics filter positioning

### DIFF
--- a/frontend/src/lib/components/AppShortcuts/AppShortcut.tsx
+++ b/frontend/src/lib/components/AppShortcuts/AppShortcut.tsx
@@ -1,4 +1,5 @@
-import { ReactElement, cloneElement, isValidElement } from 'react'
+import { useMergeRefs } from '@floating-ui/react'
+import { ReactElement, cloneElement, forwardRef, isValidElement } from 'react'
 
 import { cn } from 'lib/utils/css-classes'
 
@@ -22,16 +23,11 @@ interface AppShortcutProps extends Omit<AppShortcutType, 'ref' | 'keybind' | 'in
     disabled?: boolean
 }
 
-export function AppShortcut({
-    children,
-    name,
-    keybind,
-    intent,
-    interaction,
-    scope = 'global',
-    disabled = false,
-    priority = 0,
-}: AppShortcutProps): ReactElement {
+// forwardRef is needed so parent components (e.g. Popover) can inject refs through AppShortcut to the child element
+export const AppShortcut = forwardRef<HTMLElement, AppShortcutProps>(function AppShortcut(
+    { children, name, keybind, intent, interaction, scope = 'global', disabled = false, priority = 0 },
+    forwardedRef
+): ReactElement {
     const { callbackRef } = useAppShortcut({
         name,
         keybind,
@@ -41,6 +37,8 @@ export function AppShortcut({
         disabled,
         priority,
     })
+
+    const mergedRef = useMergeRefs([callbackRef, forwardedRef])
 
     if (!isValidElement(children)) {
         throw new Error('AppShortcut requires a single React element child')
@@ -66,7 +64,7 @@ export function AppShortcut({
     }
 
     return cloneElement(children, {
-        ref: callbackRef,
+        ref: mergedRef,
         'data-shortcut-name': name,
         'data-shortcut-keybind': keybindStrings,
         'data-shortcut-intent': intent,
@@ -74,4 +72,4 @@ export function AppShortcut({
         tooltip: finalTooltip,
         className: cn(childProps.className as string | undefined),
     } as Record<string, unknown>)
-}
+})

--- a/frontend/src/lib/components/AppShortcuts/AppShortcut.tsx
+++ b/frontend/src/lib/components/AppShortcuts/AppShortcut.tsx
@@ -23,7 +23,6 @@ interface AppShortcutProps extends Omit<AppShortcutType, 'ref' | 'keybind' | 'in
     disabled?: boolean
 }
 
-// forwardRef is needed so parent components (e.g. Popover) can inject refs through AppShortcut to the child element
 export const AppShortcut = forwardRef<HTMLElement, AppShortcutProps>(function AppShortcut(
     { children, name, keybind, intent, interaction, scope = 'global', disabled = false, priority = 0 },
     forwardedRef

--- a/frontend/src/lib/components/FilterBar.tsx
+++ b/frontend/src/lib/components/FilterBar.tsx
@@ -38,15 +38,13 @@ export const FilterBar = ({ top, left, right, className, showBorderBottom }: Fil
                     </div>
                 </div>
 
-                {/* On more than mobile, just display Foldable Fields, on smaller delegate displaying it to the expanded state */}
-                <div className="hidden sm:flex gap-2">
-                    <FoldableFilters>{right}</FoldableFilters>
-                </div>
-
+                {/* Render right content once - on mobile it's collapsible, on sm+ always visible */}
                 <div
                     className={clsx(
-                        'flex sm:hidden flex-col gap-2 overflow-hidden transition-all duration-200',
-                        expanded ? 'max-h-[500px]' : 'max-h-0'
+                        'flex gap-2',
+                        'sm:max-h-none',
+                        'max-sm:flex-col max-sm:overflow-hidden max-sm:transition-all max-sm:duration-200',
+                        expanded ? 'max-sm:max-h-[500px]' : 'max-sm:max-h-0'
                     )}
                 >
                     <FoldableFilters>{right}</FoldableFilters>


### PR DESCRIPTION
## Problem

Filter position was broken:

<img width="574" height="241" alt="CleanShot 2026-02-13 at 16 13 18" src="https://github.com/user-attachments/assets/899de313-8324-430d-8868-d37a3b409b2e" />

There were actually two bugs here:
- the first was that `AppShortcut` wasn't forwarding refs, and Popover needs a ref on its child to calculate its position. 
- the second was that `right` was being rendered twice for different viewports inside `FilterBar`. So when using the filter keyboard shortcut, `AppShortcut` was pointing to the wrong one (the offscreen mobile one) meaning it was being rendered at [0,0] rather than the visible filters.

## Changes

- use `forwardRef` with `AppShortcut`, and `useMergeRefs` to ensure the shortcut is still able to properly handle the click
- only render `right` once, making the CSS on the `div` conditional per viewport.

## How did you test this code?

Verified fix locally - shortcut now opens it correctly. Works for both viewport breakpoints.

Did some spot checks against other usages to ensure I'm not breaking anything.