### PR TITLE
fix(geoip): handle missing MMDB file gracefully instead of crashing

### DIFF
--- a/nodejs/src/utils/geoip.test.ts
+++ b/nodejs/src/utils/geoip.test.ts
@@ -30,9 +30,11 @@ describe('GeoIp', () => {
             commonCheck(geoip)
         })
 
-        it('should throw if it could not be loaded from disk if set', async () => {
+        it('should return null for lookups if MMDB file is missing', async () => {
             config.MMDB_FILE_LOCATION = 'non-existent-file.mmdb'
-            await expect(service.get()).rejects.toThrow()
+            const geoip = await service.get()
+            expect(geoip).toBeTruthy()
+            expect(geoip.city('12.87.118.0')).toBeNull()
         })
 
         it('should only load mmdb from disk once', async () => {

--- a/nodejs/src/utils/geoip.ts
+++ b/nodejs/src/utils/geoip.ts
@@ -127,8 +127,12 @@ export class GeoIPService {
 
         geoipBackgroundRefreshCounter.inc({ result: 'refreshing' })
         const mmdb = await this.loadMmdb('background refresh')
-        this._mmdb = mmdb
-        this._mmdbMetadata = metadata
+        if (mmdb) {
+            this._mmdb = mmdb
+            this._mmdbMetadata = metadata
+        } else {
+            logger.warn('🌎', 'Background MMDB refresh failed, keeping existing MMDB')
+        }
     }
 
     async get(): Promise<GeoIp> {

--- a/nodejs/src/utils/geoip.ts
+++ b/nodejs/src/utils/geoip.ts
@@ -129,7 +129,7 @@ export class GeoIPService {
         const mmdb = await this.loadMmdb('background refresh')
         if (mmdb) {
             this._mmdb = mmdb
-            this._mmdbMetadata = metadata
+            this._mmdbMetadata = metadata ?? this._mmdbMetadata
         } else {
             logger.warn('🌎', 'Background MMDB refresh failed, keeping existing MMDB')
         }

--- a/nodejs/src/utils/geoip.ts
+++ b/nodejs/src/utils/geoip.ts
@@ -51,7 +51,10 @@ export class GeoIPService {
             this._initialMmdbPromise = this.loadMmdb('initial')
                 .then((mmdb) => {
                     this._mmdb = mmdb
-                    return this.loadMmdbMetadata()
+                    if (mmdb) {
+                        return this.loadMmdbMetadata()
+                    }
+                    return undefined
                 })
                 .then((metadata) => {
                     this._mmdbMetadata = metadata
@@ -61,7 +64,7 @@ export class GeoIPService {
         return this._initialMmdbPromise
     }
 
-    private async loadMmdb(reason: string): Promise<ReaderModel> {
+    private async loadMmdb(reason: string): Promise<ReaderModel | undefined> {
         logger.info('🌎', 'Loading MMDB from disk...', {
             location: this.config.MMDB_FILE_LOCATION,
         })
@@ -76,11 +79,11 @@ export class GeoIPService {
                 async () => await Reader.open(this.config.MMDB_FILE_LOCATION)
             )
         } catch (e) {
-            logger.warn('🌎', 'Loading MMDB from disk failed!', {
+            logger.warn('🌎', 'Loading MMDB from disk failed, GeoIP lookups will be disabled', {
                 error: e.message,
                 location: this.config.MMDB_FILE_LOCATION,
             })
-            throw e
+            return undefined
         }
     }
 


### PR DESCRIPTION
## Problem

`createHub()` unconditionally creates a `GeoIPService` and calls `await geoipService.get()`, which loads the MMDB file from disk. If the file doesn't exist, `loadMmdb()` throws an unhandled exception that crashes the process.

This is a problem for services like `recording-api` that:
- Run on the `posthog-node` Docker image, which does **not** include the GeoLite2 MMDB file (unlike the Python `posthog` image which downloads it during build)
- Don't have the S3 assets volume mount that CDP services use
- Don't actually use GeoIP lookups at all

## Fix

- `loadMmdb()` now catches the error and returns `undefined` instead of rethrowing
- `ensureMmdbLoaded()` skips metadata loading when the MMDB file is unavailable
- `city()` already handles `_mmdb` being undefined via optional chaining (`this._mmdb?.city(ip) ?? null`), so no change needed there
- The hourly background refresh is also safe — it early-returns when `_mmdbMetadata` is undefined

Net effect: if the MMDB file is missing, GeoIP lookups return `null` and a warning is logged. No crash.