### PR TITLE
chore(endpoints): cleanup endpoints in sql editor sources

### DIFF
--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
@@ -83,7 +83,8 @@ export const databaseTableListLogic = kea<databaseTableListLogicType>([
         ],
         allTablesMap: [
             (s) => [s.allTables],
-            (allTables: DatabaseSchemaTable[]): Record<string, DatabaseSchemaTable> => toMapByName(allTables),
+            (allTables: DatabaseSchemaTable[]): Record<string, DatabaseSchemaTable> =>
+                toMapByName(allTables.filter((t) => t.type !== 'endpoint')),
             { resultEqualityCheck: objectsEqual },
         ],
         posthogTables: [

--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
@@ -176,7 +176,7 @@ export function EditorScene({ tabId }: { tabId?: string }): JSX.Element {
     )
 }
 
-/** Syncs queryInput from multitabEditorLogic to variablesLogic without causing EditorScene re-renders */
+/** Syncs queryInput from sqlEditorLogic to variablesLogic without causing EditorScene re-renders */
 function VariablesQuerySync(): null {
     const { queryInput } = useValues(sqlEditorLogic)
     const { setEditorQuery } = useActions(variablesLogic)

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import type { editor as importedEditor } from 'monaco-editor'
 import { memo, useMemo } from 'react'
 
-import { IconBook, IconDownload, IconInfo, IconPlayFilled } from '@posthog/icons'
+import { IconBook, IconDownload, IconInfo, IconPlayFilled, IconX } from '@posthog/icons'
 import { LemonDivider, Spinner } from '@posthog/lemon-ui'
 
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
@@ -45,6 +45,7 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
         activeTab,
         queryInput,
         editingView,
+        editingEndpoint,
         editingInsight,
         insightLoading,
         sourceQuery,
@@ -67,6 +68,9 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
         updateView,
         setSuggestedQueryInput,
         reportAIQueryPromptOpen,
+        stopEditingEndpoint,
+        stopEditingInsight,
+        stopEditingView,
     } = useActions(sqlEditorLogic)
     const { openHistoryModal } = useActions(sqlEditorLogic)
 
@@ -98,8 +102,30 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
 
     return (
         <div className="flex grow flex-col overflow-hidden">
-            {(editingView || editingInsight || insightLoading) && (
-                <div className="h-5 bg-warning-highlight">
+            {(editingView || editingInsight || editingEndpoint || insightLoading) && (
+                <div className="flex items-center h-5 bg-warning-highlight">
+                    {(editingView || editingInsight || editingEndpoint) && (
+                        <LemonButton
+                            size="xxsmall"
+                            noPadding
+                            icon={<IconX />}
+                            onClick={
+                                editingView
+                                    ? stopEditingView
+                                    : editingInsight
+                                      ? stopEditingInsight
+                                      : stopEditingEndpoint
+                            }
+                            tooltip={
+                                editingView
+                                    ? 'Stop editing view'
+                                    : editingInsight
+                                      ? 'Stop editing insight'
+                                      : 'Stop editing endpoint'
+                            }
+                            className="ml-1"
+                        />
+                    )}
                     <span className="pl-2 text-xs">
                         {editingView ? (
                             <>
@@ -108,8 +134,13 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                             </>
                         ) : editingInsight ? (
                             <>
-                                Editing insight "
-                                <Link to={urls.insightView(editingInsight.short_id)}>{editingInsight.name}</Link>"
+                                Editing insight{' '}
+                                <Link to={urls.insightView(editingInsight.short_id)}>{editingInsight.name}</Link>
+                            </>
+                        ) : editingEndpoint ? (
+                            <>
+                                Editing endpoint{' '}
+                                <Link to={urls.endpoint(editingEndpoint.name)}>{editingEndpoint.name}</Link>
                             </>
                         ) : insightLoading ? (
                             'Loading insight...'

--- a/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
@@ -8,7 +8,6 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
-import { DataWarehouseSavedQueryOrigin } from '~/queries/schema/schema-general'
 import { DataWarehouseSavedQuery, DataWarehouseSavedQueryRunHistory } from '~/types'
 
 import { PAGE_SIZE, viewsTabLogic } from './viewsTabLogic'
@@ -25,10 +24,6 @@ const getDisabledReason = (view: DataWarehouseSavedQuery): string | undefined =>
     if (view.managed_viewset_kind !== null) {
         return `Cannot delete a view that belongs to a managed viewset. You can turn the viewset off in the ${urls.dataWarehouseManagedViewsets()} page.`
     }
-    if (view.origin === DataWarehouseSavedQueryOrigin.ENDPOINT) {
-        return `Cannot delete a view that belongs to an endpoint. You can disable materialization on this endpoint's page.`
-    }
-
     return undefined
 }
 
@@ -148,12 +143,6 @@ export function ViewsTab(): JSX.Element {
                                                 managed viewset
                                             </span>
                                         </>
-                                    ) : view.origin === DataWarehouseSavedQueryOrigin.ENDPOINT ? (
-                                        <LemonTableLink
-                                            to={urls.endpoint(view.name)}
-                                            title={view.name}
-                                            description={`Created by the ${view.name} endpoint.`}
-                                        />
                                     ) : (
                                         <LemonTableLink
                                             to={urls.sqlEditor({ view_id: view.id })}

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -79,16 +79,14 @@ export const urls = {
             params.set('open_view', view_id)
         } else if (insightShortId) {
             params.set('open_insight', insightShortId)
+        } else if (endpointName) {
+            params.set('open_endpoint', endpointName)
         } else if (draftId) {
             params.set('open_draft', draftId)
         }
 
         if (outputTab) {
             params.set('output_tab', outputTab)
-        }
-
-        if (endpointName) {
-            params.set('endpoint_name', endpointName)
         }
 
         const queryString = params.toString()

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2260,6 +2260,7 @@ export interface EndpointType extends WithAccessControl {
     /** Last execution time from ClickHouse query_log table */
     last_executed_at?: string
     materialization?: EndpointVersionMaterializationType
+    columns?: { name: string; type: string }[]
 }
 
 /** Extends EndpointType with version-specific fields when fetching a specific version */

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -486,6 +486,7 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
                 ),
             )
             .exclude(deleted=True)
+            .exclude(origin=DataWarehouseSavedQuery.Origin.ENDPOINT)
             .order_by(self.ordering)
         )
 

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -268,6 +268,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             "versions_count": endpoint.versions.count(),
             "derived_from_insight": endpoint.derived_from_insight,
             "materialization": self._build_materialization_info(version),
+            "columns": version.columns if version else [],
         }
 
         if isinstance(obj, EndpointVersion):
@@ -430,6 +431,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 derived_from_insight=data.derived_from_insight,
             )
 
+            columns = EndpointVersion.extract_columns(query_dict, team_id=self.team.pk)
             EndpointVersion.objects.create(
                 endpoint=endpoint,
                 version=1,
@@ -437,6 +439,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 description=data.description or "",
                 cache_age_seconds=data.cache_age_seconds,
                 created_by=cast(User, request.user),
+                columns=columns,
             )
 
             log_activity(

--- a/products/endpoints/backend/migrations/0014_endpointversion_columns.py
+++ b/products/endpoints/backend/migrations/0014_endpointversion_columns.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("endpoints", "0013_add_endpointversion_is_active"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="endpointversion",
+            name="columns",
+            field=models.JSONField(
+                blank=True,
+                default=list,
+                help_text="SELECT column names parsed from the query at creation time",
+            ),
+        ),
+    ]

--- a/products/endpoints/backend/migrations/max_migration.txt
+++ b/products/endpoints/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0013_add_endpointversion_is_active
+0014_endpointversion_columns

--- a/products/endpoints/frontend/endpoint-tabs/EndpointQuery.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointQuery.tsx
@@ -63,9 +63,7 @@ export function EndpointQuery({ tabId }: EndpointQueryProps): JSX.Element {
         const variables = hogqlQuery.variables || {}
 
         const handleEditQuery = (): void => {
-            newTab(
-                urls.sqlEditor({ query: hogqlQuery.query, outputTab: OutputTab.Endpoint, endpointName: endpoint.name })
-            )
+            newTab(urls.sqlEditor({ endpointName: endpoint.name, outputTab: OutputTab.Endpoint }))
         }
 
         return (

--- a/products/endpoints/frontend/endpointLogic.tsx
+++ b/products/endpoints/frontend/endpointLogic.tsx
@@ -7,7 +7,7 @@ import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { debounce, slugify } from 'lib/utils'
-import { permanentlyMount } from 'lib/utils/kea-logic-builders'
+import { queryDatabaseLogic } from 'scenes/data-warehouse/editor/sidebar/queryDatabaseLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -198,6 +198,7 @@ export const endpointLogic = kea<endpointLogicType>([
                 actions.setEndpointName('')
                 actions.setEndpointDescription('')
                 actions.loadEndpoints()
+                queryDatabaseLogic.findMounted()?.actions.loadEndpoints()
                 lemonToast.success(<>Endpoint created</>, {
                     button: {
                         label: 'View',
@@ -243,6 +244,7 @@ export const endpointLogic = kea<endpointLogicType>([
             updateEndpointSuccess: ({ response, endpointName, options }) => {
                 actions.setEndpointDescription(null)
                 actions.loadEndpoints()
+                queryDatabaseLogic.findMounted()?.actions.loadEndpoints()
                 // Reload versions if we updated a specific version
                 if (options?.version) {
                     actions.loadVersions(endpointName)
@@ -318,5 +320,4 @@ export const endpointLogic = kea<endpointLogicType>([
             },
         }
     }),
-    permanentlyMount(),
 ])


### PR DESCRIPTION
## Problem

endpoints in the SQL editor were all over the place. they were showing both under Views and Endpoints, had no columns and editing was clunky.

## Changes

- **endpoint columns from the source**: `EndpointVersion.extract_columns()` parses HogQL SELECT columns + resolves types at creation time, stored as a `columns` JSONField. sidebar uses these as
fallback when schema table isn't available (for non-materialized sql-based endpoints)
- **dedicated endpoint editing flow**: `editEndpoint` action on `multitabEditorLogic` with proper tab state (`activeTab.endpoint`), `open_endpoint` URL param, stop-editing buttons —
replaces the `isUpdateMode`/`setSelectedEndpointName` pattern
- **endpoints loaded from their own API**: sidebar now fetches from `api.endpoint.list()` instead of relying on `DatabaseSchemaEndpointTable` from the schema query - key because **non-materialized endpoints don't have a table**!
- **backend endpoint filtering**: exclude endpoint-origin saved queries from `safely_get_queryset` in the saved queries API, remove all frontend `origin !== ENDPOINT` filters
(queryDatabaseLogic, viewsTabLogic, ViewsTab)
- migration: `0014_endpointversion_columns`

Before

[endpoints-in-sql-editor-before.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0cb8d2e7-2ff1-4318-93ff-7a03d196b3bc.mp4" />](https://app.graphite.com/user-attachments/video/0cb8d2e7-2ff1-4318-93ff-7a03d196b3bc.mp4)



After

[endpoints-in-sql-editor.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/176c02fd-5f2a-4221-9bab-9f9ed4910598.mp4" />](https://app.graphite.com/user-attachments/video/176c02fd-5f2a-4221-9bab-9f9ed4910598.mp4)

## How did you test this code?

- unit tests and locally checking everything over

## Publish to changelog?

no