### PR TITLE
feat(endpoints): derive is_materialized from saved_query.table_id

### DIFF
--- a/products/endpoints/backend/migrations/0017_remove_endpointversion_is_materialized_state.py
+++ b/products/endpoints/backend/migrations/0017_remove_endpointversion_is_materialized_state.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("endpoints", "0016_endpoint_soft_delete_constraint"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name="endpointversion",
+                    name="is_materialized",
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE endpoints_endpointversion ALTER COLUMN is_materialized SET DEFAULT false",
+                    reverse_sql="ALTER TABLE endpoints_endpointversion ALTER COLUMN is_materialized DROP DEFAULT",
+                ),
+            ],
+        ),
+    ]

--- a/products/endpoints/backend/migrations/max_migration.txt
+++ b/products/endpoints/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0016_endpoint_soft_delete_constraint
+0017_remove_endpointversion_is_materialized_state

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -4,7 +4,7 @@ import uuid
 import logging
 from typing import Any
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
@@ -110,10 +110,6 @@ class EndpointVersion(models.Model):
         blank=True,
         help_text="Cache age in seconds. If null, uses default interval-based caching.",
     )
-    is_materialized = models.BooleanField(
-        default=False,
-        help_text="Whether this version's query results are materialized",
-    )
     saved_query = models.ForeignKey(
         "data_warehouse.DataWarehouseSavedQuery",
         null=True,
@@ -172,6 +168,16 @@ class EndpointVersion(models.Model):
         self.saved_query = None
         self.is_materialized = False
         self.save(update_fields=["saved_query", "is_materialized"])
+
+    @property
+    def is_materialized(self) -> bool:
+        """Derived from saved_query.table_id — True only when materialization is complete."""
+        if self.saved_query_id is None:
+            return False
+        try:
+            return self.saved_query.table_id is not None
+        except ObjectDoesNotExist:
+            return False
 
     def can_materialize(self) -> tuple[bool, str]:
         """Check if this version can be materialized.
@@ -348,7 +354,6 @@ class Endpoint(CreatedMetaFields, UpdatedMetaFields, DeletedMetaFields, UUIDTMod
             created_by=user,
             cache_age_seconds=previous_cache_age,
             description=previous_description,
-            is_materialized=False,
             columns=columns,
         )
 

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -166,13 +166,12 @@ class EndpointVersion(models.Model):
         self.saved_query.revert_materialization()
         self.saved_query.soft_delete()
         self.saved_query = None
-        self.is_materialized = False
-        self.save(update_fields=["saved_query", "is_materialized"])
+        self.save(update_fields=["saved_query"])
 
     @property
     def is_materialized(self) -> bool:
         """Derived from saved_query.table_id — True only when materialization is complete."""
-        if self.saved_query_id is None:
+        if self.saved_query is None:
             return False
         try:
             return self.saved_query.table_id is not None
@@ -373,7 +372,7 @@ class Endpoint(CreatedMetaFields, UpdatedMetaFields, DeletedMetaFields, UUIDTMod
         return latest
 
     def soft_delete(self) -> None:
-        for version in self.versions.filter(is_materialized=True, saved_query__isnull=False):
+        for version in self.versions.filter(saved_query__isnull=False):
             version.disable_materialization()
 
         self.deleted = True

--- a/products/endpoints/backend/tests/test_endpoint_execution.py
+++ b/products/endpoints/backend/tests/test_endpoint_execution.py
@@ -1043,7 +1043,8 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.json()["is_materialized"])
+        # is_materialized is derived from saved_query.table_id — False until Temporal creates the table
+        self.assertFalse(response.json()["is_materialized"])
 
     def test_endpoint_with_multiple_breakdowns_cannot_be_materialized(self):
         endpoint = create_endpoint_with_version(

--- a/products/endpoints/backend/tests/test_endpoint_versioning.py
+++ b/products/endpoints/backend/tests/test_endpoint_versioning.py
@@ -344,7 +344,7 @@ class TestEndpointVersioning(ClickhouseTestMixin, APIBaseTest):
 
         from unittest.mock import patch
 
-        from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+        from products.data_warehouse.backend.models import DataWarehouseSavedQuery, DataWarehouseTable
 
         initial_query = {"kind": "HogQLQuery", "query": "SELECT * FROM events LIMIT 10"}
 
@@ -371,8 +371,15 @@ class TestEndpointVersioning(ClickhouseTestMixin, APIBaseTest):
             sync_frequency_interval=timedelta(hours=24),
             origin=DataWarehouseSavedQuery.Origin.ENDPOINT,
         )
+        old_table = DataWarehouseTable.objects.create(
+            team=self.team,
+            name=f"{endpoint.name}_v1_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            url_pattern=f"s3://test-bucket/{endpoint.name}_v1_table",
+        )
+        old_saved_query.table = old_table
+        old_saved_query.save()
         version1.saved_query = old_saved_query
-        version1.is_materialized = True
         version1.save()
 
         old_saved_query_id = old_saved_query.id
@@ -677,8 +684,7 @@ class TestEndpointVersioning(ClickhouseTestMixin, APIBaseTest):
         v1.refresh_from_db()
         v2.refresh_from_db()
 
-        # v1 should now be materialized
-        self.assertTrue(v1.is_materialized)
+        # is_materialized is now derived from saved_query.table_id, which is only set after Temporal runs
         self.assertIsNotNone(v1.saved_query)
         self.assertEqual(v1.saved_query.name, "target_version_mat_v1")
 
@@ -691,7 +697,7 @@ class TestEndpointVersioning(ClickhouseTestMixin, APIBaseTest):
 
         from datetime import timedelta
 
-        from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+        from products.data_warehouse.backend.models import DataWarehouseSavedQuery, DataWarehouseTable
 
         # Create endpoint with v1
         initial_query = {"kind": "HogQLQuery", "query": "SELECT 1"}
@@ -712,9 +718,15 @@ class TestEndpointVersioning(ClickhouseTestMixin, APIBaseTest):
             sync_frequency_interval=timedelta(hours=24),
             origin=DataWarehouseSavedQuery.Origin.ENDPOINT,
         )
+        table = DataWarehouseTable.objects.create(
+            team=self.team,
+            name="disable_v1_mat_v1_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            url_pattern="s3://test-bucket/disable_v1_mat_v1_table",
+        )
+        saved_query.table = table
+        saved_query.save()
         v1.saved_query = saved_query
-        v1.is_materialized = True
-        v1.sync_frequency = "24hour"
         v1.save()
 
         # Create v2 by changing query


### PR DESCRIPTION
**\## Problem**

we were wrongly using the saved query for is_materialized state of the endpointversion

**\## Changes**

- Replace `EndpointVersion.is_materialized` BooleanField with a `@property` that derives from `saved_query.table_id`
- An endpoint version is now "materialized" only when the Temporal workflow has completed and created the table — more accurate than the previous boolean flag
- remove the column from the django state

**\## How did you test this code?**

- unit tests

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

**\## Publish to changelog?**

no