### PR TITLE
fix: flaky test test_checkpoint_metadata_consistency_across_threads

### DIFF
--- a/rust/kafka-deduplicator/tests/checkpoint_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_tests.rs
@@ -991,6 +991,9 @@ async fn test_checkpoint_metadata_consistency_across_threads() {
     let tmp_store_dir = TempDir::new().unwrap();
     let store = create_test_dedup_store(tmp_store_dir.path(), test_topic, test_partition);
 
+    // Use a fixed timestamp to ensure consistent keys across writes and reads
+    let fixed_timestamp = "1234567890";
+
     // Write known data to store
     let test_events = vec![
         ("user-1", "token-1", "event-1"),
@@ -1003,7 +1006,7 @@ async fn test_checkpoint_metadata_consistency_across_threads() {
             .distinct_id(user)
             .token(token)
             .event(event_name)
-            .current_timestamp()
+            .timestamp(fixed_timestamp)
             .build();
         let key = (&event).into();
         let metadata = TimestampMetadata::new(&event);
@@ -1047,7 +1050,7 @@ async fn test_checkpoint_metadata_consistency_across_threads() {
             .distinct_id(user)
             .token(token)
             .event(event_name)
-            .current_timestamp()
+            .timestamp(fixed_timestamp)
             .build();
         let key = (&event).into();
         let metadata = store.get_timestamp_record(&key).unwrap();


### PR DESCRIPTION
## Problem

`test_checkpoint_metadata_consistency_across_threads` was flaky in master. This was because the timestamp generation could break the test. Moving to a fixed timestamp makes the test deterministic

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
