### PR TITLE
chore(endpoints): cleanup endpoints in SQL editor sources

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -149,6 +149,8 @@ export const QueryDatabase = (): JSX.Element => {
                 return 'materialized view'
             case 'managed-view':
                 return 'managed view'
+            case 'endpoint':
+                return 'materialized endpoint'
             case 'view':
             case 'view-table':
                 return item.record.view?.is_materialized ? 'materialized view' : 'view'
@@ -377,6 +379,35 @@ export const QueryDatabase = (): JSX.Element => {
                     )
                 }
 
+                // Show menu for endpoint tables
+                if (item.record?.type === 'endpoint') {
+                    const tableName = item.record.tableName
+                    return (
+                        <DropdownMenuGroup>
+                            <DropdownMenuItem
+                                asChild
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    router.actions.push(urls.endpoint(item.name))
+                                }}
+                            >
+                                <ButtonPrimitive menuItem>Edit endpoint</ButtonPrimitive>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                                asChild
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    sceneLogic.actions.newTab(
+                                        urls.sqlEditor({ query: `SELECT * FROM \`${tableName}\`` })
+                                    )
+                                }}
+                            >
+                                <ButtonPrimitive menuItem>Query</ButtonPrimitive>
+                            </DropdownMenuItem>
+                        </DropdownMenuGroup>
+                    )
+                }
+
                 // Show menu for views
                 if (item.record?.type === 'view' || item.record?.type === 'managed-view') {
                     // Extract view ID from item.id (format: 'view-{id}' or 'search-view-{id}')
@@ -548,7 +579,7 @@ export const QueryDatabase = (): JSX.Element => {
             }}
             renderItemTooltip={(item) => {
                 // Show tooltip with full name for items that could be truncated
-                const tooltipTypes = ['table', 'view', 'managed-view', 'draft', 'column', 'unsaved-query']
+                const tooltipTypes = ['table', 'view', 'managed-view', 'endpoint', 'draft', 'column', 'unsaved-query']
                 if (tooltipTypes.includes(item.record?.type)) {
                     if (item.record?.type === 'column' && item.record?.field?.type === 'field_traverser') {
                         const traversalChain = formatTraversalChain(item.record.field.chain)

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -486,6 +486,7 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
                 ),
             )
             .exclude(deleted=True)
+            .exclude(origin=DataWarehouseSavedQuery.Origin.ENDPOINT)
             .order_by(self.ordering)
         )
 


### PR DESCRIPTION
## Problem

endpoints in the SQL editor were all over the place. they were showing both under Views and Endpoints, had no columns and editing was clunky.

## Changes

- show endpoints under views - once, only the latest version
- exclude endpoints from SavedQuery get_queryset()

![image.png](https://app.graphite.com/user-attachments/assets/b53bd814-aee9-403f-96d6-d5665d0b5c82.png)



## How did you test this code?

- unit tests and locally checking everything over

## Publish to changelog?

no