### PR TITLE
fix(sig): properly handle token-boundaries in the embedding worker

### DIFF
--- a/rust/embedding-worker/src/metrics_utils.rs
+++ b/rust/embedding-worker/src/metrics_utils.rs
@@ -13,6 +13,7 @@ pub const EMBEDDING_TOTAL_TIME: &str = "embedding_worker_embedding_total_time";
 pub const EMBEDDING_REQUEST_TIME: &str = "embedding_worker_embedding_request_time";
 pub const EMBEDDING_TOTAL_TOKENS: &str = "embedding_worker_embedding_total_tokens";
 
+#[derive(Debug, Clone, Default)]
 pub struct RequestLabels {
     labels: Vec<(String, String)>,
 }


### PR DESCRIPTION
We're crashing in prod because doing a `take` on a token vec causes decode to fail if the token limit splits a utf-8 boundary.