### PR TITLE
fix(insights): prevent selecting dwh events as inline events

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterGroup/ActionFilterGroup.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterGroup/ActionFilterGroup.tsx
@@ -73,9 +73,11 @@ export function ActionFilterGroup({
     insightType,
 }: ActionFilterGroupProps): JSX.Element {
     const showQuickFilters = useFeatureFlag('TAXONOMIC_QUICK_FILTERS', 'test')
-    const effectiveActionsTaxonomicGroupTypes = showQuickFilters
-        ? [TaxonomicFilterGroupType.SuggestedFilters, ...actionsTaxonomicGroupTypes]
-        : actionsTaxonomicGroupTypes
+    const effectiveActionsTaxonomicGroupTypes = (
+        showQuickFilters
+            ? [TaxonomicFilterGroupType.SuggestedFilters, ...actionsTaxonomicGroupTypes]
+            : actionsTaxonomicGroupTypes
+    ).filter((groupType) => groupType !== TaxonomicFilterGroupType.DataWarehouse)
 
     const { currentTeamId } = useValues(teamLogic)
     const { removeLocalFilter, splitLocalFilter } = useActions(entityFilterLogic({ typeKey }))
@@ -276,7 +278,9 @@ export function ActionFilterGroup({
                                     hasBreakdown={hasBreakdown}
                                     disabled={disabled || readOnly}
                                     readOnly={readOnly}
-                                    actionsTaxonomicGroupTypes={actionsTaxonomicGroupTypes}
+                                    actionsTaxonomicGroupTypes={actionsTaxonomicGroupTypes.filter(
+                                        (t: TaxonomicFilterGroupType) => t !== TaxonomicFilterGroupType.DataWarehouse
+                                    )}
                                     trendsDisplayCategory={trendsDisplayCategory}
                                     showNumericalPropsOnly={showNumericalPropsOnly}
                                     dataWarehousePopoverFields={dataWarehousePopoverFields}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -256,6 +256,9 @@ export function ActionFilterRow({
     // Only use the funnel results when in funnel context
     const isStepOptional = isFunnelContext ? funnelIsStepOptional : () => false
 
+    // DWH events are not supported in inline events yet
+    const canCombine = showCombine && filter.type !== EntityTypes.DATA_WAREHOUSE
+
     const [isHogQLDropdownVisible, setIsHogQLDropdownVisible] = useState(false)
     const [isMenuVisible, setIsMenuVisible] = useState(false)
 
@@ -544,7 +547,7 @@ export function ActionFilterRow({
         !readOnly && !showPopupMenu
             ? [
                   !hideFilter && propertyFiltersButton,
-                  showCombine && combineInlineButton,
+                  canCombine && combineInlineButton,
                   !hideRename && renameRowButton,
                   !hideDuplicate && !singleFilter && duplicateRowButton,
                   !hideDeleteBtn && !singleFilter && deleteButton,
@@ -706,7 +709,7 @@ export function ActionFilterRow({
                                 {showPopupMenu ? (
                                     <>
                                         {!hideFilter && propertyFiltersButton}
-                                        {showCombine && combineInlineButton}
+                                        {canCombine && combineInlineButton}
                                         <div className="relative">
                                             <LemonMenu
                                                 placement={isTrendsContext ? 'bottom-end' : 'bottom-start'}

--- a/posthog/hogql_queries/insights/trends/utils.py
+++ b/posthog/hogql_queries/insights/trends/utils.py
@@ -87,6 +87,9 @@ def group_node_to_expr(group: GroupNode, team: Team) -> ast.Expr | None:
                 group_filters.append(node_expr)
             except Action.DoesNotExist:
                 pass
+        elif isinstance(node, DataWarehouseNode):
+            # TODO: Support DWH nodes in groups
+            pass
 
     if len(group_filters) == 0:
         return None
@@ -96,8 +99,5 @@ def group_node_to_expr(group: GroupNode, team: Team) -> ast.Expr | None:
 
     if group.operator == "OR":
         return ast.Or(exprs=group_filters)
-
-    if group.operator == "AND":
-        return ast.And(exprs=group_filters)
 
     return None


### PR DESCRIPTION
## Problem

Currently, we do not support combining DWH events. 
However, the UI allows users to select and group them, which leads to incorrect trends. 

Added as a future improvement in #42837 

## Changes

Hide the "combine" icon for DWH events, and do not allow DWH events to be selected as inline events.

## How did you test this code?

Manually

## Publish to changelog?

No