### PR TITLE
feat(ingestion):  person distinct ID disassociation tool

### DIFF
--- a/posthog/dags/detach_distinct_id.py
+++ b/posthog/dags/detach_distinct_id.py
@@ -246,11 +246,11 @@ def detach_distinct_id_op(
 
     # --- 6. Verification hints ---
     log.info("--- Verification queries (run manually) ---")
+    escaped_did = json.dumps(config.distinct_id)
     log.info(
         f"Postgres: SELECT * FROM posthog_persondistinctid "
-        f"WHERE team_id = {config.team_id} AND distinct_id = '{config.distinct_id}'"
+        f"WHERE team_id = {config.team_id} AND distinct_id = {escaped_did}"
     )
-    escaped_did = json.dumps(config.distinct_id)
     log.info(
         f"ClickHouse (pdi2): SELECT distinct_id, argMax(person_id, version), "
         f"argMax(is_deleted, version), max(version) "

--- a/posthog/dags/detach_distinct_id.py
+++ b/posthog/dags/detach_distinct_id.py
@@ -1,0 +1,256 @@
+"""Dagster job to detach a distinct_id from its person.
+
+Deletes the mapping in Postgres (posthog_persondistinctid), publishes a
+deletion message to Kafka so ClickHouse person_distinct_id2 follows suit,
+and inserts a person_distinct_id_overrides row so the squash job can fix
+the person_id embedded on historical events.
+
+Typical use: removing a sentinel ``$posthog_cookieless`` distinct_id that was
+erroneously associated with a real person due to a cookieless-ingestion bug.
+"""
+
+import json
+import uuid
+from datetime import datetime
+
+import dagster
+import pydantic
+import psycopg2.extensions
+
+from posthog.clickhouse.client import sync_execute
+from posthog.dags.common import JobOwners
+from posthog.kafka_client.client import _KafkaProducer
+from posthog.kafka_client.topics import KAFKA_PERSON_DISTINCT_ID
+
+
+class DetachDistinctIdConfig(dagster.Config):
+    """Configuration for the detach distinct_id job."""
+
+    team_id: int = pydantic.Field(description="Team ID that owns the distinct_id")
+    distinct_id: str = pydantic.Field(description="The distinct_id to detach (e.g. $posthog_cookieless)")
+    expected_person_id: str = pydantic.Field(
+        description="UUID of the person we expect the distinct_id to belong to (safety check)"
+    )
+    override_person_id: str | None = pydantic.Field(
+        default=None,
+        description=(
+            "If set, insert a person_distinct_id_overrides row pointing historical events "
+            "at this person UUID. If not set, a random dummy UUID is generated so events "
+            "become orphaned. The scheduled squash job will later rewrite the embedded "
+            "person_id on events and delete the override."
+        ),
+    )
+    dry_run: bool = pydantic.Field(
+        default=True,
+        description="If true, log what would happen without making changes",
+    )
+
+
+def _lookup_distinct_id(
+    cursor: psycopg2.extensions.cursor,
+    team_id: int,
+    distinct_id: str,
+) -> dict | None:
+    """Return the posthog_persondistinctid row + person uuid, or None."""
+    cursor.execute(
+        """
+        SELECT pdi.id, pdi.version, pdi.person_id, p.uuid
+        FROM posthog_persondistinctid pdi
+        JOIN posthog_person p ON p.id = pdi.person_id AND p.team_id = pdi.team_id
+        WHERE pdi.team_id = %s AND pdi.distinct_id = %s
+        """,
+        [team_id, distinct_id],
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    return {
+        "pdi_id": row[0],
+        "version": row[1],
+        "person_pk": row[2],
+        "person_uuid": str(row[3]),
+    }
+
+
+def _count_other_distinct_ids(
+    cursor: psycopg2.extensions.cursor,
+    team_id: int,
+    person_pk: int,
+    exclude_pdi_id: int,
+) -> int:
+    """Count how many *other* distinct_ids the person has."""
+    cursor.execute(
+        """
+        SELECT COUNT(*)
+        FROM posthog_persondistinctid
+        WHERE team_id = %s AND person_id = %s AND id != %s
+        """,
+        [team_id, person_pk, exclude_pdi_id],
+    )
+    return cursor.fetchone()[0]
+
+
+def _delete_distinct_id_row(
+    cursor: psycopg2.extensions.cursor,
+    pdi_id: int,
+) -> int:
+    """Lock and delete the posthog_persondistinctid row. Returns version."""
+    cursor.execute(
+        "SELECT version FROM posthog_persondistinctid WHERE id = %s FOR UPDATE",
+        [pdi_id],
+    )
+    row = cursor.fetchone()
+    if row is None:
+        raise RuntimeError(f"posthog_persondistinctid id={pdi_id} disappeared between lookup and delete")
+    version = row[0]
+    cursor.execute("DELETE FROM posthog_persondistinctid WHERE id = %s", [pdi_id])
+    return version
+
+
+def _publish_deletion_to_kafka(
+    producer: _KafkaProducer,
+    team_id: int,
+    distinct_id: str,
+    person_uuid: str,
+    version: int,
+) -> None:
+    """Publish an is_deleted message so ClickHouse person_distinct_id2 drops the mapping.
+
+    Uses version + 100, matching _delete_ch_distinct_id in posthog/models/person/util.py.
+    """
+    producer.produce(
+        topic=KAFKA_PERSON_DISTINCT_ID,
+        data={
+            "distinct_id": distinct_id,
+            "person_id": person_uuid,
+            "team_id": team_id,
+            "version": version + 100,
+            "is_deleted": 1,
+        },
+    )
+    producer.flush()
+
+
+def _insert_ch_override(
+    team_id: int,
+    distinct_id: str,
+    override_person_uuid: str,
+    version: int,
+) -> None:
+    """Insert a person_distinct_id_overrides row so the squash job re-attributes historical events.
+
+    Follows the same pattern as insert_override_batch in fix_person_id_overrides.py.
+    """
+    sync_execute(
+        """
+        INSERT INTO person_distinct_id_overrides
+        (team_id, distinct_id, person_id, is_deleted, version, _timestamp, _offset, _partition)
+        VALUES
+        """,
+        [(team_id, distinct_id, override_person_uuid, 0, version, datetime.now(), 0, 0)],
+    )
+
+
+@dagster.op
+def detach_distinct_id_op(
+    context: dagster.OpExecutionContext,
+    config: DetachDistinctIdConfig,
+    persons_database: dagster.ResourceParam[psycopg2.extensions.connection],
+    kafka_producer: dagster.ResourceParam[_KafkaProducer],
+) -> None:
+    """Detach a distinct_id from its person in Postgres and ClickHouse."""
+    log = context.log
+
+    log.info(f"team_id={config.team_id} distinct_id={config.distinct_id!r}")
+    log.info(f"expected_person_id={config.expected_person_id}")
+    log.info(f"dry_run={config.dry_run}")
+
+    # --- 1. Validate in Postgres ---
+    with persons_database.cursor() as cursor:
+        cursor.execute("SET application_name = 'detach_distinct_id'")
+        cursor.execute("SET lock_timeout = '5s'")
+        cursor.execute("SET statement_timeout = '30s'")
+
+        info = _lookup_distinct_id(cursor, config.team_id, config.distinct_id)
+        if info is None:
+            raise dagster.Failure(f"distinct_id={config.distinct_id!r} not found for team_id={config.team_id}")
+
+        log.info(
+            f"Found: pdi_id={info['pdi_id']} version={info['version']} "
+            f"person_uuid={info['person_uuid']} person_pk={info['person_pk']}"
+        )
+
+        if info["person_uuid"] != config.expected_person_id:
+            raise dagster.Failure(
+                f"Person mismatch: distinct_id belongs to {info['person_uuid']}, expected {config.expected_person_id}"
+            )
+
+        other_count = _count_other_distinct_ids(cursor, config.team_id, info["person_pk"], info["pdi_id"])
+        if other_count == 0:
+            raise dagster.Failure(
+                f"Cannot detach: this is the person's only distinct_id. "
+                f"Detaching would orphan person {info['person_uuid']}"
+            )
+        log.info(f"Person has {other_count} other distinct_id(s) — safe to detach")
+
+        # --- 2. Resolve override target ---
+        override_target = config.override_person_id or str(uuid.uuid4())
+        log.info(f"Override target person_id={override_target}")
+
+        # --- 3. Delete in Postgres ---
+        if config.dry_run:
+            log.info("[DRY RUN] Would delete posthog_persondistinctid row")
+            log.info("[DRY RUN] Would publish Kafka deletion to person_distinct_id2")
+            log.info(f"[DRY RUN] Would insert person_distinct_id_overrides -> {override_target}")
+            persons_database.rollback()
+            return
+
+        version = _delete_distinct_id_row(cursor, info["pdi_id"])
+        persons_database.commit()
+        log.info(f"Deleted posthog_persondistinctid id={info['pdi_id']} (version={version})")
+
+    # --- 4. Sync deletion to ClickHouse via Kafka ---
+    _publish_deletion_to_kafka(
+        kafka_producer,
+        team_id=config.team_id,
+        distinct_id=config.distinct_id,
+        person_uuid=info["person_uuid"],
+        version=version,
+    )
+    log.info(f"Published deletion to {KAFKA_PERSON_DISTINCT_ID} (version={version + 100}, is_deleted=1)")
+
+    # --- 5. Insert override so squash job fixes historical events ---
+    _insert_ch_override(
+        team_id=config.team_id,
+        distinct_id=config.distinct_id,
+        override_person_uuid=override_target,
+        version=version + 100,
+    )
+    log.info(f"Inserted person_distinct_id_overrides: {config.distinct_id!r} -> {override_target}")
+
+    # --- 6. Verification hints ---
+    log.info("--- Verification queries (run manually) ---")
+    log.info(
+        f"Postgres: SELECT * FROM posthog_persondistinctid "
+        f"WHERE team_id = {config.team_id} AND distinct_id = '{config.distinct_id}'"
+    )
+    escaped_did = json.dumps(config.distinct_id)
+    log.info(
+        f"ClickHouse (pdi2): SELECT distinct_id, argMax(person_id, version), "
+        f"argMax(is_deleted, version), max(version) "
+        f"FROM person_distinct_id2 "
+        f"WHERE team_id = {config.team_id} AND distinct_id = {escaped_did} "
+        f"GROUP BY distinct_id"
+    )
+    log.info(
+        f"ClickHouse (overrides): SELECT distinct_id, argMax(person_id, version), max(version) "
+        f"FROM person_distinct_id_overrides "
+        f"WHERE team_id = {config.team_id} AND distinct_id = {escaped_did} "
+        f"GROUP BY distinct_id"
+    )
+
+
+@dagster.job(tags={"owner": JobOwners.TEAM_INGESTION.value})
+def detach_distinct_id_job():
+    """Job to detach a distinct_id from its person in Postgres and ClickHouse."""
+    detach_distinct_id_op()

--- a/posthog/dags/locations/ingestion.py
+++ b/posthog/dags/locations/ingestion.py
@@ -2,6 +2,7 @@ import dagster
 
 from posthog.dags import (
     delete_persons_from_trigger_log,
+    detach_distinct_id,
     distinct_id_usage,
     ingestion_assets,
     person_property_reconciliation,
@@ -18,6 +19,7 @@ defs = dagster.Definitions(
     ],
     jobs=[
         delete_persons_from_trigger_log.delete_persons_from_trigger_log_job,
+        detach_distinct_id.detach_distinct_id_job,
         distinct_id_usage.distinct_id_usage_monitoring,
         person_property_reconciliation.person_property_reconciliation_job,
         persondistinctids_without_person_cleanup.persondistinctids_without_person_cleanup_job,

--- a/posthog/dags/tests/test_detach_distinct_id.py
+++ b/posthog/dags/tests/test_detach_distinct_id.py
@@ -1,0 +1,271 @@
+from uuid import UUID
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.dags.detach_distinct_id import (
+    _count_other_distinct_ids,
+    _delete_distinct_id_row,
+    _insert_ch_override,
+    _lookup_distinct_id,
+    _publish_deletion_to_kafka,
+    detach_distinct_id_job,
+)
+from posthog.kafka_client.topics import KAFKA_PERSON_DISTINCT_ID
+
+PERSON_UUID = "5e00024e-cb68-59f6-821f-6150fcffc431"
+PERSON_PK = 42
+PDI_ID = 99
+PDI_VERSION = 3
+TEAM_ID = 7
+DUMMY_OVERRIDE_UUID = "00000000-0000-0000-0000-000000000001"
+
+
+def _make_cursor(fetchone_values: list | None = None, fetchall_values: list | None = None) -> MagicMock:
+    cursor = MagicMock()
+    if fetchone_values is not None:
+        cursor.fetchone.side_effect = fetchone_values
+    if fetchall_values is not None:
+        cursor.fetchall.side_effect = fetchall_values
+    return cursor
+
+
+class TestLookupDistinctId:
+    def test_returns_row_when_found(self):
+        cursor = _make_cursor(fetchone_values=[(PDI_ID, PDI_VERSION, PERSON_PK, UUID(PERSON_UUID))])
+
+        result = _lookup_distinct_id(cursor, TEAM_ID, "$posthog_cookieless")
+
+        assert result is not None
+        assert result["pdi_id"] == PDI_ID
+        assert result["version"] == PDI_VERSION
+        assert result["person_pk"] == PERSON_PK
+        assert result["person_uuid"] == PERSON_UUID
+
+    def test_returns_none_when_not_found(self):
+        cursor = _make_cursor(fetchone_values=[None])
+
+        result = _lookup_distinct_id(cursor, TEAM_ID, "nonexistent")
+
+        assert result is None
+
+
+class TestCountOtherDistinctIds:
+    def test_returns_count(self):
+        cursor = _make_cursor(fetchone_values=[(5,)])
+
+        count = _count_other_distinct_ids(cursor, TEAM_ID, PERSON_PK, PDI_ID)
+
+        assert count == 5
+
+    def test_returns_zero_when_none(self):
+        cursor = _make_cursor(fetchone_values=[(0,)])
+
+        count = _count_other_distinct_ids(cursor, TEAM_ID, PERSON_PK, PDI_ID)
+
+        assert count == 0
+
+
+class TestDeleteDistinctIdRow:
+    def test_locks_and_deletes(self):
+        cursor = _make_cursor(fetchone_values=[(PDI_VERSION,)])
+
+        version = _delete_distinct_id_row(cursor, PDI_ID)
+
+        assert version == PDI_VERSION
+        assert cursor.execute.call_count == 2
+        # First call: SELECT FOR UPDATE
+        assert "FOR UPDATE" in cursor.execute.call_args_list[0].args[0]
+        # Second call: DELETE
+        assert "DELETE" in cursor.execute.call_args_list[1].args[0]
+
+    def test_raises_if_row_disappears(self):
+        cursor = _make_cursor(fetchone_values=[None])
+
+        with pytest.raises(RuntimeError, match="disappeared"):
+            _delete_distinct_id_row(cursor, PDI_ID)
+
+
+class TestPublishDeletionToKafka:
+    def test_publishes_with_version_plus_100(self):
+        producer = MagicMock()
+
+        _publish_deletion_to_kafka(producer, TEAM_ID, "$posthog_cookieless", PERSON_UUID, PDI_VERSION)
+
+        producer.produce.assert_called_once_with(
+            topic=KAFKA_PERSON_DISTINCT_ID,
+            data={
+                "distinct_id": "$posthog_cookieless",
+                "person_id": PERSON_UUID,
+                "team_id": TEAM_ID,
+                "version": PDI_VERSION + 100,
+                "is_deleted": 1,
+            },
+        )
+        producer.flush.assert_called_once()
+
+
+class TestInsertChOverride:
+    @patch("posthog.dags.detach_distinct_id.sync_execute")
+    def test_inserts_override_row(self, mock_sync_execute):
+        _insert_ch_override(TEAM_ID, "$posthog_cookieless", DUMMY_OVERRIDE_UUID, PDI_VERSION + 100)
+
+        mock_sync_execute.assert_called_once()
+        sql = mock_sync_execute.call_args.args[0]
+        assert "person_distinct_id_overrides" in sql
+
+        rows = mock_sync_execute.call_args.args[1]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row[0] == TEAM_ID
+        assert row[1] == "$posthog_cookieless"
+        assert row[2] == DUMMY_OVERRIDE_UUID
+        assert row[3] == 0  # is_deleted
+        assert row[4] == PDI_VERSION + 100  # version
+
+
+class TestDetachDistinctIdJob:
+    """Integration tests that run the full Dagster job with mock resources."""
+
+    def _make_connection(self, lookup_row, other_count, delete_version=PDI_VERSION):
+        """Build a mock psycopg2 connection with a cursor that responds to the
+        queries issued by detach_distinct_id_op in order."""
+        conn = MagicMock(spec=["cursor", "commit", "rollback"])
+        cursor = MagicMock()
+
+        # The op issues fetchone calls in this order:
+        # 1. _lookup_distinct_id
+        # 2. _count_other_distinct_ids
+        # 3. _delete_distinct_id_row SELECT FOR UPDATE (only when not dry_run)
+        fetchone_sequence = [lookup_row, (other_count,)]
+        if delete_version is not None:
+            fetchone_sequence.append((delete_version,))
+
+        cursor.fetchone.side_effect = fetchone_sequence
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor
+        return conn, cursor
+
+    def _run_config(self, *, dry_run: bool = True, override_person_id: str | None = None) -> dict:
+        config: dict = {
+            "team_id": TEAM_ID,
+            "distinct_id": "$posthog_cookieless",
+            "expected_person_id": PERSON_UUID,
+            "dry_run": dry_run,
+        }
+        if override_person_id is not None:
+            config["override_person_id"] = override_person_id
+        return {"ops": {"detach_distinct_id_op": {"config": config}}}
+
+    @patch("posthog.dags.detach_distinct_id.sync_execute")
+    def test_dry_run_does_not_mutate(self, mock_sync_execute):
+        lookup_row = (PDI_ID, PDI_VERSION, PERSON_PK, UUID(PERSON_UUID))
+        conn, cursor = self._make_connection(lookup_row, other_count=2)
+        producer = MagicMock()
+
+        result = detach_distinct_id_job.execute_in_process(
+            run_config=self._run_config(dry_run=True),
+            resources={"persons_database": conn, "kafka_producer": producer},
+        )
+
+        assert result.success
+        conn.commit.assert_not_called()
+        conn.rollback.assert_called_once()
+        producer.produce.assert_not_called()
+        mock_sync_execute.assert_not_called()
+
+    @patch("posthog.dags.detach_distinct_id.sync_execute")
+    @patch("posthog.dags.detach_distinct_id.uuid.uuid4", return_value=UUID(DUMMY_OVERRIDE_UUID))
+    def test_detaches_publishes_kafka_and_inserts_override(self, _mock_uuid4, mock_sync_execute):
+        lookup_row = (PDI_ID, PDI_VERSION, PERSON_PK, UUID(PERSON_UUID))
+        conn, cursor = self._make_connection(lookup_row, other_count=2)
+        producer = MagicMock()
+
+        result = detach_distinct_id_job.execute_in_process(
+            run_config=self._run_config(dry_run=False),
+            resources={"persons_database": conn, "kafka_producer": producer},
+        )
+
+        assert result.success
+        conn.commit.assert_called_once()
+
+        # Kafka deletion
+        producer.produce.assert_called_once()
+        kafka_data = producer.produce.call_args.kwargs["data"]
+        assert kafka_data["distinct_id"] == "$posthog_cookieless"
+        assert kafka_data["person_id"] == PERSON_UUID
+        assert kafka_data["is_deleted"] == 1
+        assert kafka_data["version"] == PDI_VERSION + 100
+        producer.flush.assert_called_once()
+
+        # ClickHouse override
+        mock_sync_execute.assert_called_once()
+        override_rows = mock_sync_execute.call_args.args[1]
+        assert override_rows[0][0] == TEAM_ID
+        assert override_rows[0][1] == "$posthog_cookieless"
+        assert override_rows[0][2] == DUMMY_OVERRIDE_UUID
+        assert override_rows[0][4] == PDI_VERSION + 100
+
+    @patch("posthog.dags.detach_distinct_id.sync_execute")
+    def test_uses_explicit_override_person_id(self, mock_sync_execute):
+        explicit_uuid = "11111111-2222-3333-4444-555555555555"
+        lookup_row = (PDI_ID, PDI_VERSION, PERSON_PK, UUID(PERSON_UUID))
+        conn, cursor = self._make_connection(lookup_row, other_count=2)
+        producer = MagicMock()
+
+        result = detach_distinct_id_job.execute_in_process(
+            run_config=self._run_config(dry_run=False, override_person_id=explicit_uuid),
+            resources={"persons_database": conn, "kafka_producer": producer},
+        )
+
+        assert result.success
+        mock_sync_execute.assert_called_once()
+        override_rows = mock_sync_execute.call_args.args[1]
+        assert override_rows[0][2] == explicit_uuid
+
+    def test_fails_when_distinct_id_not_found(self):
+        conn, cursor = self._make_connection(lookup_row=None, other_count=0, delete_version=None)
+        cursor.fetchone.side_effect = [None]
+        producer = MagicMock()
+
+        result = detach_distinct_id_job.execute_in_process(
+            run_config=self._run_config(dry_run=False),
+            resources={"persons_database": conn, "kafka_producer": producer},
+            raise_on_error=False,
+        )
+
+        assert not result.success
+        conn.commit.assert_not_called()
+        producer.produce.assert_not_called()
+
+    def test_fails_when_person_id_mismatch(self):
+        wrong_person = UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        lookup_row = (PDI_ID, PDI_VERSION, PERSON_PK, wrong_person)
+        conn, cursor = self._make_connection(lookup_row, other_count=2)
+        producer = MagicMock()
+
+        result = detach_distinct_id_job.execute_in_process(
+            run_config=self._run_config(dry_run=False),
+            resources={"persons_database": conn, "kafka_producer": producer},
+            raise_on_error=False,
+        )
+
+        assert not result.success
+        conn.commit.assert_not_called()
+        producer.produce.assert_not_called()
+
+    def test_fails_when_only_distinct_id(self):
+        lookup_row = (PDI_ID, PDI_VERSION, PERSON_PK, UUID(PERSON_UUID))
+        conn, cursor = self._make_connection(lookup_row, other_count=0)
+        producer = MagicMock()
+
+        result = detach_distinct_id_job.execute_in_process(
+            run_config=self._run_config(dry_run=False),
+            resources={"persons_database": conn, "kafka_producer": producer},
+            raise_on_error=False,
+        )
+
+        assert not result.success
+        conn.commit.assert_not_called()
+        producer.produce.assert_not_called()


### PR DESCRIPTION
## Problem
Part two of a fix where disassociating a particular distinct ID from a known person ID is required for data consistency to resolve a support ticket.

In this case, the "unexpected" distinct ID association was for a `$posthog_cookieless` value which should never have made it through the ingestion pipeline in that form. There is a separate PR to fix that bug, after which it will be safe to run this job for the affected team.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add a Dagster job to safely disassociate a distinct ID from an existing person ID
* Related unit tests and documentation
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; smoke test (dry run mode) to be performed after this lands in Dagster Cloud env
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
