### PR TITLE
chore: Update stale workflow configuration and enable statistics

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -37,7 +37,7 @@ jobs:
                   remove-issue-stale-when-updated: true
                   days-before-pr-stale: 7
                   days-before-pr-close: 7
-                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, please remove the `stale` label – otherwise this will be closed in another week. If you want to permanentely keep it open, use the `waiting` label."
+                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, please remove the `stale` label – otherwise this will be closed in another week. If you want to permanently keep it open, use the `waiting` label."
                   close-pr-message: "This PR was closed due to lack of activity. Feel free to reopen if it's still relevant."
                   stale-pr-label: stale
                   remove-pr-stale-when-updated: false

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -31,15 +31,16 @@ jobs:
               with:
                   days-before-issue-stale: 730
                   days-before-issue-close: 14
-                  stale-issue-message: "This issue hasn't seen activity in two years! If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in two weeks."
+                  stale-issue-message: "This issue hasn't seen activity in two years! If you want to keep it open, please remove the `stale` label – otherwise this will be closed in two weeks."
                   close-issue-message: "This issue was closed due to lack of activity. Feel free to reopen if it's still relevant."
                   stale-issue-label: stale
                   remove-issue-stale-when-updated: true
                   days-before-pr-stale: 7
                   days-before-pr-close: 7
-                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in another week. If you want to permanentely keep it open, use the `waiting` label."
+                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, please remove the `stale` label – otherwise this will be closed in another week. If you want to permanentely keep it open, use the `waiting` label."
                   close-pr-message: "This PR was closed due to lack of activity. Feel free to reopen if it's still relevant."
                   stale-pr-label: stale
-                  remove-pr-stale-when-updated: true
+                  remove-pr-stale-when-updated: false
                   exempt-pr-labels: 'waiting'
+                  enable-statistics: true
                   operations-per-run: 250


### PR DESCRIPTION
## Problem

The current stale issue/PR workflow has some usability issues and lacks statistics tracking. The message wording is confusing users about how to prevent stale items from closing.

## Changes

- Updated stale issue message to clarify that removing the stale label (not just commenting) prevents closure
- Updated stale PR message with similar clarification
- Changed `remove-pr-stale-when-updated` from `true` to `false` to ensure PRs remain marked stale even after comments
- Enabled statistics tracking for the stale workflow

## How did you test this code?

Verified the workflow configuration syntax is valid and the changes align with GitHub's stale action documentation.

## Publish to changelog?

No