### PR TITLE
fix(oauth): allow self-introspection of expired tokens per RFC 7662

### DIFF
--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -2274,6 +2274,20 @@ class TestOAuthAPI(APIBaseTest):
         data = response.json()
         self.assertFalse(data["active"])
 
+    def test_self_introspection_with_revoked_token_fails(self):
+        """A revoked (deleted) token cannot self-introspect."""
+        access_token, _ = self._create_access_and_refresh_tokens(scopes="openid")
+        token_value = access_token.token
+        access_token.delete()
+
+        response = self.post(
+            "/oauth/introspect/",
+            {"token": token_value},
+            headers={"Authorization": f"Bearer {token_value}"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     def test_introspecting_different_token_still_requires_introspection_scope(self):
         """Introspecting a different token still requires the introspection scope."""
         bearer_token, _ = self._create_access_and_refresh_tokens(scopes="openid user:read")


### PR DESCRIPTION
## Problem

Users of the PostHog MCP server get **500 errors instead of 401** when their OAuth access tokens expire ([Slack thread](https://posthog.slack.com/archives/C0AEPTEPTFC/p1771134233679559)).

**Root cause:** The introspection endpoint's `verify_request` method checks `token.is_valid()` for self-introspection. When a token is expired, this returns `False`, so the request is rejected with 403 instead of returning `{"active": false}`. This means the MCP server's `StateManager._fetchApiKey()` never reaches the `INACTIVE_OAUTH_TOKEN` code path — instead it gets an API error that propagates as an unhandled exception from `init()`, resulting in a 500.

The full cascade:
1. Expired OAuth token → MCP server `init()` → `getToolsFromContext()` → `stateManager.getApiKey()`
2. `_fetchApiKey()` tries `apiKeys().current()` → 401 (not a personal API key)
3. Falls back to `oauth().introspect()` → **403** (expired token can't self-introspect)
4. Throws `"Failed to get API key: INVALID_API_KEY"` → propagates through `init()` → **500**

## Changes

- **`posthog/api/oauth/views.py`**: Remove the `is_valid()` gate from `verify_request` in the introspection endpoint. Self-introspection now only requires the token to *exist* in the database. The `get_token_response` method already correctly returns `{"active": false}` for expired tokens, which is the correct behavior per [RFC 7662 Section 2.2](https://www.rfc-editor.org/rfc/rfc7662#section-2.2).

- **`posthog/api/oauth/test_views.py`**: Update the test to expect 200 with `active: false` instead of 403.

## How did you test this code

- Ran the updated test `test_self_introspection_with_expired_token_returns_inactive` — passes
- Ran all 20 introspection-related tests — all pass
- Verified existing behavior for valid self-introspection, client credential introspection, and different-token introspection is unchanged

## Changelog

No, this is a bug fix for an edge case in the OAuth introspection endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)