### PR TITLE
feat(experiments): Preaggregation variable TTL

### DIFF
--- a/posthog/hogql_queries/experiments/PREAGGREGATION.md
+++ b/posthog/hogql_queries/experiments/PREAGGREGATION.md
@@ -257,7 +257,7 @@ GROUP BY variant
 
 2. **Query hash determines cache sharing**: Different feature flags, variants, or exposure criteria produce different hashes. Each experiment typically has its own preaggregated data.
 
-3. **TTL and expiration**: Jobs have an `expires_at` field. The system ignores jobs expiring within 1 hour to avoid race conditions. ClickHouse TTL automatically deletes expired rows.
+3. **TTL and expiration**: Jobs use variable TTL based on data age (current day: 15 min, yesterday: 1 hour, older: 60 days). This avoids recomputing frozen historical data. The system ignores jobs expiring within 1 hour to avoid race conditions. ClickHouse TTL automatically deletes expired rows.
 
 4. **Fallback**: If preaggregation fails or isn't ready, the query falls back to scanning the events table directly.
 

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -58,8 +58,13 @@ from products.analytics_platform.backend.lazy_preaggregation.lazy_preaggregation
 
 logger = structlog.get_logger(__name__)
 
-# Default TTL for experiment exposure preaggregation (6 hours)
-DEFAULT_EXPOSURE_TTL_SECONDS = 6 * 60 * 60
+# Variable TTL for experiment exposure preaggregation
+# Current day refreshes frequently (data arriving), old data cached long
+DEFAULT_EXPOSURE_TTL_SECONDS = {
+    "0d": 15 * 60,  # 15 min
+    "1d": 60 * 60,  # 1 hour
+    "default": 60 * 24 * 60 * 60,  # 60 days - data frozen
+}
 
 MAX_EXECUTION_TIME = 600
 MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY = 37 * 1024 * 1024 * 1024  # 37 GB


### PR DESCRIPTION
## Changes
#47942 now enables variable TTL based on data age:
- Current day: 15 min (data actively arriving)
- Yesterday: 1 hour (in case of late stragglers)
- Older: 60 days
