### PR TITLE
chore(ci): auto-commit OpenAPI generated types on PRs

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -495,25 +495,55 @@ jobs:
                   npm_config_fetch_retry_maxtimeout: 60000
               run: pnpm install --frozen-lockfile
 
-            - name: Check if OpenAPI types are up to date
+            - name: Get app token for OpenAPI type commits
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog'
+              id: openapi-app-token
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
+              with:
+                  app_id: ${{ secrets.GH_APP_POSTHOG_TESTS_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_POSTHOG_TESTS_PRIVATE_KEY }}
+
+            - name: Check and update OpenAPI types
               run: |
                   ./bin/hogli build:openapi
-                  if ! git diff --exit-code; then
-                      echo ""
-                      echo "::error::OpenAPI types are out of date!"
-                      echo ""
-                      echo "The TypeScript API types in products/*/frontend/generated/ are auto-generated"
-                      echo "from Django serializers and views. When you modify the backend API, you need"
-                      echo "to regenerate these types."
-                      echo ""
-                      echo "To fix, run locally:  hogli build:openapi"
-                      echo "Then commit the updated generated files."
-                      echo ""
-                      echo "More info: https://posthog.com/handbook/engineering/type-system"
-                      echo ""
-                      echo "Questions? #team-devex on Slack"
+                  if git diff --exit-code; then
+                      echo "OpenAPI types are up to date"
+                      exit 0
+                  fi
+
+                  echo "OpenAPI types are out of date"
+
+                  # On non-PR builds or fork PRs, fail with instructions
+                  if [ "${{ github.event_name }}" != "pull_request" ] || \
+                     [ "${{ github.event.pull_request.head.repo.full_name }}" != "PostHog/posthog" ]; then
+                      echo "::error::OpenAPI types are out of date! Run locally: hogli build:openapi"
                       exit 1
                   fi
+
+                  echo "::notice::Committing updated OpenAPI types to PR branch"
+
+                  BRANCH="${{ github.event.pull_request.head.ref }}"
+                  TOKEN="${{ steps.openapi-app-token.outputs.token }}"
+
+                  git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  # Switch to PR branch and regenerate types there
+                  git fetch origin "$BRANCH"
+                  git checkout -f -B "$BRANCH" "origin/$BRANCH"
+                  ./bin/hogli build:openapi
+
+                  if git diff --exit-code; then
+                      echo "Types already up to date on PR branch"
+                      exit 0
+                  fi
+
+                  git add frontend/src/generated/
+                  git add products/*/frontend/generated/ 2>/dev/null || true
+                  git commit -m "chore: update OpenAPI generated types"
+                  git push origin "$BRANCH"
+                  echo "::notice::Pushed updated OpenAPI types to $BRANCH"
 
     django:
         needs: [changes, detect-snapshot-mode, get_clickhouse_versions]

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -504,6 +504,15 @@ jobs:
                   private_key: ${{ secrets.GH_APP_POSTHOG_TESTS_PRIVATE_KEY }}
 
             - name: Check and update OpenAPI types
+              env:
+                  EVENT_NAME: ${{ github.event_name }}
+                  HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+                  BRANCH: ${{ github.event.pull_request.head.ref }}
+                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+                  REPOSITORY: ${{ github.repository }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  APP_TOKEN: ${{ steps.openapi-app-token.outputs.token }}
+                  GH_TOKEN: ${{ steps.openapi-app-token.outputs.token }}
               run: |
                   ./bin/hogli build:openapi
                   if git diff --exit-code; then
@@ -514,8 +523,8 @@ jobs:
                   echo "OpenAPI types are out of date"
 
                   # On non-PR builds or fork PRs, fail with instructions
-                  if [ "${{ github.event_name }}" != "pull_request" ] || \
-                     [ "${{ github.event.pull_request.head.repo.full_name }}" != "PostHog/posthog" ]; then
+                  if [ "$EVENT_NAME" != "pull_request" ] || \
+                     [ "$HEAD_REPO" != "PostHog/posthog" ]; then
                       echo ""
                       echo "::error::OpenAPI types are out of date!"
                       echo ""
@@ -534,19 +543,18 @@ jobs:
 
                   echo "::notice::Committing updated OpenAPI types to PR branch"
 
-                  BRANCH="${{ github.event.pull_request.head.ref }}"
-                  TOKEN="${{ steps.openapi-app-token.outputs.token }}"
-
                   # Verify branch hasn't advanced since CI started
                   CURRENT_SHA=$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)
-                  EXPECTED_SHA="${{ github.event.pull_request.head.sha }}"
-                  if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
-                      echo "::warning::Branch advanced during workflow ($EXPECTED_SHA -> $CURRENT_SHA) — skipping auto-commit"
+                  if [ "$CURRENT_SHA" != "$HEAD_SHA" ]; then
+                      echo "::warning::Branch advanced during workflow ($HEAD_SHA -> $CURRENT_SHA) — skipping auto-commit"
                       echo "The new commit will trigger its own workflow run."
                       exit 0
                   fi
 
-                  git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
+                  # Disable auto-merge before pushing to prevent unreviewed code from merging
+                  gh pr merge --disable-auto "$PR_NUMBER" || echo "Auto-merge was not enabled"
+
+                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPOSITORY}.git"
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -516,7 +516,19 @@ jobs:
                   # On non-PR builds or fork PRs, fail with instructions
                   if [ "${{ github.event_name }}" != "pull_request" ] || \
                      [ "${{ github.event.pull_request.head.repo.full_name }}" != "PostHog/posthog" ]; then
-                      echo "::error::OpenAPI types are out of date! Run locally: hogli build:openapi"
+                      echo ""
+                      echo "::error::OpenAPI types are out of date!"
+                      echo ""
+                      echo "The TypeScript API types in products/*/frontend/generated/ are auto-generated"
+                      echo "from Django serializers and views. When you modify the backend API, you need"
+                      echo "to regenerate these types."
+                      echo ""
+                      echo "To fix, run locally:  hogli build:openapi"
+                      echo "Then commit the updated generated files."
+                      echo ""
+                      echo "More info: https://posthog.com/handbook/engineering/type-system"
+                      echo ""
+                      echo "Questions? #team-devex on Slack"
                       exit 1
                   fi
 
@@ -524,6 +536,15 @@ jobs:
 
                   BRANCH="${{ github.event.pull_request.head.ref }}"
                   TOKEN="${{ steps.openapi-app-token.outputs.token }}"
+
+                  # Verify branch hasn't advanced since CI started
+                  CURRENT_SHA=$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)
+                  EXPECTED_SHA="${{ github.event.pull_request.head.sha }}"
+                  if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
+                      echo "::warning::Branch advanced during workflow ($EXPECTED_SHA -> $CURRENT_SHA) — skipping auto-commit"
+                      echo "The new commit will trigger its own workflow run."
+                      exit 0
+                  fi
 
                   git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
                   git config user.name "github-actions[bot]"


### PR DESCRIPTION
Feels like there's no good reason not just do this automatically for people instead of making them rerun this locally

## Summary

- Instead of failing CI when OpenAPI types are out of date, automatically commit the regenerated types to the PR branch
- Uses the existing GitHub App token (same as snapshot commits) so the push triggers a new CI run
- Falls back to the existing error message on non-PR builds and fork PRs

## Test plan

- [ ] Open a PR that changes a Django serializer without updating generated types — CI should auto-commit them
- [ ] Verify fork PRs still get the error message (no access to app token secrets)
- [ ] Verify master push still gets the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)