### PR TITLE
refactor: AI form enter submission

### DIFF
--- a/frontend/src/scenes/onboarding/productSelection/ProductSelection.tsx
+++ b/frontend/src/scenes/onboarding/productSelection/ProductSelection.tsx
@@ -82,6 +82,11 @@ function ChoosePathStep(): JSX.Element {
                             placeholder="e.g., I want to understand why users drop off during checkout and run experiments to improve conversion..."
                             value={aiDescription}
                             onChange={(value) => setAiDescription(value)}
+                            onPressEnter={() => {
+                                if (aiDescription.trim()) {
+                                    submitAiRecommendation()
+                                }
+                            }}
                             rows={3}
                         />
                         <div className="flex items-center justify-between mt-3">


### PR DESCRIPTION
## Problem

Users expect pressing Enter in the signup AI form to submit the form. Previously, this action did not trigger submission, leading to a less intuitive user experience.

## Changes

Added the `onPressEnter` prop to the `LemonTextArea` component in `frontend/src/scenes/onboarding/productSelection/ProductSelection.tsx`. This prop triggers the `submitAiRecommendation()` function when Enter is pressed and the input field contains text. The `LemonTextArea` component handles this by allowing Shift+Enter for newlines.

## How did you test this code?

*   **Automated:** Ran TypeScript checks.
*   **Manual:** Verified that pressing Enter in the AI prompt field submits the form ("Get recommendations") and that Shift+Enter creates a newline within the input.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1771183679058339?thread_ts=1771183679.058339&cid=C0ACRAMJUAG)

<p><a href="https://cursor.com/background-agent?bcId=bc-007f4ee9-8c18-59b0-b9f1-1aa73e6f5a26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-007f4ee9-8c18-59b0-b9f1-1aa73e6f5a26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

