### PR TITLE
fix(ci): Fix codeowners with the github team rename

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -150,12 +150,12 @@ frontend/src/scenes/cohorts/ @PostHog/team-feature-flags
 frontend/src/scenes/feature-flags/ @PostHog/team-feature-flags
 
 # Data warehouse - owned by @PostHog/team-data-stack
-posthog/temporal/data_imports/** @PostHog/team-warehouse-pipelines
+posthog/temporal/data_imports/** @PostHog/team-warehouse-sources
 posthog/temporal/data_modeling/** @PostHog/team-data-tools
 posthog/warehouse/** @PostHog/team-data-stack
 products/data_warehouse/** @PostHog/team-data-stack
 frontend/src/scenes/data-warehouse/\*\* @PostHog/team-data-stack
-posthog/management/commands/generate_source_configs.py @PostHog/team-warehouse-pipelines
+posthog/management/commands/generate_source_configs.py @PostHog/team-warehouse-sources
 posthog/settings/data_warehouse.py @PostHog/team-data-stack
 
 # HogQL - owned by @PostHog/team-data-tools


### PR DESCRIPTION
## Changes
Forgot to update our team name in codeowners when i renamed us
