### PR TITLE
fix(llma): guard against negative input costs when cache tokens exceed input tokens

### DIFF
--- a/nodejs/src/ingestion/ai/costs/input-costs.test.ts
+++ b/nodejs/src/ingestion/ai/costs/input-costs.test.ts
@@ -264,6 +264,24 @@ describe('calculateInputCost()', () => {
             expectCostToBeCloseTo(result, 0.00663855, 8)
         })
 
+        it('handles string token values correctly for inclusive accounting', () => {
+            const event = createTestEvent({
+                properties: {
+                    $ai_provider: 'gateway',
+                    $ai_framework: 'vercel',
+                    $ai_model: 'anthropic/claude-sonnet-4.5',
+                    $ai_input_tokens: '14013',
+                    $ai_cache_read_input_tokens: '13306',
+                    $ai_cache_creation_input_tokens: '701',
+                },
+            })
+
+            const result = calculateInputCost(event, ANTHROPIC_MODEL)
+
+            // Same as the numeric inclusive test — strings must produce identical results
+            expectCostToBeCloseTo(result, 0.00663855, 8)
+        })
+
         it('falls back to exclusive accounting when Vercel gateway tokens are provably not inclusive', () => {
             // When inputTokens < cacheReadTokens + cacheWriteTokens, the tokens can't be inclusive.
             // This happens when SDKs (e.g., posthog-ai) report Anthropic-style exclusive counts

--- a/nodejs/src/ingestion/ai/costs/input-costs.ts
+++ b/nodejs/src/ingestion/ai/costs/input-costs.ts
@@ -67,7 +67,8 @@ export const calculateInputCost = (event: PluginEvent, cost: ResolvedModelCost):
         // If inputTokens < cacheReadTokens + cacheWriteTokens, the tokens can't be inclusive
         // (inclusive means cache tokens are a subset of input tokens). This guards against
         // SDKs that report exclusive counts through the Vercel gateway.
-        const isActuallyInclusive = inclusiveInputTokens && inputTokens >= cacheReadTokens + cacheWriteTokens
+        const isActuallyInclusive =
+            inclusiveInputTokens && Number(inputTokens) >= Number(cacheReadTokens) + Number(cacheWriteTokens)
         const uncachedTokens = isActuallyInclusive
             ? bigDecimal.subtract(bigDecimal.subtract(inputTokens, cacheReadTokens), cacheWriteTokens)
             : inputTokens

--- a/nodejs/src/ingestion/ai/costs/input-costs.ts
+++ b/nodejs/src/ingestion/ai/costs/input-costs.ts
@@ -64,7 +64,11 @@ export const calculateInputCost = (event: PluginEvent, cost: ResolvedModelCost):
                 : bigDecimal.multiply(bigDecimal.multiply(cost.cost.prompt_token, 0.1), cacheReadTokens)
 
         const totalCacheCost = bigDecimal.add(writeCost, cacheReadCost)
-        const uncachedTokens = inclusiveInputTokens
+        // If inputTokens < cacheReadTokens + cacheWriteTokens, the tokens can't be inclusive
+        // (inclusive means cache tokens are a subset of input tokens). This guards against
+        // SDKs that report exclusive counts through the Vercel gateway.
+        const isActuallyInclusive = inclusiveInputTokens && inputTokens >= cacheReadTokens + cacheWriteTokens
+        const uncachedTokens = isActuallyInclusive
             ? bigDecimal.subtract(bigDecimal.subtract(inputTokens, cacheReadTokens), cacheWriteTokens)
             : inputTokens
         const uncachedCost = bigDecimal.multiply(cost.cost.prompt_token, uncachedTokens)


### PR DESCRIPTION
## Problem

Customer reported all their LLM events have negative `$ai_input_cost_usd` values, breaking cost calculations. Root cause: #48021 introduced inclusive token accounting for Vercel gateway Anthropic events, but `posthog-ai` SDK reports exclusive (Anthropic-style) token counts even through the Vercel gateway. This causes `uncachedTokens` to go negative (e.g., `247 - 6287 = -6040`), producing negative costs.

## Changes

Adds a mathematical guard in the Anthropic cost calculation path: if `inputTokens < cacheReadTokens + cacheWriteTokens`, the tokens are provably not inclusive (inclusive means cache tokens are a subset of input tokens), so we fall back to exclusive accounting. No SDK version detection needed.

## How did you test this code?

- Added test case reproducing the exact customer scenario (Vercel gateway, `inputTokens=247`, `cacheReadTokens=6287`) — verifies cost is positive
- Existing inclusive accounting test still passes (tokens genuinely inclusive)
- All 34 input-costs tests pass

## Publish to changelog?

No