### PR TITLE
fix: clear property filter value when switching between date and non-date operators

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -16,6 +16,7 @@ import {
     isOperatorCohort,
     isOperatorFlag,
     isOperatorMulti,
+    isOperatorDate,
     isOperatorRange,
     isOperatorRegex,
     isOperatorSemver,
@@ -217,6 +218,13 @@ export function OperatorValueSelect({
                             setCurrentOperator(newOperator)
                             if (isOperatorCohort(newOperator)) {
                                 onChange(newOperator, value || null)
+                            } else if (
+                                isOperatorDate(newOperator) !==
+                                isOperatorDate(currentOperator || PropertyOperator.Exact)
+                            ) {
+                                // Clear value when switching between date and non-date operators
+                                // since string values are not valid dates and vice versa
+                                onChange(newOperator, null)
                             } else if (isOperatorRange(newOperator) && isNaN(value as any)) {
                                 // If the new operator is range and the value is not a number, we want to set the new value to null
                                 onChange(newOperator, null)


### PR DESCRIPTION
## Problem

When changing from a string operator (e.g. **equals**) to a date operator (e.g. **is after**) in the feature flags property filter UI, the old string value was preserved but hidden by the date picker. This allowed saving invalid non-date values with date operators.

## Changes

In `OperatorValueSelect.tsx`, added a check in the operator change handler that clears the value (`null`) whenever the operator type switches between date and non-date categories. This uses the existing `isOperatorDate()` utility.

The check is placed before the range operator check so it takes priority.

## How to test

1. Create a feature flag with a property condition using **equals** and a string value like `garbage`
2. Change the operator to **is after** (a date operator)
3. Verify the value is cleared (not silently preserved)
4. Verify the reverse also works: set a date value, switch to a string operator, value is cleared

Closes #47703