### PR TITLE
feat(product tours): make dismissOnClickOutside user-configurable

### DIFF
--- a/frontend/src/scenes/product-tours/editor/TourSettingsPanel.tsx
+++ b/frontend/src/scenes/product-tours/editor/TourSettingsPanel.tsx
@@ -213,6 +213,14 @@ export function TourSettingsPanel({ tourId }: TourSettingsPanelProps): JSX.Eleme
                     </div>
 
                     <div className="flex items-center justify-between">
+                        <span className="text-sm">Dismiss on outside clicks</span>
+                        <LemonSwitch
+                            checked={currentAppearance.dismissOnClickOutside ?? true}
+                            onChange={(dismissOnClickOutside) => updateAppearance({ dismissOnClickOutside })}
+                        />
+                    </div>
+
+                    <div className="flex items-center justify-between">
                         <Tooltip title="Branding only appears on the first step">
                             <span className="text-sm border-b border-dashed border-current">Remove branding</span>
                         </Tooltip>


### PR DESCRIPTION
## Problem

users cannot configure whether their tours dismiss on outside clicks

closes https://github.com/PostHog/posthog/issues/48130#issue-3950744261

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

expose that config option :)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->