### PR TITLE
fix: animation durations 0 is still running the animations code. just immediately finishes. let's not run it at all since it's ~54% of dashboard CPU

### DIFF
--- a/frontend/src/lib/Chart.ts
+++ b/frontend/src/lib/Chart.ts
@@ -11,7 +11,7 @@ if (registerables) {
 }
 RawChart.register(CrosshairPlugin)
 RawChart.register(ZoomPlugin)
-RawChart.defaults.animation['duration'] = 0
+RawChart.defaults.animation = false
 
 // Create positioner to put tooltip at cursor position
 Tooltip.positioners.cursor = function (_, coordinates) {

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -74,9 +74,7 @@ function MicroChart({ exposures }: MicroChartProps): JSX.Element | null {
                 options: {
                     responsive: true,
                     maintainAspectRatio: false,
-                    animation: {
-                        duration: 0,
-                    },
+                    animation: false,
                     scales: {
                         x: {
                             display: false,


### PR DESCRIPTION
the animation update cycle in chart.js is burning a tonne of CPU in dashboards but doesn't do anything because of the duration = 0

let's just turn it off