### PR TITLE
feat: add jump to timestamp option

### DIFF
--- a/frontend/src/layout/GlobalShortcuts.tsx
+++ b/frontend/src/layout/GlobalShortcuts.tsx
@@ -7,6 +7,7 @@ import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
 import { openCHQueriesDebugModal } from 'lib/components/AppShortcuts/utils/DebugCHQueries'
 import { commandLogic } from 'lib/components/Command/commandLogic'
+import { openJumpToTimestampModal } from 'lib/components/DateFilter/openJumpToTimestampModal'
 import { healthMenuLogic } from 'lib/components/HealthMenu/healthMenuLogic'
 import { helpMenuLogic } from 'lib/components/HelpMenu/helpMenuLogic'
 import { superpowersLogic } from 'lib/components/Superpowers/superpowersLogic'
@@ -155,6 +156,14 @@ export function GlobalShortcuts(): null {
         intent: 'Toggle theme (dark / light)',
         interaction: 'function',
         callback: () => toggleTheme(),
+    })
+
+    useAppShortcut({
+        name: 'jump-to-timestamp',
+        keybind: [keyBinds.jumpToTimestamp],
+        intent: 'Jump to timestamp',
+        interaction: 'function',
+        callback: openJumpToTimestampModal,
     })
 
     return null

--- a/frontend/src/lib/components/AppShortcuts/shortcuts.ts
+++ b/frontend/src/lib/components/AppShortcuts/shortcuts.ts
@@ -40,4 +40,5 @@ export const keyBinds: Record<string, string[]> = {
     allChats: ['g', 'then', '1'],
     allApps: ['g', 'then', '2'],
     theme: ['g', 'then', 't'],
+    jumpToTimestamp: ['j', 'then', 't'],
 }

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -26,6 +26,7 @@ import { DateMappingOption, PropertyOperator } from '~/types'
 
 import { PropertyFilterDatePicker } from '../PropertyFilters/components/PropertyFilterDatePicker'
 import { FixedRangeWithTimePicker } from './FixedRangeWithTimePicker'
+import { JumpToTimestampPicker } from './JumpToTimestampPicker'
 import { RollingDateRangeFilter } from './RollingDateRangeFilter'
 import { dateFilterLogic } from './dateFilterLogic'
 import { DateOption } from './rollingDateRangeFilterLogic'
@@ -48,6 +49,7 @@ export interface DateFilterProps {
     placeholder?: string
     fullWidth?: boolean
     resolvedDateRange?: ResolvedDateRangeResponse
+    showJumpToTimestamp?: boolean
 }
 
 interface RawDateFilterProps extends DateFilterProps {
@@ -96,6 +98,7 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
         explicitDate,
         showExplicitDateToggle = false,
         resolvedDateRange,
+        showJumpToTimestamp = false,
     },
     ref
 ) {
@@ -117,6 +120,7 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
         openFixedRange,
         openDateToNow,
         openFixedDate,
+        openJumpToTimestamp,
         close,
         setRangeDateFrom,
         setExplicitDate,
@@ -209,6 +213,8 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
                     setDate(String(date), '')
                 }}
             />
+        ) : view === DateFilterView.JumpToTimestamp ? (
+            <JumpToTimestampPicker onApply={(dateFrom, dateTo) => setDate(dateFrom, dateTo)} onClose={open} />
         ) : (
             <div className="deprecated-space-y-px" ref={optionsRef} onClick={(e) => e.stopPropagation()}>
                 {dateOptions.map(({ key, values, inactive }) => {
@@ -321,6 +327,14 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
                                 }}
                             />
                         </div>
+                    </>
+                )}
+                {showJumpToTimestamp && (
+                    <>
+                        <LemonDivider />
+                        <LemonButton onClick={openJumpToTimestamp} fullWidth data-attr="jump-to-timestamp-option">
+                            Jump to timestamp…
+                        </LemonButton>
                     </>
                 )}
             </div>

--- a/frontend/src/lib/components/DateFilter/JumpToTimestampForm.tsx
+++ b/frontend/src/lib/components/DateFilter/JumpToTimestampForm.tsx
@@ -1,0 +1,107 @@
+import { ReactNode, useState } from 'react'
+
+import { IconCheck, IconWarning } from '@posthog/icons'
+import { LemonInput, LemonSelect } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
+import { WindowDirection, WindowSize, computeDateRange, parseTimestampInput } from './jumpToTimestampUtils'
+
+const PLACEHOLDER_ISO = dayjs().format('YYYY-MM-DDTHH:mm:ss[Z]')
+const PLACEHOLDER_UNIX = Math.floor(Date.now() / 1000).toString()
+
+export interface JumpToTimestampFormProps {
+    onSubmit: (dateFrom: string, dateTo: string) => void
+    children: (props: { dateRange: { date_from: string; date_to: string } | null; submit: () => void }) => ReactNode
+}
+
+export function JumpToTimestampForm({ onSubmit, children }: JumpToTimestampFormProps): JSX.Element {
+    const [timestampInput, setTimestampInput] = useState('')
+    const [windowSize, setWindowSize] = useState<WindowSize>('5m')
+    const [windowDirection, setWindowDirection] = useState<WindowDirection>('around')
+
+    const hasInput = timestampInput.trim().length > 0
+    const parsed = hasInput ? parseTimestampInput(timestampInput) : null
+    const isInvalid = hasInput && !parsed
+
+    const dateRange = parsed ? computeDateRange(parsed, windowSize, windowDirection) : null
+
+    const handleSubmit = (): void => {
+        if (dateRange) {
+            onSubmit(dateRange.date_from, dateRange.date_to)
+        }
+    }
+
+    const statusSuffix = parsed ? (
+        <Tooltip title={`Parsed as: ${parsed.format('MMM D, YYYY HH:mm:ss')}`}>
+            <IconCheck className="text-success text-base" />
+        </Tooltip>
+    ) : isInvalid ? (
+        <Tooltip title="Could not parse timestamp. Try ISO 8601, unix seconds, or MM/DD/YYYY.">
+            <IconWarning className="text-danger text-base" />
+        </Tooltip>
+    ) : null
+
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div
+            onKeyDown={(e) => {
+                if (e.key === 'Enter' && dateRange) {
+                    e.preventDefault()
+                    handleSubmit()
+                }
+            }}
+        >
+            <div className="space-y-2">
+                <LemonInput
+                    className="[&_input]:[color:var(--text-3000)]"
+                    value={timestampInput}
+                    onChange={setTimestampInput}
+                    placeholder={`e.g. ${PLACEHOLDER_ISO}, ${PLACEHOLDER_UNIX}`}
+                    fullWidth
+                    autoFocus
+                    size="small"
+                    suffix={statusSuffix}
+                    data-attr="jump-to-timestamp-input"
+                />
+                <div className="flex items-center gap-2">
+                    <span className="text-xs font-medium whitespace-nowrap">Window:</span>
+                    <LemonSelect
+                        size="xsmall"
+                        value={windowSize}
+                        onChange={setWindowSize}
+                        options={[
+                            { value: '5m', label: '5 min' },
+                            { value: '10m', label: '10 min' },
+                            { value: '1h', label: '1 hour' },
+                        ]}
+                    />
+                    <LemonSelect
+                        size="xsmall"
+                        value={windowDirection}
+                        onChange={setWindowDirection}
+                        options={[
+                            { value: 'before', label: 'before' },
+                            { value: 'around', label: 'around' },
+                            { value: 'after', label: 'after' },
+                        ]}
+                    />
+                </div>
+            </div>
+            {dateRange && (
+                <div className="text-xs text-secondary mt-3">
+                    Will show events from{' '}
+                    <span className="whitespace-nowrap font-medium text-primary bg-fill-highlight-100 rounded px-0.5">
+                        {dayjs(dateRange.date_from).format('MMM D, YYYY HH:mm')}
+                    </span>{' '}
+                    to{' '}
+                    <span className="whitespace-nowrap font-medium text-primary bg-fill-highlight-100 rounded px-0.5">
+                        {dayjs(dateRange.date_to).format('MMM D, YYYY HH:mm')}
+                    </span>
+                </div>
+            )}
+            {children({ dateRange, submit: handleSubmit })}
+        </div>
+    )
+}

--- a/frontend/src/lib/components/DateFilter/JumpToTimestampPicker.tsx
+++ b/frontend/src/lib/components/DateFilter/JumpToTimestampPicker.tsx
@@ -1,0 +1,34 @@
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { JumpToTimestampForm } from './JumpToTimestampForm'
+
+export function JumpToTimestampPicker({
+    onApply,
+    onClose,
+}: {
+    onApply: (dateFrom: string, dateTo: string) => void
+    onClose: () => void
+}): JSX.Element {
+    return (
+        <div className="w-80 p-2" data-attr="jump-to-timestamp-picker">
+            <JumpToTimestampForm onSubmit={onApply}>
+                {({ dateRange, submit }) => (
+                    <div className="flex justify-between mt-3">
+                        <LemonButton size="small" type="secondary" onClick={onClose}>
+                            Back
+                        </LemonButton>
+                        <LemonButton
+                            size="small"
+                            type="primary"
+                            disabledReason={!dateRange ? 'Enter a valid timestamp' : undefined}
+                            onClick={submit}
+                            data-attr="jump-to-timestamp-apply"
+                        >
+                            Apply
+                        </LemonButton>
+                    </div>
+                )}
+            </JumpToTimestampForm>
+        </div>
+    )
+}

--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
@@ -45,6 +45,7 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
         openFixedRangeWithTime: true,
         openDateToNow: true,
         openFixedDate: true,
+        openJumpToTimestamp: true,
         close: true,
         applyRange: true,
         setFixedRangeGranularity: (granularity: 'day' | 'minute') => ({ granularity }),
@@ -72,6 +73,7 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
                 openFixedRangeWithTime: () => DateFilterView.FixedRangeWithTime,
                 openDateToNow: () => DateFilterView.DateToNow,
                 openFixedDate: () => DateFilterView.FixedDate,
+                openJumpToTimestamp: () => DateFilterView.JumpToTimestamp,
             },
         ],
         isVisible: [
@@ -82,6 +84,7 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
                 openFixedRangeWithTime: () => true,
                 openDateToNow: () => true,
                 openFixedDate: () => true,
+                openJumpToTimestamp: () => true,
                 setDate: (_, { keepPopoverOpen }) => keepPopoverOpen,
                 close: () => false,
             },

--- a/frontend/src/lib/components/DateFilter/jumpToTimestampUtils.test.ts
+++ b/frontend/src/lib/components/DateFilter/jumpToTimestampUtils.test.ts
@@ -1,0 +1,66 @@
+import { dayjs } from 'lib/dayjs'
+
+import { WindowDirection, WindowSize, computeDateRange, parseTimestampInput } from './jumpToTimestampUtils'
+
+describe('jumpToTimestamp', () => {
+    describe('parseTimestampInput', () => {
+        it.each([
+            ['unix seconds (9 digits)', '946684800', dayjs(946684800 * 1000)],
+            ['unix seconds (10 digits)', '1705312200', dayjs(1705312200 * 1000)],
+            ['unix milliseconds (13 digits)', '1705312200000', dayjs(1705312200000)],
+            ['unix float seconds', '1705312200.123', dayjs(1705312200123)],
+            ['ISO 8601 with Z', '2024-01-15T10:30:00Z', dayjs('2024-01-15T10:30:00Z')],
+            ['ISO 8601 with offset', '2024-01-15T10:30:00+05:00', dayjs('2024-01-15T10:30:00+05:00')],
+            ['date only', '2024-01-15', dayjs('2024-01-15')],
+            ['datetime with space', '2024-01-15 10:30:00', dayjs('2024-01-15 10:30:00')],
+            ['US locale MM/DD/YYYY', '01/15/2024', dayjs('01/15/2024', 'MM/DD/YYYY', true)],
+            ['compact YYYYMMDD', '20240115', dayjs('20240115', 'YYYYMMDD', true)],
+        ])('parses %s (%s)', (_label, input, expected) => {
+            const result = parseTimestampInput(input)
+            expect(result).not.toBeNull()
+            expect(result!.valueOf()).toBeCloseTo(expected.valueOf(), -2)
+        })
+
+        it.each([
+            ['empty string', ''],
+            ['whitespace only', '   '],
+            ['not a date', 'not-a-date'],
+            ['random text', 'hello world'],
+            ['too short number', '123'],
+            ['year 1999 (below 2000 boundary)', '1999-12-31'],
+        ])('returns null for invalid input: %s (%s)', (_label, input) => {
+            expect(parseTimestampInput(input)).toBeNull()
+        })
+
+        it('accepts dates at the year 2000 boundary', () => {
+            const result = parseTimestampInput('2000-01-01')
+            expect(result).not.toBeNull()
+            expect(result!.year()).toBe(2000)
+        })
+
+        it('returns null for dates too far in the future', () => {
+            const farFuture = dayjs().add(2, 'year').format('YYYY-MM-DD')
+            expect(parseTimestampInput(farFuture)).toBeNull()
+        })
+    })
+
+    describe('computeDateRange', () => {
+        const ts = dayjs('2024-01-15T12:00:00')
+
+        it.each<[WindowDirection, WindowSize, string, string]>([
+            ['before', '5m', '2024-01-15T11:55:00', '2024-01-15T12:00:00'],
+            ['before', '10m', '2024-01-15T11:50:00', '2024-01-15T12:00:00'],
+            ['before', '1h', '2024-01-15T11:00:00', '2024-01-15T12:00:00'],
+            ['around', '5m', '2024-01-15T11:57:30', '2024-01-15T12:02:30'],
+            ['around', '10m', '2024-01-15T11:55:00', '2024-01-15T12:05:00'],
+            ['around', '1h', '2024-01-15T11:30:00', '2024-01-15T12:30:00'],
+            ['after', '5m', '2024-01-15T12:00:00', '2024-01-15T12:05:00'],
+            ['after', '10m', '2024-01-15T12:00:00', '2024-01-15T12:10:00'],
+            ['after', '1h', '2024-01-15T12:00:00', '2024-01-15T13:00:00'],
+        ])('direction=%s window=%s → %s to %s', (direction, windowSize, expectedFrom, expectedTo) => {
+            const result = computeDateRange(ts, windowSize, direction)
+            expect(result.date_from).toBe(expectedFrom)
+            expect(result.date_to).toBe(expectedTo)
+        })
+    })
+})

--- a/frontend/src/lib/components/DateFilter/jumpToTimestampUtils.ts
+++ b/frontend/src/lib/components/DateFilter/jumpToTimestampUtils.ts
@@ -1,0 +1,106 @@
+import { Dayjs, dayjs } from 'lib/dayjs'
+
+export type WindowSize = '5m' | '10m' | '1h'
+export type WindowDirection = 'before' | 'around' | 'after'
+
+const WINDOW_MINUTES: Record<WindowSize, number> = {
+    '5m': 5,
+    '10m': 10,
+    '1h': 60,
+}
+
+const FALLBACK_FORMATS = ['MM/DD/YYYY', 'YYYYMMDD', 'MM/DD/YYYY HH:mm']
+
+const MAX_FUTURE_MS = 365 * 24 * 60 * 60 * 1000
+
+export function parseTimestampInput(input: string): Dayjs | null {
+    const trimmed = input.trim()
+    if (!trimmed) {
+        return null
+    }
+
+    let parsed: Dayjs | null = null
+
+    // Numeric-only: unix timestamps (require at least 9 digits for seconds)
+    if (/^\d+(\.\d+)?$/.test(trimmed)) {
+        // 8-digit numeric strings like 20240115 should try YYYYMMDD first
+        if (trimmed.length === 8) {
+            const compact = dayjs(trimmed, 'YYYYMMDD', true)
+            if (compact.isValid()) {
+                parsed = compact
+            }
+        }
+
+        if (!parsed?.isValid()) {
+            const num = parseFloat(trimmed)
+            if (trimmed.includes('.') || (trimmed.length >= 9 && trimmed.length <= 10)) {
+                parsed = dayjs(num * 1000)
+            } else if (trimmed.length >= 11) {
+                parsed = dayjs(num)
+            }
+        }
+    }
+
+    // Try dayjs native parsing (ISO 8601, YYYY-MM-DD, YYYY-MM-DD HH:mm:ss, etc.)
+    if (!parsed?.isValid()) {
+        const native = dayjs(trimmed)
+        if (native.isValid()) {
+            parsed = native
+        }
+    }
+
+    // Fallback: strict parsing with common formats
+    if (!parsed?.isValid()) {
+        for (const fmt of FALLBACK_FORMATS) {
+            const attempt = dayjs(trimmed, fmt, true)
+            if (attempt.isValid()) {
+                parsed = attempt
+                break
+            }
+        }
+    }
+
+    if (!parsed?.isValid()) {
+        return null
+    }
+
+    // Reject dates before year 2000 (no useful data that old)
+    if (parsed.year() < 2000) {
+        return null
+    }
+
+    // Reject dates unreasonably far in the future
+    if (parsed.valueOf() > Date.now() + MAX_FUTURE_MS) {
+        return null
+    }
+
+    return parsed
+}
+
+export function computeDateRange(
+    timestamp: Dayjs,
+    windowSize: WindowSize,
+    direction: WindowDirection
+): { date_from: string; date_to: string } {
+    const minutes = WINDOW_MINUTES[windowSize]
+    const fmt = 'YYYY-MM-DDTHH:mm:ss'
+
+    switch (direction) {
+        case 'before':
+            return {
+                date_from: timestamp.subtract(minutes, 'minute').format(fmt),
+                date_to: timestamp.format(fmt),
+            }
+        case 'after':
+            return {
+                date_from: timestamp.format(fmt),
+                date_to: timestamp.add(minutes, 'minute').format(fmt),
+            }
+        case 'around':
+        default:
+            return {
+                date_from: timestamp.subtract(minutes / 2, 'minute').format(fmt),
+                date_to: timestamp.add(minutes / 2, 'minute').format(fmt),
+            }
+    }
+}

--- a/frontend/src/lib/components/DateFilter/openJumpToTimestampModal.tsx
+++ b/frontend/src/lib/components/DateFilter/openJumpToTimestampModal.tsx
@@ -1,0 +1,56 @@
+import { combineUrl, router } from 'kea-router'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { getDefaultEventsSceneQuery } from 'scenes/activity/explore/defaults'
+import { urls } from 'scenes/urls'
+
+import { ActivityTab } from '~/types'
+
+import { JumpToTimestampForm } from './JumpToTimestampForm'
+
+export function openJumpToTimestampModal(): void {
+    LemonDialog.open({
+        title: 'Jump to timestamp',
+        content: (closeDialog) => <JumpToTimestampModalContent onClose={closeDialog} />,
+        primaryButton: null,
+        className: '!m-auto',
+    })
+}
+
+function JumpToTimestampModalContent({ onClose }: { onClose: () => void }): JSX.Element {
+    const handleSubmit = (dateFrom: string, dateTo: string): void => {
+        const baseQuery = getDefaultEventsSceneQuery()
+        const query = {
+            ...baseQuery,
+            source: { ...baseQuery.source, after: dateFrom, before: dateTo },
+        }
+        const url = combineUrl(urls.activity(ActivityTab.ExploreEvents), {}, { q: query }).url
+        onClose()
+        router.actions.push(url)
+    }
+
+    return (
+        <JumpToTimestampForm onSubmit={handleSubmit}>
+            {({ dateRange, submit }) => (
+                <>
+                    <p className="text-secondary text-sm mb-0 mt-4">
+                        Enter a timestamp to explore events filtered to a time window around it.
+                    </p>
+                    <div className="flex justify-end mt-4">
+                        <LemonButton
+                            size="small"
+                            type="primary"
+                            disabledReason={!dateRange ? 'Enter a valid timestamp' : undefined}
+                            onClick={submit}
+                            data-attr="jump-to-timestamp-apply"
+                        >
+                            Go to events
+                        </LemonButton>
+                    </div>
+                </>
+            )}
+        </JumpToTimestampForm>
+    )
+}

--- a/frontend/src/lib/components/DateFilter/types.ts
+++ b/frontend/src/lib/components/DateFilter/types.ts
@@ -8,6 +8,7 @@ export enum DateFilterView {
     FixedRange = 'FixedRange',
     FixedRangeWithTime = 'FixedRangeWithTime',
     FixedDate = 'FixedDate',
+    JumpToTimestamp = 'JumpToTimestamp',
 }
 
 export type DateFilterLogicProps = {

--- a/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
@@ -19,7 +19,7 @@ export type LemonFormDialogProps = LemonDialogFormPropsType &
 
 export type LemonDialogProps = Pick<
     LemonModalProps,
-    'title' | 'description' | 'width' | 'maxWidth' | 'inline' | 'footer' | 'zIndex'
+    'title' | 'description' | 'width' | 'maxWidth' | 'inline' | 'footer' | 'zIndex' | 'className'
 > & {
     primaryButton?: LemonButtonProps | null
     secondaryButton?: LemonButtonProps | null

--- a/frontend/src/queries/nodes/DataNode/DateRange.tsx
+++ b/frontend/src/queries/nodes/DataNode/DateRange.tsx
@@ -38,6 +38,7 @@ export function DateRange<
                     setQuery?.(newQuery)
                 }}
                 allowFixedRangeWithTime
+                showJumpToTimestamp
             />
         )
     }


### PR DESCRIPTION
## Problem

Resolves #39943.

When debugging issues, engineers frequently need to look at events around a specific timestamp (from logs, error reports, Sentry, etc.). Currently there's no fast way to jump directly to a point in time — you have to manually navugate to Explore events and fiddle with date filters.

## Changes

Adds a global "Jump to timestamp" shortcut (J then T) and a matching entry in the command palette (Cmd+Shift+K). It opens a centered modal where you paste a timestamp in any common  format (ISO 8601, unix seconds/ms, MM/DD/YYYY, etc.), pick a time window, and hit Enter or click "Go to events" to land on Explore events filtered to that range.

  - New keybind `j → t` and global shortcut registration
  - `JumpToTimestampForm` shared component used by both the modal and the DateFilter popover variant
  - `parseTimestampInput` with strict validation (year >= 2000, max 1 year future, no ambiguous DD/MM formats)
  - `showJumpToTimestamp` scoped to Events and Sessions queries only
  - Added `className` to `LemonDialogProps` for modal positioning

## Preview

[Screen Recording 2026-02-14 at 10.50.53.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/ff919396-a1d9-4902-8895-467b85faac0f.mov" />](https://app.graphite.com/user-attachments/video/ff919396-a1d9-4902-8895-467b85faac0f.mov)

[Screen Recording 2026-02-14 at 10.51.36.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/fc96450e-9eb8-4d73-9505-7bfc30c7780e.mov" />](https://app.graphite.com/user-attachments/video/fc96450e-9eb8-4d73-9505-7bfc30c7780e.mov)

## How did you test this code?

  - 27 unit tests covering timestamp parsing (unix seconds/ms, ISO 8601, edge boundaries), date range computation, and invalid input rejection
  - `pnpm --filter=@posthog/frontend typescript:check` — no new errors
  - Manual: `J → T` opens centered modal, `Cmd+Shift+K` shows the shortcut, Enter confirms, Esc dismisses, navigation works from any page including when already on /activity/explore

## Publish to changelog?

Yes.

Now you can filter events in Activity by jumping to a timewindow around a specific timestamp (optionally with a J + T shortcut)