### PR TITLE
feat: add name-based suggestions for resource transfers

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -481,6 +481,7 @@ posthog/models/resource_transfer/inter_project_transferer.py:0: error: "type[Mod
 posthog/models/resource_transfer/inter_project_transferer.py:0: error: "type[Model]" has no attribute "objects"  [attr-defined]
 posthog/models/resource_transfer/inter_project_transferer.py:0: error: "type[Model]" has no attribute "objects"  [attr-defined]
 posthog/models/resource_transfer/inter_project_transferer.py:0: error: "type[Model]" has no attribute "objects"  [attr-defined]
+posthog/models/resource_transfer/inter_project_transferer.py:0: error: "type[Model]" has no attribute "objects"  [attr-defined]
 posthog/models/subscription.py:0: error: Argument 2 to "SubscriptionResourceInfo" has incompatible type "str | None"; expected "str"  [arg-type]
 posthog/models/team/team.py:0: error: Argument 1 to "union" of "QuerySet" has incompatible type "QuerySet[OrganizationMembership, int]"; expected "QuerySet[Model, Model]"  [arg-type]
 posthog/models/team/team.py:0: error: Argument 1 to "union" of "QuerySet" has incompatible type "QuerySet[RoleMembership, int]"; expected "QuerySet[Model, Model]"  [arg-type]

--- a/posthog/api/test/test_resource_transfer.py
+++ b/posthog/api/test/test_resource_transfer.py
@@ -119,7 +119,7 @@ class TestResourceTransferPreview(APIBaseTest):
         assert insight_resource["suggested_substitution"]["display_name"] == "Copied insight"
 
     def test_preview_no_substitution_without_previous_transfer(self) -> None:
-        insight = Insight.objects.create(team=self.team, name="My insight")
+        insight = Insight.objects.create(team=self.team, name="My insight - Unique name")
         response = self.client.post(
             self._preview_url(),
             {

--- a/posthog/models/resource_transfer/test/test_inter_project_transferer.py
+++ b/posthog/models/resource_transfer/test/test_inter_project_transferer.py
@@ -11,9 +11,10 @@ from posthog.models.resource_transfer.inter_project_transferer import (
     build_resource_duplication_graph,
     dag_sort_duplication_graph,
     duplicate_resource_to_new_team,
+    get_suggested_substitutions,
 )
 from posthog.models.resource_transfer.resource_transfer import ResourceTransfer
-from posthog.models.resource_transfer.types import ResourceKind
+from posthog.models.resource_transfer.types import ResourceKind, ResourceTransferVertex
 
 
 class TestBuildResourceDuplicationGraph(BaseTest):
@@ -319,3 +320,197 @@ class TestSubstitutionTeamValidation(BaseTest):
                 substitutions=[(("Insight", insight.pk), ("Insight", wrong_insight.pk))],
                 created_by=self.user,
             )
+
+
+class TestGetSuggestedSubstitutions(BaseTest):
+    def _create_destination_team(self) -> Team:
+        project = Project.objects.create(id=Team.objects.increment_id_sequence(), organization=self.organization)
+        return Team.objects.create(id=project.id, project=project, organization=self.organization)
+
+    def _build_dag(self, resource: Any) -> tuple[ResourceTransferVertex, ...]:
+        graph = list(build_resource_duplication_graph(resource, set()))
+        return dag_sort_duplication_graph(graph)
+
+    def test_empty_dag_returns_no_suggestions(self) -> None:
+        dest_team = self._create_destination_team()
+        result = get_suggested_substitutions([], dest_team)
+        assert result == []
+
+    def test_immutable_vertices_are_skipped(self) -> None:
+        dest_team = self._create_destination_team()
+        insight = Insight.objects.create(team=self.team, name="My insight")
+        dag = self._build_dag(insight)
+
+        # the dag contains a Team vertex which is immutable
+        team_vertices = [v for v in dag if v.model is Team]
+        assert len(team_vertices) > 0
+
+        result = get_suggested_substitutions(dag, dest_team)
+        source_kinds = {src_key[0] for src_key, _ in result}
+        assert "Team" not in source_kinds
+
+    def test_suggests_substitution_from_transfer_record(self) -> None:
+        dest_team = self._create_destination_team()
+        source_insight = Insight.objects.create(team=self.team, name="Source insight")
+        dest_insight = Insight.objects.create(team=dest_team, name="Dest insight")
+
+        ResourceTransfer.objects.create(
+            source_team=self.team,
+            destination_team=dest_team,
+            created_by=self.user,
+            resource_kind="Insight",
+            resource_id=str(source_insight.pk),
+            duplicated_resource_id=str(dest_insight.pk),
+        )
+
+        dag = self._build_dag(source_insight)
+        result = get_suggested_substitutions(dag, dest_team)
+
+        assert (("Insight", source_insight.pk), ("Insight", dest_insight.pk)) in result
+
+    def test_suggests_substitution_from_name_match(self) -> None:
+        dest_team = self._create_destination_team()
+        source_insight = Insight.objects.create(team=self.team, name="Shared name")
+        dest_insight = Insight.objects.create(team=dest_team, name="Shared name")
+
+        dag = self._build_dag(source_insight)
+        result = get_suggested_substitutions(dag, dest_team)
+
+        assert (("Insight", source_insight.pk), ("Insight", dest_insight.pk)) in result
+
+    def test_transfer_record_takes_priority_over_name_match(self) -> None:
+        dest_team = self._create_destination_team()
+        source_insight = Insight.objects.create(team=self.team, name="Shared name")
+        name_match_insight = Insight.objects.create(team=dest_team, name="Shared name")
+        transferred_insight = Insight.objects.create(team=dest_team, name="Different name")
+
+        ResourceTransfer.objects.create(
+            source_team=self.team,
+            destination_team=dest_team,
+            created_by=self.user,
+            resource_kind="Insight",
+            resource_id=str(source_insight.pk),
+            duplicated_resource_id=str(transferred_insight.pk),
+        )
+
+        dag = self._build_dag(source_insight)
+        result = get_suggested_substitutions(dag, dest_team)
+
+        # should pick the transferred insight, not the name match
+        assert (("Insight", source_insight.pk), ("Insight", transferred_insight.pk)) in result
+        assert (("Insight", source_insight.pk), ("Insight", name_match_insight.pk)) not in result
+
+    def test_no_suggestion_when_no_transfer_record_and_no_name(self) -> None:
+        dest_team = self._create_destination_team()
+        # an insight with no name gets no name-based match
+        source_insight = Insight.objects.create(team=self.team, name="")
+
+        dag = self._build_dag(source_insight)
+        result = get_suggested_substitutions(dag, dest_team)
+
+        insight_suggestions = [(s, d) for s, d in result if s[0] == "Insight"]
+        assert insight_suggestions == []
+
+    def test_deleted_transfer_target_falls_back_to_name_match(self) -> None:
+        dest_team = self._create_destination_team()
+        source_insight = Insight.objects.create(team=self.team, name="Source name")
+        transferred_insight = Insight.objects.create(team=dest_team, name="Old copy")
+
+        ResourceTransfer.objects.create(
+            source_team=self.team,
+            destination_team=dest_team,
+            created_by=self.user,
+            resource_kind="Insight",
+            resource_id=str(source_insight.pk),
+            duplicated_resource_id=str(transferred_insight.pk),
+        )
+
+        transferred_insight.delete()
+
+        fallback_insight = Insight.objects.create(team=dest_team, name="Source name")
+
+        dag = self._build_dag(source_insight)
+        result = get_suggested_substitutions(dag, dest_team)
+
+        assert (("Insight", source_insight.pk), ("Insight", fallback_insight.pk)) in result
+
+    def test_multiple_mutable_vertices_produce_multiple_suggestions(self) -> None:
+        dest_team = self._create_destination_team()
+        dashboard = Dashboard.objects.create(team=self.team, name="My dashboard")
+        insight = Insight.objects.create(team=self.team, name="My insight")
+        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        # create transfer records so suggestions are deterministic
+        dest_dashboard = Dashboard.objects.create(team=dest_team, name="Dest dashboard")
+        dest_insight = Insight.objects.create(team=dest_team, name="Dest insight")
+
+        ResourceTransfer.objects.create(
+            source_team=self.team,
+            destination_team=dest_team,
+            created_by=self.user,
+            resource_kind="Dashboard",
+            resource_id=str(dashboard.pk),
+            duplicated_resource_id=str(dest_dashboard.pk),
+        )
+        ResourceTransfer.objects.create(
+            source_team=self.team,
+            destination_team=dest_team,
+            created_by=self.user,
+            resource_kind="Insight",
+            resource_id=str(insight.pk),
+            duplicated_resource_id=str(dest_insight.pk),
+        )
+
+        dag = self._build_dag(dashboard)
+        result = get_suggested_substitutions(dag, dest_team)
+
+        source_kinds = {src_key[0] for src_key, _ in result}
+        assert "Dashboard" in source_kinds
+        assert "Insight" in source_kinds
+
+        assert (("Dashboard", dashboard.pk), ("Dashboard", dest_dashboard.pk)) in result
+        assert (("Insight", insight.pk), ("Insight", dest_insight.pk)) in result
+
+    def test_resource_without_name_attribute_produces_no_name_suggestion(self) -> None:
+        dest_team = self._create_destination_team()
+        dashboard = Dashboard.objects.create(team=self.team, name="My dashboard")
+        insight = Insight.objects.create(team=self.team, name="My insight")
+        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        dag = self._build_dag(dashboard)
+        result = get_suggested_substitutions(dag, dest_team)
+
+        # DashboardTile has no name attribute so shouldn't get a name-based suggestion
+        tile_suggestions = [(s, d) for s, d in result if s[0] == "DashboardTile"]
+        assert tile_suggestions == []
+
+    def test_most_recent_transfer_record_is_preferred(self) -> None:
+        dest_team = self._create_destination_team()
+        source_insight = Insight.objects.create(team=self.team, name="Source")
+        old_dest = Insight.objects.create(team=dest_team, name="Old dest")
+        new_dest = Insight.objects.create(team=dest_team, name="New dest")
+
+        # older transfer
+        ResourceTransfer.objects.create(
+            source_team=self.team,
+            destination_team=dest_team,
+            created_by=self.user,
+            resource_kind="Insight",
+            resource_id=str(source_insight.pk),
+            duplicated_resource_id=str(old_dest.pk),
+        )
+        # newer transfer (created second, so last_transferred_at is later)
+        ResourceTransfer.objects.create(
+            source_team=self.team,
+            destination_team=dest_team,
+            created_by=self.user,
+            resource_kind="Insight",
+            resource_id=str(source_insight.pk),
+            duplicated_resource_id=str(new_dest.pk),
+        )
+
+        dag = self._build_dag(source_insight)
+        result = get_suggested_substitutions(dag, dest_team)
+
+        assert (("Insight", source_insight.pk), ("Insight", new_dest.pk)) in result
+        assert (("Insight", source_insight.pk), ("Insight", old_dest.pk)) not in result


### PR DESCRIPTION
## Problem

We currently only suggest based on existing transfer records, but it might also make sense to suggest if you have 2 insights named "Landing page pageviews over time".

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add additional matching step in transfer suggestions to check if the resource has a name column, and if it does, try to find another resource in the target project with the same name. If it exists, then use that as the backup suggestion.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Tests + manually
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
