### PR TITLE
fix(node): allow EncryptedFields to construct without keys

### DIFF
--- a/nodejs/src/cdp/utils/encryption-utils.test.ts
+++ b/nodejs/src/cdp/utils/encryption-utils.test.ts
@@ -10,6 +10,12 @@ describe('Encrypted fields', () => {
         encryptedFields = new EncryptedFields(encryptionSaltKeys)
     })
 
+    it('should construct with empty keys but throw on encrypt/decrypt', () => {
+        const empty = new EncryptedFields('')
+        expect(() => empty.encrypt('test')).toThrow('Encryption keys are not set')
+        expect(() => empty.decrypt('test')).toThrow('Encryption keys are not set')
+    })
+
     describe('encryption and decryption', () => {
         it('should encrypt and decrypt a string', () => {
             const encrypted = encryptedFields.encrypt('test-case')

--- a/nodejs/src/cdp/utils/encryption-utils.ts
+++ b/nodejs/src/cdp/utils/encryption-utils.ts
@@ -5,19 +5,20 @@ export class EncryptedFields {
 
     constructor(encryptionSaltKeys: string) {
         const saltKeys = encryptionSaltKeys.split(',').filter((key) => key)
-
-        if (!saltKeys.length) {
-            throw new Error('Encryption keys are not set')
-        }
-
         this.fernets = saltKeys.map((key) => new Fernet(Buffer.from(key, 'utf-8').toString('base64')))
     }
 
     encrypt(value: string): string {
+        if (!this.fernets.length) {
+            throw new Error('Encryption keys are not set')
+        }
         return this.fernets[0].encrypt(value)
     }
 
     decrypt(value: string, options?: { ignoreDecryptionErrors: boolean }): string | undefined {
+        if (!this.fernets.length) {
+            throw new Error('Encryption keys are not set')
+        }
         let error: Error | undefined
         // Iterate over all keys and try to decrypt the value
         for (const fernet of this.fernets) {


### PR DESCRIPTION
## Summary

- Recording-api pods are CrashLoopBackOff because `createHub()` unconditionally constructs `EncryptedFields`, which throws when `ENCRYPTION_SALT_KEYS` is empty
- Recording-api doesn't use `EncryptedFields` (it's a CDP concern for encrypting hog function secrets)
- Move the missing-keys guard from the constructor to `encrypt()`/`decrypt()` so construction succeeds and errors surface only when encryption is actually attempted

## Test plan

- [x] Existing encryption-utils tests pass
- [x] New test verifies empty-keys construction succeeds but encrypt/decrypt throw
- [x] TypeScript compiles clean
- [ ] Verify recording-api pods stop CrashLoopBackOff after merge