### PR TITLE
fix(managed-migrations): use disposables for polling in managedMigrationLogic

### DIFF
--- a/products/managed_migrations/frontend/managedMigrationLogic.ts
+++ b/products/managed_migrations/frontend/managedMigrationLogic.ts
@@ -227,21 +227,15 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
             }
         },
         startPolling: () => {
-            const pollInterval = setInterval(() => {
-                if (!values.isPolling) {
-                    clearInterval(pollInterval)
-                    return
-                }
-                actions.loadMigrations()
-            }, 5000)
-
-            cache.pollInterval = pollInterval
+            cache.disposables.add(() => {
+                const intervalId = setInterval(() => {
+                    actions.loadMigrations()
+                }, 5000)
+                return () => clearInterval(intervalId)
+            }, 'pollMigrations')
         },
         stopPolling: () => {
-            if (cache.pollInterval) {
-                clearInterval(cache.pollInterval)
-                cache.pollInterval = null
-            }
+            cache.disposables.dispose('pollMigrations')
         },
     })),
     selectors({


### PR DESCRIPTION
using chrome://discards we can see a little of what is stopping chrome freezing or discarding tab memory

![CleanShot 2026-02-16 at 11.06.55@2x.png](https://app.graphite.com/user-attachments/assets/0d170df6-741b-47fc-ac5b-f3911fa8f4c9.png)

let's act on that - we shouldn't poll in the background