### PR TITLE
chore(ci): drop redundant thread for priority-review slack notifications

### DIFF
--- a/.github/workflows/pr-priority-review.yml
+++ b/.github/workflows/pr-priority-review.yml
@@ -12,6 +12,7 @@ env:
 permissions:
     contents: read
     pull-requests: read
+    models: read
 
 jobs:
     # When a PR is labeled "priority-review", post to #dev-stamp-exchange
@@ -21,6 +22,39 @@ jobs:
             github.event.action == 'labeled'
             && github.event.label.name == 'priority-review'
         steps:
+            - name: Get author display name
+              id: author
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              with:
+                  script: |
+                      const { data: user } = await github.rest.users.getByUsername({
+                        username: context.payload.pull_request.user.login,
+                      });
+                      const name = user.name || context.payload.pull_request.user.login;
+                      core.setOutput('name', name.split(' ')[0]);
+
+            - name: Summarize PR
+              id: summary
+              uses: actions/ai-inference@v1
+              with:
+                  model: openai/gpt-4o-mini
+                  max-tokens: 80
+                  prompt: |
+                      You write ultra-short casual Slack summaries for code review requests.
+                      Given a PR title and author first name, produce a one-liner like:
+                      "$NAME wants a stamp for fixing the broken cohort queries"
+                      "$NAME wants a stamp for adding dark mode to the dashboard"
+
+                      Rules:
+                      - Start with "$NAME wants a stamp for ..."
+                      - Use plain English, no jargon, no quotes, no markdown
+                      - Strip conventional commit prefixes (feat, fix, chore, etc.)
+                      - Keep it under 15 words total
+                      - Just output the line, nothing else
+
+                      Author first name: ${{ steps.author.outputs.name }}
+                      PR title: ${{ github.event.pull_request.title }}
+
             - name: Escape PR title
               id: pr
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -37,7 +71,19 @@ jobs:
                         .replace(/"/g, '\\"');
                       core.setOutput('title', escaped);
 
+            # TODO: remove dry-run gate after testing
+            - name: Dry run — print Slack message
+              if: github.event.pull_request.head.ref == 'chore/priority-review-summary'
+              run: |
+                  echo "=== DRY RUN — would post to Slack ==="
+                  echo ""
+                  echo ":eyes: #${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}"
+                  echo "${{ steps.summary.outputs.response }}"
+                  echo ""
+                  echo "Author display name: ${{ steps.author.outputs.name }}"
+
             - name: Post to Slack
+              if: github.event.pull_request.head.ref != 'chore/priority-review-summary'
               id: slack
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
@@ -52,9 +98,10 @@ jobs:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":eyes: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}> by ${{ github.event.pull_request.user.login }}"
+                            text: ":eyes: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}>\n${{ steps.summary.outputs.response }}"
 
             - name: Save Slack message info
+              if: github.event.pull_request.head.ref != 'chore/priority-review-summary'
               run: |
                   echo '{}' | jq \
                     --arg channel "${{ steps.slack.outputs.channel_id }}" \
@@ -62,6 +109,7 @@ jobs:
                     '{channel: $channel, ts: $ts}' > .priority-review-slack
 
             - name: Cache Slack message info
+              if: github.event.pull_request.head.ref != 'chore/priority-review-summary'
               uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
               with:
                   path: .priority-review-slack
@@ -132,45 +180,9 @@ jobs:
                   payload: |
                       channel: "${{ steps.slack_msg.outputs.channel }}"
                       ts: "${{ steps.slack_msg.outputs.ts }}"
-                      text: "Approved: ${{ steps.pr.outputs.title }}"
+                      text: "Reviewed and approved: ${{ steps.pr.outputs.title }}"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":white_check_mark: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}> by ${{ github.event.pull_request.user.login }} — approved by ${{ github.event.review.user.login }}"
-
-            - name: Build approval message
-              if: steps.slack_msg.outputs.found == 'true'
-              id: review
-              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-              with:
-                  script: |
-                      const reviewer = context.payload.review.user.login;
-                      const body = (context.payload.review.body || '').trim();
-                      let text = `:white_check_mark: Reviewed and approved by *${reviewer}*`;
-                      if (body) {
-                        const truncated = body.length > 500
-                          ? body.substring(0, 500) + '...'
-                          : body;
-                        const quoted = truncated.split('\n').map(l => `> ${l}`).join('\n');
-                        text += '\n\n' + quoted;
-                      }
-                      // Escape for embedding in a YAML double-quoted string
-                      const escaped = text
-                        .replace(/\\/g, '\\\\')
-                        .replace(/"/g, '\\"')
-                        .replace(/\n/g, '\\n');
-                      core.setOutput('text', escaped);
-
-            - name: Thread reply with approval
-              if: steps.slack_msg.outputs.found == 'true'
-              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-              with:
-                  method: chat.postMessage
-                  token: ${{ secrets.SLACK_BOT_TOKEN }}
-                  errors: true
-                  payload: |
-                      channel: "${{ steps.slack_msg.outputs.channel }}"
-                      thread_ts: "${{ steps.slack_msg.outputs.ts }}"
-                      text: "${{ steps.review.outputs.text }}"
-                      unfurl_links: false
+                            text: ":white_check_mark: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}> by ${{ github.event.pull_request.user.login }} — reviewed and approved by ${{ github.event.review.user.login }}"

--- a/.github/workflows/pr-priority-review.yml
+++ b/.github/workflows/pr-priority-review.yml
@@ -18,39 +18,41 @@ jobs:
     notify-priority-review:
         runs-on: ubuntu-latest
         if: >-
-            (
-              github.event.action == 'labeled'
-              && github.event.label.name == 'priority-review'
-              && github.event.pull_request.draft == false
-            ) || (
-              github.event.action == 'ready_for_review'
-              && contains(github.event.pull_request.labels.*.name, 'priority-review')
+            github.event.pull_request.head.repo.full_name == github.repository
+            && contains(fromJSON('["MEMBER","OWNER"]'), github.event.pull_request.author_association)
+            && (
+              (
+                github.event.action == 'labeled'
+                && github.event.label.name == 'priority-review'
+                && github.event.pull_request.draft == false
+              ) || (
+                github.event.action == 'ready_for_review'
+                && contains(github.event.pull_request.labels.*.name, 'priority-review')
+              )
             )
         steps:
-            - name: Get author display name
-              id: author
+            - name: Get author display name and escape PR title
+              id: meta
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               with:
                   script: |
                       const { data: user } = await github.rest.users.getByUsername({
                         username: context.payload.pull_request.user.login,
                       });
-                      core.setOutput('name', user.name || context.payload.pull_request.user.login);
+                      const name = user.name || context.payload.pull_request.user.login;
 
-            - name: Escape PR title
-              id: pr
-              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-              with:
-                  script: |
-                      const title = context.payload.pull_request.title;
-                      const escaped = title
-                        .replace(/&/g, '&amp;')
-                        .replace(/</g, '&lt;')
-                        .replace(/>/g, '&gt;')
-                        .replace(/\|/g, '-')
-                        .replace(/\\/g, '\\\\')
-                        .replace(/"/g, '\\"');
-                      core.setOutput('title', escaped);
+                      function escapeSlack(str) {
+                        return str
+                          .replace(/&/g, '&amp;')
+                          .replace(/</g, '&lt;')
+                          .replace(/>/g, '&gt;')
+                          .replace(/\|/g, '-')
+                          .replace(/\\/g, '\\\\')
+                          .replace(/"/g, '\\"');
+                      }
+
+                      core.setOutput('author', escapeSlack(name));
+                      core.setOutput('title', escapeSlack(context.payload.pull_request.title));
 
             - name: Post to Slack
               id: slack
@@ -61,13 +63,13 @@ jobs:
                   errors: true
                   payload: |
                       channel: "${{ env.SLACK_CHANNEL }}"
-                      text: "Priority review requested: ${{ steps.pr.outputs.title }}"
+                      text: "Priority review requested: ${{ steps.meta.outputs.title }}"
                       unfurl_links: false
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":eyes: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}> by ${{ steps.author.outputs.name }}"
+                            text: ":eyes: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.meta.outputs.title }}> by ${{ steps.meta.outputs.author }}"
 
             - name: Save Slack message info
               run: |
@@ -82,7 +84,7 @@ jobs:
                   path: .priority-review-slack
                   key: priority-review-slack-pr-${{ github.event.pull_request.number }}
 
-    # When a priority-review PR is closed, strikethrough the Slack message
+    # When a priority-review PR is closed or merged, update the Slack message
     cleanup-closed:
         runs-on: ubuntu-latest
         if: >-
@@ -106,23 +108,28 @@ jobs:
                     echo "found=false" >> $GITHUB_OUTPUT
                   fi
 
-            - name: Escape PR title
+            - name: Escape PR title and determine status
               if: steps.slack_msg.outputs.found == 'true'
-              id: pr
+              id: meta
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               with:
                   script: |
-                      const title = context.payload.pull_request.title;
-                      const escaped = title
-                        .replace(/&/g, '&amp;')
-                        .replace(/</g, '&lt;')
-                        .replace(/>/g, '&gt;')
-                        .replace(/\|/g, '-')
-                        .replace(/\\/g, '\\\\')
-                        .replace(/"/g, '\\"');
-                      core.setOutput('title', escaped);
+                      function escapeSlack(str) {
+                        return str
+                          .replace(/&/g, '&amp;')
+                          .replace(/</g, '&lt;')
+                          .replace(/>/g, '&gt;')
+                          .replace(/\|/g, '-')
+                          .replace(/\\/g, '\\\\')
+                          .replace(/"/g, '\\"');
+                      }
 
-            - name: Strikethrough Slack message
+                      const merged = context.payload.pull_request.merged;
+                      core.setOutput('title', escapeSlack(context.payload.pull_request.title));
+                      core.setOutput('emoji', merged ? ':merged:' : ':closed:');
+                      core.setOutput('status', merged ? 'merged' : 'closed');
+
+            - name: Update Slack message
               if: steps.slack_msg.outputs.found == 'true'
               continue-on-error: true
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
@@ -133,12 +140,12 @@ jobs:
                   payload: |
                       channel: "${{ steps.slack_msg.outputs.channel }}"
                       ts: "${{ steps.slack_msg.outputs.ts }}"
-                      text: "Closed: ${{ steps.pr.outputs.title }}"
+                      text: "${{ steps.meta.outputs.status }}: ${{ steps.meta.outputs.title }}"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: "~<${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}>~ (closed)"
+                            text: "${{ steps.meta.outputs.emoji }} ~<${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.meta.outputs.title }}>~ (${{ steps.meta.outputs.status }})"
 
     # When a priority-review PR is approved, update the Slack message
     notify-reviewed:
@@ -165,34 +172,30 @@ jobs:
                     echo "found=false" >> $GITHUB_OUTPUT
                   fi
 
-            - name: Get display names
+            - name: Get display names and escape PR title
               if: steps.slack_msg.outputs.found == 'true'
-              id: names
+              id: meta
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               with:
                   script: |
+                      function escapeSlack(str) {
+                        return str
+                          .replace(/&/g, '&amp;')
+                          .replace(/</g, '&lt;')
+                          .replace(/>/g, '&gt;')
+                          .replace(/\|/g, '-')
+                          .replace(/\\/g, '\\\\')
+                          .replace(/"/g, '\\"');
+                      }
+
                       const [author, reviewer] = await Promise.all([
                         github.rest.users.getByUsername({ username: context.payload.pull_request.user.login }),
                         github.rest.users.getByUsername({ username: context.payload.review.user.login }),
                       ]);
-                      core.setOutput('author', author.data.name || context.payload.pull_request.user.login);
-                      core.setOutput('reviewer', reviewer.data.name || context.payload.review.user.login);
 
-            - name: Escape PR title
-              if: steps.slack_msg.outputs.found == 'true'
-              id: pr
-              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-              with:
-                  script: |
-                      const title = context.payload.pull_request.title;
-                      const escaped = title
-                        .replace(/&/g, '&amp;')
-                        .replace(/</g, '&lt;')
-                        .replace(/>/g, '&gt;')
-                        .replace(/\|/g, '-')
-                        .replace(/\\/g, '\\\\')
-                        .replace(/"/g, '\\"');
-                      core.setOutput('title', escaped);
+                      core.setOutput('author', escapeSlack(author.data.name || context.payload.pull_request.user.login));
+                      core.setOutput('reviewer', escapeSlack(reviewer.data.name || context.payload.review.user.login));
+                      core.setOutput('title', escapeSlack(context.payload.pull_request.title));
 
             - name: Add checkmark reaction
               if: steps.slack_msg.outputs.found == 'true'
@@ -218,9 +221,9 @@ jobs:
                   payload: |
                       channel: "${{ steps.slack_msg.outputs.channel }}"
                       ts: "${{ steps.slack_msg.outputs.ts }}"
-                      text: "Reviewed and approved: ${{ steps.pr.outputs.title }}"
+                      text: "Reviewed and approved: ${{ steps.meta.outputs.title }}"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":white_check_mark: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}> by ${{ steps.names.outputs.author }} — reviewed and approved by ${{ steps.names.outputs.reviewer }}"
+                            text: ":white_check_mark: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.meta.outputs.title }}> by ${{ steps.meta.outputs.author }} — reviewed and approved by ${{ steps.meta.outputs.reviewer }}"

--- a/.github/workflows/pr-priority-review.yml
+++ b/.github/workflows/pr-priority-review.yml
@@ -1,7 +1,7 @@
 name: Priority Review Slack Notifications
 
 on:
-    pull_request_target:
+    pull_request:
         types: [labeled]
     pull_request_review:
         types: [submitted]

--- a/.github/workflows/pr-priority-review.yml
+++ b/.github/workflows/pr-priority-review.yml
@@ -51,7 +51,7 @@ jobs:
                           .replace(/"/g, '\\"');
                       }
 
-                      core.setOutput('author', escapeSlack(name));
+                      core.setOutput('author', escapeSlack(name.split(' ')[0]));
                       core.setOutput('title', escapeSlack(context.payload.pull_request.title));
 
             - name: Post to Slack
@@ -69,7 +69,7 @@ jobs:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":eyes: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.meta.outputs.title }}> by ${{ steps.meta.outputs.author }}"
+                            text: ":eyes: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.meta.outputs.title }}>\nby ${{ steps.meta.outputs.author }}"
 
             - name: Save Slack message info
               run: |
@@ -193,8 +193,8 @@ jobs:
                         github.rest.users.getByUsername({ username: context.payload.review.user.login }),
                       ]);
 
-                      core.setOutput('author', escapeSlack(author.data.name || context.payload.pull_request.user.login));
-                      core.setOutput('reviewer', escapeSlack(reviewer.data.name || context.payload.review.user.login));
+                      core.setOutput('author', escapeSlack((author.data.name || context.payload.pull_request.user.login).split(' ')[0]));
+                      core.setOutput('reviewer', escapeSlack((reviewer.data.name || context.payload.review.user.login).split(' ')[0]));
                       core.setOutput('title', escapeSlack(context.payload.pull_request.title));
 
             - name: Add checkmark reaction
@@ -226,4 +226,4 @@ jobs:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":white_check_mark: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.meta.outputs.title }}> by ${{ steps.meta.outputs.author }} — reviewed and approved by ${{ steps.meta.outputs.reviewer }}"
+                            text: ":white_check_mark: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.meta.outputs.title }}>\nby ${{ steps.meta.outputs.author }} — reviewed and approved by ${{ steps.meta.outputs.reviewer }}"

--- a/.github/workflows/pr-priority-review.yml
+++ b/.github/workflows/pr-priority-review.yml
@@ -2,7 +2,7 @@ name: Priority Review Slack Notifications
 
 on:
     pull_request:
-        types: [labeled]
+        types: [labeled, closed, ready_for_review]
     pull_request_review:
         types: [submitted]
 
@@ -12,15 +12,20 @@ env:
 permissions:
     contents: read
     pull-requests: read
-    models: read
 
 jobs:
-    # When a PR is labeled "priority-review", post to #dev-stamp-exchange
+    # When a non-draft PR is labeled "priority-review", or a labeled PR is undrafted
     notify-priority-review:
         runs-on: ubuntu-latest
         if: >-
-            github.event.action == 'labeled'
-            && github.event.label.name == 'priority-review'
+            (
+              github.event.action == 'labeled'
+              && github.event.label.name == 'priority-review'
+              && github.event.pull_request.draft == false
+            ) || (
+              github.event.action == 'ready_for_review'
+              && contains(github.event.pull_request.labels.*.name, 'priority-review')
+            )
         steps:
             - name: Get author display name
               id: author
@@ -30,30 +35,7 @@ jobs:
                       const { data: user } = await github.rest.users.getByUsername({
                         username: context.payload.pull_request.user.login,
                       });
-                      const name = user.name || context.payload.pull_request.user.login;
-                      core.setOutput('name', name.split(' ')[0]);
-
-            - name: Summarize PR
-              id: summary
-              uses: actions/ai-inference@v1
-              with:
-                  model: openai/gpt-4o-mini
-                  max-tokens: 80
-                  prompt: |
-                      You write ultra-short casual Slack summaries for code review requests.
-                      Given a PR title and author first name, produce a one-liner like:
-                      "$NAME wants a stamp for fixing the broken cohort queries"
-                      "$NAME wants a stamp for adding dark mode to the dashboard"
-
-                      Rules:
-                      - Start with "$NAME wants a stamp for ..."
-                      - Use plain English, no jargon, no quotes, no markdown
-                      - Strip conventional commit prefixes (feat, fix, chore, etc.)
-                      - Keep it under 15 words total
-                      - Just output the line, nothing else
-
-                      Author first name: ${{ steps.author.outputs.name }}
-                      PR title: ${{ github.event.pull_request.title }}
+                      core.setOutput('name', user.name || context.payload.pull_request.user.login);
 
             - name: Escape PR title
               id: pr
@@ -61,7 +43,6 @@ jobs:
               with:
                   script: |
                       const title = context.payload.pull_request.title;
-                      // Escape for Slack mrkdwn link text, then for YAML embedding
                       const escaped = title
                         .replace(/&/g, '&amp;')
                         .replace(/</g, '&lt;')
@@ -71,19 +52,7 @@ jobs:
                         .replace(/"/g, '\\"');
                       core.setOutput('title', escaped);
 
-            # TODO: remove dry-run gate after testing
-            - name: Dry run — print Slack message
-              if: github.event.pull_request.head.ref == 'chore/priority-review-summary'
-              run: |
-                  echo "=== DRY RUN — would post to Slack ==="
-                  echo ""
-                  echo ":eyes: #${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}"
-                  echo "${{ steps.summary.outputs.response }}"
-                  echo ""
-                  echo "Author display name: ${{ steps.author.outputs.name }}"
-
             - name: Post to Slack
-              if: github.event.pull_request.head.ref != 'chore/priority-review-summary'
               id: slack
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
@@ -98,10 +67,9 @@ jobs:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":eyes: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}>\n${{ steps.summary.outputs.response }}"
+                            text: ":eyes: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}> by ${{ steps.author.outputs.name }}"
 
             - name: Save Slack message info
-              if: github.event.pull_request.head.ref != 'chore/priority-review-summary'
               run: |
                   echo '{}' | jq \
                     --arg channel "${{ steps.slack.outputs.channel_id }}" \
@@ -109,13 +77,70 @@ jobs:
                     '{channel: $channel, ts: $ts}' > .priority-review-slack
 
             - name: Cache Slack message info
-              if: github.event.pull_request.head.ref != 'chore/priority-review-summary'
               uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
               with:
                   path: .priority-review-slack
                   key: priority-review-slack-pr-${{ github.event.pull_request.number }}
 
-    # When a priority-review PR is approved, update the Slack message and thread-reply
+    # When a priority-review PR is closed, strikethrough the Slack message
+    cleanup-closed:
+        runs-on: ubuntu-latest
+        if: >-
+            github.event.action == 'closed'
+            && contains(github.event.pull_request.labels.*.name, 'priority-review')
+        steps:
+            - name: Restore Slack message info
+              uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+              with:
+                  path: .priority-review-slack
+                  key: priority-review-slack-pr-${{ github.event.pull_request.number }}
+
+            - name: Read Slack message info
+              id: slack_msg
+              run: |
+                  if [ -f .priority-review-slack ]; then
+                    echo "found=true" >> $GITHUB_OUTPUT
+                    echo "channel=$(jq -r '.channel' .priority-review-slack)" >> $GITHUB_OUTPUT
+                    echo "ts=$(jq -r '.ts' .priority-review-slack)" >> $GITHUB_OUTPUT
+                  else
+                    echo "found=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Escape PR title
+              if: steps.slack_msg.outputs.found == 'true'
+              id: pr
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              with:
+                  script: |
+                      const title = context.payload.pull_request.title;
+                      const escaped = title
+                        .replace(/&/g, '&amp;')
+                        .replace(/</g, '&lt;')
+                        .replace(/>/g, '&gt;')
+                        .replace(/\|/g, '-')
+                        .replace(/\\/g, '\\\\')
+                        .replace(/"/g, '\\"');
+                      core.setOutput('title', escaped);
+
+            - name: Strikethrough Slack message
+              if: steps.slack_msg.outputs.found == 'true'
+              continue-on-error: true
+              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              with:
+                  method: chat.update
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  errors: true
+                  payload: |
+                      channel: "${{ steps.slack_msg.outputs.channel }}"
+                      ts: "${{ steps.slack_msg.outputs.ts }}"
+                      text: "Closed: ${{ steps.pr.outputs.title }}"
+                      blocks:
+                        - type: "section"
+                          text:
+                            type: "mrkdwn"
+                            text: "~<${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}>~ (closed)"
+
+    # When a priority-review PR is approved, update the Slack message
     notify-reviewed:
         runs-on: ubuntu-latest
         if: >-
@@ -139,6 +164,19 @@ jobs:
                   else
                     echo "found=false" >> $GITHUB_OUTPUT
                   fi
+
+            - name: Get display names
+              if: steps.slack_msg.outputs.found == 'true'
+              id: names
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              with:
+                  script: |
+                      const [author, reviewer] = await Promise.all([
+                        github.rest.users.getByUsername({ username: context.payload.pull_request.user.login }),
+                        github.rest.users.getByUsername({ username: context.payload.review.user.login }),
+                      ]);
+                      core.setOutput('author', author.data.name || context.payload.pull_request.user.login);
+                      core.setOutput('reviewer', reviewer.data.name || context.payload.review.user.login);
 
             - name: Escape PR title
               if: steps.slack_msg.outputs.found == 'true'
@@ -185,4 +223,4 @@ jobs:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":white_check_mark: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}> by ${{ github.event.pull_request.user.login }} — reviewed and approved by ${{ github.event.review.user.login }}"
+                            text: ":white_check_mark: <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} ${{ steps.pr.outputs.title }}> by ${{ steps.names.outputs.author }} — reviewed and approved by ${{ steps.names.outputs.reviewer }}"


### PR DESCRIPTION
Cleans up the priority-review Slack notification workflow.

**Security**: switch trigger from `pull_request_target` to `pull_request` — no need for target since only same-repo contributors can add labels, and `pull_request` gives secrets for same-repo PRs.

**Improvements**:
- Use full GitHub display names instead of login handles
- Strikethrough the Slack message when a PR is closed
- Skip notification for draft PRs, fire when undrafted if label is present
- Drop redundant thread reply on approval (inline message update already shows who approved)

**Note**: the checkmark reaction on approval still needs `reactions:write` added to the Slack app's bot token scopes — currently fails silently with `missing_scope`.