### PR TITLE
chore(dev): Use `uv run` for hogli

### DIFF
--- a/bin/hogli
+++ b/bin/hogli
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 """Entry point for the PostHog developer CLI."""
 
 from pathlib import Path


### PR DESCRIPTION
## Problem

`hogli` doesn't quite work for me in GH Desktop, because it runs with Python without Flox, i.e. without the venv activated, somehow. I get the "click is not available" error.

## Changes

But there's a simple fix: `hogli` should just run with `uv run`. This 100% ensures the CLI runs with the venv active.