### PR TITLE
feat: show effective project access in access control

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControls.tsx
@@ -35,6 +35,9 @@ export function AccessControls({ projectId }: { projectId: string }): JSX.Elemen
         ruleModalMemberIsOrgAdmin,
         ruleModalMemberHasRoleWithAdminAccess,
         ruleModalProjectHasDefaultAdminAccess,
+        ruleModalRoleEffectiveProjectLevel,
+        ruleModalRoleHasLowerSavedLevel,
+        projectDefaultLevel,
     } = useValues(logic)
 
     const { setActiveTab, setSearchText, setFilters, openRuleModal, closeRuleModal, saveGroupedRules } =
@@ -101,6 +104,9 @@ export function AccessControls({ projectId }: { projectId: string }): JSX.Elemen
                     memberIsOrgAdmin={ruleModalMemberIsOrgAdmin}
                     memberHasRoleWithAdminAccess={ruleModalMemberHasRoleWithAdminAccess}
                     projectHasDefaultAdminAccess={ruleModalProjectHasDefaultAdminAccess}
+                    roleEffectiveProjectLevel={ruleModalRoleEffectiveProjectLevel}
+                    roleHasLowerSavedLevel={ruleModalRoleHasLowerSavedLevel}
+                    projectDefaultLevel={projectDefaultLevel}
                 />
             )}
         </>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControls.tsx
@@ -33,8 +33,8 @@ export function AccessControls({ projectId }: { projectId: string }): JSX.Elemen
         canEditAccessControls,
         canEditRoleBasedAccessControls,
         ruleModalMemberIsOrgAdmin,
-        ruleModalMemberHasAdminAccess,
-        ruleModalRoleHasAdminAccess,
+        ruleModalMemberHasRoleWithAdminAccess,
+        ruleModalProjectHasDefaultAdminAccess,
     } = useValues(logic)
 
     const { setActiveTab, setSearchText, setFilters, openRuleModal, closeRuleModal, saveGroupedRules } =
@@ -99,8 +99,8 @@ export function AccessControls({ projectId }: { projectId: string }): JSX.Elemen
                     }
                     onSave={saveGroupedRules}
                     memberIsOrgAdmin={ruleModalMemberIsOrgAdmin}
-                    memberHasAdminAccess={ruleModalMemberHasAdminAccess}
-                    roleHasAdminAccess={ruleModalRoleHasAdminAccess}
+                    memberHasRoleWithAdminAccess={ruleModalMemberHasRoleWithAdminAccess}
+                    projectHasDefaultAdminAccess={ruleModalProjectHasDefaultAdminAccess}
                 />
             )}
         </>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/GroupedAccessControlRuleModal.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/GroupedAccessControlRuleModal.tsx
@@ -24,8 +24,8 @@ export function GroupedAccessControlRuleModal(props: {
     projectId: string
     canEdit: boolean
     memberIsOrgAdmin: boolean
-    memberHasAdminAccess: boolean
-    roleHasAdminAccess: boolean
+    memberHasRoleWithAdminAccess: boolean
+    projectHasDefaultAdminAccess: boolean
 }): JSX.Element | null {
     const logic = accessControlsLogic({ projectId: props.projectId })
     const { groupedRulesForm } = useValues(logic)
@@ -94,8 +94,8 @@ export function GroupedAccessControlRuleModal(props: {
                 getLevelOptionsForResource={props.getLevelOptionsForResource}
                 canEdit={props.canEdit}
                 memberIsOrgAdmin={props.memberIsOrgAdmin}
-                memberHasAdminAccess={props.memberHasAdminAccess}
-                roleHasAdminAccess={props.roleHasAdminAccess}
+                memberHasRoleWithAdminAccess={props.memberHasRoleWithAdminAccess}
+                projectHasDefaultAdminAccess={props.projectHasDefaultAdminAccess}
             />
         </LemonModal>
     )
@@ -145,8 +145,8 @@ function GroupedAccessControlRuleModalContent(props: {
     ) => { value: AccessControlLevel; label: string; disabledReason?: string }[]
     canEdit: boolean
     memberIsOrgAdmin: boolean
-    memberHasAdminAccess: boolean
-    roleHasAdminAccess: boolean
+    memberHasRoleWithAdminAccess: boolean
+    projectHasDefaultAdminAccess: boolean
 }): JSX.Element {
     const mappedLevels = props.groupedRuleForm.levels.reduce(
         (prev, mapping) => {
@@ -164,10 +164,24 @@ function GroupedAccessControlRuleModalContent(props: {
             return 'Cannot edit'
         }
 
-        if (props.memberHasAdminAccess || props.roleHasAdminAccess) {
-            return 'Feature overrides do not apply to admins'
+        if (props.memberIsOrgAdmin) {
+            return 'User is an organization admin and can access all features in the project'
         }
-    }, [props.loading, props.canEdit, props.memberHasAdminAccess, props.roleHasAdminAccess])
+
+        if (props.projectHasDefaultAdminAccess) {
+            return 'Project default access is set to Admin, so all features are accessible'
+        }
+
+        if (props.memberHasRoleWithAdminAccess) {
+            return 'User already has a role with Admin access and can access all features in the project'
+        }
+    }, [
+        props.loading,
+        props.canEdit,
+        props.projectHasDefaultAdminAccess,
+        props.memberIsOrgAdmin,
+        props.memberHasRoleWithAdminAccess,
+    ])
 
     const disabledReasonForProject = useMemo(() => {
         if (props.loading) {
@@ -179,9 +193,13 @@ function GroupedAccessControlRuleModalContent(props: {
         }
 
         if (props.memberIsOrgAdmin) {
-            return 'Project overrides do not apply to admins'
+            return 'User is an organization admin'
         }
-    }, [props.loading, props.canEdit, props.memberIsOrgAdmin])
+
+        if (props.memberHasRoleWithAdminAccess) {
+            return 'User already has a role with Admin access'
+        }
+    }, [props.loading, props.canEdit, props.memberIsOrgAdmin, props.memberHasRoleWithAdminAccess])
 
     return (
         <div className="space-y-4">

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/GroupedAccessControlRuleModal.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/GroupedAccessControlRuleModal.tsx
@@ -196,10 +196,20 @@ function GroupedAccessControlRuleModalContent(props: {
             return 'User is an organization admin'
         }
 
+        if (props.projectHasDefaultAdminAccess) {
+            return 'Project default access is set to Admin'
+        }
+
         if (props.memberHasRoleWithAdminAccess) {
             return 'User already has a role with Admin access'
         }
-    }, [props.loading, props.canEdit, props.memberIsOrgAdmin, props.memberHasRoleWithAdminAccess])
+    }, [
+        props.loading,
+        props.canEdit,
+        props.memberIsOrgAdmin,
+        props.projectHasDefaultAdminAccess,
+        props.memberHasRoleWithAdminAccess,
+    ])
 
     return (
         <div className="space-y-4">


### PR DESCRIPTION
## Problem

An enterprise customer was confused by the Access Control UI's Members tab, which did not account for permissions granted via roles. The displayed access level does not reflect the member's actual project access, potentially leading to unnecessary overrides being created.

Also, if a user already has Admin access through roles, feature permission overrides in the Members UI are not disabled, but they won't be applied. 

## Changes
- Members and Roles tabs now shows the effective project access level instead of just the override
- Effective level = highest of: project default, member override, and any role overrides
- Org admins always show Admin level
- Feature permission overrides are disabled when a member already has Admin access (via org admin status, role, or project default), with specific explanations for each case
- Roles and members can no longer set a project access level lower than the effective access

Demo: 
https://www.loom.com/share/206b6e933ae1492e9452a07436ff0777

NOTE: Feature permissions still show the row values, not effective permissions. 

## How did you test this code?
Manually

## Publish to changelog?
no