### PR TITLE
fix(ph-ai): fixed properties query sr filters

### DIFF
--- a/ee/hogai/core/agent_modes/presets/session_replay.py
+++ b/ee/hogai/core/agent_modes/presets/session_replay.py
@@ -24,14 +24,14 @@ Assistant: I'll help you find those recordings. Let me create a todo list to ens
 *Creates todo list with the following items:*
 1. Use read_taxonomy to discover person properties for country filtering
 2. Use read_taxonomy to discover session properties for device type
-3. Use read_taxonomy to discover recording properties for errors
+3. Apply console_error_count recording filter (built-in, no discovery needed)
 4. Filter session recordings with the discovered properties
 *Begins working on the first task*
 """.strip()
 
 POSITIVE_EXAMPLE_FILTER_WITH_PROPERTIES_REASONING = """
 The assistant used the todo list because:
-1. Filtering session recordings requires discovering multiple property types (person, session, recording)
+1. Filtering session recordings requires discovering person and session properties (recording properties are built-in)
 2. Property names and values must be validated through read_taxonomy before creating filters
 3. The query involves multiple filter criteria that need to be combined
 4. The filter_session_recordings tool documentation explicitly requires using read_taxonomy for property discovery

--- a/ee/hogai/tools/replay/filter_session_recordings.py
+++ b/ee/hogai/tools/replay/filter_session_recordings.py
@@ -51,7 +51,9 @@ class FilterSessionRecordingsToolArgs(BaseModel):
         - Properties of specific events that occurred during the recording (e.g., URL visited, button clicked). **MUST use read_taxonomy to discover properties for specific event names.**
 
         **RECORDING PROPERTIES**:
-        - Recording-level metrics (console_error_count, click_count, activity_score). These are built-in and don't require discovery.
+        - Recording-level metrics: `console_error_count`, `click_count`, `keypress_count`, `mouse_activity_count`, `activity_score`. Use `type: "recording"`.
+        - These are built-in and don't require discovery via read_taxonomy.
+        - **CRITICAL**: These are NOT events. There are no events named `$keypress`, `$click`, or `$console_error`. Never use event-type filters for recording metrics.
 
         **CRITICAL**: ALWAYS use read_taxonomy to discover properties before creating filters. Never assume property names or values exist without verification. If you can't find an exact property match, try the next best match. Do not call the same tool twice for the same entity/event.
 
@@ -129,6 +131,7 @@ class FilterSessionRecordingsToolArgs(BaseModel):
         6. **Value types**: Arrays for "exact"/"is_not", single values for comparisons
         7. **Output format**: Valid JSON object only, no markdown or explanatory text
         8. **Silence**: Do not output when performing taxonomy exploration, just use the tools
+        9. **Recording properties are NOT events**: `keypress_count`, `click_count`, `console_error_count`, `mouse_activity_count`, `activity_score` always use `type: "recording"`. Events like `$keypress` or `$click` do not exist.
         """).strip()
     )
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -335,6 +335,8 @@ export function convertUniversalFiltersToRecordingsQuery(universalFilters: Recor
                     having_predicates.push(f)
                 } else if (f.key === 'comment_text') {
                     comment_text = f
+                } else {
+                    having_predicates.push(f)
                 }
             } else {
                 // Normalize filter value to ensure multi-select operators have array values

--- a/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -277,7 +277,7 @@ def convert_filters_to_recordings_query(filters: dict[str, Any]) -> RecordingsQu
             elif f.get("key") == "snapshot_source" and f.get("value"):
                 having_predicates.append(f)
             else:
-                properties.append(f)
+                having_predicates.append(asRecordingPropertyFilter(f))
         else:
             # For any other property filter
             properties.append(f)

--- a/products/replay/backend/prompts.py
+++ b/products/replay/backend/prompts.py
@@ -291,6 +291,7 @@ FILTER_EXAMPLES_PROMPT = """
 **Person**: `$geoip_country_code` (US/UK/FR), `$geoip_city_name`, custom fields
 **Event**: `$current_url`, `$event_type` ($rageclick/$pageview), `$pathname`
 **Recording**: `console_error_count`, `click_count`, `keypress_count`, `mouse_activity_count`, `activity_score`
+  Always use `"type": "recording"` for these. They are NOT events — `$keypress`, `$click`, `$console_error` do not exist as event names.
 
 # Special Patterns
 **Frustrated users (rageclicks)**:


### PR DESCRIPTION
## Problem

Session Recording metrics like `click_count`, `keypress_count` and others, are aggregate columns in the session recordings query, thjey should only exist in the `HAVING` clause.

When ph-ai put `keypress_count` with type: "recording" in the filter_group, we had a situation in which the query runner 

```
Couldn't strip it --> UnexpectedQueryProperties --> tried to apply WHERE clause --> wrong!
```

A filter like `keypress_count` >= xyz becomes a `HAVING`.

This should fix errors like the one reported by a customer [here](https://x.com/George_3d6/status/2023167551631761842) ; [internal thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1771263376087449)

## How did you test this code?

- [x] unit tests
- [x] manual tests

## Publish to changelog?

no
