### PR TITLE
Empty inbox icon

### DIFF
--- a/frontend/src/scenes/inbox/InboxScene.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconChevronRight, IconExpand } from '@posthog/icons'
+import { IconCheckCircle, IconChevronRight } from '@posthog/icons'
 import { LemonBadge, LemonButton, LemonSkeleton, LemonTag, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
@@ -144,7 +144,7 @@ function ReportRow({ report }: { report: SignalReport }): JSX.Element {
 function EmptyInbox(): JSX.Element {
     return (
         <div className="flex flex-col items-center justify-center py-16 text-center">
-            <IconExpand className="size-12 text-tertiary mb-4" />
+            <IconCheckCircle className="size-12 text-tertiary mb-4" />
             <h3 className="text-lg font-semibold mb-1">Your inbox is empty</h3>
             <p className="text-sm text-secondary max-w-md">
                 PostHog automatically analyzes user sessions and surfaces actionable reports here. Reports will appear


### PR DESCRIPTION
## Problem

The previous empty inbox icon (`IconExpand`) was semantically incorrect and confusing, as it resembled a dropdown or expand/collapse action rather than indicating an empty or completed state.

## Changes

Replaced `IconExpand` with `IconCheckCircle` in the `EmptyInbox` component within `InboxScene.tsx` to better represent an empty/completed inbox state.

## How did you test this code?

Manually verified the icon change in the UI by navigating to an empty inbox.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1771340809113209?thread_ts=1771340809.113209&cid=C09SK2PAGKF)

<p><a href="https://cursor.com/background-agent?bcId=bc-a1312bc2-160d-5c32-8f0b-acf0846635a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1312bc2-160d-5c32-8f0b-acf0846635a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

