### PR TITLE
fix(skills): resolve agent-skills-latest tag conflicts and target correct commit

### DIFF
--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -209,12 +209,14 @@ jobs:
                       products/posthog_ai/dist/skills.zip \
                       --title "Agent skills ${{ steps.version.outputs.tag }}" \
                       --notes "Build from ${{ github.sha }}" \
+                      --target "${{ github.sha }}" \
                       --latest=false
 
-                  gh release delete agent-skills-latest --yes || true
+                  gh release delete agent-skills-latest --cleanup-tag --yes || true
                   git push origin :refs/tags/agent-skills-latest || true
                   gh release create agent-skills-latest \
                       products/posthog_ai/dist/skills.zip \
                       --title "Agent skills (Latest)" \
                       --notes "Latest build — same as ${{ steps.version.outputs.tag }}" \
+                      --target "${{ github.sha }}" \
                       --latest=false

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -201,7 +201,7 @@ jobs:
                   MINOR=$(echo "${LATEST_TAG#agent-skills-v}" | cut -d. -f2)
                   echo "tag=agent-skills-v0.$((MINOR + 1)).0" >> "$GITHUB_OUTPUT"
 
-            - name: Create versioned and latest releases
+            - name: Create versioned release
               env:
                   GH_TOKEN: ${{ github.token }}
               run: |
@@ -212,11 +212,20 @@ jobs:
                       --target "${{ github.sha }}" \
                       --latest=false
 
-                  gh release delete agent-skills-latest --cleanup-tag --yes || true
-                  git push origin :refs/tags/agent-skills-latest || true
-                  gh release create agent-skills-latest \
-                      products/posthog_ai/dist/skills.zip \
-                      --title "Agent skills (Latest)" \
-                      --notes "Latest build — same as ${{ steps.version.outputs.tag }}" \
-                      --target "${{ github.sha }}" \
-                      --latest=false
+            - name: Update latest release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  if gh release view agent-skills-latest &>/dev/null; then
+                      gh release upload agent-skills-latest \
+                          products/posthog_ai/dist/skills.zip --clobber
+                      gh release edit agent-skills-latest \
+                          --notes "Latest build — same as ${{ steps.version.outputs.tag }}"
+                  else
+                      gh release create agent-skills-latest \
+                          products/posthog_ai/dist/skills.zip \
+                          --title "Agent skills (Latest)" \
+                          --notes "Latest build — same as ${{ steps.version.outputs.tag }}" \
+                          --target "${{ github.sha }}" \
+                          --latest=false
+                  fi

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -24,5 +24,6 @@
         "editor.codeActionsOnSave": {
             "source.organizeImports.ruff": "explicit"
         }
-    }
+    },
+    "git.fetchTags": false
 }


### PR DESCRIPTION
## Problem

The agent skills overwrite the tag in CI, causing conflicts, so someone from the admins might have deleted the tag. We need the static link to distribute skills across multiple consumers.

## Changes

Keep the tag static to one commit and overwrite the contents of the release. Not a perfect solution, but it's not important to keep the tag history.