### PR TITLE
feat(analytics-platform): Change team_id modulo from 16 -> 64

### DIFF
--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -108,7 +108,7 @@ class SessionsBackfillConfig(Config):
     """
 
     clickhouse_settings: dict[str, Any] | None = None
-    team_id_chunks: int | None = 16
+    team_id_chunks: int | None = 64
     max_unmerged_parts: int = 100
     parts_check_poll_frequency_seconds: int = 30
     parts_check_max_wait_seconds: int = 3600
@@ -116,7 +116,7 @@ class SessionsBackfillConfig(Config):
 
 class ExperimentalSessionsBackfillConfig(Config):
     clickhouse_settings: dict[str, Any] | None = None
-    team_id_chunks: int | None = 16
+    team_id_chunks: int | None = 64
     max_unmerged_parts: int = 100
     parts_check_poll_frequency_seconds: int = 30
     parts_check_max_wait_seconds: int = 3600


### PR DESCRIPTION
## Problem

See discussion https://posthog.slack.com/archives/C076E99B152/p1771328930955179?thread_ts=1770721296.094409&cid=C076E99B152

## Changes

Change team_id modulo from 16 -> 64 in analytics platform dags

## How did you test this code?

n/a

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
