### PR TITLE
feat: Detect CSP blocking for hedgehog mode and handle allowed violations

### DIFF
--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -201,8 +201,15 @@ function piiMaskingMenuItem(
 }
 
 function MoreMenu(): JSX.Element {
-    const { hedgehogModeEnabled, theme, posthog, piiMaskingEnabled, piiMaskingColor, piiWarning } =
-        useValues(toolbarLogic)
+    const {
+        hedgehogModeEnabled,
+        hedgehogModeAvailable,
+        theme,
+        posthog,
+        piiMaskingEnabled,
+        piiMaskingColor,
+        piiWarning,
+    } = useValues(toolbarLogic)
     const {
         setHedgehogModeEnabled,
         toggleTheme,
@@ -240,11 +247,14 @@ function MoreMenu(): JSX.Element {
                         {
                             icon: <>🦔</>,
                             label: hedgehogModeEnabled ? 'Disable hedgehog mode' : 'Hedgehog mode',
+                            disabledReason: !hedgehogModeAvailable
+                                ? "Hedgehog mode is disabled. Hedgehog mode uses `new Function` directives to render WebGL, and that requires 'unsafe-eval' in your Content Security Policy's script-src directive"
+                                : undefined,
                             onClick: () => {
                                 setHedgehogModeEnabled(!hedgehogModeEnabled)
                             },
                         },
-                        hedgehogModeEnabled
+                        hedgehogModeEnabled && hedgehogModeAvailable
                             ? {
                                   icon: <IconFlare />,
                                   label: 'Hedgehog options',

--- a/frontend/src/toolbar/hedgehog/HedgehogButton.tsx
+++ b/frontend/src/toolbar/hedgehog/HedgehogButton.tsx
@@ -5,7 +5,11 @@ import { HedgehogMode } from 'lib/components/HedgehogMode/HedgehogMode'
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
 
 export function HedgehogButton(): JSX.Element | null {
-    const { hedgehogModeEnabled } = useValues(toolbarLogic)
+    const { hedgehogModeEnabled, hedgehogModeAvailable } = useValues(toolbarLogic)
+
+    if (!hedgehogModeAvailable) {
+        return null
+    }
 
     return <HedgehogMode enabledOverride={hedgehogModeEnabled} />
 }


### PR DESCRIPTION
## Problem

The toolbar's hedgehog mode uses `new Function()` directives to render WebGL, which requires 'unsafe-eval' in the Content Security Policy's script-src directive. On sites with strict CSP settings, this causes hedgehog mode to break.

## Changes

- Added detection of CSP restrictions that block `new Function()` calls
- Disabled hedgehog mode UI when it cannot function due to CSP restrictions
- Added explanatory tooltip when hedgehog mode is unavailable
- Improved the CSP evaluation check script to allow for known/expected violations from dependencies
- Created a whitelist of allowed CSP violations with documentation of their sources

## How did you test this code?

Tested on sites with different CSP configurations:
- Sites with no CSP restrictions (hedgehog mode works normally)
- Sites with strict CSP that blocks `new Function()` (hedgehog mode properly disabled with tooltip)
- Verified the updated CSP check script correctly identifies and reports violations