### PR TITLE
fix(flags): clear value when switching between date and non-date operators

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -14,6 +14,7 @@ import {
     chooseOperatorMap,
     isMobile,
     isOperatorCohort,
+    isOperatorDate,
     isOperatorFlag,
     isOperatorMulti,
     isOperatorRange,
@@ -219,6 +220,13 @@ export function OperatorValueSelect({
                                 onChange(newOperator, value || null)
                             } else if (isOperatorRange(newOperator) && isNaN(value as any)) {
                                 // If the new operator is range and the value is not a number, we want to set the new value to null
+                                onChange(newOperator, null)
+                            } else if (
+                                isOperatorDate(newOperator) !==
+                                isOperatorDate(currentOperator || PropertyOperator.Exact)
+                            ) {
+                                // Switching between date and non-date operators — clear the value
+                                // since the value types are incompatible
                                 onChange(newOperator, null)
                             } else if (isOperatorFlag(newOperator)) {
                                 onChange(newOperator, newOperator)


### PR DESCRIPTION
## Summary

Closes #47703

- When changing a property filter from a string operator (e.g., "equals") to a date operator (e.g., "is date after"), the old string value now gets cleared instead of persisting silently
- Uses the existing `isOperatorDate` helper to detect operator type transitions
- Follows the same pattern already used for range operator transitions (line 221)

## Problem

1. Set a property filter condition with "equals" and a string value like "garbage"
2. Change the operator to a date operator like "is date after"
3. The UI shows an empty date picker, but the underlying value still holds "garbage"
4. Clicking Save persists the invalid value

## Fix

Added a check in `OperatorValueSelect.tsx` that clears the value (`null`) when the operator type changes between date and non-date. This is a 7-line change that mirrors the existing `isOperatorRange` check pattern.

## Test plan

- [ ] Set a condition with "equals" operator and a string value
- [ ] Switch to a date operator (e.g., "is date after") — value should clear
- [ ] Switch back to a string operator — value should clear (bidirectional)
- [ ] Switching between date operators (e.g., "is date before" → "is date after") should preserve the value
- [ ] Switching between string operators (e.g., "equals" → "contains") should preserve the value
- [ ] Existing operator transitions (range, flag, cohort, multi) still work as before