### PR TITLE
fix(local-dev): add observability docker profile to logs ingestion

### DIFF
--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -112,7 +112,7 @@ capabilities:
     nodejs_logs:
         description: 'Node.js Logs - log ingestion'
         requires: [event_ingestion]
-        docker_profiles: []
+        docker_profiles: [observability]
 
     nodejs_feature_flags:
         description: 'Node.js Feature Flags - evaluation scheduler'


### PR DESCRIPTION
## Problem

logs was missing the required observability stack from the docker-compose

## Changes

add observability to log ingestion's docker-profiles
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
