### PR TITLE
fix: Truncate additional tables in batch export tests

### DIFF
--- a/products/batch_exports/backend/tests/temporal/utils/clickhouse.py
+++ b/products/batch_exports/backend/tests/temporal/utils/clickhouse.py
@@ -71,7 +71,9 @@ async def create_clickhouse_tables_and_views(clickhouse_client):
 
 async def truncate_events(clickhouse_client):
     await execute_query(clickhouse_client, "TRUNCATE TABLE IF EXISTS sharded_events")
+    await execute_query(clickhouse_client, "TRUNCATE TABLE IF EXISTS distributed_events_recent")
     await execute_query(clickhouse_client, "TRUNCATE TABLE IF EXISTS events_recent")
+    await execute_query(clickhouse_client, "TRUNCATE TABLE IF EXISTS sharded_events_recent")
 
 
 async def truncate_persons(clickhouse_client):


### PR DESCRIPTION
## Problem

In https://github.com/PostHog/posthog/pull/47879, some changes were made to tables used in batch export tests. This is causing batch export tests to fail. I think the underlying cause is that new tables were added and we are not properly cleaning them up.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Added additional truncate calls in batch export clean up steps.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran a subset of failing tests locally, they are consistently passing with this change. 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
