### PR TITLE
fix(billing): add POST fallback for /v2/spend and /v2/usage

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
@@ -510,7 +509,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         try:
             params_to_pass = {k: v for k, v in serializer.validated_data.items() if v is not None}
             params_to_pass["organization_id"] = organization.id
-            params_to_pass["teams_map"] = json.dumps(teams_map)
+            params_to_pass["teams_map"] = teams_map
             res = billing_manager.get_usage_data(organization, params_to_pass)
             return Response(res, status=status.HTTP_200_OK)
         except Exception as e:
@@ -548,7 +547,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         try:
             params_to_pass = {k: v for k, v in serializer.validated_data.items() if v is not None}
             params_to_pass["organization_id"] = organization.id
-            params_to_pass["teams_map"] = json.dumps(teams_map)
+            params_to_pass["teams_map"] = teams_map
             res = billing_manager.get_spend_data(organization, params_to_pass)
             return Response(res, status=status.HTTP_200_OK)
         except Exception as e:

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -1,4 +1,3 @@
-import json
 import urllib.parse
 from datetime import datetime
 from typing import Any
@@ -1137,10 +1136,7 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         passed_params = call_args[1]  # Second arg is params dict
         self.assertEqual(passed_params["start_date"], "2025-01-01")
         self.assertEqual(passed_params["team_ids"], f"[{str(self.team.pk)}]")
-        self.assertIn("teams_map", passed_params)
-
-        teams_map_dict = json.loads(passed_params["teams_map"])
-        self.assertEqual(teams_map_dict, {str(self.team.pk): self.team.name})
+        self.assertEqual(passed_params["teams_map"], {self.team.pk: self.team.name})
 
     @patch("ee.billing.billing_manager.BillingManager.get_spend_data")
     def test_get_spend_success(self, mock_get_spend_data):
@@ -1158,10 +1154,7 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         self.assertEqual(passed_params["start_date"], "2025-01-01")
         self.assertEqual(passed_params["usage_types"], "events")
         self.assertEqual(passed_params["team_ids"], f"[{str(self.team.pk)}]")
-        self.assertIn("teams_map", passed_params)
-
-        teams_map_dict = json.loads(passed_params["teams_map"])
-        self.assertEqual(teams_map_dict, {str(self.team.pk): self.team.name})
+        self.assertEqual(passed_params["teams_map"], {self.team.pk: self.team.name})
 
     def test_get_usage_permission_denied_for_member(self):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
@@ -1187,10 +1180,7 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         mock_get_usage_data.assert_called_once()
         call_args = mock_get_usage_data.call_args[0]
         passed_params = call_args[1]
-        self.assertIn("teams_map", passed_params)
-
-        teams_map_dict = json.loads(passed_params["teams_map"])
-        self.assertEqual(teams_map_dict, {})
+        self.assertEqual(passed_params["teams_map"], {})
         mock_get_teams_map.assert_called_once()
 
     @patch("ee.billing.billing_manager.BillingManager.get_spend_data")
@@ -1205,8 +1195,5 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         mock_get_spend_data.assert_called_once()
         call_args = mock_get_spend_data.call_args[0]
         passed_params = call_args[1]
-        self.assertIn("teams_map", passed_params)
-
-        teams_map_dict = json.loads(passed_params["teams_map"])
-        self.assertEqual(teams_map_dict, {})
+        self.assertEqual(passed_params["teams_map"], {})
         mock_get_teams_map.assert_called_once()

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -690,7 +690,7 @@ class BillingManager:
         encoding) are parsed back into native types so the billing service
         receives structured data rather than escaped strings.
         """
-        result = {}
+        result: dict[str, Any] = {}
         for k, v in params.items():
             if isinstance(v, UUID):
                 result[k] = str(v)

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -1,3 +1,4 @@
+import json
 import datetime
 from typing import Any, cast
 
@@ -855,3 +856,143 @@ class TestUserUpdateBillingOrganizationUsers(BaseTest):
         assert capture_kwargs["properties"]["target_user_id"] == member.id
         assert capture_kwargs["properties"]["target_distinct_id"] == str(member.distinct_id)
         assert capture_kwargs["properties"]["target_email"] == member.email
+
+
+class TestParamSerialization(BaseTest):
+    @parameterized.expand(
+        [
+            ("teams_map", {"1": "Team A", "2": "Team B"}, '{"1": "Team A", "2": "Team B"}'),
+            ("usage_types", ["events", "recordings"], '["events", "recordings"]'),
+            ("team_ids", [1, 2, 3], "[1, 2, 3]"),
+            ("breakdowns", ["product"], '["product"]'),
+        ]
+    )
+    def test_to_query_params_serializes_complex_types(self, field_name, native_value, expected_json):
+        params = {field_name: native_value}
+        result = BillingManager._to_query_params(params)
+        assert json.loads(result[field_name]) == json.loads(expected_json)
+
+    def test_to_query_params_passes_through_scalars(self):
+        params = {"start_date": "2025-01-01", "end_date": "2025-01-31"}
+        result = BillingManager._to_query_params(params)
+        assert result == {"start_date": "2025-01-01", "end_date": "2025-01-31"}
+
+    def test_to_query_params_stringifies_uuids(self):
+        from uuid import UUID
+
+        org_id = UUID("12345678-1234-5678-1234-567812345678")
+        result = BillingManager._to_query_params({"organization_id": org_id, "teams_map": {"1": "A"}})
+        assert result["organization_id"] == "12345678-1234-5678-1234-567812345678"
+        assert result["teams_map"] == '{"1": "A"}'
+
+    def test_to_post_body_converts_organization_id_to_string(self):
+        from uuid import UUID
+
+        org_id = UUID("12345678-1234-5678-1234-567812345678")
+        result = BillingManager._to_post_body({"organization_id": org_id, "teams_map": {"1": "A"}})
+        assert result["organization_id"] == str(org_id)
+        assert result["teams_map"] == {"1": "A"}
+
+    def test_to_post_body_preserves_native_types(self):
+        params = {"teams_map": {"1": "Team A"}, "start_date": "2025-01-01"}
+        result = BillingManager._to_post_body(params)
+        assert result == params
+
+
+class TestRequestWithPostFallback(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.license = super(LicenseManager, cast(LicenseManager, License.objects)).create(
+            key="key123::key123",
+            plan="enterprise",
+            valid_until=datetime.datetime(2038, 1, 19, 3, 14, 7),
+        )
+        self.manager = BillingManager(self.license)
+
+    @parameterized.expand(
+        [
+            ("get_usage_data", 414),
+            ("get_usage_data", 431),
+            ("get_spend_data", 414),
+            ("get_spend_data", 431),
+        ]
+    )
+    @patch("ee.billing.billing_manager.requests.post")
+    @patch("ee.billing.billing_manager.requests.get")
+    def test_falls_back_to_post_on_uri_too_large(self, method_name, status_code, mock_get, mock_post):
+        mock_get.return_value = MagicMock(status_code=status_code)
+        mock_post.return_value = MagicMock(status_code=200, json=MagicMock(return_value={"results": []}))
+
+        params = {
+            "start_date": "2025-01-01",
+            "teams_map": {"1": "Team A"},
+        }
+        result = getattr(self.manager, method_name)(self.organization, params)
+
+        assert result == {"results": []}
+
+        mock_get.assert_called_once()
+        get_params = mock_get.call_args[1]["params"]
+        assert get_params["teams_map"] == '{"1": "Team A"}'
+        assert get_params["start_date"] == "2025-01-01"
+
+        mock_post.assert_called_once()
+        post_json = mock_post.call_args[1]["json"]
+        assert post_json["teams_map"] == {"1": "Team A"}
+        assert post_json["start_date"] == "2025-01-01"
+
+    @parameterized.expand([("get_usage_data",), ("get_spend_data",)])
+    @patch("ee.billing.billing_manager.requests.post")
+    @patch("ee.billing.billing_manager.requests.get")
+    def test_does_not_fall_back_on_success(self, method_name, mock_get, mock_post):
+        mock_get.return_value = MagicMock(status_code=200, json=MagicMock(return_value={"results": []}))
+
+        result = getattr(self.manager, method_name)(self.organization, {"start_date": "2025-01-01"})
+
+        assert result == {"results": []}
+        mock_get.assert_called_once()
+        mock_post.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("get_usage_data", 400),
+            ("get_usage_data", 500),
+            ("get_spend_data", 400),
+            ("get_spend_data", 500),
+        ]
+    )
+    @patch("ee.billing.billing_manager.requests.post")
+    @patch("ee.billing.billing_manager.requests.get")
+    def test_does_not_fall_back_on_non_uri_errors(self, method_name, status_code, mock_get, mock_post):
+        mock_get.return_value = MagicMock(status_code=status_code, text="error")
+
+        with self.assertRaises(Exception):
+            getattr(self.manager, method_name)(self.organization, {"start_date": "2025-01-01"})
+
+        mock_get.assert_called_once()
+        mock_post.assert_not_called()
+
+    @parameterized.expand([("get_usage_data",), ("get_spend_data",)])
+    @patch("ee.billing.billing_manager.requests.post")
+    @patch("ee.billing.billing_manager.requests.get")
+    def test_post_fallback_error_propagates(self, method_name, mock_get, mock_post):
+        mock_get.return_value = MagicMock(status_code=414)
+        mock_post.return_value = MagicMock(status_code=500, text="internal error")
+
+        with self.assertRaises(Exception):
+            getattr(self.manager, method_name)(self.organization, {"teams_map": {"1": "A"}})
+
+        mock_get.assert_called_once()
+        mock_post.assert_called_once()
+
+    @parameterized.expand([("get_usage_data",), ("get_spend_data",)])
+    @patch("ee.billing.billing_manager.requests.post")
+    @patch("ee.billing.billing_manager.requests.get")
+    def test_with_empty_params(self, method_name, mock_get, mock_post):
+        mock_get.return_value = MagicMock(status_code=200, json=MagicMock(return_value={"results": []}))
+
+        result = getattr(self.manager, method_name)(self.organization, {})
+
+        assert result == {"results": []}
+        mock_get.assert_called_once()
+        mock_post.assert_not_called()


### PR DESCRIPTION
Move teams_map serialization from the API layer into BillingManager's transport logic. When the GET request exceeds URL/header limits (414 or 431), automatically retry as POST with a JSON body.

Handle UUIDs explicitly in both _to_query_params and _to_post_body for consistent serialization across both request paths. Consolidate the duplicated usage/spend fallback test classes into a single parameterized test class with GET params assertions.

Requires: https://github.com/PostHog/billing/pull/1790 to be merged first

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
A customer hit the payload size limit for GET requests because they have 274 Projects.
Full thread for context here: [posthog.slack.com/archives/C08ERRQT41E/p1771323872175749](https://posthog.slack.com/archives/C08ERRQT41E/p1771323872175749)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

1. Verified GET path works — loaded the billing Usage page at                              
  localhost:8010/organization/billing/usage and confirmed usage data rendered correctly                       
2. Forced POST fallback — temporarily changed the condition in _request_with_post_fallback                                                                           
3. Automated tests — all 61 billing manager tests and 12 billing API usage/spend tests
  pass, covering both the GET and POST paths, JSON string parsing, UUID handling, and error
  propagation.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no
