### PR TITLE
fix: remove outside clickable area in piecharts

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -19,7 +19,7 @@ import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
-import { LineGraphProps, onChartClick, onChartHover } from 'scenes/insights/views/LineGraph/LineGraph'
+import { LineGraphProps, onChartClick } from 'scenes/insights/views/LineGraph/LineGraph'
 import { createTooltipData } from 'scenes/insights/views/LineGraph/tooltip-data'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
@@ -85,7 +85,8 @@ export function PieChart({
                     responsive: true,
                     maintainAspectRatio: false,
                     hover: {
-                        mode: 'index',
+                        mode: 'point',
+                        intersect: true,
                     },
                     layout: {
                         padding: {
@@ -99,10 +100,23 @@ export function PieChart({
                     borderRadius: 0,
                     hoverOffset: onlyOneValue || disableHoverOffset ? 0 : 16,
                     onHover(event: ChartEvent, _: ActiveElement[], chart: Chart) {
-                        onChartHover(event, chart, onClick)
+                        const nativeEvent = event.native
+                        if (!nativeEvent) {
+                            return
+                        }
+                        const target = nativeEvent?.target as HTMLDivElement
+                        const point = chart.getElementsAtEventForMode(nativeEvent, 'point', { intersect: true }, true)
+                        target.style.cursor = onClick && point.length ? 'pointer' : 'default'
                     },
                     onClick: (event: ChartEvent, _: ActiveElement[], chart: Chart) => {
-                        onChartClick(event, chart, datasets, onClick)
+                        const nativeEvent = event.native
+                        if (!nativeEvent) {
+                            return
+                        }
+                        const point = chart.getElementsAtEventForMode(nativeEvent, 'point', { intersect: true }, true)
+                        if (point.length) {
+                            onChartClick(event, chart, datasets, onClick)
+                        }
                     },
                     plugins: {
                         datalabels: {

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -104,17 +104,19 @@ export function PieChart({
                         if (!nativeEvent) {
                             return
                         }
-                        const target = nativeEvent?.target as HTMLDivElement
-                        const point = chart.getElementsAtEventForMode(nativeEvent, 'point', { intersect: true }, true)
-                        target.style.cursor = onClick && point.length ? 'pointer' : 'default'
+                        const target = nativeEvent.target as HTMLDivElement
+                        const hitsSlice =
+                            chart.getElementsAtEventForMode(nativeEvent, 'point', { intersect: true }, true).length > 0
+                        target.style.cursor = onClick && hitsSlice ? 'pointer' : 'default'
                     },
                     onClick: (event: ChartEvent, _: ActiveElement[], chart: Chart) => {
                         const nativeEvent = event.native
                         if (!nativeEvent) {
                             return
                         }
-                        const point = chart.getElementsAtEventForMode(nativeEvent, 'point', { intersect: true }, true)
-                        if (point.length) {
+                        const hitsSlice =
+                            chart.getElementsAtEventForMode(nativeEvent, 'point', { intersect: true }, true).length > 0
+                        if (hitsSlice) {
                             onChartClick(event, chart, datasets, onClick)
                         }
                     },


### PR DESCRIPTION
## Problem

Clicking anywhere in the rectangular bounding box of a pie chart (minus padding) triggers the session recording modal. Only clicking directly on a pie slice should be interactive.

## Changes

- Changed Chart.js `hover.mode` from '`index`' to '`point`' with `intersect: true` so hover effects only activate on actual slices
- Replaced shared `onChartHover`/`onChartClick` delegation with pie-specific handlers that use '`point`' intersection mode, ensuring clicks and pointer cursor only trigger on slices

## How did you test this code?

Manual testing: verified that clicking empty space around the pie chart no longer opens the modal, while clicking directly on slices still works correctly. Confirmed hover cursor only changes to pointer over actual slices.

## Publish to changelog?

No