### PR TITLE
chore: implement get_dynamic_edges for Cohort visitor

### DIFF
--- a/posthog/models/resource_transfer/visitors/cohort.py
+++ b/posthog/models/resource_transfer/visitors/cohort.py
@@ -1,6 +1,16 @@
+from __future__ import annotations
+
+from typing import Any
+
 from django.db import models
 
+from posthog.models.resource_transfer.types import ResourcePayload, ResourceTransferEdge
 from posthog.models.resource_transfer.visitors.base import ResourceTransferVisitor
+from posthog.models.resource_transfer.visitors.common import (
+    build_edges_for_ids,
+    collect_cohort_ids_from_properties,
+    rewrite_cohort_id_in_properties,
+)
 
 
 class CohortVisitor(
@@ -23,3 +33,126 @@ class CohortVisitor(
         from posthog.models import Cohort
 
         return Cohort
+
+    @classmethod
+    def get_dynamic_edges(cls, resource: Any) -> list[ResourceTransferEdge]:
+        from posthog.models import Action, Cohort
+
+        cohort_ids = cls._extract_cohort_ids(resource.filters)
+        action_ids = cls._extract_action_ids(resource.filters)
+
+        edges: list[ResourceTransferEdge] = []
+        edges.extend(build_edges_for_ids(cohort_ids, Cohort, "cohort", cls._rewrite_cohort_in_payload))
+        edges.extend(build_edges_for_ids(action_ids, Action, "action", cls._rewrite_action_in_payload))
+        return edges
+
+    @classmethod
+    def _rewrite_cohort_in_payload(cls, payload: ResourcePayload, old_pk: Any, new_pk: Any) -> ResourcePayload:
+        result = {**payload}
+        if result.get("filters"):
+            result["filters"] = cls._rewrite_cohort_id_in_filters(result["filters"], old_pk, new_pk)
+        return result
+
+    @classmethod
+    def _rewrite_action_in_payload(cls, payload: ResourcePayload, old_pk: Any, new_pk: Any) -> ResourcePayload:
+        result = {**payload}
+        if result.get("filters"):
+            result["filters"] = cls._rewrite_action_id_in_filters(result["filters"], old_pk, new_pk)
+        return result
+
+    @classmethod
+    def _extract_cohort_ids(cls, filters: dict | None) -> set[int]:
+        """Extract cohort IDs from ``filters.properties`` where ``type == "cohort"``."""
+        if not filters:
+            return set()
+        return collect_cohort_ids_from_properties(filters.get("properties"))
+
+    @classmethod
+    def _extract_action_ids(cls, filters: dict | None) -> set[int]:
+        """Extract action IDs from behavioral filters where ``event_type == "actions"``.
+
+        Covers both the primary ``key`` field and the secondary ``seq_event``
+        field used by ``performed_event_sequence`` behavioral filters.
+        """
+        if not filters:
+            return set()
+        return cls._collect_action_ids_from_properties(filters.get("properties"))
+
+    @classmethod
+    def _collect_action_ids_from_properties(cls, properties: Any) -> set[int]:
+        """Walk a (possibly nested) property-group structure and collect action IDs
+        from behavioral property filters."""
+        ids: set[int] = set()
+        if isinstance(properties, list):
+            for prop in properties:
+                if isinstance(prop, dict) and prop.get("type") == "behavioral" and prop.get("event_type") == "actions":
+                    if prop.get("key") is not None:
+                        ids.add(int(prop["key"]))
+                if isinstance(prop, dict) and prop.get("seq_event_type") == "actions":
+                    if prop.get("seq_event") is not None:
+                        ids.add(int(prop["seq_event"]))
+        elif isinstance(properties, dict):
+            for group in properties.get("values", []):
+                if isinstance(group, dict):
+                    ids.update(cls._collect_action_ids_from_properties(group.get("values", [])))
+        return ids
+
+    # --- rewriting JSON-embedded references ---
+
+    @classmethod
+    def _rewrite_cohort_id_in_filters(cls, filters: dict, old_pk: int, new_pk: int) -> dict:
+        result = {**filters}
+        if "properties" in result:
+            result["properties"] = rewrite_cohort_id_in_properties(result["properties"], old_pk, new_pk)
+        return result
+
+    @classmethod
+    def _rewrite_action_id_in_filters(cls, filters: dict, old_pk: int, new_pk: int) -> dict:
+        result = {**filters}
+        if "properties" in result:
+            result["properties"] = cls._rewrite_action_id_in_properties(result["properties"], old_pk, new_pk)
+        return result
+
+    @classmethod
+    def _rewrite_action_id_in_properties(cls, properties: Any, old_pk: int, new_pk: int) -> Any:
+        """Walk a (possibly nested) property-group structure and rewrite action IDs
+        in behavioral property filters."""
+        if isinstance(properties, list):
+            result = []
+            for prop in properties:
+                if not isinstance(prop, dict):
+                    result.append(prop)
+                    continue
+                changed = {**prop}
+                if (
+                    changed.get("type") == "behavioral"
+                    and changed.get("event_type") == "actions"
+                    and changed.get("key") is not None
+                    and int(changed["key"]) == old_pk
+                ):
+                    changed["key"] = new_pk
+                if (
+                    changed.get("seq_event_type") == "actions"
+                    and changed.get("seq_event") is not None
+                    and int(changed["seq_event"]) == old_pk
+                ):
+                    changed["seq_event"] = new_pk
+                result.append(changed)
+            return result
+        elif isinstance(properties, dict):
+            result_dict = {**properties}
+            if "values" in result_dict:
+                new_values = []
+                for group in result_dict["values"]:
+                    if isinstance(group, dict):
+                        new_group = {**group}
+                        if "values" in new_group:
+                            new_group["values"] = cls._rewrite_action_id_in_properties(
+                                new_group["values"], old_pk, new_pk
+                            )
+                        new_values.append(new_group)
+                    else:
+                        new_values.append(group)
+                result_dict["values"] = new_values
+            return result_dict
+        return properties

--- a/posthog/models/resource_transfer/visitors/common.py
+++ b/posthog/models/resource_transfer/visitors/common.py
@@ -1,0 +1,175 @@
+"""
+Shared helpers for extracting and rewriting JSON-embedded foreign-key
+references (cohort IDs, action IDs) that appear inside untyped JSON
+columns such as ``Insight.filters``, ``Insight.query``,
+``Cohort.filters``, and ``Cohort.groups``.
+
+Both ``InsightVisitor`` and ``CohortVisitor`` delegate to these
+functions so the recursive property-group walking logic lives in one
+place.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from django.db import models
+
+from posthog.models.resource_transfer.types import ResourceMap, ResourcePayload, ResourceTransferEdge, RewriteRelationFn
+
+RewritePayloadFn = Callable[[ResourcePayload, Any, Any], ResourcePayload]
+
+
+# ---------------------------------------------------------------------------
+# Extractors
+# ---------------------------------------------------------------------------
+
+
+def collect_cohort_ids_from_properties(properties: Any) -> set[int]:
+    """Walk a (possibly nested) property-group structure and return every
+    referenced cohort ID.
+
+    Handles both flat lists::
+
+        [{"type": "cohort", "value": 42}, ...]
+
+    and grouped formats::
+
+        {"type": "AND", "values": [{"type": "OR", "values": [...]}]}
+    """
+    ids: set[int] = set()
+    if isinstance(properties, list):
+        for prop in properties:
+            if isinstance(prop, dict) and prop.get("type") == "cohort" and prop.get("value") is not None:
+                ids.add(int(prop["value"]))
+    elif isinstance(properties, dict):
+        if properties.get("type") == "cohort" and properties.get("value") is not None:
+            ids.add(int(properties["value"]))
+        for group in properties.get("values", []):
+            if isinstance(group, dict):
+                ids.update(collect_cohort_ids_from_properties(group.get("values", [])))
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Rewriters
+# ---------------------------------------------------------------------------
+
+
+def rewrite_cohort_id_in_properties(properties: Any, old_pk: int, new_pk: int) -> Any:
+    """Return a shallow-copy of *properties* with *old_pk* replaced by *new_pk*
+    wherever a cohort reference appears."""
+    if isinstance(properties, list):
+        result = []
+        for prop in properties:
+            if (
+                isinstance(prop, dict)
+                and prop.get("type") == "cohort"
+                and prop.get("value") is not None
+                and int(prop["value"]) == old_pk
+            ):
+                result.append({**prop, "value": new_pk})
+            else:
+                result.append(prop)
+        return result
+    elif isinstance(properties, dict):
+        result_dict = {**properties}
+        if (
+            result_dict.get("type") == "cohort"
+            and result_dict.get("value") is not None
+            and int(result_dict["value"]) == old_pk
+        ):
+            result_dict["value"] = new_pk
+        if "values" in result_dict:
+            new_values = []
+            for group in result_dict["values"]:
+                if isinstance(group, dict):
+                    new_group = {**group}
+                    if "values" in new_group:
+                        new_group["values"] = rewrite_cohort_id_in_properties(new_group["values"], old_pk, new_pk)
+                    new_values.append(new_group)
+                else:
+                    new_values.append(group)
+            result_dict["values"] = new_values
+        return result_dict
+    return properties
+
+
+def rewrite_cohort_breakdown(breakdown: Any, old_pk: int, new_pk: int) -> Any:
+    """Rewrite a cohort breakdown value (scalar or list)."""
+    if isinstance(breakdown, list):
+        return [new_pk if isinstance(item, int) and item == old_pk else item for item in breakdown]
+    elif isinstance(breakdown, int) and breakdown == old_pk:
+        return new_pk
+    return breakdown
+
+
+# ---------------------------------------------------------------------------
+# Edge builder factory
+# ---------------------------------------------------------------------------
+
+
+def make_json_id_rewriter(
+    target_model: type[models.Model],
+    old_pk: Any,
+    rewrite_fn: RewritePayloadFn,
+) -> RewriteRelationFn:
+    """Build a ``RewriteRelationFn`` that resolves the new PK from the
+    resource map and then delegates to *rewrite_fn* to patch the payload.
+
+    Parameters
+    ----------
+    target_model:
+        The Django model class being referenced (e.g. ``Action``, ``Cohort``).
+    old_pk:
+        The original primary key embedded in JSON.
+    rewrite_fn:
+        ``(payload, old_pk, new_pk) -> payload`` -- the caller-supplied
+        function that knows *where* inside the payload to substitute.
+    """
+
+    def _rewrite(
+        payload: ResourcePayload,
+        resource_map: ResourceMap,
+    ) -> ResourcePayload:
+        from posthog.models.resource_transfer.visitors.base import ResourceTransferVisitor
+
+        target_visitor = ResourceTransferVisitor.get_visitor(target_model)
+        if target_visitor is None:
+            raise TypeError(f"Could not rewrite {target_model.__name__} because it has no configured visitor")
+
+        vertex = resource_map.get((target_visitor.kind, old_pk))
+        if vertex is None:
+            raise ValueError(
+                f"Could not rewrite JSON reference to {target_model.__name__}(pk={old_pk}): resource not found in map"
+            )
+
+        if vertex.duplicated_resource is None:
+            raise ValueError(
+                f"Could not rewrite JSON reference to {target_model.__name__}(pk={old_pk}): resource not duplicated yet"
+            )
+
+        new_pk = vertex.duplicated_resource.pk
+        return rewrite_fn(payload, old_pk, new_pk)
+
+    return _rewrite
+
+
+def build_edges_for_ids(
+    ids: set[int],
+    target_model: type[models.Model],
+    label_prefix: str,
+    rewrite_fn: RewritePayloadFn,
+) -> list[ResourceTransferEdge]:
+    """Turn a set of extracted IDs into ``ResourceTransferEdge`` objects
+    with the shared rewriter."""
+    return [
+        ResourceTransferEdge(
+            name=f"{label_prefix}:{pk}",
+            target_model=target_model,
+            target_primary_key=pk,
+            rewrite_relation=make_json_id_rewriter(target_model, pk, rewrite_fn),
+        )
+        for pk in ids
+    ]


### PR DESCRIPTION
## Problem

Cohorts can contain foreign keys to other resources in their JSON columns. This should be handled while duplicating resources.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Added the dynamic edge parser for the cohort visitor + some tests

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

