### PR TITLE
feat(workflows): pass workflow variables as globals to SQL expression

### DIFF
--- a/frontend/src/lib/components/HogQLEditor/HogQLEditor.tsx
+++ b/frontend/src/lib/components/HogQLEditor/HogQLEditor.tsx
@@ -13,6 +13,7 @@ export interface HogQLEditorProps {
     onChange: (value: string) => void
     value: string | undefined | null
     metadataSource?: AnyDataNode
+    globals?: Record<string, any>
     disablePersonProperties?: boolean
     disableAutoFocus?: boolean
     disableCmdEnter?: boolean
@@ -24,6 +25,7 @@ export function HogQLEditor({
     onChange,
     value,
     metadataSource,
+    globals,
     disableAutoFocus,
     disableCmdEnter,
     submitText,
@@ -47,6 +49,7 @@ export function HogQLEditor({
                 minHeight="78px"
                 autoFocus={!disableAutoFocus}
                 sourceQuery={metadataSource}
+                globals={globals}
                 onPressCmdEnter={
                     disableCmdEnter
                         ? undefined

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -54,6 +54,7 @@ export interface PropertyFiltersProps {
     hideBehavioralCohorts?: boolean
     addFilterDocLink?: string
     operatorAllowlist?: OperatorValueSelectProps['operatorAllowlist']
+    hogQLGlobals?: Record<string, any>
 }
 
 export function PropertyFilters({
@@ -89,6 +90,7 @@ export function PropertyFilters({
     hideBehavioralCohorts,
     addFilterDocLink,
     operatorAllowlist,
+    hogQLGlobals,
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey, sendAllKeyUpdates }
     const { filters, filtersWithNew, filterIds, filterIdsWithNew } = useValues(propertyFilterLogic(logicProps))
@@ -160,6 +162,7 @@ export function PropertyFilters({
                                             addFilterDocLink={addFilterDocLink}
                                             editable={editable}
                                             operatorAllowlist={operatorAllowlist}
+                                            hogQLGlobals={hogQLGlobals}
                                         />
                                     )}
                                     errorMessage={errorMessages && errorMessages[index]}

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -78,6 +78,7 @@ export function TaxonomicPropertyFilter({
     editable = true,
     operatorAllowlist,
     endpointFilters,
+    hogQLGlobals,
 }: PropertyFilterInternalProps): JSX.Element {
     const pageKey = useMemo(() => pageKeyInput || `filter-${uniqueMemoizedIndex++}`, [pageKeyInput])
     const showQuickFilters = useFeatureFlag('TAXONOMIC_QUICK_FILTERS', 'test')
@@ -177,6 +178,7 @@ export function TaxonomicPropertyFilter({
             hideBehavioralCohorts={hideBehavioralCohorts}
             selectFirstItem={!cohortOrOtherValue}
             endpointFilters={endpointFilters}
+            hogQLGlobals={hogQLGlobals}
         />
     )
 

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -64,4 +64,5 @@ export interface PropertyFilterInternalProps {
     hideBehavioralCohorts?: boolean
     addFilterDocLink?: string
     endpointFilters?: Record<string, any>
+    hogQLGlobals?: Record<string, any>
 }

--- a/frontend/src/lib/components/TaxonomicFilter/InlineHogQLEditor.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InlineHogQLEditor.tsx
@@ -7,9 +7,10 @@ export interface InlineHogQLEditorProps {
     value?: TaxonomicFilterValue
     onChange: (value: TaxonomicFilterValue, item?: any) => void
     metadataSource?: AnyDataNode
+    globals?: Record<string, any>
 }
 
-export function InlineHogQLEditor({ value, onChange, metadataSource }: InlineHogQLEditorProps): JSX.Element {
+export function InlineHogQLEditor({ value, onChange, metadataSource, globals }: InlineHogQLEditorProps): JSX.Element {
     return (
         <>
             <div className="taxonomic-group-title">SQL expression</div>
@@ -18,6 +19,7 @@ export function InlineHogQLEditor({ value, onChange, metadataSource }: InlineHog
                     onChange={onChange}
                     value={String(value ?? '')}
                     metadataSource={metadataSource}
+                    globals={globals}
                     submitText={value ? 'Update SQL expression' : 'Add SQL expression'}
                     disableAutoFocus // :TRICKY: No autofocus here. It's controlled in the TaxonomicFilter.
                 />

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -47,6 +47,7 @@ export function TaxonomicFilter({
     maxContextOptions,
     useVerticalLayout,
     allowNonCapturedEvents = false,
+    hogQLGlobals,
 }: TaxonomicFilterProps): JSX.Element {
     // Generate a unique key for each unique TaxonomicFilter that's rendered
     const taxonomicFilterLogicKey = useMemo(
@@ -80,6 +81,7 @@ export function TaxonomicFilter({
         autoSelectItem: true,
         allowNonCapturedEvents,
         maxContextOptions,
+        hogQLGlobals,
     }
 
     const logic = taxonomicFilterLogic(taxonomicFilterLogicProps)

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -394,6 +394,10 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             () => [(_, props) => props.hideBehavioralCohorts],
             (hideBehavioralCohorts: boolean | undefined) => hideBehavioralCohorts ?? false,
         ],
+        hogQLGlobals: [
+            () => [(_, props) => props.hogQLGlobals],
+            (hogQLGlobals: Record<string, any> | undefined) => hogQLGlobals,
+        ],
         endpointFilters: [
             () => [(_, props) => props.endpointFilters],
             (endpointFilters: Record<string, any>) => endpointFilters,
@@ -414,6 +418,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 s.hideBehavioralCohorts,
                 s.endpointFilters,
                 p.taxonomicGroupTypes,
+                s.hogQLGlobals,
             ],
             (
                 currentTeam: TeamType,
@@ -429,7 +434,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 maxContextOptions: MaxContextTaxonomicFilterOption[],
                 hideBehavioralCohorts: boolean,
                 endpointFilters: Record<string, any> | undefined,
-                propGroupTypes: TaxonomicFilterGroupType[] | undefined
+                propGroupTypes: TaxonomicFilterGroupType[] | undefined,
+                hogQLGlobals: Record<string, any> | undefined
             ): TaxonomicFilterGroup[] => {
                 const { id: teamId } = currentTeam
                 const { excludedProperties, propertyAllowList } = propertyFilters
@@ -1016,7 +1022,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         type: TaxonomicFilterGroupType.HogQLExpression,
                         render: InlineHogQLEditor,
                         getPopoverHeader: () => 'SQL expression',
-                        componentProps: { metadataSource },
+                        componentProps: { metadataSource, globals: hogQLGlobals },
                     },
                     {
                         name: 'Replay',

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -96,6 +96,7 @@ export interface TaxonomicFilterProps {
     initialSearchQuery?: string
     /** Allow users to select events that haven't been captured yet (default: false) */
     allowNonCapturedEvents?: boolean
+    hogQLGlobals?: Record<string, any>
 }
 
 export interface DataWarehousePopoverField {

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -104,6 +104,7 @@ export interface ActionFilterProps {
     excludedProperties?: TaxonomicPopoverProps['excludedProperties']
     /** Allow adding non-captured events */
     allowNonCapturedEvents?: boolean
+    hogQLGlobals?: Record<string, any>
 }
 
 export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(function ActionFilter(
@@ -140,6 +141,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         addFilterDocLink,
         excludedProperties,
         allowNonCapturedEvents,
+        hogQLGlobals,
     },
     ref
 ): JSX.Element {
@@ -208,6 +210,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         addFilterDocLink,
         excludedProperties,
         allowNonCapturedEvents,
+        hogQLGlobals,
     }
 
     const reachedLimit: boolean = Boolean(entitiesLimit && localFilters.length >= entitiesLimit)

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -177,6 +177,7 @@ export interface ActionFilterRowProps {
     addFilterDocLink?: string
     /** Allow adding non-captured events */
     allowNonCapturedEvents?: boolean
+    hogQLGlobals?: Record<string, any>
 }
 
 export function ActionFilterRow({
@@ -214,6 +215,7 @@ export function ActionFilterRow({
     addFilterDocLink,
     excludedProperties,
     allowNonCapturedEvents,
+    hogQLGlobals,
 }: ActionFilterRowProps & Pick<TaxonomicPopoverProps, 'excludedProperties' | 'allowNonCapturedEvents'>): JSX.Element {
     const showQuickFilters = useFeatureFlag('TAXONOMIC_QUICK_FILTERS', 'test')
     const effectiveActionsTaxonomicGroupTypes = showQuickFilters
@@ -859,6 +861,7 @@ export function ActionFilterRow({
                         }
                         addFilterDocLink={addFilterDocLink}
                         excludedProperties={excludedProperties}
+                        hogQLGlobals={hogQLGlobals}
                     />
                 </div>
             )}

--- a/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
@@ -1,3 +1,5 @@
+import { useValues } from 'kea'
+
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -8,7 +10,27 @@ import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { NodeKind } from '~/queries/schema/schema-general'
 import { FilterType } from '~/types'
 
+import { workflowLogic } from '../../workflowLogic'
 import { HogFlowAction } from '../types'
+
+function useSampleGlobals(): Record<string, any> {
+    const { workflow } = useValues(workflowLogic)
+    const workflowVariables: Record<string, any> = {}
+    if (workflow?.variables) {
+        for (const variable of workflow.variables) {
+            if (variable.type === 'string') {
+                workflowVariables[variable.key] = 'example_value'
+            } else if (variable.type === 'number') {
+                workflowVariables[variable.key] = 123
+            } else if (variable.type === 'boolean') {
+                workflowVariables[variable.key] = true
+            } else {
+                workflowVariables[variable.key] = null
+            }
+        }
+    }
+    return { variables: workflowVariables }
+}
 
 export type HogFlowFiltersProps = {
     filtersKey: string
@@ -23,6 +45,7 @@ export type HogFlowFiltersProps = {
  */
 export function HogFlowEventFilters({ filters, setFilters, typeKey, buttonCopy }: HogFlowFiltersProps): JSX.Element {
     const shouldShowInternalEvents = useFeatureFlag('WORKFLOWS_INTERNAL_EVENT_FILTERS')
+    const sampleGlobals = useSampleGlobals()
 
     const actionsTaxonomicGroupTypes = [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions]
     if (shouldShowInternalEvents) {
@@ -61,11 +84,13 @@ export function HogFlowEventFilters({ filters, setFilters, typeKey, buttonCopy }
             }}
             buttonCopy={buttonCopy ?? 'Add filter'}
             allowNonCapturedEvents
+            hogQLGlobals={sampleGlobals}
         />
     )
 }
 
 export function HogFlowPropertyFilters({ filtersKey, filters, setFilters }: HogFlowFiltersProps): JSX.Element {
+    const sampleGlobals = useSampleGlobals()
     return (
         <PropertyFilters
             propertyFilters={filters?.properties}
@@ -86,6 +111,7 @@ export function HogFlowPropertyFilters({ filtersKey, filters, setFilters }: HogF
                 select: defaultDataTableColumns(NodeKind.EventsQuery),
                 after: '-30d',
             }}
+            hogQLGlobals={sampleGlobals}
         />
     )
 }

--- a/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
@@ -24,6 +24,8 @@ function useSampleGlobals(): Record<string, any> {
                 workflowVariables[variable.key] = 123
             } else if (variable.type === 'boolean') {
                 workflowVariables[variable.key] = true
+            } else if (variable.type === 'dictionary' || variable.type === 'json') {
+                workflowVariables[variable.key] = {}
             } else {
                 workflowVariables[variable.key] = null
             }

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionConfiguration.tsx
@@ -61,6 +61,8 @@ export function HogFlowFunctionConfiguration({
                 workflowVariables[variable.key] = 123
             } else if (variable.type === 'boolean') {
                 workflowVariables[variable.key] = true
+            } else if (variable.type === 'dictionary' || variable.type === 'json') {
+                workflowVariables[variable.key] = {}
             } else {
                 workflowVariables[variable.key] = null
             }


### PR DESCRIPTION
###  Summary

  - Threads `hogQLGlobals` from workflow filter components down to the HogQL expression editor, so that declared workflow variables (e.g. variables.var1) get proper autocomplete and validation instead of showing `"Unable to resolve field"` errors
  - Adds a `useSampleGlobals` hook in `HogFlowFilters` that builds placeholder variable values from the workflow definition, matching the existing pattern in `HogFlowFunctionConfiguration`
  

![2026-02-16 14 05 08](https://github.com/user-attachments/assets/d83d537f-66c9-4448-8735-883e83f31133)
