### PR TITLE
feat(experiments): basic experiment template modal.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateModal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateModal.tsx
@@ -1,4 +1,4 @@
-import { useActions, useMountedLogic, useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 
 import { LemonBanner, LemonButton, LemonModal } from '@posthog/lemon-ui'
 
@@ -8,9 +8,7 @@ interface ExperimentTemplateModalProps {
     onApply: () => void
 }
 
-export function ExperimentTemplateModal({ onApply }: ExperimentTemplateModalProps): JSX.Element | null {
-    useMountedLogic(experimentTemplateModalLogic)
-
+export const ExperimentTemplateModal = ({ onApply }: ExperimentTemplateModalProps): JSX.Element | null => {
     const { isModalOpen, template } = useValues(experimentTemplateModalLogic)
     const { closeTemplateModal } = useActions(experimentTemplateModalLogic)
 

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateModal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplateModal.tsx
@@ -1,0 +1,62 @@
+import { useActions, useMountedLogic, useValues } from 'kea'
+
+import { LemonBanner, LemonButton, LemonModal } from '@posthog/lemon-ui'
+
+import { experimentTemplateModalLogic } from './experimentTemplateModalLogic'
+
+interface ExperimentTemplateModalProps {
+    onApply: () => void
+}
+
+export function ExperimentTemplateModal({ onApply }: ExperimentTemplateModalProps): JSX.Element | null {
+    useMountedLogic(experimentTemplateModalLogic)
+
+    const { isModalOpen, template } = useValues(experimentTemplateModalLogic)
+    const { closeTemplateModal } = useActions(experimentTemplateModalLogic)
+
+    if (!isModalOpen || !template) {
+        return null
+    }
+
+    const canApplyTemplate = true
+
+    return (
+        <LemonModal
+            isOpen={isModalOpen}
+            onClose={closeTemplateModal}
+            title={`Configure: ${template.name}`}
+            footer={
+                <div className="flex items-center w-full justify-end gap-2">
+                    <LemonButton type="secondary" onClick={closeTemplateModal}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={onApply}
+                        disabledReason={!canApplyTemplate ? 'Please fill in all required event fields' : undefined}
+                        data-attr="apply-experiment-template"
+                    >
+                        Apply Template
+                    </LemonButton>
+                </div>
+            }
+        >
+            <div className="space-y-4">
+                <LemonBanner type="info">
+                    <strong>Goal:</strong> {template.experimentGoal}
+                </LemonBanner>
+
+                <div className="space-y-4">
+                    {template.metrics.map((metric) => (
+                        <div key={metric.name}>{metric.name}</div>
+                    ))}
+                </div>
+
+                <LemonBanner type="success">
+                    This will add {template.metrics.length} metrics:{' '}
+                    {template.metrics.map((metric) => metric.name).join(', ')}
+                </LemonBanner>
+            </div>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplates.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/ExperimentTemplates.tsx
@@ -1,7 +1,13 @@
+import { useActions } from 'kea'
+
 import { ExperimentTemplateCard } from './ExperimentTemplateCard'
+import { ExperimentTemplateModal } from './ExperimentTemplateModal'
 import { EXPERIMENT_TEMPLATES } from './constants'
+import { experimentTemplateModalLogic } from './experimentTemplateModalLogic'
 
 export const ExperimentTemplates = (): JSX.Element => {
+    const { openTemplateModal } = useActions(experimentTemplateModalLogic)
+
     return (
         <>
             <div className="space-y-4">
@@ -14,9 +20,10 @@ export const ExperimentTemplates = (): JSX.Element => {
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {EXPERIMENT_TEMPLATES.map((template) => (
-                    <ExperimentTemplateCard key={template.id} template={template} onSelect={() => {}} />
+                    <ExperimentTemplateCard key={template.id} template={template} onSelect={openTemplateModal} />
                 ))}
             </div>
+            <ExperimentTemplateModal onApply={() => {}} />
         </>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/experimentTemplateModalLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentTemplates/experimentTemplateModalLogic.ts
@@ -1,0 +1,30 @@
+import { actions, kea, path, reducers } from 'kea'
+
+import { ExperimentTemplate } from './constants'
+import type { experimentTemplateModalLogicType } from './experimentTemplateModalLogicType'
+
+export const experimentTemplateModalLogic = kea<experimentTemplateModalLogicType>([
+    path(['scenes', 'experiments', 'ExperimentForm', 'ExperimentTemplates', 'experimentTemplateModalLogic']),
+
+    actions({
+        openTemplateModal: (template: ExperimentTemplate) => ({ template }),
+        closeTemplateModal: true,
+    }),
+
+    reducers({
+        isModalOpen: [
+            false,
+            {
+                openTemplateModal: () => true,
+                closeTemplateModal: () => false,
+            },
+        ],
+        template: [
+            null as ExperimentTemplate | null,
+            {
+                openTemplateModal: (_, { template }) => template,
+                closeTemplateModal: () => null,
+            },
+        ],
+    }),
+])


### PR DESCRIPTION
## Problem

Using a template to create an experiment requires defining key events on the user journey. To do that, we'll present the user with a modal dialog that should help answer the necessary questions to build a successful experiment.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Here, we add the basic scaffolding for a modal dialog that lets the user select key events to construct the experiment metrics.

| experiment template modal dialog |
| - |
| <img width="1604" height="1233" alt="image" src="https://github.com/user-attachments/assets/56bf8715-6b0a-44b0-b5a7-82bd4806dc99" /> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/2d36135c-c068-47cd-a0f4-6f863e67008e)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
