### PR TITLE
fix(ingestion): events w/cookieless sentinel distinct ID can be processed without translation

### DIFF
--- a/nodejs/src/ingestion/cookieless/cookieless-manager.test.ts
+++ b/nodejs/src/ingestion/cookieless/cookieless-manager.test.ts
@@ -700,21 +700,20 @@ describe('CookielessManager', () => {
             })
 
             it('should DLQ event when pass 3 re-hash fails due to day boundary race, not leak sentinel distinct_id', async () => {
-                let callCount = 0
+                // Batch has one cookieless event: pass 1 calls doHashForDay once (base hash),
+                // pass 3 calls it once (final hash with identify offset). We let pass 1 succeed
+                // then fail pass 3 to simulate a day-boundary race.
                 const originalDoHashForDay = hub.cookielessManager.doHashForDay.bind(hub.cookielessManager)
-                jest.spyOn(hub.cookielessManager, 'doHashForDay').mockImplementation(async (args) => {
-                    callCount++
-                    if (callCount === 2) {
-                        // Simulate day-boundary race: pass 1 succeeded but pass 3 re-hash fails
-                        return { success: false, reason: 'date_out_of_range' }
-                    }
-                    return originalDoHashForDay(args)
-                })
+                const spy = jest
+                    .spyOn(hub.cookielessManager, 'doHashForDay')
+                    .mockImplementationOnce((args) => originalDoHashForDay(args))
+                    .mockImplementationOnce(() => Promise.resolve({ success: false, reason: 'date_out_of_range' }))
 
                 const response = await hub.cookielessManager.doBatch([
                     { event, team, message, headers: createTestEventHeaders() },
                     { event: nonCookielessEvent, team, message, headers: createTestEventHeaders() },
                 ])
+                spy.mockRestore()
                 expect(response.length).toBe(2)
 
                 // Cookieless event should be DLQ'd, NOT ok with sentinel distinct_id
@@ -729,6 +728,57 @@ describe('CookielessManager', () => {
                 expect(nonCookielessResult.type).toBe(PipelineResultType.OK)
                 if (nonCookielessResult.type === PipelineResultType.OK) {
                     expect(nonCookielessResult.value.event).toBe(nonCookielessEvent)
+                }
+            })
+
+            it('should not inflate identify count for sibling events when $identify is DLQd in same batch', async () => {
+                // Process an anon event alone to get the baseline distinct_id at n=0
+                const baseline = await processEvent(event)
+                if (!baseline?.properties) {
+                    throw new Error('no event or properties')
+                }
+                const baselineDistinctId = baseline.distinct_id
+
+                // Batch: [identifyEvent, eventABitLater]. The identify's pass 3 re-hash
+                // is failed. The anon event should still hash with n=0 (matching baseline),
+                // not n=1 from a prematurely recorded identify.
+                //
+                // doHashForDay call sequence in doBatch:
+                //   call 1: pass 1 base hash for identifyEvent
+                //   call 2: pass 1 base hash for eventABitLater
+                //   call 3: pass 3 re-hash for identifyEvent  ← fail this one
+                //   call 4: pass 3 re-hash for eventABitLater ← should succeed
+                let callCount = 0
+                const originalDoHashForDay = hub.cookielessManager.doHashForDay.bind(hub.cookielessManager)
+                const spy = jest.spyOn(hub.cookielessManager, 'doHashForDay').mockImplementation((args) => {
+                    callCount++
+                    if (callCount === 3) {
+                        return Promise.resolve({ success: false, reason: 'date_out_of_range' })
+                    }
+                    return originalDoHashForDay(args)
+                })
+
+                const response = await hub.cookielessManager.doBatch([
+                    { event: identifyEvent, team, message, headers: createTestEventHeaders() },
+                    { event: eventABitLater, team, message, headers: createTestEventHeaders() },
+                ])
+                spy.mockRestore()
+                expect(response.length).toBe(2)
+                expect(callCount).toBe(4)
+
+                // $identify should be DLQ'd
+                const identifyResult = response[0]
+                expect(identifyResult.type).toBe(PipelineResultType.DLQ)
+                if (identifyResult.type === PipelineResultType.DLQ) {
+                    expect(identifyResult.reason).toBe('cookieless_unexpected_date_validation_failure')
+                }
+
+                // Anon event should succeed with the same distinct_id as baseline (n=0),
+                // not a different one caused by an inflated identify count
+                const anonResult = response[1]
+                expect(anonResult.type).toBe(PipelineResultType.OK)
+                if (anonResult.type === PipelineResultType.OK) {
+                    expect(anonResult.value.event.distinct_id).toEqual(baselineDistinctId)
                 }
             })
         })


### PR DESCRIPTION
## Problem
We have a corner case where `$posthog_cookieless` events can be passed forward for post processing (including Person creation/association) without having the distinct ID reformulated
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Fix cookieless handling bug
* New test to ensure proper handling of corner case
* Bonus: investigation surfaced another corner case in identify cache handling that is also fixed and tested 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
