### PR TITLE
chore(ff): Remove GE-ed Manage with Terraform code

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -310,7 +310,6 @@ export const FEATURE_FLAGS = {
     LOGS_SETTINGS_JSON: 'logs-settings-json', // owner: #team-logs
     LOGS_SETTINGS_RETENTION: 'logs-settings-retention', // owner: #team-logs
     LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
-    MANAGE_INSIGHTS_THROUGH_TERRAFORM: 'manage-insights-through-terraform', // owner: @vasco #team-analytics-platform
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics
     MAX_AI_INSIGHT_SEARCH: 'max-ai-insight-search', // owner: #team-posthog-ai
     MAX_BILLING_CONTEXT: 'max-billing-context', // owner: @pawel-cebula #team-billing

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -119,8 +119,6 @@ export function DashboardHeader(): JSX.Element | null {
     const [isPinned, setIsPinned] = useState(dashboard?.pinned)
 
     const [terraformModalOpen, setTerraformModalOpen] = useState(false)
-    const terraformFeatureEnabled = useFeatureFlag('MANAGE_INSIGHTS_THROUGH_TERRAFORM')
-
     const isNewDashboard = useMemo(() => {
         if (!dashboard || dashboardLoading) {
             return false
@@ -202,13 +200,11 @@ export function DashboardHeader(): JSX.Element | null {
                     <InterProjectDuplicationModal />
                     {canEditDashboard && <DashboardInsightColorsModal />}
                     {user?.is_staff && <DashboardTemplateEditor />}
-                    {terraformFeatureEnabled && (
-                        <TerraformExportModal
-                            isOpen={terraformModalOpen}
-                            onClose={() => setTerraformModalOpen(false)}
-                            resource={{ type: 'dashboard', data: dashboard }}
-                        />
-                    )}
+                    <TerraformExportModal
+                        isOpen={terraformModalOpen}
+                        onClose={() => setTerraformModalOpen(false)}
+                        resource={{ type: 'dashboard', data: dashboard }}
+                    />
                 </>
             )}
 
@@ -368,7 +364,7 @@ export function DashboardHeader(): JSX.Element | null {
                         />
                     )}
 
-                    {dashboard && terraformFeatureEnabled && (
+                    {dashboard && (
                         <ButtonPrimitive
                             onClick={() => setTerraformModalOpen(true)}
                             menuItem

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -371,16 +371,14 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             />
                         ) : null}
 
-                        {featureFlags[FEATURE_FLAGS.MANAGE_INSIGHTS_THROUGH_TERRAFORM] ? (
-                            <ButtonPrimitive
-                                onClick={() => setTerraformModalOpen(true)}
-                                menuItem
-                                data-attr={`${RESOURCE_TYPE}-manage-terraform`}
-                            >
-                                <IconCode2 />
-                                Manage with Terraform
-                            </ButtonPrimitive>
-                        ) : null}
+                        <ButtonPrimitive
+                            onClick={() => setTerraformModalOpen(true)}
+                            menuItem
+                            data-attr={`${RESOURCE_TYPE}-manage-terraform`}
+                        >
+                            <IconCode2 />
+                            Manage with Terraform
+                        </ButtonPrimitive>
 
                         {hasDashboardItemId && featureFlags[FEATURE_FLAGS.ENDPOINTS] ? (
                             <ButtonPrimitive


### PR DESCRIPTION
## Problem

The "Manage Insights Through Terraform" feature flag has been fully released (https://us.posthog.com/project/2/early_access_features/019b3659-332e-0000-7eab-42a785fa02c1) and is now a standard feature. This PR removes the feature flag and cleans up the code.

## Changes

Cleaned up the references to the feature flag.

## How did you test this code?

✅ CI is passing

✅ The Manage with Terraform button is available

![CleanShot 2026-02-16 at 13.31.45@2x.png](https://app.graphite.com/user-attachments/assets/b9699cde-f224-4a67-9e1c-22bebffc33be.png)

## Publish to changelog?

No