### PR TITLE
fix(funnels): fix data warehouse id column with decimal type

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -493,7 +493,7 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
                             f"""tupleElement((
                                 throwIf(isNull({{id_field}}), {{exception_message}}),
                                 toUUIDOrDefault(
-                                    {{id_field}},
+                                    toString({{id_field}}),
                                     reinterpretAsUUID(md5(concat({{table_prefix}}, toString({{id_field}}))))
                                 )
                             ), 2)""",

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_data_warehouse.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_data_warehouse.ambr
@@ -30,12 +30,12 @@
         FROM
           (SELECT toTimeZone(e.created, 'UTC') AS timestamp,
                   e.user_id AS aggregation_target,
-                  tupleElement(tuple(throwIf(isNull(e.uuid), 'Encountered a null value in posthog_test_test_table_1.uuid, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(e.uuid, reinterpretAsUUID(hex(MD5(concat('posthog_test_test_table_1_0_', ifNull(toString(e.uuid), ''))))))), 2) AS uuid,
+                  tupleElement(tuple(throwIf(isNull(e.uuid), 'Encountered a null value in posthog_test_test_table_1.uuid, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(toString(e.uuid), reinterpretAsUUID(hex(MD5(concat('posthog_test_test_table_1_0_', ifNull(toString(e.uuid), ''))))))), 2) AS uuid,
                   NULL AS `$session_id`,
                   NULL AS `$window_id`,
                   if(1, 1, 0) AS step_0,
                   if(1, 1, 0) AS step_1
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `uuid` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `properties` Nullable(String), `id_with_nulls` Nullable(Int64)') AS e
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `uuid` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `id_decimal` Decimal(18, 2), `properties` Nullable(String), `id_with_nulls` Nullable(Int64)') AS e
            WHERE and(and(greaterOrEquals(timestamp, toDateTime64('2025-11-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('2025-11-07 23:59:59.999999', 6, 'UTC'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -115,12 +115,12 @@
               WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('$pageview'))), ifNull(equals(step_0, 1), 0))
               UNION ALL SELECT toTimeZone(e.created, 'UTC') AS timestamp,
                                accurateCastOrNull(e.user_id, 'UUID') AS aggregation_target,
-                               tupleElement(tuple(throwIf(isNull(e.uuid), 'Encountered a null value in posthog_test_test_table_1.uuid, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(e.uuid, reinterpretAsUUID(hex(MD5(concat('posthog_test_test_table_1_0_', ifNull(toString(e.uuid), ''))))))), 2) AS uuid,
+                               tupleElement(tuple(throwIf(isNull(e.uuid), 'Encountered a null value in posthog_test_test_table_1.uuid, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(toString(e.uuid), reinterpretAsUUID(hex(MD5(concat('posthog_test_test_table_1_0_', ifNull(toString(e.uuid), ''))))))), 2) AS uuid,
                                NULL AS `$session_id`,
                                NULL AS `$window_id`,
                                0 AS step_0,
                                if(1, 1, 0) AS step_1
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `uuid` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `properties` Nullable(String), `id_with_nulls` Nullable(Int64)') AS e
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `uuid` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `id_decimal` Decimal(18, 2), `properties` Nullable(String), `id_with_nulls` Nullable(Int64)') AS e
               WHERE and(and(greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), ifNull(equals(step_1, 1), 0))) AS e)
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -176,12 +176,12 @@
         FROM
           (SELECT toTimeZone(e.created, 'UTC') AS timestamp,
                   e.user_id AS aggregation_target,
-                  tupleElement(tuple(throwIf(isNull(e.id), 'Encountered a null value in posthog_test_test_table_1.id, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(e.id, reinterpretAsUUID(hex(MD5(concat('posthog_test_test_table_1_0_', ifNull(toString(e.id), ''))))))), 2) AS uuid,
+                  tupleElement(tuple(throwIf(isNull(e.id), 'Encountered a null value in posthog_test_test_table_1.id, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(toString(e.id), reinterpretAsUUID(hex(MD5(concat('posthog_test_test_table_1_0_', ifNull(toString(e.id), ''))))))), 2) AS uuid,
                   NULL AS `$session_id`,
                   NULL AS `$window_id`,
                   if(1, 1, 0) AS step_0,
                   if(1, 1, 0) AS step_1
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `uuid` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `properties` Nullable(String), `id_with_nulls` Nullable(Int64)') AS e
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `uuid` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `id_decimal` Decimal(18, 2), `properties` Nullable(String), `id_with_nulls` Nullable(Int64)') AS e
            WHERE and(and(greaterOrEquals(timestamp, toDateTime64('2025-11-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('2025-11-07 23:59:59.999999', 6, 'UTC'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -237,12 +237,12 @@
         FROM
           (SELECT toTimeZone(e.created, 'UTC') AS timestamp,
                   e.user_id AS aggregation_target,
-                  tupleElement(tuple(throwIf(isNull(e.id_with_nulls), 'Encountered a null value in posthog_test_test_table_1.id_with_nulls, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(e.id_with_nulls, reinterpretAsUUID(hex(MD5(concat('posthog_test_test_table_1_0_', ifNull(toString(e.id_with_nulls), ''))))))), 2) AS uuid,
+                  tupleElement(tuple(throwIf(isNull(e.id_with_nulls), 'Encountered a null value in posthog_test_test_table_1.id_with_nulls, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(toString(e.id_with_nulls), reinterpretAsUUID(hex(MD5(concat('posthog_test_test_table_1_0_', ifNull(toString(e.id_with_nulls), ''))))))), 2) AS uuid,
                   NULL AS `$session_id`,
                   NULL AS `$window_id`,
                   if(1, 1, 0) AS step_0,
                   if(1, 1, 0) AS step_1
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `uuid` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `properties` Nullable(String), `id_with_nulls` Nullable(Int64)') AS e
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `uuid` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `id_decimal` Decimal(18, 2), `properties` Nullable(String), `id_with_nulls` Nullable(Int64)') AS e
            WHERE and(and(greaterOrEquals(timestamp, toDateTime64('2025-11-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('2025-11-07 23:59:59.999999', 6, 'UTC'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -298,12 +298,12 @@
         FROM
           (SELECT toTimeZone(e.created, 'UTC') AS timestamp,
                   e.user_id AS aggregation_target,
-                  tupleElement(tuple(throwIf(isNull(e.id_with_nulls), 'Encountered a null value in posthog_test_test_table_1.id_with_nulls, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(e.id_with_nulls, reinterpretAsUUID(hex(MD5(concat('posthog_test_test_table_1_0_', ifNull(toString(e.id_with_nulls), ''))))))), 2) AS uuid,
+                  tupleElement(tuple(throwIf(isNull(e.id_with_nulls), 'Encountered a null value in posthog_test_test_table_1.id_with_nulls, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(toString(e.id_with_nulls), reinterpretAsUUID(hex(MD5(concat('posthog_test_test_table_1_0_', ifNull(toString(e.id_with_nulls), ''))))))), 2) AS uuid,
                   NULL AS `$session_id`,
                   NULL AS `$window_id`,
                   if(isNotNull(e.id_with_nulls), 1, 0) AS step_0,
                   if(isNotNull(e.id_with_nulls), 1, 0) AS step_1
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `uuid` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `properties` Nullable(String), `id_with_nulls` Nullable(Int64)') AS e
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `uuid` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `id_decimal` Decimal(18, 2), `properties` Nullable(String), `id_with_nulls` Nullable(Int64)') AS e
            WHERE and(and(greaterOrEquals(timestamp, toDateTime64('2025-11-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('2025-11-07 23:59:59.999999', 6, 'UTC'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -373,7 +373,7 @@
            FROM
              (SELECT toTimeZone(e.created_date, 'UTC') AS timestamp,
                      coalesce(e.converted_opportunity_id, e.id) AS aggregation_target,
-                     tupleElement(tuple(throwIf(isNull(e.id), 'Encountered a null value in posthog_test_salesforce_lead.id, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(e.id, reinterpretAsUUID(hex(MD5(concat('posthog_test_salesforce_lead_0_', ifNull(toString(e.id), ''))))))), 2) AS uuid,
+                     tupleElement(tuple(throwIf(isNull(e.id), 'Encountered a null value in posthog_test_salesforce_lead.id, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(toString(e.id), reinterpretAsUUID(hex(MD5(concat('posthog_test_salesforce_lead_0_', ifNull(toString(e.id), ''))))))), 2) AS uuid,
                      NULL AS `$session_id`,
                      NULL AS `$window_id`,
                      if(1, 1, 0) AS step_0,
@@ -383,7 +383,7 @@
               WHERE and(and(greaterOrEquals(timestamp, toDateTime64('2024-05-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('2024-06-30 23:59:59.999999', 6, 'UTC'))), ifNull(equals(step_0, 1), 0))
               UNION ALL SELECT toTimeZone(e.created_date, 'UTC') AS timestamp,
                                e.id AS aggregation_target,
-                               tupleElement(tuple(throwIf(isNull(e.id), 'Encountered a null value in posthog_test_salesforce_opportunity.id, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(e.id, reinterpretAsUUID(hex(MD5(concat('posthog_test_salesforce_opportunity_1_', ifNull(toString(e.id), ''))))))), 2) AS uuid,
+                               tupleElement(tuple(throwIf(isNull(e.id), 'Encountered a null value in posthog_test_salesforce_opportunity.id, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(toString(e.id), reinterpretAsUUID(hex(MD5(concat('posthog_test_salesforce_opportunity_1_', ifNull(toString(e.id), ''))))))), 2) AS uuid,
                                NULL AS `$session_id`,
                                NULL AS `$window_id`,
                                0 AS step_0,
@@ -393,7 +393,7 @@
               WHERE and(and(greaterOrEquals(timestamp, toDateTime64('2024-05-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('2024-06-30 23:59:59.999999', 6, 'UTC'))), ifNull(equals(step_1, 1), 0))
               UNION ALL SELECT e.close_date AS timestamp,
                                e.id AS aggregation_target,
-                               tupleElement(tuple(throwIf(isNull(e.id), 'Encountered a null value in posthog_test_salesforce_opportunity.id, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(e.id, reinterpretAsUUID(hex(MD5(concat('posthog_test_salesforce_opportunity_2_', ifNull(toString(e.id), ''))))))), 2) AS uuid,
+                               tupleElement(tuple(throwIf(isNull(e.id), 'Encountered a null value in posthog_test_salesforce_opportunity.id, but a non-null value is required. Please ensure this column contains no null values, or add a filter to exclude rows with null values.'), toUUIDOrDefault(toString(e.id), reinterpretAsUUID(hex(MD5(concat('posthog_test_salesforce_opportunity_2_', ifNull(toString(e.id), ''))))))), 2) AS uuid,
                                NULL AS `$session_id`,
                                NULL AS `$window_id`,
                                0 AS step_0,

--- a/posthog/hogql_queries/insights/funnels/test/funnels_data.csv
+++ b/posthog/hogql_queries/insights/funnels/test/funnels_data.csv
@@ -1,7 +1,7 @@
-id,id_with_nulls,uuid,user_id,created,event_name,properties
-1,1,fb05509d-2cb6-4417-9f6c-7abc4212947c,d1f7bc7b-8378-3015-4347-e60e2d2f6348,2025-11-01,,"{""payment_source"": ""stripe""}"
-2,2,a1723c5b-d515-44e6-bdd6-c19f3ce95e23,cf6a408b-b00d-2458-7b24-9321c13033ec,2025-11-02,,"{""payment_source"": ""paypal""}"
-3,\N,c6dba7bf-662d-4e9a-9d55-853d673303cf,4bee5d74-a588-a205-45ef-69db7f5e8bc2,2025-11-03,,"{""payment_source"": ""stripe""}"
-4,4,0ad4c782-9dd5-4dea-a8b8-072ad98d8ea5,bc53b62b-7cc4-b3b8-0688-c6ee3dfb8539,2025-11-04,payment_succeeded,"{""payment_source"": ""paypal""}"
-5,5,8543c2b1-e485-45de-8ae5-1a3c3b246e8c,8cadb28f-1825-f158-73fa-3f228865b540,2025-11-05,payment_failed,"{""payment_source"": ""paypal""}"
-6,6,cb1d3b2f-16b9-4b41-883c-15c8f9e31e24,cf6a408b-b00d-2458-7b24-9321c13033ec,2025-11-06,,"{""payment_source"": ""paypal""}"
+id,id_with_nulls,id_decimal,uuid,user_id,created,event_name,properties
+1,1,1.11,fb05509d-2cb6-4417-9f6c-7abc4212947c,d1f7bc7b-8378-3015-4347-e60e2d2f6348,2025-11-01,,"{""payment_source"": ""stripe""}"
+2,2,2.22,a1723c5b-d515-44e6-bdd6-c19f3ce95e23,cf6a408b-b00d-2458-7b24-9321c13033ec,2025-11-02,,"{""payment_source"": ""paypal""}"
+3,\N,3.33,c6dba7bf-662d-4e9a-9d55-853d673303cf,4bee5d74-a588-a205-45ef-69db7f5e8bc2,2025-11-03,,"{""payment_source"": ""stripe""}"
+4,4,4.44,0ad4c782-9dd5-4dea-a8b8-072ad98d8ea5,bc53b62b-7cc4-b3b8-0688-c6ee3dfb8539,2025-11-04,payment_succeeded,"{""payment_source"": ""paypal""}"
+5,5,5.55,8543c2b1-e485-45de-8ae5-1a3c3b246e8c,8cadb28f-1825-f158-73fa-3f228865b540,2025-11-05,payment_failed,"{""payment_source"": ""paypal""}"
+6,6,6.66,cb1d3b2f-16b9-4b41-883c-15c8f9e31e24,cf6a408b-b00d-2458-7b24-9321c13033ec,2025-11-06,,"{""payment_source"": ""paypal""}"

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_data_warehouse.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_data_warehouse.py
@@ -44,6 +44,7 @@ class TestFunnelDataWarehouse(ClickhouseTestMixin, BaseTest):
                     "clickhouse": "Nullable(Int64)",
                     "hogql": "IntegerDatabaseField",
                 },
+                "id_decimal": {"clickhouse": "Decimal(18, 2)", "hogql": "DecimalDatabaseField"},
                 "uuid": {"clickhouse": "String", "hogql": "StringDatabaseField"},
                 "user_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
                 "created": {
@@ -230,6 +231,38 @@ class TestFunnelDataWarehouse(ClickhouseTestMixin, BaseTest):
                     id=table_name,
                     table_name=table_name,
                     id_field="id",
+                    distinct_id_field="user_id",
+                    timestamp_field="created",
+                ),
+            ],
+        )
+
+        with freeze_time("2025-11-07"):
+            runner = FunnelsQueryRunner(query=funnels_query, team=self.team, just_summarize=True)
+            response = runner.calculate()
+
+        results = response.results
+        assert results[0]["count"] == 5
+        assert results[1]["count"] == 1
+
+    def test_funnels_data_warehouse_decimal_id_column(self):
+        table_name = self.setup_data_warehouse()
+
+        funnels_query = FunnelsQuery(
+            kind="FunnelsQuery",
+            dateRange=DateRange(date_from="2025-11-01"),
+            series=[
+                DataWarehouseNode(
+                    id=table_name,
+                    table_name=table_name,
+                    id_field="id_decimal",
+                    distinct_id_field="user_id",
+                    timestamp_field="created",
+                ),
+                DataWarehouseNode(
+                    id=table_name,
+                    table_name=table_name,
+                    id_field="id_decimal",
                     distinct_id_field="user_id",
                     timestamp_field="created",
                 ),


### PR DESCRIPTION
## Problem

Experienced an issue when trying to setup a data warehouse funnel for a customer.

We use PostHog SQL `toUUIDOrDefault()` (ClickHouse `accurateCastOrNull()`) to convert the id column, which might or might not be a valid UUID. When the column is not a UUID it's expected to fall back to the default - a generated UUID. Unfortunately ClickHouse behaviour is inconsistent here: If you pass in a string that can't be parsed into a valid UUID, it falls back to the default. However if you pass in a column of a different type that can't be parsed into a valid UUID, it raises an error.

## Changes

Cast the potential UUID column to string before.

## How did you test this code?

Added a test case.