### PR TITLE
Replace lib/api with toolbarFetch in toolbar code

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -108,6 +108,9 @@ await buildInParallel(
                             'scenes/activity/explore/EventDetails',
                             'scenes/web-analytics/WebAnalyticsDashboard',
                             'scenes/session-recordings/player/snapshot-processing/DecompressionWorkerManager.ts',
+                            // lib/api makes relative URL requests that resolve to the embedded site's origin
+                            // instead of the PostHog server - use toolbarFetch from toolbarConfigLogic instead
+                            'lib/api',
                         ]
 
                         // Patterns to match for denying imports

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -2,13 +2,12 @@ import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea
 import { forms } from 'kea-forms'
 import { subscriptions } from 'kea-subscriptions'
 
-import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { urls } from 'scenes/urls'
 
 import { actionsLogic } from '~/toolbar/actions/actionsLogic'
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
-import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
+import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { ActionDraftType, ActionForm } from '~/toolbar/types'
 import {
@@ -228,15 +227,21 @@ export const actionsTabLogic = kea<actionsTabLogicType>([
 
                 let response: ActionType
                 if (selectedActionId && selectedActionId !== 'new') {
-                    response = await api.update(
+                    const fetchResponse = await toolbarFetch(
                         `${apiHost}/api/projects/@current/actions/${selectedActionId}/?temporary_token=${temporaryToken}`,
-                        actionToSave
+                        'PATCH',
+                        actionToSave,
+                        'use-as-provided'
                     )
+                    response = await fetchResponse.json()
                 } else {
-                    response = await api.create(
+                    const fetchResponse = await toolbarFetch(
                         `${apiHost}/api/projects/@current/actions/?temporary_token=${temporaryToken}`,
-                        actionToSave
+                        'POST',
+                        actionToSave,
+                        'use-as-provided'
                     )
+                    response = await fetchResponse.json()
                 }
                 breakpoint()
 

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -7,7 +7,7 @@ import { PostHog } from 'posthog-js'
 import { collectAllElementsDeep, querySelectorAllDeep } from 'query-selector-shadow-dom'
 
 import { elementToSelector } from 'lib/actionUtils'
-import { PaginatedResponse } from 'lib/api'
+import type { PaginatedResponse } from 'lib/api'
 import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
 import { createVersionChecker } from 'lib/utils/semver'
 

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -3,14 +3,13 @@ import { forms } from 'kea-forms'
 import { subscriptions } from 'kea-subscriptions'
 
 import { EXPERIMENT_TARGET_SELECTOR } from 'lib/actionUtils'
-import api, { ApiError } from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { urls } from 'scenes/urls'
 
 import { percentageDistribution } from '~/scenes/experiments/utils'
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
 import { experimentsLogic } from '~/toolbar/experiments/experimentsLogic'
-import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
+import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { WebExperiment, WebExperimentDraftType, WebExperimentForm } from '~/toolbar/types'
 import { elementToQuery, joinWithUiHost } from '~/toolbar/utils'
@@ -195,36 +194,40 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                 const { apiHost, uiHost, temporaryToken } = values
                 const { selectedExperimentId } = values
 
-                let response: WebExperiment
-                try {
-                    if (selectedExperimentId && selectedExperimentId !== 'new') {
-                        response = await api.update(
-                            `${apiHost}/api/projects/@current/web_experiments/${selectedExperimentId}/?temporary_token=${temporaryToken}`,
-                            experimentToSave
-                        )
-                    } else {
-                        response = await api.create(
-                            `${apiHost}/api/projects/@current/web_experiments/?temporary_token=${temporaryToken}`,
-                            experimentToSave
-                        )
-                    }
-
-                    experimentsLogic.actions.updateExperiment({ experiment: response })
-                    actions.selectExperiment(null)
-
-                    lemonToast.success('Experiment saved', {
-                        button: {
-                            label: 'Open in PostHog',
-                            action: () => window.open(joinWithUiHost(uiHost, urls.experiment(response.id)), '_blank'),
-                        },
-                    })
-                    breakpoint()
-                } catch (e) {
-                    const apiError = e as ApiError
-                    if (apiError) {
-                        lemonToast.error(`Experiment save failed: ${apiError.data.detail}`)
-                    }
+                let fetchResponse: Response
+                if (selectedExperimentId && selectedExperimentId !== 'new') {
+                    fetchResponse = await toolbarFetch(
+                        `${apiHost}/api/projects/@current/web_experiments/${selectedExperimentId}/?temporary_token=${temporaryToken}`,
+                        'PATCH',
+                        experimentToSave,
+                        'use-as-provided'
+                    )
+                } else {
+                    fetchResponse = await toolbarFetch(
+                        `${apiHost}/api/projects/@current/web_experiments/?temporary_token=${temporaryToken}`,
+                        'POST',
+                        experimentToSave,
+                        'use-as-provided'
+                    )
                 }
+
+                if (!fetchResponse.ok) {
+                    const errorData = await fetchResponse.json().catch(() => ({}))
+                    lemonToast.error(`Experiment save failed: ${errorData.detail || fetchResponse.statusText}`)
+                    return
+                }
+
+                const response: WebExperiment = await fetchResponse.json()
+                experimentsLogic.actions.updateExperiment({ experiment: response })
+                actions.selectExperiment(null)
+
+                lemonToast.success('Experiment saved', {
+                    button: {
+                        label: 'Open in PostHog',
+                        action: () => window.open(joinWithUiHost(uiHost, urls.experiment(response.id)), '_blank'),
+                    },
+                })
+                breakpoint()
             },
 
             // whether we show errors after touch (true) or submit (false)


### PR DESCRIPTION
## Problem

The toolbar code currently uses `lib/api` for making HTTP requests, but this module makes relative URL requests that resolve to the embedded site's origin instead of the PostHog server. This causes requests to fail when the toolbar is embedded in a different domain.

## Changes

- Replaced `api.create()` and `api.update()` calls with `toolbarFetch()` in `experimentsTabLogic.tsx` and `actionsTabLogic.tsx`
- Updated error handling to work with the native `Response` object returned by `toolbarFetch` instead of the `ApiError` wrapper
- Added `toolbarFetch` to the imports from `toolbarConfigLogic`
- Removed unused `api` and `ApiError` imports
- Added a build-time restriction in `frontend/build.mjs` to prevent future imports of `lib/api` in toolbar code
- Changed `PaginatedResponse` import in `heatmapToolbarMenuLogic.ts` to a type-only import for consistency

## How did you test this code?

The changes follow the existing pattern already used elsewhere in the toolbar codebase. The error handling logic is preserved, just adapted to work with native `Response` objects. Build configuration prevents regression of this pattern.

## Publish to changelog?

no

https://claude.ai/code/session_01URkuyoCwntsyyD3jnjQC2f