### PR TITLE
Incident.io status page

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelStatus.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelStatus.tsx
@@ -1,38 +1,19 @@
-import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
 import { IconCloud } from '@posthog/icons'
-import { LemonBadgeProps, LemonButton, Tooltip } from '@posthog/lemon-ui'
+import { LemonBadgeProps, Tooltip } from '@posthog/lemon-ui'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { IconWithBadge } from 'lib/lemon-ui/icons'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { capitalizeFirstLetter } from 'lib/utils'
 
-import { SidePanelPaneHeader } from '../components/SidePanelPaneHeader'
 import { sidePanelLogic } from '../sidePanelLogic'
-import { SidePanelDocsSkeleton } from './SidePanelDocs'
 import { INCIDENT_IO_STATUS_PAGE_BASE, sidePanelStatusIncidentIoLogic } from './sidePanelStatusIncidentIoLogic'
-import { STATUS_PAGE_BASE, sidePanelStatusLogic } from './sidePanelStatusLogic'
 
 export const SidePanelStatusIcon = (props: { className?: string; size?: LemonBadgeProps['size'] }): JSX.Element => {
-    const { featureFlags } = useValues(featureFlagLogic)
-    const useIncidentIo = !!featureFlags[FEATURE_FLAGS.INCIDENT_IO_STATUS_PAGE]
-
-    const { status: atlassianStatus, statusPage } = useValues(sidePanelStatusLogic)
-    const { status: incidentIoStatus, statusDescription: incidentIoDescription } =
-        useValues(sidePanelStatusIncidentIoLogic)
-
-    const status = useIncidentIo ? incidentIoStatus : atlassianStatus
-    const title = useIncidentIo
-        ? incidentIoDescription
-        : statusPage?.status.description
-          ? capitalizeFirstLetter(statusPage.status.description.toLowerCase())
-          : null
+    const { status, statusDescription } = useValues(sidePanelStatusIncidentIoLogic)
 
     return (
-        <Tooltip title={title} placement="left">
+        <Tooltip title={statusDescription} placement="left">
             <span {...props}>
                 <IconWithBadge
                     content={status !== 'operational' ? '!' : '✓'}
@@ -55,49 +36,11 @@ export const SidePanelStatusIcon = (props: { className?: string; size?: LemonBad
 
 export const SidePanelStatus = (): JSX.Element => {
     const { closeSidePanel } = useActions(sidePanelLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const useIncidentIo = !!featureFlags[FEATURE_FLAGS.INCIDENT_IO_STATUS_PAGE]
-    const [ready, setReady] = useState(false)
 
     useEffect(() => {
-        if (useIncidentIo) {
-            // For incident.io, we just redirect to the external status page
-            window.open(INCIDENT_IO_STATUS_PAGE_BASE, '_blank')?.focus()
-            closeSidePanel()
-        }
-    }, [useIncidentIo, closeSidePanel])
+        window.open(INCIDENT_IO_STATUS_PAGE_BASE, '_blank')?.focus()
+        closeSidePanel()
+    }, [closeSidePanel])
 
-    if (useIncidentIo) {
-        return <></>
-    }
-
-    return (
-        <>
-            <SidePanelPaneHeader>
-                <div className="flex-1" />
-                <LemonButton
-                    size="small"
-                    targetBlank
-                    // We can't use the normal `to` property as that is intercepted to open this panel :D
-                    onClick={() => {
-                        window.open(STATUS_PAGE_BASE, '_blank')?.focus()
-                        closeSidePanel()
-                    }}
-                >
-                    Open in new tab
-                </LemonButton>
-            </SidePanelPaneHeader>
-            <div className="relative flex-1 overflow-hidden">
-                <iframe
-                    src={STATUS_PAGE_BASE}
-                    title="Status"
-                    className={clsx('w-full h-full', !ready && 'hidden')}
-                    onLoad={() => setReady(true)}
-                    sandbox="allow-scripts allow-same-origin"
-                />
-
-                {!ready && <SidePanelDocsSkeleton />}
-            </div>
-        </>
-    )
+    return <></>
 }

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -13,7 +13,6 @@ import { sidePanelContextLogic } from './panels/sidePanelContextLogic'
 import { sidePanelHealthLogic } from './panels/sidePanelHealthLogic'
 import { sidePanelSdkDoctorLogic } from './panels/sidePanelSdkDoctorLogic'
 import { sidePanelStatusIncidentIoLogic } from './panels/sidePanelStatusIncidentIoLogic'
-import { sidePanelStatusLogic } from './panels/sidePanelStatusLogic'
 import type { sidePanelLogicType } from './sidePanelLogicType'
 import { sidePanelStateLogic } from './sidePanelStateLogic'
 
@@ -52,10 +51,8 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
             // We need to mount this to ensure that marking as read works when the panel closes
             sidePanelNotificationsLogic,
             ['unreadCount'],
-            sidePanelStatusLogic,
-            ['status'],
             sidePanelStatusIncidentIoLogic,
-            ['status as incidentioStatus'],
+            ['status'],
             sidePanelSdkDoctorLogic,
             ['needsAttention'],
             sidePanelHealthLogic,
@@ -122,7 +119,6 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                 s.sidePanelOpen,
                 s.unreadCount,
                 s.status,
-                s.incidentioStatus,
                 s.needsAttention,
                 s.hasIssues,
                 s.hasAvailableFeature,
@@ -133,7 +129,6 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                 sidePanelOpen,
                 unreadCount,
                 status,
-                incidentioStatus,
                 needsAttention,
                 hasIssues,
                 hasAvailableFeature
@@ -151,10 +146,7 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                         return true
                     }
 
-                    if (
-                        tab === SidePanelTab.Status &&
-                        (status !== 'operational' || incidentioStatus !== 'operational')
-                    ) {
+                    if (tab === SidePanelTab.Status && status !== 'operational') {
                         return true
                     }
 


### PR DESCRIPTION
## Problem

The application was encountering a "TypeError: Failed to fetch" error when trying to load the status page in the side panel. This was due to the `sidePanelLogic` still attempting to fetch data from the old Atlassian status page API (`https://status.posthog.com/api/v2/summary.json`), which is no longer in use after the migration to incident.io.

Closes #ISSUE_ID (Please replace ISSUE_ID with the actual issue ID if available)

## Changes

-   Removed the deprecated `sidePanelStatusLogic` connection from `sidePanelLogic.tsx`.
-   Updated `SidePanelStatus.tsx` to remove the feature flag check and exclusively use `sidePanelStatusIncidentIoLogic` for fetching status information.
-   Removed the `sidePanelStatusLogic.tsx` file as it is no longer used.

## How did you test this code?

The fix addresses the root cause identified from the stack trace. Manual testing would involve navigating to the side panel and verifying that no fetch errors occur and that the incident.io status is displayed correctly.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1771411828602089?thread_ts=1771411828.602089&cid=D0ACMC57HDE)

<p><a href="https://cursor.com/background-agent?bcId=bc-f8565792-d98b-5e89-b287-073be87c755f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8565792-d98b-5e89-b287-073be87c755f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

