### PR TITLE
fix(experiments): create metric from insight's run experiment button.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -12,7 +12,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
-import { isExperimentMetricValid } from '~/queries/schema-guards'
+import { isExperimentMetric } from '~/queries/schema-guards'
 import {
     ExperimentExposureCriteria,
     ExperimentMetric,
@@ -323,16 +323,20 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
 
                 const parsedMetric = typeof metric === 'string' ? JSON.parse(metric) : metric
 
-                if (name && isExperimentMetricValid(parsedMetric)) {
+                if (name && isExperimentMetric(parsedMetric)) {
                     actions.setExperiment({
                         ...NEW_EXPERIMENT,
                         metrics: parsedMetric ? [parsedMetric] : [],
                         name: name ?? '',
                     })
+
+                    lemonToast.success('Metric added successfully!')
+
                     return
                 }
             } catch (error) {
                 console.error('Error parsing metric from URL', error)
+                lemonToast.error('Error parsing metric from URL')
                 // Continue to draft fallback
             }
 

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -161,7 +161,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
     actions(() => ({
         setExperiment: (experiment: Experiment) => ({ experiment }),
         setExperimentValue: (name: string, value: any) => ({ name, value }),
-        resetExperiment: (experiment?: Experiment) => ({ experiment }),
+        resetExperiment: true,
         clearDraft: true,
         setExposureCriteria: (criteria: ExperimentExposureCriteria) => ({ criteria }),
         setFeatureFlagConfig: (config: {
@@ -211,7 +211,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                     },
                 }),
                 updateFeatureFlagKey: (state, { key }) => ({ ...state, feature_flag_key: key }),
-                resetExperiment: (_, { experiment }) => experiment ?? props.experiment ?? { ...NEW_EXPERIMENT },
+                resetExperiment: () => props.experiment ?? { ...NEW_EXPERIMENT },
             },
         ],
         sharedMetrics: [

--- a/frontend/src/scenes/experiments/experimentSceneLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.tsx
@@ -1,4 +1,5 @@
 import { BuiltLogic, actions, kea, listeners, path, props, reducers, selectors, sharedListeners } from 'kea'
+import { router } from 'kea-router'
 
 import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
@@ -205,9 +206,6 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
         },
         resetExperimentState: (payload, breakpoint, action, previousState) => {
             sharedListeners.ensureExperimentLogicMounted(payload, breakpoint, action, previousState)
-            if (payload.experimentConfig) {
-                values.experimentLogicRef?.logic.actions.resetExperiment(payload.experimentConfig)
-            }
         },
     })),
     tabAwareActionToUrl(({ values }) => {
@@ -228,7 +226,9 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
                       ? undefined
                       : formMode
 
-            return [urls.experiment(id, effectiveFormMode), undefined, undefined]
+            // Preserve search params (e.g. ?metric=...) when navigating to a new experiment
+            const search = id === 'new' ? router.values.currentLocation.searchParams : undefined
+            return [urls.experiment(id, effectiveFormMode), search, undefined]
         }
 
         return {


### PR DESCRIPTION
## Problem

On the insights page, funnels let you create an experiment directly from the insight page.

| funnel's _run experiment_ button |
| - |
| <img width="1389" height="323" alt="image" src="https://github.com/user-attachments/assets/fe0dc3c7-b536-48e0-ba23-d5a7322f0a6c" /> |


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

At the scene level, we are preserving the search parameters, and at the logic level, we are taking the metric and the name and adding a new metric to the draft experiment.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/25764e40-caaf-4496-84e7-bac8e98dbbfe)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
