### PR TITLE
feat(analytics-platform): Remove person default name properties

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -99,17 +99,8 @@ export const privilegeLevelToName: Record<DashboardPrivilegeLevel, string> = {
 export const PERSON_DISTINCT_ID_MAX_SIZE = 3
 export const PERSON_DISPLAY_NAME_COLUMN_NAME = 'person_display_name -- Person'
 
-// Sync with .../api/person.py and .../ingestion/webhook-formatter.ts
-export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
-    'email',
-    'Email',
-    '$email',
-    'name',
-    'Name',
-    'username',
-    'Username',
-    'UserName',
-]
+// Sync with .../api/person.py and cdp/constants.ts
+export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = ['email', 'name', 'username']
 
 // Feature Flags & Experiments
 export const INSTANTLY_AVAILABLE_PROPERTIES = [

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -99,7 +99,7 @@ export const privilegeLevelToName: Record<DashboardPrivilegeLevel, string> = {
 export const PERSON_DISTINCT_ID_MAX_SIZE = 3
 export const PERSON_DISPLAY_NAME_COLUMN_NAME = 'person_display_name -- Person'
 
-// Sync with .../api/person.py and cdp/constants.ts
+// Sync with .../api/person.py and cdp/utils.ts
 export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = ['email', 'name', 'username']
 
 // Feature Flags & Experiments

--- a/nodejs/src/cdp/utils.ts
+++ b/nodejs/src/cdp/utils.ts
@@ -16,15 +16,8 @@ export const CDP_TEST_ID = '[CDP-TEST-HIDDEN]'
 export const MAX_LOG_LENGTH = 10000
 const TRUNCATION_SUFFIX = '... (truncated)'
 
-export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
-    'email',
-    'Email',
-    'name',
-    'Name',
-    'username',
-    'Username',
-    'UserName',
-]
+// Sync with person.py and constants.tsx
+export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = ['email', 'name', 'username']
 
 export const getPersonDisplayName = (team: Team, distinctId: string, properties: Record<string, any>): string => {
     const personDisplayNameProperties = team.person_display_name_properties ?? PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -79,7 +79,7 @@ logger = structlog.get_logger(__name__)
 tracer = trace.get_tracer(__name__)
 
 DEFAULT_PAGE_LIMIT = 100
-# Sync with .../lib/constants.tsx and .../cdp/constants.ts
+# Sync with .../lib/constants.tsx and .../cdp/utils.ts
 # It's almost certainly wrong to add more properties to this list, instead convince the user to send data to use with
 # these properties, or use e.g. a CDP transformation to rewrite their events.
 #

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -83,7 +83,7 @@ DEFAULT_PAGE_LIMIT = 100
 # It's almost certainly wrong to add more properties to this list, instead convince the user to send data to use with
 # these properties, or use e.g. a CDP transformation to rewrite their events.
 #
-# If you do want to add a new columns
+# If you do want to add new columns
 # * add it to the places linked above
 # * ensure it is materialized on US and EU prod
 # * ensure the materialized columns have case-insensitive skip indexes

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -79,17 +79,20 @@ logger = structlog.get_logger(__name__)
 tracer = trace.get_tracer(__name__)
 
 DEFAULT_PAGE_LIMIT = 100
-# Sync with .../lib/constants.tsx and .../ingestion/webhook-formatter.ts
-# and make sure that they are materialized on prod!
+# Sync with .../lib/constants.tsx and .../cdp/constants.ts
+# It's almost certainly wrong to add more properties to this list, instead convince the user to send data to use with
+# these properties, or use e.g. a CDP transformation to rewrite their events.
+#
+# If you do want to add a new columns
+# * add it to the places linked above
+# * ensure it is materialized on US and EU prod
+# * ensure the materialized columns have case-insensitive skip indexes
+# * ensure that the text box search in the Persons scene is searching this column (using the Actors query)
+
 PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
     "email",
-    "Email",
-    "$email",
     "name",
-    "Name",
     "username",
-    "Username",
-    "UserName",
 ]
 
 API_PERSON_LIST_BYTES_READ_FROM_POSTGRES_COUNTER = Counter(


### PR DESCRIPTION
## Problem

We supported too many different properties for the user's name in the actors query.

This meant that queries that loaded this page were very slow, as they had to load the unmaterialized properties.

These extra properties were never fully implemented, e.g. they were never hooked up to the Person scene search bar.

Let's just remove them. If a user needs to send data in the wrong format, we can get them set up with a CDP transform.

## Changes

Remove unecessary properties and add a comment explain why they shouldn't be added back

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
