### PR TITLE
chore(cli): bump cargo-dist to v0.30.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
               # we specify bash to get pipefail; it guards against the `curl` command
               # failing. otherwise `sh` won't catch that `curl` returned non-0
               shell: bash
-              run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
+              run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.4/cargo-dist-installer.sh | sh"
             - name: Cache dist
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -6,7 +6,7 @@ members = ["cargo:./cli"]
 # Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.3"
+cargo-dist-version = "0.30.4"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app


### PR DESCRIPTION
## Summary

- Bumps cargo-dist from v0.30.3 to v0.30.4 in `dist-workspace.toml` and `.github/workflows/release.yml`
- Resolves CVE-2026-25547 (`@isaacs/brace-expansion` < 5.0.1) which was pinned in cargo-dist's static `npm-shrinkwrap.json` template and could not be overridden by end users
- Ref: https://github.com/axodotdev/cargo-dist/pull/2288

A follow-up CLI version bump + release will be needed to publish the fix to npm.

## Test plan

- [ ] Verify release workflow still runs on PR (plan step)
- [ ] After merge, cut a new CLI release to publish fixed npm package

🤖 Generated with [Claude Code](https://claude.com/claude-code)