### PR TITLE
fix(propdefs): add hardcocded default value to posthog_eventdefinition records 

### DIFF
--- a/rust/property-defs-rs/src/batch_ingestion.rs
+++ b/rust/property-defs-rs/src/batch_ingestion.rs
@@ -507,10 +507,15 @@ async fn write_event_definitions_batch(
 
         // TODO: see if we can eliminate last_seen_at from being exposed in the UI,
         // then convert this stmt to ON CONFLICT DO NOTHING
+        //
+        // enforcement_mode is hardcoded to 'allow' on INSERT so new event defs
+        // are always created in a permissive state. It is intentionally excluded
+        // from the ON CONFLICT UPDATE so user-set 'reject' values are preserved.
+        // See: https://github.com/PostHog/posthog/pull/46104
         let result = sqlx::query(
             r#"
-            INSERT INTO posthog_eventdefinition (id, name, team_id, project_id, last_seen_at, created_at)
-                (SELECT * FROM UNNEST (
+            INSERT INTO posthog_eventdefinition (id, name, team_id, project_id, last_seen_at, created_at, enforcement_mode)
+                (SELECT *, 'allow' FROM UNNEST (
                     $1::uuid[],
                     $2::varchar[],
                     $3::int[],

--- a/rust/property-defs-rs/tests/test_migrations/20240830124836_setup_propdefs_tables.sql
+++ b/rust/property-defs-rs/tests/test_migrations/20240830124836_setup_propdefs_tables.sql
@@ -9,7 +9,8 @@ CREATE TABLE IF NOT EXISTS posthog_eventdefinition (
     team_id INTEGER NOT NULL,
     project_id BIGINT NULL,
     last_seen_at TIMESTAMPTZ NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL
+    created_at TIMESTAMPTZ NOT NULL,
+    enforcement_mode VARCHAR(10) NOT NULL DEFAULT 'allow'
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS event_definition_proj_uniq ON posthog_eventdefinition (coalesce(project_id, team_id), name);


### PR DESCRIPTION
## Problem
[This PR](https://github.com/PostHog/posthog/pull/46104) broke the event definition schema confusing the propdefs services. This quick fix applies the appropriate default in the short term.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Apply expected default to non-nullable new column in event defs table
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
