### PR TITLE
feat(web-analytics): add inline filter chips on breakdown tables

### DIFF
--- a/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
+++ b/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
@@ -78,7 +78,7 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
         if (firstSlackIntegration) {
             loadAllSlackChannels()
         }
-    }, [firstSlackIntegration?.id, loadAllSlackChannels])
+    }, [firstSlackIntegration?.id, loadAllSlackChannels, firstSlackIntegration])
 
     const handleAdd = (): void => {
         if (selectedType === ALERT_NOTIFICATION_TYPE_SLACK) {

--- a/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
+++ b/frontend/src/lib/components/Alerts/views/InlineAlertNotifications.tsx
@@ -78,7 +78,7 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
         if (firstSlackIntegration) {
             loadAllSlackChannels()
         }
-    }, [firstSlackIntegration?.id, loadAllSlackChannels, firstSlackIntegration])
+    }, [firstSlackIntegration?.id, loadAllSlackChannels])
 
     const handleAdd = (): void => {
         if (selectedType === ALERT_NOTIFICATION_TYPE_SLACK) {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -401,6 +401,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_FILTERS_V2: 'web-analytics-filters-v2', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_SESSION_PROPERTY_CHARTS: 'web-analytics-session-property-charts', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_TILE_TOGGLES: 'web-analytics-tile-toggles', // owner: @lricoy #team-web-analytics
+    WEB_ANALYTICS_DRILL_DOWN: 'web-analytics-drill-down', // owner: @jabahamondes #team-web-analytics
     WEB_ANALYTICS_REGIONS_MAP: 'web-analytics-regions-map', // owner: @jordanm-posthog #team-web-analytics
     WORKFLOWS_BATCH_TRIGGERS: 'workflows-batch-triggers', // owner: #team-workflows
     WORKFLOWS_INTERNAL_EVENT_FILTERS: 'workflows-internal-event-filters', // owner: @haven #team-workflows

--- a/frontend/src/scenes/web-analytics/common.ts
+++ b/frontend/src/scenes/web-analytics/common.ts
@@ -410,6 +410,53 @@ export const webStatsBreakdownToPropertyName = (
     }
 }
 
+/** Property keys relevant to each tile, used to show filter chips across all tabs within a tile. */
+export const TILE_PROPERTY_KEYS: Partial<Record<TileId, Set<string>>> = {
+    [TileId.SOURCES]: new Set([
+        '$channel_type',
+        '$entry_referring_domain',
+        '$entry_utm_source',
+        '$entry_utm_campaign',
+        '$entry_utm_medium',
+        '$entry_utm_content',
+        '$entry_utm_term',
+    ]),
+    [TileId.DEVICES]: new Set(['$device_type', '$browser', '$os', '$viewport_width', '$viewport_height']),
+    [TileId.GEOGRAPHY]: new Set([
+        '$geoip_country_code',
+        '$geoip_subdivision_1_code',
+        '$geoip_city_name',
+        '$browser_language',
+        '$timezone_offset',
+    ]),
+    [TileId.PATHS]: new Set(['$pathname', '$entry_pathname', '$end_pathname', '$last_external_click_url']),
+}
+
+/** Human-readable labels for property keys, shown as prefixes on filter chips. */
+export const PROPERTY_KEY_LABELS: Record<string, string> = {
+    $channel_type: 'Channel',
+    $entry_referring_domain: 'Referrer',
+    $entry_utm_source: 'UTM source',
+    $entry_utm_medium: 'UTM medium',
+    $entry_utm_campaign: 'UTM campaign',
+    $entry_utm_content: 'UTM content',
+    $entry_utm_term: 'UTM term',
+    $device_type: 'Device',
+    $browser: 'Browser',
+    $os: 'OS',
+    $viewport_width: 'Width',
+    $viewport_height: 'Height',
+    $geoip_country_code: 'Country',
+    $geoip_subdivision_1_code: 'Region',
+    $geoip_city_name: 'City',
+    $browser_language: 'Language',
+    $timezone_offset: 'Timezone',
+    $pathname: 'Path',
+    $entry_pathname: 'Entry path',
+    $end_pathname: 'Exit path',
+    $last_external_click_url: 'Exit click',
+}
+
 export const getWebAnalyticsBreakdownFilter = (breakdown: WebStatsBreakdown): BreakdownFilter | undefined => {
     const property = webStatsBreakdownToPropertyName(breakdown)
 


### PR DESCRIPTION
## Problem

When a filter is applied (by clicking a row or from the global filter bar), there's no visual feedback on the table itself showing what's active. Users can't tell at a glance which filters are applied to a given tile, nor remove them inline.

## Changes

- **Filter chips**: Each breakdown tile (Sources, Devices, Geography, Paths) now shows `LemonTag` chips above the table when filters matching that tile's properties are active. Chips are closable to remove the filter.
- **Cross-tab persistence**: Chips persist across tabs within a tile (e.g., filtering by Channel stays visible when switching to UTM Source tab) via `TILE_PROPERTY_KEYS` mapping.
- **Bidirectional**: Chips reflect filters applied from any source (row click, global filter bar, URL params).
- **Labeled chips**: Property keys get human-readable labels (e.g., `$viewport_width` → "Width: 1920", `$entry_referring_domain` → "Referrer: google.com").
- **Shared hook + component**: Extracted `useActiveChipFilters(tileId)` hook and `<ActiveFilterChips />` component to avoid duplication between `WebStatsTrendTile` and `WebStatsTableTile`.
- **Feature flag**: All chip rendering is behind `web-analytics-drill-down`.

## How did you test this code?

- Enabled `web-analytics-drill-down` feature flag
- Clicked rows in Sources, Devices, Geography tables → chips appear
- Verified chips persist when switching tabs within a tile
- Verified clicking ✕ on a chip removes the filter
- Verified chips appear when filters are set from the global filter bar
- Verified UTM s/m/c referrer prefix shows correct label ("Referrer" vs "UTM source")
- TypeScript check passes with no new errors

<img width="1294" height="359" alt="image" src="https://github.com/user-attachments/assets/9fd44fca-3ffe-42b6-93e9-cf25f306f167" />


## Publish to changelog?

no