### PR TITLE
chore: clear cache on read and send from app

### DIFF
--- a/products/conversations/backend/api/tests/test_signals.py
+++ b/products/conversations/backend/api/tests/test_signals.py
@@ -233,3 +233,17 @@ class TestTicketMessageSignals(BaseTest):
         # Should fall back to first_public, not the private message
         assert self.ticket.last_message_text == "First public"
         assert self.ticket.last_message_at == first_public.created_at
+
+    @patch("products.conversations.backend.signals.invalidate_tickets_cache")
+    def test_message_invalidates_tickets_cache(self, mock_invalidate, mock_on_commit):
+        """Sending a message should invalidate the widget tickets cache."""
+        self._create_customer_message("Hello")
+
+        mock_invalidate.assert_called_once_with(self.team.id, self.widget_session_id)
+
+    @patch("products.conversations.backend.signals.invalidate_tickets_cache")
+    def test_private_message_does_not_invalidate_cache(self, mock_invalidate, mock_on_commit):
+        """Private messages should not invalidate the cache (they don't affect widget display)."""
+        self._create_team_message("Private note", is_private=True)
+
+        mock_invalidate.assert_not_called()

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -436,5 +436,6 @@ class WidgetMarkReadView(APIView):
         if ticket.unread_customer_count > 0:
             ticket.unread_customer_count = 0
             ticket.save(update_fields=["unread_customer_count", "updated_at"])
+            invalidate_tickets_cache(team.id, widget_session_id)
 
         return Response({"success": True, "unread_count": 0})

--- a/products/conversations/backend/signals.py
+++ b/products/conversations/backend/signals.py
@@ -76,13 +76,13 @@ def update_ticket_on_message(sender, instance: Comment, created: bool, **kwargs)
         # Emit analytics events and invalidate cache
         try:
             ticket = Ticket.objects.select_related("team").get(id=item_id, team_id=team_id)
+            # Invalidate widget tickets cache so list shows updated last_message
+            if ticket.widget_session_id:
+                invalidate_tickets_cache(team_id, ticket.widget_session_id)
             if is_team_message:
                 capture_message_sent(ticket, comment_id, content or "", created_by_id)
             else:
                 capture_message_received(ticket, comment_id, content or "")
-            # Invalidate widget tickets cache so list shows updated last_message
-            if ticket.widget_session_id:
-                invalidate_tickets_cache(team_id, ticket.widget_session_id)
         except Ticket.DoesNotExist:
             pass
         except Exception as e:

--- a/products/conversations/backend/signals.py
+++ b/products/conversations/backend/signals.py
@@ -9,6 +9,7 @@ import structlog
 from posthog.exceptions_capture import capture_exception
 from posthog.models.comment import Comment
 
+from .cache import invalidate_tickets_cache
 from .events import capture_message_received, capture_message_sent
 from .models import Ticket
 
@@ -33,7 +34,6 @@ def update_ticket_on_message(sender, instance: Comment, created: bool, **kwargs)
     to widget via last_message_text and to keep message_count accurate for customers.
 
     Uses transaction.on_commit() to defer work and avoid blocking the request.
-    Cache invalidation not needed - short TTLs handle staleness.
     """
     if instance.scope != "conversations_ticket":
         return
@@ -73,13 +73,16 @@ def update_ticket_on_message(sender, instance: Comment, created: bool, **kwargs)
 
         Ticket.objects.filter(id=item_id, team_id=team_id).update(**update_fields)
 
-        # Emit analytics events for workflow triggers
+        # Emit analytics events and invalidate cache
         try:
             ticket = Ticket.objects.select_related("team").get(id=item_id, team_id=team_id)
             if is_team_message:
                 capture_message_sent(ticket, comment_id, content or "", created_by_id)
             else:
                 capture_message_received(ticket, comment_id, content or "")
+            # Invalidate widget tickets cache so list shows updated last_message
+            if ticket.widget_session_id:
+                invalidate_tickets_cache(team_id, ticket.widget_session_id)
         except Ticket.DoesNotExist:
             pass
         except Exception as e:


### PR DESCRIPTION
Invalidate cache for tickets when a ticket is read by a user and when we send a message by a team member.