### PR TITLE
chore: add markdown line convention to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,6 @@ docker run --rm -v "${PWD}:/src" semgrep/semgrep semgrep --test /src/.semgrep/ru
 
 ## General
 
-- Markdown: one sentence per line, no hard wrapping
+- Markdown: prefer semantic line breaks; no hard wrapping
 - Use American English spelling
 - When mentioning PostHog products, the product names should use Sentence casing, not Title Casing. For example, 'Product analytics', not 'Product Analytics'. Any other buttons, tab text, tooltips, etc should also all use Sentence casing. For example, 'Save as view' instead of 'Save As View'.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,5 +152,6 @@ docker run --rm -v "${PWD}:/src" semgrep/semgrep semgrep --test /src/.semgrep/ru
 
 ## General
 
+- Markdown: one sentence per line, no hard wrapping
 - Use American English spelling
 - When mentioning PostHog products, the product names should use Sentence casing, not Title Casing. For example, 'Product analytics', not 'Product Analytics'. Any other buttons, tab text, tooltips, etc should also all use Sentence casing. For example, 'Save as view' instead of 'Save As View'.


### PR DESCRIPTION
77% of the repo's .md files already use semantic line breaks (one sentence per line, no hard wrapping). This adds a one-liner to AGENTS.md so LLM agents follow the same convention.

Already consistent with `.editorconfig` (`max_line_length = off`), `.prettierrc` (`proseWrap: preserve`), and `.markdownlint` (`MD013: false`).