### PR TITLE
fix: ticket mention notifications

### DIFF
--- a/posthog/models/comment/utils.py
+++ b/posthog/models/comment/utils.py
@@ -1,3 +1,5 @@
+import re
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Optional
 
 from django.conf import settings
@@ -23,23 +25,72 @@ SCOPE_TO_PATH_MAPPING: dict[str, str] = {
     "Experiment": "/experiments/{item_id}",
 }
 
+TICKET_COMMENT_SCOPES = {"conversations_ticket", "Ticket"}
+MENTION_PLACEHOLDER_PATTERN = re.compile(r"@(?:member|user):(?P<id>\d+)")
 
-def build_comment_item_url(scope: str, item_id: Optional[str], slug: Optional[str] = None) -> str:
+
+def is_ticket_comment_scope(scope: str) -> bool:
+    return scope in TICKET_COMMENT_SCOPES
+
+
+def _get_user_display_name(user: User) -> str:
+    first_name = (user.first_name or "").strip()
+    if first_name:
+        return first_name
+
+    if user.email:
+        return user.email.split("@")[0]
+
+    return f"user:{user.id}"
+
+
+def build_mention_display_name_lookup(user_ids: Iterable[int]) -> dict[int, str]:
+    unique_user_ids = set(user_ids)
+    if not unique_user_ids:
+        return {}
+
+    mentioned_users = User.objects.filter(id__in=unique_user_ids).only("id", "first_name", "email")
+    return {mentioned_user.id: _get_user_display_name(mentioned_user) for mentioned_user in mentioned_users}
+
+
+def replace_mention_placeholders(content: str, mention_display_names: dict[int, str]) -> str:
+    if not content or not mention_display_names:
+        return content
+
+    def replace_mention(match: re.Match[str]) -> str:
+        mention_id = int(match.group("id"))
+        mention_display_name = mention_display_names.get(mention_id)
+        return f"@{mention_display_name}" if mention_display_name else match.group(0)
+
+    return MENTION_PLACEHOLDER_PATTERN.sub(replace_mention, content)
+
+
+def build_comment_item_url(
+    scope: str, item_id: Optional[str], slug: Optional[str] = None, team_id: Optional[int] = None
+) -> str:
     if slug:
         url = f"{settings.SITE_URL}{slug}"
+    elif is_ticket_comment_scope(scope) and item_id and team_id is not None:
+        url = f"{settings.SITE_URL}/project/{team_id}/conversations/tickets/{item_id}"
     elif scope in SCOPE_TO_PATH_MAPPING and item_id:
         path = SCOPE_TO_PATH_MAPPING[scope].format(item_id=item_id)
         url = f"{settings.SITE_URL}{path}"
     else:
         url = settings.SITE_URL
 
-    if "#panel=discussion" not in url:
+    if is_ticket_comment_scope(scope):
+        url = url.split("#", 1)[0]
+
+    should_append_discussion_panel = not is_ticket_comment_scope(scope) and "/conversations/tickets/" not in url
+    if should_append_discussion_panel and "#panel=discussion" not in url:
         url = f"{url}#panel=discussion"
 
     return url
 
 
-def extract_plain_text_from_rich_content(rich_content: Optional[dict]) -> str:
+def extract_plain_text_from_rich_content(
+    rich_content: Optional[dict], mention_display_names: Optional[dict[int, str]] = None
+) -> str:
     if not rich_content:
         return ""
 
@@ -53,8 +104,12 @@ def extract_plain_text_from_rich_content(rich_content: Optional[dict]) -> str:
             elif node_type == "ph-mention":
                 attrs = node.get("attrs", {})
                 label = attrs.get("label", "")
+                mention_id = attrs.get("id")
                 if label:
                     text_parts.append(f"@{label}")
+                elif isinstance(mention_id, int):
+                    mention_display_name = mention_display_names.get(mention_id) if mention_display_names else None
+                    text_parts.append(f"@{mention_display_name}" if mention_display_name else f"@member:{mention_id}")
             elif node_type == "hardBreak":
                 text_parts.append("\n")
 
@@ -79,12 +134,17 @@ def produce_discussion_mention_events(
         if not commenter:
             return
 
-        mentioned_users = User.objects.filter(id__in=mentioned_user_ids).exclude(id=commenter.id)
-        if not mentioned_users.exists():
+        mentioned_users = list(User.objects.filter(id__in=mentioned_user_ids).exclude(id=commenter.id))
+        if not mentioned_users:
             return
 
-        item_url = build_comment_item_url(comment.scope, comment.item_id, slug)
-        comment_content = extract_plain_text_from_rich_content(comment.rich_content) or comment.content
+        mention_display_names = {
+            mentioned_user.id: _get_user_display_name(mentioned_user) for mentioned_user in mentioned_users
+        }
+        item_url = build_comment_item_url(comment.scope, comment.item_id, slug, team_id=comment.team_id)
+        comment_content = extract_plain_text_from_rich_content(comment.rich_content, mention_display_names)
+        if not comment_content and comment.content:
+            comment_content = replace_mention_placeholders(comment.content, mention_display_names)
 
         commenter_data = {
             "id": str(commenter.id),

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -37,7 +37,6 @@ from posthog.models.comment.utils import (
     build_mention_display_name_lookup,
     extract_plain_text_from_rich_content,
     is_ticket_comment_scope,
-    replace_mention_placeholders,
 )
 from posthog.models.hog_functions.hog_function import HogFunction
 from posthog.models.utils import UUIDT
@@ -829,8 +828,6 @@ def send_discussions_mentioned(comment_id: str, mentioned_user_ids: list[int], s
 
         mention_display_names = build_mention_display_name_lookup(mentioned_user_ids)
         comment_content = extract_plain_text_from_rich_content(comment.rich_content, mention_display_names)
-        if not comment_content and comment.content:
-            comment_content = replace_mention_placeholders(comment.content, mention_display_names)
 
         href = build_comment_item_url(comment.scope, comment.item_id, slug, team_id=comment.team_id)
         is_ticket_mention = is_ticket_comment_scope(comment.scope)

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -805,6 +805,7 @@ def send_discussions_mentioned(comment_id: str, mentioned_user_ids: list[int], s
 
         team = comment.team
         commenter = comment.created_by
+        mentioned_user_id_set = set(mentioned_user_ids)
         memberships_to_email = get_members_to_notify(team, NotificationSetting.DISCUSSIONS_MENTIONED.value)
 
         if not commenter:
@@ -819,7 +820,7 @@ def send_discussions_mentioned(comment_id: str, mentioned_user_ids: list[int], s
         memberships_to_email = [
             membership
             for membership in memberships_to_email
-            if (membership.user.id in mentioned_user_ids and membership.user != commenter)
+            if membership.user.id in mentioned_user_id_set and membership.user != commenter
         ]
 
         if not memberships_to_email:
@@ -839,8 +840,14 @@ def send_discussions_mentioned(comment_id: str, mentioned_user_ids: list[int], s
 
         if is_ticket_mention:
             ticket_reference = f"ticket #{ticket_number}" if ticket_number else "a ticket"
+            mention_heading = "You were mentioned in a ticket"
+            mention_location = ticket_reference
+            reply_button_label = "Reply to ticket"
             subject = f"[Tickets]: {commenter.first_name} mentioned you in {ticket_reference} in project '{team}'"
         else:
+            mention_heading = "You were mentioned in a discussion"
+            mention_location = "a discussion"
+            reply_button_label = "Reply to comment"
             subject = f"[Discussions]: {commenter.first_name} mentioned you in project '{team}'"
 
         campaign_key: str = f"discussions_user_mentioned_{comment.id}_updated_at_{comment.created_at.timestamp()}"
@@ -855,6 +862,9 @@ def send_discussions_mentioned(comment_id: str, mentioned_user_ids: list[int], s
                 "href": href,
                 "is_ticket_mention": is_ticket_mention,
                 "ticket_number": ticket_number,
+                "mention_heading": mention_heading,
+                "mention_location": mention_location,
+                "reply_button_label": reply_button_label,
             },
         )
 

--- a/posthog/templates/email/discussions_mentioned.html
+++ b/posthog/templates/email/discussions_mentioned.html
@@ -1,15 +1,25 @@
 {% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
-{% block heading %}You were mentioned in a discussion{% endblock %}
+{% block heading %}{% if is_ticket_mention %}You were mentioned in a ticket{% else %}You were mentioned in a discussion{% endif %}{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->
 <p>
-    <b>{{ commenter.first_name }}</b> mentioned you in a comment in the project <b>{{ team.name }}</b>.
+    <b>{{ commenter.first_name }}</b> mentioned you in a comment in
+    {% if is_ticket_mention %}
+        {% if ticket_number %}
+            ticket #{{ ticket_number }}
+        {% else %}
+            a ticket
+        {% endif %}
+    {% else %}
+        a discussion
+    {% endif %}
+    in the project <b>{{ team.name }}</b>.
 </p>
 <p>
     {{ content }}
 </p>
 <div class="mb mt text-center">
-    <a class="button" href="{{ href }}">Reply to comment</a>
+    <a class="button" href="{{ href }}">{% if is_ticket_mention %}Reply to ticket{% else %}Reply to comment{% endif %}</a>
 </div>
 <div class="mt">
     <p>

--- a/posthog/templates/email/discussions_mentioned.html
+++ b/posthog/templates/email/discussions_mentioned.html
@@ -1,25 +1,15 @@
 {% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
-{% block heading %}{% if is_ticket_mention %}You were mentioned in a ticket{% else %}You were mentioned in a discussion{% endif %}{% endblock %}
+{% block heading %}{{ mention_heading }}{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->
 <p>
-    <b>{{ commenter.first_name }}</b> mentioned you in a comment in
-    {% if is_ticket_mention %}
-        {% if ticket_number %}
-            ticket #{{ ticket_number }}
-        {% else %}
-            a ticket
-        {% endif %}
-    {% else %}
-        a discussion
-    {% endif %}
-    in the project <b>{{ team.name }}</b>.
+    <b>{{ commenter.first_name }}</b> mentioned you in a comment in {{ mention_location }} in the project <b>{{ team.name }}</b>.
 </p>
 <p>
     {{ content }}
 </p>
 <div class="mb mt text-center">
-    <a class="button" href="{{ href }}">{% if is_ticket_mention %}Reply to ticket{% else %}Reply to comment{% endif %}</a>
+    <a class="button" href="{{ href }}">{{ reply_button_label }}</a>
 </div>
 <div class="mt">
     <p>


### PR DESCRIPTION
## Problem

Users receiving mention notifications for support tickets were getting confusing and incorrect information:
1.  Emails stated "You were mentioned in a discussion" instead of "ticket".
2.  Mentioned users were displayed as `@member:129277` instead of their actual name (e.g., `@Ben`).
3.  Links in ticket mention emails incorrectly directed to `#panel=discussion` instead of the specific ticket page.

## Changes

This PR fixes ticket mention notifications by:

1.  **Correcting email copy and subject**: For `conversations_ticket` scope, emails now say "You were mentioned in a ticket" and use a `[Tickets]:` subject prefix.
    *   `posthog/tasks/email.py`
    *   `posthog/templates/email/discussions_mentioned.html`
2.  **Resolving mention placeholders**: `@member:<id>` and `@user:<id>` are now resolved to user names (e.g., `@Ben`) in email content and internal mention events.
    *   `posthog/models/comment/utils.py`
    *   `posthog/tasks/email.py`
3.  **Generating correct ticket URLs**: Ticket mention emails now link directly to `/project/<team_id>/conversations/tickets/<ticket_id>`.
    *   `posthog/models/comment/utils.py`

## How did you test this code?

*   **Automated tests**:
    *   Added a regression test in `posthog/tasks/test/test_email.py` to verify ticket-specific copy, `@name` rendering, and correct ticket URLs for mentions.
    *   Added helper tests in `posthog/api/test/test_comments.py` for ticket URL building and mention name resolution.
*   **Manual verification**:
    *   `ruff check` on touched Python files ✅
    *   `python -m compileall` on touched Python files ✅
    *   `pytest` for focused tests was attempted but blocked by ClickHouse/ZooKeeper infrastructure issues in the environment, not by assertion failures.

## Publish to changelog?

no

---
<p><a href="https://cursor.com/background-agent?bcId=bc-290f2ff9-8724-48d9-9bfa-38eaa81601cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-290f2ff9-8724-48d9-9bfa-38eaa81601cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

