### PR TITLE
chore(llma): remove clustering params tooltip from clusters tab

### DIFF
--- a/products/llm_analytics/frontend/clusters/ClustersView.tsx
+++ b/products/llm_analytics/frontend/clusters/ClustersView.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconChevronDown, IconChevronRight, IconFilter, IconGear, IconInfo } from '@posthog/icons'
+import { IconChevronDown, IconChevronRight, IconFilter, IconGear } from '@posthog/icons'
 import { LemonButton, LemonSegmentedButton, LemonSelect, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -19,56 +19,7 @@ import { clusteringConfigLogic, isValidFilter } from './clusteringConfigLogic'
 import { clustersAdminLogic } from './clustersAdminLogic'
 import { clustersLogic } from './clustersLogic'
 import { NOISE_CLUSTER_ID } from './constants'
-import { Cluster, ClusteringLevel, ClusteringParams } from './types'
-
-function ClusteringParamsTooltip({ params }: { params: ClusteringParams }): JSX.Element {
-    const formatMethodParams = (methodParams: Record<string, unknown>): string => {
-        if (!methodParams || Object.keys(methodParams).length === 0) {
-            return 'default'
-        }
-        return Object.entries(methodParams)
-            .map(([key, value]) => `${key}: ${value}`)
-            .join(', ')
-    }
-
-    return (
-        <div className="text-xs space-y-0.5 min-w-64">
-            <div className="font-semibold mb-2">Clustering parameters</div>
-            <div className="flex justify-between gap-4">
-                <span className="opacity-70 shrink-0">Clustering</span>
-                <span className="font-medium text-right">{params.clustering_method}</span>
-            </div>
-            {Object.keys(params.clustering_method_params || {}).length > 0 && (
-                <div className="flex justify-between gap-4">
-                    <span className="opacity-70 shrink-0">Method params</span>
-                    <span className="font-medium text-right">
-                        {formatMethodParams(params.clustering_method_params)}
-                    </span>
-                </div>
-            )}
-            <div className="flex justify-between gap-4">
-                <span className="opacity-70 shrink-0">Dim. reduction</span>
-                <span className="font-medium text-right">
-                    {params.dimensionality_reduction_method}
-                    {params.dimensionality_reduction_method !== 'none' &&
-                        ` (${params.dimensionality_reduction_ndims}d)`}
-                </span>
-            </div>
-            <div className="flex justify-between gap-4">
-                <span className="opacity-70 shrink-0">Visualization</span>
-                <span className="font-medium text-right">{params.visualization_method}</span>
-            </div>
-            <div className="flex justify-between gap-4">
-                <span className="opacity-70 shrink-0">Normalization</span>
-                <span className="font-medium text-right">{params.embedding_normalization}</span>
-            </div>
-            <div className="flex justify-between gap-4">
-                <span className="opacity-70 shrink-0">Max samples</span>
-                <span className="font-medium text-right">{params.max_samples.toLocaleString()}</span>
-            </div>
-        </div>
-    )
-}
+import { Cluster, ClusteringLevel } from './types'
 
 export function ClustersView(): JSX.Element {
     const {
@@ -214,14 +165,6 @@ export function ClustersView(): JSX.Element {
                                 {dayjs(currentRun.windowStart).format('MMM D')} -{' '}
                                 {dayjs(currentRun.windowEnd).format('MMM D, YYYY')}
                             </span>
-                            {currentRun.clusteringParams && (
-                                <Tooltip
-                                    title={<ClusteringParamsTooltip params={currentRun.clusteringParams} />}
-                                    placement="bottom"
-                                >
-                                    <IconInfo className="text-muted-alt cursor-help" />
-                                </Tooltip>
-                            )}
                         </div>
                     )}
 


### PR DESCRIPTION
## Summary
- Removes the clustering params info icon tooltip from the clusters tab header
- Removes unused `ClusteringParamsTooltip` component and related imports

The tooltip was confusing for users so we're cleaning it up.

## Test plan
- [ ] Verify clusters tab renders correctly without the info icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)