### PR TITLE
fix(logs): fix severity level ordering

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
@@ -11,8 +11,8 @@ import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsVi
 
 const options: Record<LogMessage['severity_text'], string> = {
     trace: 'Trace',
-    info: 'Info',
     debug: 'Debug',
+    info: 'Info',
     warn: 'Warn',
     error: 'Error',
     fatal: 'Fatal',


### PR DESCRIPTION

## Problem

severity levels were out of order, with debug coming between info and warn. Reorder into correct ascending order

<img width="380" height="564" alt="image" src="https://github.com/user-attachments/assets/8f52591d-c5dc-4067-a9bd-5af47a8c03f3" />

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

fix the order
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
No