### PR TITLE
fix(docker-compose): add recording-api Redis env vars to plugins service

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -393,6 +393,8 @@ services:
             CLICKHOUSE_VERIFY: 'false'
             COOKIELESS_REDIS_HOST: redis7
             COOKIELESS_REDIS_PORT: 6379
+            SESSION_RECORDING_API_REDIS_HOST: redis7
+            SESSION_RECORDING_API_REDIS_PORT: 6379
 
     livestream:
         image: 'ghcr.io/posthog/posthog/livestream:master'


### PR DESCRIPTION
## Summary

Adds `SESSION_RECORDING_API_REDIS_HOST` and `SESSION_RECORDING_API_REDIS_PORT` to the `plugins` service in `docker-compose.base.yml`.

Without these, the recording-api falls back to `127.0.0.1:6379` (ioredis default), causing `ECONNREFUSED` errors on hobby/local deployments.

Closes #48151