### PR TITLE
feat(signals): Improve cluster weight calculation based on team-relative impact

### DIFF
--- a/posthog/temporal/ai/video_segment_clustering/activities/a4_emit_signals_from_clusters.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/a4_emit_signals_from_clusters.py
@@ -92,12 +92,16 @@ async def emit_signals_from_clusters_activity(inputs: EmitSignalsActivityInputs)
     segment_lookup = {s.document_id: s for s in inputs.segments}
     genai_client = genai.AsyncClient(api_key=settings.GEMINI_API_KEY)
 
+    # Count total active users across all segments in the lookback window (for team-relative impact)
+    all_distinct_ids = list({s.distinct_id for s in inputs.segments if s.distinct_id})
+    active_users_in_period = await sync_to_async(count_distinct_persons)(team, all_distinct_ids)
+
     # 1. Label all clusters concurrently
     label_tasks = []
     for cluster in inputs.clusters:
         cluster_segments = [segment_lookup[sid] for sid in cluster.segment_ids if sid in segment_lookup]
         label_tasks.append(
-            generate_label_for_cluster(
+            _generate_label_for_cluster(
                 team=team,
                 cluster_id=cluster.cluster_id,
                 cluster_segments=cluster_segments,
@@ -132,11 +136,12 @@ async def emit_signals_from_clusters_activity(inputs: EmitSignalsActivityInputs)
         metrics = await calculate_task_metrics(team, cluster_segments)
         relevant_user_count = metrics["relevant_user_count"]
 
-        # Weight: not-actionable = 0.1, actionable scales with user count
-        if not cluster_label.actionable:
-            weight = 0.1
-        else:
-            weight = min(0.5, 0.1 * math.log2(1 + relevant_user_count))
+        # Decide weight based on team-relative impact
+        weight = _determine_cluster_weight_as_signal(
+            actionable=cluster_label.actionable,
+            relevant_user_count=relevant_user_count,
+            active_users_in_period=active_users_in_period,
+        )
 
         # Build segment metadata for extra field
         segment_extras = []
@@ -168,6 +173,7 @@ async def emit_signals_from_clusters_activity(inputs: EmitSignalsActivityInputs)
                     "segments": segment_extras,
                     "metrics": {
                         "relevant_user_count": relevant_user_count,
+                        "active_users_in_period": active_users_in_period,
                         "occurrence_count": metrics["occurrence_count"],
                     },
                 },
@@ -189,7 +195,7 @@ async def emit_signals_from_clusters_activity(inputs: EmitSignalsActivityInputs)
     return EmitSignalsResult(signals_emitted=signals_emitted, clusters_skipped=clusters_skipped)
 
 
-async def generate_label_for_cluster(
+async def _generate_label_for_cluster(
     *, team: Team, cluster_id: int, cluster_segments: list[VideoSegmentMetadata], genai_client
 ) -> tuple[int, ClusterLabel]:
     if not cluster_segments:
@@ -272,3 +278,23 @@ async def _call_llm_to_label_cluster(
             )
     # Should never reach here, but satisfy type checker
     raise RuntimeError("Unreachable")
+
+
+def _determine_cluster_weight_as_signal(
+    *, actionable: bool, relevant_user_count: int, active_users_in_period: int
+) -> float:
+    """Calculate signal weight based on team-relative impact.
+
+    Uses the ratio of affected users to total active users, so that
+    small teams (where each user is a large fraction) promote signals
+    faster, while large teams need broader impact to reach significance.
+
+    Actionable signals range from 0.1 (no users) to 1.0 (all users affected).
+    sqrt scaling gives meaningful weight to moderate impact ratios.
+    """
+    if not actionable:
+        return 0.1
+    if active_users_in_period <= 0:
+        return 0.1
+    impact_ratio = min(1.0, relevant_user_count / active_users_in_period)
+    return 0.1 + 0.9 * math.sqrt(impact_ratio)

--- a/posthog/temporal/ai/video_segment_clustering/tests/test_signal_weight.py
+++ b/posthog/temporal/ai/video_segment_clustering/tests/test_signal_weight.py
@@ -1,0 +1,66 @@
+import pytest
+
+from parameterized import parameterized
+
+from posthog.temporal.ai.video_segment_clustering.activities.a4_emit_signals_from_clusters import (
+    _determine_cluster_weight_as_signal,
+)
+
+
+class TestDetermineClusterWeightAsSignal:
+    @parameterized.expand(
+        [
+            # (actionable, relevant_users, active_users, expected_weight)
+            # Non-actionable always returns 0.1
+            ("not_actionable_small_team", False, 5, 10, 0.1),
+            ("not_actionable_large_team", False, 500, 1000, 0.1),
+            ("not_actionable_all_affected", False, 10, 10, 0.1),
+            # Edge cases: no active users falls back to 0.1
+            ("actionable_zero_active", True, 5, 0, 0.1),
+            ("actionable_negative_active", True, 5, -1, 0.1),
+            # Startup (10 active users): each user is 10% of the base
+            ("startup_1_of_10", True, 1, 10, pytest.approx(0.1 + 0.9 * (0.1**0.5), abs=0.01)),
+            ("startup_5_of_10", True, 5, 10, pytest.approx(0.1 + 0.9 * (0.5**0.5), abs=0.01)),
+            ("startup_all_10", True, 10, 10, 1.0),
+            # Medium team (100 active users)
+            ("medium_5_of_100", True, 5, 100, pytest.approx(0.1 + 0.9 * (0.05**0.5), abs=0.01)),
+            ("medium_50_of_100", True, 50, 100, pytest.approx(0.1 + 0.9 * (0.5**0.5), abs=0.01)),
+            ("medium_all_100", True, 100, 100, 1.0),
+            # Large team (10000 active users)
+            ("large_5_of_10000", True, 5, 10000, pytest.approx(0.1 + 0.9 * (0.0005**0.5), abs=0.01)),
+            ("large_1000_of_10000", True, 1000, 10000, pytest.approx(0.1 + 0.9 * (0.1**0.5), abs=0.01)),
+            ("large_all_10000", True, 10000, 10000, 1.0),
+            # Relevant > active (clamped to 1.0 impact ratio)
+            ("overcounted", True, 15, 10, 1.0),
+        ],
+    )
+    def test_weight_calculation(self, _name, actionable, relevant_users, active_users, expected_weight):
+        weight = _determine_cluster_weight_as_signal(
+            actionable=actionable,
+            relevant_user_count=relevant_users,
+            active_users_in_period=active_users,
+        )
+        assert weight == expected_weight
+
+    def test_weight_increases_with_impact_ratio(self):
+        """Weight is monotonically increasing with the fraction of affected users."""
+        weights = [
+            _determine_cluster_weight_as_signal(
+                actionable=True,
+                relevant_user_count=n,
+                active_users_in_period=100,
+            )
+            for n in [1, 5, 10, 25, 50, 100]
+        ]
+        for i in range(1, len(weights)):
+            assert weights[i] > weights[i - 1]
+
+    def test_same_ratio_same_weight_regardless_of_team_size(self):
+        """50% impact produces the same weight whether the team is 10 or 10000 users."""
+        weight_small = _determine_cluster_weight_as_signal(
+            actionable=True, relevant_user_count=5, active_users_in_period=10
+        )
+        weight_large = _determine_cluster_weight_as_signal(
+            actionable=True, relevant_user_count=5000, active_users_in_period=10000
+        )
+        assert weight_small == pytest.approx(weight_large, abs=0.001)


### PR DESCRIPTION
## Problem

The current signal weighting system for video segment clusters uses occurrence count for weighting, mostly. It's pretty naive, but one thing about it is it doesn't account for team size, resulting in the same weight for an signal that affect 10 users, whether a team has 20 or 2000 active users.

## Changes

Adding a team-relative impact weighting system that calculates signal importance based on the ratio of affected users to total active users. Improved the weight range from 0.1-0.5 to 0.1-1.0 for better differentiation.

## How did you test this code?

A couple unit tests.