### PR TITLE
chore(livestream): Bump Go version from 1.24 to 1.25.5

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -30,7 +30,7 @@ rust-analyzer = { pkg-path = "rust-analyzer", pkg-group = "rust-analyzer" } # ru
 lld = { pkg-path = "lld", systems = ["aarch64-darwin"] } # Faster linker for Rust dev builds on macOS
 sccache = { pkg-path = "sccache" } # Compilation cache for Rust (also used in CI)
 # Go
-go = { pkg-path = "go", version = "1.26", pkg-group = "go" }
+go = { pkg-path = "go", version = "1.26.0", pkg-group = "go" }
 golangci-lint = { pkg-path = "golangci-lint", pkg-group = "go" }
 air = { pkg-path = "air" }
 # CLI tools

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -30,7 +30,7 @@ rust-analyzer = { pkg-path = "rust-analyzer", pkg-group = "rust-analyzer" } # ru
 lld = { pkg-path = "lld", systems = ["aarch64-darwin"] } # Faster linker for Rust dev builds on macOS
 sccache = { pkg-path = "sccache" } # Compilation cache for Rust (also used in CI)
 # Go
-go = { pkg-path = "go", version = "1.26.0", pkg-group = "go" }
+go = { pkg-path = "go", version = "1.25.5", pkg-group = "go" }
 golangci-lint = { pkg-path = "golangci-lint", pkg-group = "go" }
 air = { pkg-path = "air" }
 # CLI tools

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -30,7 +30,7 @@ rust-analyzer = { pkg-path = "rust-analyzer", pkg-group = "rust-analyzer" } # ru
 lld = { pkg-path = "lld", systems = ["aarch64-darwin"] } # Faster linker for Rust dev builds on macOS
 sccache = { pkg-path = "sccache" } # Compilation cache for Rust (also used in CI)
 # Go
-go = { pkg-path = "go", version = "1.24", pkg-group = "go" }
+go = { pkg-path = "go", version = "1.26", pkg-group = "go" }
 golangci-lint = { pkg-path = "golangci-lint", pkg-group = "go" }
 air = { pkg-path = "air" }
 # CLI tools

--- a/.github/workflows/build-hobby-installer.yml
+++ b/.github/workflows/build-hobby-installer.yml
@@ -32,7 +32,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.26.0'
+                  go-version: '1.25.5'
 
             - name: Build production binary
               run: cd bin/hobby-installer && make build-linux

--- a/.github/workflows/build-hobby-installer.yml
+++ b/.github/workflows/build-hobby-installer.yml
@@ -32,7 +32,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.24'
+                  go-version: '1.26.0'
 
             - name: Build production binary
               run: cd bin/hobby-installer && make build-linux

--- a/.github/workflows/build-livestream-tui.yml
+++ b/.github/workflows/build-livestream-tui.yml
@@ -31,7 +31,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.24'
+                  go-version: '1.26.0'
 
             - name: Build production binaries
               run: cd livestream && make -f Makefile.tui build-all

--- a/.github/workflows/build-livestream-tui.yml
+++ b/.github/workflows/build-livestream-tui.yml
@@ -31,7 +31,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.26.0'
+                  go-version: '1.25.5'
 
             - name: Build production binaries
               run: cd livestream && make -f Makefile.tui build-all

--- a/.github/workflows/ci-hobby-installer.yml
+++ b/.github/workflows/ci-hobby-installer.yml
@@ -49,7 +49,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.26'
+                  go-version: '1.26.0'
 
             - name: Build
               run: cd bin/hobby-installer && make build

--- a/.github/workflows/ci-hobby-installer.yml
+++ b/.github/workflows/ci-hobby-installer.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.24'
+                  go-version: '1.26.0'
 
             - name: Run golangci-lint
               uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -49,7 +49,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.24'
+                  go-version: '1.26'
 
             - name: Build
               run: cd bin/hobby-installer && make build

--- a/.github/workflows/ci-hobby-installer.yml
+++ b/.github/workflows/ci-hobby-installer.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.26.0'
+                  go-version: '1.25.5'
 
             - name: Run golangci-lint
               uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -49,7 +49,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.26.0'
+                  go-version: '1.25.5'
 
             - name: Build
               run: cd bin/hobby-installer && make build

--- a/.github/workflows/ci-livestream-tui.yml
+++ b/.github/workflows/ci-livestream-tui.yml
@@ -49,7 +49,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.26'
+                  go-version: '1.26.0'
 
             - name: Build
               run: cd livestream && make -f Makefile.tui build

--- a/.github/workflows/ci-livestream-tui.yml
+++ b/.github/workflows/ci-livestream-tui.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.26.0'
+                  go-version: '1.25.5'
 
             - name: Run golangci-lint
               uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -49,7 +49,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.26.0'
+                  go-version: '1.25.5'
 
             - name: Build
               run: cd livestream && make -f Makefile.tui build

--- a/.github/workflows/ci-livestream-tui.yml
+++ b/.github/workflows/ci-livestream-tui.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.24'
+                  go-version: '1.26.0'
 
             - name: Run golangci-lint
               uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -49,7 +49,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.24'
+                  go-version: '1.26'
 
             - name: Build
               run: cd livestream && make -f Makefile.tui build

--- a/.github/workflows/ci-livestream.yml
+++ b/.github/workflows/ci-livestream.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
               with:
-                  go-version: '1.26.0'
+                  go-version: '1.25.5'
 
             - name: Run golangci-lint
               uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.github/workflows/ci-livestream.yml
+++ b/.github/workflows/ci-livestream.yml
@@ -20,7 +20,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
               with:
-                  go-version: '1.24'
+                  go-version: '1.26.0'
 
             - name: Run golangci-lint
               uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/bin/hobby-installer/README.md
+++ b/bin/hobby-installer/README.md
@@ -46,7 +46,7 @@ CI mode is automatically enabled when common CI environment variables are detect
 
 ### Prerequisites
 
-- Go 1.26+
+- Go 1.25+
 
 ### Build commands
 

--- a/bin/hobby-installer/README.md
+++ b/bin/hobby-installer/README.md
@@ -46,7 +46,7 @@ CI mode is automatically enabled when common CI environment variables are detect
 
 ### Prerequisites
 
-- Go 1.24+
+- Go 1.26+
 
 ### Build commands
 

--- a/bin/hobby-installer/go.mod
+++ b/bin/hobby-installer/go.mod
@@ -1,6 +1,6 @@
 module github.com/posthog/posthog/bin/hobby-installer
 
-go 1.26.0
+go 1.25.5
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/bin/hobby-installer/go.mod
+++ b/bin/hobby-installer/go.mod
@@ -1,6 +1,6 @@
 module github.com/posthog/posthog/bin/hobby-installer
 
-go 1.24
+go 1.26.0
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -175,7 +175,7 @@ intents:
 
     web_analytics:
         description: 'Web analytics, traffic analysis, and heatmaps'
-        capabilities: [event_ingestion, replay_storage, property_definitions]
+        capabilities: [event_ingestion, replay_storage, property_definitions, livestream]
 
     surveys:
         description: 'User surveys and feedback collection'

--- a/livestream/Dockerfile
+++ b/livestream/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.0 AS builder
+FROM golang:1.25.5 AS builder
 WORKDIR /code
 COPY go.sum go.mod ./
 RUN go mod download -x

--- a/livestream/Dockerfile
+++ b/livestream/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6 AS builder
+FROM golang:1.26.0 AS builder
 WORKDIR /code
 COPY go.sum go.mod ./
 RUN go mod download -x

--- a/livestream/go.mod
+++ b/livestream/go.mod
@@ -1,8 +1,6 @@
 module github.com/posthog/posthog/livestream
 
-go 1.24.2
-
-toolchain go1.24.6
+go 1.26.0
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0

--- a/livestream/go.mod
+++ b/livestream/go.mod
@@ -1,6 +1,6 @@
 module github.com/posthog/posthog/livestream
 
-go 1.26.0
+go 1.25.5
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
## Problem
Bump to the latest version of Go available in Flox

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Bump Go version
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Ran livestream service and saw events coming in
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
