### PR TITLE
feat(rust): new Rust app lifecycle management library to replace common/health

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4990,6 +4990,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "lifecycle"
+version = "0.1.0"
+dependencies = [
+ "axum 0.7.5",
+ "metrics",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "limiters"
 version = "0.1.0"
 dependencies = [
@@ -9443,6 +9455,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "common/dns",
     "common/health",
     "common/kafka",
+    "common/lifecycle",
     "common/limiters",
     "common/metrics",
     "common/profiler",
@@ -119,6 +120,7 @@ time = { version = "0.3.36", features = [
 ] }
 thiserror = { version = "2.0" }
 tokio = { version = "1.34.0", features = ["full"] }
+tokio-util = { version = "0.7", features = ["time"] }
 tower = { version = "0.4.13", features = ["default", "limit", "util"] }
 tower-http = { version = "0.5.2", features = ["cors", "decompression-br", "decompression-deflate", "decompression-gzip", "decompression-zstd", "limit", "trace"] }
 tracing = "0.1.40"

--- a/rust/common/lifecycle/Cargo.toml
+++ b/rust/common/lifecycle/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "lifecycle"
+version = "0.1.0"
+edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]
+axum = { workspace = true }
+metrics = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }

--- a/rust/common/lifecycle/README.md
+++ b/rust/common/lifecycle/README.md
@@ -202,7 +202,6 @@ After `signal_failure()`, just return — the manager records the failure immedi
 | `process_scope()` | Returns a `ProcessScopeGuard`. Ties lifecycle signaling to a method scope instead of handle drop. Use when your struct owns the handle. |
 | `report_healthy()` | Liveness heartbeat. Must be called more often than `liveness_deadline`. Missed deadlines increment a stall counter; after `stall_threshold` consecutive stalled checks, global shutdown is triggered. |
 | `report_unhealthy()` | Mark this component unhealthy. Treated the same as a stalled heartbeat by the health monitor. For immediate shutdown, use `signal_failure()` instead. |
-| `report_healthy_blocking()` | Same as `report_healthy()`; safe from sync/blocking contexts (e.g. rdkafka callbacks). |
 
 ### Common pitfalls
 

--- a/rust/common/lifecycle/README.md
+++ b/rust/common/lifecycle/README.md
@@ -2,41 +2,42 @@
 
 Unified app lifecycle management for K8s services. All features are opt-in — use only what your app needs.
 
-**Core** (always active): signal trapping, component registration with RAII drop guards, coordinated graceful shutdown, readiness probe, global shutdown timeout (default 60s).
+**Core** (always active): signal trapping, component registration with RAII drop guards, coordinated global shutdown, readiness probe,
 
-**Opt-in**: health monitoring with stall detection (`with_liveness_deadline`), liveness probe, pre-stop file polling.
+**Opt-in**: active health reporting with stall detection (`with_liveness_deadline`), graceful shutdown with per-component timeouts, liveness probe, pre-stop file polling.
 
 ## Quick Start
 
 Summary of how the library works and can be intergrated into your Rust services. All referenced features, APIs, and config details are documented below this section.
 
-* Create a `lifecycle::Manager` and configure:
-  * Optional k8s `preStop` handling
-  * Override global graceful shutdown max timeout
-* Register each app component on `Manager` and configure:
-  * Optional active health reporting (usually not needed)
-  * Optional graceful shutdown timeout (overrides global)
-  * Returns a `HealthHandle`
-* Pass or clone the health handle to the component prior to blocking in `main`:
-  * If component is a function, clone handle into it's scope
-  * If component is a struct, store handle as a field
-  * If the component runs for the full app lifecycle:
-    * Create a drop guard at the top of the processing loop
-    * Example: `let _completed = handle.process_scope();`
-    * Call `handle.work_completed();` prior to a clean exit
-    * Return an error or panic to signal completion and app shutdown
-  * If using active health reporting:
-    * Call `handle.report_healthy();` regularly
-    * Call `handle.report_unhealthy();` before unclean exit
-    * _Note:_ these can be called from sync or async they are fast and nonblocking
-    * Ensure you report health within the configured interval and number of allowed unhealthy polls
-* Prior to the end of `main.rs`, call `manager.monitor();` or `monitor_background()`
-* Graceful shutdown coordination (optional):
-  * Components checks it's health handle for app shutdown at logical work boundaries
-  * Handle has APIs for async and sync shutdown checks
-  * Handle can cloned or referenced as needed for checks in nested calls
-* Processing loop should break on shutdown signal:
-  * Shutdown cleanup should run prior to returning from loop function
+- Create a `lifecycle::Manager` and configure:
+  - Optional k8s `preStop` handling
+  - Override global graceful shutdown max timeout
+- Register each app component on `Manager` and configure:
+  - Optional active health reporting (usually not needed)
+  - Optional graceful shutdown timeout (overrides global)
+  - Returns a `HealthHandle`
+- Pass or clone the health handle to the component prior to blocking in `main`:
+  - If component is a function, clone handle into it's scope
+  - If component is a struct, store handle as a field
+  - If the component runs for the full app lifecycle:
+    - Create a drop guard at the top of the processing loop
+    - Example: `let _completed = handle.process_scope();`
+    - Call `handle.work_completed();` prior to a clean exit
+    - Return an error or panic to signal completion and app shutdown
+  - If using active health reporting:
+    - Call `handle.report_healthy();` regularly
+    - Call `handle.report_unhealthy();` before unclean exit
+    - *Note:* these can be called from sync or async they are fast and nonblocking
+    - Ensure you report health within the configured interval and number of allowed unhealthy polls
+- Prior to the end of `main.rs`, call `manager.monitor();` or `monitor_background()`
+- Shutdown coordination:
+  - Component checks health handle for app shutdown at logical work boundaries
+  - If shutdown signaled, perform cleanup as needed and `return`
+  - Handle has APIs for async and sync shutdown checks
+  - Handle can cloned or referenced as needed for checks in nested calls
+- Processing loop should break on shutdown signal:
+  - Graceful: perform cleanup prior to returning from loop function
 
 ## Manager setup
 
@@ -97,14 +98,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 All options except `name` have sensible defaults.
 
-| Method                                    | Effect                                                                                                                                                                                                         | Default      |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `Manager::builder(name)`                  | Start building a manager. `name` is emitted as the `service_name` label on all metrics.                                                                                                                        | — (required) |
-| `.with_global_shutdown_timeout(duration)` | Hard ceiling on total shutdown. Monitor returns `ShutdownTimeout` if exceeded. Prevents indefinite hangs if a component doesn't check for cancellation. (see test `global_timeout_fires_when_component_hangs`) | `60s`        |
-| `.with_trap_signals(bool)`                | Install SIGINT/SIGTERM handlers. Set `false` in tests.                                                                                                                                                         | `true`       |
-| `.with_prestop_check(bool)`               | Poll for `/tmp/shutdown` file (K8s pre-stop hook pattern).                                                                                                                                                     | `true`       |
-| `.with_health_poll_interval(duration)`    | Override health monitor poll frequency. The health monitor is automatically active when any component has `with_liveness_deadline`. (see test `stall_triggers_shutdown`)                                       | `5s`         |
-| `.build()`                                | Consume the builder and produce a `Manager`.                                                                                                                                                                   | —            |
+| Method                                    | Effect                                                                                                                                                                                                         | Default         |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `Manager::builder(name)`                  | Start building a manager. `name` is emitted as the `service_name` label on all metrics.                                                                                                                        | — (required)    |
+| `.with_global_shutdown_timeout(duration)` | Hard ceiling on total shutdown. Monitor returns `ShutdownTimeout` if exceeded. Prevents indefinite hangs if a component doesn't check for cancellation. (see test `global_timeout_fires_when_component_hangs`) | `60s`           |
+| `.with_trap_signals(bool)`                | Install SIGINT/SIGTERM handlers. Set `false` in tests.                                                                                                                                                         | `true`          |
+| `.with_prestop_check(bool)`               | Poll for pre-stop shutdown file (K8s pre-stop hook pattern).                                                                                                                                                   | `true`          |
+| `.with_prestop_path(path)`                | Override the pre-stop file path.                                                                                                                                                                               | `/tmp/shutdown` |
+| `.with_health_poll_interval(duration)`    | Override health monitor poll frequency. The health monitor is automatically active when any component has `with_liveness_deadline`. (see test `stall_triggers_shutdown`)                                       | `5s`            |
+| `.build()`                                | Consume the builder and produce a `Manager`.                                                                                                                                                                   | —               |
 
 ### register() / ComponentOptions
 
@@ -261,39 +263,39 @@ Label values: `trigger_reason` = `signal`, `prestop`, `failure`, `requested`, `d
 ## Grafana / Prometheus setup
 
 1. **Service name** — When creating the manager, set the name in `Manager::builder("kafka-deduplicator")`. This value is emitted as the `service_name` label on every lifecycle metric.
-2. **Grafana variable** — In dashboards, define a variable (e.g. `service_name`) of type _Query_ that lists values:
+2. **Grafana variable** — In dashboards, define a variable (e.g. `service_name`) of type *Query* that lists values:
   `label_values(lifecycle_shutdown_initiated_total, service_name)`
    so users can filter panels by service.
 3. **Prometheus scrape** — Ensure your app exposes the same metrics endpoint Prometheus scrapes (e.g. `/metrics`); the lifecycle crate only emits to the `metrics` facade; the app wires the recorder/exporter.
 
 ### Recommended panels (PromQL, segment by `service_name`)
 
-* **What triggered shutdown?** (table)
+- **What triggered shutdown?** (table)
 `increase(lifecycle_shutdown_initiated_total{service_name="$service_name"}[$__range])`
 by `trigger_component`, `trigger_reason`.
-* **Component shutdown duration** (heatmap)
+- **Component shutdown duration** (heatmap)
 `histogram_quantile(0.95, rate(lifecycle_component_shutdown_duration_seconds_bucket{service_name="$service_name"}[5m]))`
 by `component`, `result`.
-* **Shutdown result breakdown** (stacked bar)
+- **Shutdown result breakdown** (stacked bar)
 `sum by (component, result) increase(lifecycle_component_shutdown_result_total{service_name="$service_name"}[$__range])`.
-* **Incomplete shutdowns (SIGKILL detection)** (stat; alert if > 0)
+- **Incomplete shutdowns (SIGKILL detection)** (stat; alert if > 0)
 `increase(lifecycle_shutdown_initiated_total{service_name="$service_name"}[1h]) - increase(lifecycle_shutdown_completed_total{service_name="$service_name"}[1h])`.
-* **Component liveness** (table)
+- **Component liveness** (table)
 `lifecycle_component_healthy{service_name="$service_name"}`
 (one row per component).
 
 ### Alert rules (segment by `service_name`)
 
-* Component timeout rate > 0 over 5m:
+- Component timeout rate > 0 over 5m:
 `increase(lifecycle_component_shutdown_result_total{service_name="$service_name", result="timeout"}[5m]) > 0`
-* Incomplete shutdown count > 0 over 1h:
+- Incomplete shutdown count > 0 over 1h:
 `increase(lifecycle_shutdown_initiated_total{service_name="$service_name"}[1h]) - increase(lifecycle_shutdown_completed_total{service_name="$service_name"}[1h]) > 0`
-* Component unhealthy for > 2 consecutive scrapes: e.g. alert when `lifecycle_component_healthy{service_name="$service_name"}` is 0 for a given component for 2 scrape intervals.
+- Component unhealthy for > 2 consecutive scrapes: e.g. alert when `lifecycle_component_healthy{service_name="$service_name"}` is 0 for a given component for 2 scrape intervals.
 
 ## SIGKILL detection
 
 SIGKILL cannot be trapped. Detection is by absence:
 
-* **Logs**: "Lifecycle: shutdown initiated" present but "Lifecycle: shutdown complete" absent within the expected window → process was killed mid-shutdown. In Loki: `{app="my-worker"} |= "Lifecycle: shutdown initiated"` and absence of `|= "Lifecycle: shutdown complete"`.
-* **Metrics**: `increase(lifecycle_shutdown_initiated_total[1h]) - increase(lifecycle_shutdown_completed_total[1h]) > 0` means some shutdowns did not complete.
-* **K8s**: Pod exit code 137 is the authoritative SIGKILL signal (infrastructure-level, not emitted by this crate).
+- **Logs**: "Lifecycle: shutdown initiated" present but "Lifecycle: shutdown complete" absent within the expected window → process was killed mid-shutdown. In Loki: `{app="my-worker"} |= "Lifecycle: shutdown initiated"` and absence of `|= "Lifecycle: shutdown complete"`.
+- **Metrics**: `increase(lifecycle_shutdown_initiated_total[1h]) - increase(lifecycle_shutdown_completed_total[1h]) > 0` means some shutdowns did not complete.
+- **K8s**: Pod exit code 137 is the authoritative SIGKILL signal (infrastructure-level, not emitted by this crate).

--- a/rust/common/lifecycle/README.md
+++ b/rust/common/lifecycle/README.md
@@ -1,0 +1,50 @@
+# lifecycle
+
+Unified app lifecycle management: signal trapping (SIGINT/SIGTERM), component registration with RAII drop guards, coordinated graceful shutdown, heartbeat-based liveness, K8s readiness/liveness probes, and metrics. The monitor runs on a dedicated OS thread with an isolated tokio runtime so it stays responsive regardless of app workload.
+
+## Metrics
+
+The crate emits metrics via the `metrics` facade (no recorder installed by this crate; the parent app does that).
+
+| Metric | Type | Labels | When emitted |
+|--------|------|--------|--------------|
+| `lifecycle_shutdown_initiated_total` | Counter | `app`, `trigger_component`, `trigger_reason` | Once when shutdown begins |
+| `lifecycle_component_shutdown_duration_seconds` | Histogram | `app`, `component`, `result` | Once per component at completion/timeout/death |
+| `lifecycle_component_shutdown_result_total` | Counter | `app`, `component`, `result` | Once per component at completion/timeout/death |
+| `lifecycle_shutdown_completed_total` | Counter | `app`, `clean` | Once when monitor returns successfully |
+| `lifecycle_component_healthy` | Gauge | `app`, `component` | Continuously during normal operation |
+
+Label values: `trigger_reason` = `signal`, `prestop`, `failure`, `requested`, `died`; `result` = `completed`, `timeout`, `died`; `clean` = `true` / `false`.
+
+`lifecycle_shutdown_completed_total` is **not** emitted on global timeout or if the process is killed; that asymmetry with `lifecycle_shutdown_initiated_total` is how incomplete shutdowns (e.g. SIGKILL) are detected.
+
+## PromQL / Grafana
+
+- **What triggered shutdown?**  
+  `increase(lifecycle_shutdown_initiated_total{app="$app"}[$__range])` by `trigger_component`, `trigger_reason` (table).
+
+- **Component shutdown duration**  
+  `histogram_quantile(0.95, rate(lifecycle_component_shutdown_duration_seconds_bucket{app="$app"}[5m]))` by `component`, `result` (heatmap).
+
+- **Shutdown result breakdown**  
+  `sum by (component, result) increase(lifecycle_component_shutdown_result_total{app="$app"}[$__range])` (stacked bar).
+
+- **Incomplete shutdowns (SIGKILL detection)**  
+  `increase(lifecycle_shutdown_initiated_total{app="$app"}[1h]) - increase(lifecycle_shutdown_completed_total{app="$app"}[1h])` (stat panel; alert if > 0).
+
+- **Component liveness**  
+  `lifecycle_component_healthy{app="$app"}` (table, one row per component).
+
+### Alert rules
+
+- Component timeout rate > 0 over 5m.
+- Incomplete shutdown count > 0 over 1h.
+- Component unhealthy for > 2 consecutive scrapes.
+
+## SIGKILL detection
+
+SIGKILL cannot be trapped. Detection is by absence:
+
+- **Logs**: "Lifecycle: shutdown initiated" present but "Lifecycle: shutdown complete" absent within the expected window → process was killed mid-shutdown. In Loki: `{app="my-worker"} |= "Lifecycle: shutdown initiated"` and absence of `|= "Lifecycle: shutdown complete"`.
+- **Metrics**: `increase(lifecycle_shutdown_initiated_total[1h]) - increase(lifecycle_shutdown_completed_total[1h]) > 0` means some shutdowns did not complete.
+- **K8s**: Pod exit code 137 is the authoritative SIGKILL signal (infrastructure-level, not emitted by this crate).

--- a/rust/common/lifecycle/README.md
+++ b/rust/common/lifecycle/README.md
@@ -4,7 +4,7 @@ Unified app lifecycle management for K8s services. All features are opt-in — u
 
 **Core** (always active): signal trapping, component registration with RAII drop guards, coordinated graceful shutdown, readiness probe.
 
-**Opt-in**: health monitoring with stall detection (`with_health_poll_interval` + `with_liveness_deadline`), global shutdown timeout (`with_global_shutdown_timeout`), liveness probe, pre-stop file polling.
+**Opt-in**: health monitoring with stall detection (`with_liveness_deadline`), global shutdown timeout (`with_global_shutdown_timeout`), liveness probe, pre-stop file polling.
 
 ## Manager setup
 
@@ -40,7 +40,6 @@ use lifecycle::{ComponentOptions, Manager, ManagerOptions};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut manager = Manager::new(
         ManagerOptions::new("my-service")
-            .with_health_poll_interval(Duration::from_secs(5))     // enable health monitoring
             .with_global_shutdown_timeout(Duration::from_secs(30)), // optional: cap shutdown duration
     );
 
@@ -76,7 +75,7 @@ All options except `name` are optional with sensible defaults. Features are opt-
 | `.with_global_shutdown_timeout(duration)` | Hard ceiling on total shutdown. Monitor returns `ShutdownTimeout` if exceeded. Without this, the monitor waits indefinitely for components — K8s SIGKILL is the external backstop. (see test `global_timeout_fires_when_component_hangs`) | `None` — no ceiling |
 | `.with_trap_signals(bool)` | Install SIGINT/SIGTERM handlers. Set `false` in tests. | `true` |
 | `.with_prestop_check(bool)` | Poll for `/tmp/shutdown` file (K8s pre-stop hook pattern). | `true` |
-| `.with_health_poll_interval(duration)` | Enable health monitoring. The monitor polls component heartbeats at this interval and triggers shutdown when stall thresholds are reached. Without this, `with_liveness_deadline` on components has no effect. (see test `stall_triggers_shutdown`) | `None` — disabled |
+| `.with_health_poll_interval(duration)` | Override health monitor poll frequency. The health monitor is automatically active when any component has `with_liveness_deadline`. (see test `stall_triggers_shutdown`) | `5s` |
 
 ### register() / ComponentOptions
 
@@ -86,14 +85,14 @@ All options except `name` are optional with sensible defaults. Features are opt-
 |--------|--------|---------|
 | `ComponentOptions::new()` | Base options with defaults for all fields. | — |
 | `.with_graceful_shutdown(duration)` | Max time for this component to clean up after shutdown begins. Exceeded = marked timed out. (see test `component_timeout_then_late_drop_preserves_timeout`) | `None` — waits indefinitely (bounded by `global_shutdown_timeout` if set, or K8s SIGKILL) |
-| `.with_liveness_deadline(duration)` | Component must call `report_healthy()` within this interval or the health monitor considers it stalled. After `stall_threshold` consecutive stalled checks, the manager triggers global shutdown. Requires `with_health_poll_interval` on the manager. (see test `stall_triggers_shutdown`) | `None` — no health monitoring |
+| `.with_liveness_deadline(duration)` | Component must call `report_healthy()` within this interval or the health monitor considers it stalled. After `stall_threshold` consecutive stalled checks, the manager triggers global shutdown. (see test `stall_triggers_shutdown`) | `None` — no health monitoring |
 | `.with_stall_threshold(n)` | Number of consecutive stalled health checks before the manager triggers global shutdown. Set higher for tolerance of transient hiccups. Only meaningful with `with_liveness_deadline`. (see test `stall_threshold_allows_recovery`) | `1` — immediate shutdown on first stall |
 
 ## K8s readiness and liveness
 
 **Readiness** (`/_readiness`) returns 200 until shutdown begins, then 503. K8s uses this to stop routing traffic to the pod. No per-component logic — it's purely "is the app accepting work?" (see test `readiness_200_until_shutdown_then_503`)
 
-**Liveness** (`/_liveness`) always returns 200 — it means "the process is reachable." Health monitoring is handled internally by the manager's health poll task (enabled via `with_health_poll_interval`), not by K8s. When a component's heartbeat deadline expires, the health monitor increments a stall counter. After `stall_threshold` consecutive stalled checks, the manager triggers global shutdown via the same `ComponentEvent::Failure` path as `signal_failure()`. This ensures the app always gets coordinated graceful shutdown instead of K8s surprise-killing the pod. (see tests `stall_triggers_shutdown`, `stall_threshold_exceeded_triggers_shutdown`, `stall_threshold_allows_recovery`)
+**Liveness** (`/_liveness`) always returns 200 — it means "the process is reachable." Health monitoring is handled internally by the manager's health poll task, not by K8s. When a component's heartbeat deadline expires, the health monitor increments a stall counter. After `stall_threshold` consecutive stalled checks, the manager triggers global shutdown via the same `ComponentEvent::Failure` path as `signal_failure()`. This ensures the app always gets coordinated graceful shutdown instead of K8s surprise-killing the pod. (see tests `stall_triggers_shutdown`, `stall_threshold_exceeded_triggers_shutdown`, `stall_threshold_allows_recovery`)
 
 Components in **Starting** state (never called `report_healthy()`) are skipped by the health monitor — they won't trigger stall detection until they've reported healthy at least once. (see test `starting_component_does_not_trigger_stall`)
 
@@ -204,15 +203,15 @@ After `signal_failure()`, just return — the manager records the failure immedi
 | `request_shutdown()` | Request clean shutdown (non-fatal). Then return (drop is enough). |
 | `work_completed()` | One-shot/finite work that completes during normal operation (prevents the handle drop from signaling "died"). Not needed for long-running components — drop during shutdown is treated as completion. |
 | `process_scope()` | Returns a `ProcessScopeGuard`. Ties lifecycle signaling to a method scope instead of handle drop. Use when your struct owns the handle. |
-| `report_healthy()` | Liveness heartbeat. Must be called more often than `liveness_deadline`. When health monitoring is enabled, missed deadlines increment a stall counter; after `stall_threshold` consecutive stalled checks, global shutdown is triggered. |
-| `report_unhealthy()` | Mark this component unhealthy. When health monitoring is enabled, treated the same as a stalled heartbeat. For immediate shutdown, use `signal_failure()` instead. |
+| `report_healthy()` | Liveness heartbeat. Must be called more often than `liveness_deadline`. Missed deadlines increment a stall counter; after `stall_threshold` consecutive stalled checks, global shutdown is triggered. |
+| `report_unhealthy()` | Mark this component unhealthy. Treated the same as a stalled heartbeat by the health monitor. For immediate shutdown, use `signal_failure()` instead. |
 | `report_healthy_blocking()` | Same as `report_healthy()`; safe from sync/blocking contexts (e.g. rdkafka callbacks). |
 
 ### Common pitfalls
 
 1. **Drop during normal operation** — If the last handle (or process scope guard) is dropped while shutdown is **not** in progress, the manager treats it as "component died" and triggers shutdown. This catches panics and early returns. Dropping after shutdown begins is treated as normal completion. (see test `panic_in_task_with_process_scope_signals_died`)
 2. **Register order** — Register all components before calling `monitor()` or `monitor_background()`. The manager is consumed by those calls.
-3. **Health monitoring** — Requires both `with_health_poll_interval` on the manager AND `with_liveness_deadline` on the component. With both set, you must call `report_healthy()` more frequently than `liveness_deadline`, or the health monitor triggers global shutdown after `stall_threshold` consecutive stalled checks. Components that haven't called `report_healthy()` yet (Starting state) are skipped. If `with_health_poll_interval` is not set, liveness deadlines are inert (the manager logs a warning).
+3. **Health monitoring** — Activated by `with_liveness_deadline` on any component. You must call `report_healthy()` more frequently than `liveness_deadline`, or the health monitor triggers global shutdown after `stall_threshold` consecutive stalled checks. Components that haven't called `report_healthy()` yet (Starting state) are skipped. Use `with_health_poll_interval` on the manager to tune poll frequency (default 5s).
 4. **Struct-held handles** — If your struct owns the handle and `process()` is the run method, use `process_scope()`. Otherwise the manager is only notified when the struct is dropped, not when `process()` returns.
 
 ## Metrics

--- a/rust/common/lifecycle/README.md
+++ b/rust/common/lifecycle/README.md
@@ -2,44 +2,181 @@
 
 Unified app lifecycle management: signal trapping (SIGINT/SIGTERM), component registration with RAII drop guards, coordinated graceful shutdown, heartbeat-based liveness, K8s readiness/liveness probes, and metrics. The monitor runs on a dedicated OS thread with an isolated tokio runtime so it stays responsive regardless of app workload.
 
+## Usage
+
+### Worker (no HTTP server)
+
+Register components **before** calling `monitor()` or `monitor_background()`. In your component task, **always** call `handle.work_completed()` before returning (on both shutdown and error paths), or the handle's drop guard will signal "component died" and trigger shutdown.
+
+```rust
+use std::time::Duration;
+use lifecycle::{ComponentOptions, Manager, ManagerOptions};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "my-worker".into(),
+        global_shutdown_timeout: Duration::from_secs(30),
+        ..Default::default()
+    });
+
+    let handle = manager.register(
+        "consumer",
+        ComponentOptions::new()
+            .with_graceful_shutdown(Duration::from_secs(10))
+            .with_liveness_deadline(Duration::from_secs(30)),
+    );
+    tokio::spawn(consumer_loop(handle));
+
+    manager.monitor().await?;
+    Ok(())
+}
+
+async fn consumer_loop(handle: lifecycle::Handle) {
+    loop {
+        tokio::select! {
+            _ = handle.shutdown_recv() => {
+                // Drain in-flight work, then signal done. Must call work_completed() before return.
+                drain().await;
+                handle.work_completed();
+                return;
+            }
+            msg = recv_message() => {
+                if let Err(e) = process(msg).await {
+                    handle.signal_failure(e.to_string());
+                    handle.work_completed();
+                    return;
+                }
+                handle.report_healthy();
+            }
+        }
+    }
+}
+```
+
+### With Axum (readiness / liveness / graceful shutdown)
+
+Use `monitor_background()` so the monitor runs while the server is up; after `axum::serve` returns (due to shutdown signal), await the guard to get the final result.
+
+```rust
+use std::time::Duration;
+use axum::{Router, routing::get};
+use lifecycle::{ComponentOptions, Manager, ManagerOptions};
+use tokio::net::TcpListener;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "my-api".into(),
+        global_shutdown_timeout: Duration::from_secs(30),
+        ..Default::default()
+    });
+
+    let handle = manager.register(
+        "processor",
+        ComponentOptions::new()
+            .with_graceful_shutdown(Duration::from_secs(10))
+            .with_liveness_deadline(Duration::from_secs(30)),
+    );
+    tokio::spawn(processor_loop(handle));
+
+    let readiness = manager.readiness_handler();
+    let liveness = manager.liveness_handler();
+    let shutdown = manager.shutdown_signal();
+
+    let app = Router::new()
+        .route("/_readiness", get({
+            let r = readiness.clone();
+            move || async move { r.check().await }
+        }))
+        .route("/_liveness", get({
+            let l = liveness.clone();
+            move || async move { l.check().into_response() }
+        }));
+
+    let guard = manager.monitor_background();
+
+    let listener = TcpListener::bind("0.0.0.0:8080").await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await?;
+
+    guard.wait().await?;
+    Ok(())
+}
+```
+
+### Handle API summary
+
+| Method | Use when |
+|--------|----------|
+| `shutdown_recv()` | In `tokio::select!` to react to shutdown (e.g. stop consuming, drain, then `work_completed()`). |
+| `cancellation_token()` | Pass to sub-tasks or APIs that take a `CancellationToken`. |
+| `is_shutting_down()` | Sync check (e.g. in a hot loop) to bail out. |
+| `signal_failure(reason)` | Fatal error; triggers global shutdown. Call `work_completed()` after. |
+| `request_shutdown()` | Request clean shutdown (non-fatal). Then finish work and `work_completed()`. |
+| `work_completed()` | **Always** call before your component task returns (shutdown or error path). Otherwise the drop guard signals "died". |
+| `report_healthy()` | Liveness heartbeat (call more often than `liveness_deadline`). |
+| `report_unhealthy()` | Mark component unhealthy for liveness. |
+| `report_healthy_blocking()` | Same as `report_healthy()`; use from sync/blocking contexts (e.g. rdkafka callbacks). |
+
+### Common pitfalls
+
+1. **Forgetting `work_completed()`** — When the **last** clone of a `Handle` is dropped (e.g. when your component task returns), the drop guard runs. If you never called `work_completed()`, the manager receives "component died" and shuts down. So: on every exit path from your component (normal shutdown, error, early return), call `work_completed()` before returning.
+2. **Register order** — Register all components before calling `monitor()` or `monitor_background()`; the manager is consumed by those calls, so you cannot register afterward.
+3. **Liveness** — If you use `with_liveness_deadline`, the component must call `report_healthy()` (or `report_healthy_blocking()`) more frequently than that interval, or the liveness probe will report the component as stalled/unhealthy. With `HealthStrategy::All`, one stalled component makes the app unhealthy.
+
 ## Metrics
 
-The crate emits metrics via the `metrics` facade (no recorder installed by this crate; the parent app does that).
+The crate emits metrics via the `metrics` facade (no recorder installed by this crate; the parent app does that). All metrics are segmented by **`service_name`**: set `ManagerOptions::name` to your app’s service name (e.g. K8s service name or logical app name) so dashboards and alerts can filter by service.
 
 | Metric | Type | Labels | When emitted |
 |--------|------|--------|--------------|
-| `lifecycle_shutdown_initiated_total` | Counter | `app`, `trigger_component`, `trigger_reason` | Once when shutdown begins |
-| `lifecycle_component_shutdown_duration_seconds` | Histogram | `app`, `component`, `result` | Once per component at completion/timeout/death |
-| `lifecycle_component_shutdown_result_total` | Counter | `app`, `component`, `result` | Once per component at completion/timeout/death |
-| `lifecycle_shutdown_completed_total` | Counter | `app`, `clean` | Once when monitor returns successfully |
-| `lifecycle_component_healthy` | Gauge | `app`, `component` | Continuously during normal operation |
+| `lifecycle_shutdown_initiated_total` | Counter | `service_name`, `trigger_component`, `trigger_reason` | Once when shutdown begins |
+| `lifecycle_component_shutdown_duration_seconds` | Histogram | `service_name`, `component`, `result` | Once per component at completion/timeout/death |
+| `lifecycle_component_shutdown_result_total` | Counter | `service_name`, `component`, `result` | Once per component at completion/timeout/death |
+| `lifecycle_shutdown_completed_total` | Counter | `service_name`, `clean` | Once when monitor returns successfully |
+| `lifecycle_component_healthy` | Gauge | `service_name`, `component` | Continuously during normal operation |
 
 Label values: `trigger_reason` = `signal`, `prestop`, `failure`, `requested`, `died`; `result` = `completed`, `timeout`, `died`; `clean` = `true` / `false`.
 
 `lifecycle_shutdown_completed_total` is **not** emitted on global timeout or if the process is killed; that asymmetry with `lifecycle_shutdown_initiated_total` is how incomplete shutdowns (e.g. SIGKILL) are detected.
 
-## PromQL / Grafana
+## Grafana / Prometheus setup
 
-- **What triggered shutdown?**  
-  `increase(lifecycle_shutdown_initiated_total{app="$app"}[$__range])` by `trigger_component`, `trigger_reason` (table).
+1. **Service name** — When creating the manager, set `ManagerOptions::name` to your service name (e.g. `"kafka-deduplicator"`, `"ingestion-api"`). This value is emitted as the `service_name` label on every lifecycle metric.
+2. **Grafana variable** — In dashboards, define a variable (e.g. `service_name`) of type *Query* that lists values:  
+   `label_values(lifecycle_shutdown_initiated_total, service_name)`  
+   so users can filter panels by service.
+3. **Prometheus scrape** — Ensure your app exposes the same metrics endpoint Prometheus scrapes (e.g. `/metrics`); the lifecycle crate only emits to the `metrics` facade; the app wires the recorder/exporter.
 
-- **Component shutdown duration**  
-  `histogram_quantile(0.95, rate(lifecycle_component_shutdown_duration_seconds_bucket{app="$app"}[5m]))` by `component`, `result` (heatmap).
+### Recommended panels (PromQL, segment by `service_name`)
 
-- **Shutdown result breakdown**  
-  `sum by (component, result) increase(lifecycle_component_shutdown_result_total{app="$app"}[$__range])` (stacked bar).
+- **What triggered shutdown?** (table)  
+  `increase(lifecycle_shutdown_initiated_total{service_name="$service_name"}[$__range])`  
+  by `trigger_component`, `trigger_reason`.
 
-- **Incomplete shutdowns (SIGKILL detection)**  
-  `increase(lifecycle_shutdown_initiated_total{app="$app"}[1h]) - increase(lifecycle_shutdown_completed_total{app="$app"}[1h])` (stat panel; alert if > 0).
+- **Component shutdown duration** (heatmap)  
+  `histogram_quantile(0.95, rate(lifecycle_component_shutdown_duration_seconds_bucket{service_name="$service_name"}[5m]))`  
+  by `component`, `result`.
 
-- **Component liveness**  
-  `lifecycle_component_healthy{app="$app"}` (table, one row per component).
+- **Shutdown result breakdown** (stacked bar)  
+  `sum by (component, result) increase(lifecycle_component_shutdown_result_total{service_name="$service_name"}[$__range])`.
 
-### Alert rules
+- **Incomplete shutdowns (SIGKILL detection)** (stat; alert if > 0)  
+  `increase(lifecycle_shutdown_initiated_total{service_name="$service_name"}[1h]) - increase(lifecycle_shutdown_completed_total{service_name="$service_name"}[1h])`.
 
-- Component timeout rate > 0 over 5m.
-- Incomplete shutdown count > 0 over 1h.
-- Component unhealthy for > 2 consecutive scrapes.
+- **Component liveness** (table)  
+  `lifecycle_component_healthy{service_name="$service_name"}`  
+  (one row per component).
+
+### Alert rules (segment by `service_name`)
+
+- Component timeout rate > 0 over 5m:  
+  `increase(lifecycle_component_shutdown_result_total{service_name="$service_name", result="timeout"}[5m]) > 0`
+- Incomplete shutdown count > 0 over 1h:  
+  `increase(lifecycle_shutdown_initiated_total{service_name="$service_name"}[1h]) - increase(lifecycle_shutdown_completed_total{service_name="$service_name"}[1h]) > 0`
+- Component unhealthy for > 2 consecutive scrapes: e.g. alert when `lifecycle_component_healthy{service_name="$service_name"}` is 0 for a given component for 2 scrape intervals.
 
 ## SIGKILL detection
 

--- a/rust/common/lifecycle/src/error.rs
+++ b/rust/common/lifecycle/src/error.rs
@@ -1,0 +1,32 @@
+//! Lifecycle error types returned by the monitor.
+
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Errors returned by [`Manager::monitor`](crate::Manager::monitor) or [`MonitorGuard::wait`](crate::MonitorGuard::wait).
+#[derive(Debug, Error)]
+pub enum LifecycleError {
+    /// A component called [`Handle::signal_failure`](crate::Handle::signal_failure).
+    #[error("component '{tag}' failed: {reason}")]
+    ComponentFailure { tag: String, reason: String },
+
+    /// A component's handle was dropped without calling [`Handle::work_completed`](crate::Handle::work_completed).
+    #[error("component '{tag}' died unexpectedly")]
+    ComponentDied { tag: String },
+
+    /// Global shutdown timeout was reached with components still running.
+    #[error("shutdown timed out after {elapsed:?}, components still running: {remaining:?}")]
+    ShutdownTimeout {
+        elapsed: Duration,
+        remaining: Vec<String>,
+    },
+
+    /// OS signal (SIGINT/SIGTERM) was received.
+    #[error("signal received: {0}")]
+    Signal(String),
+
+    /// The dedicated lifecycle monitor thread panicked.
+    #[error("lifecycle monitor thread panicked")]
+    MonitorPanicked,
+}

--- a/rust/common/lifecycle/src/error.rs
+++ b/rust/common/lifecycle/src/error.rs
@@ -11,8 +11,9 @@ pub enum LifecycleError {
     #[error("component '{tag}' failed: {reason}")]
     ComponentFailure { tag: String, reason: String },
 
-    /// A component's handle was dropped without calling [`Handle::work_completed`](crate::Handle::work_completed).
-    #[error("component '{tag}' died unexpectedly")]
+    /// A component's handle was dropped during normal operation (shutdown not in progress) without
+    /// calling [`Handle::work_completed`](crate::Handle::work_completed) — e.g. panic or early return.
+    #[error("component '{tag}' exited unexpectedly (handle dropped without work_completed during normal operation)")]
     ComponentDied { tag: String },
 
     /// Global shutdown timeout was reached with components still running.

--- a/rust/common/lifecycle/src/error.rs
+++ b/rust/common/lifecycle/src/error.rs
@@ -23,10 +23,6 @@ pub enum LifecycleError {
         remaining: Vec<String>,
     },
 
-    /// OS signal (SIGINT/SIGTERM) was received.
-    #[error("signal received: {0}")]
-    Signal(String),
-
     /// The dedicated lifecycle monitor thread panicked.
     #[error("lifecycle monitor thread panicked")]
     MonitorPanicked,

--- a/rust/common/lifecycle/src/handle.rs
+++ b/rust/common/lifecycle/src/handle.rs
@@ -1,0 +1,108 @@
+//! Component handle and lifecycle events.
+
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug)]
+pub(crate) enum ComponentEvent {
+    Failure { tag: String, reason: String },
+    ShutdownRequested { tag: String },
+    WorkCompleted { tag: String },
+    Died { tag: String },
+}
+
+/// RAII handle for a registered component. Clone and pass to tasks; drop without
+/// [`work_completed`](Handle::work_completed) signals "died" to the manager.
+#[derive(Clone)]
+pub struct Handle {
+    pub(crate) inner: Arc<HandleInner>,
+}
+
+pub struct HandleInner {
+    pub(crate) tag: String,
+    pub(crate) shutdown_token: CancellationToken,
+    pub(crate) event_tx: mpsc::Sender<ComponentEvent>,
+    pub(crate) healthy_until_ms: Arc<AtomicI64>,
+    pub(crate) liveness_deadline: Option<Duration>,
+    pub(crate) completed: AtomicBool,
+}
+
+impl Handle {
+    /// Future that resolves when shutdown begins. Use in `tokio::select!` to detect shutdown.
+    pub fn shutdown_recv(&self) -> tokio_util::sync::WaitForCancellationFuture<'_> {
+        self.inner.shutdown_token.cancelled()
+    }
+
+    /// Clone of the underlying cancellation token for passing to sub-tasks.
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.inner.shutdown_token.clone()
+    }
+
+    /// Returns true if shutdown has been initiated.
+    pub fn is_shutting_down(&self) -> bool {
+        self.inner.shutdown_token.is_cancelled()
+    }
+
+    /// Signal a fatal error; triggers global shutdown.
+    pub fn signal_failure(&self, reason: impl Into<String>) {
+        drop(self.inner.event_tx.try_send(ComponentEvent::Failure {
+            tag: self.inner.tag.clone(),
+            reason: reason.into(),
+        }));
+    }
+
+    /// Request a clean shutdown (non-fatal).
+    pub fn request_shutdown(&self) {
+        drop(
+            self.inner
+                .event_tx
+                .try_send(ComponentEvent::ShutdownRequested {
+                    tag: self.inner.tag.clone(),
+                }),
+        );
+    }
+
+    /// Mark this component as finished; suppresses "died" when the handle is dropped.
+    pub fn work_completed(&self) {
+        self.inner.completed.store(true, Ordering::SeqCst);
+        drop(self.inner.event_tx.try_send(ComponentEvent::WorkCompleted {
+            tag: self.inner.tag.clone(),
+        }));
+    }
+
+    /// Report healthy; must be called more often than the configured liveness deadline.
+    pub fn report_healthy(&self) {
+        if let Some(deadline) = self.inner.liveness_deadline {
+            let now_ms = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64;
+            let until = now_ms.saturating_add(deadline.as_millis() as i64);
+            self.inner.healthy_until_ms.store(until, Ordering::Relaxed);
+        }
+    }
+
+    /// Report this component as unhealthy for liveness.
+    pub fn report_unhealthy(&self) {
+        self.inner.healthy_until_ms.store(0, Ordering::Relaxed);
+    }
+
+    /// Same as [`report_healthy`](Handle::report_healthy); safe to call from sync/blocking contexts (e.g. rdkafka callbacks).
+    pub fn report_healthy_blocking(&self) {
+        self.report_healthy();
+    }
+}
+
+impl Drop for HandleInner {
+    fn drop(&mut self) {
+        if !self.completed.load(Ordering::SeqCst) {
+            drop(self.event_tx.try_send(ComponentEvent::Died {
+                tag: self.tag.clone(),
+            }));
+        }
+    }
+}

--- a/rust/common/lifecycle/src/lib.rs
+++ b/rust/common/lifecycle/src/lib.rs
@@ -1,5 +1,5 @@
 //! Unified app lifecycle: signal trapping, component registration with RAII drop guards,
-//! coordinated graceful shutdown, heartbeat-based liveness, K8s readiness/liveness probes,
+//! coordinated graceful shutdown, internal health monitoring, K8s readiness/liveness probes,
 //! and metrics. The monitor runs on a dedicated OS thread with an isolated tokio runtime
 //! so it stays responsive regardless of app workload.
 
@@ -13,6 +13,6 @@ mod signals;
 
 pub use error::LifecycleError;
 pub use handle::{Handle, ProcessScopeGuard};
-pub use liveness::{ComponentLiveness, HealthStrategy, LivenessHandler, LivenessStatus};
+pub use liveness::{LivenessHandler, LivenessStatus};
 pub use manager::{ComponentOptions, Manager, ManagerOptions, MonitorGuard};
 pub use readiness::ReadinessHandler;

--- a/rust/common/lifecycle/src/lib.rs
+++ b/rust/common/lifecycle/src/lib.rs
@@ -14,5 +14,5 @@ mod signals;
 pub use error::LifecycleError;
 pub use handle::{Handle, ProcessScopeGuard};
 pub use liveness::{LivenessHandler, LivenessStatus};
-pub use manager::{ComponentOptions, Manager, ManagerOptions, MonitorGuard};
+pub use manager::{ComponentOptions, Manager, ManagerBuilder, MonitorGuard};
 pub use readiness::ReadinessHandler;

--- a/rust/common/lifecycle/src/lib.rs
+++ b/rust/common/lifecycle/src/lib.rs
@@ -12,7 +12,7 @@ mod readiness;
 mod signals;
 
 pub use error::LifecycleError;
-pub use handle::Handle;
+pub use handle::{Handle, ProcessScopeGuard};
 pub use liveness::{ComponentLiveness, HealthStrategy, LivenessHandler, LivenessStatus};
 pub use manager::{ComponentOptions, Manager, ManagerOptions, MonitorGuard};
 pub use readiness::ReadinessHandler;

--- a/rust/common/lifecycle/src/lib.rs
+++ b/rust/common/lifecycle/src/lib.rs
@@ -1,0 +1,18 @@
+//! Unified app lifecycle: signal trapping, component registration with RAII drop guards,
+//! coordinated graceful shutdown, heartbeat-based liveness, K8s readiness/liveness probes,
+//! and metrics. The monitor runs on a dedicated OS thread with an isolated tokio runtime
+//! so it stays responsive regardless of app workload.
+
+mod error;
+mod handle;
+mod liveness;
+mod manager;
+mod metrics;
+mod readiness;
+mod signals;
+
+pub use error::LifecycleError;
+pub use handle::Handle;
+pub use liveness::{ComponentLiveness, HealthStrategy, LivenessHandler, LivenessStatus};
+pub use manager::{ComponentOptions, Manager, ManagerOptions, MonitorGuard};
+pub use readiness::ReadinessHandler;

--- a/rust/common/lifecycle/src/liveness.rs
+++ b/rust/common/lifecycle/src/liveness.rs
@@ -14,10 +14,12 @@ pub(crate) struct LivenessComponentRef {
     pub stall_threshold: u32,
 }
 
-/// K8s liveness probe handler. Always returns 200 — liveness means "the process
-/// is reachable." Health monitoring is handled internally by the manager's monitor
-/// loop, which triggers coordinated graceful shutdown when a component stalls,
-/// rather than letting K8s surprise-kill the pod.
+/// K8s liveness probe handler. **Intentionally always returns 200.**
+///
+/// Health monitoring is handled internally by the lifecycle library's monitor loop,
+/// not by K8s liveness probes. This is a deliberate design choice: when a component
+/// stalls, the library triggers coordinated graceful shutdown instead of letting K8s
+/// surprise-kill the pod via a failed liveness check.
 #[derive(Clone)]
 pub struct LivenessHandler;
 
@@ -31,7 +33,7 @@ impl LivenessHandler {
     }
 }
 
-/// Always-healthy liveness status. Implements [`IntoResponse`] for axum.
+/// Always-healthy liveness response. This is intentional — see [`LivenessHandler`].
 pub struct LivenessStatus;
 
 impl IntoResponse for LivenessStatus {

--- a/rust/common/lifecycle/src/liveness.rs
+++ b/rust/common/lifecycle/src/liveness.rs
@@ -12,6 +12,7 @@ pub(crate) struct LivenessComponentRef {
     pub tag: String,
     pub healthy_until_ms: Arc<std::sync::atomic::AtomicI64>,
     pub stall_threshold: u32,
+    pub health_gauge: metrics::Gauge,
 }
 
 /// K8s liveness probe handler. **Intentionally always returns 200.**

--- a/rust/common/lifecycle/src/liveness.rs
+++ b/rust/common/lifecycle/src/liveness.rs
@@ -1,135 +1,41 @@
-//! Liveness probe handler and health strategy.
+//! Liveness probe handler and internal health monitoring types.
 
-use std::collections::HashMap;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 
-/// Liveness aggregation strategy. `All`: every component with a liveness deadline must
-/// be healthy (one stalled component fails the probe). `Any`: at least one healthy suffices.
-/// (see tests `liveness_strategy_all_requires_all_healthy`,
-/// `liveness_strategy_any_one_healthy_suffices`)
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum HealthStrategy {
-    All,
-    Any,
-}
-
-impl std::str::FromStr for HealthStrategy {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.trim().to_lowercase().as_str() {
-            "all" => Ok(HealthStrategy::All),
-            "any" => Ok(HealthStrategy::Any),
-            _ => Err(format!("Unknown Health Strategy: {s}, must be ALL or ANY")),
-        }
-    }
-}
-
-/// Per-component liveness state returned in the probe response.
-/// - `Starting`: no heartbeat yet (component registered but hasn't called `report_healthy()`)
-/// - `Healthy`: heartbeat received within the deadline
-/// - `Unhealthy`: component explicitly called `report_unhealthy()`
-/// - `Stalled`: heartbeat deadline expired (component stopped calling `report_healthy()`)
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ComponentLiveness {
-    Starting,
-    Healthy,
-    Unhealthy,
-    Stalled,
-}
-
+/// Internal reference to a component's health state, used by the monitor's
+/// health poll task. Not part of the public API.
 #[derive(Clone)]
 pub(crate) struct LivenessComponentRef {
     pub tag: String,
     pub healthy_until_ms: Arc<std::sync::atomic::AtomicI64>,
-    #[allow(dead_code)]
-    pub deadline: std::time::Duration,
+    pub stall_threshold: u32,
 }
 
-/// K8s liveness probe handler. Returns 200 if healthy per [`HealthStrategy`], 500 with
-/// per-component detail otherwise. K8s restarts the pod after `failureThreshold *
-/// periodSeconds` consecutive failures. Driven entirely by [`Handle::report_healthy`](crate::Handle::report_healthy) /
-/// [`Handle::report_unhealthy`](crate::Handle::report_unhealthy) — `signal_failure()` does NOT
-/// flip liveness (it triggers shutdown via readiness instead).
-/// (see test `liveness_with_process_scope_struct`)
+/// K8s liveness probe handler. Always returns 200 — liveness means "the process
+/// is reachable." Health monitoring is handled internally by the manager's monitor
+/// loop, which triggers coordinated graceful shutdown when a component stalls,
+/// rather than letting K8s surprise-kill the pod.
 #[derive(Clone)]
-pub struct LivenessHandler {
-    components: Arc<Vec<LivenessComponentRef>>,
-    strategy: HealthStrategy,
-}
+pub struct LivenessHandler;
 
 impl LivenessHandler {
-    pub(crate) fn new(
-        components: Arc<Vec<LivenessComponentRef>>,
-        strategy: HealthStrategy,
-    ) -> Self {
-        Self {
-            components,
-            strategy,
-        }
+    pub(crate) fn new() -> Self {
+        Self
     }
 
-    /// Evaluate liveness from per-component heartbeat state; no I/O, pure atomic reads.
     pub fn check(&self) -> LivenessStatus {
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
-
-        let mut components = HashMap::new();
-        let mut any_healthy = false;
-        let mut all_healthy = true;
-
-        for comp in self.components.iter() {
-            let until = comp.healthy_until_ms.load(Ordering::Relaxed);
-            let status = if until == -1 {
-                all_healthy = false;
-                ComponentLiveness::Unhealthy
-            } else if until == 0 {
-                all_healthy = false;
-                ComponentLiveness::Starting
-            } else if until > now_ms {
-                any_healthy = true;
-                ComponentLiveness::Healthy
-            } else {
-                all_healthy = false;
-                ComponentLiveness::Stalled
-            };
-            components.insert(comp.tag.clone(), status);
-        }
-
-        let healthy = match self.strategy {
-            HealthStrategy::All => !components.is_empty() && all_healthy,
-            HealthStrategy::Any => any_healthy,
-        };
-
-        LivenessStatus {
-            healthy,
-            components,
-        }
+        LivenessStatus
     }
 }
 
-/// Result of a liveness check; used for HTTP response body and status.
-#[derive(Debug)]
-pub struct LivenessStatus {
-    pub healthy: bool,
-    pub components: HashMap<String, ComponentLiveness>,
-}
+/// Always-healthy liveness status. Implements [`IntoResponse`] for axum.
+pub struct LivenessStatus;
 
 impl IntoResponse for LivenessStatus {
     fn into_response(self) -> Response {
-        let body = format!("{self:?}");
-        let status = if self.healthy {
-            StatusCode::OK
-        } else {
-            StatusCode::INTERNAL_SERVER_ERROR
-        };
-        (status, body).into_response()
+        (StatusCode::OK, "ok").into_response()
     }
 }

--- a/rust/common/lifecycle/src/liveness.rs
+++ b/rust/common/lifecycle/src/liveness.rs
@@ -75,7 +75,10 @@ impl LivenessHandler {
 
         for comp in self.components.iter() {
             let until = comp.healthy_until_ms.load(Ordering::Relaxed);
-            let status = if until == 0 {
+            let status = if until == -1 {
+                all_healthy = false;
+                ComponentLiveness::Unhealthy
+            } else if until == 0 {
                 all_healthy = false;
                 ComponentLiveness::Starting
             } else if until > now_ms {

--- a/rust/common/lifecycle/src/liveness.rs
+++ b/rust/common/lifecycle/src/liveness.rs
@@ -1,0 +1,120 @@
+//! Liveness probe handler and health strategy.
+
+use std::collections::HashMap;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+/// Liveness strategy: All components must be healthy, or any one suffices.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HealthStrategy {
+    All,
+    Any,
+}
+
+impl std::str::FromStr for HealthStrategy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "all" => Ok(HealthStrategy::All),
+            "any" => Ok(HealthStrategy::Any),
+            _ => Err(format!("Unknown Health Strategy: {s}, must be ALL or ANY")),
+        }
+    }
+}
+
+/// Per-component liveness state for the liveness probe response.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ComponentLiveness {
+    Starting,
+    Healthy,
+    Unhealthy,
+    Stalled,
+}
+
+#[derive(Clone)]
+pub(crate) struct LivenessComponentRef {
+    pub tag: String,
+    pub healthy_until_ms: Arc<std::sync::atomic::AtomicI64>,
+    #[allow(dead_code)]
+    pub deadline: std::time::Duration,
+}
+
+/// Axum-compatible liveness probe handler; returns 200 if healthy per strategy, 500 with component detail otherwise.
+#[derive(Clone)]
+pub struct LivenessHandler {
+    components: Arc<Vec<LivenessComponentRef>>,
+    strategy: HealthStrategy,
+}
+
+impl LivenessHandler {
+    pub(crate) fn new(
+        components: Arc<Vec<LivenessComponentRef>>,
+        strategy: HealthStrategy,
+    ) -> Self {
+        Self {
+            components,
+            strategy,
+        }
+    }
+
+    /// Evaluate liveness from per-component heartbeat state; no I/O, pure atomic reads.
+    pub fn check(&self) -> LivenessStatus {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+
+        let mut components = HashMap::new();
+        let mut any_healthy = false;
+        let mut all_healthy = true;
+
+        for comp in self.components.iter() {
+            let until = comp.healthy_until_ms.load(Ordering::Relaxed);
+            let status = if until == 0 {
+                all_healthy = false;
+                ComponentLiveness::Starting
+            } else if until > now_ms {
+                any_healthy = true;
+                ComponentLiveness::Healthy
+            } else {
+                all_healthy = false;
+                ComponentLiveness::Stalled
+            };
+            components.insert(comp.tag.clone(), status);
+        }
+
+        let healthy = match self.strategy {
+            HealthStrategy::All => !components.is_empty() && all_healthy,
+            HealthStrategy::Any => any_healthy,
+        };
+
+        LivenessStatus {
+            healthy,
+            components,
+        }
+    }
+}
+
+/// Result of a liveness check; used for HTTP response body and status.
+#[derive(Debug)]
+pub struct LivenessStatus {
+    pub healthy: bool,
+    pub components: HashMap<String, ComponentLiveness>,
+}
+
+impl IntoResponse for LivenessStatus {
+    fn into_response(self) -> Response {
+        let body = format!("{self:?}");
+        let status = if self.healthy {
+            StatusCode::OK
+        } else {
+            StatusCode::INTERNAL_SERVER_ERROR
+        };
+        (status, body).into_response()
+    }
+}

--- a/rust/common/lifecycle/src/manager.rs
+++ b/rust/common/lifecycle/src/manager.rs
@@ -160,6 +160,7 @@ impl Manager {
             healthy_until_ms,
             liveness_deadline: options.liveness_deadline,
             completed: std::sync::atomic::AtomicBool::new(false),
+            process_scope_signalled: std::sync::atomic::AtomicBool::new(false),
         });
 
         Handle { inner }

--- a/rust/common/lifecycle/src/manager.rs
+++ b/rust/common/lifecycle/src/manager.rs
@@ -1,0 +1,519 @@
+//! Lifecycle manager: signal trapping, component registration, graceful shutdown, readiness/liveness probes.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::error::LifecycleError;
+use crate::handle::{ComponentEvent, Handle, HandleInner};
+use crate::liveness::{HealthStrategy, LivenessComponentRef, LivenessHandler};
+use crate::metrics;
+use crate::readiness::ReadinessHandler;
+use crate::signals;
+
+/// Options for creating a lifecycle manager.
+#[derive(Clone, Debug)]
+pub struct ManagerOptions {
+    pub name: String,
+    /// Global ceiling on shutdown duration (caps sum of component timeouts).
+    pub global_shutdown_timeout: Duration,
+    /// Install SIGINT/SIGTERM handlers (default: true).
+    pub trap_signals: bool,
+    /// Enable /tmp/shutdown file check for K8s pre-stop (default: true).
+    pub enable_prestop_check: bool,
+    /// Liveness strategy: All (every component must be healthy) or Any (at least one).
+    pub liveness_strategy: HealthStrategy,
+}
+
+impl Default for ManagerOptions {
+    fn default() -> Self {
+        Self {
+            name: "app".to_string(),
+            global_shutdown_timeout: Duration::from_secs(60),
+            trap_signals: true,
+            enable_prestop_check: true,
+            liveness_strategy: HealthStrategy::All,
+        }
+    }
+}
+
+/// Options for a registered component; use builder methods with any duration type that implements `TryInto<Duration>`.
+#[derive(Clone, Debug)]
+pub struct ComponentOptions {
+    pub graceful_shutdown: Option<Duration>,
+    pub liveness_deadline: Option<Duration>,
+}
+
+impl ComponentOptions {
+    /// No graceful shutdown timeout, no liveness deadline.
+    pub fn new() -> Self {
+        Self {
+            graceful_shutdown: None,
+            liveness_deadline: None,
+        }
+    }
+
+    /// Max time this component gets for cleanup after shutdown begins.
+    pub fn with_graceful_shutdown<D>(mut self, d: D) -> Self
+    where
+        D: TryInto<Duration>,
+    {
+        self.graceful_shutdown = d.try_into().ok();
+        self
+    }
+
+    /// Liveness heartbeat deadline; component must call [`Handle::report_healthy`](crate::Handle::report_healthy) within this interval.
+    pub fn with_liveness_deadline<D>(mut self, d: D) -> Self
+    where
+        D: TryInto<Duration>,
+    {
+        self.liveness_deadline = d.try_into().ok();
+        self
+    }
+}
+
+impl Default for ComponentOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ShutdownPhase {
+    Running,
+    ShuttingDown,
+    Completed,
+    TimedOut,
+    Died,
+}
+
+struct ComponentState {
+    graceful_shutdown: Option<Duration>,
+    phase: ShutdownPhase,
+}
+
+/// Lifecycle manager: registers components, runs monitor on a dedicated OS thread, provides readiness/liveness handlers and shutdown signal.
+pub struct Manager {
+    name: String,
+    options: ManagerOptions,
+    shutdown_token: CancellationToken,
+    event_tx: mpsc::Sender<ComponentEvent>,
+    event_rx: Option<mpsc::Receiver<ComponentEvent>>,
+    components: HashMap<String, ComponentState>,
+    liveness_components: Vec<LivenessComponentRef>,
+}
+
+impl Manager {
+    /// Create a new manager with the given options.
+    pub fn new(options: ManagerOptions) -> Self {
+        let (event_tx, event_rx) = mpsc::channel(64);
+        Self {
+            name: options.name.clone(),
+            options,
+            shutdown_token: CancellationToken::new(),
+            event_tx,
+            event_rx: Some(event_rx),
+            components: HashMap::new(),
+            liveness_components: Vec::new(),
+        }
+    }
+
+    /// Register a component; returns an RAII handle. Drop without [`Handle::work_completed`](crate::Handle::work_completed) signals "died".
+    pub fn register(&mut self, tag: &str, options: ComponentOptions) -> Handle {
+        let healthy_until_ms = Arc::new(AtomicI64::new(0));
+        let tag_owned = tag.to_string();
+        let deadline = options.liveness_deadline;
+
+        if let Some(d) = options.liveness_deadline {
+            self.liveness_components.push(LivenessComponentRef {
+                tag: tag_owned.clone(),
+                healthy_until_ms: healthy_until_ms.clone(),
+                deadline: d,
+            });
+        }
+
+        self.components.insert(
+            tag_owned.clone(),
+            ComponentState {
+                graceful_shutdown: options.graceful_shutdown,
+                phase: ShutdownPhase::Running,
+            },
+        );
+
+        debug!(
+            component = %tag_owned,
+            graceful_shutdown_secs = options.graceful_shutdown.map(|d| d.as_secs_f64()),
+            liveness_deadline_secs = deadline.map(|d| d.as_secs_f64()),
+            "Lifecycle: component registered"
+        );
+
+        let inner = Arc::new(HandleInner {
+            tag: tag_owned,
+            shutdown_token: self.shutdown_token.clone(),
+            event_tx: self.event_tx.clone(),
+            healthy_until_ms,
+            liveness_deadline: options.liveness_deadline,
+            completed: std::sync::atomic::AtomicBool::new(false),
+        });
+
+        Handle { inner }
+    }
+
+    /// Axum-compatible handler for `/_readiness`; returns 200 if running, 503 if shutdown has begun.
+    pub fn readiness_handler(&self) -> ReadinessHandler {
+        ReadinessHandler::new(self.shutdown_token.clone())
+    }
+
+    /// Axum-compatible handler for `/_liveness`; returns 200 if healthy per strategy, 500 with per-component detail otherwise.
+    pub fn liveness_handler(&self) -> LivenessHandler {
+        LivenessHandler::new(
+            Arc::new(self.liveness_components.clone()),
+            self.options.liveness_strategy.clone(),
+        )
+    }
+
+    /// Future that resolves when shutdown begins; pass to `axum::serve(..., with_graceful_shutdown(shutdown_signal()))`.
+    pub fn shutdown_signal(&self) -> impl std::future::Future<Output = ()> + Send + 'static {
+        let token = self.shutdown_token.clone();
+        async move {
+            token.cancelled().await;
+        }
+    }
+
+    fn spawn_monitor_thread(mut self) -> oneshot::Receiver<Result<(), LifecycleError>> {
+        let (tx, rx) = oneshot::channel();
+        let event_rx = self
+            .event_rx
+            .take()
+            .expect("monitor already started or event_rx taken");
+
+        thread::Builder::new()
+            .name("lifecycle-monitor".into())
+            .spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to build lifecycle runtime");
+                let result = rt.block_on(self.run_monitor_loop(event_rx));
+                drop(tx.send(result));
+            })
+            .expect("failed to spawn lifecycle monitor thread");
+
+        rx
+    }
+
+    /// Spawn the monitor on a dedicated OS thread and await completion; returns when all components finish or time out.
+    pub async fn monitor(self) -> Result<(), LifecycleError> {
+        let rx = self.spawn_monitor_thread();
+        rx.await.map_err(|_| LifecycleError::MonitorPanicked)?
+    }
+
+    /// Same as [`monitor`](Manager::monitor) but returns immediately with a guard; await the guard after the HTTP server exits.
+    pub fn monitor_background(self) -> MonitorGuard {
+        MonitorGuard {
+            rx: self.spawn_monitor_thread(),
+        }
+    }
+
+    async fn run_monitor_loop(
+        mut self,
+        mut event_rx: mpsc::Receiver<ComponentEvent>,
+    ) -> Result<(), LifecycleError> {
+        let _span = tracing::info_span!("lifecycle", app = %self.name).entered();
+        let name = self.name.clone();
+        let trap_signals = self.options.trap_signals;
+        let enable_prestop = self.options.enable_prestop_check;
+        let global_timeout = self.options.global_shutdown_timeout;
+        let shutdown_token = self.shutdown_token.clone();
+
+        if trap_signals {
+            let token = shutdown_token.clone();
+            tokio::spawn(async move {
+                signals::wait_for_shutdown_signal().await;
+                token.cancel();
+            });
+        }
+
+        if enable_prestop {
+            let token = shutdown_token.clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(1));
+                loop {
+                    interval.tick().await;
+                    if std::path::Path::new("/tmp/shutdown").exists() {
+                        info!(
+                            trigger_reason = "prestop",
+                            "Lifecycle: shutdown initiated, prestop file detected"
+                        );
+                        token.cancel();
+                        break;
+                    }
+                }
+            });
+        }
+
+        let name_for_metrics = name.clone();
+        let liveness_for_metrics = self.liveness_components.clone();
+        let gauge_token = shutdown_token.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(5));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let now_ms = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_millis() as i64;
+                        for comp in &liveness_for_metrics {
+                            let until = comp.healthy_until_ms.load(Ordering::Relaxed);
+                            let healthy = until > 0 && until > now_ms;
+                            metrics::emit_component_healthy(&name_for_metrics, &comp.tag, healthy);
+                        }
+                    }
+                    _ = gauge_token.cancelled() => break,
+                }
+            }
+        });
+
+        let mut first_failure: Option<LifecycleError> = None;
+
+        loop {
+            tokio::select! {
+                biased;
+
+                Some(event) = event_rx.recv() => {
+                    match event {
+                        ComponentEvent::Failure { tag, reason } => {
+                            metrics::emit_shutdown_initiated(&name, &tag, "failure");
+                            warn!(trigger_component = %tag, trigger_reason = "failure",
+                                "Lifecycle: shutdown initiated: {reason:#}");
+                            shutdown_token.cancel();
+                            if let Some(s) = self.components.get_mut(&tag) {
+                                s.phase = ShutdownPhase::Died;
+                            }
+                            first_failure = first_failure.or(Some(LifecycleError::ComponentFailure { tag, reason }));
+                            break;
+                        }
+                        ComponentEvent::Died { tag } => {
+                            metrics::emit_shutdown_initiated(&name, &tag, "died");
+                            warn!(trigger_component = %tag, trigger_reason = "died",
+                                "Lifecycle: shutdown initiated, component died unexpectedly");
+                            shutdown_token.cancel();
+                            if let Some(s) = self.components.get_mut(&tag) {
+                                s.phase = ShutdownPhase::Died;
+                            }
+                            first_failure = first_failure.or(Some(LifecycleError::ComponentDied { tag }));
+                            break;
+                        }
+                        ComponentEvent::ShutdownRequested { tag } => {
+                            metrics::emit_shutdown_initiated(&name, &tag, "requested");
+                            info!(trigger_component = %tag, trigger_reason = "requested",
+                                "Lifecycle: shutdown requested by component");
+                            shutdown_token.cancel();
+                            break;
+                        }
+                        ComponentEvent::WorkCompleted { tag } => {
+                            if let Some(s) = self.components.get_mut(&tag) {
+                                s.phase = ShutdownPhase::Completed;
+                            }
+                            let done = self.components.values().all(|s| s.phase != ShutdownPhase::Running && s.phase != ShutdownPhase::ShuttingDown);
+                            if done {
+                                return self.finalize(Instant::now(), first_failure);
+                            }
+                        }
+                    }
+                }
+                _ = shutdown_token.cancelled() => {
+                    metrics::emit_shutdown_initiated(&name, "system", "signal");
+                    info!(trigger_reason = "signal", "Lifecycle: shutdown initiated");
+                    break;
+                }
+            }
+        }
+
+        for s in self.components.values_mut() {
+            if s.phase == ShutdownPhase::Running {
+                s.phase = ShutdownPhase::ShuttingDown;
+            }
+        }
+
+        let all_done = self.components.values().all(|s| {
+            s.phase == ShutdownPhase::Completed
+                || s.phase == ShutdownPhase::Died
+                || s.phase == ShutdownPhase::TimedOut
+        });
+        if all_done {
+            return self.finalize(Instant::now(), first_failure);
+        }
+
+        let shutdown_clock = Instant::now();
+        let global_deadline = shutdown_clock + global_timeout;
+        let mut component_deadlines: Vec<(String, Instant)> = self
+            .components
+            .iter()
+            .filter_map(|(tag, s)| {
+                s.graceful_shutdown
+                    .map(|d| (tag.clone(), shutdown_clock + d))
+            })
+            .collect();
+        component_deadlines.sort_by(|a, b| a.1.cmp(&b.1));
+
+        loop {
+            let now = Instant::now();
+            if now >= global_deadline {
+                let remaining: Vec<String> = self
+                    .components
+                    .iter()
+                    .filter(|(_, s)| {
+                        s.phase != ShutdownPhase::Completed
+                            && s.phase != ShutdownPhase::TimedOut
+                            && s.phase != ShutdownPhase::Died
+                    })
+                    .map(|(t, _)| t.clone())
+                    .collect();
+                for tag in &remaining {
+                    metrics::emit_component_shutdown_result(&name, tag, "timeout");
+                }
+                warn!(
+                    total_duration_secs = global_timeout.as_secs_f64(),
+                    remaining = ?remaining,
+                    "Lifecycle: global shutdown timeout reached"
+                );
+                return Err(LifecycleError::ShutdownTimeout {
+                    elapsed: global_timeout,
+                    remaining,
+                });
+            }
+
+            let next_component_timeout = component_deadlines
+                .iter()
+                .find(|(tag, _)| {
+                    self.components
+                        .get(tag)
+                        .map(|s| s.phase == ShutdownPhase::ShuttingDown)
+                        == Some(true)
+                })
+                .map(|(_, t)| *t);
+
+            let wait_duration = [
+                next_component_timeout.map(|t| t.saturating_duration_since(now)),
+                Some(global_deadline.saturating_duration_since(now)),
+            ]
+            .into_iter()
+            .flatten()
+            .min()
+            .unwrap_or(Duration::from_secs(1));
+
+            tokio::select! {
+                biased;
+
+                Some(event) = event_rx.recv() => {
+                    match event {
+                        ComponentEvent::WorkCompleted { tag } => {
+                            if let Some(s) = self.components.get_mut(&tag) {
+                                s.phase = ShutdownPhase::Completed;
+                                let elapsed = shutdown_clock.elapsed();
+                                metrics::emit_component_shutdown_duration(&name, &tag, "completed", elapsed.as_secs_f64());
+                                metrics::emit_component_shutdown_result(&name, &tag, "completed");
+                                info!(component = %tag,
+                                    duration_secs = elapsed.as_secs_f64(),
+                                    result = "completed",
+                                    "Lifecycle: component completed shutdown");
+                            }
+                        }
+                        ComponentEvent::Died { tag } => {
+                            if let Some(s) = self.components.get_mut(&tag) {
+                                s.phase = ShutdownPhase::Died;
+                                let elapsed = shutdown_clock.elapsed();
+                                metrics::emit_component_shutdown_duration(&name, &tag, "died", elapsed.as_secs_f64());
+                                metrics::emit_component_shutdown_result(&name, &tag, "died");
+                                warn!(component = %tag,
+                                    duration_secs = elapsed.as_secs_f64(),
+                                    result = "died",
+                                    "Lifecycle: component died during shutdown");
+                            }
+                        }
+                        _ => {}
+                    }
+                    let all_done = self.components.values().all(|s| {
+                        s.phase == ShutdownPhase::Completed || s.phase == ShutdownPhase::Died || s.phase == ShutdownPhase::TimedOut
+                    });
+                    if all_done {
+                        return self.finalize(shutdown_clock, first_failure);
+                    }
+                }
+                _ = tokio::time::sleep(wait_duration) => {
+                    let now = Instant::now();
+                    for (tag, deadline) in &component_deadlines {
+                        if now >= *deadline {
+                            if let Some(s) = self.components.get_mut(tag) {
+                                if s.phase == ShutdownPhase::ShuttingDown {
+                                    s.phase = ShutdownPhase::TimedOut;
+                                    if let Some(d) = s.graceful_shutdown {
+                                        metrics::emit_component_shutdown_duration(&name, tag, "timeout", d.as_secs_f64());
+                                    }
+                                    metrics::emit_component_shutdown_result(&name, tag, "timeout");
+                                    warn!(component = %tag,
+                                        duration_secs = s.graceful_shutdown.unwrap_or_default().as_secs_f64(),
+                                        result = "timeout",
+                                        "Lifecycle: component timed out during graceful shutdown");
+                                }
+                            }
+                        }
+                    }
+                    let all_done = self.components.values().all(|s| {
+                        s.phase == ShutdownPhase::Completed || s.phase == ShutdownPhase::Died || s.phase == ShutdownPhase::TimedOut
+                    });
+                    if all_done {
+                        return self.finalize(shutdown_clock, first_failure);
+                    }
+                }
+            }
+        }
+    }
+
+    fn finalize(
+        &self,
+        shutdown_clock: Instant,
+        first_failure: Option<LifecycleError>,
+    ) -> Result<(), LifecycleError> {
+        let total = shutdown_clock.elapsed();
+        let clean = self
+            .components
+            .values()
+            .all(|s| s.phase == ShutdownPhase::Completed);
+        metrics::emit_shutdown_completed(&self.name, clean);
+        if clean {
+            info!(
+                clean = true,
+                total_duration_secs = total.as_secs_f64(),
+                "Lifecycle: shutdown complete"
+            );
+        } else {
+            warn!(
+                clean = false,
+                total_duration_secs = total.as_secs_f64(),
+                "Lifecycle: shutdown complete with failures"
+            );
+        }
+        first_failure.map_or(Ok(()), Err)
+    }
+}
+
+/// Guard returned by [`Manager::monitor_background`]; await to get the monitor result.
+pub struct MonitorGuard {
+    rx: oneshot::Receiver<Result<(), LifecycleError>>,
+}
+
+impl MonitorGuard {
+    /// Await the monitor thread's completion; returns the same `Result` as [`Manager::monitor`](Manager::monitor).
+    pub async fn wait(self) -> Result<(), LifecycleError> {
+        self.rx.await.map_err(|_| LifecycleError::MonitorPanicked)?
+    }
+}

--- a/rust/common/lifecycle/src/manager.rs
+++ b/rust/common/lifecycle/src/manager.rs
@@ -35,6 +35,43 @@ pub struct ManagerOptions {
     pub health_poll_interval: Duration,
 }
 
+impl ManagerOptions {
+    /// Create options with the given service name and all other fields set to defaults.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Hard ceiling on total shutdown duration. If all components haven't finished
+    /// within this window, monitor returns [`LifecycleError::ShutdownTimeout`].
+    /// Default: 60s.
+    pub fn with_global_shutdown_timeout(mut self, d: Duration) -> Self {
+        self.global_shutdown_timeout = d;
+        self
+    }
+
+    /// Install SIGINT/SIGTERM handlers. Default: true. Set false in tests.
+    pub fn with_trap_signals(mut self, enabled: bool) -> Self {
+        self.trap_signals = enabled;
+        self
+    }
+
+    /// Poll for `/tmp/shutdown` file (K8s pre-stop hook pattern). Default: true.
+    pub fn with_prestop_check(mut self, enabled: bool) -> Self {
+        self.enable_prestop_check = enabled;
+        self
+    }
+
+    /// How often the health monitor polls component heartbeats. Default: 5s.
+    /// Lower values detect stalls faster but use more CPU.
+    pub fn with_health_poll_interval(mut self, d: Duration) -> Self {
+        self.health_poll_interval = d;
+        self
+    }
+}
+
 impl Default for ManagerOptions {
     fn default() -> Self {
         Self {

--- a/rust/common/lifecycle/src/metrics.rs
+++ b/rust/common/lifecycle/src/metrics.rs
@@ -4,7 +4,6 @@ pub(crate) const METRIC_COMPONENT_SHUTDOWN_DURATION: &str =
     "lifecycle_component_shutdown_duration_seconds";
 pub(crate) const METRIC_COMPONENT_SHUTDOWN_RESULT: &str =
     "lifecycle_component_shutdown_result_total";
-pub(crate) const METRIC_COMPONENT_HEALTHY: &str = "lifecycle_component_healthy";
 
 pub(crate) fn emit_shutdown_initiated(
     service_name: &str,
@@ -52,13 +51,4 @@ pub(crate) fn emit_component_shutdown_result(service_name: &str, component: &str
         "result" => result.to_string()
     )
     .increment(1);
-}
-
-pub(crate) fn emit_component_healthy(service_name: &str, component: &str, healthy: bool) {
-    metrics::gauge!(
-        METRIC_COMPONENT_HEALTHY,
-        "service_name" => service_name.to_string(),
-        "component" => component.to_string()
-    )
-    .set(if healthy { 1.0 } else { 0.0 });
 }

--- a/rust/common/lifecycle/src/metrics.rs
+++ b/rust/common/lifecycle/src/metrics.rs
@@ -6,54 +6,58 @@ pub(crate) const METRIC_COMPONENT_SHUTDOWN_RESULT: &str =
     "lifecycle_component_shutdown_result_total";
 pub(crate) const METRIC_COMPONENT_HEALTHY: &str = "lifecycle_component_healthy";
 
-pub(crate) fn emit_shutdown_initiated(app: &str, trigger_component: &str, trigger_reason: &str) {
+pub(crate) fn emit_shutdown_initiated(
+    service_name: &str,
+    trigger_component: &str,
+    trigger_reason: &str,
+) {
     metrics::counter!(
         METRIC_SHUTDOWN_INITIATED,
-        "app" => app.to_string(),
+        "service_name" => service_name.to_string(),
         "trigger_component" => trigger_component.to_string(),
         "trigger_reason" => trigger_reason.to_string()
     )
     .increment(1);
 }
 
-pub(crate) fn emit_shutdown_completed(app: &str, clean: bool) {
+pub(crate) fn emit_shutdown_completed(service_name: &str, clean: bool) {
     metrics::counter!(
         METRIC_SHUTDOWN_COMPLETED,
-        "app" => app.to_string(),
+        "service_name" => service_name.to_string(),
         "clean" => clean.to_string()
     )
     .increment(1);
 }
 
 pub(crate) fn emit_component_shutdown_duration(
-    app: &str,
+    service_name: &str,
     component: &str,
     result: &str,
     duration_secs: f64,
 ) {
     metrics::histogram!(
         METRIC_COMPONENT_SHUTDOWN_DURATION,
-        "app" => app.to_string(),
+        "service_name" => service_name.to_string(),
         "component" => component.to_string(),
         "result" => result.to_string()
     )
     .record(duration_secs);
 }
 
-pub(crate) fn emit_component_shutdown_result(app: &str, component: &str, result: &str) {
+pub(crate) fn emit_component_shutdown_result(service_name: &str, component: &str, result: &str) {
     metrics::counter!(
         METRIC_COMPONENT_SHUTDOWN_RESULT,
-        "app" => app.to_string(),
+        "service_name" => service_name.to_string(),
         "component" => component.to_string(),
         "result" => result.to_string()
     )
     .increment(1);
 }
 
-pub(crate) fn emit_component_healthy(app: &str, component: &str, healthy: bool) {
+pub(crate) fn emit_component_healthy(service_name: &str, component: &str, healthy: bool) {
     metrics::gauge!(
         METRIC_COMPONENT_HEALTHY,
-        "app" => app.to_string(),
+        "service_name" => service_name.to_string(),
         "component" => component.to_string()
     )
     .set(if healthy { 1.0 } else { 0.0 });

--- a/rust/common/lifecycle/src/metrics.rs
+++ b/rust/common/lifecycle/src/metrics.rs
@@ -1,0 +1,60 @@
+pub(crate) const METRIC_SHUTDOWN_INITIATED: &str = "lifecycle_shutdown_initiated_total";
+pub(crate) const METRIC_SHUTDOWN_COMPLETED: &str = "lifecycle_shutdown_completed_total";
+pub(crate) const METRIC_COMPONENT_SHUTDOWN_DURATION: &str =
+    "lifecycle_component_shutdown_duration_seconds";
+pub(crate) const METRIC_COMPONENT_SHUTDOWN_RESULT: &str =
+    "lifecycle_component_shutdown_result_total";
+pub(crate) const METRIC_COMPONENT_HEALTHY: &str = "lifecycle_component_healthy";
+
+pub(crate) fn emit_shutdown_initiated(app: &str, trigger_component: &str, trigger_reason: &str) {
+    metrics::counter!(
+        METRIC_SHUTDOWN_INITIATED,
+        "app" => app.to_string(),
+        "trigger_component" => trigger_component.to_string(),
+        "trigger_reason" => trigger_reason.to_string()
+    )
+    .increment(1);
+}
+
+pub(crate) fn emit_shutdown_completed(app: &str, clean: bool) {
+    metrics::counter!(
+        METRIC_SHUTDOWN_COMPLETED,
+        "app" => app.to_string(),
+        "clean" => clean.to_string()
+    )
+    .increment(1);
+}
+
+pub(crate) fn emit_component_shutdown_duration(
+    app: &str,
+    component: &str,
+    result: &str,
+    duration_secs: f64,
+) {
+    metrics::histogram!(
+        METRIC_COMPONENT_SHUTDOWN_DURATION,
+        "app" => app.to_string(),
+        "component" => component.to_string(),
+        "result" => result.to_string()
+    )
+    .record(duration_secs);
+}
+
+pub(crate) fn emit_component_shutdown_result(app: &str, component: &str, result: &str) {
+    metrics::counter!(
+        METRIC_COMPONENT_SHUTDOWN_RESULT,
+        "app" => app.to_string(),
+        "component" => component.to_string(),
+        "result" => result.to_string()
+    )
+    .increment(1);
+}
+
+pub(crate) fn emit_component_healthy(app: &str, component: &str, healthy: bool) {
+    metrics::gauge!(
+        METRIC_COMPONENT_HEALTHY,
+        "app" => app.to_string(),
+        "component" => component.to_string()
+    )
+    .set(if healthy { 1.0 } else { 0.0 });
+}

--- a/rust/common/lifecycle/src/readiness.rs
+++ b/rust/common/lifecycle/src/readiness.rs
@@ -13,7 +13,7 @@ pub struct ReadinessHandler {
 }
 
 impl ReadinessHandler {
-    pub fn new(shutdown_token: CancellationToken) -> Self {
+    pub(crate) fn new(shutdown_token: CancellationToken) -> Self {
         Self { shutdown_token }
     }
 

--- a/rust/common/lifecycle/src/readiness.rs
+++ b/rust/common/lifecycle/src/readiness.rs
@@ -3,7 +3,10 @@
 use axum::http::StatusCode;
 use tokio_util::sync::CancellationToken;
 
-/// Axum-compatible readiness probe; returns 200 if not shutting down, 503 if shutdown has begun.
+/// K8s readiness probe handler. Returns 200 while the app is running, 503 after shutdown
+/// begins. K8s stops routing traffic to the pod when readiness fails. No per-component
+/// logic — readiness is purely "is the app accepting work?"
+/// (see test `readiness_200_until_shutdown_then_503`)
 #[derive(Clone)]
 pub struct ReadinessHandler {
     shutdown_token: CancellationToken,

--- a/rust/common/lifecycle/src/readiness.rs
+++ b/rust/common/lifecycle/src/readiness.rs
@@ -1,0 +1,25 @@
+//! K8s readiness probe handler.
+
+use axum::http::StatusCode;
+use tokio_util::sync::CancellationToken;
+
+/// Axum-compatible readiness probe; returns 200 if not shutting down, 503 if shutdown has begun.
+#[derive(Clone)]
+pub struct ReadinessHandler {
+    shutdown_token: CancellationToken,
+}
+
+impl ReadinessHandler {
+    pub fn new(shutdown_token: CancellationToken) -> Self {
+        Self { shutdown_token }
+    }
+
+    /// Returns OK or SERVICE_UNAVAILABLE based on shutdown token; no I/O.
+    pub async fn check(&self) -> StatusCode {
+        if self.shutdown_token.is_cancelled() {
+            StatusCode::SERVICE_UNAVAILABLE
+        } else {
+            StatusCode::OK
+        }
+    }
+}

--- a/rust/common/lifecycle/src/signals.rs
+++ b/rust/common/lifecycle/src/signals.rs
@@ -1,0 +1,12 @@
+use tokio::signal::unix::SignalKind;
+
+pub(crate) async fn wait_for_shutdown_signal() {
+    let ctrl_c = tokio::signal::ctrl_c();
+    let mut sigterm = tokio::signal::unix::signal(SignalKind::terminate())
+        .expect("failed to install SIGTERM handler");
+
+    tokio::select! {
+        _ = ctrl_c => tracing::info!("received SIGINT"),
+        _ = sigterm.recv() => tracing::info!("received SIGTERM"),
+    }
+}

--- a/rust/common/lifecycle/tests/lifecycle_tests.rs
+++ b/rust/common/lifecycle/tests/lifecycle_tests.rs
@@ -2,6 +2,129 @@ use std::time::Duration;
 
 use lifecycle::{ComponentOptions, HealthStrategy, LifecycleError, Manager, ManagerOptions};
 
+// --- Correct patterns (documented for integrators) ---
+
+/// Correct pattern: component loop selects on shutdown_recv(), drains, then calls work_completed() before return.
+#[tokio::test]
+async fn component_loop_calls_work_completed_on_shutdown_path() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(5),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::All,
+    });
+    let handle = manager.register("worker", ComponentOptions::new());
+    let guard = manager.monitor_background();
+    let handle_in_task = handle.clone();
+
+    tokio::spawn(async move {
+        let mut done = false;
+        while !done {
+            tokio::select! {
+                _ = handle_in_task.shutdown_recv() => {
+                    done = true;
+                }
+                _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+            }
+        }
+        handle_in_task.work_completed();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    handle.request_shutdown();
+    tokio::task::yield_now().await;
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("component_loop_calls_work_completed_on_shutdown_path timed out");
+    assert!(result.is_ok());
+}
+
+/// signal_failure() triggers shutdown and monitor returns ComponentFailure.
+#[tokio::test]
+async fn signal_failure_returns_component_failure() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(2),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::All,
+    });
+    let handle = manager.register("worker", ComponentOptions::new());
+    let guard = manager.monitor_background();
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        handle.signal_failure("something broke");
+        handle.work_completed();
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("signal_failure_returns_component_failure timed out");
+    assert!(matches!(
+        result,
+        Err(LifecycleError::ComponentFailure { tag, reason }) if tag == "worker" && reason == "something broke"
+    ));
+}
+
+/// Pitfall: component task returns without calling work_completed() (e.g. early return on error).
+/// The last Handle clone is dropped when the task exits → drop guard fires → manager gets Died.
+#[tokio::test]
+async fn component_exits_without_work_completed_signals_died() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(2),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::All,
+    });
+    let handle = manager.register("worker", ComponentOptions::new());
+    let guard = manager.monitor_background();
+
+    tokio::spawn(async move {
+        let _handle_owned = handle;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        // Simulate "early return on error" without calling work_completed()
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("component_exits_without_work_completed_signals_died timed out");
+    assert!(matches!(
+        result,
+        Err(LifecycleError::ComponentDied { tag }) if tag == "worker"
+    ));
+}
+
+/// report_unhealthy() makes liveness report the component as unhealthy.
+#[tokio::test]
+async fn report_unhealthy_makes_liveness_unhealthy() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(1),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::All,
+    });
+    let handle = manager.register(
+        "worker",
+        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
+    );
+    let liveness = manager.liveness_handler();
+
+    handle.report_healthy();
+    assert!(liveness.check().healthy);
+
+    handle.report_unhealthy();
+    let status = liveness.check();
+    assert!(!status.healthy);
+    assert_eq!(
+        status.components.get("worker").unwrap(),
+        &lifecycle::ComponentLiveness::Unhealthy
+    );
+}
+
 #[tokio::test]
 async fn readiness_returns_200_until_shutdown() {
     let mut manager = Manager::new(ManagerOptions {
@@ -24,7 +147,10 @@ async fn readiness_returns_200_until_shutdown() {
         handle_for_shutdown.work_completed();
     });
 
-    guard.wait().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("readiness_returns_200_until_shutdown timed out")
+        .unwrap();
     assert_eq!(readiness.check().await.as_u16(), 503);
 }
 
@@ -120,7 +246,9 @@ async fn handle_drop_without_work_completed_signals_died() {
     let handle = manager.register("worker", ComponentOptions::new());
     let guard = manager.monitor_background();
     drop(handle);
-    let result = guard.wait().await;
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("handle_drop_without_work_completed_signals_died timed out");
     assert!(matches!(
         result,
         Err(LifecycleError::ComponentDied { tag }) if tag == "worker"
@@ -141,7 +269,9 @@ async fn work_completed_prevents_died_on_drop() {
     let guard = manager.monitor_background();
     drop(handle);
     tokio::time::sleep(Duration::from_millis(100)).await;
-    let result = guard.wait().await;
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("work_completed_prevents_died_on_drop timed out");
     assert!(result.is_ok());
 }
 
@@ -162,7 +292,9 @@ async fn request_shutdown_then_work_completed_clean_shutdown() {
         tokio::time::sleep(Duration::from_millis(20)).await;
         handle.work_completed();
     });
-    let result = guard.wait().await;
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("request_shutdown_then_work_completed_clean_shutdown timed out");
     assert!(result.is_ok());
 }
 
@@ -184,6 +316,8 @@ async fn component_timeout_during_graceful_shutdown() {
         tokio::time::sleep(Duration::from_millis(20)).await;
         handle.request_shutdown();
     });
-    let result = guard.wait().await;
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("component_timeout_during_graceful_shutdown timed out");
     assert!(result.is_ok());
 }

--- a/rust/common/lifecycle/tests/lifecycle_tests.rs
+++ b/rust/common/lifecycle/tests/lifecycle_tests.rs
@@ -1,161 +1,361 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use lifecycle::{ComponentOptions, HealthStrategy, LifecycleError, Manager, ManagerOptions};
 
-// --- Correct patterns (documented for integrators) ---
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-/// Correct pattern: component loop selects on shutdown_recv(), then returns (drop during shutdown = completion).
-/// Spawn holds the only handle; it requests shutdown then waits for it, so when it returns the drop sends WorkCompleted.
-#[tokio::test]
-async fn component_loop_exit_during_shutdown_without_work_completed_ok() {
-    let mut manager = Manager::new(ManagerOptions {
+fn test_manager() -> Manager {
+    Manager::new(ManagerOptions {
         name: "test".into(),
         global_shutdown_timeout: Duration::from_secs(5),
         trap_signals: false,
         enable_prestop_check: false,
         liveness_strategy: HealthStrategy::All,
-    });
-    let handle = manager.register("worker", ComponentOptions::new());
+    })
+}
+
+fn liveness_opts() -> ComponentOptions {
+    ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30))
+}
+
+// ---------------------------------------------------------------------------
+// Realistic component structs
+//
+// These model how real services use the lifecycle crate. Both own a Handle
+// on the struct (the typical pattern) and create a process_scope guard at
+// the top of process(). ComponentB adds an inner do_work() method that
+// accesses the handle via &self — demonstrating that child methods can
+// freely call any handle API (report_healthy, shutdown_recv, etc.) without
+// affecting the process_scope guard.
+// ---------------------------------------------------------------------------
+
+/// Simple looping component. process_scope guard ties lifecycle to process().
+struct ComponentA {
+    handle: lifecycle::Handle,
+}
+
+impl ComponentA {
+    async fn process(&self) {
+        let _guard = self.handle.process_scope();
+        loop {
+            tokio::select! {
+                _ = self.handle.shutdown_recv() => return,
+                _ = tokio::time::sleep(Duration::from_millis(50)) => {
+                    self.handle.report_healthy();
+                }
+            }
+        }
+    }
+}
+
+/// Looping component with an inner do_work() method. process() creates the
+/// guard and delegates work each iteration. do_work() does a single select!
+/// (not looped) — it checks for cancellation alongside fake work, and returns
+/// without triggering the guard. Only process() returning drops the guard.
+///
+/// On error, process() calls signal_failure() and returns — the guard drop
+/// during shutdown is harmlessly ignored by the manager.
+struct ComponentB {
+    handle: lifecycle::Handle,
+    fail_flag: Arc<AtomicBool>,
+}
+
+impl ComponentB {
+    fn new(handle: lifecycle::Handle) -> Self {
+        Self {
+            handle,
+            fail_flag: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    async fn process(&self) {
+        let _guard = self.handle.process_scope();
+        loop {
+            tokio::select! {
+                _ = self.handle.shutdown_recv() => return,
+                result = self.do_work() => {
+                    match result {
+                        Ok(()) => self.handle.report_healthy(),
+                        Err(reason) => {
+                            self.handle.signal_failure(reason);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn do_work(&self) -> Result<(), String> {
+        if self.fail_flag.load(Ordering::SeqCst) {
+            return Err("injected failure".into());
+        }
+        tokio::select! {
+            _ = self.handle.shutdown_recv() => Ok(()),
+            _ = tokio::time::sleep(Duration::from_millis(10)) => Ok(()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Section 1: Struct-based integration tests (process_scope guard)
+//
+// These tests use ComponentA and ComponentB to demonstrate the recommended
+// pattern: struct owns Handle, process() creates a process_scope guard,
+// child methods access the handle freely. The guard ties lifecycle signaling
+// to the process() scope, not the struct's lifetime.
+// ---------------------------------------------------------------------------
+
+/// ComponentA: simple loop, clean shutdown. Guard dropped on return → Ok.
+/// Demonstrates: process_scope, shutdown_recv, report_healthy.
+#[tokio::test]
+async fn component_a_clean_shutdown() {
+    let mut manager = test_manager();
+    let handle = manager.register("a", liveness_opts());
     let guard = manager.monitor_background();
 
-    tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        handle.request_shutdown();
-        handle.shutdown_recv().await;
-    });
+    let comp = ComponentA {
+        handle: handle.clone(),
+    };
+    tokio::spawn(async move { comp.process().await });
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    handle.request_shutdown();
 
     let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
         .await
-        .expect("component_loop_exit_during_shutdown_without_work_completed_ok timed out");
+        .expect("timed out");
     assert!(result.is_ok());
 }
 
-/// signal_failure() triggers shutdown and monitor returns ComponentFailure.
+/// ComponentB: loop with inner do_work(), clean shutdown. do_work() checks
+/// shutdown_recv in a select! alongside fake work — returns without triggering
+/// the guard. Only process() returning drops the guard.
+/// Demonstrates: process_scope, child method using handle, report_healthy.
 #[tokio::test]
-async fn signal_failure_returns_component_failure() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(2),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
+async fn component_b_clean_shutdown_with_do_work() {
+    let mut manager = test_manager();
+    let handle = manager.register("b", liveness_opts());
+    let guard = manager.monitor_background();
+
+    let comp = ComponentB::new(handle.clone());
+    tokio::spawn(async move { comp.process().await });
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    handle.request_shutdown();
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(result.is_ok());
+}
+
+/// ComponentB: do_work() returns Err, process() calls signal_failure() and
+/// returns → manager records ComponentFailure, guard drop is harmlessly ignored.
+/// Demonstrates: error propagation from child method, signal_failure from process().
+#[tokio::test]
+async fn component_b_do_work_signals_failure() {
+    let mut manager = test_manager();
+    let handle = manager.register("b", ComponentOptions::new());
+    let guard = manager.monitor_background();
+
+    let comp = ComponentB::new(handle.clone());
+    // Set the fail flag so do_work returns Err on next call
+    comp.fail_flag.store(true, Ordering::SeqCst);
+    tokio::spawn(async move { comp.process().await });
+
+    // Wait for struct to drop after task exits
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    drop(handle);
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(matches!(
+        result,
+        Err(LifecycleError::ComponentFailure { tag, reason })
+            if tag == "b" && reason == "injected failure"
+    ));
+}
+
+/// ComponentB: report_healthy() is called from the process loop after each
+/// successful do_work(). Liveness probe starts as !healthy (Starting), then
+/// reflects Healthy once heartbeats arrive.
+/// Demonstrates: liveness driven by report_healthy in a struct-based component.
+#[tokio::test]
+async fn component_b_reports_healthy_from_process() {
+    let mut manager = test_manager();
+    let handle = manager.register("b", liveness_opts());
+    let liveness = manager.liveness_handler();
+
+    // Initially Starting (no report_healthy yet)
+    assert!(!liveness.check().healthy);
+
+    let comp = ComponentB::new(handle.clone());
+    let guard = manager.monitor_background();
+    tokio::spawn(async move { comp.process().await });
+
+    // Let a few do_work iterations run so report_healthy is called
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    assert!(liveness.check().healthy);
+
+    handle.request_shutdown();
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(result.is_ok());
+}
+
+/// Two components (A + B) registered on the same manager. request_shutdown()
+/// from either triggers global shutdown — both see it via shutdown_recv() and
+/// exit cleanly. Readiness flips to 503 so K8s stops routing traffic.
+/// Demonstrates: multi-component registration, shared shutdown signal.
+#[tokio::test]
+async fn component_a_and_b_multi_component_shutdown() {
+    let mut manager = test_manager();
+    let ha = manager.register("a", liveness_opts());
+    let hb = manager.register("b", liveness_opts());
+    let guard = manager.monitor_background();
+
+    let comp_a = ComponentA { handle: ha.clone() };
+    let comp_b = ComponentB::new(hb.clone());
+
+    tokio::spawn(async move { comp_a.process().await });
+    tokio::spawn(async move { comp_b.process().await });
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    ha.request_shutdown(); // triggers global shutdown, both components see it
+
+    // Drop the "struct" clones
+    drop(ha);
+    drop(hb);
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(result.is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// Section 2: Direct API usage (no process_scope guard)
+//
+// These tests show the "handle moved into task" pattern where the spawned
+// task IS the scope — when it returns, the last handle clone drops and the
+// drop guard notifies the manager. No struct, no process_scope().
+// ---------------------------------------------------------------------------
+
+/// signal_failure() triggers global shutdown; just return and let the handle
+/// drop. Manager records ComponentFailure; the drop during shutdown is ignored.
+/// K8s effect: readiness flips to 503, liveness stays healthy during shutdown.
+#[tokio::test]
+async fn direct_signal_failure_then_drop() {
+    let mut manager = test_manager();
     let handle = manager.register("worker", ComponentOptions::new());
     let guard = manager.monitor_background();
 
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(20)).await;
         handle.signal_failure("something broke");
+        // No work_completed() — just return; drop during shutdown is fine
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(matches!(
+        result,
+        Err(LifecycleError::ComponentFailure { tag, reason })
+            if tag == "worker" && reason == "something broke"
+    ));
+}
+
+/// request_shutdown() + work_completed(): clean non-fatal shutdown. The component
+/// requests shutdown, finishes remaining work, then calls work_completed().
+/// Demonstrates: the explicit completion path (alternative to drop-as-completion).
+#[tokio::test]
+async fn direct_request_shutdown_with_work_completed() {
+    let mut manager = test_manager();
+    let handle = manager.register("worker", ComponentOptions::new());
+    let guard = manager.monitor_background();
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        handle.request_shutdown();
+        tokio::time::sleep(Duration::from_millis(20)).await;
         handle.work_completed();
     });
 
     let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
         .await
-        .expect("signal_failure_returns_component_failure timed out");
-    assert!(matches!(
-        result,
-        Err(LifecycleError::ComponentFailure { tag, reason }) if tag == "worker" && reason == "something broke"
-    ));
+        .expect("timed out");
+    assert!(result.is_ok());
 }
 
-/// Pitfall: component task returns without calling work_completed() (e.g. early return on error).
-/// The last Handle clone is dropped when the task exits → drop guard fires → manager gets Died.
+/// Handle moved into spawned task. Task requests shutdown, awaits shutdown_recv(),
+/// then returns — handle drop during shutdown is treated as normal completion.
+/// No work_completed() call needed. This is the simplest correct pattern for
+/// long-running components without a struct.
 #[tokio::test]
-async fn component_exits_without_work_completed_signals_died() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(2),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
+async fn direct_handle_drop_during_shutdown_is_completion() {
+    let mut manager = test_manager();
     let handle = manager.register("worker", ComponentOptions::new());
     let guard = manager.monitor_background();
 
     tokio::spawn(async move {
-        let _handle_owned = handle;
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        // Simulate "early return on error" without calling work_completed()
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        handle.request_shutdown();
+        handle.shutdown_recv().await;
+        // handle dropped here — shutdown in progress, so treated as WorkCompleted
     });
 
     let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
         .await
-        .expect("component_exits_without_work_completed_signals_died timed out");
-    assert!(matches!(
-        result,
-        Err(LifecycleError::ComponentDied { tag }) if tag == "worker"
-    ));
+        .expect("timed out");
+    assert!(result.is_ok());
 }
 
-/// report_unhealthy() makes liveness report the component as unhealthy.
+/// work_completed() for one-shot/finite work: call it when work finishes during
+/// normal operation so the subsequent handle drop doesn't signal "died". This is
+/// the only case where work_completed() is needed — long-running components that
+/// exit on shutdown don't need it (drop during shutdown is completion).
 #[tokio::test]
-async fn report_unhealthy_makes_liveness_unhealthy() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(1),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
-    let handle = manager.register(
-        "worker",
-        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
-    );
-    let liveness = manager.liveness_handler();
-
-    handle.report_healthy();
-    assert!(liveness.check().healthy);
-
-    handle.report_unhealthy();
-    let status = liveness.check();
-    assert!(!status.healthy);
-    assert_eq!(
-        status.components.get("worker").unwrap(),
-        &lifecycle::ComponentLiveness::Unhealthy
-    );
-}
-
-#[tokio::test]
-async fn readiness_returns_200_until_shutdown() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(5),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
+async fn direct_work_completed_prevents_died_on_drop() {
+    let mut manager = test_manager();
     let handle = manager.register("worker", ComponentOptions::new());
-    let readiness = manager.readiness_handler();
-    assert_eq!(readiness.check().await.as_u16(), 200);
-
+    handle.work_completed();
     let guard = manager.monitor_background();
-    tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        handle.request_shutdown();
-        tokio::time::sleep(Duration::from_millis(80)).await;
-    });
+    drop(handle);
+    tokio::time::sleep(Duration::from_millis(50)).await;
 
-    tokio::time::timeout(Duration::from_secs(10), guard.wait())
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
         .await
-        .expect("readiness_returns_200_until_shutdown timed out")
-        .unwrap();
-    assert_eq!(readiness.check().await.as_u16(), 503);
+        .expect("timed out");
+    assert!(result.is_ok());
 }
 
+// ---------------------------------------------------------------------------
+// Section 3: Liveness and readiness
+//
+// Liveness is driven by report_healthy() / report_unhealthy() calls on
+// handles. K8s probes this endpoint and restarts the pod if it fails
+// failureThreshold consecutive times. Readiness is driven by the shutdown
+// token — it flips to 503 when any shutdown trigger fires, telling K8s to
+// stop routing traffic.
+// ---------------------------------------------------------------------------
+
+/// Components start as Starting (liveness probe fails). After calling
+/// report_healthy(), the probe returns Healthy.
+/// K8s effect: pod is not "live" until the first heartbeat arrives.
 #[tokio::test]
-async fn liveness_unhealthy_until_report_healthy() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(1),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
-    let handle = manager.register(
-        "worker",
-        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
-    );
+async fn liveness_starts_as_starting_until_report_healthy() {
+    let mut manager = test_manager();
+    let handle = manager.register("worker", liveness_opts());
     let liveness = manager.liveness_handler();
+
     let status = liveness.check();
     assert!(!status.healthy);
     assert_eq!(
@@ -172,274 +372,150 @@ async fn liveness_unhealthy_until_report_healthy() {
     );
 }
 
+/// report_unhealthy() explicitly marks the component as Unhealthy. Calling
+/// report_healthy() again would recover it. This is distinct from Stalled
+/// (heartbeat deadline expired) — Unhealthy is an explicit signal.
+/// K8s effect: liveness probe returns 500; K8s eventually restarts the pod.
 #[tokio::test]
-async fn liveness_strategy_all_requires_all_healthy() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(1),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
-    let h1 = manager.register(
-        "a",
-        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
-    );
-    let h2 = manager.register(
-        "b",
-        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
-    );
+async fn liveness_report_unhealthy() {
+    let mut manager = test_manager();
+    let handle = manager.register("worker", liveness_opts());
     let liveness = manager.liveness_handler();
-    h1.report_healthy();
+
+    handle.report_healthy();
+    assert!(liveness.check().healthy);
+
+    handle.report_unhealthy();
     let status = liveness.check();
     assert!(!status.healthy);
-
-    h2.report_healthy();
-    let status = liveness.check();
-    assert!(status.healthy);
+    assert_eq!(
+        status.components.get("worker").unwrap(),
+        &lifecycle::ComponentLiveness::Unhealthy
+    );
 }
 
+/// End-to-end: ComponentB runs with process_scope, calls report_healthy() on
+/// each successful do_work() iteration. Liveness reflects Healthy while
+/// running. After shutdown, the guard drops cleanly and the struct-held
+/// handle is dropped without double-signaling.
+/// Demonstrates: liveness + process_scope + struct-held handle working together.
+#[tokio::test]
+async fn liveness_with_process_scope_struct() {
+    let mut manager = test_manager();
+    let handle = manager.register("b", liveness_opts());
+    let liveness = manager.liveness_handler();
+    let guard = manager.monitor_background();
+
+    let comp = ComponentB::new(handle.clone());
+    tokio::spawn(async move { comp.process().await });
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    assert!(liveness.check().healthy);
+
+    handle.request_shutdown();
+    drop(handle);
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
+    assert!(result.is_ok());
+}
+
+/// HealthStrategy::All: every component must be healthy for the probe to pass.
+/// One Starting/Stalled/Unhealthy component fails the whole probe.
+#[tokio::test]
+async fn liveness_strategy_all_requires_all_healthy() {
+    let mut manager = test_manager();
+    let h1 = manager.register("a", liveness_opts());
+    let h2 = manager.register("b", liveness_opts());
+    let liveness = manager.liveness_handler();
+
+    h1.report_healthy();
+    assert!(!liveness.check().healthy); // b still Starting
+
+    h2.report_healthy();
+    assert!(liveness.check().healthy);
+}
+
+/// HealthStrategy::Any: at least one healthy component is enough.
 #[tokio::test]
 async fn liveness_strategy_any_one_healthy_suffices() {
     let mut manager = Manager::new(ManagerOptions {
         name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(1),
+        global_shutdown_timeout: Duration::from_secs(5),
         trap_signals: false,
         enable_prestop_check: false,
         liveness_strategy: HealthStrategy::Any,
     });
-    let h1 = manager.register(
-        "a",
-        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
-    );
-    let _h2 = manager.register(
-        "b",
-        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
-    );
+    let h1 = manager.register("a", liveness_opts());
+    let _h2 = manager.register("b", liveness_opts());
     let liveness = manager.liveness_handler();
+
     h1.report_healthy();
-    let status = liveness.check();
-    assert!(status.healthy);
+    assert!(liveness.check().healthy);
 }
 
+/// Readiness returns 200 while running, 503 after shutdown begins.
+/// K8s effect: once 503, K8s removes the pod from service endpoints and
+/// stops routing new traffic. This happens before liveness is affected.
 #[tokio::test]
-async fn handle_drop_without_work_completed_signals_died() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(2),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
+async fn readiness_200_until_shutdown_then_503() {
+    let mut manager = test_manager();
+    let handle = manager.register("worker", ComponentOptions::new());
+    let readiness = manager.readiness_handler();
+    assert_eq!(readiness.check().await.as_u16(), 200);
+
+    let guard = manager.monitor_background();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handle.request_shutdown();
+        tokio::time::sleep(Duration::from_millis(80)).await;
     });
+
+    tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out")
+        .unwrap();
+    assert_eq!(readiness.check().await.as_u16(), 503);
+}
+
+// ---------------------------------------------------------------------------
+// Section 4: Drop guard edge cases
+//
+// These tests verify the safety net: drops during normal operation (panics,
+// early returns) trigger shutdown, while drops during shutdown are benign.
+// Also covers process_scope deduplication guarantees.
+// ---------------------------------------------------------------------------
+
+/// Handle dropped during normal operation (no shutdown in progress) → manager
+/// receives Died, triggers global shutdown, returns ComponentDied error.
+/// This is the safety net for panics and accidental early returns.
+#[tokio::test]
+async fn handle_drop_during_normal_operation_signals_died() {
+    let mut manager = test_manager();
     let handle = manager.register("worker", ComponentOptions::new());
     let guard = manager.monitor_background();
     drop(handle);
+
     let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
         .await
-        .expect("handle_drop_without_work_completed_signals_died timed out");
+        .expect("timed out");
     assert!(matches!(
         result,
         Err(LifecycleError::ComponentDied { tag }) if tag == "worker"
     ));
 }
 
+/// Struct outlives its process_scope guard. When the guard fires (process
+/// returns), it signals once. When the struct is later dropped and
+/// HandleInner::drop runs, it sees process_scope_signalled=true and skips.
+/// No double-signal, no spurious errors.
 #[tokio::test]
-async fn work_completed_prevents_died_on_drop() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(2),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
-    let handle = manager.register("worker", ComponentOptions::new());
-    handle.work_completed();
-    let guard = manager.monitor_background();
-    drop(handle);
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
-        .await
-        .expect("work_completed_prevents_died_on_drop timed out");
-    assert!(result.is_ok());
-}
-
-/// After shutdown signalled, component exits without work_completed(); drop is treated as completion.
-#[tokio::test]
-async fn request_shutdown_then_exit_without_work_completed_ok() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(5),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
-    let handle = manager.register("worker", ComponentOptions::new());
-    let guard = manager.monitor_background();
-    tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        handle.request_shutdown();
-        tokio::time::sleep(Duration::from_millis(30)).await;
-    });
-    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
-        .await
-        .expect("request_shutdown_then_exit_without_work_completed_ok timed out");
-    assert!(result.is_ok());
-}
-
-#[tokio::test]
-async fn request_shutdown_then_work_completed_clean_shutdown() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(5),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
-    let handle = manager.register("worker", ComponentOptions::new());
-    let guard = manager.monitor_background();
-    tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        handle.request_shutdown();
-        tokio::time::sleep(Duration::from_millis(20)).await;
-        handle.work_completed();
-    });
-    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
-        .await
-        .expect("request_shutdown_then_work_completed_clean_shutdown timed out");
-    assert!(result.is_ok());
-}
-
-#[tokio::test]
-async fn component_timeout_during_graceful_shutdown() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(5),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
-    let handle = manager.register(
-        "worker",
-        ComponentOptions::new().with_graceful_shutdown(Duration::from_millis(50)),
-    );
-    let guard = manager.monitor_background();
-    tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(20)).await;
-        handle.request_shutdown();
-    });
-    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
-        .await
-        .expect("component_timeout_during_graceful_shutdown timed out");
-    assert!(result.is_ok());
-}
-
-/// Component exceeds graceful shutdown window, monitor marks TimedOut; late drop sends WorkCompleted
-/// but manager does not overwrite TimedOut with Completed.
-#[tokio::test]
-async fn component_timeout_then_late_drop_stays_timed_out() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(5),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
-    let handle = manager.register(
-        "worker",
-        ComponentOptions::new().with_graceful_shutdown(Duration::from_millis(50)),
-    );
-    let guard = manager.monitor_background();
-    tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(20)).await;
-        handle.request_shutdown();
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    });
-    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
-        .await
-        .expect("component_timeout_then_late_drop_stays_timed_out timed out");
-    assert!(result.is_ok());
-}
-
-// --- ProcessScopeGuard tests ---
-
-/// Guard dropped during shutdown sends WorkCompleted, monitor returns Ok.
-#[tokio::test]
-async fn process_scope_guard_drop_during_shutdown_sends_work_completed() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(5),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
+async fn process_scope_prevents_double_signal_from_struct() {
+    let mut manager = test_manager();
     let handle = manager.register("worker", ComponentOptions::new());
     let guard = manager.monitor_background();
 
-    // Simulate struct-held handle: task clones handle, creates process scope, then exits on shutdown.
-    let h = handle.clone();
-    tokio::spawn(async move {
-        let _scope = h.process_scope();
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        h.request_shutdown();
-        h.shutdown_recv().await;
-        // _scope dropped here → WorkCompleted (shutdown in progress)
-    });
-    // Drop "struct" clone after task finishes
-    tokio::time::sleep(Duration::from_millis(200)).await;
-    drop(handle);
-
-    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
-        .await
-        .expect("process_scope_guard_drop_during_shutdown_sends_work_completed timed out");
-    assert!(result.is_ok());
-}
-
-/// Guard dropped without shutdown sends Died, monitor returns ComponentDied.
-#[tokio::test]
-async fn process_scope_guard_drop_without_shutdown_sends_died() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(5),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
-    let handle = manager.register("worker", ComponentOptions::new());
-    let guard = manager.monitor_background();
-
-    let h = handle.clone();
-    tokio::spawn(async move {
-        let _scope = h.process_scope();
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        // _scope dropped here → Died (shutdown not in progress)
-    });
-    tokio::time::sleep(Duration::from_millis(200)).await;
-    drop(handle);
-
-    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
-        .await
-        .expect("process_scope_guard_drop_without_shutdown_sends_died timed out");
-    assert!(matches!(
-        result,
-        Err(LifecycleError::ComponentDied { tag }) if tag == "worker"
-    ));
-}
-
-/// Struct keeps handle after guard is dropped; HandleInner::drop skips sending because
-/// process_scope_signalled is already set. Manager gets exactly one event.
-#[tokio::test]
-async fn process_scope_guard_struct_keeps_handle_no_double_signal() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(5),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
-    let handle = manager.register("worker", ComponentOptions::new());
-    let guard = manager.monitor_background();
-
-    // "struct" holds handle; task uses process_scope then exits
     let h = handle.clone();
     tokio::spawn(async move {
         let _scope = h.process_scope();
@@ -449,26 +525,22 @@ async fn process_scope_guard_struct_keeps_handle_no_double_signal() {
         // _scope dropped → WorkCompleted (first and only event)
     });
 
-    // "struct" clone dropped later — HandleInner::drop sees process_scope_signalled=true, skips
+    // "struct" clone dropped later — should not double-signal
     tokio::time::sleep(Duration::from_millis(300)).await;
     drop(handle);
 
     let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
         .await
-        .expect("process_scope_guard_struct_keeps_handle_no_double_signal timed out");
+        .expect("timed out");
     assert!(result.is_ok());
 }
 
-/// Creating two guards from the same handle: only the first dropped sends an event.
+/// Two guards from the same handle: only the first dropped sends an event.
+/// Second guard and handle drop are both no-ops. Typical usage is one guard
+/// per process() call, but this verifies the dedup is safe regardless.
 #[tokio::test]
-async fn process_scope_guard_multiple_guards_only_first_sends() {
-    let mut manager = Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(5),
-        trap_signals: false,
-        enable_prestop_check: false,
-        liveness_strategy: HealthStrategy::All,
-    });
+async fn multiple_process_scope_guards_only_first_sends() {
+    let mut manager = test_manager();
     let handle = manager.register("worker", ComponentOptions::new());
     let guard = manager.monitor_background();
 
@@ -478,13 +550,38 @@ async fn process_scope_guard_multiple_guards_only_first_sends() {
         tokio::time::sleep(Duration::from_millis(30)).await;
         handle.request_shutdown();
         handle.shutdown_recv().await;
-        drop(scope1); // sends WorkCompleted
-        drop(scope2); // sees process_scope_signalled=true, skips
-        // handle dropped last — HandleInner::drop sees process_scope_signalled=true, skips
+        drop(scope1);
+        drop(scope2);
     });
 
     let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
         .await
-        .expect("process_scope_guard_multiple_guards_only_first_sends timed out");
+        .expect("timed out");
+    assert!(result.is_ok());
+}
+
+/// Component exceeds its with_graceful_shutdown budget. Manager marks it
+/// TimedOut. When the handle is eventually dropped (sending a late WorkCompleted),
+/// the manager does not overwrite TimedOut with Completed — metrics correctly
+/// reflect the timeout.
+#[tokio::test]
+async fn component_timeout_then_late_drop_preserves_timeout() {
+    let mut manager = test_manager();
+    let handle = manager.register(
+        "worker",
+        ComponentOptions::new().with_graceful_shutdown(Duration::from_millis(50)),
+    );
+    let guard = manager.monitor_background();
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        handle.request_shutdown();
+        // Hold handle past the 50ms graceful shutdown window
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(10), guard.wait())
+        .await
+        .expect("timed out");
     assert!(result.is_ok());
 }

--- a/rust/common/lifecycle/tests/lifecycle_tests.rs
+++ b/rust/common/lifecycle/tests/lifecycle_tests.rs
@@ -1,0 +1,189 @@
+use std::time::Duration;
+
+use lifecycle::{ComponentOptions, HealthStrategy, LifecycleError, Manager, ManagerOptions};
+
+#[tokio::test]
+async fn readiness_returns_200_until_shutdown() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(5),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::All,
+    });
+    let handle = manager.register("worker", ComponentOptions::new());
+    let readiness = manager.readiness_handler();
+    assert_eq!(readiness.check().await.as_u16(), 200);
+
+    let guard = manager.monitor_background();
+    let handle_for_shutdown = handle.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handle_for_shutdown.request_shutdown();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        handle_for_shutdown.work_completed();
+    });
+
+    guard.wait().await.unwrap();
+    assert_eq!(readiness.check().await.as_u16(), 503);
+}
+
+#[tokio::test]
+async fn liveness_unhealthy_until_report_healthy() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(1),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::All,
+    });
+    let handle = manager.register(
+        "worker",
+        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
+    );
+    let liveness = manager.liveness_handler();
+    let status = liveness.check();
+    assert!(!status.healthy);
+    assert_eq!(
+        status.components.get("worker").unwrap(),
+        &lifecycle::ComponentLiveness::Starting
+    );
+
+    handle.report_healthy();
+    let status = liveness.check();
+    assert!(status.healthy);
+    assert_eq!(
+        status.components.get("worker").unwrap(),
+        &lifecycle::ComponentLiveness::Healthy
+    );
+}
+
+#[tokio::test]
+async fn liveness_strategy_all_requires_all_healthy() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(1),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::All,
+    });
+    let h1 = manager.register(
+        "a",
+        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
+    );
+    let h2 = manager.register(
+        "b",
+        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
+    );
+    let liveness = manager.liveness_handler();
+    h1.report_healthy();
+    let status = liveness.check();
+    assert!(!status.healthy);
+
+    h2.report_healthy();
+    let status = liveness.check();
+    assert!(status.healthy);
+}
+
+#[tokio::test]
+async fn liveness_strategy_any_one_healthy_suffices() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(1),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::Any,
+    });
+    let h1 = manager.register(
+        "a",
+        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
+    );
+    let _h2 = manager.register(
+        "b",
+        ComponentOptions::new().with_liveness_deadline(Duration::from_secs(30)),
+    );
+    let liveness = manager.liveness_handler();
+    h1.report_healthy();
+    let status = liveness.check();
+    assert!(status.healthy);
+}
+
+#[tokio::test]
+async fn handle_drop_without_work_completed_signals_died() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(2),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::All,
+    });
+    let handle = manager.register("worker", ComponentOptions::new());
+    let guard = manager.monitor_background();
+    drop(handle);
+    let result = guard.wait().await;
+    assert!(matches!(
+        result,
+        Err(LifecycleError::ComponentDied { tag }) if tag == "worker"
+    ));
+}
+
+#[tokio::test]
+async fn work_completed_prevents_died_on_drop() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(2),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::All,
+    });
+    let handle = manager.register("worker", ComponentOptions::new());
+    handle.work_completed();
+    let guard = manager.monitor_background();
+    drop(handle);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let result = guard.wait().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn request_shutdown_then_work_completed_clean_shutdown() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(5),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::All,
+    });
+    let handle = manager.register("worker", ComponentOptions::new());
+    let guard = manager.monitor_background();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handle.request_shutdown();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        handle.work_completed();
+    });
+    let result = guard.wait().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn component_timeout_during_graceful_shutdown() {
+    let mut manager = Manager::new(ManagerOptions {
+        name: "test".into(),
+        global_shutdown_timeout: Duration::from_secs(5),
+        trap_signals: false,
+        enable_prestop_check: false,
+        liveness_strategy: HealthStrategy::All,
+    });
+    let handle = manager.register(
+        "worker",
+        ComponentOptions::new().with_graceful_shutdown(Duration::from_millis(50)),
+    );
+    let guard = manager.monitor_background();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        handle.request_shutdown();
+    });
+    let result = guard.wait().await;
+    assert!(result.is_ok());
+}

--- a/rust/common/lifecycle/tests/lifecycle_tests.rs
+++ b/rust/common/lifecycle/tests/lifecycle_tests.rs
@@ -9,24 +9,23 @@ use lifecycle::{ComponentOptions, LifecycleError, Manager, ManagerOptions};
 // ---------------------------------------------------------------------------
 
 fn test_manager() -> Manager {
-    Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(5),
-        trap_signals: false,
-        enable_prestop_check: false,
-        health_poll_interval: Duration::from_secs(5),
-    })
+    Manager::new(
+        ManagerOptions::new("test")
+            .with_global_shutdown_timeout(Duration::from_secs(5))
+            .with_trap_signals(false)
+            .with_prestop_check(false),
+    )
 }
 
 /// Manager with fast health polling for stall detection tests.
 fn fast_poll_manager(poll_ms: u64) -> Manager {
-    Manager::new(ManagerOptions {
-        name: "test".into(),
-        global_shutdown_timeout: Duration::from_secs(5),
-        trap_signals: false,
-        enable_prestop_check: false,
-        health_poll_interval: Duration::from_millis(poll_ms),
-    })
+    Manager::new(
+        ManagerOptions::new("test")
+            .with_global_shutdown_timeout(Duration::from_secs(5))
+            .with_trap_signals(false)
+            .with_prestop_check(false)
+            .with_health_poll_interval(Duration::from_millis(poll_ms)),
+    )
 }
 
 fn liveness_opts() -> ComponentOptions {

--- a/rust/common/lifecycle/tests/lifecycle_tests.rs
+++ b/rust/common/lifecycle/tests/lifecycle_tests.rs
@@ -793,7 +793,9 @@ async fn failure_during_drain_resolves_component_without_global_timeout() {
 
     let result = tokio::time::timeout(Duration::from_millis(500), guard.wait())
         .await
-        .expect("manager should resolve promptly via Failure in drain, not wait for global timeout");
+        .expect(
+            "manager should resolve promptly via Failure in drain, not wait for global timeout",
+        );
 
     assert!(matches!(
         result,


### PR DESCRIPTION
## Problem
The current `common/health` library has some friction points I'd like to address:
* Requires reporting health status back to the registry for all components
* Doesn't support graceful shutdown
* Doesn't integrate k8s preStop -> terminationGraceSeconds handling
* Doesn't handle thread starvation or utilization-related skew/delays when app resources are saturated
* Doesn't integrate rich shutdown reporting
    * Which component triggered shutdown (or k8s/deploy?)
    * Which components completed shutdown gracefully, which timed out
    * How long did each component in the shutdown sequence take?

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

**Note: not all Rust services will require all the features this library adds.** The library's features are **opt-in**; only use what you need.

* `lifecycle::Manager` handles full app lifecycle:
   * Provides integrated k8s `preStop`, `_readiness`, and `_liveness` endpoints
   * Coordinates app shutdown (k8s/global or component-triggered)
   * Runs on 1 dedicated OS thread (`tokio::Runtime`) to avoid app-level starvation/utilization skewing lifecycle management responsiveness

*  Create a `lifecycle::HealthHandle` for each long-running component:
    * **Drop guard shutdown coordination** for long-lived components
        * Just return an error or panic to indicate process health
    * Simple APIs to check for global app shutdown at work boundaries
    * Graceful shutdown: break processing loop, clean up as desired before return
    * Optionally report health status directly, if desired
* Rich metrics and logging to help maintainers understand:
    * Which components are triggering shutdown and why
    * Did k8s trigger shutdown or did a component fail?
    * Did the components complete graceful shutdown prior to lifecycle timeouts or k8s SIGKILL?
* Rich documentation and test suite with usage examples:
    * Goal: help you (or your LLM) integrate the library into your service correctly
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Will integrate into a non-critical path app (`kafka-deduplicator`) once landed, to evaluate against goals and apply polish, before rolling out elsewhere.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
