### PR TITLE
fix(replay): account for negative cohort query in hybrid query

### DIFF
--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -154,11 +154,19 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
             return False
 
         # Don't use hybrid query if there are negative operators
-        # Negative operators (IS_NOT, NOT_ICONTAINS, etc.) would match too many people
+        # Negative operators (IS_NOT, NOT_ICONTAINS, NOT_IN, etc.) would match too many people
         # For example, "email doesn't contain @company.com" matches almost everyone
+        # Or "user not in cohort X" matches everyone except cohort members
         # This would load 100-1000 random people and miss the actual recordings we want
+        HYBRID_QUERY_UNSAFE_OPERATORS = [
+            PropertyOperator.IS_NOT_SET,
+            PropertyOperator.IS_NOT,
+            PropertyOperator.NOT_REGEX,
+            PropertyOperator.NOT_ICONTAINS,
+            PropertyOperator.NOT_IN,  # Cohort negation (e.g., user not in cohort X)
+        ]
         for prop in person_properties:
-            if is_negative_prop(prop):
+            if hasattr(prop, "operator") and prop.operator in HYBRID_QUERY_UNSAFE_OPERATORS:
                 return False
 
         # Check if at least one property is eligible for hybrid query


### PR DESCRIPTION
## Problem

we dont want cohorts to explode this eitehr so fall back to existing behavior for Cohorts

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
