### PR TITLE
Feature flag insights empty

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -1063,7 +1063,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                 loadRelatedInsights: async () => {
                     if (props.id && props.id !== 'new' && values.featureFlag.key) {
                         const response = await api.get<PaginatedResponse<InsightModel>>(
-                            `api/environments/${values.currentProjectId}/insights/?feature_flag=${values.featureFlag.key}&order=-created_at`
+                            `api/environments/${values.currentTeamId}/insights/?feature_flag=${values.featureFlag.key}&order=-created_at`
                         )
                         return response.results.map((legacyInsight) => getQueryBasedInsightModel(legacyInsight))
                     }


### PR DESCRIPTION
## Problem

Users were unable to see related insights on a feature flag page, even when insights existed. This was due to the API call for fetching related insights incorrectly using `currentProjectId` instead of `currentTeamId` for the `/api/environments/{team_id}/insights/` endpoint, resulting in no data being returned.

## Changes

Updated the `loadRelatedInsights` function in `frontend/src/scenes/feature-flags/featureFlagLogic.ts` to use `values.currentTeamId` instead of `values.currentProjectId` when constructing the API endpoint for fetching insights related to a feature flag.

## How did you test this code?

Manually verified that insights associated with a feature flag now correctly appear on the feature flag's detail page.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1771288491781949?thread_ts=1771288491.781949&cid=D0ACMC57HDE)

<p><a href="https://cursor.com/background-agent?bcId=bc-22f1563d-3dbb-5a30-8e50-4d36bbaed31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22f1563d-3dbb-5a30-8e50-4d36bbaed31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

