### PR TITLE
fix: show top 2 matching results in taxonomic filter

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.scss
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.scss
@@ -1,6 +1,6 @@
 .taxonomic-infinite-list {
     flex-grow: 1;
-    min-height: 200px;
+    min-height: 272px;
 
     &.empty-infinite-list {
         display: flex;

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -543,31 +543,31 @@ describe('taxonomicFilterLogic', () => {
         it.each([
             {
                 query: '$pageview',
-                expectedMatchName: '$pageview',
+                expectedMatches: [{ name: '$pageview' }],
                 description: 'single matching result is promoted',
             },
             {
                 query: 'event',
-                expectedMatchName: 'event1',
-                description: 'first of multiple matching results is promoted',
+                expectedMatches: [{ name: 'event1' }, { name: 'test event' }],
+                description: 'top two matching results are promoted',
             },
-        ])('$description (query=$query)', async ({ query, expectedMatchName }) => {
+        ])('$description (query=$query)', async ({ query, expectedMatches }) => {
             expect(quickLogic.values.activeTab).toBe(TaxonomicFilterGroupType.SuggestedFilters)
 
             await expectLogic(quickLogic, () => {
                 quickLogic.actions.setSearchQuery(query)
             })
-                .toDispatchActions(['setSearchQuery', 'appendTopMatch'])
+                .toDispatchActions(['setSearchQuery', 'appendTopMatches'])
                 .delay(1)
                 .clearHistory()
                 .toMatchValues({
                     activeTab: TaxonomicFilterGroupType.SuggestedFilters,
-                    topMatchItems: [
+                    topMatchItems: expectedMatches.map((m) =>
                         expect.objectContaining({
-                            name: expectedMatchName,
+                            ...m,
                             group: TaxonomicFilterGroupType.Events,
-                        }),
-                    ],
+                        })
+                    ),
                 })
         })
 
@@ -575,7 +575,7 @@ describe('taxonomicFilterLogic', () => {
             await expectLogic(quickLogic, () => {
                 quickLogic.actions.setSearchQuery('$pageview')
             })
-                .toDispatchActions(['setSearchQuery', 'appendTopMatch'])
+                .toDispatchActions(['setSearchQuery', 'appendTopMatches'])
                 .delay(1)
 
             expect(quickLogic.values.topMatchItems).toHaveLength(1)

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -294,7 +294,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             groupType,
             results,
         }),
-        appendTopMatch: (item: TaxonomicDefinitionTypes & { group: TaxonomicFilterGroupType }) => ({ item }),
+        appendTopMatches: (items: (TaxonomicDefinitionTypes & { group: TaxonomicFilterGroupType })[]) => ({ items }),
     })),
     reducers(({ props, selectors }) => ({
         searchQuery: [
@@ -330,17 +330,16 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             [] as (TaxonomicDefinitionTypes & { group: TaxonomicFilterGroupType })[],
             {
                 setSearchQuery: () => [],
-                appendTopMatch: (
+                appendTopMatches: (
                     state: (TaxonomicDefinitionTypes & { group: TaxonomicFilterGroupType })[],
-                    { item }: { item: TaxonomicDefinitionTypes & { group: TaxonomicFilterGroupType } }
+                    { items }: { items: (TaxonomicDefinitionTypes & { group: TaxonomicFilterGroupType })[] }
                 ) => {
-                    const existingIndex = state.findIndex((i) => i.group === item.group)
-                    if (existingIndex >= 0) {
-                        const next = [...state]
-                        next[existingIndex] = item
-                        return next
+                    if (items.length === 0) {
+                        return state
                     }
-                    return [...state, item]
+                    const group = items[0].group
+                    const next = state.filter((i) => i.group !== group)
+                    return [...next, ...items]
                 },
             },
         ],
@@ -1346,12 +1345,14 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             ) {
                 const logic = values.infiniteListLogics[groupType]
                 if (logic?.isMounted()) {
-                    const match = logic.values.topMatchForQuery
-                    if (match) {
-                        actions.appendTopMatch({
-                            ...match,
-                            group: groupType as TaxonomicFilterGroupType,
-                        })
+                    const matches = logic.values.topMatchesForQuery
+                    if (matches.length > 0) {
+                        actions.appendTopMatches(
+                            matches.map((match) => ({
+                                ...match,
+                                group: groupType as TaxonomicFilterGroupType,
+                            }))
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## Problem

The taxonomic filter currently only promotes a single top match when searching. Users would benefit from seeing the top 2 matching results to have more options without needing to scroll through the full list.

## Changes

- Modified `appendTopMatch` action to `appendTopMatches` to handle multiple items instead of a single item
- Updated the reducer logic to replace all items in the same group rather than just updating a single item
- Changed `topMatchForQuery` selector to `topMatchesForQuery` in `infiniteListLogic` to return up to 2 matching results instead of just 1
- Updated the matching logic to skip disabled items and collect up to 2 valid matches
- Increased minimum height of infinite list from 200px to 272px to accommodate the additional result
- Updated tests to verify the new behavior of promoting top 2 matches

## How did you test this code?

- Updated unit tests in `taxonomicFilterLogic.test.ts` to verify that top 2 matching results are promoted
- Tests verify both single and multiple matching results are correctly promoted
- Tests confirm the action dispatches and values match expected behavior

https://claude.ai/code/session_01EFsqU3291b6KViWCWB7e63