### PR TITLE
fix(deduplicator): rebalance tracking counter bug

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4704,6 +4704,7 @@ dependencies = [
  "opentelemetry 0.22.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk 0.22.1",
+ "rand 0.8.5",
  "rayon",
  "rdkafka",
  "rocksdb",

--- a/rust/kafka-deduplicator/Cargo.toml
+++ b/rust/kafka-deduplicator/Cargo.toml
@@ -30,6 +30,7 @@ once_cell = "1.21"
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true }
+rand = { workspace = true }
 rayon = "1.10.0"
 rdkafka = { workspace = true }
 rocksdb = "0.24.0"

--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -105,8 +105,8 @@ impl Default for CheckpointConfig {
             s3_attempt_timeout: Duration::from_secs(20),
             s3_max_retries: 3,
             checkpoint_import_attempt_depth: 10,
-            max_concurrent_checkpoint_file_downloads: 50,
-            max_concurrent_checkpoint_file_uploads: 25,
+            max_concurrent_checkpoint_file_downloads: 100,
+            max_concurrent_checkpoint_file_uploads: 100,
             checkpoint_partition_import_timeout: Duration::from_secs(240),
         }
     }

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -30,6 +30,7 @@ use crate::store_manager::StoreManager;
 use anyhow::Result;
 use chrono::Utc;
 use dashmap::DashMap;
+use rand::seq::SliceRandom;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -173,11 +174,12 @@ impl CheckpointManager {
                     // the inner loop can block but if we miss a few ticks before
                     // completing the full partition loop, it's OK
                     _ = interval.tick() => {
-                        let candidates: Vec<Partition> = store_manager
+                        let mut candidates: Vec<Partition> = store_manager
                             .stores()
                             .iter()
                             .map(|entry| entry.key().clone())
                             .collect();
+                        candidates.shuffle(&mut rand::thread_rng());
                         let store_count = candidates.len();
                         if store_count == 0 {
                             debug!("No stores to flush");

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -267,12 +267,12 @@ pub struct Config {
     // Limits memory usage by bounding the number of in-flight HTTP connections
     // Critical during rebalance when many partitions are assigned simultaneously
     // Higher values speed up rebalance; streaming bounds memory per download to ~8KB
-    #[envconfig(default = "50")]
+    #[envconfig(default = "100")]
     pub max_concurrent_checkpoint_file_downloads: usize,
 
     // Maximum concurrent S3 file uploads during checkpoint export
     // Less critical than downloads since uploads are bounded by max_concurrent_checkpoints
-    #[envconfig(default = "25")]
+    #[envconfig(default = "100")]
     pub max_concurrent_checkpoint_file_uploads: usize,
 
     // Maximum time allowed for a complete checkpoint import for a single partition (seconds).


### PR DESCRIPTION
## Problem
Recent change to minimize rebalance churn and extra checkpoint imports from S3 carried a bug in rebalance tracking that was blocking exports due to counter underflow
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Fix rebalance tracking bugs
* Raise default S3 upload/download limits on `object_store` as recent bucket path changes unlocks more GET/PUT bandwidth we can use to stay within `session.timeout.ms` window per-pod 🤞 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
