### PR TITLE
feat(product tours): support translations on survey buttons

### DIFF
--- a/frontend/src/scenes/product-tours/editor/SurveyStepEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/SurveyStepEditor.tsx
@@ -150,6 +150,28 @@ export function SurveyStepEditor({ survey, onChange, isEditingTranslation }: Sur
                     </div>
                 </div>
             )}
+
+            {currentSurvey.type === 'open' && (
+                <div className="space-y-1">
+                    <label className="text-xs font-medium">Submit button text</label>
+                    <LemonInput
+                        value={currentSurvey.submitButtonText ?? 'Submit'}
+                        onChange={(value) => updateSurvey({ submitButtonText: value })}
+                        size="small"
+                        fullWidth
+                    />
+                </div>
+            )}
+
+            <div className="space-y-1">
+                <label className="text-xs font-medium">Back button text</label>
+                <LemonInput
+                    value={currentSurvey.backButtonText ?? 'Back'}
+                    onChange={(value) => updateSurvey({ backButtonText: value })}
+                    size="small"
+                    fullWidth
+                />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/product-tours/stepUtils.tsx
+++ b/frontend/src/scenes/product-tours/stepUtils.tsx
@@ -154,8 +154,14 @@ export function getExplainerStepContent(): JSONContent {
 }
 
 export function getDefaultSurveyContent(type: ProductTourSurveyQuestionType): ProductTourSurveyQuestion {
+    const defaults: Partial<ProductTourSurveyQuestion> = {
+        backButtonText: 'Back',
+        submitButtonText: 'Submit',
+    }
+
     if (type === 'rating') {
         return {
+            ...defaults,
             type: 'rating',
             questionText: DEFAULT_RATING_QUESTION,
             display: 'emoji',
@@ -165,6 +171,7 @@ export function getDefaultSurveyContent(type: ProductTourSurveyQuestionType): Pr
         }
     }
     return {
+        ...defaults,
         type: 'open',
         questionText: DEFAULT_OPEN_QUESTION,
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3356,6 +3356,8 @@ export interface ProductTourSurveyQuestion {
     lowerBoundLabel?: string
     /** Label for high end of rating scale (e.g., "Very likely") */
     upperBoundLabel?: string
+    submitButtonText?: string
+    backButtonText?: string
 }
 
 export type ProductTourProgressionTriggerType = 'button' | 'click'
@@ -3456,7 +3458,10 @@ export interface ProductTourStepTranslation {
         primary?: Pick<ProductTourStepButton, 'text'>
         secondary?: Pick<ProductTourStepButton, 'text'>
     }
-    survey?: Pick<ProductTourSurveyQuestion, 'questionText' | 'lowerBoundLabel' | 'upperBoundLabel'>
+    survey?: Pick<
+        ProductTourSurveyQuestion,
+        'questionText' | 'lowerBoundLabel' | 'upperBoundLabel' | 'submitButtonText' | 'backButtonText'
+    >
 }
 
 /** Tracks a snapshot of steps at a point in time for funnel analysis */


### PR DESCRIPTION
## Problem

product tour survey buttons are hard-coded "submit" and "back"

closes https://github.com/PostHog/posthog/issues/47968#issue-3940215543

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

makes these buttons customizable + translation support for them

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->