### PR TITLE
chore(llma): exclude batch_actions_ traces from project 2 workflows

### DIFF
--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -2995,56 +2995,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.10
   '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."queryable_folder",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."description",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.11
-  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -3063,7 +3013,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.12
+# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.11
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -3093,7 +3043,7 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.13
+# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.12
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
@@ -3101,6 +3051,18 @@
          AND "posthog_sessionrecordingviewed"."user_id" = 99999
          AND "posthog_sessionrecordingviewed"."session_id" IN ('at_base_time_plus_20',
                                                                'at_base_time'))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.13
+  '''
+  SELECT "posthog_sessionrecordingviewed"."session_id",
+         "posthog_user"."email"
+  FROM "posthog_sessionrecordingviewed"
+  INNER JOIN "posthog_user" ON ("posthog_sessionrecordingviewed"."user_id" = "posthog_user"."id")
+  WHERE ("posthog_sessionrecordingviewed"."session_id" IN ('at_base_time_plus_20',
+                                                           'at_base_time')
+         AND "posthog_sessionrecordingviewed"."team_id" = 99999
+         AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.14
@@ -3460,19 +3422,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.8
   '''
-  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
-         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
-         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
-         "posthog_teamrevenueanalyticsconfig"."events",
-         "posthog_teamrevenueanalyticsconfig"."goals",
-         "posthog_teamrevenueanalyticsconfig"."base_currency"
-  FROM "posthog_teamrevenueanalyticsconfig"
-  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.9
-  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -3500,6 +3449,56 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.9
+  '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."queryable_folder",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."description",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending

--- a/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
@@ -48,10 +48,13 @@ logger = structlog.get_logger(__name__)
 
 # Per-team trace filters to scope which traces are included in clustering.
 # team_id=2 (PostHog internal): only cluster posthog_ai traces, excluding
-# summarization LLM calls, playground, and other internal noise.
+# summarization LLM calls, playground, batch action summarization, and other internal noise.
 # TODO: generalize via FF payload config so any team can define filters without code changes.
 PER_TEAM_TRACE_FILTERS: dict[int, list[dict[str, Any]]] = {
-    2: [{"key": "ai_product", "value": "posthog_ai", "operator": "exact", "type": "event"}],
+    2: [
+        {"key": "ai_product", "value": "posthog_ai", "operator": "exact", "type": "event"},
+        {"key": "$ai_trace_id", "value": "batch_actions_", "operator": "not_icontains", "type": "event"},
+    ],
 }
 
 

--- a/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
@@ -53,7 +53,7 @@ logger = structlog.get_logger(__name__)
 PER_TEAM_TRACE_FILTERS: dict[int, list[dict[str, Any]]] = {
     2: [
         {"key": "ai_product", "value": "posthog_ai", "operator": "exact", "type": "event"},
-        {"key": "$ai_trace_id", "value": "batch_actions_", "operator": "not_icontains", "type": "event"},
+        {"key": "$ai_trace_id", "value": "^batch_actions_", "operator": "not_regex", "type": "event"},
     ],
 }
 

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -67,7 +67,7 @@ logger = structlog.get_logger(__name__)
 PER_TEAM_TRACE_FILTERS: dict[int, list[dict[str, Any]]] = {
     2: [
         {"key": "ai_product", "value": "posthog_ai", "operator": "exact", "type": "event"},
-        {"key": "$ai_trace_id", "value": "batch_actions_", "operator": "not_icontains", "type": "event"},
+        {"key": "$ai_trace_id", "value": "^batch_actions_", "operator": "not_regex", "type": "event"},
     ],
 }
 

--- a/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/coordinator.py
@@ -62,10 +62,13 @@ logger = structlog.get_logger(__name__)
 
 # Per-team trace filters to scope which traces are included in summarization sampling.
 # team_id=2 (PostHog internal): only summarize posthog_ai traces, excluding
-# summarization LLM calls, playground, and other internal noise.
+# summarization LLM calls, playground, batch action summarization, and other internal noise.
 # TODO: generalize via FF payload config so any team can define filters without code changes.
 PER_TEAM_TRACE_FILTERS: dict[int, list[dict[str, Any]]] = {
-    2: [{"key": "ai_product", "value": "posthog_ai", "operator": "exact", "type": "event"}],
+    2: [
+        {"key": "ai_product", "value": "posthog_ai", "operator": "exact", "type": "event"},
+        {"key": "$ai_trace_id", "value": "batch_actions_", "operator": "not_icontains", "type": "event"},
+    ],
 }
 
 


### PR DESCRIPTION
## Problem

The action summarizer (`ee/hogai/summarizers/chains.py`) generates LLM traces with `ai_product=posthog_ai` and trace IDs prefixed with `batch_actions_`. These pass through the existing project 2 filter (`ai_product == "posthog_ai"`) and show up in internal LLM analytics summarization and clustering results as noise.

## Changes

Added a `$ai_trace_id not_icontains "batch_actions_"` filter to `PER_TEAM_TRACE_FILTERS` for team 2 in both:
- `posthog/temporal/llm_analytics/trace_summarization/coordinator.py`
- `posthog/temporal/llm_analytics/trace_clustering/coordinator.py`

## How did you test this code?

Verified the filter structure matches the existing PostHog property filter format used by `property_to_expr()` in the sampling and data layers.

## Publish to changelog?

No