### PR TITLE
fix: don't change title in the background

### DIFF
--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.test.ts
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.test.ts
@@ -20,7 +20,7 @@ describe('breadcrumbsLogic', () => {
         sceneLogic({ scenes }).mount()
     })
 
-    it('sets document.title', async () => {
+    it('sets document.title when page is visible', async () => {
         expect(global.document.title).toEqual('')
 
         logic = breadcrumbsLogic()
@@ -33,6 +33,26 @@ describe('breadcrumbsLogic', () => {
 
         router.actions.push(urls.dashboards())
         await expectLogic(logic).delay(1).toMatchValues({ documentTitle: 'Dashboards • PostHog' })
+        expect(global.document.title).toEqual('Dashboards • PostHog')
+    })
+
+    it('defers document.title update when page is hidden', async () => {
+        logic = breadcrumbsLogic()
+        logic.mount()
+
+        router.actions.push(urls.savedInsights())
+        await expectLogic(logic).delay(1).toMatchValues({ documentTitle: 'Product analytics • PostHog' })
+        expect(global.document.title).toEqual('Product analytics • PostHog')
+
+        Object.defineProperty(document, 'visibilityState', { value: 'hidden', writable: true })
+
+        router.actions.push(urls.dashboards())
+        await expectLogic(logic).delay(1).toMatchValues({ documentTitle: 'Dashboards • PostHog' })
+        expect(global.document.title).toEqual('Product analytics • PostHog')
+
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+
         expect(global.document.title).toEqual('Dashboards • PostHog')
     })
 })


### PR DESCRIPTION
![CleanShot 2026-02-15 at 22.41.15.gif](https://app.graphite.com/user-attachments/assets/68c54314-403c-4123-aa6e-02ea0bf10fa9.gif)

on chrome://discards/ it reports that posthog pages could not be discarded because they are setting the title or favicon and so it can't recover memory

but they've been in the background for hours with no interaction

the robot claims there is only one place where we're setting document title