### PR TITLE
fix(experiments): search all feature flags in experiment creation dropdown

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanel.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanel.tsx
@@ -39,7 +39,7 @@ export function VariantsPanel({ experiment, updateFeatureFlag, disabled = false 
         clearFeatureFlagKeyValidation,
     } = useActions(variantsPanelLogic({ experiment, disabled }))
 
-    const { openSelectExistingFeatureFlagModal, closeSelectExistingFeatureFlagModal } = useActions(
+    const { openSelectExistingFeatureFlagModal, closeSelectExistingFeatureFlagModal, setFilters } = useActions(
         selectExistingFeatureFlagModalLogic
     )
     const { reportExperimentFeatureFlagSelected } = useActions(eventUsageLogic)
@@ -146,6 +146,7 @@ export function VariantsPanel({ experiment, updateFeatureFlag, disabled = false 
                         options={featureFlagOptions}
                         value={currentAutocompleteValue}
                         onChange={handleFeatureFlagSelection}
+                        onInputChange={(value) => setFilters({ search: value || undefined, page: 1 })}
                         inputTransform={(value) => value.replace(/\s+/g, '-')}
                         allowCustomValues
                         formatCreateLabel={(input) => (


### PR DESCRIPTION
## Problem

The feature flag selector in experiment creation only loaded the 100 most recent eligible flags and filtered client-side with Fuse.js. If the desired flag wasn't in that initial set, it was impossible to find.

## Changes

Wire up `onInputChange` on the `LemonInputSelect` to trigger server-side search via the existing `setFilters` action (which debounces at 300ms). The backend `eligible_feature_flags` endpoint already supports a `search` query parameter. Client-side fuzzy filtering still runs instantly for immediate feedback while the API call is in flight.

A loading indicator is also there to not surprise the user when the list changes after the API responds

https://github.com/user-attachments/assets/f87b7d47-5466-4c9b-8c4e-5a3b7a93bd9d

## Testing

- Existing tests pass (127 VariantsPanel tests)
- Manually verified: typing in the dropdown now triggers network requests to `eligible_feature_flags/?search=...`, returning matches across all flags