### PR TITLE
fix(Insights): Display issues on horizontal bar chart

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -226,6 +226,7 @@ export interface LineGraphProps {
     hideAnnotations?: boolean
     hideXAxis?: boolean
     hideYAxis?: boolean
+    inCardView?: boolean
     legend?: DeepPartial<LegendOptions<ChartType>>
     yAxisScaleType?: string | null
     showMultipleYAxes?: boolean | null
@@ -270,6 +271,7 @@ export function LineGraph_({
     hideAnnotations,
     hideXAxis,
     hideYAxis,
+    inCardView,
     yAxisScaleType,
     showMultipleYAxes = false,
     legend = { display: false },
@@ -855,7 +857,7 @@ export function LineGraph_({
                 },
             }
 
-            const truncateRows = !inSurveyView && !!insightProps.dashboardId
+            const truncateRows = !inSurveyView && !!inCardView
 
             if (type === GraphType.Bar) {
                 if (hideXAxis || hideYAxis) {

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -16,7 +16,11 @@ import { trendsDataLogic } from '../trendsDataLogic'
 
 type DataSet = any
 
-export function ActionsHorizontalBar({ showPersonsModal = true, context }: ChartParams): JSX.Element | null {
+export function ActionsHorizontalBar({
+    showPersonsModal = true,
+    context,
+    inCardView,
+}: ChartParams): JSX.Element | null {
     const [data, setData] = useState<DataSet[] | null>(null)
     const [total, setTotal] = useState(0)
 
@@ -101,6 +105,7 @@ export function ActionsHorizontalBar({ showPersonsModal = true, context }: Chart
                 context?.ignoreActionsInSeriesLabels || (isSingleSeriesDefinition && !!breakdownFilter?.breakdown)
             }
             isStacked={false}
+            inCardView={inCardView}
             onClick={
                 context?.onDataPointClick || (showPersonsModal && !trendsFilter?.formula && !hasDataWarehouseSeries)
                     ? (point) => {


### PR DESCRIPTION
## Problem
https://posthoghelp.zendesk.com/agent/tickets/50406 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/53184)

Customer is seeing the horizontal bar chart get clipped at the bottom and now show all the results.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
I found this only happens when viewing from a dashboard, and was truncating the rows. 
Using a isCardView prop we do not truncate the rows for this case.

Issue:
<img width="1297" height="849" alt="Screenshot 2026-02-17 at 07 57 39" src="https://github.com/user-attachments/assets/9a8e67aa-d568-45c8-8cca-34581fc15693" />

Fixed:
<img width="1031" height="853" alt="Screenshot 2026-02-17 at 08 59 43" src="https://github.com/user-attachments/assets/8e8b6939-43ba-48f7-82c9-78752505eaf7" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
