### PR TITLE
fix: Mcp expired token status

### DIFF
--- a/services/mcp/src/lib/auth-error-response.ts
+++ b/services/mcp/src/lib/auth-error-response.ts
@@ -1,0 +1,21 @@
+import { ErrorCode } from '@/lib/errors'
+
+const AUTH_ERROR_CODES = [ErrorCode.INACTIVE_OAUTH_TOKEN, ErrorCode.INVALID_API_KEY]
+
+/**
+ * Converts known auth failures from MCP internals into 401 responses.
+ */
+export const mapAuthErrorResponse = async (response: Response): Promise<Response> => {
+    if (response.ok) {
+        return response
+    }
+
+    const body = await response.clone().text()
+    const isAuthError = AUTH_ERROR_CODES.some((errorCode) => body.includes(errorCode))
+
+    if (isAuthError) {
+        return new Response('OAuth token is inactive', { status: 401 })
+    }
+
+    return response
+}

--- a/services/mcp/tests/unit/auth-error-response.test.ts
+++ b/services/mcp/tests/unit/auth-error-response.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { mapAuthErrorResponse } from '@/lib/auth-error-response'
+import { ErrorCode } from '@/lib/errors'
+
+describe('mapAuthErrorResponse', () => {
+    it.each([ErrorCode.INACTIVE_OAUTH_TOKEN, ErrorCode.INVALID_API_KEY])(
+        'maps %s responses to 401',
+        async (errorCode) => {
+            const response = new Response(`request failed: ${errorCode}`, { status: 500 })
+
+            const mappedResponse = await mapAuthErrorResponse(response)
+
+            expect(mappedResponse.status).toBe(401)
+            expect(await mappedResponse.text()).toBe('OAuth token is inactive')
+        }
+    )
+
+    it('keeps unrelated non-OK responses unchanged', async () => {
+        const response = new Response('request failed: SOMETHING_ELSE', { status: 500 })
+
+        const mappedResponse = await mapAuthErrorResponse(response)
+
+        expect(mappedResponse).toBe(response)
+    })
+
+    it('keeps successful responses unchanged', async () => {
+        const response = new Response('ok', { status: 200 })
+
+        const mappedResponse = await mapAuthErrorResponse(response)
+
+        expect(mappedResponse).toBe(response)
+    })
+})


### PR DESCRIPTION
## Problem

Previously, the MCP (services/mcp) would return a `500 Internal Server Error` for expired or inactive OAuth tokens. This is incorrect; an authentication failure should result in a `401 Unauthorized` status code. This also affected cases where `INVALID_API_KEY` was surfaced, which should also be a `401`.

## Changes

- Introduced `services/mcp/src/lib/auth-error-response.ts` to explicitly map `INACTIVE_OAUTH_TOKEN` and `INVALID_API_KEY` errors to a `401 Unauthorized` response with the message "OAuth token is inactive".
- Integrated this new error mapper into the main `services/mcp/src/index.ts` for both `/mcp` and `/sse` routes, ensuring these specific authentication failures are correctly handled.
- Added new unit tests in `services/mcp/tests/unit/auth-error-response.test.ts` to verify that:
    - `INACTIVE_OAUTH_TOKEN` results in a 401.
    - `INVALID_API_KEY` results in a 401.
    - Unrelated 500 errors remain unchanged.
    - Successful responses are unaffected.

## How did you test this code?

The following commands were run and all tests passed:
- `pnpm vitest run tests/unit/auth-error-response.test.ts`
- `pnpm vitest run tests/unit/oauth-region.test.ts tests/unit/auth-error-response.test.ts`

## Publish to changelog?

Yes

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b2a3bffb-d4be-46ff-86f4-9e40a0d9ae5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b2a3bffb-d4be-46ff-86f4-9e40a0d9ae5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

