### PR TITLE
fix(experiments): remove redundant validation errors checks.

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -37,7 +37,6 @@ import {
     getDelta,
     getMetricSubtitleValues,
     getNiceTickValues,
-    hasValidationFailures,
     isBayesianResult,
     isDeltaPositive,
     isSignificant,
@@ -506,7 +505,6 @@ interface MetricRowGroupProps {
     onRemoveBreakdown: (index: number) => void
     error?: any
     isLoading?: boolean
-    hasMinimumExposureForResults?: boolean
     exposuresLoading?: boolean
     showDetailsModal: boolean
 }
@@ -527,7 +525,6 @@ export function MetricRowGroup({
     onRemoveBreakdown,
     error,
     isLoading,
-    hasMinimumExposureForResults = true,
     exposuresLoading = false,
     showDetailsModal,
 }: MetricRowGroupProps): JSX.Element {
@@ -669,11 +666,7 @@ export function MetricRowGroup({
         })
     }
 
-    // Handle loading, API errors, or missing result
-    // Note: If result has validation_failures but no API error, we'll show the data with inline warnings
-    const hasResultWithValidationFailures = result && hasValidationFailures(result)
-
-    if (isLoading || error || !result || (!hasMinimumExposureForResults && !hasResultWithValidationFailures)) {
+    if (isLoading || error || !result) {
         const hasError = !!error
 
         return (

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -33,7 +33,7 @@ export function MetricsTable({
     getInsightType,
     showDetailsModal = true,
 }: MetricsTableProps): JSX.Element {
-    const { experiment, hasMinimumExposureForResults, exposuresLoading } = useValues(experimentLogic)
+    const { experiment, exposuresLoading } = useValues(experimentLogic)
     const { duplicateMetric, updateExperimentMetrics, updateMetricBreakdown, removeMetricBreakdown } =
         useActions(experimentLogic)
 
@@ -151,7 +151,6 @@ export function MetricsTable({
                                 }}
                                 error={error}
                                 isLoading={isLoading}
-                                hasMinimumExposureForResults={hasMinimumExposureForResults}
                                 exposuresLoading={exposuresLoading}
                                 showDetailsModal={showDetailsModal}
                             />


### PR DESCRIPTION
## Problem

In some cases, when exposures are low, but there are no validation failures (`hasMinimumExposureForResults === false` and `hasResultWithValidationFailures === false`), we take the error route, but `ChartEmptyState` bails because there's no error.

The double negative is confusing, and this has been broken for a while.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This check is unnecessary because the `DeltaChart` component already handles validation errors with a _Not enough data yet_ message. We can improve this in the future.

| before | after |
| - | - |
| <img width="1349" height="978" alt="Screenshot 2026-02-17 at 17 29 23" src="https://github.com/user-attachments/assets/46a1cad6-c415-4914-902b-1b164dd6076b" /> | <img width="1351" height="973" alt="Screenshot 2026-02-17 at 17 29 47" src="https://github.com/user-attachments/assets/e1d3cf72-a36e-4970-bd29-e532db355b04" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/c60b9c4a-340a-42fc-a106-801173dd1e09)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
