### PR TITLE
feat: Support navigation to top-level settings sections

### DIFF
--- a/frontend/src/scenes/settings/settingsLogic.ts
+++ b/frontend/src/scenes/settings/settingsLogic.ts
@@ -209,14 +209,18 @@ export const settingsLogic = kea<settingsLogicType>([
         navigateToSetting: ({ sectionId, settingId }) => {
             const section = values.sections.find((s) => s.id === sectionId)
             if (section) {
-                actions.selectSection(sectionId, section.level)
                 actions.setSearchTerm('')
-                setTimeout(() => {
-                    const element = document.getElementById(settingId)
-                    if (element) {
-                        element.scrollIntoView({ behavior: 'smooth', block: 'start' })
-                    }
-                }, 200)
+                if (section.to) {
+                    router.actions.push(section.to)
+                } else {
+                    actions.selectSection(sectionId, section.level)
+                    setTimeout(() => {
+                        const element = document.getElementById(settingId)
+                        if (element) {
+                            element.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                        }
+                    }, 200)
+                }
             }
         },
     })),
@@ -463,6 +467,24 @@ export const settingsLogic = kea<settingsLogicType>([
                             description:
                                 setting.searchDescription ??
                                 (typeof setting.description === 'string' ? setting.description : ''),
+                        })
+                    }
+                }
+
+                // Index sections that are top-level links with no settings (e.g. Billing)
+                for (const section of sections) {
+                    if (section.settings.length === 0) {
+                        const sectionTitle =
+                            typeof section.title === 'string' ? section.title : section.id.replace(/[-]/g, ' ')
+
+                        entries.push({
+                            settingId: section.id as SettingId,
+                            settingTitle: sectionTitle,
+                            sectionId: section.id,
+                            sectionTitle,
+                            level: section.level,
+                            keywords: '',
+                            description: '',
                         })
                     }
                 }


### PR DESCRIPTION
## Problem

When navigating to settings, sections that are top-level links with no settings (like Billing) are not properly handled in the search functionality. Additionally, when navigating to a section that has a direct URL (`to` property), the logic doesn't redirect to that URL.

## Changes

- Enhanced the `navigateToSetting` function to check if a section has a direct URL (`to` property) and use router navigation in that case
- Added indexing for top-level sections with no settings to make them searchable in the settings search functionality
- Improved search capabilities by including section titles in the search index even when they don't have specific settings

## How did you test this code?

Tested by navigating to various settings sections, including those with direct URLs and those without settings. Verified that search functionality now properly finds and navigates to top-level sections like Billing.

## Publish to changelog?

No