### PR TITLE
chore(ds): improve pipeline v3 consumer offset strategy and tune redis TTL

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
@@ -73,13 +73,35 @@ class KafkaConsumerService:
             if isinstance(self._kafka_hosts, list)
             else self._kafka_hosts,
             "group.id": self._config.consumer_group,
-            "auto.offset.reset": "earliest",
+            "auto.offset.reset": "latest",
             "enable.auto.commit": False,
             "security.protocol": self._kafka_security_protocol or _KafkaSecurityProtocol.PLAINTEXT,
         }
         consumer = ConfluentConsumer(config)
-        consumer.subscribe([self._config.input_topic])
+        consumer.subscribe(
+            [self._config.input_topic],
+            on_assign=self._on_assign,
+            on_revoke=self._on_revoke,
+        )
         return consumer
+
+    def _on_assign(self, consumer: ConfluentConsumer, partitions: list) -> None:
+        for p in partitions:
+            logger.info(
+                "partition_assigned",
+                topic=p.topic,
+                partition=p.partition,
+                offset=p.offset,
+            )
+
+    def _on_revoke(self, consumer: ConfluentConsumer, partitions: list) -> None:
+        for p in partitions:
+            logger.info(
+                "partition_revoked",
+                topic=p.topic,
+                partition=p.partition,
+                offset=p.offset,
+            )
 
     def _get_dlq_producer(self) -> _KafkaProducer:
         if self._dlq_producer is None:

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
@@ -102,6 +102,10 @@ class KafkaConsumerService:
                 partition=p.partition,
                 offset=p.offset,
             )
+        try:
+            consumer.commit(asynchronous=False)
+        except Exception:
+            logger.warning("failed_to_commit_on_revoke")
 
     def _get_dlq_producer(self) -> _KafkaProducer:
         if self._dlq_producer is None:

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
@@ -1,0 +1,115 @@
+from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
+
+from posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.consumer import KafkaConsumerService
+from posthog.temporal.data_imports.pipelines.pipeline_v3.load.config import ConsumerConfig
+
+
+def _make_config(**kwargs) -> ConsumerConfig:
+    defaults = {
+        "input_topic": "test-topic",
+        "consumer_group": "test-group",
+        "dlq_topic": "test-dlq",
+    }
+    defaults.update(kwargs)
+    return ConsumerConfig(**defaults)
+
+
+def _make_service(**kwargs) -> KafkaConsumerService:
+    defaults: dict = {
+        "config": _make_config(),
+        "process_message": MagicMock(),
+        "kafka_hosts": ["localhost:9092"],
+        "kafka_security_protocol": "PLAINTEXT",
+    }
+    defaults.update(kwargs)
+    return KafkaConsumerService(**defaults)
+
+
+class TestKafkaConsumerServiceConfig:
+    def test_consumer_uses_latest_offset_reset(self):
+        service = _make_service()
+
+        with patch(
+            "posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.consumer.ConfluentConsumer"
+        ) as mock_consumer_cls:
+            mock_consumer_cls.return_value = MagicMock()
+            service._create_consumer()
+
+            config = mock_consumer_cls.call_args[0][0]
+            assert config["auto.offset.reset"] == "latest"
+
+    def test_subscribe_registers_callbacks(self):
+        service = _make_service()
+
+        with patch(
+            "posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.consumer.ConfluentConsumer"
+        ) as mock_consumer_cls:
+            mock_instance = MagicMock()
+            mock_consumer_cls.return_value = mock_instance
+            service._create_consumer()
+
+            mock_instance.subscribe.assert_called_once_with(
+                ["test-topic"],
+                on_assign=service._on_assign,
+                on_revoke=service._on_revoke,
+            )
+
+
+class TestKafkaConsumerServiceCallbacks:
+    @parameterized.expand(
+        [
+            ("single_partition", [("test-topic", 0, 42)]),
+            ("multiple_partitions", [("test-topic", 0, 10), ("test-topic", 1, 20)]),
+        ]
+    )
+    def test_on_assign_logs_partition_info(self, _name, partition_data):
+        service = _make_service()
+        partitions = []
+        for topic, partition, offset in partition_data:
+            p = MagicMock()
+            p.topic = topic
+            p.partition = partition
+            p.offset = offset
+            partitions.append(p)
+
+        with patch("posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.consumer.logger") as mock_logger:
+            service._on_assign(MagicMock(), partitions)
+
+            assert mock_logger.info.call_count == len(partition_data)
+            for topic, partition, offset in partition_data:
+                mock_logger.info.assert_any_call(
+                    "partition_assigned",
+                    topic=topic,
+                    partition=partition,
+                    offset=offset,
+                )
+
+    @parameterized.expand(
+        [
+            ("single_partition", [("test-topic", 0, 42)]),
+            ("multiple_partitions", [("test-topic", 0, 10), ("test-topic", 1, 20)]),
+        ]
+    )
+    def test_on_revoke_logs_partition_info(self, _name, partition_data):
+        service = _make_service()
+        partitions = []
+        for topic, partition, offset in partition_data:
+            p = MagicMock()
+            p.topic = topic
+            p.partition = partition
+            p.offset = offset
+            partitions.append(p)
+
+        with patch("posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.consumer.logger") as mock_logger:
+            service._on_revoke(MagicMock(), partitions)
+
+            assert mock_logger.info.call_count == len(partition_data)
+            for topic, partition, offset in partition_data:
+                mock_logger.info.assert_any_call(
+                    "partition_revoked",
+                    topic=topic,
+                    partition=partition,
+                    offset=offset,
+                )

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/idempotency.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/idempotency.py
@@ -10,7 +10,7 @@ from posthog.redis import get_client
 logger = structlog.get_logger(__name__)
 
 IDEMPOTENCY_KEY_PREFIX = "warehouse_pipelines:processed"
-IDEMPOTENCY_TTL_SECONDS = 48 * 60 * 60  # 2 days (48 hours)
+IDEMPOTENCY_TTL_SECONDS = 72 * 60 * 60  # 3 days (72 hours) same as the topic retention period
 
 
 @contextmanager

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -149,7 +149,8 @@ def _run_post_load_for_already_processed_batch(export_signal: ExportSignalMessag
         id=export_signal.job_id
     )
     schema = job.schema
-    assert schema is not None
+    if schema is None:
+        raise ValueError(f"ExternalDataJob {export_signal.job_id} has no schema")
 
     delta_table_helper = DeltaTableHelper(
         resource_name=export_signal.resource_name,
@@ -228,7 +229,8 @@ def process_message(message: Any) -> None:
         id=export_signal.job_id
     )
     schema = job.schema
-    assert schema is not None
+    if schema is None:
+        raise ValueError(f"ExternalDataJob {export_signal.job_id} has no schema")
 
     delta_table_helper = DeltaTableHelper(
         resource_name=export_signal.resource_name,

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/__init__.py
@@ -6,11 +6,7 @@ from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.common import (
     get_data_folder,
     strip_s3_protocol,
 )
-from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.reader import (
-    list_parquet_files,
-    read_all_batches,
-    read_parquet,
-)
+from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.reader import list_parquet_files, read_parquet
 from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.writer import S3BatchWriter
 
 __all__ = [
@@ -21,7 +17,6 @@ __all__ = [
     "get_base_folder",
     "get_data_folder",
     "list_parquet_files",
-    "read_all_batches",
     "read_parquet",
     "strip_s3_protocol",
 ]

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/reader.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/s3/reader.py
@@ -38,21 +38,3 @@ def list_parquet_files(data_folder: str) -> list[str]:
     except FileNotFoundError:
         logger.debug("data_folder_not_found", data_folder=data_folder)
         return []
-
-
-def read_all_batches(data_folder: str) -> pa.Table:
-    parquet_files = list_parquet_files(data_folder)
-
-    if not parquet_files:
-        logger.debug("no_parquet_files_found", data_folder=data_folder)
-        return pa.table({})
-
-    tables = [read_parquet(f) for f in parquet_files]
-
-    if len(tables) == 1:
-        return tables[0]
-
-    combined = pa.concat_tables(tables)
-    logger.debug("batches_combined", data_folder=data_folder, total_rows=combined.num_rows, batch_count=len(tables))
-
-    return combined


### PR DESCRIPTION
## Problem

Second small PR for consumer improvements focused on:

1. offset strategy (when the consumer dies, we need to resume from latests, not earliest)
2. added a bit more of observability (more of this to come)
3. clean up a bit

## Changes

  * Changed `auto.offset.reset` from `earliest` to `latest` in Kafka consumer configuration
  * Added `on_assign` and `on_revoke` partition callbacks with structured logging for better observability
  * Increased Redis idempotency TTL from 48 hours to 72 hours to match topic retention period
  * Replaced bare `assert schema is not None` with explicit `ValueError` in processor.py
  * Removed unused `read_all_batches` function from S3 reader module
  * Added unit tests for consumer configuration and partition callbacks

## How did you test this code?
  * New unit tests
  * All tests pass
  * Local run with FF


## Publish to changelog?
NO
