### PR TITLE
Clarify feature flag enabled/disabled toggle state

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -1132,31 +1132,38 @@ function FeatureFlagRollout({
                                         Deleted
                                     </LemonTag>
                                 ) : (
-                                    <div className="flex gap-2">
-                                        <AccessControlAction
-                                            resourceType={AccessControlResourceType.FeatureFlag}
-                                            minAccessLevel={AccessControlLevel.Editor}
-                                            userAccessLevel={featureFlag.user_access_level}
-                                        >
-                                            <LemonSwitch
-                                                onChange={(newValue) => {
-                                                    toggleFeatureFlagActive(newValue)
-                                                }}
-                                                label={featureFlag.active ? 'Enabled' : 'Disabled'}
-                                                loading={featureFlagActiveUpdateLoading}
-                                                disabledReason={
-                                                    !featureFlag.can_edit
-                                                        ? "You only have view access to this feature flag. To make changes, contact the flag's creator."
-                                                        : null
-                                                }
-                                                checked={featureFlag.active}
-                                            />
-                                        </AccessControlAction>
+                                    <>
+                                        <div className="flex gap-2">
+                                            <AccessControlAction
+                                                resourceType={AccessControlResourceType.FeatureFlag}
+                                                minAccessLevel={AccessControlLevel.Editor}
+                                                userAccessLevel={featureFlag.user_access_level}
+                                            >
+                                                <LemonSwitch
+                                                    onChange={(newValue) => {
+                                                        toggleFeatureFlagActive(newValue)
+                                                    }}
+                                                    label={featureFlag.active ? 'Enabled' : 'Disabled'}
+                                                    loading={featureFlagActiveUpdateLoading}
+                                                    disabledReason={
+                                                        !featureFlag.can_edit
+                                                            ? "You only have view access to this feature flag. To make changes, contact the flag's creator."
+                                                            : null
+                                                    }
+                                                    checked={featureFlag.active}
+                                                />
+                                            </AccessControlAction>
 
-                                        {!featureFlag.is_remote_configuration && (
-                                            <FeatureFlagStatusIndicator flagStatus={flagStatus} />
-                                        )}
-                                    </div>
+                                            {!featureFlag.is_remote_configuration && (
+                                                <FeatureFlagStatusIndicator flagStatus={flagStatus} />
+                                            )}
+                                        </div>
+                                        <div className="text-secondary text-sm mt-1">
+                                            {featureFlag.active
+                                                ? 'Feature flag is ON — users may receive this feature'
+                                                : 'Feature flag is OFF — feature will not be served'}
+                                        </div>
+                                    </>
                                 )}
                             </div>
                             <div>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -1140,6 +1140,11 @@ function FeatureFlagRollout({
                                                 userAccessLevel={featureFlag.user_access_level}
                                             >
                                                 <LemonSwitch
+                                                    aria-label={
+                                                        featureFlag.active
+                                                            ? 'Feature flag ON — users may receive this feature'
+                                                            : 'Feature flag OFF — feature will not be served'
+                                                    }
                                                     onChange={(newValue) => {
                                                         toggleFeatureFlagActive(newValue)
                                                     }}


### PR DESCRIPTION
## Problem
The feature flag status toggle shows "Enabled/Disabled", which can be ambiguous — it may appear that the toggle itself is disabled rather than indicating the flag state.

## Changes
Add helper text under the toggle clarifying whether the feature is being served to users:

- ON → Feature flag is ON — users may receive this feature
- OFF → Feature flag is OFF — feature will not be served

No logic changes — UI clarification only.

## How did you test this code?
Verified the component logic and ensured the helper text updates based on `featureFlag.active` state.

## Publish to changelog?
no
