### PR TITLE
feat(analytics-platform): Support variable TTL for different ages of data

### DIFF
--- a/products/analytics_platform/backend/lazy_preaggregation/README.md
+++ b/products/analytics_platform/backend/lazy_preaggregation/README.md
@@ -52,7 +52,7 @@ from datetime import datetime
 from products.analytics_platform.backend.lazy_preaggregation.lazy_preaggregation_executor import ensure_preaggregated, PreaggregationTable
 from posthog.hogql import ast
 
-# Ensure that the given query is preaggregated
+# Ensure that the given query is preaggregated with variable TTLs
 preagg_result = ensure_preaggregated(
     team=self.team,
     insert_query="""
@@ -68,10 +68,25 @@ preagg_result = ensure_preaggregated(
     """,
     time_range_start=datetime(2025, 12, 18),
     time_range_end=datetime(2025, 12, 25),
-    ttl_seconds=24 * 60 * 60,
+    # Variable TTL: recent data refreshes more often
+    ttl_seconds={
+        "0d": 15 * 60,           # current day: 15 min
+        "1d": 60 * 60,            # previous day: 1 hour
+        "7d": 24 * 60 * 60,       # last week: 1 day
+        "default": 7 * 24 * 60 * 60,  # older: 7 days
+    },
     table=PreaggregationTable.PREAGGREGATION_RESULTS,
     # Custom placeholders can be passed too
     placeholders={"some_filter": ast.Constant(value="filter_value")},
+)
+
+# A single int TTL still works for uniform expiry
+preagg_result = ensure_preaggregated(
+    team=self.team,
+    insert_query="...",
+    time_range_start=datetime(2025, 12, 18),
+    time_range_end=datetime(2025, 12, 25),
+    ttl_seconds=24 * 60 * 60,  # 1 day for all ranges
 )
 
 # Then query from this table directly using the job_ids
@@ -96,6 +111,20 @@ query = parse_select(
 )
 # note that this is using HogQL, which automatically adds a team_id condition
 ```
+
+### Variable TTL
+
+The `ttl_seconds` parameter accepts either an `int` (uniform TTL) or a `dict` mapping date strings to TTL values in seconds. Dict keys are parsed using `relative_date_parse` with the team's timezone:
+
+- `"0d"` — cutoff at start of today: windows from today onward match
+- `"1d"` — cutoff at start of yesterday: windows from yesterday onward match
+- `"7d"` — cutoff 7 days ago: windows from last week onward match
+- `"24h"` — cutoff 24 hours ago
+- `"2w"` — cutoff 2 weeks ago
+- `"2026-02-15"` — cutoff at a specific date
+- `"default"` — fallback TTL for windows older than all cutoffs
+
+Rules are matched most-specific first (shortest period wins). On the **read path**, existing jobs that are too stale for the requested TTL are skipped and recomputed. On the **write path**, each job is created with the TTL appropriate for its date range — ranges with different TTLs are never merged into a single job.
 
 ## Concurrency and race conditions
 
@@ -146,6 +175,5 @@ Stale jobs are marked FAILED and the normal replacement flow kicks in. This mean
 ## TODOs
 
 - While we are waiting, we block an entire django thread despite not doing any useful work. We should make it easier for people to use e.g. celery with this, this would involve using async queries though.
-- The TTL of an inserted job should be conditional on how recent the data is. Data from the same day might want a very short (e.g. 15 mins!) TTL, or to be skipped entirely and UNION'ed with real data, which we could make a bit easier.
 - The stale enum value isn't used for anything, we just mark stale jobs as errored
 - Add posthog logging for state transitions

--- a/products/analytics_platform/backend/lazy_preaggregation/tests/test_lazy_preaggregation_executor.py
+++ b/products/analytics_platform/backend/lazy_preaggregation/tests/test_lazy_preaggregation_executor.py
@@ -47,10 +47,6 @@ from products.analytics_platform.backend.lazy_preaggregation.preaggregation_noti
     job_channel,
     set_ch_query_started,
 )
-from products.analytics_platform.backend.lazy_preaggregation.preaggregation_notifications import (
-    job_channel,
-    set_ch_query_started,
-)
 from products.analytics_platform.backend.models import PreaggregationJob
 
 
@@ -1647,28 +1643,6 @@ class TestPreaggregationExecutorExecute(BaseTest):
             status=PreaggregationJob.Status.PENDING,
             expires_at=django_timezone.now() + timedelta(days=7),
         )
-
-        def mock_wait(pubsub, duration):
-            pending_job.status = PreaggregationJob.Status.READY
-            pending_job.computed_at = django_timezone.now()
-            pending_job.save()
-            return {"type": b"message", "channel": job_channel(pending_job.id).encode(), "data": b"ready"}
-
-        executor = PreaggregationExecutor(wait_timeout_seconds=5.0, poll_interval_seconds=0.1)
-        with patch.object(executor, "_wait_for_notification", side_effect=mock_wait):
-            result = executor.execute(
-                team=self.team,
-                query_info=query_info,
-                start=datetime(2024, 1, 1, tzinfo=UTC),
-                end=datetime(2024, 1, 2, tzinfo=UTC),
-                run_insert=lambda t, j: None,
-            )
-
-        assert result.ready is True
-        assert pending_job.id in result.job_ids
-
-    def test_timeout_when_job_stays_pending(self):
-        query_info, query_hash = self._make_query_info()
 
         def mock_wait(pubsub, duration):
             pending_job.status = PreaggregationJob.Status.READY


### PR DESCRIPTION
## Problem

We might want to preaggregate data with a different TTL depending on how recent the data is. You might want a TTL of only 15 minutes for the current day, but data older than 30 days could have a TTL of weeks.

## Changes

You can now do something like this:
```typescript
preagg_result = ensure_preaggregated(
    team=self.team,
    insert_query="""SELECT whatever FROM STUFF""",
    time_range_start=datetime(2026, 02, 13),
    time_range_end=datetime(2025, 01, 13),
    # Variable TTL: recent data refreshes more often
    ttl_seconds={
        "0d": 15 * 60,           # current day: 15 min
        "1d": 60 * 60,            # previous day: 1 hour
        "7d": 24 * 60 * 60,       # last week: 1 day
        "default": 7 * 24 * 60 * 60,  # older: 7 days
    },
    table=PreaggregationTable.YOUR_TABLE
)
```

## How did you test this code?

Added many tests

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
