### PR TITLE
chore(err): add embedding worker dependency to mprocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,7 +165,11 @@ data/seaweedfs/
 # Ignore Agent OS (Claude Code) files
 .claude/agents/agent-os
 .claude/commands/agent-os
+
 agent-os/
 
 # MCP build files
 services/mcp/ui-apps-dist
+
+# Product skills
+.claude/skills/error-tracking

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -109,6 +109,7 @@ procs:
         shell: |-
             bin/wait-for-docker && \
             bin/start-rust-service embedding-worker
+        autostart: false
         capability: embedding_service
 
     feature-flags:

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -147,7 +147,7 @@ intents:
 
     error_tracking:
         description: 'Track and analyze application errors'
-        capabilities: [event_ingestion, error_symbolication, property_definitions, nodejs_cdp]
+        capabilities: [event_ingestion, error_symbolication, embedding_service, property_definitions, nodejs_cdp]
 
     session_replay:
         description: 'Record and replay user sessions'


### PR DESCRIPTION
## Problem

- Error tracking needs the embedding worker for similar issues query

## Changes

- Add embedding worker requirement
- Ignore a local product skill