### PR TITLE
feat(llma): add prompt endpoint latency metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for a
 - `feat`: New feature or functionality (touches production code)
 - `fix`: Bug fix (touches production code)
 - `chore`: Non-production changes (docs, tests, config, CI, refactoring agents instructions, etc.)
+- Scope convention: use `llma` for LLM analytics changes (for example, `feat(llma): ...`)
 
 ### Format
 

--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -17,6 +17,8 @@ from posthog.permissions import AccessControlPermission, PostHogFeatureFlagPermi
 from posthog.rate_limit import BurstRateThrottle, SustainedRateThrottle
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 
+from products.llm_analytics.backend.api.metrics import llma_track_latency
+
 RESERVED_PROMPT_NAMES = {"new"}
 
 
@@ -166,6 +168,7 @@ class LLMPromptViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, Forbid
         url_path=r"name/(?P<prompt_name>[^/]+)",
         required_scopes=["llm_prompt:read"],
     )
+    @llma_track_latency("llma_prompts_get_by_name")
     @monitor(feature=None, endpoint="llma_prompts_get_by_name", method="GET")
     def get_by_name(self, request: Request, prompt_name: str = "", **kwargs) -> Response:
         try:
@@ -192,22 +195,27 @@ class LLMPromptViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, Forbid
         serializer = self.get_serializer(prompt)
         return Response(serializer.data)
 
+    @llma_track_latency("llma_prompts_list")
     @monitor(feature=None, endpoint="llma_prompts_list", method="GET")
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 
+    @llma_track_latency("llma_prompts_retrieve")
     @monitor(feature=None, endpoint="llma_prompts_retrieve", method="GET")
     def retrieve(self, request, *args, **kwargs):
         return super().retrieve(request, *args, **kwargs)
 
+    @llma_track_latency("llma_prompts_create")
     @monitor(feature=None, endpoint="llma_prompts_create", method="POST")
     def create(self, request, *args, **kwargs):
         return super().create(request, *args, **kwargs)
 
+    @llma_track_latency("llma_prompts_update")
     @monitor(feature=None, endpoint="llma_prompts_update", method="PUT")
     def update(self, request, *args, **kwargs):
         return super().update(request, *args, **kwargs)
 
+    @llma_track_latency("llma_prompts_partial_update")
     @monitor(feature=None, endpoint="llma_prompts_partial_update", method="PATCH")
     def partial_update(self, request, *args, **kwargs):
         return super().partial_update(request, *args, **kwargs)


### PR DESCRIPTION
## Problem

Prompt management endpoints for LLM analytics had request/error counters, but no latency histogram coverage for Grafana. This made it hard to monitor endpoint duration alongside request volume and failures.

## Changes

- Added `llma_track_latency(...)` instrumentation to prompt endpoints in `posthog/api/llm_prompt.py`:
  - `llma_prompts_get_by_name`
  - `llma_prompts_list`
  - `llma_prompts_retrieve`
  - `llma_prompts_create`
  - `llma_prompts_update`
  - `llma_prompts_partial_update`
- Kept existing `@monitor(...)` usage in place for request/error counters.
- Updated `AGENTS.md` commit guidance to document `llma` as the scope convention for LLM analytics changes.

## How did you test this code?

- Ran: `uv run pytest posthog/api/test/test_llm_prompt.py`
- Change is instrumentation-only and follows the same decorator pattern already used across other LLM analytics APIs.

## Publish to changelog?

do not publish to changelog
