### PR TITLE
fix(replay): remove order by in GLOBALIN clause

### DIFF
--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -101,6 +101,22 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
         group_by: list[ast.Expr],
         limit_expr: ast.Expr,
     ) -> ast.SelectQuery:
+        # NOTE: ORDER BY can cause incorrect results in globalIn contexts on distributed ClickHouse tables.
+        # The ORDER BY was meant to prefer recent sessions when hitting LIMIT, but we saw a
+        # with a bad experience filtering out 60% of results incorrectly
+        # We use a feature flag to control this behavior for safe rollout.
+
+        remove_order_by = posthoganalytics.feature_enabled(
+            "remove-order-by-for-event-subquery",
+            str(self._team.organization.id),
+            send_feature_flag_events=False,
+        )
+
+        order_by = None
+        if not remove_order_by:
+            # Legacy behavior: include ORDER BY (may cause incorrect results)
+            order_by = [ast.OrderExpr(expr=ast.Call(name="min", args=[ast.Field(chain=["timestamp"])]), order="DESC")]
+
         return ast.SelectQuery(
             select=select_expr if isinstance(select_expr, list) else [select_expr],
             select_from=ast.JoinExpr(
@@ -109,7 +125,7 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
             where=self._where_predicates(where_expr),
             having=self._having_predicates(),
             group_by=group_by,
-            order_by=[ast.OrderExpr(expr=ast.Call(name="min", args=[ast.Field(chain=["timestamp"])]), order="DESC")],
+            order_by=order_by,
             limit=limit_expr,
         )
 


### PR DESCRIPTION
## Problem

whew
ran a bunch of diagnostic scripts figuring out exactly what query ended up being produced by our Session Replay filters, and saw that recording that DID NOT match the filters were being incorrectly filtered out

There are a few closely related clickhouse issues (allsince resolved) to indicate this might not be the most shocking thing: 


 - #56790: GLOBAL IN doesn't work correctly - https://github.com/ClickHouse/ClickHouse/issues/56790
 - #84718: ORDER BY + LIMIT corruption https://github.com/ClickHouse/ClickHouse/issues/84718

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

For this subquery remove the order by... 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

ran scripts on some spot checks that we had from a client experiencing this issue via toolbox: 

![Screenshot 2026-02-13 at 2.57.40 PM.png](https://app.graphite.com/user-attachments/assets/589b06ce-e4b0-433e-b3d9-096f05344ba7.png)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
