### PR TITLE
chore(ph-ai): slicing guideline hogql for cdp

### DIFF
--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -293,6 +293,7 @@ replaceAll(arg: string, needle: string, replacement: string): string
 generateUUIDv4(): string
 position(haystack: string, needle: string): integer
 positionCaseInsensitive(haystack: string, needle: string): integer
+substring(arg: string, offset: integer, length?: integer): string
 Objects and arrays
 length(arg: any[] | object): integer
 empty(arg: any[] | object): boolean
@@ -397,6 +398,11 @@ let str := 'string'
 print(str || ' world') // prints 'string world', SQL concat
 print(f'hello {str}') // prints 'hello string'
 print(f'hello {f'{str} world'}') // prints 'hello string world'
+String truncation
+// Truncate a string to a maximum length
+if (length(s) > 2000) {
+    s := substring(s, 1, 2000)
+}
 Functions and lambdas
 Functions are first class variables, just like in JavaScript. You can define them with fun, or inline as lambdas:
 
@@ -456,6 +462,7 @@ Here are a few key differences compared to other programming languages:
 - All arrays in Hog start from index 1. Yes, for real. Trust us, we know. However that's how SQL has always worked, so we adopted it.
 - The easiest way to debug your code is to print() the variables in question, and then check the logs.
 - Strings must always be written with 'single quotes'. You may use f-string templates like f'Hello {name}'.
+- Never use arr[a:b]; Hog does not support slice syntax. Use substring(str, offset, length) for strings.
 - delete does not work in Hog.
 
 """

--- a/products/cdp/backend/test_max_tools.py
+++ b/products/cdp/backend/test_max_tools.py
@@ -1,0 +1,45 @@
+import pytest
+
+from parameterized import parameterized
+
+from products.cdp.backend.max_tools import CreateHogTransformationFunctionTool
+
+from ee.hogai.chat_agent.schema_generator.parsers import PydanticOutputParserException
+
+
+class TestParseOutput:
+    @parameterized.expand(
+        [
+            (
+                "slice_syntax",
+                "let x := content[1:2000]",
+                "no viable alternative at input",
+            ),
+            (
+                "double_ampersand",
+                "if (a && b) { print(a) }",
+                "no viable alternative at input",
+            ),
+        ]
+    )
+    def test_parse_output_includes_specific_parse_error(self, _name, hog_code, expected_fragment):
+        tool = CreateHogTransformationFunctionTool.__new__(CreateHogTransformationFunctionTool)
+        with pytest.raises(PydanticOutputParserException) as exc_info:
+            tool._parse_output(f"<hog_code>{hog_code}</hog_code>")
+        assert expected_fragment in str(exc_info.value)
+
+    def test_parse_output_generic_error_for_non_syntax_issues(self):
+        # Code that parses but fails at the HyphenatedPropertyDetector stage
+        hog_code = "let x := event.some-prop"
+        tool = CreateHogTransformationFunctionTool.__new__(CreateHogTransformationFunctionTool)
+        with pytest.raises(PydanticOutputParserException) as exc_info:
+            tool._parse_output(f"<hog_code>{hog_code}</hog_code>")
+        assert "The Hog code failed to compile" in str(exc_info.value)
+        # Should NOT contain a specific parse error since it's not a syntax error
+        assert "no viable alternative" not in str(exc_info.value)
+
+    def test_parse_output_valid_code(self):
+        hog_code = "let x := 1\nreturn event"
+        tool = CreateHogTransformationFunctionTool.__new__(CreateHogTransformationFunctionTool)
+        result = tool._parse_output(f"<hog_code>{hog_code}</hog_code>")
+        assert result.hog_code == hog_code


### PR DESCRIPTION
## Problem

Fixes some slicing hogql generation issues in the (old) cdp MaxTool and better exception feedback handling at the agent level.

<img width="686" height="200" alt="CleanShot 2026-02-17 at 3  00 09" src="https://github.com/user-attachments/assets/b71581ba-9f33-4186-a498-35172c80aa9c" />

[link ref](https://us.posthog.com/project/2/error_tracking/019ab8b7-65bf-75b3-a76c-25964a8cd14b?timestamp=2026-01-30T12:47:21.486000-08:00&dateRange=%7B%22date_from%22:%22-3m%22,%22date_to%22:%22%22%7D&filterGroup=%7B%22type%22:%22AND%22,%22values%22:%5B%7B%22type%22:%22AND%22,%22values%22:%5B%7B%22key%22:%22tag%22,%22value%22:%5B%22max_ai%22%5D,%22operator%22:%22exact%22,%22type%22:%22event%22%7D%5D%7D%5D%7D)