### PR TITLE
feat(experiments): experiment templates panel.

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -276,6 +276,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENTS_FF_CROSS_SELL: 'experiments-ff-cross-sell', // owner: @rodrigoi #team-experiments
     EXPERIMENT_QUERY_PREAGGREGATION: 'experiment-query-preaggregation', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
+    EXPERIMENTS_TEMPLATES: 'experiments-templates', // owner: @rodrigoi #team-experiments
     FEATURE_FLAG_COHORT_CREATION: 'feature-flag-cohort-creation', // owner: #team-feature-flags
     FEATURE_FLAGS_V2: 'feature-flags-v2', // owner: @dmarticus #team-feature-flags
     FEATURE_FLAG_USAGE_DASHBOARD_CHECKBOX: 'feature-flag-usage-dashboard-checkbox', // owner: #team-feature-flags, globally disabled, enables opt-out of auto dashboard creation

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.tsx
@@ -2,6 +2,7 @@ import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
 import { IconErrorOutline } from 'lib/lemon-ui/icons'
@@ -15,6 +16,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import type { Experiment } from '~/types'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
+import { ExperimentTemplates } from './ExperimentTemplates'
 import { ExposureCriteriaPanel } from './ExposureCriteriaPanel'
 import { MetricsPanel } from './MetricsPanel'
 import { VariantsPanel } from './VariantsPanel'
@@ -45,6 +47,7 @@ export const ExperimentForm = ({ draftExperiment, tabId }: ExperimentFormProps):
         sharedMetrics,
         isExperimentSubmitting,
         isEditMode,
+        featureFlags,
     } = useValues(logic)
     const {
         setExperimentValue,
@@ -166,6 +169,19 @@ export const ExperimentForm = ({ draftExperiment, tabId }: ExperimentFormProps):
         <div>
             <SceneContent>
                 {renderFormHeader()}
+
+                {!isEditMode && (
+                    <>
+                        {/**
+                         * this is a temporary placement for development purposes only.
+                         * This should go higher up in the form, as a stand alone page or
+                         * step zero of the wizard.
+                         */}
+                        {featureFlags[FEATURE_FLAGS.EXPERIMENTS_TEMPLATES] && <ExperimentTemplates />}
+                        <SceneDivider />
+                    </>
+                )}
+
                 <VariantsPanel experiment={experiment} updateFeatureFlag={setFeatureFlagConfig} disabled={isEditMode} />
                 <ExposureCriteriaPanel experiment={experiment} onChange={setExposureCriteria} />
                 <MetricsPanel

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateCard.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateCard.tsx
@@ -1,3 +1,5 @@
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+
 import { ExperimentTemplate } from './constants'
 
 type ExperimentTemplateCardProps = {
@@ -17,6 +19,17 @@ export const ExperimentTemplateCard = ({ template, onSelect }: ExperimentTemplat
                 <div className="flex-1 min-w-0">
                     <h3 className="font-semibold text-base mb-1">{template.name}</h3>
                     <p className="text-sm text-muted">{template.description}</p>
+                </div>
+            </div>
+
+            <div className="mt-auto pt-2 border-t">
+                <div className="flex items-center gap-2">
+                    <LemonTag size="small" type="success">
+                        {template.metrics.length} metrics
+                    </LemonTag>
+                    {template.metrics.map((metric) => (
+                        <span className="text-xs text-muted truncate">{metric.name}</span>
+                    ))}
                 </div>
             </div>
         </button>

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateCard.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateCard.tsx
@@ -27,8 +27,10 @@ export const ExperimentTemplateCard = ({ template, onSelect }: ExperimentTemplat
                     <LemonTag size="small" type="success">
                         {template.metrics.length} metrics
                     </LemonTag>
-                    {template.metrics.map((metric) => (
-                        <span className="text-xs text-muted truncate">{metric.name}</span>
+                    {template.metrics.map((metric, index) => (
+                        <span key={index} className="text-xs text-muted truncate">
+                            {metric.name}
+                        </span>
                     ))}
                 </div>
             </div>

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateCard.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateCard.tsx
@@ -1,0 +1,16 @@
+import { ExperimentTemplate } from './constants'
+
+type ExperimentTemplateCardProps = {
+    template: ExperimentTemplate
+}
+
+export const ExperimentTemplateCard = ({ template }: ExperimentTemplateCardProps): JSX.Element => {
+    return (
+        <div>
+            <h3>{template.name}</h3>
+            <p>{template.description}</p>
+            <p>{template.experimentGoal}</p>
+            <div>{template.icon}</div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateCard.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateCard.tsx
@@ -2,15 +2,23 @@ import { ExperimentTemplate } from './constants'
 
 type ExperimentTemplateCardProps = {
     template: ExperimentTemplate
+    onSelect: (template: ExperimentTemplate) => void
 }
 
-export const ExperimentTemplateCard = ({ template }: ExperimentTemplateCardProps): JSX.Element => {
+export const ExperimentTemplateCard = ({ template, onSelect }: ExperimentTemplateCardProps): JSX.Element => {
     return (
-        <div>
-            <h3>{template.name}</h3>
-            <p>{template.description}</p>
-            <p>{template.experimentGoal}</p>
-            <div>{template.icon}</div>
-        </div>
+        <button
+            className="relative flex flex-col bg-bg-light border border-border rounded-lg hover:border-primary-3000-hover focus:border-primary-3000-hover focus:outline-none transition-colors text-left h-full group p-4 cursor-pointer"
+            data-attr="experiment-template-card"
+            onClick={() => onSelect(template)}
+        >
+            <div className="flex items-start gap-3 mb-3">
+                <div className="flex-shrink-0">{template.icon}</div>
+                <div className="flex-1 min-w-0">
+                    <h3 className="font-semibold text-base mb-1">{template.name}</h3>
+                    <p className="text-sm text-muted">{template.description}</p>
+                </div>
+            </div>
+        </button>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplates.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplates.tsx
@@ -14,7 +14,7 @@ export const ExperimentTemplates = (): JSX.Element => {
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {EXPERIMENT_TEMPLATES.map((template) => (
-                    <ExperimentTemplateCard key={template.id} template={template} />
+                    <ExperimentTemplateCard key={template.id} template={template} onSelect={() => {}} />
                 ))}
             </div>
         </>

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplates.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplates.tsx
@@ -1,12 +1,22 @@
+import { ExperimentTemplateCard } from './ExperimentTemplateCard'
+import { EXPERIMENT_TEMPLATES } from './constants'
+
 export const ExperimentTemplates = (): JSX.Element => {
     return (
-        <div className="space-y-4">
-            <div>
-                <h3 className="font-semibold text-base mb-1">Start with a template</h3>
-                <p className="text-sm text-muted">
-                    Choose a pre-configured experiment template to quickly set up your metrics
-                </p>
+        <>
+            <div className="space-y-4">
+                <div>
+                    <h3 className="font-semibold text-base mb-1">Start with a template</h3>
+                    <p className="text-sm text-muted">
+                        Choose a pre-configured experiment template to quickly set up your metrics
+                    </p>
+                </div>
             </div>
-        </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {EXPERIMENT_TEMPLATES.map((template) => (
+                    <ExperimentTemplateCard key={template.id} template={template} />
+                ))}
+            </div>
+        </>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplates.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplates.tsx
@@ -1,0 +1,12 @@
+export const ExperimentTemplates = (): JSX.Element => {
+    return (
+        <div className="space-y-4">
+            <div>
+                <h3 className="font-semibold text-base mb-1">Start with a template</h3>
+                <p className="text-sm text-muted">
+                    Choose a pre-configured experiment template to quickly set up your metrics
+                </p>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/constants.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/constants.tsx
@@ -1,0 +1,65 @@
+import { IconBell, IconBox, IconGraph, IconTarget, IconTrending, IconUser } from '@posthog/icons'
+
+export const EXPERIMENT_TEMPLATE_IDS = {
+    CHECKOUT_FLOW: 'checkout-flow',
+    PRICING_PAGE: 'pricing-page',
+    ONBOARDING: 'onboarding',
+    PRODUCT_PAGE: 'product-page',
+    FEATURE_ADOPTION: 'feature-adoption',
+    MESSAGING: 'messaging',
+} as const
+
+export type ExperimentTemplateId = (typeof EXPERIMENT_TEMPLATE_IDS)[keyof typeof EXPERIMENT_TEMPLATE_IDS]
+
+export type ExperimentTemplate = {
+    id: ExperimentTemplateId
+    name: string
+    description: string
+    experimentGoal: string
+    icon: React.ReactNode
+}
+
+export const EXPERIMENT_TEMPLATES: ExperimentTemplate[] = [
+    {
+        id: EXPERIMENT_TEMPLATE_IDS.CHECKOUT_FLOW,
+        name: 'Checkout Flow Optimization',
+        description: 'Increase purchase completion rate',
+        experimentGoal: 'Optimize conversion from checkout start to completed purchase',
+        icon: <IconTrending className="text-2xl" />,
+    },
+    {
+        id: EXPERIMENT_TEMPLATE_IDS.PRICING_PAGE,
+        name: 'Pricing Page Testing',
+        description: 'Optimize plan selection and signup rate',
+        experimentGoal: 'Increase conversion from pricing page view to completed signup',
+        icon: <IconGraph className="text-2xl" />,
+    },
+    {
+        id: EXPERIMENT_TEMPLATE_IDS.ONBOARDING,
+        name: 'Onboarding Activation',
+        description: 'Increase trial-to-paid conversion',
+        experimentGoal: 'Optimize activation flow and trial-to-paid conversion',
+        icon: <IconUser className="text-2xl" />,
+    },
+    {
+        id: EXPERIMENT_TEMPLATE_IDS.PRODUCT_PAGE,
+        name: 'Product Page Conversion',
+        description: 'Increase add-to-cart and purchase rates',
+        experimentGoal: 'Optimize product page to drive add-to-cart and purchases',
+        icon: <IconBox className="text-2xl" />,
+    },
+    {
+        id: EXPERIMENT_TEMPLATE_IDS.FEATURE_ADOPTION,
+        name: 'Feature Adoption',
+        description: 'Drive engagement with new/core features',
+        experimentGoal: 'Increase discovery and usage of key features',
+        icon: <IconTarget className="text-2xl" />,
+    },
+    {
+        id: EXPERIMENT_TEMPLATE_IDS.MESSAGING,
+        name: 'In-App Messaging & Notification Testing',
+        description: 'Optimize engagement with notifications',
+        experimentGoal: 'Maximize engagement with notifications, tooltips, and CTAs',
+        icon: <IconBell className="text-2xl" />,
+    },
+]

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/constants.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/constants.tsx
@@ -17,6 +17,7 @@ export type ExperimentTemplate = {
     description: string
     experimentGoal: string
     icon: React.ReactNode
+    metrics: { name: string }[]
 }
 
 export const EXPERIMENT_TEMPLATES: ExperimentTemplate[] = [
@@ -26,6 +27,12 @@ export const EXPERIMENT_TEMPLATES: ExperimentTemplate[] = [
         description: 'Increase purchase completion rate',
         experimentGoal: 'Optimize conversion from checkout start to completed purchase',
         icon: <IconTrending className="text-2xl" />,
+        metrics: [
+            { name: 'Conversion rate' },
+            { name: 'Average order value' },
+            { name: 'Checkout abandonment rate' },
+            { name: 'Time to purchase' },
+        ],
     },
     {
         id: EXPERIMENT_TEMPLATE_IDS.PRICING_PAGE,
@@ -33,6 +40,12 @@ export const EXPERIMENT_TEMPLATES: ExperimentTemplate[] = [
         description: 'Optimize plan selection and signup rate',
         experimentGoal: 'Increase conversion from pricing page view to completed signup',
         icon: <IconGraph className="text-2xl" />,
+        metrics: [
+            { name: 'Click-through rate' },
+            { name: 'Plan selection rate' },
+            { name: 'Conversion to signup' },
+            { name: 'Revenue per visitor' },
+        ],
     },
     {
         id: EXPERIMENT_TEMPLATE_IDS.ONBOARDING,
@@ -40,6 +53,12 @@ export const EXPERIMENT_TEMPLATES: ExperimentTemplate[] = [
         description: 'Increase trial-to-paid conversion',
         experimentGoal: 'Optimize activation flow and trial-to-paid conversion',
         icon: <IconUser className="text-2xl" />,
+        metrics: [
+            { name: 'Activation rate' },
+            { name: 'Time to first value' },
+            { name: 'Trial-to-paid conversion' },
+            { name: 'Feature adoption' },
+        ],
     },
     {
         id: EXPERIMENT_TEMPLATE_IDS.PRODUCT_PAGE,
@@ -47,6 +66,12 @@ export const EXPERIMENT_TEMPLATES: ExperimentTemplate[] = [
         description: 'Increase add-to-cart and purchase rates',
         experimentGoal: 'Optimize product page to drive add-to-cart and purchases',
         icon: <IconBox className="text-2xl" />,
+        metrics: [
+            { name: 'Add-to-cart rate' },
+            { name: 'Purchase conversion rate' },
+            { name: 'Revenue per visitor' },
+            { name: 'Bounce rate' },
+        ],
     },
     {
         id: EXPERIMENT_TEMPLATE_IDS.FEATURE_ADOPTION,
@@ -54,6 +79,12 @@ export const EXPERIMENT_TEMPLATES: ExperimentTemplate[] = [
         description: 'Drive engagement with new/core features',
         experimentGoal: 'Increase discovery and usage of key features',
         icon: <IconTarget className="text-2xl" />,
+        metrics: [
+            { name: 'Feature adoption rate' },
+            { name: 'Repeat usage rate' },
+            { name: 'Time to first use' },
+            { name: 'User retention' },
+        ],
     },
     {
         id: EXPERIMENT_TEMPLATE_IDS.MESSAGING,
@@ -61,5 +92,12 @@ export const EXPERIMENT_TEMPLATES: ExperimentTemplate[] = [
         description: 'Optimize engagement with notifications',
         experimentGoal: 'Maximize engagement with notifications, tooltips, and CTAs',
         icon: <IconBell className="text-2xl" />,
+        metrics: [
+            { name: 'Click-through rate' },
+            { name: 'Engagement rate' },
+            { name: 'Dismissal rate' },
+            { name: 'Time to action' },
+            { name: 'Conversion from notification' },
+        ],
     },
 ]

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/index.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/index.ts
@@ -1,0 +1,1 @@
+export { ExperimentTemplates } from './ExperimentTemplates'


### PR DESCRIPTION
## Problem

A successfully launched experiment requires a relatively high level of involvement when configuring goals and metrics. We need to provide alternatives to simplify the process of creating a successful experiment.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We'll provide the user with six preconfigured scenarios as templates. This is the first PR that hides the new components behind a feature flag.

| templates panel |
| - |
| <img width="1621" height="1235" alt="image" src="https://github.com/user-attachments/assets/8662d54d-b678-4d73-823a-62c14ebfa4b0" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/fdbf5d58-1a37-45d5-b20c-ce2121325f0a)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
