### PR TITLE
fix(workflows): publish to ws instead of msk

### DIFF
--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -633,10 +633,10 @@ describe('CDP API', () => {
 
     describe('batch hogflow invocations', () => {
         let batchHogFlow: HogFlow
-        let originalKafkaProducer: any
+        let originalCdpKafkaProducer: any
 
         beforeEach(async () => {
-            originalKafkaProducer = hub.kafkaProducer
+            originalCdpKafkaProducer = api['cdpKafkaProducer']
             batchHogFlow = await insertHogFlow({
                 id: new UUIDT().toString(),
                 name: 'test batch hog flow',
@@ -662,7 +662,7 @@ describe('CDP API', () => {
         })
 
         afterEach(() => {
-            hub.kafkaProducer = originalKafkaProducer
+            api['cdpKafkaProducer'] = originalCdpKafkaProducer
         })
 
         it('errors if missing team', async () => {
@@ -712,7 +712,7 @@ describe('CDP API', () => {
 
         it('queues batch job request to kafka', async () => {
             const mockProduce = jest.fn().mockResolvedValue(undefined)
-            hub.kafkaProducer = { produce: mockProduce } as any
+            api['cdpKafkaProducer'] = { produce: mockProduce } as any
 
             const res = await supertest(app)
                 .post(`/api/projects/${batchHogFlow.team_id}/hog_flows/${batchHogFlow.id}/batch_invocations/job-123`)
@@ -743,7 +743,7 @@ describe('CDP API', () => {
 
         it('queues batch job with filters from hog flow config when not provided', async () => {
             const mockProduce = jest.fn().mockResolvedValue(undefined)
-            hub.kafkaProducer = { produce: mockProduce } as any
+            api['cdpKafkaProducer'] = { produce: mockProduce } as any
 
             const res = await supertest(app)
                 .post(`/api/projects/${batchHogFlow.team_id}/hog_flows/${batchHogFlow.id}/batch_invocations/job-456`)
@@ -769,14 +769,14 @@ describe('CDP API', () => {
         })
 
         it('errors if kafka producer not available', async () => {
-            hub.kafkaProducer = undefined as any
+            api['cdpKafkaProducer'] = undefined as any
 
             const res = await supertest(app)
                 .post(`/api/projects/${batchHogFlow.team_id}/hog_flows/${batchHogFlow.id}/batch_invocations/job-123`)
                 .send({})
 
             expect(res.status).toEqual(500)
-            expect(res.body.error).toEqual('Kafka producer not available')
+            expect(res.body.error).toEqual('CDP Kafka producer not available')
         })
     })
 })

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -1,4 +1,4 @@
-import '../../tests/helpers/mocks/producer.mock'
+import { MockKafkaProducerWrapper } from '../../tests/helpers/mocks/producer.mock'
 import { mockFetch } from '../../tests/helpers/mocks/request.mock'
 
 import { Server } from 'http'
@@ -634,6 +634,13 @@ describe('CDP API', () => {
     describe('batch hogflow invocations', () => {
         let batchHogFlow: HogFlow
         let originalCdpKafkaProducer: any
+
+        it('creates CDP kafka producer with CDP_PRODUCER mode on start', async () => {
+            const freshApi = new CdpApi(hub)
+            await freshApi.start()
+            expect(MockKafkaProducerWrapper.create).toHaveBeenCalledWith(hub.KAFKA_CLIENT_RACK, 'CDP_PRODUCER')
+            await freshApi.stop()
+        })
 
         beforeEach(async () => {
             originalCdpKafkaProducer = api['cdpKafkaProducer']

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -7,6 +7,7 @@ import { ModifiedRequest } from '~/api/router'
 import { createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
 import { KAFKA_CDP_BATCH_HOGFLOW_REQUESTS } from '~/config/kafka-topics'
 
+import { KafkaProducerWrapper } from '../kafka/producer'
 import { HealthCheckResult, HealthCheckResultError, HealthCheckResultOk, Hub, PluginServerService } from '../types'
 import { logger } from '../utils/logger'
 import { UUID, UUIDT, delay } from '../utils/utils'
@@ -75,6 +76,7 @@ export class CdpApi {
     private emailTrackingService: EmailTrackingService
     private recipientPreferencesService: RecipientPreferencesService
     private recipientTokensService: RecipientTokensService
+    private cdpKafkaProducer?: KafkaProducerWrapper
 
     constructor(private hub: CdpApiHub) {
         this.hogFunctionManager = new HogFunctionManagerService(hub)
@@ -129,11 +131,12 @@ export class CdpApi {
     }
 
     async start(): Promise<void> {
+        this.cdpKafkaProducer = await KafkaProducerWrapper.create(this.hub.KAFKA_CLIENT_RACK, 'CDP_PRODUCER')
         await this.cdpSourceWebhooksConsumer.start()
     }
 
     async stop(): Promise<void> {
-        await Promise.all([this.cdpSourceWebhooksConsumer.stop()])
+        await Promise.all([this.cdpSourceWebhooksConsumer.stop(), this.cdpKafkaProducer?.disconnect()])
     }
 
     isHealthy(): HealthCheckResult {
@@ -536,14 +539,13 @@ export class CdpApi {
                 return res.status(404).json({ error: 'Workflow not found' })
             }
 
-            // Queue a message for the CDP batch producer to consume
-            const kafkaProducer = this.hub.kafkaProducer
-            if (!kafkaProducer) {
-                return res.status(500).json({ error: 'Kafka producer not available' })
-            }
-
             if (hogFlow.trigger.type !== 'batch') {
                 return res.status(400).json({ error: 'Only batch Workflows are supported for batch jobs' })
+            }
+
+            // Queue a message for the CDP batch producer to consume via the CDP-specific Kafka cluster
+            if (!this.cdpKafkaProducer) {
+                return res.status(500).json({ error: 'CDP Kafka producer not available' })
             }
 
             const batchHogFlowRequest = {
@@ -556,7 +558,7 @@ export class CdpApi {
                 },
             }
 
-            await kafkaProducer.produce({
+            await this.cdpKafkaProducer.produce({
                 topic: KAFKA_CDP_BATCH_HOGFLOW_REQUESTS,
                 value: Buffer.from(JSON.stringify(batchHogFlowRequest)),
                 key: `${team.id}_${hogFlow.id}`,


### PR DESCRIPTION
## Problem

The `CdpApi.postHogFlowBatchInvocation` endpoint produces messages to the KAFKA_CDP_BATCH_HOGFLOW_REQUESTS topic using `hub.kafkaProducer`. The default hub Kafka producer points at MSK.                                                                              
                                    
However, the `CdpBatchHogFlowRequestsConsumer` that reads from this topic is deployed with `KAFKA_CONSUMER_METADATA_BROKER_LIST` pointing at WS.

This means the producer writes to MSK but the consumer reads from WS messages are never consumed.

## Changes

Use a dedicated CDP Kafka producer for producing batch hogflow requests, matching how other CDP services like the Cyclotron job queues already produce to WS.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- adjusted the tests
