### PR TITLE
fix(alerts): default notification type and channel display for inline setup

### DIFF
--- a/frontend/src/lib/components/Alerts/alertNotificationLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertNotificationLogic.ts
@@ -35,6 +35,7 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
 
     connect({
         values: [projectLogic, ['currentProjectId'], integrationsLogic, ['slackIntegrations']],
+        actions: [integrationsLogic, ['loadIntegrationsSuccess']],
     }),
 
     actions({
@@ -114,6 +115,11 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
     })),
 
     listeners(({ actions, values }) => ({
+        loadIntegrationsSuccess: () => {
+            if (!values.firstSlackIntegration) {
+                actions.setSelectedType(ALERT_NOTIFICATION_TYPE_WEBHOOK)
+            }
+        },
         deleteExistingHogFunction: async ({ hogFunction }) => {
             await deleteWithUndo({
                 endpoint: `projects/${values.currentProjectId}/hog_functions`,
@@ -160,12 +166,9 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
         },
     })),
 
-    afterMount(({ actions, props, values }) => {
+    afterMount(({ actions, props }) => {
         if (props.alertId) {
             actions.loadExistingHogFunctions()
-        }
-        if (!values.firstSlackIntegration) {
-            actions.setSelectedType(ALERT_NOTIFICATION_TYPE_WEBHOOK)
         }
     }),
 ])

--- a/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
+++ b/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
@@ -18,7 +18,15 @@ import { ALERT_NOTIFICATION_TYPE_OPTIONS, alertNotificationLogic } from '../aler
 function getHogFunctionDestination(hf: HogFunctionType): { type: string; detail: string | null } {
     const channelValue = hf.inputs?.channel?.value
     if (channelValue) {
-        const channelName = typeof channelValue === 'string' ? channelValue.split('|')[1]?.replace('#', '') : null
+        let channelName: string | null = null
+        if (typeof channelValue === 'string') {
+            const parts = channelValue.split('|')
+            channelName = parts[1]?.replace('#', '') ?? null
+        }
+        if (!channelName) {
+            const match = hf.name?.match(/Slack #(.+)$/)
+            channelName = match?.[1] ?? null
+        }
         return { type: 'Slack', detail: channelName ? `#${channelName}` : null }
     }
     const urlValue = hf.inputs?.url?.value

--- a/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
+++ b/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
@@ -78,7 +78,7 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
         if (firstSlackIntegration && existingHogFunctions.length > 0) {
             loadAllSlackChannels()
         }
-    }, [firstSlackIntegration?.id, existingHogFunctions.length])
+    }, [firstSlackIntegration?.id, existingHogFunctions.length, loadAllSlackChannels])
 
     const handleAdd = (): void => {
         if (selectedType === ALERT_NOTIFICATION_TYPE_SLACK) {

--- a/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
+++ b/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
@@ -1,9 +1,11 @@
 import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
 
 import { IconExternal, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonSelect, LemonSkeleton, LemonTag } from '@posthog/lemon-ui'
 
 import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
+import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
 import {
     ALERT_NOTIFICATION_TYPE_SLACK,
     ALERT_NOTIFICATION_TYPE_WEBHOOK,
@@ -11,23 +13,31 @@ import {
 } from 'lib/utils/alertUtils'
 import { urls } from 'scenes/urls'
 
-import { HogFunctionType } from '~/types'
+import { HogFunctionType, SlackChannelType } from '~/types'
 
 import { ALERT_NOTIFICATION_TYPE_OPTIONS, alertNotificationLogic } from '../alertNotificationLogic'
 
-function getHogFunctionDestination(hf: HogFunctionType): { type: string; detail: string | null } {
+function resolveSlackChannelName(channelValue: string, slackChannels: SlackChannelType[]): string | null {
+    const parts = channelValue.split('|')
+    const namePart = parts[1]?.replace('#', '')
+    if (namePart) {
+        return namePart
+    }
+    const channelId = parts[0]
+    return slackChannels.find((c) => c.id === channelId)?.name ?? null
+}
+
+function getHogFunctionDestination(
+    hf: HogFunctionType,
+    slackChannels: SlackChannelType[]
+): { type: string; detail: string | null } {
     const channelValue = hf.inputs?.channel?.value
-    if (channelValue) {
-        let channelName: string | null = null
-        if (typeof channelValue === 'string') {
-            const parts = channelValue.split('|')
-            channelName = parts[1]?.replace('#', '') ?? null
-        }
-        if (!channelName) {
-            const match = hf.name?.match(/Slack #(.+)$/)
-            channelName = match?.[1] ?? null
-        }
+    if (channelValue && typeof channelValue === 'string') {
+        const channelName = resolveSlackChannelName(channelValue, slackChannels)
         return { type: 'Slack', detail: channelName ? `#${channelName}` : null }
+    }
+    if (channelValue) {
+        return { type: 'Slack', detail: null }
     }
     const urlValue = hf.inputs?.url?.value
     if (urlValue && typeof urlValue === 'string') {
@@ -60,17 +70,29 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
         setWebhookUrl,
     } = useActions(logic)
 
+    const slackLogic = slackIntegrationLogic({ id: firstSlackIntegration?.id ?? 0 })
+    const { slackChannels } = useValues(slackLogic)
+    const { loadAllSlackChannels } = useActions(slackLogic)
+
+    useEffect(() => {
+        if (firstSlackIntegration && existingHogFunctions.length > 0) {
+            loadAllSlackChannels()
+        }
+    }, [firstSlackIntegration?.id, existingHogFunctions.length])
+
     const handleAdd = (): void => {
         if (selectedType === ALERT_NOTIFICATION_TYPE_SLACK) {
             if (!slackChannelValue || !firstSlackIntegration) {
                 return
             }
-            const channelName = slackChannelValue.split('|')[1]?.replace('#', '') ?? slackChannelValue
+            const parts = slackChannelValue.split('|')
+            const channelId = parts[0]
+            const channelName = parts[1]?.replace('#', '') ?? channelId
 
             const notification: PendingAlertNotification = {
                 type: ALERT_NOTIFICATION_TYPE_SLACK,
                 slackWorkspaceId: firstSlackIntegration.id,
-                slackChannelId: slackChannelValue,
+                slackChannelId: channelId,
                 slackChannelName: channelName,
             }
             addPendingNotification(notification)
@@ -100,7 +122,7 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
                     ) : existingHogFunctions.length > 0 ? (
                         <div className="space-y-2">
                             {existingHogFunctions.map((hf) => {
-                                const { type: destType, detail } = getHogFunctionDestination(hf)
+                                const { type: destType, detail } = getHogFunctionDestination(hf, slackChannels)
                                 return (
                                     <div
                                         key={hf.id}

--- a/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
+++ b/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
@@ -75,10 +75,10 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
     const { loadAllSlackChannels } = useActions(slackLogic)
 
     useEffect(() => {
-        if (firstSlackIntegration && existingHogFunctions.length > 0) {
+        if (firstSlackIntegration) {
             loadAllSlackChannels()
         }
-    }, [firstSlackIntegration?.id, existingHogFunctions.length, loadAllSlackChannels])
+    }, [firstSlackIntegration?.id, loadAllSlackChannels])
 
     const handleAdd = (): void => {
         if (selectedType === ALERT_NOTIFICATION_TYPE_SLACK) {

--- a/frontend/src/lib/utils/alertUtils.test.ts
+++ b/frontend/src/lib/utils/alertUtils.test.ts
@@ -33,7 +33,7 @@ describe('alertUtils', () => {
                 notification: {
                     type: 'slack' as const,
                     slackWorkspaceId: 42,
-                    slackChannelId: 'C12345|#general',
+                    slackChannelId: 'C12345',
                     slackChannelName: 'general',
                 },
                 alertName: 'Daily revenue check',
@@ -83,14 +83,14 @@ describe('alertUtils', () => {
             const notification: PendingAlertNotification = {
                 type: 'slack',
                 slackWorkspaceId: 42,
-                slackChannelId: 'C12345|#general',
+                slackChannelId: 'C12345',
                 slackChannelName: 'general',
             }
 
             const result = buildHogFunctionPayload('alert-789', 'My alert', notification)
 
             expect(result.inputs?.slack_workspace).toEqual({ value: 42 })
-            expect(result.inputs?.channel).toEqual({ value: 'C12345|#general' })
+            expect(result.inputs?.channel).toEqual({ value: 'C12345' })
         })
 
         it('sets correct webhook input values', () => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

Fixes two issues with the inline alert notification setup from https://github.com/PostHog/posthog/pull/47316:

- **Slack not defaulting when configured**: The `afterMount` check ran synchronously before
`integrationsLogic` finished loading, so `slackIntegrations` was always `undefined` and the
selector fell through to Webhook. Moved the check into a `loadIntegrationsSuccess` listener
so it runs after integrations are actually available.
- **Channel name not showing for existing Slack notifications**: Existing notifications created
through the CDP page store just the channel ID (e.g. `C12345`) without the `|#name` suffix,
so `split('|')[1]` returned `undefined`. Added a fallback that extracts the channel name from
the hog function's name field (which follows the `"AlertName: Slack #general"` convention). Not having this, shows a single "Slack" entry (unlike in the screenshot below where it was added as a new thing), thus fixing it so that it also works with existing slack integrations.

## ![CleanShot 2026-02-16 at 13.49.53@2x.png](https://app.graphite.com/user-attachments/assets/8856a09d-838a-4bcd-92dd-d9e652d09ada.png)



## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

See above ^

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->


✅ - CI is passing

Otherwise this is difficult to test locally due to me not having Slack wired up. On production, this is all hidden behind a feature flag, therefore I will test / verify it is all working once it's deployed before rolling it out to everyone.


👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._



## Publish to changelog?

No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->