### PR TITLE
feat(ci): publish playwright report to cloudflare pages on PRs

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -520,13 +520,15 @@ jobs:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
               run: |
-                  BRANCH=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'master' }}
+                  BRANCH="${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'master' }}"
                   npx --yes wrangler@3 pages deploy playwright/playwright-report \
                     --project-name=playwright-report \
                     --branch="$BRANCH" \
                     --commit-dirty=true 2>&1 | tee /tmp/wrangler-output.txt
-                  URL=$(grep -oP 'https://\S+\.pages\.dev' /tmp/wrangler-output.txt | tail -1)
-                  echo "deployment-url=$URL" >> $GITHUB_OUTPUT
+                  URL=$(grep -oP 'https://\S+\.pages\.dev' /tmp/wrangler-output.txt | tail -1 || true)
+                  if [ -n "$URL" ]; then
+                      echo "deployment-url=$URL" >> $GITHUB_OUTPUT
+                  fi
 
             - name: Write report URL to job summary
               if: always() && steps.cf-deploy.outputs.deployment-url != ''
@@ -540,20 +542,25 @@ jobs:
 
             - name: Upsert report URL comment on PR
               if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |
                       const fs = require('fs');
                       const marker = '<!-- playwright-report-comment -->';
                       const reportUrl = '${{ steps.cf-deploy.outputs.deployment-url }}';
-                      const passed = '${{ job.status }}' === 'success';
-                      const icon = passed ? '✅' : '❌';
+                      const jobPassed = '${{ job.status }}' === 'success';
 
-                      // Collect failed and flaky tests from JSON report
+                      // Collect failed and flaky tests from JSON report — only populated when
+                      // results.json exists (i.e. tests actually ran). If the file is missing
+                      // (setup failure, cancelled, etc.) extraLines stays empty and we treat
+                      // it the same as "no failures found", so we don't delete an existing
+                      // comment that may have relevant info from a previous run.
                       let extraLines = '';
+                      let resultsRead = false;
                       try {
                           const results = JSON.parse(fs.readFileSync('playwright/results.json', 'utf8'));
+                          resultsRead = true;
                           const failed = [];
                           const flaky = [];
                           function collect(suites) {
@@ -586,8 +593,8 @@ jobs:
                       });
                       const existing = comments.find(c => c.body.includes(marker));
 
-                      // Delete the comment when all tests pass — no noise for green PRs
-                      if (!extraLines) {
+                      // Only clean up the comment when we actually read results and they're clean
+                      if (resultsRead && !extraLines) {
                           if (existing) {
                               await github.rest.issues.deleteComment({
                                   owner: context.repo.owner,
@@ -598,8 +605,12 @@ jobs:
                           return;
                       }
 
+                      // Skip posting if there's nothing useful to show
+                      if (!extraLines && !reportUrl) return;
+
+                      const reportLink = reportUrl ? ` · [View test results →](${reportUrl})` : '';
                       const footer = '\n\n---\n*Annoyed by this comment? Make the tests green and it\'ll disappear!*';
-                      const body = `${marker}\n🎭 Playwright report · [View test results →](${reportUrl})${extraLines}${footer}`;
+                      const body = `${marker}\n🎭 Playwright report${reportLink}${extraLines}${footer}`;
 
                       if (existing) {
                           await github.rest.issues.updateComment({

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -515,17 +515,17 @@ jobs:
             - name: Publish report to Cloudflare Pages
               if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
               id: cf-deploy
+              continue-on-error: true
               env:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
               run: |
                   BRANCH=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'master' }}
-                  OUTPUT=$(npx --yes wrangler@3 pages deploy playwright/playwright-report \
+                  npx --yes wrangler@3 pages deploy playwright/playwright-report \
                     --project-name=playwright-report \
                     --branch="$BRANCH" \
-                    --commit-dirty=true 2>&1)
-                  echo "$OUTPUT"
-                  URL=$(echo "$OUTPUT" | grep -oP 'https://\S+\.pages\.dev' | tail -1)
+                    --commit-dirty=true 2>&1 | tee /tmp/wrangler-output.txt
+                  URL=$(grep -oP 'https://\S+\.pages\.dev' /tmp/wrangler-output.txt | tail -1)
                   echo "deployment-url=$URL" >> $GITHUB_OUTPUT
 
             - name: Write report URL to job summary
@@ -544,11 +544,36 @@ jobs:
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |
+                      const fs = require('fs');
                       const marker = '<!-- playwright-report-comment -->';
                       const reportUrl = '${{ steps.cf-deploy.outputs.deployment-url }}';
                       const passed = '${{ job.status }}' === 'success';
                       const icon = passed ? '✅' : '❌';
-                      const body = `${marker}\n${icon} Playwright report: [view report](${reportUrl})`;
+
+                      // Collect flaky tests from JSON report
+                      let flakyLines = '';
+                      try {
+                          const results = JSON.parse(fs.readFileSync('playwright/results.json', 'utf8'));
+                          const flaky = [];
+                          function collect(suites) {
+                              for (const suite of suites || []) {
+                                  for (const spec of suite.specs || []) {
+                                      for (const test of spec.tests || []) {
+                                          if (test.status === 'flaky') {
+                                              flaky.push(`- ${spec.title} (${test.projectName})`);
+                                          }
+                                      }
+                                  }
+                                  collect(suite.suites);
+                              }
+                          }
+                          collect(results.suites);
+                          if (flaky.length > 0) {
+                              flakyLines = `\n\n⚠️ **${flaky.length} flaky test${flaky.length > 1 ? 's' : ''}:**\n${flaky.join('\n')}`;
+                          }
+                      } catch {}
+
+                      const body = `${marker}\n${icon} Playwright report: [view report](${reportUrl})${flakyLines}`;
 
                       const { data: comments } = await github.rest.issues.listComments({
                           owner: context.repo.owner,

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -519,6 +519,7 @@ jobs:
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  packageManager: npm
                   command: pages deploy playwright/playwright-report --project-name=playwright-report --branch=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'master' }}
 
             - name: Write report URL to job summary

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -515,12 +515,18 @@ jobs:
             - name: Publish report to Cloudflare Pages
               if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
               id: cf-deploy
-              uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
-              with:
-                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-                  packageManager: npm
-                  command: pages deploy playwright/playwright-report --project-name=playwright-report --branch=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'master' }}
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+              run: |
+                  BRANCH=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'master' }}
+                  OUTPUT=$(npx --yes wrangler@3 pages deploy playwright/playwright-report \
+                    --project-name=playwright-report \
+                    --branch="$BRANCH" \
+                    --commit-dirty=true 2>&1)
+                  echo "$OUTPUT"
+                  URL=$(echo "$OUTPUT" | grep -oP 'https://\S+\.pages\.dev' | tail -1)
+                  echo "deployment-url=$URL" >> $GITHUB_OUTPUT
 
             - name: Write report URL to job summary
               if: always() && steps.cf-deploy.outputs.deployment-url != ''

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -550,16 +550,19 @@ jobs:
                       const passed = '${{ job.status }}' === 'success';
                       const icon = passed ? '✅' : '❌';
 
-                      // Collect flaky tests from JSON report
-                      let flakyLines = '';
+                      // Collect failed and flaky tests from JSON report
+                      let extraLines = '';
                       try {
                           const results = JSON.parse(fs.readFileSync('playwright/results.json', 'utf8'));
+                          const failed = [];
                           const flaky = [];
                           function collect(suites) {
                               for (const suite of suites || []) {
                                   for (const spec of suite.specs || []) {
                                       for (const test of spec.tests || []) {
-                                          if (test.status === 'flaky') {
+                                          if (test.status === 'unexpected') {
+                                              failed.push(`- ${spec.title} (${test.projectName})`);
+                                          } else if (test.status === 'flaky') {
                                               flaky.push(`- ${spec.title} (${test.projectName})`);
                                           }
                                       }
@@ -568,12 +571,15 @@ jobs:
                               }
                           }
                           collect(results.suites);
+                          if (failed.length > 0) {
+                              extraLines += `\n\n❌ **${failed.length} failed test${failed.length > 1 ? 's' : ''}:**\n${failed.join('\n')}`;
+                          }
                           if (flaky.length > 0) {
-                              flakyLines = `\n\n⚠️ **${flaky.length} flaky test${flaky.length > 1 ? 's' : ''}:**\n${flaky.join('\n')}`;
+                              extraLines += `\n\n⚠️ **${flaky.length} flaky test${flaky.length > 1 ? 's' : ''}:**\n${flaky.join('\n')}`;
                           }
                       } catch {}
 
-                      const body = `${marker}\n${icon} Playwright report: [view report](${reportUrl})${flakyLines}`;
+                      const body = `${marker}\n${icon} Playwright report: [view report](${reportUrl})${extraLines}`;
 
                       const { data: comments } = await github.rest.issues.listComments({
                           owner: context.repo.owner,

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -512,6 +512,49 @@ jobs:
                   path: playwright/junit-results.xml
                   if-no-files-found: ignore
 
+            - name: Publish report to Cloudflare Pages
+              if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              id: cf-deploy
+              uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  command: pages deploy playwright/playwright-report --project-name=playwright-report --branch=pr-${{ github.event.number }}
+
+            - name: Upsert report URL comment on PR
+              if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const marker = '<!-- playwright-report-comment -->';
+                      const reportUrl = '${{ steps.cf-deploy.outputs.deployment-url }}';
+                      const passed = '${{ job.status }}' === 'success';
+                      const icon = passed ? '✅' : '❌';
+                      const body = `${marker}\n${icon} Playwright report: [view report](${reportUrl})`;
+
+                      const { data: comments } = await github.rest.issues.listComments({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.issue.number,
+                      });
+                      const existing = comments.find(c => c.body.includes(marker));
+                      if (existing) {
+                          await github.rest.issues.updateComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              comment_id: existing.id,
+                              body,
+                          });
+                      } else {
+                          await github.rest.issues.createComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: context.issue.number,
+                              body,
+                          });
+                      }
+
     capture-run-time:
         name: Capture run time
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -513,13 +513,23 @@ jobs:
                   if-no-files-found: ignore
 
             - name: Publish report to Cloudflare Pages
-              if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+              if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
               id: cf-deploy
               uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-                  command: pages deploy playwright/playwright-report --project-name=playwright-report --branch=pr-${{ github.event.number }}
+                  command: pages deploy playwright/playwright-report --project-name=playwright-report --branch=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'master' }}
+
+            - name: Write report URL to job summary
+              if: always() && steps.cf-deploy.outputs.deployment-url != ''
+              run: |
+                  echo "## 🎭 Playwright report" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Report URL:** ${{ steps.cf-deploy.outputs.deployment-url }}" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "- Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- Run: [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
 
             - name: Upsert report URL comment on PR
               if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -579,14 +579,28 @@ jobs:
                           }
                       } catch {}
 
-                      const body = `${marker}\n${icon} Playwright report: [view report](${reportUrl})${extraLines}`;
-
                       const { data: comments } = await github.rest.issues.listComments({
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           issue_number: context.issue.number,
                       });
                       const existing = comments.find(c => c.body.includes(marker));
+
+                      // Delete the comment when all tests pass — no noise for green PRs
+                      if (!extraLines) {
+                          if (existing) {
+                              await github.rest.issues.deleteComment({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  comment_id: existing.id,
+                              });
+                          }
+                          return;
+                      }
+
+                      const footer = '\n\n---\n*Annoyed by this comment? Make the tests green and it\'ll disappear!*';
+                      const body = `${marker}\n🎭 Playwright report · [View test results →](${reportUrl})${extraLines}${footer}`;
+
                       if (existing) {
                           await github.rest.issues.updateComment({
                               owner: context.repo.owner,

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
     reporter: [
         ['html', { open: 'never' }],
         ...(process.env.CI ? [['junit', { outputFile: 'junit-results.xml' }] as const] : []),
+        ...(process.env.CI ? [['json', { outputFile: 'results.json' }] as const] : []),
     ],
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {


### PR DESCRIPTION
Deploys the Playwright HTML report to Cloudflare Pages after each E2E run so reviewers get a direct link without having to download artifacts from GitHub.

**How it works**

- After tests finish, wrangler deploys `playwright/playwright-report/` to the `playwright-report` CF Pages project
- Each PR gets a stable URL via `--branch=pr-{number}` — reruns overwrite, no accumulation
- A single PR comment is upserted (find-or-update) with pass/fail status and the report link
- Only runs on non-fork PRs (secrets unavailable on forks)

**Prerequisite**: the `playwright-report` CF Pages project must exist with direct upload enabled (already set up).