### PR TITLE
fix(persons): person deletion bug during distinct id reset

### DIFF
--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -1371,7 +1371,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
         # Verify: PG distinct_id version was bumped
         pg_distinct_id = PersonDistinctId.objects.get(team_id=self.team.pk, distinct_id="distinct_id")
-        assert pg_distinct_id.version > 107
+        assert (pg_distinct_id.version or 0) > 107
 
         # Verify: CH distinct_id is reset
         ch_pdi = sync_execute(

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -1326,100 +1326,82 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json()["detail"] == "Not found."
 
-    @mock.patch(
-        f"{posthog.models.person.deletion.__name__}.create_person_distinct_id",
-        wraps=posthog.models.person.deletion.create_person_distinct_id,
-    )
     @pytest.mark.flaky(reruns=2)
-    def test_reset_person_distinct_id(self, mocked_ch_call):
-        # clickhouse only deleted person and distinct id that should be updated
-        ch_only_deleted_person_uuid = create_person(
-            uuid=str(uuid4()),
+    def test_reset_person_distinct_id(self):
+        # Simulate the real-world scenario: person deleted in CH (soft delete with high version),
+        # then the same distinct_id is reused which creates a new person in PG with the same
+        # deterministic UUID. The new person's CH row has a lower version than the deletion,
+        # so ReplacingMergeTree keeps the deleted state.
+        shared_uuid = str(uuid4())
+
+        # Phase 1: Person and distinct_id exist in CH as deleted
+        create_person(
+            uuid=shared_uuid,
             team_id=self.team.pk,
             is_deleted=True,
-            version=5,
+            version=105,
             sync=True,
         )
         create_person_distinct_id(
             team_id=self.team.pk,
             distinct_id="distinct_id",
-            person_id=ch_only_deleted_person_uuid,
+            person_id=shared_uuid,
             is_deleted=True,
-            version=7,
+            version=107,
             sync=True,
         )
-        create_person_distinct_id(
-            team_id=self.team.pk,
-            distinct_id="distinct_id-2",
-            person_id=ch_only_deleted_person_uuid,
-            is_deleted=False,
-            version=9,
-            sync=True,
-        )
-        # reuse
-        person_linked_to_after = Person.objects.create(
-            team_id=self.team.pk, properties={"abcdefg": 11112}, version=1, uuid=uuid4()
-        )
+
+        # Phase 2: New event reuses the distinct_id, creating a new person in PG
+        # with the same deterministic UUID. The signal writes to CH with version=0,
+        # which is ignored because 0 < 105.
+        person = Person.objects.create(team_id=self.team.pk, properties={"abcdefg": 11112}, version=0, uuid=shared_uuid)
         PersonDistinctId.objects.create(
             team_id=self.team.pk,
-            person=person_linked_to_after,
+            person=person,
             distinct_id="distinct_id",
             version=0,
         )
-        PersonDistinctId.objects.create(
-            team_id=self.team.pk,
-            person=person_linked_to_after,
-            distinct_id="distinct_id-2",
-            version=0,
-        )
 
-        distinct_id_version = posthog.models.person.deletion._get_version_for_distinct_id(self.team.pk, "distinct_id")
-
+        # Phase 3: Reset
         response = self.client.post(
             f"/api/projects/{self.team.pk}/persons/reset_person_distinct_id/",
-            {
-                "distinct_id": "distinct_id",
-            },
+            {"distinct_id": "distinct_id"},
         )
-
         assert response.status_code == status.HTTP_202_ACCEPTED
 
-        # postgres
-        pg_distinct_ids = PersonDistinctId.objects.all()
-        self.assertEqual(len(pg_distinct_ids), 2)
+        # Verify: PG distinct_id version was bumped
+        pg_distinct_id = PersonDistinctId.objects.get(team_id=self.team.pk, distinct_id="distinct_id")
+        assert pg_distinct_id.version > 107
 
-        self.assertEqual(pg_distinct_ids[0].distinct_id, "distinct_id-2")
-        self.assertEqual(pg_distinct_ids[0].version, 0)
-        self.assertEqual(pg_distinct_ids[1].distinct_id, "distinct_id")
-        assert (pg_distinct_ids[1].version or 0) > distinct_id_version
-
-        self.assertEqual(pg_distinct_ids[0].person.uuid, person_linked_to_after.uuid)
-        self.assertEqual(pg_distinct_ids[1].person.uuid, person_linked_to_after.uuid)
-
-        # CH
-        ch_person_distinct_ids = sync_execute(
+        # Verify: CH distinct_id is reset
+        ch_pdi = sync_execute(
             f"""
-            SELECT person_id, team_id, distinct_id, version, is_deleted FROM {PERSON_DISTINCT_ID2_TABLE} FINAL WHERE team_id = %(team_id)s and distinct_id ='distinct_id' ORDER BY version, distinct_id
+            SELECT person_id, version, is_deleted
+            FROM {PERSON_DISTINCT_ID2_TABLE} FINAL
+            WHERE team_id = %(team_id)s AND distinct_id = 'distinct_id'
             """,
             {"team_id": self.team.pk},
         )
+        self.assertEqual(len(ch_pdi), 1)
+        self.assertEqual(ch_pdi[0][2], 0)  # is_deleted
+        assert ch_pdi[0][1] > 107  # version beats deletion
 
-        self.assertEqual(
-            ch_person_distinct_ids,
-            [
-                (person_linked_to_after.uuid, self.team.pk, "distinct_id", pg_distinct_ids[1].version, False),
-            ],
+        # Verify: CH person is also reset (the core bug fix)
+        ch_person = sync_execute(
+            """
+            SELECT argMax(is_deleted, version), max(version)
+            FROM person FINAL
+            WHERE team_id = %(team_id)s AND id = %(person_id)s
+            """,
+            {"team_id": self.team.pk, "person_id": shared_uuid},
         )
-        self.assertEqual(mocked_ch_call.call_count, 1)
-        # Second call has nothing to do
-        response = self.client.post(
-            f"/api/projects/{self.team.pk}/persons/reset_distinct_id/",
-            {
-                "distinct_id": "distinct_id",
-            },
-        )
+        self.assertEqual(len(ch_person), 1)
+        self.assertEqual(ch_person[0][0], 0)  # is_deleted
+        assert ch_person[0][1] > 105  # version beats deletion
 
-        self.assertEqual(mocked_ch_call.call_count, 1)
+        # Verify: PG person version is updated so future plugin-server updates aren't ignored
+        person.refresh_from_db()
+        assert person.version > 105
 
     @mock.patch(
         f"{posthog.models.person.deletion.__name__}.create_person_distinct_id",

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -1386,7 +1386,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(ch_pdi[0][2], 0)  # is_deleted
         assert ch_pdi[0][1] > 107  # version beats deletion
 
-        # Verify: CH person is also reset (the core bug fix)
+        # Verify: CH person is also reset
         ch_person = sync_execute(
             """
             SELECT argMax(is_deleted, version), max(version)

--- a/posthog/models/person/deletion.py
+++ b/posthog/models/person/deletion.py
@@ -117,7 +117,7 @@ def _get_person_version_if_deleted(team_id: int, person_uuid: str) -> Optional[i
         """,
         {"team_id": team_id, "person_id": person_uuid},
     )
-    if len(rows) == 0 or rows[0][0] is None:
+    if len(rows) == 0:
         return None
     max_version, is_deleted = rows[0]
     if not is_deleted:
@@ -136,7 +136,7 @@ def _reset_person_in_clickhouse(team_id: int, person: Person, db_alias: str) -> 
 
     # Update Postgres version so future updates from the plugin-server
     # (which reads version from Postgres) won't be ignored by ClickHouse
-    Person.objects.using(db_alias).filter(pk=person.pk).update(version=new_version)
+    Person.objects.using(db_alias).filter(pk=person.pk, version__lt=new_version).update(version=new_version)
 
     create_person(
         uuid=person_uuid,

--- a/posthog/models/person/deletion.py
+++ b/posthog/models/person/deletion.py
@@ -6,8 +6,8 @@ import structlog
 from rest_framework.exceptions import NotFound
 
 from posthog.clickhouse.client import sync_execute
-from posthog.models.person import PersonDistinctId
-from posthog.models.person.util import create_person_distinct_id
+from posthog.models.person import Person, PersonDistinctId
+from posthog.models.person.util import create_person, create_person_distinct_id
 
 logger = structlog.get_logger(__name__)
 
@@ -64,6 +64,7 @@ def _get_version_for_distinct_id(team_id: int, distinct_id: str) -> int:
 def _updated_distinct_ids(team_id: int, distinct_id_versions: list[tuple[str, int]]):
     # Determine the correct database for PersonDistinctId writes (handles persons_db_writer routing in production)
     db_alias = router.db_for_write(PersonDistinctId) or "default"
+    reset_person_uuids: set[str] = set()
 
     for distinct_id, version in distinct_id_versions:
         # this can throw but this script can safely be re-run as
@@ -76,13 +77,22 @@ def _updated_distinct_ids(team_id: int, distinct_id_versions: list[tuple[str, in
 
         # Update ClickHouse via Kafka message
         if person_distinct_id:
+            person_uuid = str(person_distinct_id.person.uuid)
+
             create_person_distinct_id(
                 team_id=team_id,
                 distinct_id=distinct_id,
-                person_id=str(person_distinct_id.person.uuid),
+                person_id=person_uuid,
                 version=version,
                 is_deleted=False,
             )
+
+            # Also reset the person record in ClickHouse — the soft-deleted person row
+            # has a high version that causes ReplacingMergeTree to keep the deleted state,
+            # making the person invisible to analytics queries
+            if person_uuid not in reset_person_uuids:
+                reset_person_uuids.add(person_uuid)
+                _reset_person_in_clickhouse(team_id, person_distinct_id.person, db_alias)
 
 
 def _update_distinct_id_in_postgres(distinct_id: str, version: int, team_id: int) -> Optional[PersonDistinctId]:
@@ -95,3 +105,45 @@ def _update_distinct_id_in_postgres(distinct_id: str, version: int, team_id: int
     person_distinct_id.version = version
     person_distinct_id.save()
     return person_distinct_id
+
+
+def _get_person_version_if_deleted(team_id: int, person_uuid: str) -> Optional[int]:
+    """Returns the max version if the person is soft-deleted in ClickHouse, None otherwise."""
+    rows = sync_execute(
+        """
+            SELECT max(version), argMax(is_deleted, version)
+            FROM person
+            WHERE team_id = %(team_id)s AND id = %(person_id)s
+        """,
+        {"team_id": team_id, "person_id": person_uuid},
+    )
+    if len(rows) == 0 or rows[0][0] is None:
+        return None
+    max_version, is_deleted = rows[0]
+    if not is_deleted:
+        return None
+    return max_version
+
+
+def _reset_person_in_clickhouse(team_id: int, person: Person, db_alias: str) -> None:
+    person_uuid = str(person.uuid)
+    max_version = _get_person_version_if_deleted(team_id, person_uuid)
+    if max_version is None:
+        return
+
+    new_version = max_version + 100
+    logger.info(f"Resetting person {person_uuid} in ClickHouse to version {new_version}")
+
+    # Update Postgres version so future updates from the plugin-server
+    # (which reads version from Postgres) won't be ignored by ClickHouse
+    Person.objects.using(db_alias).filter(pk=person.pk).update(version=new_version)
+
+    create_person(
+        uuid=person_uuid,
+        team_id=team_id,
+        version=new_version,
+        properties=person.properties,
+        is_identified=person.is_identified,
+        is_deleted=False,
+        created_at=person.created_at,
+    )


### PR DESCRIPTION
## Problem

When a person is deleted and their distinct ID is later reused,
the reset endpoint (`POST /api/projects/{id}/persons/reset_person_distinct_id`) only fixes the `person_distinct_id2` table in ClickHouse.
The `person` table is left with `is_deleted=1` at a high version, making the person invisible to all analytics queries.

Here's the full sequence that triggers the bug:

1. **Delete person** — Postgres hard-deletes the records. ClickHouse soft-deletes with `is_deleted=1, version=original+100`.
2. **New event reuses the distinct ID** — Because PostHog uses deterministic UUIDs (`uuid5(namespace, "team_id:distinct_id")`),
   the new person gets the same UUID as the deleted one. Postgres creates the person with `version=0`.
   ClickHouse receives the creation message but ignores it because `version 0 < version 100`.
3. **Call reset** — The reset endpoint bumps the `person_distinct_id2` version above the deletion, fixing that mapping.
   But the `person` record in ClickHouse still has `is_deleted=1` at the high deletion version — the person remains invisible.

As a secondary consequence, the Postgres person stays at `version=0` while ClickHouse has the person at `version=100`.
Any future person property updates from the plugin-server (which reads version from Postgres and increments by 1)
would also be silently ignored by ClickHouse.


## Changes

**`posthog/models/person/deletion.py`**

- Added `_get_person_version_if_deleted()` — queries ClickHouse for the person's effective state using `argMax(is_deleted, version)`.
  Returns the max version only if the person is currently soft-deleted, avoiding unnecessary resets for non-deleted persons.
- Added `_reset_person_in_clickhouse()` — sends a new person row to ClickHouse via Kafka with `is_deleted=False` and `version=max_version+100`
  (overriding the deletion). Also updates the Postgres person version so future plugin-server updates won't be ignored by ClickHouse.
- Updated `_updated_distinct_ids()` to call `_reset_person_in_clickhouse` for each unique person involved in the reset,
  deduplicating via a `reset_person_uuids` set so the same person is only reset once even when multiple distinct IDs point to it.

**`posthog/api/test/test_person.py`**

- Rewrote `test_reset_person_distinct_id` to reproduce the real-world bug:
  uses the same UUID for the deleted CH person and the re-created PG person (matching deterministic UUID behavior).
- Added assertions verifying the CH `person` record is reset (`is_deleted=0`, version higher than deletion).
- Added assertion that the PG person version is updated to stay in sync with ClickHouse.


## How did you test this code?

- Rewrote the existing `test_reset_person_distinct_id` test to simulate the exact real-world flow:
  deleted person in CH with high version, re-created person in PG with same deterministic UUID and low version,
  then called the reset endpoint and verified all four conditions are satisfied:
  1. CH `person_distinct_id2` has `is_deleted=0` with version higher than deletion
  2. CH `person` has `is_deleted=0` with version higher than deletion
  3. PG `PersonDistinctId.version` is bumped above the CH deletion version
  4. PG `Person.version` is bumped above the CH deletion version
- Verified the existing `test_reset_person_distinct_id_not_found` test still passes (no regression for the case where the distinct ID hasn't been reused yet).