### PR TITLE
fix(dashboards/insights): order tags column

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -139,7 +139,7 @@ export function DashboardsTable({
             title: 'Tags',
             dataIndex: 'tags' as keyof DashboardType,
             render: function Render(tags: DashboardType['tags']) {
-                return tags ? <ObjectTags tags={tags} staticOnly /> : null
+                return tags ? <ObjectTags tags={[...tags].sort()} staticOnly /> : null
             },
         } as LemonTableColumn<DashboardType, keyof DashboardType | undefined>,
         createdByColumn<DashboardType>() as LemonTableColumn<DashboardType, keyof DashboardType | undefined>,

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -742,7 +742,7 @@ export function SavedInsights(): JSX.Element {
             dataIndex: 'tags' as keyof QueryBasedInsightModel,
             key: 'tags',
             render: function renderTags(tags: string[]) {
-                return <ObjectTags tags={tags} staticOnly />
+                return <ObjectTags tags={[...tags].sort()} staticOnly />
             },
         },
         {


### PR DESCRIPTION
## Problem
Tags column on all insights/dashboards page doesn't sort the tag names

## Changes
<img width="544" height="550" alt="image" src="https://github.com/user-attachments/assets/f113cf5c-6b5f-4283-853f-902c04864c41" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
