### PR TITLE
fix(propdefs): add default "allow" value to enforcement_mode col on posthog_eventdefinition

### DIFF
--- a/posthog/migrations/1013_eventdefinition_enforcement_mode_db_default.py
+++ b/posthog/migrations/1013_eventdefinition_enforcement_mode_db_default.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1012_eventschema_enforcement_mode_idx"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            # Ensure the DB itself enforces the default for non-Django writers
+            # (e.g. property-defs-rs). See: https://github.com/PostHog/posthog/pull/46104
+            sql="ALTER TABLE posthog_eventdefinition ALTER COLUMN enforcement_mode SET DEFAULT 'allow'",
+            reverse_sql="ALTER TABLE posthog_eventdefinition ALTER COLUMN enforcement_mode DROP DEFAULT",
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1012_eventschema_enforcement_mode_idx
+1013_eventdefinition_enforcement_mode_db_default


### PR DESCRIPTION
## Problem
Another solution to [the schema change introduced here](https://github.com/PostHog/posthog/pull/46104) breaking the propdefs service in production at the moment.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Migration to re-apply the `allow` default value to the new column at the DB level
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
