### PR TITLE
fix: docs link now show external link behind flag

### DIFF
--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import { IconExternal, IconOpenSidebar, IconSend } from '@posthog/icons'
 
 import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitiveProps, buttonPrimitiveVariants } from 'lib/ui/Button/ButtonPrimitives'
 import {
@@ -147,6 +148,7 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
         },
         ref
     ) => {
+        const isRemovingSidePanel = useFeatureFlag('UX_REMOVE_SIDEPANEL')
         const externalLink = isExternalLink(to)
         const { elementProps: draggableProps } = useNotebookDrag({
             href: typeof to === 'string' ? to : undefined,
@@ -245,11 +247,11 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
             >
                 {children}
                 {targetBlankIcon &&
-                    (shouldOpenInDocsPanel && sidePanelStateLogic.isMounted() ? (
+                    (shouldOpenInDocsPanel && sidePanelStateLogic.isMounted() && !isRemovingSidePanel ? (
                         <IconOpenSidebar />
                     ) : href?.startsWith('mailto:') ? (
                         <IconSend />
-                    ) : target === '_blank' ? (
+                    ) : target === '_blank' || (shouldOpenInDocsPanel && isRemovingSidePanel) ? (
                         <IconExternal className={buttonProps ? 'size-3' : ''} />
                     ) : null)}
             </a>

--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -6,7 +6,6 @@ import React from 'react'
 import { IconExternal, IconOpenSidebar, IconSend } from '@posthog/icons'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitiveProps, buttonPrimitiveVariants } from 'lib/ui/Button/ButtonPrimitives'
 import {
@@ -148,7 +147,8 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
         },
         ref
     ) => {
-        const isRemovingSidePanel = useFeatureFlag('UX_REMOVE_SIDEPANEL')
+        const mountedFeatureFlagLogic = featureFlagLogic.findMounted()
+        const isRemovingSidePanel = !!mountedFeatureFlagLogic?.values.featureFlags?.[FEATURE_FLAGS.UX_REMOVE_SIDEPANEL]
         const externalLink = isExternalLink(to)
         const { elementProps: draggableProps } = useNotebookDrag({
             href: typeof to === 'string' ? to : undefined,
@@ -170,12 +170,8 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
             }
 
             const mountedSidePanelLogic = sidePanelStateLogic.findMounted()
-            const mountedFeatureFlagLogic = featureFlagLogic.findMounted()
-            const { featureFlags } = mountedFeatureFlagLogic?.values || {}
 
-            const isRemovingSidePanelFlag = featureFlags?.[FEATURE_FLAGS.UX_REMOVE_SIDEPANEL]
-
-            if (shouldOpenInDocsPanel && mountedSidePanelLogic && !isRemovingSidePanelFlag) {
+            if (shouldOpenInDocsPanel && mountedSidePanelLogic && !isRemovingSidePanel) {
                 // TRICKY: We do this instead of hooks as there is some weird cyclic issue in tests
                 const { sidePanelOpen } = mountedSidePanelLogic.values
                 const { openSidePanel } = mountedSidePanelLogic.actions


### PR DESCRIPTION
## Problem
behind sidepanel flag, docs link still had side panel icon

## Changes
when flag is on, docs link now have external icon

<img width="177" height="133" alt="image" src="https://github.com/user-attachments/assets/09f091ee-e2a4-418a-823f-92d25cb75f71" />


## How did you test this code?
locally

## Publish to changelog?
no