### PR TITLE
fix(Insights): CreatedBy Filter not loading users

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.test.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.test.tsx
@@ -1,0 +1,121 @@
+import { MOCK_DEFAULT_BASIC_USER, MOCK_SECOND_BASIC_USER } from 'lib/api.mock'
+
+import '@testing-library/jest-dom'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { SavedInsightsFilters } from './SavedInsightsFilters'
+import { SavedInsightFilters, cleanFilters } from './savedInsightsLogic'
+
+const DEFAULT_FILTERS: SavedInsightFilters = cleanFilters({})
+
+describe('SavedInsightsFilters Created by dropdown', () => {
+    let setFilters: jest.Mock
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/organizations/@current/members/': {
+                    results: [
+                        {
+                            id: '1',
+                            user: MOCK_DEFAULT_BASIC_USER,
+                            level: 8,
+                            joined_at: '2020-09-24T15:05:26.758796Z',
+                            updated_at: '2020-09-24T15:05:26.758837Z',
+                            is_2fa_enabled: false,
+                            has_social_auth: false,
+                            last_login: '2020-09-24T15:05:26.758796Z',
+                        },
+                        {
+                            id: '2',
+                            user: MOCK_SECOND_BASIC_USER,
+                            level: 1,
+                            joined_at: '2021-03-11T19:11:11Z',
+                            updated_at: '2021-03-11T19:11:11Z',
+                            is_2fa_enabled: false,
+                            has_social_auth: false,
+                            last_login: '2021-03-11T19:11:11Z',
+                        },
+                    ],
+                },
+            },
+        })
+        initKeaTests()
+        setFilters = jest.fn()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    function renderFilters(filters: Partial<SavedInsightFilters> = {}): void {
+        render(
+            <Provider>
+                <SavedInsightsFilters filters={{ ...DEFAULT_FILTERS, ...filters }} setFilters={setFilters} />
+            </Provider>
+        )
+    }
+
+    it('loads and displays members when dropdown opens', async () => {
+        renderFilters()
+        await userEvent.click(screen.getByText('Created by'))
+
+        await waitFor(() => {
+            expect(screen.getByText('John')).toBeInTheDocument()
+            expect(screen.getByText('Rose')).toBeInTheDocument()
+        })
+    })
+
+    it('filters members by search term', async () => {
+        renderFilters()
+        await userEvent.click(screen.getByText('Created by'))
+
+        await waitFor(() => {
+            expect(screen.getByText('John')).toBeInTheDocument()
+        })
+
+        const overlay = screen.getByText('John').closest('.max-w-100')!
+        const searchInput = within(overlay as HTMLElement).getByPlaceholderText('Search')
+        await userEvent.type(searchInput, 'Rose')
+
+        await waitFor(() => {
+            expect(screen.getByText('Rose')).toBeInTheDocument()
+            expect(screen.queryByText('John')).not.toBeInTheDocument()
+        })
+    })
+
+    it('shows no matches for unrecognized search', async () => {
+        renderFilters()
+        await userEvent.click(screen.getByText('Created by'))
+
+        await waitFor(() => {
+            expect(screen.getByText('John')).toBeInTheDocument()
+        })
+
+        const overlay = screen.getByText('John').closest('.max-w-100')!
+        const searchInput = within(overlay as HTMLElement).getByPlaceholderText('Search')
+        await userEvent.type(searchInput, 'zzzzz')
+
+        await waitFor(() => {
+            expect(screen.getByText('No matches')).toBeInTheDocument()
+        })
+    })
+
+    it('toggles member selection and calls setFilters', async () => {
+        renderFilters()
+        await userEvent.click(screen.getByText('Created by'))
+
+        await waitFor(() => {
+            expect(screen.getByText('Rose')).toBeInTheDocument()
+        })
+
+        await userEvent.click(screen.getByText('Rose'))
+
+        expect(setFilters).toHaveBeenCalledWith({ createdBy: [MOCK_SECOND_BASIC_USER.id] })
+    })
+})

--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
@@ -26,7 +26,7 @@ export function SavedInsightsFilters({
 }): JSX.Element {
     const { search, hideFeatureFlagInsights, createdBy, favorited, tags, insightType } = filters
 
-    const { meFirstMembers, filteredMembers, search: memberSearch } = useValues(membersLogic)
+    const { meFirstMembers, filteredMembers, membersLoading, search: memberSearch } = useValues(membersLogic)
     const { setSearch: setMemberSearch, ensureAllMembersLoaded } = useActions(membersLogic)
 
     const handleMemberToggle = (userId: number): void => {
@@ -81,11 +81,14 @@ export function SavedInsightsFilters({
                             matchWidth={false}
                             placement="bottom-end"
                             actionable
+                            onVisibilityChange={(visible) => {
+                                if (visible) {
+                                    ensureAllMembersLoaded()
+                                    setMemberSearch('')
+                                }
+                            }}
                             overlay={
-                                <div
-                                    className="max-w-100 deprecated-space-y-2"
-                                    onClick={() => ensureAllMembersLoaded()}
-                                >
+                                <div className="max-w-100 deprecated-space-y-2">
                                     <LemonInput
                                         type="search"
                                         placeholder="Search"
@@ -124,7 +127,11 @@ export function SavedInsightsFilters({
                                                 </LemonButton>
                                             </li>
                                         ))}
-                                        {filteredMembers.length === 0 ? (
+                                        {membersLoading ? (
+                                            <div className="p-2 text-secondary italic truncate border-t">
+                                                Loading...
+                                            </div>
+                                        ) : filteredMembers.length === 0 ? (
                                             <div className="p-2 text-secondary italic truncate border-t">
                                                 {memberSearch ? <span>No matches</span> : <span>No users</span>}
                                             </div>


### PR DESCRIPTION
## Problem
The createdBy filter is not loading users

https://posthog.slack.com/archives/C045L1VEG87/p1771412400233059

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
See tests, and tried filtering by myself locally. It worked.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
